### PR TITLE
[improve][cli] Expose updateLocalTopicOnly to UpdatePartitionedCmd

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -594,6 +594,10 @@ public class CmdTopics extends CmdBase {
                 "--partitions" }, description = "Number of partitions for the topic", required = true)
         private int numPartitions;
 
+        @Parameter(names = { "-ulo",
+                "--update-local-only"}, description = "Update partitions number for topic in local cluster only")
+        private boolean updateLocalOnly = false;
+
         @Parameter(names = { "-f",
                 "--force" }, description = "Update forcefully without validating existing partitioned topic")
         private boolean force;
@@ -601,7 +605,7 @@ public class CmdTopics extends CmdBase {
         @Override
         void run() throws Exception {
             String topic = validateTopicName(params);
-            getTopics().updatePartitionedTopic(topic, numPartitions, false, force);
+            getTopics().updatePartitionedTopic(topic, numPartitions, updateLocalOnly, force);
         }
     }
 


### PR DESCRIPTION

### Motivation

We can set `updateLocalTopicOnly` when updating partitions by PulsarAdmin like 
```java
 admin.topics().updatePartitionedTopic(partitionedTopicName, newPartitions, false, false);
```
But `updateLocalTopicOnly` is not exposed to CLI command `UpdatePartitionedCmd`
```shell
$ bin/pulsar-admin topics update-partitioned-topic

  Options:
    -f, --force
      Update forcefully without validating existing partitioned topic
      Default: false
  * -p, --partitions
      Number of partitions for the topic
      Default: 0
```

### Modifications
expose`updateLocalTopicOnly`  to CLI command `UpdatePartitionedCmd` by adding a new option "--update-local-only" or "-ulo".


### Verifying this change

- [ ] Make sure that the change passes the CI checks.


### Documentation

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->


### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE --> https://github.com/aloyszhang/pulsar/pull/12

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
