### PR TITLE
[fix][io] Fix Alluxio sink to respect the alluxioMasterHost property

### DIFF
--- a/pulsar-io/alluxio/src/main/java/org/apache/pulsar/io/alluxio/sink/AlluxioSink.java
+++ b/pulsar-io/alluxio/src/main/java/org/apache/pulsar/io/alluxio/sink/AlluxioSink.java
@@ -92,7 +92,7 @@ public class AlluxioSink implements Sink<GenericObject> {
         // initialize FileSystem
         String alluxioMasterHost = alluxioSinkConfig.getAlluxioMasterHost();
         int alluxioMasterPort = alluxioSinkConfig.getAlluxioMasterPort();
-        InstancedConfiguration.defaults().set(PropertyKey.MASTER_HOSTNAME, alluxioMasterHost);
+        configuration.set(PropertyKey.MASTER_HOSTNAME, alluxioMasterHost);
         configuration.set(PropertyKey.MASTER_RPC_PORT, alluxioMasterPort);
         if (alluxioSinkConfig.getSecurityLoginUser() != null) {
             configuration.set(PropertyKey.SECURITY_LOGIN_USERNAME, alluxioSinkConfig.getSecurityLoginUser());

--- a/pulsar-io/alluxio/src/test/java/org/apache/pulsar/io/alluxio/sink/AlluxioSinkTest.java
+++ b/pulsar-io/alluxio/src/test/java/org/apache/pulsar/io/alluxio/sink/AlluxioSinkTest.java
@@ -64,6 +64,7 @@ public class AlluxioSinkTest {
 
     protected Map<String, Object> map;
     protected AlluxioSink sink;
+    protected LocalAlluxioCluster cluster;
 
     @Mock
     protected Record<GenericObject> mockRecord;
@@ -86,10 +87,16 @@ public class AlluxioSinkTest {
     }
 
     @BeforeMethod
-    public final void setUp() {
+    public final void setUp() throws Exception {
+        cluster = setupSingleMasterCluster();
+
         map = new HashMap<>();
-        map.put("alluxioMasterHost", "localhost");
-        map.put("alluxioMasterPort", "19998");
+        // alluxioMasterHost should be set via LocalAlluxioCluster#getHostname
+        // instead of using a fixed value "localhost", since it seems that
+        // LocalAlluxioCluster may bind other address than localhost
+        // when the node has multiple network interfaces.
+        map.put("alluxioMasterHost", cluster.getHostname());
+        map.put("alluxioMasterPort", cluster.getMasterRpcPort());
         map.put("alluxioDir", "/pulsar");
         map.put("filePrefix", "prefix");
         map.put("schemaEnable", "true");
@@ -127,8 +134,6 @@ public class AlluxioSinkTest {
 
         String alluxioDir = "/pulsar";
 
-        LocalAlluxioCluster cluster = setupSingleMasterCluster();
-
         sink = new AlluxioSink();
         sink.open(map, mockSinkContext);
 
@@ -155,8 +160,6 @@ public class AlluxioSinkTest {
         map.put("alluxioDir", "/pulsar");
 
         String alluxioDir = "/pulsar";
-
-        LocalAlluxioCluster cluster = setupSingleMasterCluster();
 
         sink = new AlluxioSink();
         sink.open(map, mockSinkContext);


### PR DESCRIPTION
### Motivation

Currently, the Alluxio sink always refers to localhost regardless of the `alluxioMasterHost` property.

Suppose we have a local Pulsar cluster (192.168.2.2) and a remote Alluxio cluster (192.168.33.10), as follows:

```
$ ip address show

...

2: enp1s0f1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether e0:4f:43:e8:4c:86 brd ff:ff:ff:ff:ff:ff
    inet 192.168.2.2/24 brd 192.168.2.255 scope global noprefixroute enp1s0f1
       valid_lft forever preferred_lft forever

...

$ curl -sL http://192.168.33.10:19999/api/v1/master/info | jq .version
"2.7.3"
```

Build the Alluxio sink on the master branch and deploy it to the local Pulsar:

```
$ mvn clean install -DskipTests

...

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  14:00 min
[INFO] Finished at: 2023-01-10T16:49:55+09:00
[INFO] ------------------------------------------------------------------------
$ mkdir connectors
$ cp pulsar-io/alluxio/target/pulsar-io-alluxio-2.12.0-SNAPSHOT.nar connectors
$ bin/pulsar standalone
```

Enable the Alluxio sink and ingest some messages into the topic in question:

```
$ bin/pulsar-admin sink available-sinks
alluxio
Writes data into Alluxio
----------------------------------------
$ cat /tmp/alluxio-sink.yml
configs:
    alluxioMasterHost: "192.168.33.10"
    alluxioMasterPort: "19998"
    alluxioDir: "pulsar"
    filePrefix: "TopicA"
    fileExtension: ".txt"
    lineSeparator: "\n"
    rotationRecords: 10
    rotationInterval: "-1"
$ bin/pulsar-admin sinks create \
    --tenant public \
    --namespace default \
    --name alluxio-sink \
    --sink-type alluxio \
    --sink-config-file /tmp/alluxio-sink.yml \
    --inputs TopicA
Created successfully
$ for i in $(seq 0 9); do bin/pulsar-client produce -m "key-$i" -n 1 TopicA; done

...

$ cat logs/functions/public/default/alluxio-sink/alluxio-sink-0.log

...

2023-01-10T17:02:23,453+0900 [public/default/alluxio-sink-0] ERROR org.apache.pulsar.functions.instance.JavaInstanceRunnable - [public/default/alluxio-sink:0] Uncaught exception in Java Instance
alluxio.exception.status.UnavailableException: Failed to connect to master (192.168.2.2/<unresolved>:19998) after 44 attempts.Please check if Alluxio master is currently running on "192.168.2.2/<unresolved>:19998". Service="FileSystemMasterClient"
	at alluxio.AbstractClient.connect(AbstractClient.java:279) ~[?:?]
	at alluxio.client.file.BaseFileSystem.rpc(BaseFileSystem.java:572) ~[?:?]
	at alluxio.client.file.BaseFileSystem.exists(BaseFileSystem.java:202) ~[?:?]
	at alluxio.client.file.FileSystem.exists(FileSystem.java:275) ~[?:?]
	at org.apache.pulsar.io.alluxio.sink.AlluxioSink.open(AlluxioSink.java:108) ~[?:?]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.setupOutput(JavaInstanceRunnable.java:935) ~[pulsar-functions-instance.jar:2.12.0-SNAPSHOT]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.setup(JavaInstanceRunnable.java:251) ~[pulsar-functions-instance.jar:2.12.0-SNAPSHOT]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:290) ~[pulsar-functions-instance.jar:2.12.0-SNAPSHOT]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: alluxio.exception.status.UnavailableException: Failed to handshake with master 192.168.2.2/<unresolved>:19998 to load cluster default configuration values: UNAVAILABLE: io exception
	at alluxio.util.ConfigurationUtils.loadConfiguration(ConfigurationUtils.java:521) ~[?:?]
	at alluxio.ClientContext.loadConf(ClientContext.java:134) ~[?:?]
	at alluxio.ClientContext.loadConfIfNotLoaded(ClientContext.java:158) ~[?:?]
	at alluxio.AbstractClient.beforeConnect(AbstractClient.java:176) ~[?:?]
	at alluxio.AbstractClient.connect(AbstractClient.java:224) ~[?:?]
	... 8 more
```

As the error messages indicate, the Alluxio sink tried to access the local address (192.168.2.2), in spite of the value of `alluxioMasterHost` (192.168.33.10).

### Modifications

The reason of this behavior is in the following line.
https://github.com/apache/pulsar/blob/master/pulsar-io/alluxio/src/main/java/org/apache/pulsar/io/alluxio/sink/AlluxioSink.java#L95

The value of `alluxioMasterHost` is set to the default configuration in that line, but the configuration object which is really used to create `FileSystem` is already instantiated before it, so it's ineffective.
https://github.com/apache/pulsar/blob/master/pulsar-io/alluxio/src/main/java/org/apache/pulsar/io/alluxio/sink/AlluxioSink.java#L100

This PR fixes this wrong implementation.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

I manually ensured that the ingested messages were output as an Alluxio file with this PR, as follows:

Before ingesting messages:

```
$ bin/alluxio fs ls /pulsar
(the directory is empty)
```

During ingestion:

```
$ bin/alluxio fs ls -R /pulsar
-rw-r--r--  sekikn         sekikn                       0   NOT_PERSISTED 01-10-2023 13:24:52:718 100% /pulsar/tmp/380f0218-3eff-497e-bd47-b4092879a0a9_tmp.txt
drwxr-xr-x  sekikn         sekikn                       1   NOT_PERSISTED 01-10-2023 13:24:52:718  DIR /pulsar/tmp
```

After ingestion:

```
$ bin/alluxio fs ls -R /pulsar
-rw-r--r--  sekikn         sekikn                      60   NOT_PERSISTED 01-10-2023 13:25:22:821 100% /pulsar/TopicA-1673357122834.txt
drwxr-xr-x  sekikn         sekikn                       0   NOT_PERSISTED 01-10-2023 13:25:22:839  DIR /pulsar/tmp
$ bin/alluxio fs cat /pulsar/TopicA-1673357122834.txt
key-0
key-1
key-2
key-3
key-4
key-5
key-6
key-7
key-8
key-9
```

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/sekikn/incubator-pulsar/pull/5

A few tests failed, but all of them seem to be unrelated to this fix.

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
