### PR TITLE
[fix][sec] upgrade org.postgresql:postgresql to  42.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@ flexible messaging model and an intuitive client API.</description>
     <guice.version>5.1.0</guice.version>
     <sqlite-jdbc.version>3.36.0.3</sqlite-jdbc.version>
     <mysql-jdbc.version>8.0.11</mysql-jdbc.version>
-    <postgresql-jdbc.version>42.4.1</postgresql-jdbc.version>
+    <postgresql-jdbc.version>42.5.1</postgresql-jdbc.version>
     <clickhouse-jdbc.version>0.3.2-patch11</clickhouse-jdbc.version>
     <mariadb-jdbc.version>2.7.5</mariadb-jdbc.version>
     <openmldb-jdbc.version>0.4.4-hotfix1</openmldb-jdbc.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.postgresql:postgresql 42.4.1
- [CVE-2022-41946](https://www.oscs1024.com/hd/CVE-2022-41946)


### What did I do？
Upgrade org.postgresql:postgresql from 42.4.1 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->