### PR TITLE
[fix][ci] Pick ubuntu mirror that uses http://

### DIFF
--- a/build/pulsar_ci_tool.sh
+++ b/build/pulsar_ci_tool.sh
@@ -57,8 +57,9 @@ function ci_pick_ubuntu_mirror() {
   UBUNTU_MIRROR=$({
     # choose mirrors that are up-to-date by checking the Last-Modified header for
     {
-      # randomly choose up to 10 mirrors
-      curl -s http://mirrors.ubuntu.com/mirrors.txt | shuf -n 10
+      # randomly choose up to 10 mirrors using http:// protocol
+      # (https isn't supported in docker containers that don't have ca-certificates installed)
+      curl -s http://mirrors.ubuntu.com/mirrors.txt | grep '^http://' | shuf -n 10
       # also consider Azure's Ubuntu mirror
       echo http://azure.archive.ubuntu.com/ubuntu/
     } | xargs -I {} sh -c 'echo "$(curl -m 5 -sI {}dists/$(lsb_release -c | cut -f2)-security/Contents-$(dpkg --print-architecture).gz|sed s/\\r\$//|grep Last-Modified|awk -F": " "{ print \$2 }" | LANG=C date -f- -u +%s)" "{}"' | sort -rg | awk '{ if (NR==1) TS=$1; if ($1 == TS) print $2 }'


### PR DESCRIPTION
### Motivation

- docker image building fails with https:// mirrors because of missing ca-certificates package
- follow up on #19225 changes

example failure: https://github.com/apache/pulsar/actions/runs/3917809248/jobs/6697895837#step:11:9928

```
[INFO] DOCKER> Err:7 https://mirror.fcix.net/ubuntu focal-backports Release
[INFO] DOCKER> Certificate verification failed: The certificate is NOT trusted. The certificate issuer is unknown.  Could not handshake: Error in the certificate verification. [IP: 23.152.160.16 443]
[INFO] DOCKER> Err:8 https://mirror.fcix.net/ubuntu focal-security Release
  Certificate verification failed: The certificate is NOT trusted. The certificate issuer is unknown.  Could not handshake: Error in the certificate verification. [IP: 23.152.160.16 443]
[INFO] DOCKER> Reading package lists...
[INFO] DOCKER> 
[INFO] DOCKER> [91mW: https://mirror.fcix.net/ubuntu/dists/focal/InRelease: No system certificates available. Try installing ca-certificates.
```

### Modifications

- require mirror with "http://"

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->