### PR TITLE
[improve][client] Use Jackson's ObjectReader in Client's JSON readers

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/JacksonJsonReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/JacksonJsonReader.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.impl.schema.reader;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import java.io.IOException;
 import java.io.InputStream;
 import org.apache.pulsar.client.api.SchemaSerializationException;
@@ -33,17 +34,17 @@ import org.slf4j.LoggerFactory;
  */
 public class JacksonJsonReader<T> implements SchemaReader<T> {
     private final Class<T> pojo;
-    private final ObjectMapper objectMapper;
+    private final ObjectReader objectReader;
 
     public JacksonJsonReader(ObjectMapper objectMapper, Class<T> pojo) {
         this.pojo = pojo;
-        this.objectMapper = objectMapper;
+        this.objectReader = pojo != null ? objectMapper.readerFor(pojo) : objectMapper.reader();
     }
 
     @Override
     public T read(byte[] bytes, int offset, int length) {
         try {
-            return objectMapper.readValue(bytes, offset, length, this.pojo);
+            return objectReader.readValue(bytes, offset, length);
         } catch (IOException e) {
             throw new SchemaSerializationException(e);
         }
@@ -52,7 +53,7 @@ public class JacksonJsonReader<T> implements SchemaReader<T> {
     @Override
     public T read(InputStream inputStream) {
         try {
-            return objectMapper.readValue(inputStream, pojo);
+            return objectReader.readValue(inputStream, pojo);
         } catch (IOException e) {
             throw new SchemaSerializationException(e);
         } finally {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/JsonReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/JsonReader.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.impl.schema.reader;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import java.io.IOException;
 import java.io.InputStream;
 import org.apache.pulsar.client.api.SchemaSerializationException;
@@ -35,17 +36,17 @@ import org.slf4j.LoggerFactory;
 @Deprecated
 public class JsonReader<T> implements SchemaReader<T> {
     private final Class<T> pojo;
-    private final ObjectMapper objectMapper;
+    private final ObjectReader objectReader;
 
     public JsonReader(ObjectMapper objectMapper, Class<T> pojo) {
         this.pojo = pojo;
-        this.objectMapper = objectMapper;
+        this.objectReader = pojo != null ? objectMapper.readerFor(pojo) : objectMapper.reader();
     }
 
     @Override
     public T read(byte[] bytes, int offset, int length) {
         try {
-            return objectMapper.readValue(bytes, offset, length, this.pojo);
+            return objectReader.readValue(bytes, offset, length);
         } catch (IOException e) {
             throw new SchemaSerializationException(e);
         }
@@ -54,7 +55,7 @@ public class JsonReader<T> implements SchemaReader<T> {
     @Override
     public T read(InputStream inputStream) {
         try {
-            return objectMapper.readValue(inputStream, pojo);
+            return objectReader.readValue(inputStream);
         } catch (IOException e) {
             throw new SchemaSerializationException(e);
         } finally {


### PR DESCRIPTION
### Motivation

- benefits: 
  - no need to lookup the type when reading happens. 
     - The type gets fetched from cache once. 
     - Since a reference is kept, it won't overflow from a busy Jackson TypeFactory LRU cache.

### Modifications

Replace ObjectMapper usage with ObjectReader in JacksonJsonReader and JsonReader classes.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->