### PR TITLE
[fix][authentication] Make AuthenticationProviderBasic refreshes data and role

### DIFF
--- a/pulsar-broker-common/src/test/resources/authentication/basic/.htpasswd
+++ b/pulsar-broker-common/src/test/resources/authentication/basic/.htpasswd
@@ -1,2 +1,3 @@
 superUser:mQQQIsyvvKRtU
 superUser2:$apr1$foobarmq$kuSZlLgOITksCkRgl57ie/
+client1:$apr1$GiGKS2JU$N6soC.W2fIQ/oPVej37cM.


### PR DESCRIPTION
### Motivation

`AuthenticationProviderBasic` defaults to use the `OneStageAuthenticationState`, which can only refresh one authentication data and role. Once the client sends the different authentication data to the broker, this auth state doesn't work.

### Modifications

- Override the `newAuthState` to using `BasicAuthenticationState` instead of `OneStageAuthenticationState`
- Override the `authenticateAsync` to simplify default implementation

### Verifying this change

- [x] Make sure that the change passes the CI checks.

Added test

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
