### PR TITLE
[fix][test] Fix ProxyPrometheusMetricsTest flakiness and consistently close JAX-RS clients in tests

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminRestTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminRestTest.java
@@ -31,6 +31,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.common.policies.data.ClusterData;
@@ -55,6 +56,7 @@ public class AdminRestTest extends MockedPulsarServiceBaseTest {
     public void testRejectUnknownEntityProperties() throws Exception{
         // Build request command.
         int port = pulsar.getWebService().getListenPortHTTP().get();
+        @Cleanup
         Client client = ClientBuilder.newClient();
         WebTarget target = client.target("http://127.0.0.1:" + port
                 + "/admin/v2/persistent/" + namespaceName + "/" + topicNameSuffix + "/retention");
@@ -86,7 +88,6 @@ public class AdminRestTest extends MockedPulsarServiceBaseTest {
         response1.close();
         response2.close();
         response3.close();
-        client.close();
     }
 
     private String parseResponseEntity(Object entity) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/MetricsAuthenticationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/MetricsAuthenticationTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.stats;
 import com.google.common.collect.Sets;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.glassfish.jersey.client.ClientConfig;
@@ -52,6 +53,7 @@ public class MetricsAuthenticationTest extends MockedPulsarServiceBaseTest {
     void testGetMetricsByAuthenticate() throws Exception {
         conf.setAuthenticateMetricsEndpoint(true);
         super.internalSetup();
+        @Cleanup
         Client client = javax.ws.rs.client.ClientBuilder.newClient(new ClientConfig().register(LoggingFeature.class));
         Response r = client.target(this.pulsar.getWebServiceAddress()).path("/metrics").request().get();
         Assert.assertEquals(r.getStatus(), Response.Status.UNAUTHORIZED.getStatusCode());
@@ -60,6 +62,7 @@ public class MetricsAuthenticationTest extends MockedPulsarServiceBaseTest {
     @Test
     void testGetMetricsByDefault() throws Exception {
         super.internalSetup();
+        @Cleanup
         Client client = javax.ws.rs.client.ClientBuilder.newClient(new ClientConfig().register(LoggingFeature.class));
         Response r = client.target(this.pulsar.getWebServiceAddress()).path("/metrics").request().get();
         Assert.assertEquals(r.getStatus(), Response.Status.OK.getStatusCode());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionBatchWriterMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionBatchWriterMetricsTest.java
@@ -34,6 +34,7 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -123,6 +124,7 @@ public class TransactionBatchWriterMetricsTest extends MockedPulsarServiceBaseTe
         sendAndAckSomeMessages();
 
         // call metrics
+        @Cleanup
         Client client = ClientBuilder.newClient();
         WebTarget target = client.target(brokerUrl + "/metrics/get");
         Response response = target.request(MediaType.APPLICATION_JSON_TYPE).buildGet().invoke();
@@ -167,7 +169,6 @@ public class TransactionBatchWriterMetricsTest extends MockedPulsarServiceBaseTe
 
         // cleanup.
         response.close();
-        client.close();
         admin.topics().delete(topicName, true);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthenticationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthenticationTest.java
@@ -33,6 +33,7 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import lombok.Cleanup;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.websocket.WebSocketService;
@@ -174,6 +175,7 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
         SimpleProducerSocket produceSocket = new SimpleProducerSocket();
 
         final String baseUrl = "http://localhost:" + proxyServer.getListenPortHTTP().get() + "/admin/v2/proxy-stats/";
+        @Cleanup
         Client client = ClientBuilder.newClient();
 
         try {
@@ -197,7 +199,6 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
         } finally {
             consumeClient.stop();
             produceClient.stop();
-            client.close();
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
@@ -48,6 +48,7 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import lombok.Cleanup;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerAccessMode;
@@ -630,6 +631,7 @@ public class ProxyPublishConsumeTest extends ProducerConsumerBase {
                 assertTrue(consumeSocket1.getReceivedMessagesCount() >= 2);
             });
 
+            @Cleanup
             Client client = ClientBuilder.newClient(new ClientConfig().register(LoggingFeature.class));
             final String baseUrl = pulsar.getSafeWebServiceAddress()
                     .replace(Integer.toString(pulsar.getConfiguration().getWebServicePort().get()),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/v1/V1_ProxyAuthenticationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/v1/V1_ProxyAuthenticationTest.java
@@ -32,6 +32,7 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import lombok.Cleanup;
 import org.apache.pulsar.client.api.v1.V1_ProducerConsumerBase;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.websocket.WebSocketService;
@@ -172,6 +173,7 @@ public class V1_ProxyAuthenticationTest extends V1_ProducerConsumerBase {
         SimpleProducerSocket produceSocket = new SimpleProducerSocket();
 
         final String baseUrl = "http://localhost:" + proxyServer.getListenPortHTTP().get() + "/admin/proxy-stats/";
+        @Cleanup
         Client client = ClientBuilder.newClient();
 
         try {
@@ -195,7 +197,6 @@ public class V1_ProxyAuthenticationTest extends V1_ProducerConsumerBase {
         } finally {
             consumeClient.stop();
             produceClient.stop();
-            client.close();
         }
     }
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyIsAHttpProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyIsAHttpProxyTest.java
@@ -148,6 +148,7 @@ public class ProxyIsAHttpProxyTest extends MockedPulsarServiceBaseTest {
 
         backingServer1.stop();
         backingServer2.stop();
+        client.close();
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyPrometheusMetricsTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyPrometheusMetricsTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Multimap;
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -37,10 +38,12 @@ import java.util.regex.Pattern;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
+import lombok.Cleanup;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
+import org.awaitility.Awaitility;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.logging.LoggingFeature;
 import org.mockito.Mockito;
@@ -105,31 +108,37 @@ public class ProxyPrometheusMetricsTest extends MockedPulsarServiceBaseTest {
         Counter counter = Counter.build("test_counter", "a test counter").create();
         Collector collector = counter.register();
         try {
-            Client httpClient = ClientBuilder.newClient(new ClientConfig().register(LoggingFeature.class));
-            Response r = httpClient.target(proxyWebServer.getServiceUri()).path("/metrics").request()
-                    .get();
-            Assert.assertEquals(r.getStatus(), Response.Status.OK.getStatusCode());
-            String response = r.readEntity(String.class).trim();
+            Awaitility.await().pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
+                Multimap<String, Metric> metrics = getMetrics();
 
-            Multimap<String, Metric> metrics = parseMetrics(response);
+                // Check that ProxyService metrics are present
+                List<Metric> cm = (List<Metric>) metrics.get("pulsar_proxy_binary_bytes_total");
+                assertEquals(cm.size(), 1);
+                assertEquals(cm.get(0).tags.get("cluster"), TEST_CLUSTER);
 
-            // Check that ProxyService metrics are present
-            List<Metric> cm = (List<Metric>) metrics.get("pulsar_proxy_binary_bytes_total");
-            assertEquals(cm.size(), 1);
-            assertEquals(cm.get(0).tags.get("cluster"), TEST_CLUSTER);
+                // Check that any Prometheus metric registered in the default CollectorRegistry is present
+                List<Metric> cm2 = (List<Metric>) metrics.get("test_metrics");
+                assertEquals(cm2.size(), 1);
+                assertEquals(cm2.get(0).tags.get("label1"), "xyz");
 
-            // Check that any Prometheus metric registered in the default CollectorRegistry is present
-            List<Metric> cm2 = (List<Metric>) metrics.get("test_metrics");
-            assertEquals(cm2.size(), 1);
-            assertEquals(cm2.get(0).tags.get("label1"), "xyz");
-
-            // Check that PrometheusRawMetricsProvider metrics are present
-            List<Metric> cm3 = (List<Metric>) metrics.get("test_counter_total");
-            assertEquals(cm3.size(), 1);
-            assertEquals(cm3.get(0).tags.get("cluster"), TEST_CLUSTER);
+                // Check that PrometheusRawMetricsProvider metrics are present
+                List<Metric> cm3 = (List<Metric>) metrics.get("test_counter_total");
+                assertEquals(cm3.size(), 1);
+                assertEquals(cm3.get(0).tags.get("cluster"), TEST_CLUSTER);
+            });
         } finally {
             CollectorRegistry.defaultRegistry.unregister(collector);
         }
+    }
+
+    private Multimap<String, Metric> getMetrics() {
+        @Cleanup
+        Client httpClient = ClientBuilder.newClient(new ClientConfig().register(LoggingFeature.class));
+        Response r = httpClient.target(proxyWebServer.getServiceUri()).path("/metrics").request()
+                .get();
+        Assert.assertEquals(r.getStatus(), Response.Status.OK.getStatusCode());
+        String response = r.readEntity(String.class).trim();
+        return parseMetrics(response);
     }
 
     /**

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyStatsTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyStatsTest.java
@@ -125,6 +125,7 @@ public class ProxyStatsTest extends MockedPulsarServiceBaseTest {
             consumer.acknowledge(msg);
         }
 
+        @Cleanup
         Client httpClient = ClientBuilder.newClient(new ClientConfig().register(LoggingFeature.class));
         Response r = httpClient.target(proxyWebServer.getServiceUri()).path("/proxy-stats/connections").request()
                 .get();
@@ -175,6 +176,7 @@ public class ProxyStatsTest extends MockedPulsarServiceBaseTest {
             msg = consumer2.receive(1, TimeUnit.SECONDS);
         }
 
+        @Cleanup
         Client httpClient = ClientBuilder.newClient(new ClientConfig().register(LoggingFeature.class));
         Response r = httpClient.target(proxyWebServer.getServiceUri()).path("/proxy-stats/topics").request()
                 .get();
@@ -198,6 +200,7 @@ public class ProxyStatsTest extends MockedPulsarServiceBaseTest {
     public void testChangeLogLevel() {
         Assert.assertEquals(proxyService.getProxyLogLevel(), 2);
         int newLogLevel = 1;
+        @Cleanup
         Client httpClient = ClientBuilder.newClient(new ClientConfig().register(LoggingFeature.class));
         Response r = httpClient.target(proxyWebServer.getServiceUri()).path("/proxy-stats/logging/" + newLogLevel)
                 .request().post(Entity.entity("", MediaType.APPLICATION_JSON));

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithJwtAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithJwtAuthorizationTest.java
@@ -410,6 +410,7 @@ public class ProxyWithJwtAuthorizationTest extends ProducerConsumerBase {
         ProxyServiceStarter.addWebServerHandlers(webServer, proxyConfig, proxyService,
                 new BrokerDiscoveryProvider(proxyConfig, resource));
         webServer.start();
+        @Cleanup
         Client client = javax.ws.rs.client.ClientBuilder.newClient(new ClientConfig().register(LoggingFeature.class));
         try {
             Response r = client.target(webServer.getServiceUri()).path("/metrics").request().get();

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/UnauthedAdminProxyHandlerTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/UnauthedAdminProxyHandlerTest.java
@@ -30,6 +30,7 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 
+import lombok.Cleanup;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.broker.resources.PulsarResources;
@@ -114,12 +115,12 @@ public class UnauthedAdminProxyHandlerTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testVipStatus() throws Exception {
+        @Cleanup
         Client client = ClientBuilder.newClient(new ClientConfig().register(LoggingFeature.class));
         WebTarget webTarget = client.target("http://127.0.0.1:" + webServer.getListenPortHTTP().get())
                 .path("/status.html");
         String response = webTarget.request().get(String.class);
         Assert.assertEquals(response, "OK");
-        client.close();
     }
 
     static class AdminProxyWrapper extends AdminProxyHandler {


### PR DESCRIPTION
Fixes #19216

### Motivation

See https://github.com/apache/pulsar/pull/19217#issuecomment-1381096161 for details of the remaining problem in ProxyPrometheusMetricsTest

### Modifications

- Use Awaitility to wait until metrics are available
- Consistently close JAX-RS clients in all tests

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->