### PR TITLE
[fix] [ml] messagesConsumedCounter of cursor is larger than total entries of ML

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -180,6 +180,25 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             .newUpdater(ManagedLedgerImpl.class, "entriesAddedCounter");
     @SuppressWarnings("unused")
     private volatile long entriesAddedCounter = 0;
+    /**
+     * After writing a new entry, {@link #entriesAddedCounter} and {@link #lastConfirmedEntry} will be changed. To
+     * improve performance, changes to these two variables are not included in the lock block, which will cause us to be
+     * unable to determine whether the two variables match.
+     *
+     * This field can help to verify that {@link #entriesAddedCounter} and {@link #lastConfirmedEntry} match.
+     * Value will be -1 if {@link #entriesAddedCounter} or {@link #lastConfirmedEntry} is changing, else equals to
+     * {@link #entriesAddedCounter}.
+     *
+     * We can use this field this way:
+     * <pre>{@code
+     *   long counterBefore = entriesAddedCounterState;
+     *   long lac = lastConfirmedEntry;
+     *   long counterAfter = entriesAddedCounterState;
+     *   // if "counterBefore" and counterAfter" both large than -1 and "counterBefore" equals with "counterAfter", it
+     *   // means "counterAfter"/"counterBefore" matches "lac".
+     * }</pre>
+     **/
+    volatile long entriesAddedCounterState = entriesAddedCounter;
 
     static final AtomicLongFieldUpdater<ManagedLedgerImpl> NUMBER_OF_ENTRIES_UPDATER = AtomicLongFieldUpdater
             .newUpdater(ManagedLedgerImpl.class, "numberOfEntries");
@@ -348,7 +367,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         this.executor = bookKeeper.getMainWorkerPool().chooseThread(name);
         TOTAL_SIZE_UPDATER.set(this, 0);
         NUMBER_OF_ENTRIES_UPDATER.set(this, 0);
-        ENTRIES_ADDED_COUNTER_UPDATER.set(this, 0);
+        setEntriesAddedCounter(0);
         STATE_UPDATER.set(this, State.None);
         this.ledgersStat = null;
         this.mbean = new ManagedLedgerMBeanImpl(this);
@@ -3630,16 +3649,19 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
      */
     Pair<PositionImpl, Long> getLastPositionAndCounter() {
         PositionImpl pos;
-        long count;
+        long countBefore;
+        long countAfter;
 
         do {
+            countBefore = entriesAddedCounterState;
             pos = lastConfirmedEntry;
-            count = ENTRIES_ADDED_COUNTER_UPDATER.get(this);
+            countAfter = entriesAddedCounterState;
 
             // Ensure no entry was written while reading the two values
-        } while (pos.compareTo(lastConfirmedEntry) != 0);
+        } while (countBefore < 0 || countAfter < 0 || countBefore != countAfter
+                || pos.compareTo(lastConfirmedEntry) != 0);
 
-        return Pair.of(pos, count);
+        return Pair.of(pos, countAfter);
     }
 
     /**
@@ -4186,6 +4208,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     @VisibleForTesting
     public void setEntriesAddedCounter(long count) {
         ENTRIES_ADDED_COUNTER_UPDATER.set(this, count);
+        entriesAddedCounterState = entriesAddedCounter;
     }
 
     private static final Logger log = LoggerFactory.getLogger(ManagedLedgerImpl.class);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -234,8 +234,10 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
         }
 
         PositionImpl lastEntry = PositionImpl.get(ledgerId, entryId);
+        ml.entriesAddedCounterState = -1;
         ManagedLedgerImpl.ENTRIES_ADDED_COUNTER_UPDATER.incrementAndGet(ml);
         ml.lastConfirmedEntry = lastEntry;
+        ml.entriesAddedCounterState = ml.getEntriesAddedCounter();
 
         if (closeWhenDone) {
             log.info("[{}] Closing ledger {} for being full", ml.getName(), ledgerId);


### PR DESCRIPTION
### Motivation

#### 1.A compensation mechanism for backlog less than 0

The field `backlog` of the subscription can be less than zero(this only can be caused by messagesConsumedCounter of cursor is larger than total entries of ML). We can see that there is a patch here to handle this scenario:

https://github.com/apache/pulsar/blob/e2851da923a729423de54dc3a95d1e7a43b6e08a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L1110-L1114

----

####  2.Backlog wrong caused by `messagesConsumedCounter` wrong

When `create subscription(initialized position to earliest)` and `send messages` are executed concurrently, an incorrect count occurs, leading to the field `backlog` of subscription less than 0. For example:

##### 2-1. Create a new topic, the field `currentLedger` of the managed ledger is `3`. Then send 10 messages.

##### 2-2. Concurrently processes
| time | thread: `create new cursor`| thread: `add entry`|
| --- | --- | --- |
| 1 | | increment `entriesAddedCounter`( before: `0`, after: `1` ) of ML | 
| 2 | get `entriesAddedCounter` of ML: `1` | |
| 3 | get `lastConfirmedEntry` of ML: `3:0` | |
| 4 | set `messagesConsumedCounter` to `1` | |
| 4 | set `markDeletePosition` to `3:0` | |
| 5 | | update `lastConfirmedEntry(3:1)` of ML |

<strong>(Highlight)</strong>Now consumer doesn't consume any messages, but `messagesConsumedCounter` of cursor is already `1`

##### 2-3. Error occur
- After sending 10 messages, the field `entriesAddedCounter` of ML will be `10`
- After consuming all 10 messages, the `messagesConsumedCounter` of the cursor will be `1 + 10`
- Then `ManagedLedgerImpl.ENTRIES_ADDED_COUNTER_UPDATER.get(ledger) - messagesConsumedCounter` will be `-1`.

----

#### 3. Reproduce issue
Since it is hard to write a non-invasive test. (Highlight)You can reproduce by `StatsBackLogTest.testMessagesConsumedCounterCorrect` in PR https://github.com/apache/pulsar/pull/19353

### Modifications

- Add a field that can help to verify that `entriesAddedCounter` and `lastConfirmedEntry` match, and use it to get matching `entriesAddedCounter` and `lastConfirmedEntry`.
- TODO I will write a test later




### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- https://github.com/poorbarcode/pulsar/pull/57
