### PR TITLE
[fix][broker] Pass subName for subscription operations in ServerCnx

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1279,8 +1279,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         if (!Strings.isNullOrEmpty(initialSubscriptionName)) {
             isAuthorizedFuture =
                     isAuthorizedFuture.thenCombine(
-                            isTopicOperationAllowed(topicName, TopicOperation.SUBSCRIBE, authenticationData,
-                                    originalAuthData),
+                            isTopicOperationAllowed(topicName, initialSubscriptionName, TopicOperation.SUBSCRIBE),
                             (canProduce, canSubscribe) -> canProduce && canSubscribe);
         }
 


### PR DESCRIPTION
### Motivation

When a DLQ producer connects, it creates a subscription when configured to do so. The `subscriptionName` should be passed to the `authorizationProvider` to properly determine authorization.

### Modifications

* Pass `initialSubscriptionName` to `isTopicOperationAllowed` method in the `ServerCnx`.

### Verifying this change

I am going to work on generic tests to cover this case (and some others) when I do #19183.

### Does this pull request potentially affect one of the following parts:

This is not a breaking change.

### Documentation

- [x] `doc-not-needed`

This only impacts users that have subscription level permissions, which are not well documented. We should improve those docs eventually, but there is no need to fix those docs while making this fix.

### Matching PR in forked repository

PR in forked repository: https://github.com/michaeljmarshall/pulsar/pull/11