### PR TITLE
[fix][broker] Let TokenAuthState update authenticationDataSource

### DIFF
--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
@@ -23,7 +23,10 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.common.collect.Lists;
@@ -912,6 +915,40 @@ public class AuthenticationProviderTokenTest {
 
         boolean doFilter = provider.authenticateHttpRequest(servletRequest, null);
         assertTrue(doFilter, "Authentication should have passed");
+    }
+
+    @Test
+    public void testTokenStateUpdatesAuthenticationDataSource() throws Exception {
+        SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
+
+        @Cleanup
+        AuthenticationProviderToken provider = new AuthenticationProviderToken();
+
+        Properties properties = new Properties();
+        properties.setProperty(AuthenticationProviderToken.CONF_TOKEN_SECRET_KEY,
+                AuthTokenUtils.encodeKeyBase64(secretKey));
+
+        ServiceConfiguration conf = new ServiceConfiguration();
+        conf.setProperties(properties);
+        provider.initialize(conf);
+
+        String firstToken = AuthTokenUtils.createToken(secretKey, SUBJECT, Optional.empty());
+
+        AuthenticationState authState = provider.newAuthState(AuthData.of(firstToken.getBytes()),null, null);
+
+        AuthenticationDataSource firstAuthDataSource = authState.getAuthDataSource();
+        assertNotNull(firstAuthDataSource, "Should be initialized.");
+
+        String secondToken = AuthTokenUtils.createToken(secretKey, SUBJECT,
+                Optional.of(new Date(System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(3))));
+
+        AuthData challenge = authState.authenticate(AuthData.of(secondToken.getBytes()));
+        AuthenticationDataSource secondAuthDataSource = authState.getAuthDataSource();
+
+        assertNull(challenge, "TokenAuth doesn't respond with challenges");
+        assertNotNull(secondAuthDataSource, "Created authDataSource");
+
+        assertNotEquals(firstAuthDataSource, secondAuthDataSource);
     }
 
     private static String createTokenWithAudience(Key signingKey, String audienceClaim, List<String> audience) {

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
@@ -26,7 +26,6 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.common.collect.Lists;


### PR DESCRIPTION
### Motivation

We use the result of `TokenAuthenticationState#getAuthDataSource` to pass to the `AuthorizationProvider`. For custom implementations, it is important that this information is up to date.

The `TokenAuthenticationState` field `AuthenticationDataSource` is set on initialization and never again. Given that tokens can be refreshed, we should update the field `TokenAuthenticationState#authenticationDataSource` when the `authenticate` method is called.

### Modifications

* Update the `authenticationDataSource` when `authenticate` is called.

### Verifying this change

A new test is added to cover this change.

### Does this pull request potentially affect one of the following parts:

This change will  only affect third party `AuthorizationProvider` implementations. It's possible that it could break their integration, though unlikely. Note that we update the `authRole` when `authenticate` is called.

### Documentation

- [x] `doc-not-needed` 

We do not document this kind of internal behavior anywhere.

### Matching PR in forked repository

PR in forked repository: https://github.com/michaeljmarshall/pulsar/pull/15