### PR TITLE
[fix][ci] Require coverage upload jobs to succeed before deleting intermediate build artifacts

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -1321,7 +1321,8 @@ jobs:
       'macos-build',
       'unit-tests-upload-coverage',
       'integration-tests-upload-coverage',
-      'system-tests-upload-coverage'
+      'system-tests-upload-coverage',
+      'owasp-dep-check'
     ]
     steps:
       - name: Check that all required jobs were completed successfully
@@ -1350,7 +1351,7 @@ jobs:
         uses: apache/pulsar-test-infra/gh-actions-artifact-client/dist@master
 
       - name: Delete maven repository binaries from GitHub Actions Artifacts
-        if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
+        if: ${{ needs.preconditions.outputs.docs_only != 'true' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         run: |
           gh-actions-artifact-client.js delete pulsar-maven-repository-binaries.tar.zst || true
           gh-actions-artifact-client.js delete pulsar-server-distribution.tar.zst || true


### PR DESCRIPTION
### Motivation

Uploading coverage to Codecov might fail. Uploading requires the intermediate pulsar-maven-repository-binaries.tar.zst so this shouldn't be deleted if one of the upload jobs has failed.

### Modifications

Add proper condition to deletion step. This PR will also skip deletion if owasp-dep-check or flaky-systems-tests fail.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->