### PR TITLE
[improve][ml] Use correct isActive method for cursor

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3662,7 +3662,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     public void activateCursor(ManagedCursor cursor) {
         synchronized (activeCursors) {
-            if (!cursor.isActive()) {
+            if (activeCursors.get(cursor.getName()) == null) {
                 Position positionForOrdering = config.isCacheEvictionByMarkDeletedPosition()
                         ? cursor.getMarkDeletedPosition()
                         : cursor.getReadPosition();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3662,7 +3662,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     public void activateCursor(ManagedCursor cursor) {
         synchronized (activeCursors) {
-            if (activeCursors.get(cursor.getName()) == null) {
+            if (!isCursorActive(cursor)) {
                 Position positionForOrdering = config.isCacheEvictionByMarkDeletedPosition()
                         ? cursor.getMarkDeletedPosition()
                         : cursor.getReadPosition();


### PR DESCRIPTION
### Motivation

In https://github.com/apache/pulsar/pull/19159, we made a change motivated by simplifying the code. However, one problem is that it changed the level of abstraction by calling the `ManagedCursor` class, which could technically have a different definition of `isActive`. In order to retain the original meaning, I am reverting that PR and using a method in the `ManagedLedgerImpl` class to simplify the code.

Other relevant context: https://github.com/apache/pulsar/pull/19159#pullrequestreview-1244210656 and https://github.com/apache/pulsar/pull/19159#discussion_r1067185187

### Modifications

* Revert https://github.com/apache/pulsar/pull/19159
* Use `isCursorActive` method instead.

### Verifying this change

This is a return to the previous state with a cosmetic change, so the current test coverage should suffice.

### Does this pull request potentially affect one of the following parts:

No breaking changes.

### Documentation

- [x] `doc-not-needed`

### Matching PR in forked repository

PR in forked repository: skipping the PR