### PR TITLE
[cleanup][txn] Use MLTransactionMetadataStore in integration tests

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/transaction/TransactionTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/transaction/TransactionTestBase.java
@@ -39,8 +39,6 @@ public abstract class TransactionTestBase extends PulsarTestSuite {
         super.beforeStartCluster();
         for (BrokerContainer brokerContainer : pulsarCluster.getBrokers()) {
             brokerContainer.withEnv("transactionCoordinatorEnabled", "true");
-            brokerContainer.withEnv("transactionMetadataStoreProviderClassName",
-                    "org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider");
             brokerContainer.withEnv("transactionBufferProviderClassName",
                     "org.apache.pulsar.broker.transaction.buffer.impl.TopicTransactionBufferProvider");
             brokerContainer.withEnv("acknowledgmentAtBatchIndexLevelEnabled", "true");


### PR DESCRIPTION
### Motivation

Transaction's integration tests use the in memory implementation for the txn metadata store.
Since they're very important test to ensure stability of the transactions feature, it's better to use the default store which is actually designed to run in production environments. 

### Modifications

* Do not set `InMemTransactionMetadataStoreProvider` in the integration tests setup
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
