### PR TITLE
[improve] [ml] Reduce the lock time when calculating backlog size

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3869,12 +3869,14 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         for (int i = 0; i < 10; i++) {
             positions.add(ledger.addEntry(new byte[1]));
         }
+        PositionImpl largerThanLastLedgerId = PositionImpl.get(positions.get(9).getLedgerId() + 100, 1);
 
         // case1: Slowest position is null.
         MLSnapshotForBacklogSize mlSnapshot1 = ledger.snapshotForBacklogSize(false);
         Assert.assertEquals(ledger.getEstimatedBacklogSize(new PositionImpl(-1, -1), mlSnapshot1), 10);
         Assert.assertEquals(ledger.getEstimatedBacklogSize(((PositionImpl) positions.get(1)), mlSnapshot1), 8);
         Assert.assertEquals(ledger.getEstimatedBacklogSize(((PositionImpl) positions.get(9)).getNext(), mlSnapshot1), 0);
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(largerThanLastLedgerId, mlSnapshot1), 0);
         mlSnapshot1.recycle();
 
         // case2: Slowest position is not null.
@@ -3885,6 +3887,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         Assert.assertEquals(ledger.getEstimatedBacklogSize(new PositionImpl(-1, -1), mlSnapshot2), 8);
         Assert.assertEquals(ledger.getEstimatedBacklogSize(((PositionImpl) positions.get(5)), mlSnapshot2), 4);
         Assert.assertEquals(ledger.getEstimatedBacklogSize(((PositionImpl) positions.get(9)).getNext(), mlSnapshot2), 0);
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(largerThanLastLedgerId, mlSnapshot2), 0);
         mlSnapshot2.recycle();
 
         // case3: Slowest position is not null & @param containsConsumedLedgers is true.
@@ -3892,6 +3895,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         Assert.assertEquals(ledger.getEstimatedBacklogSize(new PositionImpl(-1, -1), mlSnapshot3), 10);
         Assert.assertEquals(ledger.getEstimatedBacklogSize(((PositionImpl) positions.get(5)), mlSnapshot3), 4);
         Assert.assertEquals(ledger.getEstimatedBacklogSize(((PositionImpl) positions.get(9)).getNext(), mlSnapshot3), 0);
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(largerThanLastLedgerId, mlSnapshot3), 0);
         mlSnapshot3.recycle();
 
         // cleanup.

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -125,6 +125,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.policies.data.EnsemblePlacementPolicyConfig;
 import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
+import org.apache.pulsar.common.policies.data.stats.MLSnapshotForBacklogSize;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.Stat;
 import org.apache.pulsar.metadata.api.extended.SessionEvent;
@@ -3850,9 +3851,51 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
             positions.add(ledger.addEntry(new byte[1]));
         }
 
-        Assert.assertEquals(ledger.getEstimatedBacklogSize(new PositionImpl(-1, -1)), 10);
-        Assert.assertEquals(ledger.getEstimatedBacklogSize(((PositionImpl) positions.get(1))), 8);
-        Assert.assertEquals(ledger.getEstimatedBacklogSize(((PositionImpl) positions.get(9)).getNext()), 0);
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(new PositionImpl(-1, -1), null), 10);
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(((PositionImpl) positions.get(1)), null), 8);
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(((PositionImpl) positions.get(9)).getNext(), null), 0);
+        ledger.close();
+    }
+
+    @Test
+    public void testGetEstimatedBacklogSizeWithMLSnapshot() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(2);
+        config.setRetentionTime(-1, TimeUnit.SECONDS);
+        config.setRetentionSizeInMB(-1);
+        ManagedLedgerImpl ledger =
+                (ManagedLedgerImpl) factory.open("testGetEstimatedBacklogSizeWithMLSnapshot", config);
+        List<Position> positions = new ArrayList<>(10);
+        for (int i = 0; i < 10; i++) {
+            positions.add(ledger.addEntry(new byte[1]));
+        }
+
+        // case1: Slowest position is null.
+        MLSnapshotForBacklogSize mlSnapshot1 = ledger.snapshotForBacklogSize(false);
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(new PositionImpl(-1, -1), mlSnapshot1), 10);
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(((PositionImpl) positions.get(1)), mlSnapshot1), 8);
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(((PositionImpl) positions.get(9)).getNext(), mlSnapshot1), 0);
+        mlSnapshot1.recycle();
+
+        // case2: Slowest position is not null.
+        ManagedCursor cursor1 = mock(ManagedCursor.class);
+        when(cursor1.getName()).thenReturn("cursor1");
+        ledger.getCursors().add(cursor1, (positions.get(2)));
+        MLSnapshotForBacklogSize mlSnapshot2 = ledger.snapshotForBacklogSize(false);
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(new PositionImpl(-1, -1), mlSnapshot2), 8);
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(((PositionImpl) positions.get(5)), mlSnapshot2), 4);
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(((PositionImpl) positions.get(9)).getNext(), mlSnapshot2), 0);
+        mlSnapshot2.recycle();
+
+        // case3: Slowest position is not null & @param containsConsumedLedgers is true.
+        MLSnapshotForBacklogSize mlSnapshot3 = ledger.snapshotForBacklogSize(true);
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(new PositionImpl(-1, -1), mlSnapshot3), 10);
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(((PositionImpl) positions.get(5)), mlSnapshot3), 4);
+        Assert.assertEquals(ledger.getEstimatedBacklogSize(((PositionImpl) positions.get(9)).getNext(), mlSnapshot3), 0);
+        mlSnapshot3.recycle();
+
+        // cleanup.
+        ledger.getCursors().removeCursor(cursor1.getName());
         ledger.close();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3305,7 +3305,7 @@ public class PersistentTopicsBase extends AdminResource {
                                         if (messageId.getLedgerId() == -1) {
                                             asyncResponse.resume(managedLedger.getTotalSize());
                                         } else {
-                                            asyncResponse.resume(managedLedger.getEstimatedBacklogSize(pos));
+                                            asyncResponse.resume(managedLedger.getEstimatedBacklogSize(pos, null));
                                         }
                                     }).exceptionally(ex -> {
                                         // If the exception is not redirect exception we need to log it.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -36,6 +36,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ClearBacklogCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCallback;
@@ -86,6 +87,7 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.TransactionInPendingAckStats;
 import org.apache.pulsar.common.policies.data.TransactionPendingAckStats;
 import org.apache.pulsar.common.policies.data.stats.ConsumerStatsImpl;
+import org.apache.pulsar.common.policies.data.stats.MLSnapshotForBacklogSize;
 import org.apache.pulsar.common.policies.data.stats.SubscriptionStatsImpl;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.stats.PositionInPendingAckStats;
@@ -1066,7 +1068,8 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
     }
 
     public SubscriptionStatsImpl getStats(Boolean getPreciseBacklog, boolean subscriptionBacklogSize,
-                                          boolean getEarliestTimeInBacklog) {
+                                          boolean getEarliestTimeInBacklog,
+                                          @Nullable MLSnapshotForBacklogSize mlSnapshot) {
         SubscriptionStatsImpl subStats = new SubscriptionStatsImpl();
         subStats.lastExpireTimestamp = lastExpireTimestamp;
         subStats.lastConsumedFlowTimestamp = lastConsumedFlowTimestamp;
@@ -1130,7 +1133,7 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
         subStats.msgBacklog = getNumberOfEntriesInBacklog(getPreciseBacklog);
         if (subscriptionBacklogSize) {
             subStats.backlogSize = ((ManagedLedgerImpl) topic.getManagedLedger())
-                    .getEstimatedBacklogSize((PositionImpl) cursor.getMarkDeletedPosition());
+                    .getEstimatedBacklogSize((PositionImpl) cursor.getMarkDeletedPosition(), mlSnapshot);
         } else {
             subStats.backlogSize = -1;
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -2169,7 +2169,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         sub1.addConsumer(consumer1);
         consumer1.close();
 
-        SubscriptionStatsImpl stats1 = sub1.getStats(false, false, false);
+        SubscriptionStatsImpl stats1 = sub1.getStats(false, false, false, null);
         assertEquals(stats1.keySharedMode, "AUTO_SPLIT");
         assertFalse(stats1.allowOutOfOrderDelivery);
 
@@ -2180,7 +2180,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         sub2.addConsumer(consumer2);
         consumer2.close();
 
-        SubscriptionStatsImpl stats2 = sub2.getStats(false, false, false);
+        SubscriptionStatsImpl stats2 = sub2.getStats(false, false, false, null);
         assertEquals(stats2.keySharedMode, "AUTO_SPLIT");
         assertTrue(stats2.allowOutOfOrderDelivery);
 
@@ -2192,7 +2192,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         sub3.addConsumer(consumer3);
         consumer3.close();
 
-        SubscriptionStatsImpl stats3 = sub3.getStats(false, false, false);
+        SubscriptionStatsImpl stats3 = sub3.getStats(false, false, false, null);
         assertEquals(stats3.keySharedMode, "STICKY");
         assertFalse(stats3.allowOutOfOrderDelivery);
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/MLSnapshotForBacklogSize.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/MLSnapshotForBacklogSize.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data.stats;
+
+import io.netty.util.Recycler;
+import io.netty.util.concurrent.FastThreadLocal;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import lombok.Getter;
+
+/**
+ * A value object that represents the snapshot of a managed ledger and is used to calculate the "backlogSize" of a
+ * topic's subscriptions.
+ */
+public class MLSnapshotForBacklogSize {
+
+    private static final FastThreadLocal<MLSnapshotForBacklogSize> ML_SNAPSHOT_THREAD_LOCAL =
+            new FastThreadLocal<MLSnapshotForBacklogSize>(){
+                protected MLSnapshotForBacklogSize initialValue() throws Exception {
+                    return new MLSnapshotForBacklogSize();
+                }
+            };
+
+    /** Corresponds to the 'ManagedLedgerImpl.ledgers' field. **/
+    @Getter
+    private NavigableMap<Long, SimpleLedgerInfo> ledgers = new TreeMap<>();
+
+    /** Corresponds to the 'ManagedLedgerImpl.currentLedger' field. **/
+    @Getter
+    private long currentLedger;
+
+    /** Corresponds to the 'ManagedLedgerImpl.currentLedgerSize' field. **/
+    @Getter
+    private long currentLedgerSize;
+
+    /** Corresponds to the 'ManagedLedgerImpl.currentLedgerEntries' field. **/
+    @Getter
+    private long currentLedgerEntries;
+
+    /** Corresponds to the 'ManagedLedgerImpl.totalSize' field. **/
+    @Getter
+    private long totalSize;
+
+    private MLSnapshotForBacklogSize(){}
+
+    public static MLSnapshotForBacklogSize newInstance(long currentLedger, long currentLedgerSize,
+                                                       long currentLedgerEntries, long totalSize){
+        MLSnapshotForBacklogSize v = ML_SNAPSHOT_THREAD_LOCAL.get();
+        v.currentLedger = currentLedger;
+        v.currentLedgerSize = currentLedgerSize;
+        v.currentLedgerEntries = currentLedgerEntries;
+        v.totalSize = totalSize;
+        return v;
+    }
+
+    public void recycle(){
+        currentLedger = 0;
+        currentLedgerSize = 0;
+        currentLedgerEntries = 0;
+        totalSize = 0;
+        ledgers.values().forEach(simpleLedgerInfo -> simpleLedgerInfo.recycle());
+        // Avoid can not GC the overstretched collection.
+        if (ledgers.size() > 8192) {
+            ledgers = new TreeMap<>();
+        } else {
+            ledgers.clear();
+        }
+    }
+
+    public static final class SimpleLedgerInfo {
+
+        private final Recycler.Handle<SimpleLedgerInfo> handle;
+        @Getter
+        private long size;
+        @Getter
+        private long entries;
+
+        private static final Recycler<SimpleLedgerInfo> SIMPLE_LEDGER_INFO_RECYCLER =
+                new Recycler<SimpleLedgerInfo>(512) {
+                    @Override
+                    protected SimpleLedgerInfo newObject(Handle<SimpleLedgerInfo> handle) {
+                        return new SimpleLedgerInfo(handle);
+                    }
+                };
+
+        private SimpleLedgerInfo(Recycler.Handle<SimpleLedgerInfo> handle){
+            this.handle = handle;
+        }
+
+        public static SimpleLedgerInfo newInstance(long size, long entries){
+            SimpleLedgerInfo info = SIMPLE_LEDGER_INFO_RECYCLER.get();
+            info.size = size;
+            info.entries = entries;
+            return info;
+        }
+
+        public void recycle(){
+            size = 0;
+            entries = 0;
+            handle.recycle(this);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

When we call `pulsar-admin topics stats`, we calculate the backlog size of each subscription; during this process, managed-ledger's synchronization lock is used(see `code-1` below), which affects the sending of messages. If there are `N` subscriptions under this topic, then will acquire this synchronization lock N times , which magnifies the impact.

#### Code-1: synchronization in ManagedLedger

https://github.com/apache/pulsar/blob/644be5fdd6d080accffd72229b2e21e35a27d722/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L1269-L1283

### Modifications

<strong>(Highlight)</strong>No matter how many subscriptions there are, the synchronization lock in the managed ledger is only acquired once when `pulsar-admin topics stats` is called.
- Take a snapshot of the Managed ledger (which would require a lock to ensure that multiple variables match), and then use the snapshot to calculate backlog size for each subscription(this will incur excess memory).

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- https://github.com/poorbarcode/pulsar/pull/55
