### PR TITLE
[fix][ci] Fix coverage condition for master branch

### DIFF
--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -76,7 +76,7 @@ jobs:
         run: |
           echo "collect_coverage=${{ 
           (steps.check_changes.outputs.docs_only != 'true' && github.event_name != 'workflow_dispatch' 
-            && (github.base_ref == 'master' || github.ref == 'master')) 
+            && (github.base_ref == 'master' || github.ref_name == 'master')) 
           || (github.event_name == 'workflow_dispatch' && github.event.inputs.collect_coverage == 'true')
           }}"  >> $GITHUB_OUTPUT
 

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -78,7 +78,7 @@ jobs:
         run: |
           echo "collect_coverage=${{ 
           (steps.check_changes.outputs.docs_only != 'true' && github.event_name != 'workflow_dispatch' 
-            && (github.base_ref == 'master' || github.ref == 'master')) 
+            && (github.base_ref == 'master' || github.ref_name == 'master')) 
           || (github.event_name == 'workflow_dispatch' && github.event.inputs.collect_coverage == 'true')
           }}"  >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
### Motivation

- master branch doesn't currently collect coverage for scheduled builds
- github.ref_name should be used in the coverage condition.
  - github.ref is the in format refs/heads/<branch> github.ref_name is in format <branch>
  - [docs for github context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)

### Modifications

- github.ref -> github.ref_name

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->