### PR TITLE
[improve][broker] Documentation for AuthenticationState contract

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationState.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationState.java
@@ -18,16 +18,25 @@
  */
 package org.apache.pulsar.broker.authentication;
 
+import java.net.SocketAddress;
 import java.util.concurrent.CompletableFuture;
 import javax.naming.AuthenticationException;
+import javax.net.ssl.SSLSession;
 import org.apache.pulsar.common.api.AuthData;
 import org.apache.pulsar.common.util.FutureUtil;
 
 /**
  * Interface for authentication state.
- *
- * It tell broker whether the authentication is completed or not,
- * if completed, what is the AuthRole is.
+ * <p>
+ * Pulsar integrates with this class in the following order:
+ * 1. Initialize the class by calling {@link AuthenticationProvider#newAuthState(AuthData, SocketAddress, SSLSession)}
+ * 2. Call {@link #authenticate(AuthData)}. If result is not null, send to client. And call
+ *    {@link #authenticate(AuthData)} with the client's response. Repeat until result of {@link #authenticate(AuthData)}
+ *    is null or an exception.
+ * 3. Call {@link #getAuthRole()} and {@link #getAuthDataSource()} to use for authentication. It is expected that these
+ *    responses update with each call to {@link #authenticate(AuthData)}.
+ * 4. Poll {@link #isExpired()} until it returns true.
+ * 5. Call {@link #refreshAuthentication()} and GoTo step 2 when client responds.
  */
 public interface AuthenticationState {
     /**


### PR DESCRIPTION
PIP 97: https://github.com/apache/pulsar/issues/12105

### Motivation

While working on PIP 97, I noticed that we do not have a clear contract for the `AuthenticationState` interface. We use the interface in one way in the `ServerCnx` class, but some of our official implementations do not align with the usage and the API. The PR itself provides my proposed authoritative documentation.

When we agree on the content of this PR, I will follow up with some changes to the `TokenAuthenticationState` class and potentially others.

### Modifications

* Add documentation on how the `AuthenticationState` interface will be used by Pulsar.

### Verifying this change

I have studied the code closely to understand how it works, and more importantly, how it should work.

### Does this pull request potentially affect one of the following parts:

This change could affect how plugins interact with the `AuthenticationState` object.

### Documentation

- [x] `doc`

This is a documentation change.