### PR TITLE
[fix] [broker] Counter of pending send messages in Replicator incorrect if schema future not complete

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
@@ -187,6 +187,7 @@ public class GeoPersistentReplicator extends PersistentReplicator {
                     PENDING_MESSAGES_UPDATER.incrementAndGet(this);
                     shouldRollbackPendingSendAdd.setTrue();
                     producer.sendAsync(msg, ProducerSendCallback.create(this, entry, msg));
+                    shouldRollbackPendingSendAdd.setFalse();
                     atLeastOneMessageSentForReplication = true;
                 }
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
@@ -25,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.client.api.transaction.TxnID;
@@ -57,6 +58,7 @@ public class GeoPersistentReplicator extends PersistentReplicator {
         boolean isEnableReplicatedSubscriptions =
                 brokerService.pulsar().getConfiguration().isEnableReplicatedSubscriptions();
 
+        final MutableBoolean shouldRollbackPendingSendAdd = new MutableBoolean(false);
         try {
             // This flag is set to true when we skip at least one local message,
             // in order to skip remaining local messages.
@@ -152,6 +154,7 @@ public class GeoPersistentReplicator extends PersistentReplicator {
 
                 // Increment pending messages for messages produced locally
                 PENDING_MESSAGES_UPDATER.incrementAndGet(this);
+                shouldRollbackPendingSendAdd.setTrue();
 
                 msgOut.recordEvent(headersAndPayload.readableBytes());
 
@@ -161,6 +164,8 @@ public class GeoPersistentReplicator extends PersistentReplicator {
 
                 CompletableFuture<SchemaInfo> schemaFuture = getSchemaInfo(msg);
                 if (!schemaFuture.isDone() || schemaFuture.isCompletedExceptionally()) {
+                    PENDING_MESSAGES_UPDATER.decrementAndGet(this);
+                    shouldRollbackPendingSendAdd.setFalse();
                     entry.release();
                     headersAndPayload.release();
                     msg.recycle();
@@ -185,11 +190,17 @@ public class GeoPersistentReplicator extends PersistentReplicator {
                     msg.getMessageBuilder().clearTxnidMostBits();
                     msg.getMessageBuilder().clearTxnidLeastBits();
                     producer.sendAsync(msg, ProducerSendCallback.create(this, entry, msg));
+                    shouldRollbackPendingSendAdd.setFalse();
                     atLeastOneMessageSentForReplication = true;
                 }
             }
         } catch (Exception e) {
-            log.error("[{}] Unexpected exception: {}", replicatorId, e.getMessage(), e);
+            log.error("[{}] Unexpected exception in replication task: {}", replicatorId, e.getMessage(), e);
+        } finally {
+            if (shouldRollbackPendingSendAdd.isTrue()){
+                PENDING_MESSAGES_UPDATER.decrementAndGet(this);
+                shouldRollbackPendingSendAdd.setFalse();
+            }
         }
         return atLeastOneMessageSentForReplication;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ShadowReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ShadowReplicator.java
@@ -24,6 +24,7 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.client.impl.MessageIdImpl;
@@ -57,6 +58,7 @@ public class ShadowReplicator extends PersistentReplicator {
     protected boolean replicateEntries(List<Entry> entries) {
         boolean atLeastOneMessageSentForReplication = false;
 
+        final MutableBoolean shouldRollbackPendingSendAdd = new MutableBoolean(false);
         try {
             // This flag is set to true when we skip at least one local message,
             // in order to skip remaining local messages.
@@ -113,10 +115,15 @@ public class ShadowReplicator extends PersistentReplicator {
 
                 // Increment pending messages for messages produced locally
                 PENDING_MESSAGES_UPDATER.incrementAndGet(this);
+                shouldRollbackPendingSendAdd.setTrue();
                 producer.sendAsync(msg, ProducerSendCallback.create(this, entry, msg));
                 atLeastOneMessageSentForReplication = true;
             }
         } catch (Exception e) {
+            if (shouldRollbackPendingSendAdd.isTrue()) {
+                PENDING_MESSAGES_UPDATER.decrementAndGet(this);
+                shouldRollbackPendingSendAdd.setFalse();
+            }
             log.error("[{}] Unexpected exception in replication task for shadow topic: {}",
                     replicatorId, e.getMessage(), e);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ShadowReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ShadowReplicator.java
@@ -24,6 +24,7 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.client.impl.MessageIdImpl;
@@ -57,6 +58,7 @@ public class ShadowReplicator extends PersistentReplicator {
     protected boolean replicateEntries(List<Entry> entries) {
         boolean atLeastOneMessageSentForReplication = false;
 
+        final MutableBoolean shouldRollbackPendingSendAdd = new MutableBoolean(false);
         try {
             // This flag is set to true when we skip at least one local message,
             // in order to skip remaining local messages.
@@ -105,6 +107,7 @@ public class ShadowReplicator extends PersistentReplicator {
 
                 // Increment pending messages for messages produced locally
                 PENDING_MESSAGES_UPDATER.incrementAndGet(this);
+                shouldRollbackPendingSendAdd.setTrue();
 
                 msgOut.recordEvent(headersAndPayload.readableBytes());
 
@@ -115,10 +118,17 @@ public class ShadowReplicator extends PersistentReplicator {
                 headersAndPayload.retain();
 
                 producer.sendAsync(msg, ProducerSendCallback.create(this, entry, msg));
+                shouldRollbackPendingSendAdd.setFalse();
                 atLeastOneMessageSentForReplication = true;
             }
         } catch (Exception e) {
-            log.error("[{}] Unexpected exception: {}", replicatorId, e.getMessage(), e);
+            log.error("[{}] Unexpected exception in replication task for shadow topic: {}",
+                    replicatorId, e.getMessage(), e);
+        } finally {
+            if (shouldRollbackPendingSendAdd.isTrue()) {
+                PENDING_MESSAGES_UPDATER.decrementAndGet(this);
+                shouldRollbackPendingSendAdd.setFalse();
+            }
         }
         return atLeastOneMessageSentForReplication;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ShadowReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ShadowReplicator.java
@@ -117,6 +117,7 @@ public class ShadowReplicator extends PersistentReplicator {
                 PENDING_MESSAGES_UPDATER.incrementAndGet(this);
                 shouldRollbackPendingSendAdd.setTrue();
                 producer.sendAsync(msg, ProducerSendCallback.create(this, entry, msg));
+                shouldRollbackPendingSendAdd.setFalse();
                 atLeastOneMessageSentForReplication = true;
             }
         } catch (Exception e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -51,7 +51,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -558,7 +558,6 @@ public class ReplicatorTest extends ReplicatorTestBase {
                     producer.close();
                     Thread.sleep(100);
                 } catch (Exception e){
-                    e.printStackTrace();
                 }
             }
         });

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -571,7 +571,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         pulsar1.getConfiguration().setReplicationProducerQueueSize(originalReplicationProducerQueueSize);
     }
 
-    public static void waitReplicateFinish(TopicName topicName, PulsarAdmin admin){
+    private static void waitReplicateFinish(TopicName topicName, PulsarAdmin admin){
         Awaitility.await().untilAsserted(() -> {
             for (Map.Entry<String, ? extends ReplicatorStats> subStats :
                     admin.topics().getStats(topicName.toString(), true, false, false).getReplication().entrySet()){
@@ -580,7 +580,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         });
     }
 
-    public static PersistentReplicator ensureReplicatorCreated(TopicName topicName, PulsarService pulsar) {
+    private static PersistentReplicator ensureReplicatorCreated(TopicName topicName, PulsarService pulsar) {
         PersistentTopic persistentTopic =
                 (PersistentTopic) pulsar.getBrokerService().getTopic(topicName.toString(), false).join().get();
         Awaitility.await().until(() -> !persistentTopic.getReplicators().isEmpty());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -520,6 +520,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
 
     @Test
     public void testReplicationWillNotStuckByIncompleteSchemaFuture() throws Exception {
+        int originalReplicationProducerQueueSize = pulsar1.getConfiguration().getReplicationProducerQueueSize();
         pulsar1.getConfiguration().setReplicationProducerQueueSize(5);
         // Init replicator and send many messages.
         PulsarClient client1 = pulsar1.getClient();
@@ -568,6 +569,9 @@ public class ReplicatorTest extends ReplicatorTestBase {
         ensureReplicatorCreated(topic, pulsar1);
         sendTask.join();
         waitReplicateFinish(topic, admin1);
+
+        // cleanup
+        pulsar1.getConfiguration().setReplicationProducerQueueSize(originalReplicationProducerQueueSize);
     }
 
     public static void waitReplicateFinish(TopicName topicName, PulsarAdmin admin){

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -551,7 +551,6 @@ public class ReplicatorTest extends ReplicatorTestBase {
                         """, i)).build());
                     Producer producer = client1
                             .newProducer(schema)
-                            .producerName("ABC_" + UUID.randomUUID().toString())
                             .topic(topic.toString())
                             .create();
                     producer.send(String.valueOf(i).toString().getBytes());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.broker.service;
 import static org.apache.pulsar.broker.BrokerTestUtil.newUniqueName;
 import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.retryStrategically;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
@@ -37,7 +36,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -489,46 +487,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
     }
 
     @Test
-    public void testCounterCorrectWhenWithSendError() throws Exception {
-        // Init replicator and send many messages.
-        PulsarClient client1 = pulsar1.getClient();
-        final TopicName topic = TopicName
-                .get(BrokerTestUtil.newUniqueName("persistent://pulsar/ns1/testReplicationWithGetSchemaError"));
-        final String subName = "my-sub";
-        @Cleanup
-        Consumer<GenericRecord> consumer1 = client1.newConsumer(Schema.AUTO_CONSUME())
-                .topic(topic.toString())
-                .subscriptionName(subName)
-                .receiverQueueSize(10)
-                .subscribe();
-        @Cleanup
-        Producer<Schemas.PersonOne> producer1 = client1.newProducer(Schema.AVRO(Schemas.PersonOne.class))
-                .topic(topic.toString())
-                .enableBatching(false)
-                .create();
-        for (int i = 0; i < 20; i++) {
-            producer1.send(new Schemas.PersonOne(i));
-        }
-
-        // Make error when send messages to another cluster.
-        PersistentReplicator replicator = getAnyReplicator(topic, pulsar1);
-        ManagedCursorImpl cursor = getCursor(topic, subName, pulsar1);
-        List<Entry> originalEntries = cursor.readEntries(1);
-        Entry errorEntry = spy(originalEntries.get(0));
-        doAnswer(invocation -> {
-            throw new NullPointerException("error entry in test");
-        }).when(errorEntry).getLedgerId();
-        replicator.readEntriesComplete(Collections.singletonList(errorEntry), null);
-
-        waitReplicateFinish(topic, admin1, pulsar1);
-        // Verify "pendingMessages" still is correct even if error occurs.
-        Awaitility.await().untilAsserted(() -> {
-            assertEquals((int) WhiteboxImpl.getInternalState(replicator, "pendingMessages"), 0);
-        });
-    }
-
-    @Test
-    public void testCounterCorrectWhenWaitingSchemaLoad() throws Exception {
+    public void testCounterOfPendingMessagesCorrect() throws Exception {
         // Init replicator and send many messages.
         PulsarClient client1 = pulsar1.getClient();
         final TopicName topic = TopicName
@@ -549,12 +508,9 @@ public class ReplicatorTest extends ReplicatorTestBase {
             producer.send(new Schemas.PersonOne(i));
         }
 
-        // There is a fairly high probability that schemaFuture is incomplete, so there is no need to construct the
-        // exception manually.
-        PersistentReplicator replicator = getAnyReplicator(topic, pulsar1);
-
-        waitReplicateFinish(topic, admin1, pulsar1);
         // Verify "pendingMessages" still is correct even if error occurs.
+        PersistentReplicator replicator = getAnyReplicator(topic, pulsar1);
+        waitReplicateFinish(topic, admin1, pulsar1);
         Awaitility.await().untilAsserted(() -> {
             assertEquals((int) WhiteboxImpl.getInternalState(replicator, "pendingMessages"), 0);
         });
@@ -580,12 +536,6 @@ public class ReplicatorTest extends ReplicatorTestBase {
                 (PersistentTopic) pulsar.getBrokerService().getTopic(topicName.toString(), false).join().get();
         Awaitility.await().until(() -> !persistentTopic.getReplicators().isEmpty());
         return (PersistentReplicator) persistentTopic.getReplicators().values().iterator().next();
-    }
-
-    public static ManagedCursorImpl getCursor(TopicName topicName, String subName, PulsarService pulsar) throws Exception{
-        PersistentTopic persistentTopic =
-                (PersistentTopic) pulsar.getBrokerService().getTopic(topicName.toString(), false).join().get();
-        return (ManagedCursorImpl) persistentTopic.getSubscription(subName).getCursor();
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ShadowReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ShadowReplicatorTest.java
@@ -181,7 +181,7 @@ public class ShadowReplicatorTest extends BrokerTestBase {
 
         // Verify "pendingMessages" still is correct even if error occurs.
         PersistentReplicator replicator = getAnyShadowReplicator(sourceTopicName, pulsar);
-        ReplicatorTest.waitReplicateFinish(sourceTopicName, admin, pulsar);
+        ReplicatorTest.waitReplicateFinish(sourceTopicName, admin);
         Awaitility.await().untilAsserted(() -> {
             assertEquals((int) WhiteboxImpl.getInternalState(replicator, "pendingMessages"), 0);
         });


### PR DESCRIPTION
### Motivation
The Replication task execution process works like this:
- read messages from the origin cluster
- load schema
- send to the target cluster

Because the network across the cluster is unstable, the sending task may be slower, so if the number of messages being sent is too large, the replication task will be suspended. There is a counter(`pendingMessages `) in `Replicator` indicating the count of sending messages. 

<strong>(Highlight)</strong>There is a problem that causes the counter to be inaccurate when the scheme future is incomplete. If the counter is as large as the config `replicationProducerQueueSize,` the replication task will be stuck. You can reproduce by `ReplicatorTest.testReplicationWillNotStuckByIncompleteSchemaFuture`.

### Modifications
- Make that the counter is correct when exceptions occur or the `schemaFuture` is incomplete
- Same change for `ShadowReplicator`

### Documentation
- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository:
- https://github.com/poorbarcode/pulsar/pull/52
