### PR TITLE
[improve][broker] Add ref count for sticky hash to optimize the performance of Key_Shared subscription

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
@@ -116,7 +116,7 @@ public class MessageRedeliveryController {
     }
 
     public void clear() {
-        if (hashesToBeBlocked != null) {
+        if (!allowOutOfOrderDelivery) {
             hashesToBeBlocked.clear();
             hashesRefCount.clear();
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
@@ -29,9 +29,12 @@ import org.apache.pulsar.common.util.collections.ConcurrentLongLongPairHashMap;
 import org.apache.pulsar.common.util.collections.ConcurrentLongLongPairHashMap.LongPair;
 import org.apache.pulsar.utils.ConcurrentBitmapSortedLongPairSet;
 
+import javax.annotation.concurrent.NotThreadSafe;
+
 /**
  * The MessageRedeliveryController is a non-thread-safe container for maintaining the redelivery messages.
  */
+@NotThreadSafe
 public class MessageRedeliveryController {
 
     private final boolean allowOutOfOrderDelivery;
@@ -65,7 +68,7 @@ public class MessageRedeliveryController {
             } else {
                 // Return -1 means the key was not present
                 long stored = hashesRefCount.get(stickyKeyHash);
-                hashesRefCount.put(stickyKeyHash, stored > 0 ? ++ stored : 1);
+                hashesRefCount.put(stickyKeyHash, stored > 0 ? ++stored : 1);
             }
         }
         messagesToRedeliver.add(ledgerId, entryId);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
@@ -23,22 +23,34 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NavigableSet;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.bookkeeper.util.collections.ConcurrentLongLongHashMap;
 import org.apache.pulsar.common.util.collections.ConcurrentLongLongPairHashMap;
 import org.apache.pulsar.common.util.collections.ConcurrentLongLongPairHashMap.LongPair;
 import org.apache.pulsar.utils.ConcurrentBitmapSortedLongPairSet;
 
+/**
+ * The MessageRedeliveryController is a non-thread-safe container for maintaining the redelivery messages.
+ */
 public class MessageRedeliveryController {
+
+    private final boolean allowOutOfOrderDelivery;
     private final ConcurrentBitmapSortedLongPairSet messagesToRedeliver;
     private final ConcurrentLongLongPairHashMap hashesToBeBlocked;
+    private final ConcurrentLongLongHashMap hashesRefCount;
 
     public MessageRedeliveryController(boolean allowOutOfOrderDelivery) {
+        this.allowOutOfOrderDelivery = allowOutOfOrderDelivery;
         this.messagesToRedeliver = new ConcurrentBitmapSortedLongPairSet();
-        this.hashesToBeBlocked = allowOutOfOrderDelivery
-                ? null
-                : ConcurrentLongLongPairHashMap
+        if (!allowOutOfOrderDelivery) {
+            this.hashesToBeBlocked = ConcurrentLongLongPairHashMap
                     .newBuilder().concurrencyLevel(2).expectedItems(128).autoShrink(true).build();
+            this.hashesRefCount = ConcurrentLongLongHashMap
+                    .newBuilder().concurrencyLevel(2).expectedItems(128).autoShrink(true).build();
+        } else {
+            this.hashesToBeBlocked = null;
+            this.hashesRefCount = null;
+        }
     }
 
     public void add(long ledgerId, long entryId) {
@@ -46,21 +58,43 @@ public class MessageRedeliveryController {
     }
 
     public void add(long ledgerId, long entryId, long stickyKeyHash) {
-        if (hashesToBeBlocked != null) {
-            hashesToBeBlocked.put(ledgerId, entryId, stickyKeyHash, 0);
+        if (!allowOutOfOrderDelivery) {
+            boolean inserted = hashesToBeBlocked.putIfAbsent(ledgerId, entryId, stickyKeyHash, 0);
+            if (!inserted) {
+                hashesToBeBlocked.put(ledgerId, entryId, stickyKeyHash, 0);
+            } else {
+                // Return -1 means the key was not present
+                long stored = hashesRefCount.get(stickyKeyHash);
+                hashesRefCount.put(stickyKeyHash, stored > 0 ? ++ stored : 1);
+            }
         }
         messagesToRedeliver.add(ledgerId, entryId);
     }
 
     public void remove(long ledgerId, long entryId) {
-        if (hashesToBeBlocked != null) {
-            hashesToBeBlocked.remove(ledgerId, entryId);
+        if (!allowOutOfOrderDelivery) {
+            removeFromHashBlocker(ledgerId, entryId);
         }
         messagesToRedeliver.remove(ledgerId, entryId);
     }
 
+    private void removeFromHashBlocker(long ledgerId, long entryId) {
+        LongPair value = hashesToBeBlocked.get(ledgerId, entryId);
+        if (value != null) {
+            boolean removed = hashesToBeBlocked.remove(ledgerId, entryId, value.first, 0);
+            if (removed) {
+                long exists = hashesRefCount.get(value.first);
+                if (exists == 1) {
+                    hashesRefCount.remove(value.first, exists);
+                } else if (exists > 0) {
+                    hashesRefCount.put(value.first, exists - 1);
+                }
+            }
+        }
+    }
+
     public void removeAllUpTo(long markDeleteLedgerId, long markDeleteEntryId) {
-        if (hashesToBeBlocked != null) {
+        if (!allowOutOfOrderDelivery) {
             List<LongPair> keysToRemove = new ArrayList<>();
             hashesToBeBlocked.forEach((ledgerId, entryId, stickyKeyHash, none) -> {
                 if (ComparisonChain.start().compare(ledgerId, markDeleteLedgerId).compare(entryId, markDeleteEntryId)
@@ -68,7 +102,7 @@ public class MessageRedeliveryController {
                     keysToRemove.add(new LongPair(ledgerId, entryId));
                 }
             });
-            keysToRemove.forEach(longPair -> hashesToBeBlocked.remove(longPair.first, longPair.second));
+            keysToRemove.forEach(longPair -> removeFromHashBlocker(longPair.first, longPair.second));
             keysToRemove.clear();
         }
         messagesToRedeliver.removeUpTo(markDeleteLedgerId, markDeleteEntryId + 1);
@@ -81,6 +115,7 @@ public class MessageRedeliveryController {
     public void clear() {
         if (hashesToBeBlocked != null) {
             hashesToBeBlocked.clear();
+            hashesRefCount.clear();
         }
         messagesToRedeliver.clear();
     }
@@ -90,15 +125,14 @@ public class MessageRedeliveryController {
     }
 
     public boolean containsStickyKeyHashes(Set<Integer> stickyKeyHashes) {
-        final AtomicBoolean isContained = new AtomicBoolean(false);
-        if (hashesToBeBlocked != null) {
-            hashesToBeBlocked.forEach((ledgerId, entryId, stickyKeyHash, none) -> {
-                if (!isContained.get() && stickyKeyHashes.contains((int) stickyKeyHash)) {
-                    isContained.set(true);
+        if (!allowOutOfOrderDelivery) {
+            for (Integer stickyKeyHash : stickyKeyHashes) {
+                if (hashesRefCount.containsKey(stickyKeyHash)) {
+                    return true;
                 }
-            });
+            }
         }
-        return isContained.get();
+        return false;
     }
 
     public NavigableSet<PositionImpl> getMessagesToReplayNow(int maxMessagesToRead) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
@@ -23,13 +23,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NavigableSet;
 import java.util.Set;
+import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.util.collections.ConcurrentLongLongHashMap;
 import org.apache.pulsar.common.util.collections.ConcurrentLongLongPairHashMap;
 import org.apache.pulsar.common.util.collections.ConcurrentLongLongPairHashMap.LongPair;
 import org.apache.pulsar.utils.ConcurrentBitmapSortedLongPairSet;
-
-import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * The MessageRedeliveryController is a non-thread-safe container for maintaining the redelivery messages.


### PR DESCRIPTION
### Motivation

Add ref count for sticky hash to optimize the performance of the Key_Shared subscription.

![flamegraph-long](https://user-images.githubusercontent.com/12592133/211476906-d6b5604a-bc91-4359-9d33-96c5d9225427.svg)

The root cause is [here](https://github.com/apache/pulsar/pull/10762/files#diff-4c2d35368b21e5c33d65886196e8673c04a69f5c5cb888cdd04c29f8823502fdR97-R100). We are going to go through all the redelivery messages to check if contains the hash from a given sticky hash set.

### Modifications

Introduce a ref count map for the sticky hash set to make the method `containsStickyKeyHashes` works more efficiently.

With this fix

<img width="1844" alt="image" src="https://user-images.githubusercontent.com/12592133/211520975-db1fa584-140d-4c57-93fc-64fe809eb07b.png">


### Verifying this change

Updated the existing test to cover the new changes.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->