### PR TITLE
[improve][ci] Upload native crash dump files hs_err_*.log & core.* in CI unit tests

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -267,12 +267,15 @@ jobs:
           path: surefire-reports
           retention-days: 7
 
-      - name: Upload possible heap dump
+      - name: Upload possible heap dump, core dump or crash files
         uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
-          name: Unit-${{ matrix.group }}-heapdump
-          path: /tmp/*.hprof
+          name: Unit-${{ matrix.group }}-dumps
+          path: |
+            /tmp/*.hprof
+            **/hs_err_*.log
+            **/core.*
           retention-days: 7
           if-no-files-found: ignore
 


### PR DESCRIPTION
### Motivation

- helps investigate issues when there's a JVM crash such as #19250

### Modifications

- upload native crash dump files hs_err_*.log & core.* in CI unit tests

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->