### PR TITLE
[improve][broker] Optimization lower boundary strategy

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
@@ -227,7 +227,8 @@ public class ThresholdShedder implements LoadSheddingStrategy {
                 maxUsageBrokerName = broker;
             }
             // Whether any brokers with low usage in the cluster.
-            if (currentUsage < avgUsage - threshold) {
+            double lowerUsage = avgUsage - threshold;
+            if (currentUsage < lowerUsage || lowerUsage <= 0) {
                 hasBrokerBelowLowerBound = true;
             }
         }


### PR DESCRIPTION

### Motivation

There are 3 brokers: 

- broker0 is loaded at 10%, bundle throughput is 10MB.
- broker1 is loaded at 0%

The average load is `0.1 / 2 = 0.05`, It will be below the threshold: `0.1`.

So the unload will not be triggered, at this point, there will be an idle broker.



### Modifications

Triggers unloading when the average load is less than the threshold value.

### Verifying this change

- [x] Make sure that the change passes the CI checks.



This change added tests and can be verified as follows:

*(example:)*
  - https://github.com/apache/pulsar/blob/73a1dd28f11741f1e7e9cfc071f9b7cdfa0a3226/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedderTest.java#L368

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/crossoverJie/pulsar/pull/5
