### PR TITLE
[fix][broker] Topic could be in fenced state forever if deletion fails

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1268,9 +1268,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                                                 topic, exception.getMessage());
                                                         deleteLedgerComplete(ctx);
                                                     } else {
-                                                        unfenceTopicToResume();
                                                         log.error("[{}] Error deleting topic",
                                                                 topic, exception);
+                                                        unfenceTopicToResume();
                                                         deleteFuture.completeExceptionally(
                                                                 new PersistenceException(exception));
                                                     }
@@ -1291,8 +1291,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 return deleteFuture;
                 }).whenComplete((value, ex) -> {
                     if (ex != null) {
-                        unfenceTopicToResume();
                         log.error("[{}] Error deleting topic", topic, ex);
+                        unfenceTopicToResume();
                     }
                 });
         } finally {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1289,6 +1289,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 });
 
                 return deleteFuture;
+                }).whenComplete((value, ex) -> {
+                    if (ex != null) {
+                        unfenceTopicToResume();
+                        log.error("[{}] Error deleting topic", topic, ex);
+                    }
                 });
         } finally {
             lock.writeLock().unlock();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.broker.service;
 import static org.apache.pulsar.broker.BrokerTestUtil.spyWithClassAndConstructorArgs;
 import static org.apache.pulsar.broker.BrokerTestUtil.spyWithClassAndConstructorArgsRecordingInvocations;
 import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.createMockBookKeeper;
-import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.createMockZooKeeper;
 import static org.apache.pulsar.common.protocol.Commands.DEFAULT_CONSUMER_EPOCH;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -131,12 +130,14 @@ import org.apache.pulsar.common.api.proto.ProducerAccessMode;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.TopicPolicies;
 import org.apache.pulsar.common.policies.data.stats.SubscriptionStatsImpl;
 import org.apache.pulsar.common.protocol.ByteBufPair;
 import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.util.Codec;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.GracefulExecutorServicesShutdown;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
@@ -144,8 +145,8 @@ import org.apache.pulsar.compaction.CompactedTopic;
 import org.apache.pulsar.compaction.CompactedTopicContext;
 import org.apache.pulsar.compaction.Compactor;
 import org.apache.pulsar.metadata.api.MetadataStore;
-import org.apache.pulsar.metadata.impl.ZKMetadataStore;
-import org.apache.zookeeper.ZooKeeper;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.impl.FaultInjectionMetadataStore;
 import org.awaitility.Awaitility;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -165,7 +166,6 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
     private SchemaRegistryService schemaRegistryService;
     private ManagedLedgerFactory mlFactoryMock;
     private ServerCnx serverCnx;
-    private MetadataStore store;
     private ManagedLedger ledgerMock;
     private ManagedCursor cursorMock;
 
@@ -211,17 +211,15 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
             return null;
         }).when(mlFactoryMock).asyncDelete(any(), any(), any());
         // Mock metaStore.
-        ZooKeeper mockZk = createMockZooKeeper();
         doReturn(createMockBookKeeper(executor))
             .when(pulsar).getBookKeeperClient();
         doReturn(executor).when(pulsar).getOrderedExecutor();
-        store = new ZKMetadataStore(mockZk);
-        doReturn(store).when(pulsar).getLocalMetadataStore();
-        doReturn(store).when(pulsar).getConfigurationMetadataStore();
+        doReturn(metadataStore).when(pulsar).getLocalMetadataStore();
+        doReturn(metadataStore).when(pulsar).getConfigurationMetadataStore();
         // Mock pulsarResources.
-        PulsarResources pulsarResources = spyWithClassAndConstructorArgs(PulsarResources.class, store, store);
-        NamespaceResources nsr = spyWithClassAndConstructorArgs(NamespaceResources.class, store, 30);
-        TopicResources tsr = spyWithClassAndConstructorArgs(TopicResources.class, store);
+        PulsarResources pulsarResources = spyWithClassAndConstructorArgs(PulsarResources.class, metadataStore, metadataStore);
+        NamespaceResources nsr = spyWithClassAndConstructorArgs(NamespaceResources.class, metadataStore, 30);
+        TopicResources tsr = spyWithClassAndConstructorArgs(TopicResources.class, metadataStore);
         doReturn(nsr).when(pulsarResources).getNamespaceResources();
         doReturn(tsr).when(pulsarResources).getTopicResources();
         PulsarServiceMockSupport.mockPulsarServiceProps(pulsar, () -> {
@@ -268,7 +266,6 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
                 .shutdown(executor)
                 .handle().get();
         EventLoopUtil.shutdownGracefully(eventLoopGroup).get();
-        store.close();
     }
 
     @Test
@@ -1615,6 +1612,45 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
             }).when(cursorMock).asyncMarkDelete(any(), any(), any(MarkDeleteCallback.class), any());
     }
 
+
+    @Test
+    public void testDeleteTopicDeleteOnMetadataStoreFailed() throws Exception {
+
+        doReturn(CompletableFuture.completedFuture(null)).when(ledgerMock).asyncTruncate();
+
+        // create topic
+        brokerService.pulsar().getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                .createPartitionedTopic(TopicName.get(successTopicName), new PartitionedTopicMetadata(2));
+        PersistentTopic topic = (PersistentTopic) brokerService.getOrCreateTopic(successTopicName).get();
+
+        Field isFencedField = AbstractTopic.class.getDeclaredField("isFenced");
+        isFencedField.setAccessible(true);
+        Field isClosingOrDeletingField = PersistentTopic.class.getDeclaredField("isClosingOrDeleting");
+        isClosingOrDeletingField.setAccessible(true);
+
+        assertFalse((boolean) isFencedField.get(topic));
+        assertFalse((boolean) isClosingOrDeletingField.get(topic));
+
+        metadataStore.failConditional(new MetadataStoreException("injected error"), (op, path) -> {
+            if (op == FaultInjectionMetadataStore.OperationType.PUT
+                && path.equals("/admin/partitioned-topics/prop/use/ns-abc/persistent/successTopic")) {
+                return true;
+            }
+            return false;
+        });
+        try {
+            topic.delete().get();
+            fail();
+        } catch (ExecutionException e) {
+            final Throwable t = FutureUtil.unwrapCompletionException(e);
+            assertTrue(t.getMessage().contains("injected error"));
+        }
+        assertFalse((boolean) isFencedField.get(topic));
+        assertFalse((boolean) isClosingOrDeletingField.get(topic));
+
+    }
+
+
     @Test
     public void testFailoverSubscription() throws Exception {
         PersistentTopic topic1 = new PersistentTopic(successTopicName, ledgerMock, brokerService);
@@ -2330,8 +2366,8 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         topic.initialize();
         assertEquals(topic.getHierarchyTopicPolicies().getReplicationClusters().get(), Collections.emptyList());
 
-        PulsarResources pulsarResources = spyWithClassAndConstructorArgs(PulsarResources.class, store, store);
-        NamespaceResources nsr = spyWithClassAndConstructorArgs(NamespaceResources.class, store, 30);
+        PulsarResources pulsarResources = spyWithClassAndConstructorArgs(PulsarResources.class, metadataStore, metadataStore);
+        NamespaceResources nsr = spyWithClassAndConstructorArgs(NamespaceResources.class, metadataStore, 30);
         doReturn(nsr).when(pulsarResources).getNamespaceResources();
         PulsarServiceMockSupport.mockPulsarServiceProps(pulsar, () -> {
             doReturn(pulsarResources).when(pulsar).getPulsarResources();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -144,7 +144,6 @@ import org.apache.pulsar.common.util.netty.EventLoopUtil;
 import org.apache.pulsar.compaction.CompactedTopic;
 import org.apache.pulsar.compaction.CompactedTopicContext;
 import org.apache.pulsar.compaction.Compactor;
-import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.impl.FaultInjectionMetadataStore;
 import org.awaitility.Awaitility;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/FaultInjectionMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/FaultInjectionMetadataStore.java
@@ -169,7 +169,8 @@ public class FaultInjectionMetadataStore implements MetadataStoreExtended {
         if (metadataCache instanceof MetadataCacheImpl) {
             FieldUtils.writeField(metadataCache, "store", this, true);
         } else {
-            throw new UnsupportedOperationException("Metadata cache implementation not supported by FaultInjectionMetadataStore");
+            throw new UnsupportedOperationException("Metadata cache implementation "
+                    + metadataCache.getClass().getName() + " not supported by FaultInjectionMetadataStore");
         }
         return metadataCache;
     }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/FaultInjectionMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/FaultInjectionMetadataStore.java
@@ -28,6 +28,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import lombok.Data;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataCache;
@@ -39,6 +41,7 @@ import org.apache.pulsar.metadata.api.Stat;
 import org.apache.pulsar.metadata.api.extended.CreateOption;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.api.extended.SessionEvent;
+import org.apache.pulsar.metadata.cache.impl.MetadataCacheImpl;
 
 /**
  * Add possibility to inject failures during tests that interact with MetadataStore.
@@ -148,17 +151,27 @@ public class FaultInjectionMetadataStore implements MetadataStoreExtended {
 
     @Override
     public <T> MetadataCache<T> getMetadataCache(Class<T> clazz, MetadataCacheConfig cacheConfig) {
-        return store.getMetadataCache(clazz, cacheConfig);
+        return injectMetadataStoreInMetadataCache(store.getMetadataCache(clazz, cacheConfig));
     }
 
     @Override
     public <T> MetadataCache<T> getMetadataCache(TypeReference<T> typeRef, MetadataCacheConfig cacheConfig) {
-        return store.getMetadataCache(typeRef, cacheConfig);
+        return injectMetadataStoreInMetadataCache(store.getMetadataCache(typeRef, cacheConfig));
     }
 
     @Override
     public <T> MetadataCache<T> getMetadataCache(MetadataSerde<T> serde, MetadataCacheConfig cacheConfig) {
-        return store.getMetadataCache(serde, cacheConfig);
+        return injectMetadataStoreInMetadataCache(store.getMetadataCache(serde, cacheConfig));
+    }
+
+    @SneakyThrows
+    private <T> MetadataCache<T> injectMetadataStoreInMetadataCache(MetadataCache<T> metadataCache) {
+        if (metadataCache instanceof MetadataCacheImpl) {
+            FieldUtils.writeField(metadataCache, "store", this, true);
+        } else {
+            throw new UnsupportedOperationException("Metadata cache implementation not supported by FaultInjectionMetadataStore");
+        }
+        return metadataCache;
     }
 
     @Override


### PR DESCRIPTION
### Motivation

There's blind spot in the topic deletion where, if an exception occurs during the partitioned metadata update, the topic ends in a fenced state and it can't be deleted or used. With a broker restarts, the topic is deletable again. However the topic might be in an inconsistent state.

### Modifications

* Removed fenced flag in the topic if an error occurs during the partition metadata update
* Add unit test
* (tests) Fix `FaultInjectionMetadataStore` to be usable also from the MetadataCache methods 

### Verifying this change

- [x] Make sure that the change passes the CI checks.
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

