### PR TITLE
[cleanup][broker] Pass subName to authz provider on unsubscribe

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1582,7 +1582,7 @@ public class PersistentTopicsBase extends AdminResource {
                                                                                           boolean authoritative,
                                                                                           boolean force) {
         return validateTopicOwnershipAsync(topicName, authoritative)
-                .thenCompose((__) -> validateTopicOperationAsync(topicName, TopicOperation.UNSUBSCRIBE))
+                .thenCompose((__) -> validateTopicOperationAsync(topicName, TopicOperation.UNSUBSCRIBE, subName))
                 .thenCompose(__ -> getTopicReferenceAsync(topicName))
                 .thenCompose((topic) -> {
                     Subscription sub = topic.getSubscription(subName);


### PR DESCRIPTION
### Motivation

In https://github.com/apache/pulsar/pull/15347, there is a regression where the `subName` needed to be passed to the authorization provider. That PR is not released, so this PR is just cleanup

### Modifications

* Pass `subName` for `validateTopicOperationAsync` in `PersistentTopicsBase#internalDeleteSubscriptionForNonPartitionedTopicAsync`

### Verifying this change
We should add testing to this part of the code base to prevent future regressions.

### Does this pull request potentially affect one of the following parts:
This is not a breaking change.

### Documentation

- [x] `doc-not-needed`
