### PR TITLE
[improve][test] Run cleanup methods even when failfast mode is enabled

### DIFF
--- a/buildtools/src/main/java/org/apache/pulsar/tests/FailFastNotifier.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/FailFastNotifier.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.tests;
 import org.testng.IInvokedMethod;
 import org.testng.IInvokedMethodListener;
 import org.testng.ITestListener;
+import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.SkipException;
 
@@ -84,7 +85,11 @@ public class FailFastNotifier
 
     @Override
     public void beforeInvocation(IInvokedMethod iInvokedMethod, ITestResult iTestResult) {
-        if (FAIL_FAST_ENABLED && FailFastEventsSingleton.getInstance().isSkipAfterFailure()) {
+        ITestNGMethod iTestNGMethod = iInvokedMethod.getTestMethod();
+        if (FAIL_FAST_ENABLED && FailFastEventsSingleton.getInstance().isSkipAfterFailure()
+                && !(iTestNGMethod.isAfterMethodConfiguration()
+                || iTestNGMethod.isAfterClassConfiguration()
+                || iTestNGMethod.isAfterTestConfiguration())) {
             throw new FailFastSkipException("Skipped after failure since testFailFast system property is set.");
         }
     }


### PR DESCRIPTION
### Motivation

- cleanup didn't happen for tests after failures when failfast mode is activated

### Modifications

- ignore the failfast solution for @After* methods 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->