### PR TITLE
[fix] [doc] fix multiple apis in the automatically generated documentation use the same anchor point

### DIFF
--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -697,11 +697,13 @@
           <plugin>
             <groupId>com.github.kongchen</groupId>
             <artifactId>swagger-maven-plugin</artifactId>
-            <version>3.1.7</version>
+            <version>3.1.8</version>
             <configuration>
               <apiSources>
                 <apiSource>
                   <springmvc>false</springmvc>
+                  <operationIdFormat>{{className}}_{{methodName}}</operationIdFormat>
+                  <outputFormats>json</outputFormats>
                   <locations>
                     <location>org.apache.pulsar.broker.admin.v2.Bookies</location>
                     <location>org.apache.pulsar.broker.admin.v2.BrokerStats</location>
@@ -737,6 +739,8 @@
                 </apiSource>
                 <apiSource>
                   <springmvc>false</springmvc>
+                  <operationIdFormat>{{className}}_{{methodName}}</operationIdFormat>
+                  <outputFormats>json</outputFormats>
                   <locations>org.apache.pulsar.broker.lookup.v2</locations>
                   <schemes>http,https</schemes>
                   <basePath>/lookup</basePath>
@@ -754,6 +758,8 @@
                 </apiSource>
                 <apiSource>
                   <springmvc>false</springmvc>
+                  <operationIdFormat>{{className}}_{{methodName}}</operationIdFormat>
+                  <outputFormats>json</outputFormats>
                   <locations>org.apache.pulsar.broker.admin.v3.Functions</locations>
                   <schemes>http,https</schemes>
                   <basePath>/admin/v3</basePath>
@@ -771,6 +777,8 @@
                 </apiSource>
                 <apiSource>
                   <springmvc>false</springmvc>
+                  <operationIdFormat>{{className}}_{{methodName}}</operationIdFormat>
+                  <outputFormats>json</outputFormats>
                   <locations>org.apache.pulsar.broker.admin.v3.Transactions</locations>
                   <schemes>http,https</schemes>
                   <basePath>/admin/v3</basePath>
@@ -788,6 +796,8 @@
                 </apiSource>
                 <apiSource>
                   <springmvc>false</springmvc>
+                  <operationIdFormat>{{className}}_{{methodName}}</operationIdFormat>
+                  <outputFormats>json</outputFormats>
                   <locations>org.apache.pulsar.broker.admin.v3.Sources</locations>
                   <schemes>http,https</schemes>
                   <basePath>/admin/v3</basePath>
@@ -805,6 +815,8 @@
                 </apiSource>
                 <apiSource>
                   <springmvc>false</springmvc>
+                  <operationIdFormat>{{className}}_{{methodName}}</operationIdFormat>
+                  <outputFormats>json</outputFormats>
                   <locations>org.apache.pulsar.broker.admin.v3.Sinks</locations>
                   <schemes>http,https</schemes>
                   <basePath>/admin/v3</basePath>
@@ -822,6 +834,8 @@
                 </apiSource>
                 <apiSource>
                   <springmvc>false</springmvc>
+                  <operationIdFormat>{{className}}_{{methodName}}</operationIdFormat>
+                  <outputFormats>json</outputFormats>
                   <locations>org.apache.pulsar.broker.admin.v3.Packages</locations>
                   <schemes>http,https</schemes>
                   <basePath>/admin/v3</basePath>


### PR DESCRIPTION
### Motivation

Now that site [admin-rest-api](https://pulsar.apache.org/admin-rest-api) is automatically generated through swagger, each API in the site has its own link that we can walk through, the generated rule of API-link is `https://pulsar.apache.org/admin-rest-api/#operation/{operationId}`, we call the suffix `#operation/{operationId}` of link anchor.

Since the {operationId}'s default value is the method name of the endpoint class, and there has the same method name in the multi endpoint-classes, such as `Namespaces.setDispatchRate` and `PersistentTopics.setDispatchRate`, so these both APIs will generate the same link: `https://pulsar.apache.org/admin-rest-api/#operation/setDispatchRate`.

### Modifications

In the update to version `3.1.8` of `swagger-maven-plugin,` there are another ways to set `operationId`: The Operation Id Format. see https://github.com/kongchen/swagger-maven-plugin/blob/e4cf3af6ed4a4987b2269a05b7037549bc4a5511/src/main/java/com/github/kongchen/swagger/docgen/reader/AbstractReader.java#L535-L540. So we can generate `operationId` using the specified rule `{className}_{methodName}.`

<img width="621" alt="截屏2023-03-08 16 04 47" src="https://user-images.githubusercontent.com/25195800/223656076-bee1e182-b1c3-43f7-afb4-a64a7d1f79df.png">



### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [x] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- https://github.com/poorbarcode/pulsar/pull/51
