### PR TITLE
[improve][misc] Register Jackson Java 8 support modules by default

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -254,6 +254,9 @@ The Apache Software License, Version 2.0
      - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.13.4.jar
      - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.13.4.jar
      - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.13.4.jar
+     - com.fasterxml.jackson.datatype-jackson-datatype-jdk8-2.13.4.jar
+     - com.fasterxml.jackson.datatype-jackson-datatype-jsr310-2.13.4.jar
+     - com.fasterxml.jackson.module-jackson-module-parameter-names-2.13.4.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.9.1.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-2.0.1.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -319,6 +319,9 @@ The Apache Software License, Version 2.0
      - jackson-jaxrs-json-provider-2.13.4.jar
      - jackson-module-jaxb-annotations-2.13.4.jar
      - jackson-module-jsonSchema-2.13.4.jar
+     - jackson-datatype-jdk8-2.13.4.jar
+     - jackson-datatype-jsr310-2.13.4.jar
+     - jackson-module-parameter-names-2.13.4.jar
  * Conscrypt -- conscrypt-openjdk-uber-2.5.2.jar
  * Gson
     - gson-2.8.9.jar

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -63,6 +63,21 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-parameter-names</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/ObjectMapperFactory.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/ObjectMapperFactory.java
@@ -27,6 +27,9 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ClassUtils;
@@ -167,6 +170,13 @@ public class ObjectMapperFactory {
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
         mapper.setSerializationInclusion(Include.NON_NULL);
+
+        // enable Jackson Java 8 support modules
+        // https://github.com/FasterXML/jackson-modules-java8
+        mapper.registerModule(new ParameterNamesModule())
+            .registerModule(new Jdk8Module())
+            .registerModule(new JavaTimeModule());
+
         setAnnotationsModule(mapper);
         return mapper;
     }


### PR DESCRIPTION
### Description

- Jackson contains Java 8 support modules that haven't been added and registered in Pulsar.
  - more information about modules: https://github.com/FasterXML/jackson-modules-java8

This change applies to Jackson usage on the server side (Broker, Pulsar Functions etc.) and on the client.

### Modifications

- Add Parameter names, Java 8 Date/time and Java 8 Datatypes modules and register them by default

### Additional context

dev mailing list thread: https://lists.apache.org/thread/9bxs90q0m5phhytz6480b6fcnfclxt3s

This PR depends on #19160 so that the properly configured ObjectMapper instances are used. 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/125

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
