### PR TITLE
[improve][schema] Do not print error log with stacktrace for 404

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -846,6 +846,13 @@ public abstract class AdminResource extends PulsarWebResource {
                 == Status.TEMPORARY_REDIRECT.getStatusCode();
     }
 
+    protected static boolean isNotFoundException(Throwable ex) {
+        Throwable realCause = FutureUtil.unwrapCompletionException(ex);
+        return realCause instanceof WebApplicationException
+                && ((WebApplicationException) realCause).getResponse().getStatus()
+                == Status.NOT_FOUND.getStatusCode();
+    }
+
     protected static String getTopicNotFoundErrorMessage(String topic) {
         return String.format("Topic %s not found", topic);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
@@ -230,5 +230,10 @@ public class SchemasResourceBase extends AdminResource {
                 .thenCompose(__ -> validateTopicOperationAsync(topicName, operation));
     }
 
+
+    protected boolean shouldPrintErrorLog(Throwable ex) {
+        return !isRedirectException(ex) && !isNotFoundException(ex);
+    }
+
     private static final Logger log = LoggerFactory.getLogger(SchemasResourceBase.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/SchemasResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/SchemasResource.java
@@ -89,10 +89,10 @@ public class SchemasResource extends SchemasResourceBase {
     ) {
         validateTopicName(tenant, cluster, namespace, topic);
         getSchemaAsync(authoritative)
-                .thenApply(schemaAndMetadata -> convertToSchemaResponse(schemaAndMetadata))
+                .thenApply(this::convertToSchemaResponse)
                 .thenApply(response::resume)
                 .exceptionally(ex -> {
-                    if (!isRedirectException(ex)) {
+                    if (shouldPrintErrorLog(ex)) {
                         log.error("[{}] Failed to get schema for topic {}", clientAppId(), topicName, ex);
                     }
                     resumeAsyncResponseExceptionally(response, ex);
@@ -124,10 +124,10 @@ public class SchemasResource extends SchemasResourceBase {
     ) {
         validateTopicName(tenant, cluster, namespace, topic);
         getSchemaAsync(authoritative, version)
-                .thenApply(schemaAndMetadata -> convertToSchemaResponse(schemaAndMetadata))
+                .thenApply(this::convertToSchemaResponse)
                 .thenAccept(response::resume)
                 .exceptionally(ex -> {
-                    if (!isRedirectException(ex)) {
+                    if (shouldPrintErrorLog(ex)) {
                         log.error("[{}] Failed to get schema for topic {} with version {}",
                                 clientAppId(), topicName, version, ex);
                     }
@@ -159,10 +159,10 @@ public class SchemasResource extends SchemasResourceBase {
     ) {
         validateTopicName(tenant, cluster, namespace, topic);
         getAllSchemasAsync(authoritative)
-                .thenApply(schemaAndMetadata -> convertToAllVersionsSchemaResponse(schemaAndMetadata))
+                .thenApply(this::convertToAllVersionsSchemaResponse)
                 .thenAccept(response::resume)
                 .exceptionally(ex -> {
-                    if (!isRedirectException(ex)) {
+                    if (shouldPrintErrorLog(ex)) {
                         log.error("[{}] Failed to get all schemas for topic {}", clientAppId(), topicName, ex);
                     }
                     resumeAsyncResponseExceptionally(response, ex);
@@ -197,7 +197,7 @@ public class SchemasResource extends SchemasResourceBase {
                     response.resume(DeleteSchemaResponse.builder().version(getLongSchemaVersion(version)).build());
                 })
                 .exceptionally(ex -> {
-                    if (!isRedirectException(ex)) {
+                    if (shouldPrintErrorLog(ex)) {
                         log.error("[{}] Failed to delete schemas for topic {}", clientAppId(), topicName, ex);
                     }
                     resumeAsyncResponseExceptionally(response, ex);
@@ -252,7 +252,7 @@ public class SchemasResource extends SchemasResourceBase {
                         response.resume(Response.status(422, /* Unprocessable Entity */
                                 root.getMessage()).build());
                     } else {
-                        if (!isRedirectException(ex)) {
+                        if (shouldPrintErrorLog(ex)) {
                             log.error("[{}] Failed to post schemas for topic {}", clientAppId(), topicName, root);
                         }
                         resumeAsyncResponseExceptionally(response, ex);
@@ -301,7 +301,7 @@ public class SchemasResource extends SchemasResourceBase {
                                 .schemaCompatibilityStrategy(pair.getRight().name()).build())
                         .build()))
                 .exceptionally(ex -> {
-                    if (!isRedirectException(ex)) {
+                    if (shouldPrintErrorLog(ex)) {
                         log.error("[{}] Failed to test compatibility for topic {}", clientAppId(), topicName, ex);
                     }
                     resumeAsyncResponseExceptionally(response, ex);
@@ -347,7 +347,7 @@ public class SchemasResource extends SchemasResourceBase {
         getVersionBySchemaAsync(payload, authoritative)
                 .thenAccept(version -> response.resume(LongSchemaVersionResponse.builder().version(version).build()))
                 .exceptionally(ex -> {
-                    if (!isRedirectException(ex)) {
+                    if (shouldPrintErrorLog(ex)) {
                         log.error("[{}] Failed to get version by schema for topic {}", clientAppId(), topicName, ex);
                     }
                     resumeAsyncResponseExceptionally(response, ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/SchemasResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/SchemasResource.java
@@ -89,10 +89,10 @@ public class SchemasResource extends SchemasResourceBase {
             @Suspended final AsyncResponse response) {
         validateTopicName(tenant, namespace, topic);
         getSchemaAsync(authoritative)
-                .thenApply(schemaAndMetadata -> convertToSchemaResponse(schemaAndMetadata))
+                .thenApply(this::convertToSchemaResponse)
                 .thenApply(response::resume)
                 .exceptionally(ex -> {
-                    if (!isRedirectException(ex)) {
+                    if (shouldPrintErrorLog(ex)) {
                         log.error("[{}] Failed to get schema for topic {}", clientAppId(), topicName, ex);
                     }
                     resumeAsyncResponseExceptionally(response, ex);
@@ -122,10 +122,10 @@ public class SchemasResource extends SchemasResourceBase {
             @Suspended final AsyncResponse response) {
         validateTopicName(tenant, namespace, topic);
         getSchemaAsync(authoritative, version)
-                .thenApply(schemaAndMetadata -> convertToSchemaResponse(schemaAndMetadata))
+                .thenApply(this::convertToSchemaResponse)
                 .thenAccept(response::resume)
                 .exceptionally(ex -> {
-                    if (!isRedirectException(ex)) {
+                    if (shouldPrintErrorLog(ex)) {
                         log.error("[{}] Failed to get schema for topic {} with version {}",
                                 clientAppId(), topicName, version, ex);
                     }
@@ -155,10 +155,10 @@ public class SchemasResource extends SchemasResourceBase {
             @Suspended final AsyncResponse response) {
         validateTopicName(tenant, namespace, topic);
         getAllSchemasAsync(authoritative)
-                .thenApply(schemaAndMetadata -> convertToAllVersionsSchemaResponse(schemaAndMetadata))
+                .thenApply(this::convertToAllVersionsSchemaResponse)
                 .thenAccept(response::resume)
                 .exceptionally(ex -> {
-                    if (!isRedirectException(ex)) {
+                    if (shouldPrintErrorLog(ex)) {
                         log.error("[{}] Failed to get all schemas for topic {}", clientAppId(), topicName, ex);
                     }
                     resumeAsyncResponseExceptionally(response, ex);
@@ -191,7 +191,7 @@ public class SchemasResource extends SchemasResourceBase {
                     response.resume(DeleteSchemaResponse.builder().version(getLongSchemaVersion(version)).build());
                 })
                 .exceptionally(ex -> {
-                    if (!isRedirectException(ex)) {
+                    if (shouldPrintErrorLog(ex)) {
                         log.error("[{}] Failed to delete schemas for topic {}", clientAppId(), topicName, ex);
                     }
                     resumeAsyncResponseExceptionally(response, ex);
@@ -238,7 +238,7 @@ public class SchemasResource extends SchemasResourceBase {
                         response.resume(Response.status(422, /* Unprocessable Entity */
                                 root.getMessage()).build());
                     } else {
-                        if (!isRedirectException(ex)) {
+                        if (shouldPrintErrorLog(ex)) {
                             log.error("[{}] Failed to post schemas for topic {}", clientAppId(), topicName, root);
                         }
                         resumeAsyncResponseExceptionally(response, ex);
@@ -278,7 +278,7 @@ public class SchemasResource extends SchemasResourceBase {
                                 .schemaCompatibilityStrategy(pair.getRight().name()).build())
                         .build()))
                 .exceptionally(ex -> {
-                    if (!isRedirectException(ex)) {
+                    if (shouldPrintErrorLog(ex)) {
                         log.error("[{}] Failed to test compatibility for topic {}", clientAppId(), topicName, ex);
                     }
                     resumeAsyncResponseExceptionally(response, ex);
@@ -315,7 +315,7 @@ public class SchemasResource extends SchemasResourceBase {
         getVersionBySchemaAsync(payload, authoritative)
                 .thenAccept(version -> response.resume(LongSchemaVersionResponse.builder().version(version).build()))
                 .exceptionally(ex -> {
-                    if (!isRedirectException(ex)) {
+                    if (shouldPrintErrorLog(ex)) {
                         log.error("[{}] Failed to get version by schema for topic {}", clientAppId(), topicName, ex);
                     }
                     resumeAsyncResponseExceptionally(response, ex);


### PR DESCRIPTION
### Motivation

We have the INFO log to show the schema not found, or the topic is found.
The error logs for the not found exception are just making noise.

```
2023-01-04T20:33:26,341 - INFO  - [metadata-store-12-1:Slf4jRequestLogWriter@62] - 127.0.0.1 - - [04/Jan/2023:20:33:26 +0800] "GET /admin/v2/schemas/public/default/test111/schema HTTP/1.1" 404 29 "-" "Pulsar-Java-v2.12.0-SNAPSHOT" 118
```

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->