### PR TITLE
[fix][ci] Fix "CI - OWASP Dependency Check" for other than master branch

### DIFF
--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -21,43 +21,40 @@ name: CI - OWASP Dependency Check
 on:
   schedule:
     - cron: '15 0 * * *'
+  workflow_dispatch:
 
 env:
   MAVEN_OPTS: -Xss1500k -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 
 jobs:
   run-owasp-dependency-check:
-    if: ${{ github.repository == 'apache/pulsar' }}
-    name: Run OWASP Dependency Check for ${{ matrix.name }}
+    if: ${{ github.repository == 'apache/pulsar' || github.event_name == 'workflow_dispatch' }}
+    name: Run OWASP Dependency Check for ${{ matrix.branch }}
     env:
-      JOB_NAME: Run OWASP Dependency Check for ${{ matrix.name }}
+      JOB_NAME: Run OWASP Dependency Check for ${{ matrix.branch }}
     runs-on: ubuntu-20.04
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: master
-            checkout_branch: 'master'
-          - name: branch-2.11
-            checkout_branch: 'branch-2.11'
-          - name: branch-2.10
-            checkout_branch: 'branch-2.10'
-          - name: branch-2.9
-            checkout_branch: 'branch-2.9'
-          - name: branch-2.8
-            checkout_branch: 'branch-2.8'
+          - branch: master
+          - branch: branch-2.11
+          - branch: branch-2.10
+          - branch: branch-2.9
+          - branch: branch-2.8
 
     steps:
       - name: checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ matrix.checkout_branch }}
+          ref: ${{ matrix.branch }}
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
 
       - name: Configure Gradle Enterprise
+        if: ${{ matrix.branch == 'master' }}
         uses: ./.github/actions/gradle-enterprise
         with:
           token: ${{ secrets.GE_ACCESS_TOKEN }}
@@ -76,21 +73,21 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-
 
       - name: Set up JDK 17
-        if: ${{ matrix.name != 'branch-2.8' && matrix.name != 'branch-2.9' && matrix.name != 'branch-2.10' }}
+        if: ${{ matrix.branch != 'branch-2.8' && matrix.branch != 'branch-2.9' && matrix.branch != 'branch-2.10' }}
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 17
 
       - name: Set up JDK 11
-        if: ${{ matrix.name == 'branch-2.8' || matrix.name == 'branch-2.9' || matrix.name == 'branch-2.10' }}
+        if: ${{ matrix.branch == 'branch-2.8' || matrix.branch == 'branch-2.9' || matrix.branch == 'branch-2.10' }}
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 11
 
       - name: run install by skip tests
-        run: mvn -q -B -ntp clean install -DskipTests
+        run: mvn -B -ntp clean install -DskipTests -Dspotbugs.skip=true  -Dlicense.skip=true -Dcheckstyle.skip=true -Drat.skip=true -DskipDocker=true
 
       - name: run OWASP Dependency Check for distribution/server (-DfailBuildOnAnyVulnerability=true)
         run: mvn -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl distribution/server -DfailBuildOnAnyVulnerability=true
@@ -102,7 +99,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: owasp-dependency-check-reports-${{ matrix.checkout_branch }}
+          name: owasp-dependency-check-reports-${{ matrix.branch }}
           path: |
             distribution/server/target/dependency-check-report.html
             distribution/offloaders/target/dependency-check-report.html

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -41,8 +41,11 @@ jobs:
           - branch: master
           - branch: branch-2.11
           - branch: branch-2.10
+            jdk: 11
           - branch: branch-2.9
+            jdk: 11
           - branch: branch-2.8
+            jdk: 11
 
     steps:
       - name: checkout
@@ -72,19 +75,11 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Set up JDK 17
-        if: ${{ matrix.branch != 'branch-2.8' && matrix.branch != 'branch-2.9' && matrix.branch != 'branch-2.10' }}
+      - name: Set up JDK ${{ matrix.jdk || '17' }}
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
-
-      - name: Set up JDK 11
-        if: ${{ matrix.branch == 'branch-2.8' || matrix.branch == 'branch-2.9' || matrix.branch == 'branch-2.10' }}
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: 11
+          java-version: ${{ matrix.jdk || '17' }}
 
       - name: run install by skip tests
         run: mvn -B -ntp clean install -DskipTests -Dspotbugs.skip=true  -Dlicense.skip=true -Dcheckstyle.skip=true -Drat.skip=true -DskipDocker=true

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -29,9 +29,9 @@ env:
 jobs:
   run-owasp-dependency-check:
     if: ${{ github.repository == 'apache/pulsar' || github.event_name == 'workflow_dispatch' }}
-    name: Run OWASP Dependency Check for ${{ matrix.branch }}
+    name: Check ${{ matrix.branch }}
     env:
-      JOB_NAME: Run OWASP Dependency Check for ${{ matrix.branch }}
+      JOB_NAME: Check ${{ matrix.branch }}
     runs-on: ubuntu-20.04
     timeout-minutes: 45
     strategy:


### PR DESCRIPTION
### Motivation

- "Configure Gradle Enterprise" step fails for other than master branch

### Modifications

- don't run "Configure Gradle Enterprise" step for other branches

- also improve the workflow
  - simplify matrix variables
  - optimize the "mvn clean install" build by skipping as much as possible
  - allow triggering manually (workflow_dispatch)

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

Test run of "CI - OWASP Dependency Check" in forked repository: 
https://github.com/lhotari/pulsar/actions/runs/3994121428