### PR TITLE
[fix][build] Upgrade dependency-check-maven plugin to fix broken OWASP check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,7 @@ flexible messaging model and an intuitive client API.</description>
     <errorprone-slf4j.version>0.1.4</errorprone-slf4j.version>
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
-    <dependency-check-maven.version>7.1.0</dependency-check-maven.version>
+    <dependency-check-maven.version>7.4.4</dependency-check-maven.version>
     <roaringbitmap.version>0.9.15</roaringbitmap.version>
     <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
     <lombok.plugin.version>1.18.20.0</lombok.plugin.version>

--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -176,4 +176,9 @@
     <notes>commons-net is not used at all and therefore commons-net vulnerability CVE-2021-37533 is a false positive.</notes>
     <cve>CVE-2021-37533</cve>
   </suppress>
+
+  <suppress>
+    <notes>fredsmith utils library is not used at all. CVE-2021-4277 is a false positive.</notes>
+    <cve>CVE-2021-4277</cve>
+  </suppress>
 </suppressions>

--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -186,4 +186,9 @@
     <notes>yaml_project is not used at all. Any CVEs reported for yaml_project are false positives.</notes>
     <cpe>cpe:/a:yaml_project:yaml</cpe>
   </suppress>
+
+  <suppress>
+    <notes>flat_project is not used at all.</notes>
+    <cpe>cpe:/a:flat_project:flat</cpe>
+  </suppress>
 </suppressions>

--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -181,4 +181,9 @@
     <notes>fredsmith utils library is not used at all. CVE-2021-4277 is a false positive.</notes>
     <cve>CVE-2021-4277</cve>
   </suppress>
+
+  <suppress>
+    <notes>yaml_project is not used at all. Any CVEs reported for yaml_project are false positives.</notes>
+    <cpe>cpe:/a:yaml_project:yaml</cpe>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### Motivation

- 7.4.4 includes fix for issue https://github.com/jeremylong/DependencyCheck/issues/5220

Error:  org.owasp.dependencycheck.data.nvdcve.DatabaseException: Error updating 'CVE-2020-36569' org.owasp.dependencycheck.data.update.exception.UpdateException: org.owasp.dependencycheck.data.nvdcve.DatabaseException: Error updating 'CVE-2020-36569' ...
Caused by: org.h2.jdbc.JdbcBatchUpdateException: Value too long for column "VERSIONENDEXCLUDING CHARACTER VARYING(60)": "'0.0.0-20160722212129-ac0cc4484ad4_before_v0.0.0-20200131131040-063a3fb69896' (75)"; SQL statement:

### Modifications

Upgrade dependency-check maven plugin to 7.4.4 version.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/127

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->