### PR TITLE
[fix][build] Fix "An error has occurred in JaCoCo report generation"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@ flexible messaging model and an intuitive client API.</description>
     <testRetryCount>1</testRetryCount>
     <testJacocoAgentArgument/>
     <testHeapDumpPath>/tmp</testHeapDumpPath>
+    <surefire.shutdown>kill</surefire.shutdown>
     <docker.organization>apachepulsar</docker.organization>
     <skipSourceReleaseAssembly>false</skipSourceReleaseAssembly>
     <skipBuildDistribution>false</skipBuildDistribution>
@@ -1485,7 +1486,7 @@ flexible messaging model and an intuitive client API.</description>
           </argLine>
           <reuseForks>${testReuseFork}</reuseForks>
           <forkCount>${testForkCount}</forkCount>
-          <shutdown>kill</shutdown>
+          <shutdown>${surefire.shutdown}</shutdown>
           <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
           <trimStackTrace>false</trimStackTrace>
           <systemPropertyVariables>
@@ -1938,6 +1939,7 @@ flexible messaging model and an intuitive client API.</description>
       <id>coverage</id>
       <properties>
         <testJacocoAgentArgument>@{jacoco.agent.argument}</testJacocoAgentArgument>
+        <surefire.shutdown>exit</surefire.shutdown>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
Fixes #19227

### Motivation

Builds fail sporadically with error message `An error has occurred in JaCoCo report generation. Error while creating report: Unknown block type 61.` in CI. One possible reason is that jacoco write the coverage file in a shutdown hook and this is terminated when surefire.shutdown is set to `kill`.

### Modifications

- set surefire.shutdown to "exit" when "coverage" profile is active
  - jacoco doesn't support using the surefire.shutdown=kill mode

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/131

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->