### PR TITLE
[fix][fn] Fix TLS configuration for fn worker to broker if auth disabled

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionTlsTest.java
@@ -139,6 +139,9 @@ public class PulsarFunctionTlsTest {
             workerConfig.setBrokerClientAuthenticationEnabled(true);
             workerConfig.setTlsEnabled(true);
             workerConfig.setUseTls(true);
+            workerConfig.setTlsEnableHostnameVerification(true);
+            workerConfig.setTlsAllowInsecureConnection(false);
+            workerConfig.setBrokerClientTrustCertsFilePath(TLS_SERVER_CERT_FILE_PATH);
             fnWorkerServices[i] = WorkerServiceLoader.load(workerConfig);
 
             configurations[i] = config;

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerService.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerService.java
@@ -127,51 +127,46 @@ public class PulsarWorkerService implements WorkerService {
             @Override
             public PulsarAdmin newPulsarAdmin(String pulsarServiceUrl, WorkerConfig workerConfig) {
                 // using isBrokerClientAuthenticationEnabled instead of isAuthenticationEnabled in function-worker
+                final String brokerClientAuthenticationPlugin;
+                final String brokerClientAuthenticationParameters;
                 if (workerConfig.isBrokerClientAuthenticationEnabled()) {
-                    return WorkerUtils.getPulsarAdminClient(
+                    brokerClientAuthenticationPlugin = workerConfig.getBrokerClientAuthenticationPlugin();
+                    brokerClientAuthenticationParameters = workerConfig.getBrokerClientAuthenticationParameters();
+                } else {
+                    brokerClientAuthenticationPlugin = null;
+                    brokerClientAuthenticationParameters = null;
+                }
+                return WorkerUtils.getPulsarAdminClient(
                         pulsarServiceUrl,
-                        workerConfig.getBrokerClientAuthenticationPlugin(),
-                        workerConfig.getBrokerClientAuthenticationParameters(),
+                        brokerClientAuthenticationPlugin,
+                        brokerClientAuthenticationParameters,
                         workerConfig.getBrokerClientTrustCertsFilePath(),
                         workerConfig.isTlsAllowInsecureConnection(),
                         workerConfig.isTlsEnableHostnameVerification(),
                         workerConfig);
-                } else {
-                    return WorkerUtils.getPulsarAdminClient(
-                            pulsarServiceUrl,
-                            null,
-                            null,
-                            null,
-                            workerConfig.isTlsAllowInsecureConnection(),
-                            workerConfig.isTlsEnableHostnameVerification(),
-                            workerConfig);
-                }
             }
 
             @Override
             public PulsarClient newPulsarClient(String pulsarServiceUrl, WorkerConfig workerConfig) {
                 // using isBrokerClientAuthenticationEnabled instead of isAuthenticationEnabled in function-worker
+                final String brokerClientAuthenticationPlugin;
+                final String brokerClientAuthenticationParameters;
                 if (workerConfig.isBrokerClientAuthenticationEnabled()) {
-                    return WorkerUtils.getPulsarClient(
+                    brokerClientAuthenticationPlugin = workerConfig.getBrokerClientAuthenticationPlugin();
+                    brokerClientAuthenticationParameters = workerConfig.getBrokerClientAuthenticationParameters();
+                } else {
+                    brokerClientAuthenticationPlugin = null;
+                    brokerClientAuthenticationParameters = null;
+                }
+                return WorkerUtils.getPulsarClient(
                         pulsarServiceUrl,
-                        workerConfig.getBrokerClientAuthenticationPlugin(),
-                        workerConfig.getBrokerClientAuthenticationParameters(),
+                        brokerClientAuthenticationPlugin,
+                        brokerClientAuthenticationParameters,
                         workerConfig.isUseTls(),
                         workerConfig.getBrokerClientTrustCertsFilePath(),
                         workerConfig.isTlsAllowInsecureConnection(),
                         workerConfig.isTlsEnableHostnameVerification(),
                         workerConfig);
-                } else {
-                    return WorkerUtils.getPulsarClient(
-                            pulsarServiceUrl,
-                            null,
-                            null,
-                            null,
-                            null,
-                            workerConfig.isTlsAllowInsecureConnection(),
-                            workerConfig.isTlsEnableHostnameVerification(),
-                            workerConfig);
-                }
             }
         };
     }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
@@ -228,26 +228,15 @@ public final class WorkerUtils {
         return dlogUri;
     }
 
-    public static PulsarAdmin getPulsarAdminClient(String pulsarWebServiceUrl) {
-        return getPulsarAdminClient(pulsarWebServiceUrl, null, null, null, null, null, null);
-    }
-
     public static PulsarAdmin getPulsarAdminClient(String pulsarWebServiceUrl, String authPlugin, String authParams,
                                                    String tlsTrustCertsFilePath, Boolean allowTlsInsecureConnection,
-                                                   Boolean enableTlsHostnameVerificationEnable) {
-        return getPulsarAdminClient(pulsarWebServiceUrl, authPlugin, authParams, tlsTrustCertsFilePath,
-                allowTlsInsecureConnection, enableTlsHostnameVerificationEnable, null);
-    }
-
-    public static PulsarAdmin getPulsarAdminClient(String pulsarWebServiceUrl, String authPlugin, String authParams,
-                                                   String tlsTrustCertsFilePath, Boolean allowTlsInsecureConnection,
-                                                   Boolean enableTlsHostnameVerificationEnable,
+                                                   Boolean enableTlsHostnameVerification,
                                                    WorkerConfig workerConfig) {
         log.info("Create Pulsar Admin to service url {}: "
                         + "authPlugin = {}, authParams = {}, "
-                        + "tlsTrustCerts = {}, allowTlsInsecureConnector = {}, enableTlsHostnameVerification = {}",
+                        + "tlsTrustCerts = {}, allowTlsInsecureConnection = {}, enableTlsHostnameVerification = {}",
                 pulsarWebServiceUrl, authPlugin, authParams,
-                tlsTrustCertsFilePath, allowTlsInsecureConnection, enableTlsHostnameVerificationEnable);
+                tlsTrustCertsFilePath, allowTlsInsecureConnection, enableTlsHostnameVerification);
         try {
             PulsarAdminBuilder adminBuilder = PulsarAdmin.builder().serviceHttpUrl(pulsarWebServiceUrl);
             if (workerConfig != null) {
@@ -266,8 +255,8 @@ public final class WorkerUtils {
             if (allowTlsInsecureConnection != null) {
                 adminBuilder.allowTlsInsecureConnection(allowTlsInsecureConnection);
             }
-            if (enableTlsHostnameVerificationEnable != null) {
-                adminBuilder.enableTlsHostnameVerification(enableTlsHostnameVerificationEnable);
+            if (enableTlsHostnameVerification != null) {
+                adminBuilder.enableTlsHostnameVerification(enableTlsHostnameVerification);
             }
 
             return adminBuilder.build();
@@ -275,11 +264,6 @@ public final class WorkerUtils {
             log.error("Error creating pulsar admin client", e);
             throw new RuntimeException(e);
         }
-    }
-
-    public static PulsarClient getPulsarClient(String pulsarServiceUrl) {
-        return getPulsarClient(pulsarServiceUrl, null, null, null,
-                null, null, null, null);
     }
 
     public static PulsarClient getPulsarClient(String pulsarServiceUrl, String authPlugin, String authParams,


### PR DESCRIPTION
### Motivation

Regression of https://github.com/apache/pulsar/pull/11681

In case of standalone functions worker, the pulsar client connected to the broker doesn't pick up the `brokerClientTrustCertsFilePath` configuration if authentication is disabled.

This causes issues if `TlsEnableHostnameVerification=true` and the certificate is self signed.

I don't think is much critical since non authenticated clusters are very rare when tls is enabled. 

### Modifications

* Pass the `brokerClientTrustCertsFilePath` option if auth is disabled

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
