### PR TITLE
[feat][cli] Add read command to pulsar-client-tools

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
@@ -19,7 +19,9 @@
 package org.apache.pulsar.client.cli;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import java.time.Duration;
 import java.util.Properties;
 import java.util.UUID;
@@ -191,6 +193,55 @@ public class PulsarClientToolTest extends BrokerTestBase {
         } catch (Exception e) {
             Assert.fail("consumer was unable to receive messages", e);
         }
+    }
+
+    @Test(timeOut = 20000)
+    public void testRead() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("serviceUrl", brokerUrl.toString());
+        properties.setProperty("useTls", "false");
+
+        final String topicName = getTopicWithRandomSuffix("reader");
+
+        int numberOfMessages = 10;
+        @Cleanup("shutdownNow")
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        executor.execute(() -> {
+            try {
+                PulsarClientTool pulsarClientToolReader = new PulsarClientTool(properties);
+                String[] args = {"read", "-m", "Latest", "-n", Integer.toString(numberOfMessages), "--hex", "-r", "30",
+                        topicName};
+                assertEquals(pulsarClientToolReader.run(args), 0);
+                future.complete(null);
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+        });
+
+        // Make sure subscription has been created
+        retryStrategically((test) -> {
+            try {
+                return admin.topics().getSubscriptions(topicName).size() == 1;
+            } catch (Exception e) {
+                return false;
+            }
+        }, 10, 500);
+
+        assertEquals(admin.topics().getSubscriptions(topicName).size(), 1);
+        assertTrue(admin.topics().getSubscriptions(topicName).get(0).startsWith("reader-"));
+        PulsarClientTool pulsarClientToolProducer = new PulsarClientTool(properties);
+
+        String[] args = {"produce", "--messages", "Have a nice day", "-n", Integer.toString(numberOfMessages), "-r",
+                "20", "-p", "key1=value1", "-p", "key2=value2", "-k", "partition_key", topicName};
+        assertEquals(pulsarClientToolProducer.run(args), 0);
+        assertFalse(future.isCompletedExceptionally());
+        future.get();
+
+        Awaitility.await()
+                .ignoreExceptions()
+                .atMost(Duration.ofMillis(20000))
+                .until(()->admin.topics().getSubscriptions(topicName).size() == 0);
     }
 
     @Test(timeOut = 20000)

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
@@ -210,7 +210,7 @@ public class PulsarClientToolTest extends BrokerTestBase {
         executor.execute(() -> {
             try {
                 PulsarClientTool pulsarClientToolReader = new PulsarClientTool(properties);
-                String[] args = {"read", "-m", "Latest", "-n", Integer.toString(numberOfMessages), "--hex", "-r", "30",
+                String[] args = {"read", "-m", "latest", "-n", Integer.toString(numberOfMessages), "--hex", "-r", "30",
                         topicName};
                 assertEquals(pulsarClientToolReader.run(args), 0);
                 future.complete(null);

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolWsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolWsTest.java
@@ -143,4 +143,52 @@ public class PulsarClientToolWsTest extends BrokerTestBase {
         Assert.assertNotNull(subscriptions);
         Assert.assertEquals(subscriptions.size(), 1);
     }
+
+    @Test(timeOut = 30000)
+    public void testWebSocketReader() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("serviceUrl", brokerUrl.toString());
+        properties.setProperty("useTls", "false");
+
+        final String topicName = "persistent://my-property/my-ns/test/topic-" + UUID.randomUUID();
+
+        int numberOfMessages = 10;
+        {
+            @Cleanup("shutdown")
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            executor.execute(() -> {
+                try {
+                    PulsarClientTool pulsarClientToolReader = new PulsarClientTool(properties);
+                    String[] args = {"read", "-m", "Latest", "-n", Integer.toString(numberOfMessages), "--hex", "-r",
+                            "30", topicName};
+                    Assert.assertEquals(pulsarClientToolReader.run(args), 0);
+                    future.complete(null);
+                } catch (Throwable t) {
+                    future.completeExceptionally(t);
+                }
+            });
+
+            // Make sure subscription has been created
+            Awaitility.await()
+                    .pollInterval(Duration.ofMillis(200))
+                    .ignoreExceptions().untilAsserted(() -> {
+                Assert.assertEquals(admin.topics().getSubscriptions(topicName).size(), 1);
+                Assert.assertTrue(admin.topics().getSubscriptions(topicName).get(0).startsWith("reader-"));
+            });
+
+            PulsarClientTool pulsarClientToolProducer = new PulsarClientTool(properties);
+
+            String[] args = {"produce", "--messages", "Have a nice day", "-n", Integer.toString(numberOfMessages), "-r",
+                    "20", "-p", "key1=value1", "-p", "key2=value2", "-k", "partition_key", topicName};
+            Assert.assertEquals(pulsarClientToolProducer.run(args), 0);
+            future.get();
+            Assert.assertFalse(future.isCompletedExceptionally());
+        }
+
+        Awaitility.await()
+                .ignoreExceptions().untilAsserted(() -> {
+            Assert.assertEquals(admin.topics().getSubscriptions(topicName).size(), 0);
+        });
+    }
 }

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolWsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolWsTest.java
@@ -160,7 +160,7 @@ public class PulsarClientToolWsTest extends BrokerTestBase {
             executor.execute(() -> {
                 try {
                     PulsarClientTool pulsarClientToolReader = new PulsarClientTool(properties);
-                    String[] args = {"read", "-m", "Latest", "-n", Integer.toString(numberOfMessages), "--hex", "-r",
+                    String[] args = {"read", "-m", "latest", "-n", Integer.toString(numberOfMessages), "--hex", "-r",
                             "30", topicName};
                     Assert.assertEquals(pulsarClientToolReader.run(args), 0);
                     future.complete(null);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/AbstractCmdConsume.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/AbstractCmdConsume.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.cli;
+
+import static org.apache.pulsar.client.internal.PulsarClientImplementationBinding.getBytes;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.HexDump;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.ClientBuilder;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.schema.Field;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.util.collections.GrowableArrayBlockingQueue;
+import org.eclipse.jetty.websocket.api.RemoteEndpoint;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * common part of consume command and read command of pulsar-client.
+ *
+ */
+public abstract class AbstractCmdConsume {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(PulsarClientTool.class);
+    protected static final String MESSAGE_BOUNDARY = "----- got message -----";
+
+    protected ClientBuilder clientBuilder;
+    protected Authentication authentication;
+    protected String serviceURL;
+
+    public AbstractCmdConsume() {
+        // Do nothing
+    }
+
+    /**
+     * Set client configuration.
+     *
+     */
+    public void updateConfig(ClientBuilder clientBuilder, Authentication authentication, String serviceURL) {
+        this.clientBuilder = clientBuilder;
+        this.authentication = authentication;
+        this.serviceURL = serviceURL;
+    }
+
+    /**
+     * Interprets the message to create a string representation.
+     *
+     * @param message
+     *            The message to interpret
+     * @param displayHex
+     *            Whether to display BytesMessages in hexdump style, ignored for simple text messages
+     * @return String representation of the message
+     */
+    protected String interpretMessage(Message<?> message, boolean displayHex) throws IOException {
+        StringBuilder sb = new StringBuilder();
+
+        String properties = Arrays.toString(message.getProperties().entrySet().toArray());
+
+        String data;
+        Object value = message.getValue();
+        if (value == null) {
+            data = "null";
+        } else if (value instanceof byte[]) {
+            byte[] msgData = (byte[]) value;
+            data = interpretByteArray(displayHex, msgData);
+        } else if (value instanceof GenericObject) {
+            Map<String, Object> asMap = genericObjectToMap((GenericObject) value, displayHex);
+            data = asMap.toString();
+        } else if (value instanceof ByteBuffer) {
+            data = new String(getBytes((ByteBuffer) value));
+        } else {
+            data = value.toString();
+        }
+
+        String key = null;
+        if (message.hasKey()) {
+            key = message.getKey();
+        }
+
+        sb.append("key:[").append(key).append("], ");
+        if (!properties.isEmpty()) {
+            sb.append("properties:").append(properties).append(", ");
+        }
+        sb.append("content:").append(data);
+
+        return sb.toString();
+    }
+
+    protected static String interpretByteArray(boolean displayHex, byte[] msgData) throws IOException {
+        String data;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        if (!displayHex) {
+            return new String(msgData);
+        } else {
+            HexDump.dump(msgData, 0, out, 0);
+            return out.toString();
+        }
+    }
+
+    protected static Map<String, Object> genericObjectToMap(GenericObject value, boolean displayHex)
+            throws IOException {
+        switch (value.getSchemaType()) {
+            case AVRO:
+            case JSON:
+            case PROTOBUF_NATIVE:
+                    return genericRecordToMap((GenericRecord) value, displayHex);
+            case KEY_VALUE:
+                    return keyValueToMap((KeyValue) value.getNativeObject(), displayHex);
+            default:
+                return primitiveValueToMap(value.getNativeObject(), displayHex);
+        }
+    }
+
+    protected static Map<String, Object> keyValueToMap(KeyValue value, boolean displayHex) throws IOException {
+        if (value == null) {
+            return ImmutableMap.of("value", "NULL");
+        }
+        return ImmutableMap.of("key", primitiveValueToMap(value.getKey(), displayHex),
+                "value", primitiveValueToMap(value.getValue(), displayHex));
+    }
+
+    protected static Map<String, Object> primitiveValueToMap(Object value, boolean displayHex) throws IOException {
+        if (value == null) {
+            return ImmutableMap.of("value", "NULL");
+        }
+        if (value instanceof GenericObject) {
+            return genericObjectToMap((GenericObject) value, displayHex);
+        }
+        if (value instanceof byte[]) {
+            value = interpretByteArray(displayHex, (byte[]) value);
+        }
+        return ImmutableMap.of("value", value.toString(), "type", value.getClass());
+    }
+
+    protected static Map<String, Object> genericRecordToMap(GenericRecord value, boolean displayHex)
+            throws IOException {
+        Map<String, Object> res = new HashMap<>();
+        for (Field f : value.getFields()) {
+            Object fieldValue = value.getField(f);
+            if (fieldValue instanceof GenericRecord) {
+                fieldValue = genericRecordToMap((GenericRecord) fieldValue, displayHex);
+            } else if (fieldValue == null) {
+                fieldValue =  "NULL";
+            } else if (fieldValue instanceof byte[]) {
+                fieldValue = interpretByteArray(displayHex, (byte[]) fieldValue);
+            }
+            res.put(f.getName(), fieldValue);
+        }
+        return res;
+    }
+
+    @WebSocket(maxTextMessageSize = 64 * 1024)
+    public static class ConsumerSocket {
+        private static final String X_PULSAR_MESSAGE_ID = "messageId";
+        private final CountDownLatch closeLatch;
+        private Session session;
+        private CompletableFuture<Void> connected;
+        final BlockingQueue<String> incomingMessages;
+
+        public ConsumerSocket(CompletableFuture<Void> connected) {
+            this.closeLatch = new CountDownLatch(1);
+            this.connected = connected;
+            this.incomingMessages = new GrowableArrayBlockingQueue<>();
+        }
+
+        public boolean awaitClose(int duration, TimeUnit unit) throws InterruptedException {
+            return this.closeLatch.await(duration, unit);
+        }
+
+        @OnWebSocketClose
+        public void onClose(int statusCode, String reason) {
+            log.info("Connection closed: {} - {}", statusCode, reason);
+            this.session = null;
+            this.closeLatch.countDown();
+        }
+
+        @OnWebSocketConnect
+        public void onConnect(Session session) throws InterruptedException {
+            log.info("Got connect: {}", session);
+            this.session = session;
+            this.connected.complete(null);
+        }
+
+        @OnWebSocketMessage
+        public synchronized void onMessage(String msg) throws Exception {
+            JsonObject message = new Gson().fromJson(msg, JsonObject.class);
+            JsonObject ack = new JsonObject();
+            String messageId = message.get(X_PULSAR_MESSAGE_ID).getAsString();
+            ack.add("messageId", new JsonPrimitive(messageId));
+            // Acking the proxy
+            this.getRemote().sendString(ack.toString());
+            this.incomingMessages.put(msg);
+        }
+
+        public String receive(long timeout, TimeUnit unit) throws Exception {
+            return incomingMessages.poll(timeout, unit);
+        }
+
+        public RemoteEndpoint getRemote() {
+            return this.session.getRemote();
+        }
+
+        public Session getSession() {
+            return this.session;
+        }
+
+        public void close() {
+            this.session.close();
+        }
+
+        private static final Logger log = LoggerFactory.getLogger(ConsumerSocket.class);
+    }
+
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdRead.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdRead.java
@@ -32,47 +32,45 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
-import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Reader;
+import org.apache.pulsar.client.api.ReaderBuilder;
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.SubscriptionInitialPosition;
-import org.apache.pulsar.client.api.SubscriptionMode;
-import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.naming.TopicName;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 
 /**
- * pulsar-client consume command implementation.
+ * pulsar-client read command implementation.
  *
  */
-@Parameters(commandDescription = "Consume messages from a specified topic")
-public class CmdConsume extends AbstractCmdConsume {
+@Parameters(commandDescription = "Read messages from a specified topic")
+public class CmdRead extends AbstractCmdConsume {
+
+    private static final Pattern MSG_ID_PATTERN = Pattern.compile("^(-?[1-9][0-9]*|0):(-?[1-9][0-9]*|0)$");
 
     @Parameter(description = "TopicName", required = true)
     private List<String> mainOptions = new ArrayList<String>();
 
-    @Parameter(names = { "-t", "--subscription-type" }, description = "Subscription type.")
-    private SubscriptionType subscriptionType = SubscriptionType.Exclusive;
+    @Parameter(names = { "-m", "--start-message-id" },
+            description = "Initial reader position, it can be 'Latest', 'Earliest' or '<ledgerId>:<entryId>'")
+    private String startMessageId = "Latest";
 
-    @Parameter(names = { "-m", "--subscription-mode" }, description = "Subscription mode.")
-    private SubscriptionMode subscriptionMode = SubscriptionMode.Durable;
-
-    @Parameter(names = { "-p", "--subscription-position" }, description = "Subscription position.")
-    private SubscriptionInitialPosition subscriptionInitialPosition = SubscriptionInitialPosition.Latest;
-
-    @Parameter(names = { "-s", "--subscription-name" }, required = true, description = "Subscription name.")
-    private String subscriptionName;
+    @Parameter(names = { "-i", "--start-message-id-inclusive" },
+            description = "Whether to include the position specified by -m option.")
+    private boolean startMessageIdInclusive = false;
 
     @Parameter(names = { "-n",
-            "--num-messages" }, description = "Number of messages to consume, 0 means to consume forever.")
-    private int numMessagesToConsume = 1;
+            "--num-messages" }, description = "Number of messages to read, 0 means to read forever.")
+    private int numMessagesToRead = 1;
 
     @Parameter(names = { "--hex" }, description = "Display binary messages in hex.")
     private boolean displayHex = false;
@@ -80,14 +78,11 @@ public class CmdConsume extends AbstractCmdConsume {
     @Parameter(names = { "--hide-content" }, description = "Do not write the message to console.")
     private boolean hideContent = false;
 
-    @Parameter(names = { "-r", "--rate" }, description = "Rate (in msg/sec) at which to consume, "
-            + "value 0 means to consume messages as fast as possible.")
-    private double consumeRate = 0;
+    @Parameter(names = { "-r", "--rate" }, description = "Rate (in msg/sec) at which to read, "
+            + "value 0 means to read messages as fast as possible.")
+    private double readRate = 0;
 
-    @Parameter(names = { "--regex" }, description = "Indicate the topic name is a regex pattern")
-    private boolean isRegex = false;
-
-    @Parameter(names = {"-q", "--queue-size"}, description = "Consumer receiver queue size.")
+    @Parameter(names = {"-q", "--queue-size"}, description = "Reader receiver queue size.")
     private int receiverQueueSize = 0;
 
     @Parameter(names = { "-mc", "--max_chunked_msg" }, description = "Max pending chunk messages")
@@ -103,19 +98,19 @@ public class CmdConsume extends AbstractCmdConsume {
     private String encKeyValue;
 
     @Parameter(names = { "-st", "--schema-type"},
-            description = "Set a schema type on the consumer, it can be 'bytes' or 'auto_consume'")
+            description = "Set a schema type on the reader, it can be 'bytes' or 'auto_consume'")
     private String schemaType = "bytes";
 
     @Parameter(names = { "-pm", "--pool-messages" }, description = "Use the pooled message", arity = 1)
     private boolean poolMessages = true;
 
-    public CmdConsume() {
+    public CmdRead() {
         // Do nothing
         super();
     }
 
     /**
-     * Run the consume command.
+     * Run the read command.
      *
      * @return 0 for success, < 0 otherwise
      */
@@ -123,47 +118,40 @@ public class CmdConsume extends AbstractCmdConsume {
         if (mainOptions.size() != 1) {
             throw (new ParameterException("Please provide one and only one topic name."));
         }
-        if (this.subscriptionName == null || this.subscriptionName.isEmpty()) {
-            throw (new ParameterException("Subscription name is not provided."));
-        }
-        if (this.numMessagesToConsume < 0) {
+        if (this.numMessagesToRead < 0) {
             throw (new ParameterException("Number of messages should be zero or positive."));
         }
 
         String topic = this.mainOptions.get(0);
 
         if (this.serviceURL.startsWith("ws")) {
-            return consumeFromWebSocket(topic);
+            return readFromWebSocket(topic);
         } else {
-            return consume(topic);
+            return read(topic);
         }
     }
 
-    private int consume(String topic) {
-        int numMessagesConsumed = 0;
+    private int read(String topic) {
+        int numMessagesRead = 0;
         int returnCode = 0;
 
         try (PulsarClient client = clientBuilder.build()){
-            ConsumerBuilder<?> builder;
+            ReaderBuilder<?> builder;
+
             Schema<?> schema = poolMessages ? Schema.BYTEBUFFER : Schema.BYTES;
             if ("auto_consume".equals(schemaType)) {
                 schema = Schema.AUTO_CONSUME();
             } else if (!"bytes".equals(schemaType)) {
                 throw new IllegalArgumentException("schema type must be 'bytes' or 'auto_consume'");
             }
-            builder = client.newConsumer(schema)
-                    .subscriptionName(this.subscriptionName)
-                    .subscriptionType(subscriptionType)
-                    .subscriptionMode(subscriptionMode)
-                    .subscriptionInitialPosition(subscriptionInitialPosition)
+            builder = client.newReader(schema)
+                    .topic(topic)
+                    .startMessageId(parseMessageId(startMessageId))
                     .poolMessages(poolMessages);
 
-            if (isRegex) {
-                builder.topicsPattern(Pattern.compile(topic));
-            } else {
-                builder.topic(topic);
+            if (this.startMessageIdInclusive) {
+                builder.startMessageIdInclusive();
             }
-
             if (this.maxPendingChunkedMessage > 0) {
                 builder.maxPendingChunkedMessage(this.maxPendingChunkedMessage);
             }
@@ -177,27 +165,26 @@ public class CmdConsume extends AbstractCmdConsume {
                 builder.defaultCryptoKeyReader(this.encKeyValue);
             }
 
-            try (Consumer<?> consumer = builder.subscribe();) {
-                RateLimiter limiter = (this.consumeRate > 0) ? RateLimiter.create(this.consumeRate) : null;
-                while (this.numMessagesToConsume == 0 || numMessagesConsumed < this.numMessagesToConsume) {
+            try (Reader<?> reader = builder.create()) {
+                RateLimiter limiter = (this.readRate > 0) ? RateLimiter.create(this.readRate) : null;
+                while (this.numMessagesToRead == 0 || numMessagesRead < this.numMessagesToRead) {
                     if (limiter != null) {
                         limiter.acquire();
                     }
 
-                    Message<?> msg = consumer.receive(5, TimeUnit.SECONDS);
+                    Message<?> msg = reader.readNext(5, TimeUnit.SECONDS);
                     if (msg == null) {
-                        LOG.debug("No message to consume after waiting for 5 seconds.");
+                        LOG.debug("No message to read after waiting for 5 seconds.");
                     } else {
                         try {
-                            numMessagesConsumed += 1;
+                            numMessagesRead += 1;
                             if (!hideContent) {
                                 System.out.println(MESSAGE_BOUNDARY);
                                 String output = this.interpretMessage(msg, displayHex);
                                 System.out.println(output);
-                            } else if (numMessagesConsumed % 1000 == 0) {
-                                System.out.println("Received " + numMessagesConsumed + " messages");
+                            } else if (numMessagesRead % 1000 == 0) {
+                                System.out.println("Received " + numMessagesRead + " messages");
                             }
-                            consumer.acknowledge(msg);
                         } finally {
                             msg.release();
                         }
@@ -205,11 +192,11 @@ public class CmdConsume extends AbstractCmdConsume {
                 }
             }
         } catch (Exception e) {
-            LOG.error("Error while consuming messages");
+            LOG.error("Error while reading messages");
             LOG.error(e.getMessage(), e);
             returnCode = -1;
         } finally {
-            LOG.info("{} messages successfully consumed", numMessagesConsumed);
+            LOG.info("{} messages successfully read", numMessagesRead);
         }
 
         return returnCode;
@@ -218,7 +205,7 @@ public class CmdConsume extends AbstractCmdConsume {
 
     @SuppressWarnings("deprecation")
     @VisibleForTesting
-    public String getWebSocketConsumeUri(String topic) {
+    public String getWebSocketReadUri(String topic) {
         String serviceURLWithoutTrailingSlash = serviceURL.substring(0,
                 serviceURL.endsWith("/") ? serviceURL.length() - 1 : serviceURL.length());
 
@@ -232,28 +219,34 @@ public class CmdConsume extends AbstractCmdConsume {
                     topicName.getCluster(), topicName.getNamespacePortion(), topicName.getLocalName());
         }
 
-        String uriFormat = "%s/ws" + (topicName.isV2() ? "/v2/" : "/")
-                + "consumer/%s/%s?subscriptionType=%s&subscriptionMode=%s";
-        return String.format(uriFormat, serviceURLWithoutTrailingSlash, wsTopic, subscriptionName,
-                subscriptionType.toString(), subscriptionMode.toString());
+        String msgIdQueryParam;
+        if ("Latest".equals(startMessageId) || "Earliest".equals(startMessageId)) {
+            msgIdQueryParam = startMessageId.toLowerCase();
+        } else {
+            MessageId msgId = parseMessageId(startMessageId);
+            msgIdQueryParam = Base64.getEncoder().encodeToString(msgId.toByteArray());
+        }
+
+        String uriFormat = "%s/ws" + (topicName.isV2() ? "/v2/" : "/") + "reader/%s?messageId=%s";
+        return String.format(uriFormat, serviceURLWithoutTrailingSlash, wsTopic, msgIdQueryParam);
     }
 
     @SuppressWarnings("deprecation")
-    private int consumeFromWebSocket(String topic) {
-        int numMessagesConsumed = 0;
+    private int readFromWebSocket(String topic) {
+        int numMessagesRead = 0;
         int returnCode = 0;
 
-        URI consumerUri = URI.create(getWebSocketConsumeUri(topic));
+        URI readerUri = URI.create(getWebSocketReadUri(topic));
 
-        WebSocketClient consumeClient = new WebSocketClient(new SslContextFactory(true));
-        ClientUpgradeRequest consumeRequest = new ClientUpgradeRequest();
+        WebSocketClient readClient = new WebSocketClient(new SslContextFactory(true));
+        ClientUpgradeRequest readRequest = new ClientUpgradeRequest();
         try {
             if (authentication != null) {
                 authentication.start();
                 AuthenticationDataProvider authData = authentication.getAuthData();
                 if (authData.hasDataForHttp()) {
                     for (Map.Entry<String, String> kv : authData.getHttpHeaders()) {
-                        consumeRequest.setHeader(kv.getKey(), kv.getValue());
+                        readRequest.setHeader(kv.getKey(), kv.getValue());
                     }
                 }
             }
@@ -262,17 +255,17 @@ public class CmdConsume extends AbstractCmdConsume {
             return -1;
         }
         CompletableFuture<Void> connected = new CompletableFuture<>();
-        ConsumerSocket consumerSocket = new ConsumerSocket(connected);
+        ConsumerSocket readerSocket = new ConsumerSocket(connected);
         try {
-            consumeClient.start();
+            readClient.start();
         } catch (Exception e) {
             LOG.error("Failed to start websocket-client", e);
             return -1;
         }
 
         try {
-            LOG.info("Trying to create websocket session..{}", consumerUri);
-            consumeClient.connect(consumerSocket, consumerUri, consumeRequest);
+            LOG.info("Trying to create websocket session..{}", readerUri);
+            readClient.connect(readerSocket, readerUri, readRequest);
             connected.get();
         } catch (Exception e) {
             LOG.error("Failed to create web-socket session", e);
@@ -280,14 +273,14 @@ public class CmdConsume extends AbstractCmdConsume {
         }
 
         try {
-            RateLimiter limiter = (this.consumeRate > 0) ? RateLimiter.create(this.consumeRate) : null;
-            while (this.numMessagesToConsume == 0 || numMessagesConsumed < this.numMessagesToConsume) {
+            RateLimiter limiter = (this.readRate > 0) ? RateLimiter.create(this.readRate) : null;
+            while (this.numMessagesToRead == 0 || numMessagesRead < this.numMessagesToRead) {
                 if (limiter != null) {
                     limiter.acquire();
                 }
-                String msg = consumerSocket.receive(5, TimeUnit.SECONDS);
+                String msg = readerSocket.receive(5, TimeUnit.SECONDS);
                 if (msg == null) {
-                    LOG.debug("No message to consume after waiting for 5 seconds.");
+                    LOG.debug("No message to read after waiting for 5 seconds.");
                 } else {
                     try {
                         String output = interpretByteArray(displayHex, Base64.getDecoder().decode(msg));
@@ -295,19 +288,37 @@ public class CmdConsume extends AbstractCmdConsume {
                     } catch (Exception e) {
                         System.out.println(msg);
                     }
-                    numMessagesConsumed += 1;
+                    numMessagesRead += 1;
                 }
             }
-            consumerSocket.awaitClose(2, TimeUnit.SECONDS);
+            readerSocket.awaitClose(2, TimeUnit.SECONDS);
         } catch (Exception e) {
-            LOG.error("Error while consuming messages");
+            LOG.error("Error while reading messages");
             LOG.error(e.getMessage(), e);
             returnCode = -1;
         } finally {
-            LOG.info("{} messages successfully consumed", numMessagesConsumed);
+            LOG.info("{} messages successfully read", numMessagesRead);
         }
 
         return returnCode;
+    }
+
+    @VisibleForTesting
+    static MessageId parseMessageId(String msgIdStr) {
+        MessageId msgId;
+        if ("Latest".equals(msgIdStr)) {
+            msgId = MessageId.latest;
+        } else if ("Earliest".equals(msgIdStr)) {
+            msgId = MessageId.earliest;
+        } else {
+            Matcher matcher = MSG_ID_PATTERN.matcher(msgIdStr);
+            if (matcher.find()) {
+                msgId = new MessageIdImpl(Long.parseLong(matcher.group(1)), Long.parseLong(matcher.group(2)), -1);
+            } else {
+                throw new IllegalArgumentException("Message ID must be 'Latest', 'Earliest' or '<ledgerId>:<entryId>'");
+            }
+        }
+        return msgId;
     }
 
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdRead.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdRead.java
@@ -61,8 +61,8 @@ public class CmdRead extends AbstractCmdConsume {
     private List<String> mainOptions = new ArrayList<String>();
 
     @Parameter(names = { "-m", "--start-message-id" },
-            description = "Initial reader position, it can be 'Latest', 'Earliest' or '<ledgerId>:<entryId>'")
-    private String startMessageId = "Latest";
+            description = "Initial reader position, it can be 'latest', 'earliest' or '<ledgerId>:<entryId>'")
+    private String startMessageId = "latest";
 
     @Parameter(names = { "-i", "--start-message-id-inclusive" },
             description = "Whether to include the position specified by -m option.")
@@ -220,8 +220,8 @@ public class CmdRead extends AbstractCmdConsume {
         }
 
         String msgIdQueryParam;
-        if ("Latest".equals(startMessageId) || "Earliest".equals(startMessageId)) {
-            msgIdQueryParam = startMessageId.toLowerCase();
+        if ("latest".equals(startMessageId) || "earliest".equals(startMessageId)) {
+            msgIdQueryParam = startMessageId;
         } else {
             MessageId msgId = parseMessageId(startMessageId);
             msgIdQueryParam = Base64.getEncoder().encodeToString(msgId.toByteArray());
@@ -306,16 +306,16 @@ public class CmdRead extends AbstractCmdConsume {
     @VisibleForTesting
     static MessageId parseMessageId(String msgIdStr) {
         MessageId msgId;
-        if ("Latest".equals(msgIdStr)) {
+        if ("latest".equals(msgIdStr)) {
             msgId = MessageId.latest;
-        } else if ("Earliest".equals(msgIdStr)) {
+        } else if ("earliest".equals(msgIdStr)) {
             msgId = MessageId.earliest;
         } else {
             Matcher matcher = MSG_ID_PATTERN.matcher(msgIdStr);
             if (matcher.find()) {
                 msgId = new MessageIdImpl(Long.parseLong(matcher.group(1)), Long.parseLong(matcher.group(2)), -1);
             } else {
-                throw new IllegalArgumentException("Message ID must be 'Latest', 'Earliest' or '<ledgerId>:<entryId>'");
+                throw new IllegalArgumentException("Message ID must be 'latest', 'earliest' or '<ledgerId>:<entryId>'");
             }
         }
         return msgId;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -99,6 +99,7 @@ public class PulsarClientTool {
     IUsageFormatter usageFormatter;
     protected CmdProduce produceCommand;
     protected CmdConsume consumeCommand;
+    protected CmdRead readCommand;
     CmdGenerateDocumentation generateDocumentation;
 
     public PulsarClientTool(Properties properties) {
@@ -126,6 +127,7 @@ public class PulsarClientTool {
     protected void initJCommander() {
         produceCommand = new CmdProduce();
         consumeCommand = new CmdConsume();
+        readCommand = new CmdRead();
         generateDocumentation = new CmdGenerateDocumentation();
 
         this.jcommander = new JCommander();
@@ -134,6 +136,7 @@ public class PulsarClientTool {
         jcommander.addObject(rootParams);
         jcommander.addCommand("produce", produceCommand);
         jcommander.addCommand("consume", consumeCommand);
+        jcommander.addCommand("read", readCommand);
         jcommander.addCommand("generate_documentation", generateDocumentation);
     }
 
@@ -196,6 +199,7 @@ public class PulsarClientTool {
         }
         this.produceCommand.updateConfig(clientBuilder, authentication, this.rootParams.serviceURL);
         this.consumeCommand.updateConfig(clientBuilder, authentication, this.rootParams.serviceURL);
+        this.readCommand.updateConfig(clientBuilder, authentication, this.rootParams.serviceURL);
     }
 
     public int run(String[] args) {
@@ -231,6 +235,8 @@ public class PulsarClientTool {
                 return produceCommand.run();
             } else if ("consume".equals(chosenCommand)) {
                 return consumeCommand.run();
+            } else if ("read".equals(chosenCommand)) {
+                return readCommand.run();
             } else if ("generate_documentation".equals(chosenCommand)) {
                 return generateDocumentation.run();
             } else {

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/TestCmdRead.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/TestCmdRead.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.cli;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.lang.reflect.Field;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class TestCmdRead {
+
+    @DataProvider(name = "startMessageIds")
+    public Object[][] startMessageIds() {
+        return new Object[][] {
+            { "Latest", "latest" },
+            { "Earliest", "earliest" },
+            { "10:0", "CAoQADAA" },
+            { "10:1", "CAoQATAA" },
+        };
+    }
+
+    @Test(dataProvider = "startMessageIds")
+    public void testGetWebSocketReadUri(String msgId, String msgIdQueryParam) throws Exception {
+        CmdRead cmdRead = new CmdRead();
+        cmdRead.updateConfig(null, null, "ws://localhost:8080/");
+        Field startMessageIdField = CmdRead.class.getDeclaredField("startMessageId");
+        startMessageIdField.setAccessible(true);
+        startMessageIdField.set(cmdRead, msgId);
+
+        String topicNameV1 = "persistent://public/cluster/default/t1";
+        assertEquals(cmdRead.getWebSocketReadUri(topicNameV1),
+                "ws://localhost:8080/ws/reader/persistent/public/cluster/default/t1?messageId=" + msgIdQueryParam);
+
+        String topicNameV2 = "persistent://public/default/t2";
+        assertEquals(cmdRead.getWebSocketReadUri(topicNameV2),
+                "ws://localhost:8080/ws/v2/reader/persistent/public/default/t2?messageId=" + msgIdQueryParam);
+    }
+
+    @Test
+    public void testPrseMessageId() {
+        assertEquals(CmdRead.parseMessageId("Latest"), MessageId.latest);
+        assertEquals(CmdRead.parseMessageId("Earliest"), MessageId.earliest);
+        assertEquals(CmdRead.parseMessageId("20:-1"), new MessageIdImpl(20, -1, -1));
+        assertEquals(CmdRead.parseMessageId("30:0"), new MessageIdImpl(30, 0, -1));
+        try {
+            CmdRead.parseMessageId("invalid");
+            fail("Should fail to parse invalid message ID");
+        } catch (Throwable t) {
+            assertTrue(t instanceof IllegalArgumentException);
+        }
+    }
+
+}

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/TestCmdRead.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/TestCmdRead.java
@@ -58,7 +58,7 @@ public class TestCmdRead {
     }
 
     @Test
-    public void testPrseMessageId() {
+    public void testParseMessageId() {
         assertEquals(CmdRead.parseMessageId("latest"), MessageId.latest);
         assertEquals(CmdRead.parseMessageId("earliest"), MessageId.earliest);
         assertEquals(CmdRead.parseMessageId("20:-1"), new MessageIdImpl(20, -1, -1));

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/TestCmdRead.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/TestCmdRead.java
@@ -33,8 +33,8 @@ public class TestCmdRead {
     @DataProvider(name = "startMessageIds")
     public Object[][] startMessageIds() {
         return new Object[][] {
-            { "Latest", "latest" },
-            { "Earliest", "earliest" },
+            { "latest", "latest" },
+            { "earliest", "earliest" },
             { "10:0", "CAoQADAA" },
             { "10:1", "CAoQATAA" },
         };
@@ -59,8 +59,8 @@ public class TestCmdRead {
 
     @Test
     public void testPrseMessageId() {
-        assertEquals(CmdRead.parseMessageId("Latest"), MessageId.latest);
-        assertEquals(CmdRead.parseMessageId("Earliest"), MessageId.earliest);
+        assertEquals(CmdRead.parseMessageId("latest"), MessageId.latest);
+        assertEquals(CmdRead.parseMessageId("earliest"), MessageId.earliest);
         assertEquals(CmdRead.parseMessageId("20:-1"), new MessageIdImpl(20, -1, -1));
         assertEquals(CmdRead.parseMessageId("30:0"), new MessageIdImpl(30, 0, -1));
         try {


### PR DESCRIPTION
### Motivation

I thought it would be convenient to create a reader easily with CLI, so I added the read command to pulsar-client-tools.

Example of use:
```sh
$ ./bin/pulsar-client read -m 48:-1 -n 5 persistent://public/default/t1

----- got message -----
key:[null], properties:[], content:m0
----- got message -----
key:[null], properties:[], content:m1
----- got message -----
key:[null], properties:[], content:m2
----- got message -----
key:[null], properties:[], content:m3
----- got message -----
key:[null], properties:[], content:m4
```

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
