### PR TITLE
[fix][broker] AbstractBatchedMetadataStore - use AlreadyClosedException instead of IllegalStateException

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/batching/AbstractBatchedMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/batching/AbstractBatchedMetadataStore.java
@@ -31,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataEventSynchronizer;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.Stat;
 import org.apache.pulsar.metadata.api.extended.CreateOption;
 import org.apache.pulsar.metadata.impl.AbstractMetadataStore;
@@ -84,7 +85,8 @@ public abstract class AbstractBatchedMetadataStore extends AbstractMetadataStore
     public void close() throws Exception {
         if (enabled) {
             // Fail all the pending items
-            Exception ex = new IllegalStateException("Metadata store is getting closed");
+            MetadataStoreException ex =
+                    new MetadataStoreException.AlreadyClosedException("Metadata store is getting closed");
             readOps.drain(op -> op.getFuture().completeExceptionally(ex));
             writeOps.drain(op -> op.getFuture().completeExceptionally(ex));
 


### PR DESCRIPTION
### Motivation

When the broker is shutting down AbstractBatchedMetadataStore completes exceptionally the pending operations with a generic IllegalStateException. All the code that is depending on the MetadataStore usually expects instances of MetadataStoreException and they may not properly react to this error.

This is generally not a big deal because the broker is shutting down, but we should improve it 

### Modifications

Complete the pending operations with AlreadyClosedException instead of IllegalStateException

### Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
