### PR TITLE
[fix][broker] Fix race condition while updating partition number

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -4446,7 +4446,7 @@ public class PersistentTopicsBase extends AdminResource {
                     final String topicNamePartition = topicName.getPartition(i).toString();
                     CompletableFuture<Void> future = new CompletableFuture<>();
                     admin.topics().createSubscriptionAsync(topicNamePartition,
-                                    subscription, MessageId.latest, replicated).whenComplete((__, ex) -> {
+                                    subscription, MessageId.earliest, replicated).whenComplete((__, ex) -> {
                         if (ex == null) {
                             future.complete(null);
                         } else {


### PR DESCRIPTION
### Motivation

We use `latest` to copy subscriptions from another topic; there is a gap between the topic creation and subscription. In this period, If some new producer sends messages to the new topic partition. There may look like some messages are lost on the user side.

Because there is a new topic partition, I think it's Ok to change `latest` to `earliest`.
### Modifications

- Use `earliest` instead of `latest`.

### Verifying this change

It's hard to add the test case.

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->