### PR TITLE
[fix][test] Fix flaky test ReplicatorTest.testDoNotReplicateSystemTopic

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -1484,6 +1484,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         admin1.namespaces().createNamespace(namespace, Sets.newHashSet("r1", "r2", "r3"));
         String topic = TopicName.get("persistent", NamespaceName.get(namespace),
                 "testDoesNotReplicateSystemTopic").toString();
+        admin1.topics().createNonPartitionedTopic(topic);
         String systemTopic = TopicName.get("persistent", NamespaceName.get(namespace),
                 SystemTopicNames.TRANSACTION_BUFFER_SNAPSHOT).toString();
 
@@ -1496,7 +1497,6 @@ public class ReplicatorTest extends ReplicatorTestBase {
                 .subscriptionName("sub-rep")
                 .subscribe();
 
-        admin1.topics().createNonPartitionedTopic(topic);
         // Replicator will not replicate System Topic other than topic policies
         initTransaction(2, admin1, pulsar1.getBrokerServiceUrl(), pulsar1);
         @Cleanup
@@ -1520,11 +1520,13 @@ public class ReplicatorTest extends ReplicatorTestBase {
         assertNull(consumerFromR2.receive(5, TimeUnit.SECONDS));
         transaction.commit();
 
-        Awaitility.await().untilAsserted(() -> {
-            Assert.assertEquals(admin1.topics().getStats(systemTopic).getReplication().size(), 0);
-            Assert.assertEquals(admin2.topics().getStats(systemTopic).getReplication().size(), 0);
-            Assert.assertEquals(admin3.topics().getStats(systemTopic).getReplication().size(), 0);
-        });
+        // wait before evaluating stats for the system topics
+        Thread.sleep(500L);
+
+        Assert.assertEquals(admin1.topics().getStats(systemTopic).getReplication().size(), 0);
+        Assert.assertEquals(admin2.topics().getStats(systemTopic).getReplication().size(), 0);
+        Assert.assertEquals(admin3.topics().getStats(systemTopic).getReplication().size(), 0);
+
         Assert.assertEquals(consumerFromR2.receive(5, TimeUnit.SECONDS).getValue(),
                 "1".getBytes(StandardCharsets.UTF_8));
         cleanup();


### PR DESCRIPTION
Fixes #19297

### Motivation

ReplicatorTest.testDoNotReplicateSystemTopic is flaky, see #19297

### Modifications

- Move topic creation before creating the consumer. 
  -  Creating the consumer created a race for creating the topic via replication and that caused the flakiness
- Fix invalid way to check for topic stats. The usage of Awaitility was invalid in this case and it caused a 10 second delay.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->