### PR TITLE
[cleanup][txn] Cleanup duplicated logic.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
@@ -103,22 +103,13 @@ public class TransactionImpl implements Transaction , TimerTask {
 
     // register the topics that will be modified by this transaction
     public CompletableFuture<Void> registerProducedTopic(String topic) {
-        CompletableFuture<Void> completableFuture = new CompletableFuture<>();
-        if (checkIfOpen(completableFuture)) {
-            synchronized (TransactionImpl.this) {
-                // we need to issue the request to TC to register the produced topic
-                return registerPartitionMap.compute(topic, (key, future) -> {
-                    if (future != null) {
-                        return future.thenCompose(ignored -> CompletableFuture.completedFuture(null));
-                    } else {
-                        return tcClient.addPublishPartitionToTxnAsync(
-                                txnId, Lists.newArrayList(topic))
-                                .thenCompose(ignored -> CompletableFuture.completedFuture(null));
-                    }
-                });
-            }
+        if (state == State.OPEN) {
+            // we need to issue the request to TC to register the produced topic
+            return registerPartitionMap.computeIfAbsent(topic, key -> tcClient.addPublishPartitionToTxnAsync(
+                    txnId, Lists.newArrayList(topic)));
         }
-        return completableFuture;
+        return CompletableFuture.failedFuture(
+                new InvalidTxnStatusException(txnId.toString(), state.name(), State.OPEN.name()));
     }
 
     public void registerSendOp(CompletableFuture<MessageId> newSendFuture) {
@@ -144,22 +135,13 @@ public class TransactionImpl implements Transaction , TimerTask {
 
     // register the topics that will be modified by this transaction
     public CompletableFuture<Void> registerAckedTopic(String topic, String subscription) {
-        CompletableFuture<Void> completableFuture = new CompletableFuture<>();
-        if (checkIfOpen(completableFuture)) {
-            synchronized (TransactionImpl.this) {
-                // we need to issue the request to TC to register the acked topic
-                return registerSubscriptionMap.compute(Pair.of(topic, subscription), (key, future) -> {
-                    if (future != null) {
-                        return future.thenCompose(ignored -> CompletableFuture.completedFuture(null));
-                    } else {
-                        return tcClient.addSubscriptionToTxnAsync(
-                                txnId, topic, subscription)
-                                .thenCompose(ignored -> CompletableFuture.completedFuture(null));
-                    }
-                });
-            }
+        if (state == State.OPEN) {
+            // we need to issue the request to TC to register the acked topic
+            return registerSubscriptionMap.computeIfAbsent(Pair.of(topic, subscription),
+                    key -> tcClient.addSubscriptionToTxnAsync(txnId, topic, subscription));
         }
-        return completableFuture;
+        return CompletableFuture.failedFuture(
+                new InvalidTxnStatusException(txnId.toString(), state.name(), State.OPEN.name()));
     }
 
     public void registerAckOp(CompletableFuture<Void> newAckFuture) {


### PR DESCRIPTION
### Motivation

I found some logic that can be cleaned up after reading this part of the code. ( reduce more `CompletableFuture` objects)

### Modifications

- Remove meaningless `.thenCompose(ignored -> CompletableFuture.completedFuture(null))`, cause original future is return `CompletableFuture<Void>`.
- Remove `synchronized` blocks, because `registerPartitionMap` and `registerSubscriptionMap` is concurrent hashmap.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
