### PR TITLE
[cleanup][proxy] Remove unused AuthenticationDataSource variable

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
@@ -90,7 +90,6 @@ public class ProxyConnection extends PulsarHandler {
             new AtomicLong(ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE / 2));
     private final ProxyService service;
     private final DnsAddressResolverGroup dnsAddressResolverGroup;
-    AuthenticationDataSource authenticationData;
     private State state;
 
     private LookupProxyHandler lookupProxyHandler = null;
@@ -518,7 +517,6 @@ public class ProxyConnection extends PulsarHandler {
             }
 
             authState = authenticationProvider.newAuthState(clientData, remoteAddress, sslSession);
-            authenticationData = authState.getAuthDataSource();
             doAuthentication(clientData);
         } catch (Exception e) {
             LOG.warn("[{}] Unable to authenticate: ", remoteAddress, e);

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
@@ -47,7 +47,6 @@ import javax.net.ssl.SSLSession;
 import lombok.Getter;
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.broker.PulsarServerException;
-import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
 import org.apache.pulsar.broker.authentication.AuthenticationState;
 import org.apache.pulsar.broker.limiter.ConnectionController;


### PR DESCRIPTION
### Motivation

The `AuthenticationDataSource` variable was added to the `ProxyConnection` class in https://github.com/apache/pulsar/pull/1200. It is no longer needed.

Note that we store this variable in the `ServerCnx` because it is used for authorization. Because we do not do authorization in the proxy, we don't need it.

### Modifications

* Remove unused variable

### Verifying this change

This is a trivial change.

### Does this pull request potentially affect one of the following parts:

The only conceivable way this is a breaking change is if a third party implementation implemented their library so that `authState.getAuthDataSource()` has a side effect.

### Documentation

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->

No docs needed.