### PR TITLE
[branch-2.8][cherry-pick]  Cleanup state when lock revalidation gets LockBusyException

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
@@ -106,7 +106,9 @@ class LockManagerImpl<T> implements LockManager<T> {
     private void handleSessionEvent(SessionEvent se) {
         if (se == SessionEvent.SessionReestablished) {
             log.info("Metadata store session has been re-established. Revalidating all the existing locks.");
-            locks.values().forEach(ResourceLockImpl::revalidate);
+            for (ResourceLockImpl<T> lock : locks.values()) {
+                lock.revalidate(true);
+            }
         } else if (se == SessionEvent.Reconnected) {
             log.info("Metadata store connection has been re-established. Revalidating locks that were pending.");
             locks.values().forEach(ResourceLockImpl::revalidateIfNeededAfterReconnection);

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LockManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LockManagerTest.java
@@ -241,19 +241,16 @@ public class LockManagerTest extends BaseMetadataStoreTest {
         }
 
         @Cleanup
-        MetadataStoreExtended store1 = MetadataStoreExtended.create(url,
-                MetadataStoreConfig.builder().build());
-        @Cleanup
-        MetadataStoreExtended store2 = MetadataStoreExtended.create(url,
+        MetadataStoreExtended store = MetadataStoreExtended.create(url,
                 MetadataStoreConfig.builder().build());
 
         @Cleanup
-        CoordinationService cs1 = new CoordinationServiceImpl(store1);
+        CoordinationService cs1 = new CoordinationServiceImpl(store);
         @Cleanup
         LockManager<String> lm1 = cs1.getLockManager(String.class);
 
         @Cleanup
-        CoordinationService cs2 = new CoordinationServiceImpl(store2);
+        CoordinationService cs2 = new CoordinationServiceImpl(store);
         @Cleanup
         LockManager<String> lm2 = cs2.getLockManager(String.class);
 

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LockManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/LockManagerTest.java
@@ -232,7 +232,7 @@ public class LockManagerTest extends BaseMetadataStoreTest {
     }
 
     @Test(dataProvider = "impl")
-    public void testCleanUpStateWhenRevalidationGotLockBusy(String provider, Supplier<String> urlSupplier)
+    public void testCleanUpStateWhenRevalidationGotLockBusy(String provider, String url)
             throws Exception {
 
         if (provider.equals("Memory") || provider.equals("RocksDB")) {
@@ -241,10 +241,10 @@ public class LockManagerTest extends BaseMetadataStoreTest {
         }
 
         @Cleanup
-        MetadataStoreExtended store1 = MetadataStoreExtended.create(urlSupplier.get(),
+        MetadataStoreExtended store1 = MetadataStoreExtended.create(url,
                 MetadataStoreConfig.builder().build());
         @Cleanup
-        MetadataStoreExtended store2 = MetadataStoreExtended.create(urlSupplier.get(),
+        MetadataStoreExtended store2 = MetadataStoreExtended.create(url,
                 MetadataStoreConfig.builder().build());
 
         @Cleanup


### PR DESCRIPTION
### Motivation
chery pick PR to branch-2.8 : https://github.com/apache/pulsar/pull/17700

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lordcheng10/pulsar/pull/43 <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
