### PR TITLE
[branch-2.9] Fix compile error caused by cherry-pick #19167.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
@@ -46,8 +46,7 @@ public class MessageRedeliveryController {
         if (!allowOutOfOrderDelivery) {
             this.hashesToBeBlocked = ConcurrentLongLongPairHashMap
                     .newBuilder().concurrencyLevel(2).expectedItems(128).autoShrink(true).build();
-            this.hashesRefCount = ConcurrentLongLongHashMap
-                    .newBuilder().concurrencyLevel(2).expectedItems(128).autoShrink(true).build();
+            this.hashesRefCount = new ConcurrentLongLongHashMap(128, 2);
         } else {
             this.hashesToBeBlocked = null;
             this.hashesRefCount = null;


### PR DESCRIPTION
## Motivation

Fix compile error caused by cherry-pick #19167 

The commit is https://github.com/apache/pulsar/commit/e310713be433e6e36a4191deb74ae8e5d0a03820

<img width="858" alt="image" src="https://user-images.githubusercontent.com/74767115/212631756-2f2be172-2ecd-41a9-8e1e-b9c7b75a73ec.png">

## Modification

- Use the constructor instead of the builder pattern.