### PR TITLE
[cleanup][broker] Deprecate blocking AuthorizationService, AuthorizationProvider methods

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
@@ -61,7 +61,8 @@ public interface AuthorizationProvider extends Closeable {
     }
 
     /**
-     * @deprecated Use method {@link #isSuperUser(String, AuthenticationDataSource, ServiceConfiguration)}
+     * @deprecated - Use method {@link #isSuperUser(String, AuthenticationDataSource, ServiceConfiguration)}.
+     * Will be removed after 2.12.
      * Check if specified role is a super user
      * @param role the role to check
      * @return a CompletableFuture containing a boolean in which true means the role is a super user
@@ -297,6 +298,10 @@ public interface AuthorizationProvider extends Closeable {
                 operation.toString(), tenantName)));
     }
 
+    /**
+     * @deprecated - will be removed after 2.12. Use async variant.
+     */
+    @Deprecated
     default Boolean allowTenantOperation(String tenantName, String role, TenantOperation operation,
                                          AuthenticationDataSource authData) {
         try {
@@ -326,6 +331,10 @@ public interface AuthorizationProvider extends Closeable {
                     + "the Authorization provider you are using."));
     }
 
+    /**
+     * @deprecated - will be removed after 2.12. Use async variant.
+     */
+    @Deprecated
     default Boolean allowNamespaceOperation(NamespaceName namespaceName,
                                             String role,
                                             NamespaceOperation operation,
@@ -397,6 +406,10 @@ public interface AuthorizationProvider extends Closeable {
                         + "is not supported by is not supported by the Authorization provider you are using."));
     }
 
+    /**
+     * @deprecated - will be removed after 2.12. Use async variant.
+     */
+    @Deprecated
     default Boolean allowNamespacePolicyOperation(NamespaceName namespaceName,
                                                   PolicyName policy,
                                                   PolicyOperation operation,
@@ -471,6 +484,10 @@ public interface AuthorizationProvider extends Closeable {
                     + "provider you are using."));
     }
 
+    /**
+     * @deprecated - will be removed after 2.12. Use async variant.
+     */
+    @Deprecated
     default Boolean allowTopicOperation(TopicName topicName,
                                         String role,
                                         TopicOperation operation,
@@ -541,6 +558,10 @@ public interface AuthorizationProvider extends Closeable {
                         + "is not supported by the Authorization provider you are using."));
     }
 
+    /**
+     * @deprecated - will be removed after 2.12. Use async variant.
+     */
+    @Deprecated
     default Boolean allowTopicPolicyOperation(TopicName topicName,
                                               String role,
                                               PolicyName policy,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -353,6 +353,10 @@ public class AuthorizationService {
         }
     }
 
+    /**
+     * @deprecated - will be removed after 2.12. Use async variant.
+     */
+    @Deprecated
     public boolean allowTenantOperation(String tenantName,
                                         TenantOperation operation,
                                         String originalRole,
@@ -451,6 +455,10 @@ public class AuthorizationService {
         }
     }
 
+    /**
+     * @deprecated - will be removed after 2.12. Use async variant.
+     */
+    @Deprecated
     public boolean allowNamespacePolicyOperation(NamespaceName namespaceName,
                                                  PolicyName policy,
                                                  PolicyOperation operation,
@@ -513,6 +521,10 @@ public class AuthorizationService {
     }
 
 
+    /**
+     * @deprecated - will be removed after 2.12. Use async variant.
+     */
+    @Deprecated
     public Boolean allowTopicPolicyOperation(TopicName topicName,
                                              PolicyName policy,
                                              PolicyOperation operation,
@@ -595,6 +607,10 @@ public class AuthorizationService {
         }
     }
 
+    /**
+     * @deprecated - will be removed after 2.12. Use async variant.
+     */
+    @Deprecated
     public Boolean allowTopicOperation(TopicName topicName,
                                        TopicOperation operation,
                                        String originalRole,


### PR DESCRIPTION
Mailing list discussion: https://lists.apache.org/thread/sogsqz656cq5xvw1t014khogv6w33br6

### Motivation

With the acceptance of PIP 149, we've made a clear move to remove blocking calls in the Pulsar code base. The `AuthorizationService` and the `AuthorizationProvider` has some unused methods that synchronous wrappers for async methods. Since these methods are unused, I propose we deprecate them in 2.12 and remove them in 2.13.

### Modifications

* Add `@Deprecated` annotation and an updated javadoc.

### Verifying this change

I relied on IDE's usage finder to indicate that these methods are unused.

### Does this pull request potentially affect one of the following parts:

- [x] The public API

This will eventually affect the public API for the `AuthorizationService` and the `AuthorizationProvider`, which only impacts users that are running custom code inside the Pulsar Broker.

I will send an email to the mailing list to make sure this change does not go unnoticed.

### Documentation

- [x] `doc-not-needed`

We do not document the `AuthorizationService` API or the `AuthorizationProvider` anywhere but the source code, so I see no need to document this change.

### Matching PR in forked repository

Skipping the forked PR because it is a trivial update.