### PR TITLE
[fix] [admin] setOffloadThreshold response before it's finished

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -2047,7 +2047,7 @@ public abstract class NamespacesBase extends AdminResource {
 
         validateNamespacePolicyOperationAsync(namespaceName, PolicyName.OFFLOAD, PolicyOperation.WRITE)
                 .thenApply(v -> validatePoliciesReadOnlyAccessAsync())
-                .thenApply(v -> updatePoliciesAsync(namespaceName,
+                .thenCompose(v -> updatePoliciesAsync(namespaceName,
                         policies -> {
                             if (policies.offload_policies == null) {
                                 policies.offload_policies = new OffloadPoliciesImpl();


### PR DESCRIPTION
Fixes #19366

### Motivation

Admin API `setOffloadThreshold` response before it is finished.

You can reproduce by `AdminApiOffloadTest.testSetNamespaceOffloadPolicies`, If you append `sleep(1000)` after this line(https://github.com/apache/pulsar/blob/1cd1aef3c74fac0a2ded99da05b658578d8481e7/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java#L468), the chances of problems occurring increase to 100%

### Modifications

response after it is finishied

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
-  https://github.com/poorbarcode/pulsar/pull/60