### PR TITLE
[improve][misc] Follow up on ObjectMapper sharing changes

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/ObjectMapperFactory.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/ObjectMapperFactory.java
@@ -266,24 +266,26 @@ public class ObjectMapperFactory {
     }
 
     /**
-     * Clears the caches tied to the ObjectMapper instances.
-     * This is used in tests to ensure that classloaders and class references don't leak between tests.
-     * Jackson's ObjectMapper doesn't expose a public API for clearing all caches so this solution is partial.
+     * Clears the caches tied to the ObjectMapper instances and replaces the singleton ObjectMapper instance.
+     *
+     * This can be used in tests to ensure that classloaders and class references don't leak across tests.
      */
     public static void clearCaches() {
-        clearCachesForObjectMapper(getMapper().getObjectMapper());
-        clearCachesForObjectMapper(getYamlMapper().getObjectMapper());
+        clearTypeFactoryCache(getMapper().getObjectMapper());
+        clearTypeFactoryCache(getYamlMapper().getObjectMapper());
+        clearTypeFactoryCache(getMapperWithIncludeAlways().getObjectMapper());
+        replaceSingletonInstances();
     }
 
-    private static void clearCachesForObjectMapper(ObjectMapper objectMapper) {
+    private static void clearTypeFactoryCache(ObjectMapper objectMapper) {
         objectMapper.getTypeFactory().clearCache();
     }
 
-    /**
+    /*
      * Replaces the existing singleton ObjectMapper instances with new instances.
      * This is used in tests to ensure that classloaders and class references don't leak between tests.
      */
-    public static void refresh() {
+    private static void replaceSingletonInstances() {
         MAPPER_REFERENCE.set(new MapperReference(createObjectMapperInstance()));
         INSTANCE_WITH_INCLUDE_ALWAYS.set(new MapperReference(createObjectMapperWithIncludeAlways()));
         YAML_MAPPER_REFERENCE.set(new MapperReference(createYamlInstance()));


### PR DESCRIPTION
### Motivation

Follow up on ObjectMapper sharing changes made in #19160.


### Modifications

- use ObjectMapperFactory.create() to create a new ObjectMapper for JSONSchema
- simplify state clean up methods so that ObjectMapperFactory and JSONSchema both have a single static method "clearCaches()" to clean up state
  - this is useful in tests so that classes / classloaders don't leak between tests
- update custom TestNG listener SingletonCleanerListener to call the methods

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/130

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->