### PR TITLE
[fix][ci] Fix codecov reporting by configuring to wait for all builds sending coverage

### DIFF
--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -1,0 +1,58 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Upload to Codecov with retries
+description: |
+  Uploads to codecov with multiple retries as a workaround 
+  for these issues
+    - https://github.com/codecov/codecov-action/issues/598
+    - https://github.com/codecov/codecov-action/issues/837
+inputs:
+  flags:
+    # see https://github.com/codecov/codecov-action#arguments
+    description: 'Flag the upload to group coverage metrics. Multiple flags are separated by a comma.'
+runs:
+  using: composite
+  steps:
+    - name: "Upload to Codecov (attempt #1)"
+      id: codecov-upload-1
+      uses: codecov/codecov-action@v3
+      continue-on-error: true
+      with:
+        flags: ${{ inputs.flags }}
+        fail_ci_if_error: true
+        verbose: true
+    - name: "Upload to Codecov (attempt #2)"
+      id: codecov-upload-2
+      if: steps.codecov-upload-1.outcome == 'failure'
+      uses: codecov/codecov-action@v3
+      continue-on-error: true
+      with:
+        flags: ${{ inputs.flags }}
+        fail_ci_if_error: true
+        verbose: true
+    - name: "Upload to Codecov (attempt #3)"
+      id: codecov-upload-3
+      if: steps.codecov-upload-2.outcome == 'failure'
+      uses: codecov/codecov-action@v3
+      continue-on-error: true
+      with:
+        flags: ${{ inputs.flags }}
+        fail_ci_if_error: true
+        verbose: true

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -129,8 +129,7 @@ jobs:
 
       - name: Upload to Codecov
         if: ${{ github.repository == 'apache/pulsar' }}
-        uses: codecov/codecov-action@v3
-        continue-on-error: true
+        uses: ./.github/actions/upload-coverage
         with:
           flags: unittests
 

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -127,6 +127,13 @@ jobs:
         if: ${{ always() }}
         uses: ./.github/actions/copy-test-reports
 
+      - name: Upload to Codecov
+        if: ${{ github.repository == 'apache/pulsar' }}
+        uses: codecov/codecov-action@v3
+        continue-on-error: true
+        with:
+          flags: unittests
+
       - name: Publish Test Report
         uses: apache/pulsar-test-infra/action-junit-report@master
         if: ${{ always() }}

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -248,8 +248,7 @@ jobs:
 
       - name: Upload to Codecov
         if: ${{ github.repository == 'apache/pulsar' }}
-        uses: codecov/codecov-action@v3
-        continue-on-error: true
+        uses: ./.github/actions/upload-coverage
         with:
           flags: unittests
 

--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -33,19 +33,16 @@ function mvn_test() {
         clean_arg="clean"
         shift
     fi
-    if echo "${FUNCNAME[@]}" | grep "flaky"; then
-      TARGET="verify"
-    else
-      TARGET="verify -Pcoverage"
-    fi
+    local coverage_arg="-Pcoverage"
+    local target="verify"
     if [[ "$1" == "--install" ]]; then
-      TARGET="install"
+      target="install"
       shift
     fi
     echo "::group::Run tests for " "$@"
     # use "verify" instead of "test" to workaround MDEP-187 issue in pulsar-functions-worker and pulsar-broker projects with the maven-dependency-plugin's copy goal
     # Error message was "Artifact has not been packaged yet. When used on reactor artifact, copy should be executed after packaging: see MDEP-187"
-    $MVN_TEST_OPTIONS $clean_arg $TARGET "$@" "${COMMANDLINE_ARGS[@]}"
+    $MVN_TEST_OPTIONS $clean_arg $target $coverage_arg "$@" "${COMMANDLINE_ARGS[@]}"
     echo "::endgroup::"
     set +x
     "$SCRIPT_DIR/pulsar_ci_tool.sh" move_test_reports

--- a/codecov.yml
+++ b/codecov.yml
@@ -19,8 +19,14 @@
 
 codecov:
   require_ci_to_pass: yes
+  notify:
+    # should match the number of builds sending coverage reports
+    # currently pulsar-ci.yaml contains 9 builds and pulsar-ci-flaky.yaml contains 1 build
+    after_n_builds: 10
 
 comment:
+  # should match the number of builds sending coverage reports
+  after_n_builds: 10
   layout: "reach, diff, flags, files"
   behavior: default
   require_changes: false

--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@ flexible messaging model and an intuitive client API.</description>
     <git-commit-id-plugin.version>4.0.2</git-commit-id-plugin.version>
     <wagon-ssh-external.version>3.4.3</wagon-ssh-external.version>
     <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
-    <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
     <spotbugs-maven-plugin.version>4.2.2</spotbugs-maven-plugin.version>
     <spotbugs.version>4.2.2</spotbugs.version>
     <errorprone.version>2.5.1</errorprone.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1487,6 +1487,7 @@ flexible messaging model and an intuitive client API.</description>
           <reuseForks>${testReuseFork}</reuseForks>
           <forkCount>${testForkCount}</forkCount>
           <shutdown>${surefire.shutdown}</shutdown>
+          <forkedProcessExitTimeoutInSeconds>60</forkedProcessExitTimeoutInSeconds>
           <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
           <trimStackTrace>false</trimStackTrace>
           <systemPropertyVariables>


### PR DESCRIPTION
### Motivation

- currently the codecov reporting processes the uploaded coverage reports too early and thus the coverage result is invalid.
- the `after_n_builds` configuration setting should be used for waiting for all builds to finish before merging the coverage reports from parallel builds.
  - see https://docs.codecov.com/docs/notifications#preventing-notifications-until-after-n-builds

### Modifications

Set `after_n_builds` to 10.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->