### PR TITLE
[improve][broker,proxy] Use ChannelVoidPromise to avoid useless promise objects creation

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
@@ -38,6 +38,7 @@ import org.apache.pulsar.common.api.proto.TxnAction;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.util.netty.NettyChannelUtil;
 
 @Slf4j
 public class PulsarCommandSenderImpl implements PulsarCommandSender {
@@ -55,7 +56,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newPartitionMetadataResponseCommand(error, errorMsg, requestId);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
     @Override
@@ -63,7 +64,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newPartitionMetadataResponseCommand(partitions, requestId);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
     @Override
@@ -71,7 +72,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newSuccessCommand(requestId);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
     @Override
@@ -79,7 +80,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newErrorCommand(requestId, error, message);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
     @Override
@@ -87,7 +88,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newProducerSuccessCommand(requestId, producerName, schemaVersion);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
     @Override
@@ -98,7 +99,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 schemaVersion, topicEpoch, isProducerReady);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
     @Override
@@ -108,7 +109,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 entryId);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
     @Override
@@ -116,7 +117,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newSendErrorCommand(producerId, sequenceId, error, errorMsg);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
     @Override
@@ -126,7 +127,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 filtered, changed, requestId);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
     @Override
@@ -134,7 +135,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newGetSchemaResponseCommand(requestId, schema, version);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
     @Override
@@ -142,7 +143,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newGetSchemaResponseErrorCommand(requestId, error, errorMessage);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
     @Override
@@ -150,7 +151,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newGetOrCreateSchemaResponseCommand(requestId, schemaVersion);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
     @Override
@@ -159,7 +160,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 Commands.newGetOrCreateSchemaResponseErrorCommand(requestId, error, errorMessage);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
     @Override
@@ -168,7 +169,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 clientProtocolVersion, maxMessageSize, supportsTopicWatchers);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
     @Override
@@ -179,7 +180,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 authoritative, response, requestId, proxyThroughServiceUrl);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
     @Override
@@ -187,7 +188,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newLookupErrorResponseCommand(error, errorMsg, requestId);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
     @Override
@@ -196,7 +197,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
             // if the client is older than `v12`, we don't need to send consumer group changes.
             return;
         }
-        writeAndFlushVoidPromise(Commands.newActiveConsumerChange(consumerId, isActive));
+        writeAndFlush(Commands.newActiveConsumerChange(consumerId, isActive));
     }
 
     @Override
@@ -204,7 +205,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         // Only send notification if the client understand the command
         if (cnx.getRemoteEndpointProtocolVersion() >= ProtocolVersion.v9.getValue()) {
             log.info("[{}] Notifying consumer that end of topic has been reached", this);
-            writeAndFlushVoidPromise(Commands.newReachedEndOfTopic(consumerId));
+            writeAndFlush(Commands.newReachedEndOfTopic(consumerId));
         }
     }
 
@@ -213,7 +214,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         // Only send notification if the client understand the command
         if (cnx.getRemoteEndpointProtocolVersion() >= ProtocolVersion.v20.getValue()) {
             log.info("[{}] Notifying {} that topic is migrated", type.name(), resourceId);
-            writeAndFlushVoidPromise(Commands.newTopicMigrated(type, resourceId, brokerUrl, brokerUrlTls));
+            writeAndFlush(Commands.newTopicMigrated(type, resourceId, brokerUrl, brokerUrlTls));
             return true;
         }
         return false;
@@ -307,7 +308,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newTcClientConnectResponse(requestId, error, message);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
     @Override
@@ -321,7 +322,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 txnID.getMostSigBits());
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
         if (this.interceptor != null) {
             this.interceptor.txnOpened(tcID, txnID.toString());
         }
@@ -332,7 +333,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newTxnResponse(requestId, tcID, error, message);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
     @Override
@@ -341,7 +342,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 txnID.getMostSigBits());
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
         if (this.interceptor != null) {
             this.interceptor.txnEnded(txnID.toString(), txnAction);
         }
@@ -353,7 +354,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 txnID.getMostSigBits(), error, message);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
         if (this.interceptor != null) {
             this.interceptor.txnEnded(txnID.toString(), TxnAction.ABORT_VALUE);
         }
@@ -375,11 +376,11 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
     private void interceptAndWriteCommand(BaseCommand command) {
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        writeAndFlushVoidPromise(outBuf);
+        writeAndFlush(outBuf);
     }
 
-    private void writeAndFlushVoidPromise(ByteBuf outBuf) {
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+    private void writeAndFlush(ByteBuf outBuf) {
+        NettyChannelUtil.writeAndFlushWithVoidPromise(cnx.ctx(), outBuf);
     }
 
     private void safeIntercept(BaseCommand command, ServerCnx cnx) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
@@ -55,7 +55,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newPartitionMetadataResponseCommand(error, errorMsg, requestId);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
     }
 
     @Override
@@ -63,7 +63,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newPartitionMetadataResponseCommand(partitions, requestId);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
     }
 
     @Override
@@ -71,7 +71,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newSuccessCommand(requestId);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
     }
 
     @Override
@@ -79,7 +79,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newErrorCommand(requestId, error, message);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
     }
 
     @Override
@@ -87,7 +87,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newProducerSuccessCommand(requestId, producerName, schemaVersion);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
     }
 
     @Override
@@ -98,7 +98,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 schemaVersion, topicEpoch, isProducerReady);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
     }
 
     @Override
@@ -108,7 +108,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 entryId);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
     }
 
     @Override
@@ -116,7 +116,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newSendErrorCommand(producerId, sequenceId, error, errorMsg);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
     }
 
     @Override
@@ -126,7 +126,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 filtered, changed, requestId);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
     }
 
     @Override
@@ -134,7 +134,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newGetSchemaResponseCommand(requestId, schema, version);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
     }
 
     @Override
@@ -142,7 +142,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newGetSchemaResponseErrorCommand(requestId, error, errorMessage);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
     }
 
     @Override
@@ -150,7 +150,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newGetOrCreateSchemaResponseCommand(requestId, schemaVersion);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
     }
 
     @Override
@@ -159,7 +159,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 Commands.newGetOrCreateSchemaResponseErrorCommand(requestId, error, errorMessage);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
     }
 
     @Override
@@ -168,7 +168,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 clientProtocolVersion, maxMessageSize, supportsTopicWatchers);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
     }
 
     @Override
@@ -179,7 +179,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 authoritative, response, requestId, proxyThroughServiceUrl);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
     }
 
     @Override
@@ -187,7 +187,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newLookupErrorResponseCommand(error, errorMsg, requestId);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
     }
 
     @Override
@@ -196,9 +196,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
             // if the client is older than `v12`, we don't need to send consumer group changes.
             return;
         }
-        cnx.ctx().writeAndFlush(
-                Commands.newActiveConsumerChange(consumerId, isActive),
-                cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(Commands.newActiveConsumerChange(consumerId, isActive));
     }
 
     @Override
@@ -206,7 +204,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         // Only send notification if the client understand the command
         if (cnx.getRemoteEndpointProtocolVersion() >= ProtocolVersion.v9.getValue()) {
             log.info("[{}] Notifying consumer that end of topic has been reached", this);
-            cnx.ctx().writeAndFlush(Commands.newReachedEndOfTopic(consumerId), cnx.ctx().voidPromise());
+            writeAndFlushVoidPromise(Commands.newReachedEndOfTopic(consumerId));
         }
     }
 
@@ -215,8 +213,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         // Only send notification if the client understand the command
         if (cnx.getRemoteEndpointProtocolVersion() >= ProtocolVersion.v20.getValue()) {
             log.info("[{}] Notifying {} that topic is migrated", type.name(), resourceId);
-            cnx.ctx().writeAndFlush(Commands.newTopicMigrated(type, resourceId, brokerUrl, brokerUrlTls),
-                    cnx.ctx().voidPromise());
+            writeAndFlushVoidPromise(Commands.newTopicMigrated(type, resourceId, brokerUrl, brokerUrlTls));
             return true;
         }
         return false;
@@ -310,7 +307,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newTcClientConnectResponse(requestId, error, message);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
     }
 
     @Override
@@ -324,7 +321,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 txnID.getMostSigBits());
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
         if (this.interceptor != null) {
             this.interceptor.txnOpened(tcID, txnID.toString());
         }
@@ -335,7 +332,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
         BaseCommand command = Commands.newTxnResponse(requestId, tcID, error, message);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
     }
 
     @Override
@@ -344,7 +341,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 txnID.getMostSigBits());
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
         if (this.interceptor != null) {
             this.interceptor.txnEnded(txnID.toString(), txnAction);
         }
@@ -356,7 +353,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 txnID.getMostSigBits(), error, message);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
+        writeAndFlushVoidPromise(outBuf);
         if (this.interceptor != null) {
             this.interceptor.txnEnded(txnID.toString(), TxnAction.ABORT_VALUE);
         }
@@ -378,7 +375,11 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
     private void interceptAndWriteCommand(BaseCommand command) {
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
-        cnx.ctx().writeAndFlush(outBuf);
+        writeAndFlushVoidPromise(outBuf);
+    }
+
+    private void writeAndFlushVoidPromise(ByteBuf outBuf) {
+        cnx.ctx().writeAndFlush(outBuf, cnx.ctx().voidPromise());
     }
 
     private void safeIntercept(BaseCommand command, ServerCnx cnx) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -32,7 +32,6 @@ import static org.apache.pulsar.common.protocol.Commands.newLookupErrorResponse;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
@@ -85,6 +85,7 @@ import org.apache.pulsar.common.api.proto.CommandWatchTopicListSuccess;
 import org.apache.pulsar.common.api.proto.CommandWatchTopicUpdate;
 import org.apache.pulsar.common.api.proto.ServerError;
 import org.apache.pulsar.common.intercept.InterceptException;
+import org.apache.pulsar.common.util.netty.NettyChannelUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -132,7 +133,8 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
                     interceptCommand(cmd);
                     handlePartitionMetadataRequest(cmd.getPartitionMetadata());
                 } catch (InterceptException e) {
-                    writeAndFlushVoidPromise(ctx, Commands.newPartitionMetadataResponse(getServerError(e.getErrorCode()),
+                    writeAndFlush(ctx,
+                            Commands.newPartitionMetadataResponse(getServerError(e.getErrorCode()),
                             e.getMessage(), cmd.getPartitionMetadata().getRequestId()));
                 }
                 break;
@@ -206,7 +208,7 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
                     interceptCommand(cmd);
                     handleProducer(cmd.getProducer());
                 } catch (InterceptException e) {
-                    writeAndFlushVoidPromise(ctx, Commands.newError(cmd.getProducer().getRequestId(),
+                    writeAndFlush(ctx, Commands.newError(cmd.getProducer().getRequestId(),
                             getServerError(e.getErrorCode()), e.getMessage()));
                 }
                 break;
@@ -219,7 +221,7 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
                     ByteBuf headersAndPayload = buffer.markReaderIndex();
                     handleSend(cmd.getSend(), headersAndPayload);
                 } catch (InterceptException e) {
-                    writeAndFlushVoidPromise(ctx, Commands.newSendError(cmd.getSend().getProducerId(),
+                    writeAndFlush(ctx, Commands.newSendError(cmd.getSend().getProducerId(),
                             cmd.getSend().getSequenceId(), getServerError(e.getErrorCode()), e.getMessage()));
                 }
                 break;
@@ -240,7 +242,7 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
                     interceptCommand(cmd);
                     handleSubscribe(cmd.getSubscribe());
                 } catch (InterceptException e) {
-                    writeAndFlushVoidPromise(ctx, Commands.newError(cmd.getSubscribe().getRequestId(),
+                    writeAndFlush(ctx, Commands.newError(cmd.getSubscribe().getRequestId(),
                             getServerError(e.getErrorCode()), e.getMessage()));
                 }
                 break;
@@ -267,8 +269,13 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
                     interceptCommand(cmd);
                     handleSeek(cmd.getSeek());
                 } catch (InterceptException e) {
-                    writeAndFlushVoidPromise(ctx, Commands.newError(cmd.getSeek().getRequestId(), getServerError(e.getErrorCode()),
-                            e.getMessage()));
+                    writeAndFlush(ctx,
+                            Commands.newError(
+                                    cmd.getSeek().getRequestId(),
+                                    getServerError(e.getErrorCode()),
+                                    e.getMessage()
+                            )
+                    );
                 }
                 break;
 
@@ -327,7 +334,7 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
                     interceptCommand(cmd);
                     handleGetTopicsOfNamespace(cmd.getGetTopicsOfNamespace());
                 } catch (InterceptException e) {
-                    writeAndFlushVoidPromise(ctx, Commands.newError(cmd.getGetTopicsOfNamespace().getRequestId(),
+                    writeAndFlush(ctx, Commands.newError(cmd.getGetTopicsOfNamespace().getRequestId(),
                             getServerError(e.getErrorCode()), e.getMessage()));
                 }
                 break;
@@ -343,7 +350,7 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
                     interceptCommand(cmd);
                     handleGetSchema(cmd.getGetSchema());
                 } catch (InterceptException e) {
-                    writeAndFlushVoidPromise(ctx, Commands.newGetSchemaResponseError(cmd.getGetSchema().getRequestId(),
+                    writeAndFlush(ctx, Commands.newGetSchemaResponseError(cmd.getGetSchema().getRequestId(),
                             getServerError(e.getErrorCode()), e.getMessage()));
                 }
                 break;
@@ -359,7 +366,7 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
                     interceptCommand(cmd);
                     handleGetOrCreateSchema(cmd.getGetOrCreateSchema());
                 } catch (InterceptException e) {
-                    writeAndFlushVoidPromise(ctx, Commands.newGetOrCreateSchemaResponseError(
+                    writeAndFlush(ctx, Commands.newGetOrCreateSchemaResponseError(
                             cmd.getGetOrCreateSchema().getRequestId(), getServerError(e.getErrorCode()),
                             e.getMessage()));
                 }
@@ -733,7 +740,7 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
 
     private static final Logger log = LoggerFactory.getLogger(PulsarDecoder.class);
 
-    private void writeAndFlushVoidPromise(ChannelOutboundInvoker ctx, ByteBuf cmd) {
-        ctx.writeAndFlush(cmd, ctx.voidPromise());
+    private void writeAndFlush(ChannelOutboundInvoker ctx, ByteBuf cmd) {
+        NettyChannelUtil.writeAndFlushWithVoidPromise(ctx, cmd);
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/NettyChannelUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/NettyChannelUtil.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelOutboundInvoker;
+
+/**
+ * Contains utility methods for working with Netty Channels.
+ */
+public class NettyChannelUtil {
+
+    public static void writeAndFlushWithVoidPromise(ChannelOutboundInvoker ctx, ByteBuf cmd) {
+        ctx.writeAndFlush(cmd, ctx.voidPromise());
+    }
+
+    public static void writeAndFlushWithClosePromise(ChannelOutboundInvoker ctx, ByteBuf cmd) {
+        ctx.writeAndFlush(cmd).addListener(ChannelFutureListener.CLOSE);
+    }
+
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/NettyChannelUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/NettyChannelUtil.java
@@ -21,18 +21,43 @@ package org.apache.pulsar.common.util.netty;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelOutboundInvoker;
+import io.netty.channel.VoidChannelPromise;
 
 /**
  * Contains utility methods for working with Netty Channels.
  */
-public class NettyChannelUtil {
+public final class NettyChannelUtil {
 
-    public static void writeAndFlushWithVoidPromise(ChannelOutboundInvoker ctx, ByteBuf cmd) {
-        ctx.writeAndFlush(cmd, ctx.voidPromise());
+    private NettyChannelUtil() {
     }
 
-    public static void writeAndFlushWithClosePromise(ChannelOutboundInvoker ctx, ByteBuf cmd) {
-        ctx.writeAndFlush(cmd).addListener(ChannelFutureListener.CLOSE);
+    /**
+     * Write and flush the message to the channel.
+     *
+     * The promise is an instance of {@link VoidChannelPromise} that properly propagates exceptions up to the pipeline.
+     * Netty has many ad-hoc optimization if the promise is an instance of {@link VoidChannelPromise}.
+     * Lastly, it reduces pollution of useless {@link io.netty.channel.ChannelPromise} objects created
+     * by the default write and flush method {@link ChannelOutboundInvoker#writeAndFlush(Object)}.
+     * See https://stackoverflow.com/q/54169262 and https://stackoverflow.com/a/9030420 for more details.
+     *
+     * @param ctx channel's context
+     * @param msg buffer to write in the channel
+     */
+    public static void writeAndFlushWithVoidPromise(ChannelOutboundInvoker ctx, ByteBuf msg) {
+        ctx.writeAndFlush(msg, ctx.voidPromise());
+    }
+
+    /**
+     * Write and flush the message to the channel and the close the channel.
+     *
+     * This method is particularly helpful when the connection is in an invalid state
+     * and therefore a new connection must be created to continue.
+     *
+     * @param ctx channel's context
+     * @param msg buffer to write in the channel
+     */
+    public static void writeAndFlushWithClosePromise(ChannelOutboundInvoker ctx, ByteBuf msg) {
+        ctx.writeAndFlush(msg).addListener(ChannelFutureListener.CLOSE);
     }
 
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/netty/NettyChannelUtilTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/netty/NettyChannelUtilTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util.netty;
+
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelOutboundInvoker;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.VoidChannelPromise;
+import java.nio.charset.StandardCharsets;
+import org.testng.annotations.Test;
+
+public class NettyChannelUtilTest {
+
+    @Test
+    public void testWriteAndFlushWithVoidPromise() {
+        final ChannelOutboundInvoker ctx = mock(ChannelOutboundInvoker.class);
+        final VoidChannelPromise voidChannelPromise = mock(VoidChannelPromise.class);
+        when(ctx.voidPromise()).thenReturn(voidChannelPromise);
+        final byte[] data = "test".getBytes(StandardCharsets.UTF_8);
+        final ByteBuf byteBuf = Unpooled.wrappedBuffer(data, 0, data.length);
+        try {
+            NettyChannelUtil.writeAndFlushWithVoidPromise(ctx, byteBuf);
+            verify(ctx).writeAndFlush(same(byteBuf), same(voidChannelPromise));
+            verify(ctx).voidPromise();
+        } finally {
+            byteBuf.release();
+        }
+    }
+
+    @Test
+    public void testWriteAndFlushWithClosePromise() {
+        final ChannelOutboundInvoker ctx = mock(ChannelOutboundInvoker.class);
+        final ChannelPromise promise = mock(ChannelPromise.class);
+
+        final byte[] data = "test".getBytes(StandardCharsets.UTF_8);
+        final ByteBuf byteBuf = Unpooled.wrappedBuffer(data, 0, data.length);
+        when(ctx.writeAndFlush(same(byteBuf))).thenReturn(promise);
+        try {
+            NettyChannelUtil.writeAndFlushWithClosePromise(ctx, byteBuf);
+            verify(ctx).writeAndFlush(same(byteBuf));
+            verify(promise).addListener(same(ChannelFutureListener.CLOSE));
+        } finally {
+            byteBuf.release();
+        }
+    }
+}

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
@@ -26,7 +26,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
@@ -65,6 +64,7 @@ import org.apache.pulsar.common.util.NettyClientSslContextRefresher;
 import org.apache.pulsar.common.util.SecurityUtility;
 import org.apache.pulsar.common.util.SslContextAutoRefreshBuilder;
 import org.apache.pulsar.common.util.keystoretls.NettySSLContextAutoRefreshBuilder;
+import org.apache.pulsar.common.util.netty.NettyChannelUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -238,8 +238,8 @@ public class DirectProxyHandler {
 
     private void writeHAProxyMessage() {
         if (proxyConnection.hasHAProxyMessage()) {
-            outboundChannel.writeAndFlush(encodeProxyProtocolMessage(proxyConnection.getHAProxyMessage()))
-                    .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+            final ByteBuf msg = encodeProxyProtocolMessage(proxyConnection.getHAProxyMessage());
+            writeAndFlush(msg);
         } else {
             if (inboundChannel.remoteAddress() instanceof InetSocketAddress
                     && inboundChannel.localAddress() instanceof InetSocketAddress) {
@@ -252,8 +252,8 @@ public class DirectProxyHandler {
                 HAProxyMessage msg = new HAProxyMessage(HAProxyProtocolVersion.V1, HAProxyCommand.PROXY,
                         HAProxyProxiedProtocol.TCP4, sourceAddress, destinationAddress, sourcePort,
                         destinationPort);
-                outboundChannel.writeAndFlush(encodeProxyProtocolMessage(msg))
-                        .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+                final ByteBuf encodedMsg = encodeProxyProtocolMessage(msg);
+                writeAndFlush(encodedMsg);
                 msg.release();
             }
         }
@@ -323,11 +323,11 @@ public class DirectProxyHandler {
             // Send the Connect command to broker
             authenticationDataProvider = authentication.getAuthData(remoteHostName);
             AuthData authData = authenticationDataProvider.authenticate(AuthData.INIT_AUTH_DATA);
-            ByteBuf command;
-            command = Commands.newConnect(authentication.getAuthMethodName(), authData, protocolVersion, "Pulsar proxy",
-                    null /* target broker */, originalPrincipal, clientAuthData, clientAuthMethod);
-            outboundChannel.writeAndFlush(command)
-                    .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+            ByteBuf command = Commands.newConnect(
+                    authentication.getAuthMethodName(), authData, protocolVersion,
+                    "Pulsar proxy", null /* target broker */,
+                    originalPrincipal, clientAuthData, clientAuthMethod);
+            writeAndFlush(command);
             isTlsOutboundChannel = ProxyConnection.isTlsChannel(inboundChannel);
         }
 
@@ -358,8 +358,7 @@ public class DirectProxyHandler {
                 if (msg instanceof ByteBuf) {
                     ProxyService.BYTES_COUNTER.inc(((ByteBuf) msg).readableBytes());
                 }
-                inboundChannel.writeAndFlush(msg)
-                        .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+                inboundChannel.writeAndFlush(msg, inboundChannel.voidPromise());
 
                 if (service.proxyZeroCopyModeEnabled && service.proxyLogLevel == 0) {
                     if (!isTlsOutboundChannel && !DirectProxyHandler.this.proxyConnection.isTlsInboundChannel) {
@@ -412,8 +411,7 @@ public class DirectProxyHandler {
                     log.debug("{} Mutual auth {}", ctx.channel(), authentication.getAuthMethodName());
                 }
 
-                outboundChannel.writeAndFlush(request)
-                        .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+                writeAndFlush(request);
             } catch (Exception e) {
                 log.error("Error mutual verify", e);
             }
@@ -493,6 +491,10 @@ public class DirectProxyHandler {
             log.warn("[{}] [{}] Caught exception: {}", inboundChannel, outboundChannel, cause.getMessage(), cause);
             ctx.close();
         }
+    }
+
+    private void writeAndFlush(ByteBuf cmd) {
+        NettyChannelUtil.writeAndFlushWithVoidPromise(outboundChannel, cmd);
     }
 
     private static final Logger log = LoggerFactory.getLogger(DirectProxyHandler.class);

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/LookupProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/LookupProxyHandler.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.proxy.server;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelOutboundInvoker;
 import io.prometheus.client.Counter;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -113,7 +114,7 @@ public class LookupProxyHandler {
                 log.debug("Lookup Request ID {} from {} rejected - {}.", clientRequestId, clientAddress,
                         throttlingErrorMessage);
             }
-            proxyConnection.ctx().writeAndFlush(Commands.newLookupErrorResponse(ServerError.ServiceNotReady,
+            writeAndFlushVoidPromise(Commands.newLookupErrorResponse(ServerError.ServiceNotReady,
                     throttlingErrorMessage, clientRequestId));
         }
 
@@ -122,7 +123,7 @@ public class LookupProxyHandler {
     private void performLookup(long clientRequestId, String topic, String brokerServiceUrl, boolean authoritative,
             int numberOfRetries) {
         if (numberOfRetries == 0) {
-            proxyConnection.ctx().writeAndFlush(Commands.newLookupErrorResponse(ServerError.ServiceNotReady,
+            writeAndFlushVoidPromise(Commands.newLookupErrorResponse(ServerError.ServiceNotReady,
                     "Reached max number of redirections", clientRequestId));
             return;
         }
@@ -131,7 +132,7 @@ public class LookupProxyHandler {
         try {
             brokerURI = new URI(brokerServiceUrl);
         } catch (URISyntaxException e) {
-            proxyConnection.ctx().writeAndFlush(
+            writeAndFlushVoidPromise(
                     Commands.newLookupErrorResponse(ServerError.MetadataError, e.getMessage(), clientRequestId));
             return;
         }
@@ -150,7 +151,7 @@ public class LookupProxyHandler {
             clientCnx.newLookup(command, requestId).whenComplete((r, t) -> {
                 if (t != null) {
                     log.warn("[{}] Failed to lookup topic {}: {}", clientAddress, topic, t.getMessage());
-                    proxyConnection.ctx().writeAndFlush(
+                    writeAndFlushVoidPromise(
                         Commands.newLookupErrorResponse(getServerError(t), t.getMessage(), clientRequestId));
                 } else {
                     String brokerUrl = connectWithTLS ? r.brokerUrlTls : r.brokerUrl;
@@ -170,7 +171,7 @@ public class LookupProxyHandler {
                                             + " with clientReq Id '{}' and lookup-broker {}",
                                     addr, topic, clientRequestId, brokerUrl);
                         }
-                        proxyConnection.ctx().writeAndFlush(Commands.newLookupResponse(brokerUrl, brokerUrl, true,
+                        writeAndFlushVoidPromise(Commands.newLookupResponse(brokerUrl, brokerUrl, true,
                             LookupType.Connect, clientRequestId, true /* this is coming from proxy */));
                     }
                 }
@@ -178,7 +179,7 @@ public class LookupProxyHandler {
             });
         }).exceptionally(ex -> {
             // Failed to connect to backend broker
-            proxyConnection.ctx().writeAndFlush(
+            writeAndFlushVoidPromise(
                     Commands.newLookupErrorResponse(getServerError(ex), ex.getMessage(), clientRequestId));
             return null;
         });
@@ -202,7 +203,7 @@ public class LookupProxyHandler {
                 log.debug("PartitionMetaData Request ID {} from {} rejected - {}.", clientRequestId, clientAddress,
                         throttlingErrorMessage);
             }
-            proxyConnection.ctx().writeAndFlush(Commands.newPartitionMetadataResponse(ServerError.ServiceNotReady,
+            writeAndFlushVoidPromise(Commands.newPartitionMetadataResponse(ServerError.ServiceNotReady,
                     throttlingErrorMessage, clientRequestId));
         }
     }
@@ -239,17 +240,17 @@ public class LookupProxyHandler {
                 if (t != null) {
                     log.warn("[{}] failed to get Partitioned metadata : {}", topicName.toString(),
                         t.getMessage(), t);
-                    proxyConnection.ctx().writeAndFlush(Commands.newLookupErrorResponse(getServerError(t),
+                    writeAndFlushVoidPromise(Commands.newLookupErrorResponse(getServerError(t),
                         t.getMessage(), clientRequestId));
                 } else {
-                    proxyConnection.ctx().writeAndFlush(
+                    writeAndFlushVoidPromise(
                         Commands.newPartitionMetadataResponse(r.partitions, clientRequestId));
                 }
                 proxyConnection.getConnectionPool().releaseConnection(clientCnx);
             });
         }).exceptionally(ex -> {
             // Failed to connect to backend broker
-            proxyConnection.ctx().writeAndFlush(Commands.newPartitionMetadataResponse(getServerError(ex),
+            writeAndFlushVoidPromise(Commands.newPartitionMetadataResponse(getServerError(ex),
                     ex.getMessage(), clientRequestId));
             return null;
         });
@@ -275,7 +276,7 @@ public class LookupProxyHandler {
                 log.debug("GetTopicsOfNamespace Request ID {} from {} rejected - {}.", requestId, clientAddress,
                     throttlingErrorMessage);
             }
-            proxyConnection.ctx().writeAndFlush(Commands.newError(
+            writeAndFlushVoidPromise(Commands.newError(
                 requestId, ServerError.ServiceNotReady, throttlingErrorMessage
             ));
         }
@@ -304,7 +305,7 @@ public class LookupProxyHandler {
                                              String topicsHash,
                                              CommandGetTopicsOfNamespace.Mode mode) {
         if (numberOfRetries == 0) {
-            proxyConnection.ctx().writeAndFlush(Commands.newError(clientRequestId, ServerError.ServiceNotReady,
+            writeAndFlushVoidPromise(Commands.newError(clientRequestId, ServerError.ServiceNotReady,
                     "Reached max number of redirections"));
             return;
         }
@@ -329,10 +330,10 @@ public class LookupProxyHandler {
                 if (t != null) {
                     log.warn("[{}] Failed to get TopicsOfNamespace {}: {}",
                             clientAddress, namespaceName, t.getMessage());
-                    proxyConnection.ctx().writeAndFlush(
+                    writeAndFlushVoidPromise(
                         Commands.newError(clientRequestId, getServerError(t), t.getMessage()));
                 } else {
-                    proxyConnection.ctx().writeAndFlush(
+                    writeAndFlushVoidPromise(
                         Commands.newGetTopicsOfNamespaceResponse(r.getTopics(), r.getTopicsHash(), r.isFiltered(),
                                 r.isChanged(), clientRequestId));
                 }
@@ -341,7 +342,7 @@ public class LookupProxyHandler {
             proxyConnection.getConnectionPool().releaseConnection(clientCnx);
         }).exceptionally(ex -> {
             // Failed to connect to backend broker
-            proxyConnection.ctx().writeAndFlush(
+            writeAndFlushVoidPromise(
                     Commands.newError(clientRequestId, getServerError(ex), ex.getMessage()));
             return null;
         });
@@ -384,10 +385,10 @@ public class LookupProxyHandler {
             clientCnx.sendGetRawSchema(command, requestId).whenComplete((r, t) -> {
                 if (t != null) {
                     log.warn("[{}] Failed to get schema {}: {}", clientAddress, topic, t);
-                    proxyConnection.ctx().writeAndFlush(
+                    writeAndFlushVoidPromise(
                         Commands.newError(clientRequestId, getServerError(t), t.getMessage()));
                 } else {
-                    proxyConnection.ctx().writeAndFlush(
+                    writeAndFlushVoidPromise(
                         Commands.newGetSchemaResponse(clientRequestId, r));
                 }
 
@@ -395,7 +396,7 @@ public class LookupProxyHandler {
             });
         }).exceptionally(ex -> {
             // Failed to connect to backend broker
-            proxyConnection.ctx().writeAndFlush(
+            writeAndFlushVoidPromise(
                     Commands.newError(clientRequestId, getServerError(ex), ex.getMessage()));
             return null;
         });
@@ -414,7 +415,7 @@ public class LookupProxyHandler {
             availableBroker = discoveryProvider.nextBroker();
         } catch (Exception e) {
             log.warn("[{}] Failed to get next active broker {}", clientAddress, e.getMessage(), e);
-            proxyConnection.ctx().writeAndFlush(Commands.newError(
+            writeAndFlushVoidPromise(Commands.newError(
                     clientRequestId, ServerError.ServiceNotReady, e.getMessage()
             ));
             return null;
@@ -427,7 +428,7 @@ public class LookupProxyHandler {
         try {
             brokerURI = new URI(brokerServiceUrl);
         } catch (URISyntaxException e) {
-            proxyConnection.ctx().writeAndFlush(
+            writeAndFlushVoidPromise(
                     Commands.newError(clientRequestId, ServerError.MetadataError, e.getMessage()));
             return null;
         }
@@ -444,6 +445,10 @@ public class LookupProxyHandler {
             responseError = ServerError.ServiceNotReady;
         }
         return responseError;
+    }
+
+    private void writeAndFlushVoidPromise(ByteBuf cmd) {
+        proxyConnection.ctx().writeAndFlush(cmd);
     }
 
     private static final Logger log = LoggerFactory.getLogger(LookupProxyHandler.class);

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
@@ -71,6 +71,7 @@ import org.apache.pulsar.common.api.proto.ProtocolVersion;
 import org.apache.pulsar.common.api.proto.ServerError;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.protocol.PulsarHandler;
+import org.apache.pulsar.common.util.netty.NettyChannelUtil;
 import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -261,8 +262,8 @@ public class ProxyConnection extends PulsarHandler {
                     directProxyHandler.getInboundChannelRequestsRate().recordEvent(bytes);
                     ProxyService.BYTES_COUNTER.inc(bytes);
                 }
-                directProxyHandler.outboundChannel.writeAndFlush(msg)
-                        .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+                directProxyHandler.outboundChannel
+                        .writeAndFlush(msg, directProxyHandler.outboundChannel.voidPromise());
 
                 if (service.proxyZeroCopyModeEnabled && service.proxyLogLevel == 0) {
                     if (!directProxyHandler.isTlsOutboundChannel && !isTlsInboundChannel) {
@@ -345,10 +346,9 @@ public class ProxyConnection extends PulsarHandler {
                 state = State.Closing;
                 LOG.warn("[{}] Target broker '{}' isn't available. authenticated with {} role {}.",
                         remoteAddress, proxyToBrokerUrl, authMethod, clientAuthRole);
-                ctx()
-                        .writeAndFlush(
-                                Commands.newError(-1, ServerError.ServiceNotReady, "Target broker isn't available."))
-                        .addListener(ChannelFutureListener.CLOSE);
+                final ByteBuf msg = Commands.newError(-1,
+                        ServerError.ServiceNotReady, "Target broker isn't available.");
+                writeAndFlushAndClose(msg);
                 return;
             }
 
@@ -369,11 +369,9 @@ public class ProxyConnection extends PulsarHandler {
                             LOG.error("[{}] Error validating target broker '{}'. authenticated with {} role {}.",
                                     remoteAddress, proxyToBrokerUrl, authMethod, clientAuthRole, throwable);
                         }
-                        ctx()
-                                .writeAndFlush(
-                                        Commands.newError(-1, ServerError.ServiceNotReady,
-                                                "Target broker cannot be validated."))
-                                .addListener(ChannelFutureListener.CLOSE);
+                        final ByteBuf msg = Commands.newError(-1, ServerError.ServiceNotReady,
+                                "Target broker cannot be validated.");
+                        writeAndFlushAndClose(msg);
                         return null;
                     });
         } else {
@@ -382,8 +380,8 @@ public class ProxyConnection extends PulsarHandler {
             // partitions metadata lookups
             state = State.ProxyLookupRequests;
             lookupProxyHandler = new LookupProxyHandler(service, this);
-            ctx.writeAndFlush(Commands.newConnected(protocolVersionToAdvertise, false))
-                    .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+            final ByteBuf msg = Commands.newConnected(protocolVersionToAdvertise, false);
+            writeAndFlush(msg);
         }
     }
 
@@ -394,9 +392,9 @@ public class ProxyConnection extends PulsarHandler {
             state = State.ProxyConnectionToBroker;
             int maxMessageSize =
                     connected.hasMaxMessageSize() ? connected.getMaxMessageSize() : Commands.INVALID_MAX_MESSAGE_SIZE;
-            ctx.writeAndFlush(Commands.newConnected(connected.getProtocolVersion(), maxMessageSize,
-                            connected.hasFeatureFlags() && connected.getFeatureFlags().isSupportsTopicWatchers()))
-                    .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+            final ByteBuf msg = Commands.newConnected(connected.getProtocolVersion(), maxMessageSize,
+                    connected.hasFeatureFlags() && connected.getFeatureFlags().isSupportsTopicWatchers());
+            writeAndFlush(msg);
         } else {
             LOG.warn("[{}] Channel is {}. ProxyConnection is in {}. "
                             + "Closing connection to broker '{}'.",
@@ -445,8 +443,8 @@ public class ProxyConnection extends PulsarHandler {
         }
 
         // auth not complete, continue auth with client side.
-        ctx.writeAndFlush(Commands.newAuthChallenge(authMethod, brokerData, protocolVersionToAdvertise))
-                .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        final ByteBuf msg = Commands.newAuthChallenge(authMethod, brokerData, protocolVersionToAdvertise);
+        writeAndFlush(msg);
         if (LOG.isDebugEnabled()) {
             LOG.debug("[{}] Authentication in progress client by method {}.",
                     remoteAddress, authMethod);
@@ -524,8 +522,8 @@ public class ProxyConnection extends PulsarHandler {
             doAuthentication(clientData);
         } catch (Exception e) {
             LOG.warn("[{}] Unable to authenticate: ", remoteAddress, e);
-            ctx.writeAndFlush(Commands.newError(-1, ServerError.AuthenticationError, "Failed to authenticate"))
-                    .addListener(ChannelFutureListener.CLOSE);
+            final ByteBuf msg = Commands.newError(-1, ServerError.AuthenticationError, "Failed to authenticate");
+            writeAndFlushAndClose(msg);
         }
     }
 
@@ -589,10 +587,10 @@ public class ProxyConnection extends PulsarHandler {
                 });
             }
         } catch (Exception e) {
-            String msg = "Unable to handleAuthResponse";
-            LOG.warn("[{}] {} ", remoteAddress, msg, e);
-            ctx.writeAndFlush(Commands.newError(-1, ServerError.AuthenticationError, msg))
-                    .addListener(ChannelFutureListener.CLOSE);
+            String errorMsg = "Unable to handleAuthResponse";
+            LOG.warn("[{}] {} ", remoteAddress, errorMsg, e);
+            final ByteBuf msg = Commands.newError(-1, ServerError.AuthenticationError, errorMsg);
+            writeAndFlushAndClose(msg);
         }
     }
 
@@ -726,5 +724,13 @@ public class ProxyConnection extends PulsarHandler {
                 && pulsarServiceUrl.length() == expectedPrefix.length() + brokerHostPort.length()
                 && pulsarServiceUrl.startsWith(expectedPrefix)
                 && pulsarServiceUrl.startsWith(brokerHostPort, expectedPrefix.length());
+    }
+
+    private void writeAndFlush(ByteBuf cmd) {
+        NettyChannelUtil.writeAndFlushWithVoidPromise(ctx, cmd);
+    }
+
+    private void writeAndFlushAndClose(ByteBuf cmd) {
+        NettyChannelUtil.writeAndFlushWithClosePromise(ctx, cmd);
     }
 }


### PR DESCRIPTION
### Motivation

In the broker and proxy most of the writes callback are not considered. In those cases we can save useless allocations of default channel promises by using the `voidPromise()` method.

### Modifications

* Use `VoidChannelPromise` if the promise result is never checked

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
