### PR TITLE
[feat][ci] Collect code coverage for integration tests from docker containers

### DIFF
--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -19,7 +19,8 @@
 
 name: Upload to Codecov with retries
 description: |
-  Uploads to codecov with multiple retries as a workaround 
+  Checks that the current repository is public and then
+  uploads to codecov with multiple retries as a workaround 
   for these issues
     - https://github.com/codecov/codecov-action/issues/598
     - https://github.com/codecov/codecov-action/issues/837
@@ -30,8 +31,26 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: "Check that repository is public"
+      id: repo-check
+      shell: bash
+      run: |
+        if [[ "${{ github.server_url }}" != "https://github.com" ]]; then
+          echo "Not using github.com server ('${{ github.server_url }}'). Skipping uploading of coverage metrics."
+          echo "passed=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+        REPO_URL="${{ github.server_url }}/${{ github.repository }}"
+        {
+          # public repository url will respond to http HEAD request
+          curl -X HEAD -fs "$REPO_URL" && echo "passed=true" >> $GITHUB_OUTPUT
+        } || {
+          echo "$REPO_URL isn't a public repository. Skipping uploading of coverage metrics."
+          echo "passed=false" >> $GITHUB_OUTPUT
+        }
     - name: "Upload to Codecov (attempt #1)"
       id: codecov-upload-1
+      if: steps.repo-check.outputs.passed == 'true'
       uses: codecov/codecov-action@v3
       continue-on-error: true
       with:

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -128,7 +128,6 @@ jobs:
         uses: ./.github/actions/copy-test-reports
 
       - name: Upload to Codecov
-        if: ${{ github.repository == 'apache/pulsar' }}
         uses: ./.github/actions/upload-coverage
         with:
           flags: unittests

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -247,7 +247,6 @@ jobs:
         uses: ./.github/actions/copy-test-reports
 
       - name: Upload to Codecov
-        if: ${{ github.repository == 'apache/pulsar' }}
         uses: ./.github/actions/upload-coverage
         with:
           flags: unittests
@@ -377,6 +376,7 @@ jobs:
         include:
           - name: Backwards Compatibility
             group: BACKWARDS_COMPAT
+            no_coverage: true
 
           - name: Cli
             group: CLI
@@ -388,15 +388,18 @@ jobs:
             group: SHADE_RUN
             runtime_jdk: 8
             setup: ./build/run_integration_group.sh SHADE_BUILD
+            no_coverage: true
 
           - name: Shade on Java 11
             group: SHADE_RUN
             runtime_jdk: 11
             setup: ./build/run_integration_group.sh SHADE_BUILD
+            no_coverage: true
 
           - name: Shade on Java 17
             group: SHADE_RUN
             setup: ./build/run_integration_group.sh SHADE_BUILD
+            no_coverage: true
 
           - name: Standalone
             group: STANDALONE
@@ -467,7 +470,15 @@ jobs:
 
       - name: Run integration test group '${{ matrix.group }}'
         run: |
-          ./build/run_integration_group.sh ${{ matrix.group }}
+          if [[ "${{ matrix.no_coverage }}" != "true" ]]; then
+            coverage_args="--coverage"
+          fi
+          ./build/run_integration_group.sh ${{ matrix.group }} $coverage_args
+
+      - name: Upload to Codecov
+        uses: ./.github/actions/upload-coverage
+        with:
+          flags: inttests
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()
@@ -739,7 +750,12 @@ jobs:
 
       - name: Run system test group '${{ matrix.group }}'
         run: |
-          ./build/run_integration_group.sh ${{ matrix.group }}
+          ./build/run_integration_group.sh ${{ matrix.group }} --coverage
+
+      - name: Upload to Codecov
+        uses: ./.github/actions/upload-coverage
+        with:
+          flags: systests
 
       - name: print JVM thread dumps when cancelled
         if: cancelled()

--- a/codecov.yml
+++ b/codecov.yml
@@ -21,12 +21,17 @@ codecov:
   require_ci_to_pass: yes
   notify:
     # should match the number of builds sending coverage reports
-    # currently pulsar-ci.yaml contains 9 builds and pulsar-ci-flaky.yaml contains 1 build
-    after_n_builds: 10
+    # pulsar-ci.yaml contains:
+    #   - 9 unit test builds
+    #   - 4 integration test builds (without 'no_coverage: true')
+    #   - 8 system test build
+    # pulsar-ci-flaky.yaml contains:
+    #   - 1 build
+    after_n_builds: 22
 
 comment:
   # should match the number of builds sending coverage reports
-  after_n_builds: 10
+  after_n_builds: 22
   layout: "reach, diff, flags, files"
   behavior: default
   require_changes: false

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,8 @@ flexible messaging model and an intuitive client API.</description>
     <testFailFast>true</testFailFast>
     <testFailFastFile></testFailFastFile>
     <testJacocoAgentArgument/>
+    <integrationtest.coverage.enabled>false</integrationtest.coverage.enabled>
+    <integrationtest.coverage.dir>${project.build.directory}</integrationtest.coverage.dir>
     <testHeapDumpPath>/tmp</testHeapDumpPath>
     <surefire.shutdown>kill</surefire.shutdown>
     <docker.organization>apachepulsar</docker.organization>

--- a/tests/docker-images/latest-version-image/conf/bookie.conf
+++ b/tests/docker-images/latest-version-image/conf/bookie.conf
@@ -25,3 +25,4 @@ directory=/pulsar
 environment=PULSAR_MEM="-Xmx128M -XX:MaxDirectMemorySize=512M",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar bookie
 user=pulsar
+stopwaitsecs=15

--- a/tests/docker-images/latest-version-image/conf/broker.conf
+++ b/tests/docker-images/latest-version-image/conf/broker.conf
@@ -25,3 +25,4 @@ directory=/pulsar
 environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar broker
 user=pulsar
+stopwaitsecs=15

--- a/tests/docker-images/latest-version-image/conf/functions_worker.conf
+++ b/tests/docker-images/latest-version-image/conf/functions_worker.conf
@@ -25,3 +25,4 @@ directory=/pulsar
 environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar functions-worker
 user=pulsar
+stopwaitsecs=15

--- a/tests/docker-images/latest-version-image/conf/global-zk.conf
+++ b/tests/docker-images/latest-version-image/conf/global-zk.conf
@@ -25,3 +25,4 @@ directory=/pulsar
 environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar configuration-store
 user=pulsar
+stopwaitsecs=15

--- a/tests/docker-images/latest-version-image/conf/local-zk.conf
+++ b/tests/docker-images/latest-version-image/conf/local-zk.conf
@@ -25,3 +25,4 @@ directory=/pulsar
 environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar zookeeper
 user=pulsar
+stopwaitsecs=15

--- a/tests/docker-images/latest-version-image/conf/presto_worker.conf
+++ b/tests/docker-images/latest-version-image/conf/presto_worker.conf
@@ -25,3 +25,4 @@ directory=/pulsar
 environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar sql-worker start
 user=pulsar
+stopwaitsecs=15

--- a/tests/docker-images/latest-version-image/conf/proxy.conf
+++ b/tests/docker-images/latest-version-image/conf/proxy.conf
@@ -25,3 +25,4 @@ directory=/pulsar
 environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar proxy
 user=pulsar
+stopwaitsecs=15

--- a/tests/docker-images/latest-version-image/conf/websocket.conf
+++ b/tests/docker-images/latest-version-image/conf/websocket.conf
@@ -25,3 +25,4 @@ directory=/pulsar
 environment=PULSAR_MEM="-Xmx128M",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar websocket
 user=pulsar
+stopwaitsecs=15

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -280,7 +280,8 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx1G -XX:MaxDirectMemorySize=1G
-              -Dio.netty.leakDetectionLevel=advanced -Dconfluent.version=${confluent.version}
+              -Dio.netty.leakDetectionLevel=advanced -Dconfluent.version=${confluent.version} -Djacoco.version=${jacoco-maven-plugin.version}
+              -Dintegrationtest.coverage.enabled=${integrationtest.coverage.enabled} -Dintegrationtest.coverage.dir=${integrationtest.coverage.dir}
               ${test.additional.args}
               </argLine>
               <skipTests>false</skipTests>

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ChaosContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ChaosContainer.java
@@ -63,6 +63,10 @@ public class ChaosContainer<SelfT extends ChaosContainer<SelfT>> extends Generic
     @Override
     public void stop() {
         beforeStop();
+        doStop();
+    }
+
+    protected void doStop() {
         super.stop();
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ZKContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ZKContainer.java
@@ -69,4 +69,9 @@ public class ZKContainer<SelfT extends PulsarContainer<SelfT>> extends PulsarCon
             );
         }
     }
+
+    @Override
+    protected boolean isCodeCoverageEnabled() {
+        return false;
+    }
 }


### PR DESCRIPTION
### Motivation

Code coverage metrics don't currently consider integration tests and systems tests that are run as part of the Pulsar CI pipeline. There hasn't been a way to measure the total code coverage of Pulsar CI pipeline tests although it would be useful to see what parts of Pulsar code base are tested and what aren't.

### Modifications

- Add solution to Pulsar Testcontainer based integration tests so that the Jacoco agent gets activated for processes that are run inside Docker containers
  - A directory from the host is mounted in the docker container. This directory is used for storing the Jacoco exec files.
- The code coverage should be uploaded to codecov for all public code repositories. This is now changed so that it's possible to get coverage metrics for builds running in a fork.
- Graceful shutdown of Java processes is needed for collecting Jacoco exec data since by default, the Jacoco agent dumps the exec data to a file in a shutdown hook. 
  - For processes managed with supervisor, it's necessary to run "supervisorctl stop all" to trigger a graceful shutdown
    - It was necessary to stop Zookeeper last for preventing shutdown getting stuck for Brokers or Bookies.
- Creating the Jacoco XML report needed for Codecov is created using Jacoco command line tools. 
  - The script has been added as part of `build/run_integration_group.sh` script.
    - The jar files of the Docker image is needed to create the XML report from the exec files. 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/134

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->