### PR TITLE
[fix][ci] Fix CI issue where ubuntu apt repository azure.archive.ubuntu.com isn't available

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -291,8 +291,6 @@ jobs:
     timeout-minutes: 60
     needs: ['preconditions', 'build-and-license-check']
     if: ${{ needs.preconditions.outputs.docs_only != 'true'}}
-    env:
-      UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -337,6 +335,11 @@ jobs:
         run: |
           cd $HOME
           $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh restore_tar_from_github_actions_artifacts pulsar-maven-repository-binaries
+
+      - name: Pick ubuntu mirror for the docker image build
+        run: |
+          # pick the closest ubuntu mirror and set it to UBUNTU_MIRROR environment variable
+          $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh pick_ubuntu_mirror
 
       - name: Build java-test-image docker image
         run: |
@@ -538,8 +541,6 @@ jobs:
     timeout-minutes: 60
     needs: ['preconditions', 'build-and-license-check']
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
-    env:
-      UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -588,6 +589,11 @@ jobs:
         run: |
           cd $HOME
           $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh restore_tar_from_github_actions_artifacts pulsar-maven-repository-binaries
+
+      - name: Pick ubuntu mirror for the docker image build
+        run: |
+          # pick the closest ubuntu mirror and set it to UBUNTU_MIRROR environment variable
+          $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh pick_ubuntu_mirror
 
       - name: Build latest-version-image docker image
         run: |

--- a/build/pulsar_ci_tool.sh
+++ b/build/pulsar_ci_tool.sh
@@ -57,11 +57,11 @@ function ci_pick_ubuntu_mirror() {
   UBUNTU_MIRROR=$({
     # choose mirrors that are up-to-date by checking the Last-Modified header for
     {
-      curl -s http://mirrors.ubuntu.com/mirrors.txt
+      # randomly choose up to 10 mirrors
+      curl -s http://mirrors.ubuntu.com/mirrors.txt | shuf -n 10
       # also consider Azure's Ubuntu mirror
       echo http://azure.archive.ubuntu.com/ubuntu/
-    } | shuf -n 10 \
-      | xargs -I {} sh -c 'echo "$(curl -m 5 -sI {}dists/$(lsb_release -c | cut -f2)-security/Contents-$(dpkg --print-architecture).gz|sed s/\\r\$//|grep Last-Modified|awk -F": " "{ print \$2 }" | LANG=C date -f- -u +%s)" "{}"' | sort -rg | awk '{ if (NR==1) TS=$1; if ($1 == TS) print $2 }'
+    } | xargs -I {} sh -c 'echo "$(curl -m 5 -sI {}dists/$(lsb_release -c | cut -f2)-security/Contents-$(dpkg --print-architecture).gz|sed s/\\r\$//|grep Last-Modified|awk -F": " "{ print \$2 }" | LANG=C date -f- -u +%s)" "{}"' | sort -rg | awk '{ if (NR==1) TS=$1; if ($1 == TS) print $2 }'
   } | xargs -I {} sh -c 'echo `curl -r 0-102400 -m 5 -s -w %{speed_download} -o /dev/null {}ls-lR.gz` {}' \
     |sort -g -r |head -1| awk '{ print $2  }')
   if [ -z "$UBUNTU_MIRROR" ]; then

--- a/build/pulsar_ci_tool.sh
+++ b/build/pulsar_ci_tool.sh
@@ -74,8 +74,10 @@ function ci_pick_ubuntu_mirror() {
     sudo sed -i "s|$OLD_MIRROR|$UBUNTU_MIRROR|g" /etc/apt/sources.list
     sudo apt-get update
   fi
-  # set the chosen mirror also in the UBUNTU_MIRROR environment variable that can be used by docker builds
+  # set the chosen mirror also in the UBUNTU_MIRROR and UBUNTU_SECURITY_MIRROR environment variables
+  # that can be used by docker builds
   echo "UBUNTU_MIRROR=$UBUNTU_MIRROR" >> $GITHUB_ENV
+  echo "UBUNTU_SECURITY_MIRROR=$UBUNTU_MIRROR" >> $GITHUB_ENV
 }
 
 # installs a tool executable if it's not found on the PATH

--- a/build/pulsar_ci_tool.sh
+++ b/build/pulsar_ci_tool.sh
@@ -52,13 +52,39 @@ function ci_dependency_check() {
   _ci_mvn -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl '!pulsar-client-tools-test' "$@"
 }
 
+function ci_pick_ubuntu_mirror() {
+  echo "Choosing fastest ubuntu mirror based on download speed..."
+  UBUNTU_MIRROR=$({
+    curl -s http://mirrors.ubuntu.com/mirrors.txt | shuf -n 5
+    echo http://azure.archive.ubuntu.com/ubuntu/
+  } | xargs -I {} sh -c 'echo `curl -r 0-102400 -m 5 -s -w %{speed_download} -o /dev/null {}ls-lR.gz` {}' \
+    |sort -g -r |head -1| awk '{ print $2  }')
+  if [ -z "$UBUNTU_MIRROR" ]; then
+      # fallback to full mirrors list
+      UBUNTU_MIRROR="mirror://mirrors.ubuntu.com/mirrors.txt"
+  fi
+  OLD_MIRROR=$(cat /etc/apt/sources.list | grep '^deb ' | head -1 | awk '{ print $2 }')
+  echo "Picked '$UBUNTU_MIRROR'. Current mirror is '$OLD_MIRROR'."
+  if [[ "$OLD_MIRROR" != "$UBUNTU_MIRROR" ]]; then
+    sudo sed -i "s|$OLD_MIRROR|$UBUNTU_MIRROR|g" /etc/apt/sources.list
+    sudo apt-get update
+  fi
+  # set the chosen mirror also in the UBUNTU_MIRROR environment variable that can be used by docker builds
+  echo "UBUNTU_MIRROR=$UBUNTU_MIRROR" >> $GITHUB_ENV
+}
+
 # installs a tool executable if it's not found on the PATH
 function ci_install_tool() {
   local tool_executable=$1
   local tool_package=${2:-$1}
   if ! command -v $tool_executable &>/dev/null; then
     echo "::group::Installing ${tool_package}"
-    sudo apt-get -y install ${tool_package} >/dev/null
+    sudo apt-get -y install ${tool_package} >/dev/null || {
+      echo "Installing the package failed. Switching the ubuntu mirror and retrying..."
+      ci_pick_ubuntu_mirror
+      # retry after picking the ubuntu mirror
+      sudo apt-get -y install ${tool_package}
+    }
     echo '::endgroup::'
   fi
 }

--- a/build/pulsar_ci_tool.sh
+++ b/build/pulsar_ci_tool.sh
@@ -76,8 +76,13 @@ function ci_pick_ubuntu_mirror() {
   fi
   # set the chosen mirror also in the UBUNTU_MIRROR and UBUNTU_SECURITY_MIRROR environment variables
   # that can be used by docker builds
-  echo "UBUNTU_MIRROR=$UBUNTU_MIRROR" >> $GITHUB_ENV
-  echo "UBUNTU_SECURITY_MIRROR=$UBUNTU_MIRROR" >> $GITHUB_ENV
+  export UBUNTU_MIRROR
+  export UBUNTU_SECURITY_MIRROR=$UBUNTU_MIRROR
+  # make environment variables available for later GitHub Actions steps
+  if [ -n "$GITHUB_ENV" ]; then
+    echo "UBUNTU_MIRROR=$UBUNTU_MIRROR" >> $GITHUB_ENV
+    echo "UBUNTU_SECURITY_MIRROR=$UBUNTU_SECURITY_MIRROR" >> $GITHUB_ENV
+  fi
 }
 
 # installs a tool executable if it's not found on the PATH

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -57,7 +57,7 @@ ARG UBUNTU_SECURITY_MIRROR=http://security.ubuntu.com/ubuntu/
 
 # Install some utilities
 RUN sed -i -e "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-mirror://mirrors.ubuntu.com/mirrors.txt}|g" \
-     -e "s|http://security\.ubuntu\.com/ubuntu/|${UBUNTU_SECURITY_MIRROR:-http://security.ubuntu.com/ubuntu/}|g" etc/apt/sources.list \
+     -e "s|http://security\.ubuntu\.com/ubuntu/|${UBUNTU_SECURITY_MIRROR:-http://security.ubuntu.com/ubuntu/}|g" /etc/apt/sources.list \
      && echo 'Acquire::http::Timeout "30";\nAcquire::ftp::Timeout "30";\nAcquire::Retries "3";' > /etc/apt/apt.conf.d/99timeout_and_retries \
      && apt-get update \
      && apt-get -y dist-upgrade \

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -53,9 +53,11 @@ FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG UBUNTU_MIRROR=mirror://mirrors.ubuntu.com/mirrors.txt
+ARG UBUNTU_SECURITY_MIRROR=http://security.ubuntu.com/ubuntu/
 
 # Install some utilities
-RUN sed -i "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-mirror://mirrors.ubuntu.com/mirrors.txt}|g" /etc/apt/sources.list \
+RUN sed -i -e "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-mirror://mirrors.ubuntu.com/mirrors.txt}|g" \
+     -e "s|http://security\.ubuntu\.com/ubuntu/|${UBUNTU_SECURITY_MIRROR:-http://security.ubuntu.com/ubuntu/}|g" etc/apt/sources.list \
      && echo 'Acquire::http::Timeout "30";\nAcquire::ftp::Timeout "30";\nAcquire::Retries "3";' > /etc/apt/apt.conf.d/99timeout_and_retries \
      && apt-get update \
      && apt-get -y dist-upgrade \

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -54,6 +54,7 @@
         <docker.buildArg.PULSAR_TARBALL>target/pulsar-server-distribution-${project.version}-bin.tar.gz</docker.buildArg.PULSAR_TARBALL>
         <docker.buildArg.PULSAR_CLIENT_PYTHON_VERSION>${pulsar.client.python.version}</docker.buildArg.PULSAR_CLIENT_PYTHON_VERSION>
         <docker.buildArg.UBUNTU_MIRROR>${env.UBUNTU_MIRROR}</docker.buildArg.UBUNTU_MIRROR>
+        <docker.buildArg.UBUNTU_SECURITY_MIRROR>${env.UBUNTU_SECURITY_MIRROR}</docker.buildArg.UBUNTU_SECURITY_MIRROR>
       </properties>
       <build>
         <plugins>

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -34,8 +34,10 @@ WORKDIR /pulsar
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG UBUNTU_MIRROR=mirror://mirrors.ubuntu.com/mirrors.txt
+ARG UBUNTU_SECURITY_MIRROR=http://security.ubuntu.com/ubuntu/
 
-RUN sed -i "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-mirror://mirrors.ubuntu.com/mirrors.txt}|g" /etc/apt/sources.list \
+RUN sed -i -e "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-mirror://mirrors.ubuntu.com/mirrors.txt}|g" \
+     -e "s|http://security\.ubuntu\.com/ubuntu/|${UBUNTU_SECURITY_MIRROR:-http://security.ubuntu.com/ubuntu/}|g" etc/apt/sources.list \
      && apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install wget apt-transport-https

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -37,7 +37,7 @@ ARG UBUNTU_MIRROR=mirror://mirrors.ubuntu.com/mirrors.txt
 ARG UBUNTU_SECURITY_MIRROR=http://security.ubuntu.com/ubuntu/
 
 RUN sed -i -e "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-mirror://mirrors.ubuntu.com/mirrors.txt}|g" \
-     -e "s|http://security\.ubuntu\.com/ubuntu/|${UBUNTU_SECURITY_MIRROR:-http://security.ubuntu.com/ubuntu/}|g" etc/apt/sources.list \
+     -e "s|http://security\.ubuntu\.com/ubuntu/|${UBUNTU_SECURITY_MIRROR:-http://security.ubuntu.com/ubuntu/}|g" /etc/apt/sources.list \
      && apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install wget apt-transport-https

--- a/tests/docker-images/java-test-image/pom.xml
+++ b/tests/docker-images/java-test-image/pom.xml
@@ -36,6 +36,7 @@
       <properties>
         <docker.buildArg.PULSAR_TARBALL>target/pulsar-server-distribution-bin.tar.gz</docker.buildArg.PULSAR_TARBALL>
         <docker.buildArg.UBUNTU_MIRROR>${env.UBUNTU_MIRROR}</docker.buildArg.UBUNTU_MIRROR>
+        <docker.buildArg.UBUNTU_SECURITY_MIRROR>${env.UBUNTU_SECURITY_MIRROR}</docker.buildArg.UBUNTU_SECURITY_MIRROR>
       </properties>
       <activation>
         <property>


### PR DESCRIPTION
### Motivation

There's a problem with azure.archive.ubuntu.com apt mirror that causes many builds to fail. I reported it by adding a comment to an existing issue: https://github.com/actions/runner-images/issues/675#issuecomment-1381389712 . However, there's a need to apply a fix so that apache/pulsar CI doesn't get blocked by the problem.

### Modifications

- use custom shell script to pick the closest available ubuntu mirror if apt-get install fails
  -  script is based on https://askubuntu.com/a/719551 with some improvements
- set the chosen mirror to UBUNTU_MIRROR and UBUNTU_SECURITY_MIRROR environment variables to be used in docker image building

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->