### PR TITLE
[Do not merge][Issue] Reproduce:messagesConsumedCounter of cursor is …

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -993,6 +993,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             public void operationComplete() {
                 log.info("[{}] Opened new cursor: {}", name, cursor);
                 cursor.setActive();
+                if (name.startsWith("my-property/my-ns/persistent/tp_") && !cursors.isEmpty()) {
+                    ProcessCoordinator.waitAndChangeStep(2);
+                }
                 synchronized (ManagedLedgerImpl.this) {
                     // Update the ack position (ignoring entries that were written while the cursor was being created)
                     cursor.initializeCursorPosition(InitialPosition.Earliest == initialPosition
@@ -3638,7 +3641,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
             // Ensure no entry was written while reading the two values
         } while (pos.compareTo(lastConfirmedEntry) != 0);
-
+        if (name.startsWith("my-property/my-ns/persistent/tp_") && !cursors.isEmpty()) {
+            ProcessCoordinator.waitAndChangeStep(3);
+        }
         return Pair.of(pos, count);
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -235,6 +235,10 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
 
         PositionImpl lastEntry = PositionImpl.get(ledgerId, entryId);
         ManagedLedgerImpl.ENTRIES_ADDED_COUNTER_UPDATER.incrementAndGet(ml);
+        if (ml.name.startsWith("my-property/my-ns/persistent/tp_")){
+            ProcessCoordinator.waitAndChangeStep(1);
+            ProcessCoordinator.waitAndChangeStep(4);
+        }
         ml.lastConfirmedEntry = lastEntry;
 
         if (closeWhenDone) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ProcessCoordinator.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ProcessCoordinator.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ProcessCoordinator {
+
+    private static final AtomicInteger COORDINATOR = new AtomicInteger();
+
+    public static void stop() {
+        COORDINATOR.set(Integer.MAX_VALUE);
+    }
+
+    public static void start() {
+        COORDINATOR.set(0);
+    }
+
+    public static void waitAndChangeStep(int toStep){
+        if (COORDINATOR.get() >= toStep){
+            return;
+        }
+        while (!COORDINATOR.compareAndSet(toStep - 1, toStep)){
+            log.info("Process coordinator {} -> {}", toStep - 1, toStep);
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {}
+        }
+    }
+
+    public static int getCurrentStep(){
+        return COORDINATOR.get();
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/StatsBackLogTest.java
+++ b/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/StatsBackLogTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker-api")
+public class StatsBackLogTest extends ProducerConsumerBase {
+
+    private static final int MAX_ENTRY_COUNT_PER_LEDGER = 10;
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    protected void doInitConf() throws Exception {
+        conf.setManagedLedgerMaxEntriesPerLedger(5);
+        conf.setManagedLedgerMinLedgerRolloverTimeMinutes(0);
+        conf.setRetentionCheckIntervalInSeconds(Integer.MAX_VALUE);
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    private PersistentTopic getPersistentTopic(String topicName){
+        return (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false).join().get();
+    }
+
+    private ManagedLedgerImpl getManagedLedger(String topicName){
+        return (ManagedLedgerImpl) getPersistentTopic(topicName).getManagedLedger();
+    }
+
+    private ManagedCursorImpl getManagedCursor(String topicName, String subName){
+        for (ManagedCursor cursor : getManagedLedger (topicName).getCursors()){
+            if (cursor.getName().equals(subName)){
+                return (ManagedCursorImpl) cursor;
+            }
+        }
+        return null;
+    }
+
+    private SendInfo sendMessages(int ledgerCount, int entryCountPerLedger, Producer<String> producer,
+                                      String topicName) throws Exception{
+        List<MessageId> messageIds = new ArrayList<>(ledgerCount * entryCountPerLedger);
+        MessageIdImpl startMessageId = null;
+        MessageIdImpl lastMessageId = null;
+        for (int m = 0; m < ledgerCount; m++) {
+            for (int n = 0; n < entryCountPerLedger; n++) {
+                lastMessageId = (MessageIdImpl) producer.send(String.format("%s:%s", m, n));
+                if (startMessageId == null){
+                    startMessageId = lastMessageId;
+                }
+                messageIds.add(lastMessageId);
+            }
+            if (entryCountPerLedger < MAX_ENTRY_COUNT_PER_LEDGER) {
+                admin.topics().unload(topicName);
+            }
+        }
+        return new SendInfo(messageIds, startMessageId, lastMessageId);
+    }
+
+    private void consumeAllMessages(Consumer<String> consumer) throws Exception {
+        Message<String> lastMessage;
+        while (true){
+            lastMessage = consumer.receive(2, TimeUnit.SECONDS);
+            if (lastMessage == null){
+                break;
+            }
+            consumer.acknowledge(lastMessage);
+        }
+    }
+
+    @AllArgsConstructor
+    private static class SendInfo {
+        List<MessageId> messageIds;
+        MessageIdImpl firstMessageId;
+        MessageIdImpl lastMessageId;
+    }
+
+    @DataProvider(name = "initialPosition")
+    public Object[][] entryCountPerLedger() {
+        return new Object[][]{
+                {SubscriptionInitialPosition.Earliest},
+                {SubscriptionInitialPosition.Latest}
+        };
+    }
+
+    @Test(dataProvider = "initialPosition")
+    public void testMessagesConsumedCounterCorrect(SubscriptionInitialPosition initialPosition) throws Exception {
+        String topicName = String.format("persistent://my-property/my-ns/%s",
+                BrokerTestUtil.newUniqueName("tp_"));
+        String subName1 = "sub1";
+        String subName2 = "sub2";
+
+        Consumer<String> consumer1 = pulsarClient.newConsumer(Schema.STRING).topic(topicName.toString())
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscriptionName(subName1).subscribe();
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName.toString())
+                .enableBatching(false).create();
+
+        CompletableFuture<SendInfo> sendFuture = new CompletableFuture<>();
+        new Thread(() -> {
+            try {
+                sendFuture.complete(sendMessages(1, MAX_ENTRY_COUNT_PER_LEDGER, producer, topicName));
+            } catch (Exception e) {
+                sendFuture.completeExceptionally(e);
+            }
+        }).start();
+
+        Consumer<String> consumer2 = pulsarClient.newConsumer(Schema.STRING).topic(topicName.toString())
+                .subscriptionInitialPosition(initialPosition)
+                .isAckReceiptEnabled(true)
+                .subscriptionName(subName2).subscribe();
+        sendFuture.join();
+
+        consumeAllMessages(consumer2);
+
+        int backlog = 0;
+        PositionImpl sub2MarkDeleted = (PositionImpl) getManagedCursor(topicName, subName2).getMarkDeletedPosition();
+        for (MessageId msgId : sendFuture.join().messageIds){
+            MessageIdImpl msgIdImpl = (MessageIdImpl) msgId;
+            if (msgIdImpl.getLedgerId() > sub2MarkDeleted.getLedgerId()){
+                backlog++;
+            } else if (msgIdImpl.getLedgerId() == sub2MarkDeleted.getLedgerId()){
+                if (msgIdImpl.getEntryId() > sub2MarkDeleted.getEntryId()){
+                    backlog++;
+                }
+            }
+        }
+
+        assertEquals(getManagedCursor(topicName, subName1).getNumberOfEntriesInBacklog(false),
+                sendFuture.join().messageIds.size());
+        assertEquals(getManagedCursor(topicName, subName1).getNumberOfEntriesInBacklog(true),
+                sendFuture.join().messageIds.size());
+        assertEquals(getManagedCursor(topicName, subName2).getNumberOfEntriesInBacklog(false), backlog);
+        assertEquals(getManagedCursor(topicName, subName2).getNumberOfEntriesInBacklog(true), backlog);
+
+        assertTrue(getManagedCursor(topicName, subName2).getMessagesConsumedCounter()
+                < sendFuture.join().messageIds.size());
+
+        // cleanup.
+        producer.close();
+        consumer1.close();
+        consumer2.close();
+        admin.topics().delete(topicName, false);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/StatsBackLogTest.java
+++ b/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/StatsBackLogTest.java
@@ -181,7 +181,7 @@ public class StatsBackLogTest extends ProducerConsumerBase {
         assertEquals(getManagedCursor(topicName, subName2).getNumberOfEntriesInBacklog(true), backlog);
 
         assertTrue(getManagedCursor(topicName, subName2).getMessagesConsumedCounter()
-                < sendFuture.join().messageIds.size());
+                <= sendFuture.join().messageIds.size());
 
         // cleanup.
         producer.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/MockedBookKeeperClientFactory.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/MockedBookKeeperClientFactory.java
@@ -41,7 +41,7 @@ public class MockedBookKeeperClientFactory implements BookKeeperClientFactory {
     public MockedBookKeeperClientFactory() {
         try {
             executor = OrderedExecutor.newBuilder()
-                    .numThreads(1)
+                    .numThreads(16)
                     .name("mock-bk-client-factory")
                     .build();
             mockedBk = new PulsarMockBookKeeper(executor);


### PR DESCRIPTION
### This is an issue, not a PR( show the way of reproduce issue)

#### 1.A compensation mechanism for backlog less than 0

The field `backlog` of the subscription can be less than zero(this only can be caused by messagesConsumedCounter of cursor is larger than total entries of ML). We can see that there is a patch here to handle this scenario:

https://github.com/apache/pulsar/blob/e2851da923a729423de54dc3a95d1e7a43b6e08a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L1110-L1114

----

####  2.Backlog wrong caused by `messagesConsumedCounter` wrong

When `create subscription(initialized position to earliest)` and `send messages` are executed concurrently, an incorrect count occurs, leading to the field `backlog` of subscription less than 0. For example:

##### 2-1. Create a new topic, the field `currentLedger` of the managed ledger is `3`. Then send 10 messages.

##### 2-2. Concurrently processes
| time | thread: `create new cursor`| thread: `add entry`|
| --- | --- | --- |
| 1 | | increment `entriesAddedCounter`( before: `0`, after: `1` ) of ML | 
| 2 | get `entriesAddedCounter` of ML: `1` | |
| 3 | get `lastConfirmedEntry` of ML: `3:0` | |
| 4 | set `messagesConsumedCounter` to `1` | |
| 4 | set `markDeletePosition` to `3:0` | |
| 5 | | update `lastConfirmedEntry(3:1)` of ML |

<strong>(Highlight)</strong>Now consumer doesn't consume any messages, but `messagesConsumedCounter` of cursor is already `1`

##### 2-3. Error occur
- After sending 10 messages, the field `entriesAddedCounter` of ML will be `10`
- After consuming all 10 messages, the `messagesConsumedCounter` of the cursor will be `1 + 10`
- Then `ManagedLedgerImpl.ENTRIES_ADDED_COUNTER_UPDATER.get(ledger) - messagesConsumedCounter` will be `-1`.

----

#### 3. Reproduce issue
Since it is hard to write a non-invasive test. You can reproduce by `StatsBackLogTest.testMessagesConsumedCounterCorrect`