### PR TITLE
[fix][broker] Allow user lookup topic name with `-partition-` but no metadata

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1165,11 +1165,16 @@ public class NamespaceService implements AutoCloseable {
     public CompletableFuture<Boolean> checkTopicExists(TopicName topic) {
         if (topic.isPersistent()) {
             if (topic.isPartitioned()) {
-                return pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
-                        .partitionedTopicExistsAsync(TopicName.get(topic.getPartitionedTopicName()))
-                        .thenCompose(exists -> exists
-                                ? pulsar.getPulsarResources().getTopicResources().persistentTopicExists(topic)
-                                : CompletableFuture.completedFuture(false));
+                return pulsar.getBrokerService()
+                        .fetchPartitionedTopicMetadataAsync(TopicName.get(topic.getPartitionedTopicName()))
+                        .thenCompose(metadata -> {
+                            // Allow crate non-partitioned persistent topic that name includes `-partition-`
+                            if (metadata.partitions == 0
+                                    || topic.getPartitionIndex() < metadata.partitions) {
+                                return pulsar.getPulsarResources().getTopicResources().persistentTopicExists(topic);
+                            }
+                            return CompletableFuture.completedFuture(false);
+                        });
             } else {
                 return pulsar.getPulsarResources().getTopicResources().persistentTopicExists(topic);
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1168,7 +1168,7 @@ public class NamespaceService implements AutoCloseable {
                 return pulsar.getBrokerService()
                         .fetchPartitionedTopicMetadataAsync(TopicName.get(topic.getPartitionedTopicName()))
                         .thenCompose(metadata -> {
-                            // Allow crate non-partitioned persistent topic that name includes `-partition-`
+                            // Allow creating the non-partitioned persistent topic that name includes `-partition-`
                             if (metadata.partitions == 0
                                     || topic.getPartitionIndex() < metadata.partitions) {
                                 return pulsar.getPulsarResources().getTopicResources().persistentTopicExists(topic);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -442,7 +442,7 @@ public class PersistentTopicTest extends BrokerTestBase {
         // Check this topic has no partition metadata.
         Assert.assertThrows(PulsarAdminException.NotFoundException.class,
                 () -> admin.topics().getPartitionedTopicMetadata(topicName));
-        // Reconnect to the broker, expect successful, because the topic is existed in the broker.
+        // Reconnect to the broker and expect successful because the topic has existed in the broker.
         producer = pulsarClient.newProducer()
                 .topic(partition2)
                 .create();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -428,18 +428,29 @@ public class PersistentTopicTest extends BrokerTestBase {
         final String topicName = "persistent://prop/ns-abc/testCompatibilityWithPartitionKeyword";
         TopicName topicNameEntity = TopicName.get(topicName);
         String partition2 = topicNameEntity.getPartition(2).toString();
+        // Create a non-partitioned topic with -partition- keyword
         Producer<byte[]> producer = pulsarClient.newProducer()
                 .topic(partition2)
                 .create();
         List<String> topics = admin.topics().getList("prop/ns-abc");
+        // Close previous producer to simulate reconnect
         producer.close();
+        // Disable auto topic creation
         conf.setAllowAutoTopicCreation(false);
+        // Check the topic exist in the list.
         Assert.assertTrue(topics.contains(partition2));
+        // Check this topic has no partition metadata.
         Assert.assertThrows(PulsarAdminException.NotFoundException.class,
                 () -> admin.topics().getPartitionedTopicMetadata(topicName));
+        // Reconnect to the broker, expect successful, because the topic is existed in the broker.
         producer = pulsarClient.newProducer()
                 .topic(partition2)
                 .create();
         producer.close();
+        // Check the topic exist in the list again.
+        Assert.assertTrue(topics.contains(partition2));
+        // Check this topic has no partition metadata again.
+        Assert.assertThrows(PulsarAdminException.NotFoundException.class,
+                () -> admin.topics().getPartitionedTopicMetadata(topicName));
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -422,4 +422,24 @@ public class PersistentTopicTest extends BrokerTestBase {
         }
         Assert.assertEquals(admin.topics().getPartitionedTopicMetadata(topicName).partitions, 4);
     }
+
+    @Test
+    public void testCompatibilityWithPartitionKeyword() throws PulsarAdminException, PulsarClientException {
+        final String topicName = "persistent://prop/ns-abc/testCompatibilityWithPartitionKeyword";
+        TopicName topicNameEntity = TopicName.get(topicName);
+        String partition2 = topicNameEntity.getPartition(2).toString();
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(partition2)
+                .create();
+        List<String> topics = admin.topics().getList("prop/ns-abc");
+        producer.close();
+        conf.setAllowAutoTopicCreation(false);
+        Assert.assertTrue(topics.contains(partition2));
+        Assert.assertThrows(PulsarAdminException.NotFoundException.class,
+                () -> admin.topics().getPartitionedTopicMetadata(topicName));
+        producer = pulsarClient.newProducer()
+                .topic(partition2)
+                .create();
+        producer.close();
+    }
 }


### PR DESCRIPTION
### Motivation

This behaviour is broken by PR #18193,

In the previous version, we could use the pulsar client to look up the topic with the `-partition-` keyword. Even this topic doesn't have partition metadata. But currently, we can't do that. You can check the test to know the detail.

### Modifications

- Allow user lookup topic name with `-partition-` but no metadata

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->