### PR TITLE
[improve][txn] Move checked exception into builder when newTransaction.

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
@@ -336,5 +336,5 @@ public interface PulsarClient extends Closeable {
      *             if transactions are not enabled
      * @since 2.7.0
      */
-    TransactionBuilder newTransaction() throws PulsarClientException;
+    TransactionBuilder newTransaction();
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -1188,10 +1188,7 @@ public class PulsarClientImpl implements PulsarClient {
     // This method should be exposed in the PulsarClient interface. Only expose it when all the transaction features
     // are completed.
     // @Override
-    public TransactionBuilder newTransaction() throws PulsarClientException {
-        if (!conf.isEnableTransaction()) {
-            throw new PulsarClientException.InvalidConfigurationException("Transactions are not enabled");
-        }
+    public TransactionBuilder newTransaction() {
         return new TransactionBuilderImpl(this, tcClient);
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionBuilderImpl.java
@@ -21,9 +21,11 @@ package org.apache.pulsar.client.impl.transaction;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.client.api.transaction.TransactionBuilder;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.common.util.FutureUtil;
 
 /**
  * The default implementation of transaction builder to build transactions.
@@ -50,6 +52,10 @@ public class TransactionBuilderImpl implements TransactionBuilder {
 
     @Override
     public CompletableFuture<Transaction> build() {
+        if (!client.getConfiguration().isEnableTransaction()) {
+            return FutureUtil.failedFuture(
+                    new PulsarClientException.InvalidConfigurationException("Transactions are not enabled"));
+        }
         // talk to TC to begin a transaction
         //       the builder is responsible for locating the transaction coorindator (TC)
         //       and start the transaction to get the transaction id.

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
@@ -188,16 +188,6 @@ public class PulsarClientImplTest {
         client.timer().stop();
     }
 
-    @Test(expectedExceptions = PulsarClientException.InvalidConfigurationException.class)
-    public void testNewTransactionWhenDisable() throws Exception {
-        ClientConfigurationData conf = new ClientConfigurationData();
-        conf.setServiceUrl("pulsar://localhost:6650");
-        conf.setEnableTransaction(false);
-        try (PulsarClientImpl client = new PulsarClientImpl(conf)) {
-            client.newTransaction();
-        }
-    }
-
     @Test
     public void testResourceCleanup() throws Exception {
         ClientConfigurationData conf = new ClientConfigurationData();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TransactionBuilderTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TransactionBuilderTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+public class TransactionBuilderTest {
+
+    @Test
+    public void checkClientEnableTransactionConfiguration() throws PulsarClientException {
+        final PulsarClient client = PulsarClient.builder()
+                .serviceUrl("pulsar://localhost:6650")
+                .enableTransaction(false)
+                .build();
+        try {
+            client.newTransaction()
+                    .withTransactionTimeout(1, TimeUnit.MINUTES)
+                    .build().get();
+            Assert.fail("Expect exception");
+        } catch (InterruptedException | ExecutionException ex) {
+            Assert.assertTrue(ex.getCause()
+                    instanceof PulsarClientException.InvalidConfigurationException);
+        }
+        client.close();
+    }
+}


### PR DESCRIPTION
### Motivation

Submit this PR to discuss if we can accept moving this checked exception into the builder to avoid adding more useless try-catch blocks.

In practice, we should create the new transaction like this:

```java
final TransactionBuilder transactionBuilder;
try {
    transactionBuilder = client.newTransaction();
} catch (PulsarClientException e) {
    // handle this exception.
    return;
}
CompletableFuture<Transaction> txnFuture = transactionBuilder
        .withTransactionTimeout(1, TimeUnit.MINUTES)
        .build();
```
But this exception only throws by 

```java
 public TransactionBuilder newTransaction() throws PulsarClientException {
    if (!conf.isEnableTransaction()) {
        throw new PulsarClientException.InvalidConfigurationException("Transactions are not enabled");
    }
    return new TransactionBuilderImpl(this, tcClient);
}
```
Therefore, even if we enabled the transaction, we still need to handle this checked exception. Maybe we can move this checked exception into the builder or make this exception to be runtime to avoid writing the more useless try-catch blocks.

```java
client.newTransaction()
      .withTransactionTimeout(1, TimeUnit.MINUTES)
      .build()
      .thenCompose(transaction -> {
          // do somethings
      }).exceptionally(ex -> {
          // handle exception
      });
```
It is better, isn't it?

### Modifications

- Moving checked exceptions into the builder.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
