### PR TITLE
[improve] Add configuration for NonPeristentTopic expired subscriptions auto clean

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -224,6 +224,10 @@ activeConsumerFailoverDelayTimeMillis=1000
 # When it is 0, inactive subscriptions are not deleted automatically
 subscriptionExpirationTimeMinutes=0
 
+# How long to delete inactive subscriptions from last consuming for non-persistent topic.
+# When it is 0, inactive subscriptions are not deleted automatically
+nonPersistentSubscriptionExpirationTimeMinutes=0
+
 # Enable subscription message redelivery tracker to send redelivery count to consumer (default is enabled)
 subscriptionRedeliveryTrackerEnabled=true
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -707,6 +707,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int subscriptionExpirationTimeMinutes = 0;
     @FieldContext(
             category = CATEGORY_POLICIES,
+            doc = "How long to delete inactive subscriptions from last consuming for non-persistent topic."
+                    + " When it is 0, inactive subscriptions are not deleted automatically",
+            minValue = 0
+    )
+    private int nonPersistentSubscriptionExpirationTimeMinutes = 0;
+    @FieldContext(
+            category = CATEGORY_POLICIES,
             dynamic = true,
             doc = "Enable subscription message redelivery tracker to send redelivery "
                     + "count to consumer (default is enabled)"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -1026,8 +1026,8 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                     .getPolicies(name.getNamespaceObject())
                     .orElseThrow(MetadataStoreException.NotFoundException::new);
             final int defaultExpirationTime = brokerService.pulsar().getConfiguration()
-                    .getSubscriptionExpirationTimeMinutes();
-            final Integer nsExpirationTime = policies.subscription_expiration_time_minutes;
+                    .getNonPersistentSubscriptionExpirationTimeMinutes();
+            final Integer nsExpirationTime = policies.non_persistent_subscription_expiration_time_minutes;
             final long expirationTimeMillis = TimeUnit.MINUTES
                     .toMillis(nsExpirationTime == null ? defaultExpirationTime : nsExpirationTime);
             if (expirationTimeMillis > 0) {

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
@@ -62,6 +62,8 @@ public class Policies {
     @SuppressWarnings("checkstyle:MemberName")
     public Integer subscription_expiration_time_minutes = null;
     @SuppressWarnings("checkstyle:MemberName")
+    public Integer non_persistent_subscription_expiration_time_minutes = null;
+    @SuppressWarnings("checkstyle:MemberName")
     public RetentionPolicies retention_policies = null;
     public boolean deleted = false;
     public static final String FIRST_BOUNDARY = "0x00000000";
@@ -141,7 +143,8 @@ public class Policies {
                 clusterSubscribeRate, deduplicationEnabled, autoTopicCreationOverride,
                 autoSubscriptionCreationOverride, persistence,
                 bundles, latency_stats_sample_rate,
-                message_ttl_in_seconds, subscription_expiration_time_minutes, retention_policies,
+                message_ttl_in_seconds, subscription_expiration_time_minutes,
+                non_persistent_subscription_expiration_time_minutes, retention_policies,
                 encryption_required, delayed_delivery_policies, inactive_topic_policies,
                 subscription_auth_mode,
                 max_producers_per_topic,
@@ -180,6 +183,8 @@ public class Policies {
                     && Objects.equals(message_ttl_in_seconds,
                             other.message_ttl_in_seconds)
                     && Objects.equals(subscription_expiration_time_minutes, other.subscription_expiration_time_minutes)
+                    && Objects.equals(non_persistent_subscription_expiration_time_minutes,
+                            other.non_persistent_subscription_expiration_time_minutes)
                     && Objects.equals(retention_policies, other.retention_policies)
                     && Objects.equals(encryption_required, other.encryption_required)
                     && Objects.equals(delayed_delivery_policies, other.delayed_delivery_policies)


### PR DESCRIPTION
### Motivation

For expired  subscriptions auto clean, we only a configuration named `subscriptionExpirationTimeMinutes`.

It works on both `PersistentTopic` and `NonPersistentTopic`.

For a `NonPersistentTopic`, we can clear its expired subscriptions without psychological burden. But if we enable the expired subscriptions auto clean on a `PersistentTopic`, it may lead to data loss.

This PR introduced a new configuration named `nonPersistentSubscriptionExpirationTimeMinutes`, it only works on `NonPersistentTopic` expired subscriptions auto clean, but will not affect on `PersistentTopic`.

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository:  https://github.com/tjiuming/pulsar/pull/18