### PR TITLE
[fix][cli] Shell syntax

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -274,7 +274,7 @@ if [ -z "$PULSAR_TRINO_CONF" ]; then
     fi
 fi
 
-if [ -z "$FUNCTIONS_LOG_CONF"]; then
+if [ -z "$FUNCTIONS_LOG_CONF" ]; then
   FUNCTIONS_LOG_CONF=$DEFAULT_FUNCTIONS_LOG_CONF
 fi
 


### PR DESCRIPTION
The original code can produce:

```
bash: [: missing `]'
```

... if `$FUNCTIONS_LOG_CONF` is not empty.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 