### PR TITLE
[improve][ci] Improve test fail fast: disable for non-PR builds, fail parallel forked test procs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,8 @@ flexible messaging model and an intuitive client API.</description>
     <testForkCount>4</testForkCount>
     <testRealAWS>false</testRealAWS>
     <testRetryCount>1</testRetryCount>
+    <testFailFast>true</testFailFast>
+    <testFailFastFile></testFailFastFile>
     <testJacocoAgentArgument/>
     <testHeapDumpPath>/tmp</testHeapDumpPath>
     <surefire.shutdown>kill</surefire.shutdown>
@@ -1493,6 +1495,8 @@ flexible messaging model and an intuitive client API.</description>
           <systemPropertyVariables>
             <testRealAWS>${testRealAWS}</testRealAWS>
             <testRetryCount>${testRetryCount}</testRetryCount>
+            <testFailFast>${testFailFast}</testFailFast>
+            <testFailFastFile>${testFailFastFile}</testFailFastFile>
           </systemPropertyVariables>
           <properties>
             <property>


### PR DESCRIPTION
### Motivation

Currently, there's a custom fail fast mode implemented as a TestNG listener in https://github.com/apache/pulsar/blob/master/buildtools/src/main/java/org/apache/pulsar/tests/FailFastNotifier.java. 
The purpose of this is to speed up pull request builds by failing the build at the first error.
Surefire's fail fast feature (`-Dsurefire.skipAfterFailureCount=1`) was unusable because of bug https://issues.apache.org/jira/browse/SUREFIRE-1762, when the solution was implemented.

The FailFastNotifier solution doesn't currently work properly since it doesn't stop parallel test processes.
This PR implements a solution for that gap.

This PR also disables the fail fast mode for all non-PR builds in GitHub Actions so that there will be better coverage for Gradle Enterprise build scans that run for apache/pulsar branches.
For example, the builds for master branch can be found at https://github.com/apache/pulsar/actions/workflows/pulsar-ci.yaml?query=branch%3Amaster . The summary view of each build contains the links to ge.apache.org Gradle Enterprise instance.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/133

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->