### PR TITLE
[improve][broker] Follow up #19230 to tighten the validation scope

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1034,6 +1034,11 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         try {
             validateTopicName(tenant, namespace, encodedTopic);
+            if (topicName.isPartitioned()) {
+                // There's no way to create the partition topic with `-partition-{index}`, So we can reject it.
+                throw new RestException(Response.Status.PRECONDITION_FAILED,
+                        "Partitioned Topic Name should not contain '-partition-'");
+            }
             internalDeletePartitionedTopic(asyncResponse, authoritative, force);
         } catch (WebApplicationException wae) {
             asyncResponse.resume(wae);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PartitionKeywordCompatibilityTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PartitionKeywordCompatibilityTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service.persistent;
 
 
+import static org.testng.Assert.fail;
 import lombok.Cleanup;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -73,5 +74,31 @@ public class PartitionKeywordCompatibilityTest extends BrokerTestBase {
         partitionedTopicList = admin.topics().getPartitionedTopicList("public/default");
         Assert.assertFalse(topics.contains(topicName));
         Assert.assertFalse(partitionedTopicList.contains(topicName));
+    }
+
+    @Test
+    public void testDeletePartitionedTopicValidation() throws PulsarAdminException {
+        final String topicName = "persistent://public/default/testDeletePartitionedTopicValidation";
+        final String partitionKeywordTopic = "persistent://public/default/testDelete-partition-edTopicValidation";
+        final String partitionedTopic = "persistent://public/default/testDeletePartitionedTopicValidation-partition-0";
+        try {
+            admin.topics().deletePartitionedTopic(topicName);
+            fail("expect not found!");
+        } catch (PulsarAdminException.NotFoundException ex) {
+            //ok
+        }
+        try {
+            admin.topics().deletePartitionedTopic(partitionKeywordTopic);
+            fail("expect not found!");
+        } catch (PulsarAdminException.NotFoundException ex) {
+            //ok
+        }
+        try {
+            admin.topics().deletePartitionedTopic(partitionedTopic);
+            fail("expect illegal argument");
+        } catch (PulsarAdminException.PreconditionFailedException ex) {
+            Assert.assertTrue(ex.getMessage().contains("should not contain '-partition-'"));
+            // ok
+        }
     }
 }


### PR DESCRIPTION
### Motivation
This PR is following up #19230

As @yuruguo mentioned https://github.com/apache/pulsar/pull/19230#issuecomment-1382865057, we can tighten the validation scope.

I've checked the logic and found we have no way to create the partition topic with the `-partition-{index}` template. So we can righten the validation scope.

I will keep working on the partition topic section and try to clarify the concept and logic. Plus, ensuring compatibility.

### Modifications

- tighten the validation scope

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->