### PR TITLE
[fix][broker] Fix bk config file path in pulsarStandalone

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -103,6 +103,10 @@ public class PulsarStandalone implements AutoCloseable {
         this.configFile = configFile;
     }
 
+    public void setBkConfigFile(String bkConfigFile) {
+        this.bkConfigFile = bkConfigFile;
+    }
+
     public void setWipeData(boolean wipeData) {
         this.wipeData = wipeData;
     }
@@ -153,6 +157,10 @@ public class PulsarStandalone implements AutoCloseable {
 
     public String getConfigFile() {
         return configFile;
+    }
+
+    public String getBkConfigFile() {
+        return bkConfigFile;
     }
 
     public boolean isWipeData() {
@@ -213,6 +221,9 @@ public class PulsarStandalone implements AutoCloseable {
 
     @Parameter(names = { "-c", "--config" }, description = "Configuration file path")
     private String configFile;
+
+    @Parameter(names = { "--bk-config" }, description = "Bookkeeper Configuration file path")
+    private String bkConfigFile;
 
     @Parameter(names = { "--wipe-data" }, description = "Clean up previous ZK/BK data")
     private boolean wipeData = false;
@@ -445,7 +456,7 @@ public class PulsarStandalone implements AutoCloseable {
         }
 
         ServerConfiguration bkServerConf = new ServerConfiguration();
-        bkServerConf.loadConf(new File(configFile).toURI().toURL());
+        bkServerConf.loadConf(new File(bkConfigFile).toURI().toURL());
         calculateCacheSize(bkServerConf);
         bkCluster = BKCluster.builder()
                 .baseServerConfiguration(bkServerConf)
@@ -462,7 +473,7 @@ public class PulsarStandalone implements AutoCloseable {
     private void startBookieWithZookeeper() throws Exception {
         log.info("Starting BK & ZK cluster");
         ServerConfiguration bkServerConf = new ServerConfiguration();
-        bkServerConf.loadConf(new File(configFile).toURI().toURL());
+        bkServerConf.loadConf(new File(bkConfigFile).toURI().toURL());
         calculateCacheSize(bkServerConf);
         // Start LocalBookKeeper
         bkEnsemble = new LocalBookkeeperEnsemble(


### PR DESCRIPTION
### Motivation

`configFile` in PulsarStandalone is set for  broker config,  we shouldn't  set it for bookkeeper config.  So here we need add a new `bkConfigFile` for bookkeeper config

### Modifications

Added a new `bkConfigFile` for bookkeeper config

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/AnonHxy/pulsar/pull/25
