### PR TITLE
[revert] "[fix][broker] change name limitTime to limitTimeInSec (#19053)"

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -394,7 +394,7 @@ public abstract class AdminResource extends PulsarWebResource {
         }
         // time based quota is in second
         if (retention.getRetentionTimeInMinutes() > 0
-                && quota.getLimitTimeInSec() >= retention.getRetentionTimeInMinutes() * 60) {
+                && quota.getLimitTime() >= retention.getRetentionTimeInMinutes() * 60) {
             return false;
         }
         return true;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -197,7 +197,7 @@ public class BacklogQuotaManager {
         if (preciseTimeBasedBacklogQuotaCheck) {
             // Set the reduction factor to 90%. The aim is to drop down the backlog to 90% of the quota limit.
             double reductionFactor = 0.9;
-            int target = (int) (reductionFactor * quota.getLimitTimeInSec());
+            int target = (int) (reductionFactor * quota.getLimitTime());
             if (log.isDebugEnabled()) {
                 log.debug("[{}] target backlog expire time is [{}]", persistentTopic.getName(), target);
             }
@@ -226,7 +226,7 @@ public class BacklogQuotaManager {
                     }
                     // Timestamp only > 0 if ledger has been closed
                     if (ledgerInfo.getTimestamp() > 0
-                            && currentMillis - ledgerInfo.getTimestamp() > quota.getLimitTimeInSec() * 1000) {
+                            && currentMillis - ledgerInfo.getTimestamp() > quota.getLimitTime() * 1000) {
                         // skip whole ledger for the slowest cursor
                         PositionImpl nextPosition =
                                 PositionImpl.get(mLedger.getNextValidLedger(ledgerInfo.getLedgerId()), -1);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2729,7 +2729,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
      */
     public CompletableFuture<Boolean> checkTimeBacklogExceeded() {
         TopicName topicName = TopicName.get(getName());
-        int backlogQuotaLimitInSecond = getBacklogQuota(BacklogQuotaType.message_age).getLimitTimeInSec();
+        int backlogQuotaLimitInSecond = getBacklogQuota(BacklogQuotaType.message_age).getLimitTime();
 
         // If backlog quota by time is not set and we have no durable cursor.
         if (backlogQuotaLimitInSecond <= 0
@@ -2785,7 +2785,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     private CompletableFuture<Boolean> slowestReaderTimeBasedBacklogQuotaCheck(PositionImpl slowestPosition)
             throws ExecutionException, InterruptedException {
-        int backlogQuotaLimitInSecond = getBacklogQuota(BacklogQuotaType.message_age).getLimitTimeInSec();
+        int backlogQuotaLimitInSecond = getBacklogQuota(BacklogQuotaType.message_age).getLimitTime();
         Long ledgerId = slowestPosition.getLedgerId();
         if (((ManagedLedgerImpl) ledger).getLedgersInfo().lastKey().equals(ledgerId)) {
             return CompletableFuture.completedFuture(false);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -162,7 +162,7 @@ public class NamespaceStatsAggregator {
             stats.backlogQuotaLimit = topic
                     .getBacklogQuota(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize();
             stats.backlogQuotaLimitTime = topic
-                    .getBacklogQuota(BacklogQuota.BacklogQuotaType.message_age).getLimitTimeInSec();
+                    .getBacklogQuota(BacklogQuota.BacklogQuotaType.message_age).getLimitTime();
 
             stats.managedLedgerStats.storageWriteLatencyBuckets
                     .addAll(mlStats.getInternalAddEntryLatencyBuckets());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTopicPoliciesTest.java
@@ -83,7 +83,7 @@ public class ReplicatorTopicPoliciesTest extends ReplicatorTestBase {
         // set BacklogQuota
         BacklogQuotaImpl backlogQuota = new BacklogQuotaImpl();
         backlogQuota.setLimitSize(1);
-        backlogQuota.setLimitTimeInSec(2);
+        backlogQuota.setLimitTime(2);
         // local
         admin1.topicPolicies().setBacklogQuota(topic, backlogQuota);
         Awaitility.await().untilAsserted(() ->

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/BacklogQuota.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/BacklogQuota.java
@@ -49,7 +49,7 @@ public interface BacklogQuota {
      *
      * @return quota limit in second
      */
-    int getLimitTimeInSec();
+    int getLimitTime();
 
     RetentionPolicy getPolicy();
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/impl/BacklogQuotaImpl.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/impl/BacklogQuotaImpl.java
@@ -45,12 +45,12 @@ public class BacklogQuotaImpl implements BacklogQuota {
     /**
      * backlog quota by time in second.
      */
-    private int limitTimeInSec;
+    private int limitTime;
     private RetentionPolicy policy;
 
-    public BacklogQuotaImpl(long limitSize, int limitTimeInSec, RetentionPolicy policy) {
+    public BacklogQuotaImpl(long limitSize, int limitTime, RetentionPolicy policy) {
         this.limitSize = limitSize;
-        this.limitTimeInSec = limitTimeInSec;
+        this.limitTime = limitTime;
         this.policy = policy;
     }
 
@@ -80,12 +80,12 @@ public class BacklogQuotaImpl implements BacklogQuota {
         this.limit = limitSize;
     }
 
-    public int getLimitTimeInSec() {
-        return limitTimeInSec;
+    public int getLimitTime() {
+        return limitTime;
     }
 
-    public void setLimitTimeInSec(int limitTimeInSec) {
-        this.limitTimeInSec = limitTimeInSec;
+    public void setLimitTime(int limitTime) {
+        this.limitTime = limitTime;
     }
 
     public RetentionPolicy getPolicy() {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BacklogQuotaCompatibilityTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BacklogQuotaCompatibilityTest.java
@@ -47,7 +47,7 @@ public class BacklogQuotaCompatibilityTest {
         Policies writePolicy = new Policies();
         BacklogQuotaImpl writeBacklogQuota = new BacklogQuotaImpl();
         writeBacklogQuota.setLimit(1024);
-        writeBacklogQuota.setLimitTimeInSec(60);
+        writeBacklogQuota.setLimitTime(60);
         writeBacklogQuota.setPolicy(testPolicy);
         HashMap<BacklogQuota.BacklogQuotaType, BacklogQuota> quotaHashMap = new HashMap<>();
         quotaHashMap.put(BacklogQuota.BacklogQuotaType.destination_storage, writeBacklogQuota);
@@ -56,7 +56,7 @@ public class BacklogQuotaCompatibilityTest {
         Policies policies = simpleType.deserialize("/path", serialize, null);
         BacklogQuota readBacklogQuota = policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage);
         Assert.assertEquals(readBacklogQuota.getLimitSize(), 1024);
-        Assert.assertEquals(readBacklogQuota.getLimitTimeInSec(), 60);
+        Assert.assertEquals(readBacklogQuota.getLimitTime(), 60);
         Assert.assertEquals(readBacklogQuota.getPolicy(), testPolicy);
     }
 
@@ -65,7 +65,7 @@ public class BacklogQuotaCompatibilityTest {
         Policies writePolicy = new Policies();
         BacklogQuotaImpl writeBacklogQuota = new BacklogQuotaImpl();
         writeBacklogQuota.setLimitSize(1024);
-        writeBacklogQuota.setLimitTimeInSec(60);
+        writeBacklogQuota.setLimitTime(60);
         writeBacklogQuota.setPolicy(testPolicy);
         HashMap<BacklogQuota.BacklogQuotaType, BacklogQuota> quotaHashMap = new HashMap<>();
         quotaHashMap.put(BacklogQuota.BacklogQuotaType.destination_storage, writeBacklogQuota);
@@ -74,7 +74,7 @@ public class BacklogQuotaCompatibilityTest {
         Policies policies = simpleType.deserialize("/path", serialize, null);
         BacklogQuota readBacklogQuota = policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage);
         Assert.assertEquals(readBacklogQuota.getLimit(), 1024);
-        Assert.assertEquals(readBacklogQuota.getLimitTimeInSec(), 60);
+        Assert.assertEquals(readBacklogQuota.getLimitTime(), 60);
         Assert.assertEquals(readBacklogQuota.getPolicy(), testPolicy);
     }
 
@@ -103,7 +103,7 @@ public class BacklogQuotaCompatibilityTest {
         Policies policies = simpleType.deserialize(null, oldPolicyStr.getBytes(), null);
         assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize(),
                 1001);
-        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitTimeInSec(),
+        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitTime(),
                 0);
         assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getPolicy(),
                 BacklogQuota.RetentionPolicy.consumer_backlog_eviction);
@@ -125,7 +125,7 @@ public class BacklogQuotaCompatibilityTest {
         Policies policies = simpleType.deserialize(null, oldPolicyStr.getBytes(), null);
         assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize(),
                 0);
-        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitTimeInSec(),
+        assertEquals(policies.backlog_quota_map.get(BacklogQuota.BacklogQuotaType.destination_storage).getLimitTime(),
                 0);
     }
 


### PR DESCRIPTION
This reverts commit fd5037ddeab4746202539509818f2b7977698537.

### Motivation

As described in https://github.com/apache/pulsar/pull/19053#pullrequestreview-1234929550, the commit to be reverted introduced a breaking change in a non-backwards compatible way. This is especially important because the datastructure in question is used for ser/de of zk metadata.  Instead of making one-off changes to variable names, I would prefer to first establish a standard/spec, and then apply it generally to all names. Pulsar certainly has room to improve names, but we must prioritize the user experience when changing these names. We also need to make sure that we cover upgrade and downgrade scenarios so that we do not break environments.

### Modifications

* Revert #19053.

### Verifying this change

This should be trivial.

### Does this pull request potentially affect one of the following parts:

This reverts a breaking change.

### Documentation

- [x] `doc-not-needed`

I'll send an email to the mailing list to discuss how we should handle these in the future.
