### PR TITLE
[fix][sec] Exclude log4j from openmldb

### DIFF
--- a/pulsar-io/jdbc/openmldb/pom.xml
+++ b/pulsar-io/jdbc/openmldb/pom.xml
@@ -42,6 +42,16 @@
       <artifactId>openmldb-jdbc</artifactId>
       <version>${openmldb-jdbc.version}</version>
       <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.4paradigm.openmldb</groupId>


### PR DESCRIPTION
### Motivation

Fix [CVE-2019-17571](https://www.cve.org/CVERecord?id=CVE-2019-17571)

```
Introduced through: org.apache.pulsar:pulsar-io-jdbc-openmldb@2.12.0-SNAPSHOT › com.4paradigm.openmldb:openmldb-jdbc@0.4.4-hotfix1 › log4j:log4j@1.2.17
Introduced through: org.apache.pulsar:pulsar-io-jdbc-openmldb@2.12.0-SNAPSHOT › com.4paradigm.openmldb:openmldb-jdbc@0.4.4-hotfix1 › org.slf4j:slf4j-log4j12@1.7.21 › log4j:log4j@1.2.17
```

### Modifications

Exclude log4j from openmldb.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->