### PR TITLE
[fix][txn] Fix transactions disabled error message

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -2308,7 +2308,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         if (!service.getPulsar().getConfig().isTransactionCoordinatorEnabled()) {
             BrokerServiceException.NotAllowedException ex =
                     new BrokerServiceException.NotAllowedException(
-                            "Transaction manager is not not enabled");
+                            "Transactions are not enabled.");
             commandSender.sendErrorResponse(requestId, BrokerServiceException.getClientErrorCode(ex), ex.getMessage());
             return false;
         } else {


### PR DESCRIPTION
### Motivation

If the broker has not enabled the transactions feature and a transactions command is received, it returns the error 
`Transaction manager is not not enabled` which is wrong (and also transaction manager doesn't mean anything in Pulsar)

### Modifications

* Return a better error message `Transactions are not enabled.` 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->