### PR TITLE
[improve][ci] CI code coverage collecting improvements 

### DIFF
--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -134,7 +134,7 @@ jobs:
         run: |
           $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh create_test_coverage_report 
           cd $GITHUB_WORKSPACE/target
-          zip -r jacoco_test_coverage_report_flaky.zip jacoco_test_coverage_report
+          zip -qr jacoco_test_coverage_report_flaky.zip jacoco_test_coverage_report
 
       - name: Upload Jacoco report files to build artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -22,6 +22,8 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    - cron: '0 12 * * *'
   workflow_dispatch:
 
 concurrency:
@@ -39,6 +41,7 @@ jobs:
   preconditions:
     name: Preconditions
     runs-on: ubuntu-20.04
+    if: (github.event_name != 'schedule') || (github.repository == 'apache/pulsar')
     outputs:
       docs_only: ${{ steps.check_changes.outputs.docs_only }}
       changed_tests: ${{ steps.changes.outputs.tests_files }}

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -339,7 +339,7 @@ jobs:
           $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh restore_unittest_coverage_files
           $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh create_test_coverage_report 
           cd $GITHUB_WORKSPACE/target
-          zip -r jacoco_test_coverage_report_unittests.zip jacoco_test_coverage_report
+          zip -qr jacoco_test_coverage_report_unittests.zip jacoco_test_coverage_report
 
       - name: Upload Jacoco report files to build artifacts
         uses: actions/upload-artifact@v3
@@ -657,7 +657,7 @@ jobs:
           $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh create_inttest_coverage_report 
           $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh create_test_coverage_report
           cd $GITHUB_WORKSPACE/target
-          zip -r jacoco_test_coverage_report_inttests.zip jacoco_test_coverage_report jacoco_inttest_coverage_report
+          zip -qr jacoco_test_coverage_report_inttests.zip jacoco_test_coverage_report jacoco_inttest_coverage_report
 
       - name: Upload Jacoco report files to build artifacts
         uses: actions/upload-artifact@v3
@@ -1020,7 +1020,7 @@ jobs:
           $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh create_inttest_coverage_report
           $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh create_test_coverage_report
           cd $GITHUB_WORKSPACE/target
-          zip -r jacoco_test_coverage_report_systests.zip jacoco_test_coverage_report jacoco_inttest_coverage_report
+          zip -qr jacoco_test_coverage_report_systests.zip jacoco_test_coverage_report jacoco_inttest_coverage_report
 
       - name: Upload Jacoco report files to build artifacts
         uses: actions/upload-artifact@v3

--- a/build/pulsar_ci_tool.sh
+++ b/build/pulsar_ci_tool.sh
@@ -468,7 +468,7 @@ ci_create_test_coverage_report() {
     cd "$SCRIPT_DIR/.."
   fi
 
-  local execFiles=$(find . -path "*/target/jacoco*.exec" -printf "%P\n" )
+  local execFiles=$(find . -path "*/target/jacoco*.exec" -size +10c -printf "%P\n" )
   if [[ -n "$execFiles" ]]; then
     mkdir -p /tmp/jacocoDir
     if [ ! -f /tmp/jacocoDir/jacococli.jar ]; then

--- a/build/pulsar_ci_tool.sh
+++ b/build/pulsar_ci_tool.sh
@@ -387,6 +387,7 @@ _ci_upload_coverage_files() {
                 tar -I zstd -cPf - \
                   --transform="flags=r;s|\\(/jacoco.*\\).exec$|\\1_${testtype}_${testgroup}.exec|" \
                   --transform="flags=r;s|\\(/tmp/jacocoDir/.*\\).exec$|\\1_${testtype}_${testgroup}.exec|" \
+                  --exclude="*/META-INF/bundled-dependencies/*" \
                   $GITHUB_WORKSPACE/target/classpath_* \
                   $(find "$GITHUB_WORKSPACE" -path "*/target/jacoco*.exec" -printf "%p\n%h/classes\n" | sort | uniq) \
                   $([ -d /tmp/jacocoDir ] && echo "/tmp/jacocoDir" ) \

--- a/build/pulsar_ci_tool.sh
+++ b/build/pulsar_ci_tool.sh
@@ -359,9 +359,14 @@ _ci_upload_coverage_files() {
 
     ci_install_tool xmlstarlet
 
-    # iterate the exec files that were found
-    for execFile in $execFiles; do
-      local project=$(dirname "$(dirname "$execFile")")
+    local projects=$({
+      for execFile in $execFiles; do
+        echo $(dirname "$(dirname "$execFile")")
+      done
+    } | sort | uniq)
+
+    # iterate the projects
+    for project in $projects; do
       local artifactId=$(xmlstarlet sel -t -m _:project -v _:artifactId -n $project/pom.xml)
       # find the test scope classpath for the project
       mvn -f $project/pom.xml -DincludeScope=test -Dscan=false dependency:build-classpath  -B | { grep 'Dependencies classpath:' -A1 || true; } | tail -1 \

--- a/build/pulsar_ci_tool.sh
+++ b/build/pulsar_ci_tool.sh
@@ -352,7 +352,7 @@ _ci_upload_coverage_files() {
 
   local classpathFile="target/classpath_${testtype}_${testgroup}"
 
-  local execFiles=$(find . -path "*/target/jacoco.exec" -printf "%P\n")
+  local execFiles=$(find . -path "*/target/jacoco*.exec" -printf "%P\n")
   if [[ -n "$execFiles" ]]; then
     # create temp file
     local completeClasspathFile=$(mktemp -t tmp.classpath.XXXX)
@@ -361,7 +361,7 @@ _ci_upload_coverage_files() {
 
     # iterate the exec files that were found
     for execFile in $execFiles; do
-      local project="${execFile/%"/target/jacoco.exec"}"
+      local project=$(dirname "$(dirname "$execFile")")
       local artifactId=$(xmlstarlet sel -t -m _:project -v _:artifactId -n $project/pom.xml)
       # find the test scope classpath for the project
       mvn -f $project/pom.xml -DincludeScope=test -Dscan=false dependency:build-classpath  -B | { grep 'Dependencies classpath:' -A1 || true; } | tail -1 \
@@ -373,17 +373,17 @@ _ci_upload_coverage_files() {
     # delete temp file
     rm $completeClasspathFile
 
-    # upload target/jacoco.exec, target/classes and any dependent jar files that were built during the unit test execution
+    # upload target/jacoco*.exec, target/classes and any dependent jar files that were built during the unit test execution
     # transform jacoco exec filenames by appending "_${testtype}_${testgroup}" to the filename part to make the files unique
     # so that they don't get overridden when all files are extracted to the same working directory before merging
     (
       cd /
       ci_store_tar_to_github_actions_artifacts coverage_and_deps_${testtype}_${testgroup} \
                 tar -I zstd -cPf - \
-                  --transform="flags=r;s|/jacoco.exec$|/jacoco_${testtype}_${testgroup}.exec|" \
+                  --transform="flags=r;s|\\(/jacoco.*\\).exec$|\\1_${testtype}_${testgroup}.exec|" \
                   --transform="flags=r;s|\\(/tmp/jacocoDir/.*\\).exec$|\\1_${testtype}_${testgroup}.exec|" \
                   $GITHUB_WORKSPACE/target/classpath_* \
-                  $(find "$GITHUB_WORKSPACE" -path "*/target/jacoco.exec" -printf "%p\n%h/classes\n") \
+                  $(find "$GITHUB_WORKSPACE" -path "*/target/jacoco*.exec" -printf "%p\n%h/classes\n" | sort | uniq) \
                   $([ -d /tmp/jacocoDir ] && echo "/tmp/jacocoDir" ) \
                   $([[ $store_deps -eq 1 ]] && { cat $GITHUB_WORKSPACE/$classpathFile | sort | uniq | { grep -v -Fx -f /tmp/provided_pulsar_maven_artifacts || true; }; } || true)
     )
@@ -442,7 +442,7 @@ _ci_delete_coverage_files() {
   )
 }
 
-# creates an aggregated jacoco xml report for all projects that contain a target/jacoco.exec file
+# creates an aggregated jacoco xml report for all projects that contain a target/jacoco*.exec file
 #
 # the default maven jacoco report has multiple problems:
 # - by default, jacoco:report goal will only report coverage for the current project. it is not suitable for Pulsar's
@@ -454,7 +454,7 @@ _ci_delete_coverage_files() {
 #            the build results to run unit tests.
 #
 # This solution resolves the problem by using the Jacoco command line tool to generate the report.
-# It assumes that all projects that contain a target/jacoco.exec file will also contain compiled classfiles.
+# It assumes that all projects that contain a target/jacoco*.exec file will also contain compiled classfiles.
 ci_create_test_coverage_report() {
   echo "::group::Create test coverage report"
   if [ -n "$GITHUB_WORKSPACE" ]; then
@@ -463,7 +463,7 @@ ci_create_test_coverage_report() {
     cd "$SCRIPT_DIR/.."
   fi
 
-  local execFiles=$(find . '(' -path "*/target/jacoco.exec" -or -path "*/target/jacoco_*.exec" ')' -printf "%P\n" )
+  local execFiles=$(find . -path "*/target/jacoco*.exec" -printf "%P\n" )
   if [[ -n "$execFiles" ]]; then
     mkdir -p /tmp/jacocoDir
     if [ ! -f /tmp/jacocoDir/jacococli.jar ]; then

--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -128,12 +128,12 @@ function print_testng_failures() {
 function test_group_broker_flaky() {
   echo "::endgroup::"
   echo "::group::Running quarantined tests"
-  mvn_test -pl pulsar-broker -Dgroups='quarantine' -DexcludedGroups='' -DfailIfNoTests=false \
+  mvn_test --no-fail-fast -pl pulsar-broker -Dgroups='quarantine' -DexcludedGroups='' -DfailIfNoTests=false \
     -DtestForkCount=2 ||
     print_testng_failures pulsar-broker/target/surefire-reports/testng-failed.xml "Quarantined test failure in" "Quarantined test failures"
   echo "::endgroup::"
   echo "::group::Running flaky tests"
-  mvn_test -pl pulsar-broker -Dgroups='flaky' -DtestForkCount=2
+  mvn_test --no-fail-fast -pl pulsar-broker -Dgroups='flaky' -DtestForkCount=2
   echo "::endgroup::"
 }
 
@@ -168,7 +168,7 @@ function test_group_other() {
     perl -0777 -p -e 's/\n(\S)/,$1/g')
   if [ -n "${modules_with_quarantined_tests}" ]; then
     echo "::group::Running quarantined tests outside of pulsar-broker & pulsar-proxy (if any)"
-    mvn_test -pl "${modules_with_quarantined_tests}" test -Dgroups='quarantine' -DexcludedGroups='' \
+    mvn_test --no-fail-fast -pl "${modules_with_quarantined_tests}" test -Dgroups='quarantine' -DexcludedGroups='' \
       -DfailIfNoTests=false || \
         echo "::warning::There were test failures in the 'quarantine' test group."
     echo "::endgroup::"

--- a/pom.xml
+++ b/pom.xml
@@ -1968,6 +1968,7 @@ flexible messaging model and an intuitive client API.</description>
                 <configuration>
                   <!-- use unique jacoco exec files for every forked test process -->
                   <destFile>${project.build.directory}/jacoco_${maven.build.timestamp}_${surefire.forkNumber}.exec</destFile>
+                  <append>true</append>
                   <includes>
                     <include>org.apache.pulsar.*</include>
                     <include>org.apache.bookkeeper.mledger.*</include>

--- a/pom.xml
+++ b/pom.xml
@@ -1966,6 +1966,8 @@ flexible messaging model and an intuitive client API.</description>
                   <goal>prepare-agent</goal>
                 </goals>
                 <configuration>
+                  <!-- use unique jacoco exec files for every forked test process -->
+                  <destFile>${project.build.directory}/jacoco_${maven.build.timestamp}_${surefire.forkNumber}.exec</destFile>
                   <includes>
                     <include>org.apache.pulsar.*</include>
                     <include>org.apache.bookkeeper.mledger.*</include>


### PR DESCRIPTION
### Motivation

Code coverage for master branch need pulsar-ci-flaky to run with a scheduled job since flaky tests are also part of
the coverage. 
This PR contains some improvements and follow up on #19264 and #19296 changes.

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

- add scheduling to pulsar-ci-flaky
- make Jacoco agent use unique files for forked test processes to reduce chances of file corruption and contention
- don't use failfast mode for flaky tests and quarantined tests since it impacts coverage results
- suppress excessive logging when zipping jacoco html reports
- filter out empty .exec files
- skip uploading pulsar-io META-INF/bundled-dependencies files which take up over 900MB

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->