### PR TITLE
[improve][broker] Replace authenticate with authenticateAsync

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProvider.java
@@ -156,7 +156,7 @@ public interface AuthenticationProvider extends Closeable {
     @Deprecated
     default boolean authenticateHttpRequest(HttpServletRequest request, HttpServletResponse response) throws Exception {
         AuthenticationState authenticationState = newHttpAuthState(request);
-        String role = authenticate(authenticationState.getAuthDataSource());
+        String role = authenticateAsync(authenticationState.getAuthDataSource()).get();
         request.setAttribute(AuthenticatedRoleAttributeName, role);
         request.setAttribute(AuthenticatedDataAttributeName, authenticationState.getAuthDataSource());
         return true;


### PR DESCRIPTION
PIP: #12105 

### Motivation

In order to support `AuthenticationProvider` implementations that only implement `authenticateAsync`, we need to replace the call to `authenticate` with `authenticateAsync` in the default method definition in `AuthenticationProvider#authenticateHttpRequest`.

This PR is necessary to get the tests passing in https://github.com/apache/pulsar/pull/19292.

I should have implemented #19197 this way from the beginning.

### Modifications

* Replace `authenticate` with `authenticateAsync`.

### Verifying this change

This PR is covered by the tests in `AuthenticationServiceTest`.

### Does this pull request potentially affect one of the following parts:

This is not a breaking change because the code was only just recently introduced to master branch.

### Documentation
- [x] `doc-not-needed`

### Matching PR in forked repository

PR in forked repository: this is a trivial change, so adding label to test now