### PR TITLE
[fix][test] Fix pulsar-proxy test flakiness related to metrics

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
@@ -245,7 +245,6 @@ public class ProxyServiceStarter {
             if (server != null) {
                 server.stop();
             }
-            CollectorRegistry.defaultRegistry.clear();
         } catch (Exception e) {
             log.warn("server couldn't stop gracefully {}", e.getMessage(), e);
         } finally {


### PR DESCRIPTION
Fixes #19216 

### Motivation

See #19216 and #19062 . Fixes a problem with pulsar-proxy flakiness related to metrics.

### Modifications

- revert #19062 change that caused #19216 
- fix the problem that #19062 attempted to fix by tracking whether the metrics have already been registered

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->