### PR TITLE
[feat][broker] OneStageAuth State: move authn out of constructor

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/OneStageAuthenticationState.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/OneStageAuthenticationState.java
@@ -61,8 +61,10 @@ public class OneStageAuthenticationState implements AuthenticationState {
     }
 
     public OneStageAuthenticationState(HttpServletRequest request, AuthenticationProvider provider) {
+        // Must initialize this here for backwards compatibility with http authentication
         this.authenticationDataSource = new AuthenticationDataHttps(request);
         this.provider = provider;
+        // These are not used when invoking this constructor.
         this.remoteAddress = null;
         this.sslSession = null;
     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/OneStageAuthenticationState.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/OneStageAuthenticationState.java
@@ -20,39 +20,58 @@ package org.apache.pulsar.broker.authentication;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import java.net.SocketAddress;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import javax.naming.AuthenticationException;
 import javax.net.ssl.SSLSession;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.pulsar.common.api.AuthData;
 
 /**
- * Interface for authentication state.
- *
- * It tell broker whether the authentication is completed or not,
- * if completed, what is the AuthRole is.
+ * A class to track single stage authentication. This class assumes that:
+ * 1. {@link #authenticateAsync(AuthData)} is called once and when the {@link CompletableFuture} completes,
+ *    authentication is complete.
+ * 2. Authentication does not expire, so {@link #isExpired()} always returns false.
+ * <p>
+ * See {@link AuthenticationState} for Pulsar's contract on how this interface is used by Pulsar.
  */
 public class OneStageAuthenticationState implements AuthenticationState {
 
-    private final AuthenticationDataSource authenticationDataSource;
-    private final String authRole;
+    private AuthenticationDataSource authenticationDataSource;
+    private final SocketAddress remoteAddress;
+    private final SSLSession sslSession;
+    private final AuthenticationProvider provider;
+    private volatile String authRole;
 
+
+    /**
+     * Constructor for a {@link OneStageAuthenticationState} where there is no authentication performed during
+     * initialization.
+     * @param remoteAddress - remoteAddress associated with the {@link AuthenticationState}
+     * @param sslSession - sslSession associated with the {@link AuthenticationState}
+     * @param provider - {@link AuthenticationProvider} to use to verify {@link AuthData}
+     */
     public OneStageAuthenticationState(AuthData authData,
                                        SocketAddress remoteAddress,
                                        SSLSession sslSession,
-                                       AuthenticationProvider provider) throws AuthenticationException {
-        this.authenticationDataSource = new AuthenticationDataCommand(
-            new String(authData.getBytes(), UTF_8), remoteAddress, sslSession);
-        this.authRole = provider.authenticate(authenticationDataSource);
+                                       AuthenticationProvider provider) {
+        this.provider = provider;
+        this.remoteAddress = remoteAddress;
+        this.sslSession = sslSession;
     }
 
-    public OneStageAuthenticationState(HttpServletRequest request, AuthenticationProvider provider)
-            throws AuthenticationException {
+    public OneStageAuthenticationState(HttpServletRequest request, AuthenticationProvider provider) {
         this.authenticationDataSource = new AuthenticationDataHttps(request);
-        this.authRole = provider.authenticate(authenticationDataSource);
+        this.provider = provider;
+        this.remoteAddress = null;
+        this.sslSession = null;
     }
 
     @Override
-    public String getAuthRole() {
+    public String getAuthRole() throws AuthenticationException {
+        if (authRole == null) {
+            throw new AuthenticationException("Must authenticate before calling getAuthRole");
+        }
         return authRole;
     }
 
@@ -61,13 +80,47 @@ public class OneStageAuthenticationState implements AuthenticationState {
         return authenticationDataSource;
     }
 
+    /**
+     * Warning: this method is not intended to be called concurrently.
+     */
     @Override
-    public AuthData authenticate(AuthData authData) {
-        return null;
+    public CompletableFuture<AuthData> authenticateAsync(AuthData authData) {
+        if (authRole != null) {
+            // Authentication is already completed
+            return CompletableFuture.completedFuture(null);
+        }
+        this.authenticationDataSource = new AuthenticationDataCommand(
+                new String(authData.getBytes(), UTF_8), remoteAddress, sslSession);
+
+        return provider
+                .authenticateAsync(authenticationDataSource)
+                .thenApply(role -> {
+                    this.authRole = role;
+                    // Single stage authentication always returns null
+                    return null;
+                });
     }
 
+    /**
+     * @deprecated use {@link #authenticateAsync(AuthData)}
+     */
+    @Deprecated(since = "2.12.0")
+    @Override
+    public AuthData authenticate(AuthData authData) throws AuthenticationException {
+        try {
+            return authenticateAsync(authData).get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * @deprecated rely on result from {@link #authenticateAsync(AuthData)}. For more information, see the Javadoc
+     * for {@link AuthenticationState#isComplete()}.
+     */
+    @Deprecated(since = "2.12.0")
     @Override
     public boolean isComplete() {
-        return true;
+        return authRole != null;
     }
 }

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/OneStageAuthenticationStateTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/OneStageAuthenticationStateTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.broker.authentication;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.common.api.AuthData;
+import org.testng.annotations.Test;
+import javax.naming.AuthenticationException;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.LongAdder;
+
+public class OneStageAuthenticationStateTest {
+
+    public static class CountingAuthenticationProvider implements AuthenticationProvider {
+        public LongAdder authCallCount = new LongAdder();
+
+        @Override
+        public void initialize(ServiceConfiguration config) throws IOException {
+        }
+
+        @Override
+        public String getAuthMethodName() {
+            return null;
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+
+        @Override
+        public CompletableFuture<String> authenticateAsync(AuthenticationDataSource authData) {
+            authCallCount.increment();
+            return CompletableFuture.completedFuture(authData.getCommandData());
+        }
+    }
+
+    @Test
+    public void verifyAuthenticateAsyncIsCalledExactlyOnceAndSetsRole() throws Exception {
+        CountingAuthenticationProvider provider = new CountingAuthenticationProvider();
+        AuthData authData = AuthData.of("role".getBytes());
+        OneStageAuthenticationState authState = new OneStageAuthenticationState(authData, null, null, provider);
+        assertEquals(provider.authCallCount.sum(), 0, "Auth count should not increase yet");
+        AuthData challenge = authState.authenticateAsync(authData).get();
+        assertNull(challenge);
+        assertEquals(provider.authCallCount.sum(), 1, "Call authenticate only once");
+        assertEquals(authState.getAuthRole(), "role");
+        AuthenticationDataSource firstAuthenticationDataSource = authState.getAuthDataSource();
+        assertTrue(firstAuthenticationDataSource instanceof AuthenticationDataCommand);
+
+        // Verify subsequent call to authenticate does not change data
+        AuthData secondChallenge = authState.authenticateAsync(AuthData.of("admin".getBytes())).get();
+        assertNull(secondChallenge);
+        assertEquals(authState.getAuthRole(), "role");
+        AuthenticationDataSource secondAuthenticationDataSource = authState.getAuthDataSource();
+        assertSame(secondAuthenticationDataSource, firstAuthenticationDataSource);
+        assertEquals(provider.authCallCount.sum(), 1, "Call authenticate only once, even later.");
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void verifyAuthenticateIsCalledExactlyOnceAndSetsRole() throws Exception {
+        CountingAuthenticationProvider provider = new CountingAuthenticationProvider();
+        AuthData authData = AuthData.of("role".getBytes());
+        OneStageAuthenticationState authState = new OneStageAuthenticationState(authData, null, null, provider);
+        assertEquals(provider.authCallCount.sum(), 0, "Auth count should not increase yet");
+        assertFalse(authState.isComplete());
+        AuthData challenge = authState.authenticate(authData);
+        assertNull(challenge);
+        assertTrue(authState.isComplete());
+        assertEquals(provider.authCallCount.sum(), 1, "Call authenticate only once");
+        assertEquals(authState.getAuthRole(), "role");
+        AuthenticationDataSource firstAuthenticationDataSource = authState.getAuthDataSource();
+        assertTrue(firstAuthenticationDataSource instanceof AuthenticationDataCommand);
+
+        // Verify subsequent call to authenticate does not change data
+        AuthData secondChallenge = authState.authenticate(AuthData.of("admin".getBytes()));
+        assertNull(secondChallenge);
+        assertEquals(authState.getAuthRole(), "role");
+        AuthenticationDataSource secondAuthenticationDataSource = authState.getAuthDataSource();
+        assertSame(secondAuthenticationDataSource, firstAuthenticationDataSource);
+        assertEquals(provider.authCallCount.sum(), 1, "Call authenticate only once, even later.");
+    }
+
+    @Test
+    public void verifyGetAuthRoleBeforeAuthenticateFails() {
+        CountingAuthenticationProvider provider = new CountingAuthenticationProvider();
+        AuthData authData = AuthData.of("role".getBytes());
+        OneStageAuthenticationState authState = new OneStageAuthenticationState(authData, null, null, provider);
+        assertThrows(AuthenticationException.class, authState::getAuthRole);
+        assertNull(authState.getAuthDataSource());
+    }
+
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -947,10 +947,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                     + " using auth method [%s] is not available", originalAuthMethod));
                 }
 
+                AuthData originalAuthDataCopy =  AuthData.of(connect.getOriginalAuthData().getBytes());
                 originalAuthState = originalAuthenticationProvider.newAuthState(
-                        AuthData.of(connect.getOriginalAuthData().getBytes()),
+                        originalAuthDataCopy,
                         remoteAddress,
                         sslSession);
+                originalAuthState.authenticate(originalAuthDataCopy);
                 originalAuthData = originalAuthState.getAuthDataSource();
                 originalPrincipal = originalAuthState.getAuthRole();
 


### PR DESCRIPTION
PIP: #12105

### Motivation

In order to implement PIP 97, we must replace `authenticate` calls with `authenticateAsync`. This PR makes those changes for `OneStageAuthenticationState`. It also moves the call to authenticate the `AuthData` out of the constructor and into the `authenticateAsync` method.

One assumption I make in this PR, is that there will not be concurrent calls to the same `AuthenticationState#authenticateAsync` method. That seems like a reasonable assumption because Pulsar uses this state object in the netty eventloop handlers, but please let me know if you disagree.

### Modifications

* Move the `authenticate` call out of the constructor so that authentication is only done on the first pass through the `authenticateAsync` method.
* Make `authenticate` backwards compatible for any plugins that are using it.

### Verifying this change

New tests are added to verify the new and the old code.

### Does this pull request potentially affect one of the following parts:

This could break 3rd party plugins in the broker if they were relying on authentication to happen in the constructor. In order to make those implementations fail fast, this PR includes a change to throw an exception when the `getAuthRole` is called without first calling `authenticateAsync` or `authenticate`. That makes these changes semi-backwards compatible.

### Documentation

- [x] `doc-not-needed`

### Matching PR in forked repository

PR in forked repository: https://github.com/michaeljmarshall/pulsar/pull/17