### PR TITLE
[fix][broker] Fix more times  lookup request get the diff broker when set bundle affinity broker

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -832,6 +832,13 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         try {
             synchronized (brokerCandidateCache) {
                 final String bundle = serviceUnit.toString();
+                final String bundleRange = LoadManagerShared.getBundleRangeFromBundleName(bundle);
+                // Set bundle affinity broker to preallocatedBundleToBroker.
+                final String affinityBroker = setNamespaceBundleAffinity(bundleRange, null);
+                if (StringUtils.isNotBlank(affinityBroker) && getAvailableBrokers().contains(affinityBroker)) {
+                    preallocatedBundleToBroker.put(bundle, affinityBroker);
+                }
+
                 if (preallocatedBundleToBroker.containsKey(bundle)) {
                     // If the given bundle is already in preallocated, return the selected broker.
                     return Optional.of(preallocatedBundleToBroker.get(bundle));
@@ -913,7 +920,6 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                 preallocatedBundleToBroker.put(bundle, broker.get());
 
                 final String namespaceName = LoadManagerShared.getNamespaceNameFromBundleName(bundle);
-                final String bundleRange = LoadManagerShared.getBundleRangeFromBundleName(bundle);
                 final ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>> namespaceToBundleRange =
                         brokerToNamespaceToBundleRange
                                 .computeIfAbsent(broker.get(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerWrapper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerWrapper.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.LoadManager;
@@ -66,11 +65,6 @@ public class ModularLoadManagerWrapper implements LoadManager {
 
     @Override
     public Optional<ResourceUnit> getLeastLoaded(final ServiceUnitId serviceUnit) {
-        String bundleRange = LoadManagerShared.getBundleRangeFromBundleName(serviceUnit.toString());
-        String affinityBroker = loadManager.setNamespaceBundleAffinity(bundleRange, null);
-        if (!StringUtils.isBlank(affinityBroker)) {
-            return Optional.of(buildBrokerResourceUnit(affinityBroker));
-        }
         Optional<String> leastLoadedBroker = loadManager.selectBrokerForAssignment(serviceUnit);
         return leastLoadedBroker.map(this::buildBrokerResourceUnit);
     }


### PR DESCRIPTION
### Motivation
Some pulsar client concurrent lookup request may get different broker for assignment when we set bundle affinity broker
and unload the bundle.

The `loadManager.setNamespaceBundleAffinity` only can make sure return the correct bundle affinity broker to the first be handled request, and other request will invoke `selectBrokerForAssignment` to choice another broker as candidate broker for the bundle. 
In the concurrent time, we can not always make sure the first look up client which get the correct bundle affinity broker can completed the redirect look up request, which will cause the bundle unload to affinity broker as our exception.
https://github.com/apache/pulsar/blob/299bd70fdfa023768e94a8ee4347d39337b6cbd4/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerWrapper.java#L68-L76

So, we should set the affinity broker to `preallocatedBundleToBroker` to permit the look up request can get the same broker on the time.

### Modifications
1. Set the bundle affinity broker  to `preallocatedBundleToBroker`;
2. add some unit test;

### Documentation
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->


### Matching PR in forked repository

PR in forked repository: https://github.com/Nicklee007/pulsar/pull/8