### PR TITLE
[improve][io] Upgrade HBase to 2.4.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@ flexible messaging model and an intuitive client API.</description>
     <opencensus.version>0.28.0</opencensus.version>
     <hadoop2.version>2.10.2</hadoop2.version>
     <hadoop3.version>3.3.4</hadoop3.version>
-    <hbase.version>2.4.9</hbase.version>
+    <hbase.version>2.4.15</hbase.version>
     <guava.version>31.0.1-jre</guava.version>
     <jcip.version>1.0</jcip.version>
     <prometheus-jmx.version>0.16.1</prometheus-jmx.version>


### PR DESCRIPTION
### Motivation

Currently, the HBase sink uses HBase 2.4.9, which is released over a years ago.

### Modifications

This PR upgrades HBase to the current latest version of the 2.4.x line so that we can ensure the HBase sink works with it.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `HbaseGenericRecordSinkTest`.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/sekikn/incubator-pulsar/pull/8

The CI above failed on the PULSAR_IO_ORA test group, but it's irrelevant to this PR.