### PR TITLE
[branch-2.11][ci] Fix license check issue

### DIFF
--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -398,7 +398,7 @@ The Apache Software License, Version 2.0
     - websocket-api-9.4.48.v20220622.jar
     - websocket-client-9.4.48.v20220622.jar
     - websocket-common-9.4.48.v20220622.jar
- * SnakeYaml -- snakeyaml-1.31.jar
+ * SnakeYaml -- snakeyaml-1.32.jar
  * Google Error Prone Annotations - error_prone_annotations-2.5.1.jar
  * Javassist -- javassist-3.25.0-GA.jar
   * Apache Avro


### PR DESCRIPTION
### Motivation

Fix license check issues that occur in #19206, and #19205.
This may introduce by #17779

```
Run src/check-binary-license.sh ./distribution/server/target/apache-pulsar-*-bin.tar.gz && src/check-binary-license.sh ./distribution/shell/target/apache-pulsar-shell-*-bin.tar.gz
snakeyaml-1.32.jar unaccounted for in LICENSE
snakeyaml-1.31.jar mentioned in LICENSE, but not bundled

```


### Documentation

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->


### Matching PR in forked repository

PR in forked repository:  https://github.com/Technoboy-/pulsar/pull/27
