### PR TITLE
[improve][test] Migrate tests to use PulsarTestContext

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -26,6 +26,7 @@
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
     <version>23</version>
+    <relativePath />
   </parent>
 
   <groupId>org.apache.pulsar</groupId>

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -744,10 +744,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             }
             pulsarResources = newPulsarResources();
 
-            orderedExecutor = OrderedExecutor.newBuilder()
-                    .numThreads(config.getNumOrderedExecutorThreads())
-                    .name("pulsar-ordered")
-                    .build();
+            orderedExecutor = newOrderedExecutor();
 
             // Initialize the message protocol handlers
             protocolHandlers = ProtocolHandlers.load(config);
@@ -919,6 +916,14 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         } finally {
             mutex.unlock();
         }
+    }
+
+    @VisibleForTesting
+    protected OrderedExecutor newOrderedExecutor() {
+        return OrderedExecutor.newBuilder()
+                .numThreads(config.getNumOrderedExecutorThreads())
+                .name("pulsar-ordered")
+                .build();
     }
 
     @VisibleForTesting

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PreInterceptFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PreInterceptFilter.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.web;
 
 import java.io.IOException;
+import java.util.Objects;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -40,8 +41,8 @@ public class PreInterceptFilter implements Filter {
     private final ExceptionHandler exceptionHandler;
 
     public PreInterceptFilter(BrokerInterceptor interceptor, ExceptionHandler exceptionHandler) {
-        this.interceptor = interceptor;
-        this.exceptionHandler = exceptionHandler;
+        this.interceptor = Objects.requireNonNull(interceptor);
+        this.exceptionHandler = Objects.requireNonNull(exceptionHandler);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ProcessHandlerFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ProcessHandlerFilter.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.web;
 
 import java.io.IOException;
+import java.util.Objects;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -34,7 +35,7 @@ public class ProcessHandlerFilter implements Filter {
     private final BrokerInterceptor interceptor;
 
     public ProcessHandlerFilter(BrokerInterceptor brokerInterceptor) {
-        this.interceptor = brokerInterceptor;
+        this.interceptor = Objects.requireNonNull(brokerInterceptor);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ProcessHandlerFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ProcessHandlerFilter.java
@@ -27,24 +27,20 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.ws.rs.core.MediaType;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 
 public class ProcessHandlerFilter implements Filter {
 
     private final BrokerInterceptor interceptor;
-    private final boolean interceptorEnabled;
 
-    public ProcessHandlerFilter(PulsarService pulsar) {
-        this.interceptor = pulsar.getBrokerInterceptor();
-        this.interceptorEnabled = !pulsar.getConfig().getBrokerInterceptors().isEmpty();
+    public ProcessHandlerFilter(BrokerInterceptor brokerInterceptor) {
+        this.interceptor = brokerInterceptor;
     }
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
-        if (interceptorEnabled
-                && !StringUtils.containsIgnoreCase(request.getContentType(), MediaType.MULTIPART_FORM_DATA)
+        if (!StringUtils.containsIgnoreCase(request.getContentType(), MediaType.MULTIPART_FORM_DATA)
                 && !StringUtils.containsIgnoreCase(request.getContentType(), MediaType.APPLICATION_OCTET_STREAM)) {
             interceptor.onFilter(request, response, chain);
         } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ResponseHandlerFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ResponseHandlerFilter.java
@@ -46,12 +46,10 @@ public class ResponseHandlerFilter implements Filter {
 
     private final String brokerAddress;
     private final BrokerInterceptor interceptor;
-    private final boolean interceptorEnabled;
 
     public ResponseHandlerFilter(PulsarService pulsar) {
         this.brokerAddress = pulsar.getAdvertisedAddress();
         this.interceptor = pulsar.getBrokerInterceptor();
-        this.interceptorEnabled = !pulsar.getConfig().getBrokerInterceptors().isEmpty();
     }
 
     @Override
@@ -104,8 +102,7 @@ public class ResponseHandlerFilter implements Filter {
     }
 
     private void handleInterceptor(ServletRequest request, ServletResponse response) {
-        if (interceptorEnabled
-                && !StringUtils.containsIgnoreCase(request.getContentType(), MediaType.MULTIPART_FORM_DATA)
+        if (!StringUtils.containsIgnoreCase(request.getContentType(), MediaType.MULTIPART_FORM_DATA)
                 && !StringUtils.containsIgnoreCase(request.getContentType(), MediaType.APPLICATION_OCTET_STREAM)) {
             try {
                 interceptor.onWebserviceResponse(request, response);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ResponseHandlerFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ResponseHandlerFilter.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.web;
 
 import java.io.IOException;
+import java.util.Objects;
 import javax.servlet.AsyncEvent;
 import javax.servlet.AsyncListener;
 import javax.servlet.Filter;
@@ -49,7 +50,7 @@ public class ResponseHandlerFilter implements Filter {
 
     public ResponseHandlerFilter(PulsarService pulsar) {
         this.brokerAddress = pulsar.getAdvertisedAddress();
-        this.interceptor = pulsar.getBrokerInterceptor();
+        this.interceptor = Objects.requireNonNull(pulsar.getBrokerInterceptor());
     }
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerAdditionalServletTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerAdditionalServletTest.java
@@ -66,7 +66,7 @@ public class BrokerAdditionalServletTest extends MockedPulsarServiceBaseTest {
     }
 
     @Override
-    protected void beforePulsarStartMocks(PulsarService pulsar) throws Exception {
+    protected void beforePulsarStart(PulsarService pulsar) throws Exception {
         mockAdditionalServlet(pulsar);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerBaseTest.java
@@ -21,22 +21,21 @@ package org.apache.pulsar.broker;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.util.PortManager;
-import org.apache.pulsar.metadata.api.MetadataStoreException;
-import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
-import org.apache.pulsar.metadata.impl.ZKMetadataStore;
-import org.apache.zookeeper.MockZooKeeperSession;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
+@Slf4j
 public abstract class MultiBrokerBaseTest extends MockedPulsarServiceBaseTest {
+    protected List<PulsarTestContext> additionalPulsarTestContexts;
     protected List<PulsarService> additionalBrokers;
     protected List<PulsarAdmin> additionalBrokerAdmins;
     protected List<PulsarClient> additionalBrokerClients;
@@ -64,8 +63,11 @@ public abstract class MultiBrokerBaseTest extends MockedPulsarServiceBaseTest {
         additionalBrokers = new ArrayList<>(numberOfAdditionalBrokers);
         additionalBrokerAdmins = new ArrayList<>(numberOfAdditionalBrokers);
         additionalBrokerClients = new ArrayList<>(numberOfAdditionalBrokers);
+        additionalPulsarTestContexts = new ArrayList<>(numberOfAdditionalBrokers);
         for (int i = 0; i < numberOfAdditionalBrokers; i++) {
-            PulsarService pulsarService = createAdditionalBroker(i);
+            PulsarTestContext pulsarTestContext = createAdditionalBroker(i);
+            additionalPulsarTestContexts.add(i, pulsarTestContext);
+            PulsarService pulsarService = pulsarTestContext.getPulsarService();
             additionalBrokers.add(i, pulsarService);
             PulsarAdminBuilder pulsarAdminBuilder =
                     PulsarAdmin.builder().serviceHttpUrl(pulsarService.getWebServiceAddress() != null
@@ -81,20 +83,8 @@ public abstract class MultiBrokerBaseTest extends MockedPulsarServiceBaseTest {
         return getDefaultConf();
     }
 
-    protected PulsarService createAdditionalBroker(int additionalBrokerIndex) throws Exception {
-        return startBroker(createConfForAdditionalBroker(additionalBrokerIndex));
-    }
-
-    @Override
-    protected MetadataStoreExtended createLocalMetadataStore() throws MetadataStoreException {
-        // use MockZooKeeperSession to provide a unique session id for each instance
-        return new ZKMetadataStore(MockZooKeeperSession.newInstance(mockZooKeeper));
-    }
-
-    @Override
-    protected MetadataStoreExtended createConfigurationMetadataStore() throws MetadataStoreException {
-        // use MockZooKeeperSession to provide a unique session id for each instance
-        return new ZKMetadataStore(MockZooKeeperSession.newInstance(mockZooKeeperGlobal));
+    protected PulsarTestContext createAdditionalBroker(int additionalBrokerIndex) throws Exception {
+        return createAdditionalPulsarTestContext(createConfForAdditionalBroker(additionalBrokerIndex));
     }
 
     @AfterClass(alwaysRun = true)
@@ -121,19 +111,21 @@ public abstract class MultiBrokerBaseTest extends MockedPulsarServiceBaseTest {
             }
             additionalBrokerClients = null;
         }
-        if (additionalBrokers != null) {
-            for (PulsarService pulsarService : additionalBrokers) {
+        if (additionalPulsarTestContexts != null) {
+            for (PulsarTestContext pulsarTestContext : additionalPulsarTestContexts) {
+                PulsarService pulsarService = pulsarTestContext.getPulsarService();
                 try {
                     pulsarService.getConfiguration().setBrokerShutdownTimeoutMs(0L);
-                    pulsarService.close();
+                    pulsarTestContext.close();
                     pulsarService.getConfiguration().getBrokerServicePort().ifPresent(PortManager::releaseLockedPort);
                     pulsarService.getConfiguration().getWebServicePort().ifPresent(PortManager::releaseLockedPort);
                     pulsarService.getConfiguration().getWebServicePortTls().ifPresent(PortManager::releaseLockedPort);
-                } catch (PulsarServerException e) {
-                    // ignore
+                } catch (Exception e) {
+                    log.warn("Failed to stop additional broker", e);
                 }
             }
             additionalBrokers = null;
+            additionalPulsarTestContexts = null;
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerTestZKBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerTestZKBaseTest.java
@@ -54,15 +54,15 @@ public abstract class MultiBrokerTestZKBaseTest extends MultiBrokerBaseTest {
     @Override
     protected PulsarTestContext.Builder createPulsarTestContextBuilder(ServiceConfiguration conf) {
         return super.createPulsarTestContextBuilder(conf)
-                .localMetadataStore(createMetadataStore())
-                .configurationMetadataStore(createMetadataStore());
+                .localMetadataStore(createMetadataStore(MetadataStoreConfig.METADATA_STORE))
+                .configurationMetadataStore(createMetadataStore(MetadataStoreConfig.CONFIGURATION_METADATA_STORE));
     }
 
     @NotNull
-    protected MetadataStoreExtended createMetadataStore()  {
+    protected MetadataStoreExtended createMetadataStore(String metadataStoreName)  {
         try {
             return MetadataStoreExtended.create(testZKServer.getConnectionString(),
-                    MetadataStoreConfig.builder().build());
+                    MetadataStoreConfig.builder().metadataStoreName(metadataStoreName).build());
         } catch (MetadataStoreException e) {
             throw new RuntimeException(e);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerTestZKBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerTestZKBaseTest.java
@@ -19,10 +19,12 @@
 package org.apache.pulsar.broker;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.metadata.TestZKServer;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Multiple brokers with a real test Zookeeper server (instead of the mock server)
@@ -50,12 +52,19 @@ public abstract class MultiBrokerTestZKBaseTest extends MultiBrokerBaseTest {
     }
 
     @Override
-    protected MetadataStoreExtended createLocalMetadataStore() throws MetadataStoreException {
-        return MetadataStoreExtended.create(testZKServer.getConnectionString(), MetadataStoreConfig.builder().build());
+    protected PulsarTestContext.Builder createPulsarTestContextBuilder(ServiceConfiguration conf) {
+        return super.createPulsarTestContextBuilder(conf)
+                .localMetadataStore(createMetadataStore())
+                .configurationMetadataStore(createMetadataStore());
     }
 
-    @Override
-    protected MetadataStoreExtended createConfigurationMetadataStore() throws MetadataStoreException {
-        return MetadataStoreExtended.create(testZKServer.getConnectionString(), MetadataStoreConfig.builder().build());
+    @NotNull
+    protected MetadataStoreExtended createMetadataStore()  {
+        try {
+            return MetadataStoreExtended.create(testZKServer.getConnectionString(),
+                    MetadataStoreConfig.builder().build());
+        } catch (MetadataStoreException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceCloseTest.java
@@ -18,10 +18,8 @@
  */
 package org.apache.pulsar.broker;
 
-import static org.mockito.Mockito.spy;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
-
 import java.util.concurrent.ScheduledFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -47,16 +45,12 @@ public class PulsarServiceCloseTest extends MockedPulsarServiceBaseTest {
         super.internalCleanup();
     }
 
-    protected PulsarService startBrokerWithoutAuthorization(ServiceConfiguration conf) throws Exception {
+    @Override
+    protected ServiceConfiguration getDefaultConf() {
+        ServiceConfiguration conf = super.getDefaultConf();
         conf.setBrokerShutdownTimeoutMs(1000 * 60 * 5);
         conf.setLoadBalancerSheddingIntervalMinutes(30);
-        PulsarService pulsar = spy(newPulsarService(conf));
-        setupBrokerMocks(pulsar);
-        beforePulsarStartMocks(pulsar);
-        pulsar.start();
-        log.info("Pulsar started. brokerServiceUrl: {} webServiceAddress: {}", pulsar.getBrokerServiceUrl(),
-                pulsar.getWebServiceAddress());
-        return pulsar;
+        return conf;
     }
 
     @Test(timeOut = 30_000)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceTest.java
@@ -85,18 +85,8 @@ public class PulsarServiceTest extends MockedPulsarServiceBaseTest {
      */
     @Test
     public void testGetWorkerServiceException() throws Exception {
-        init();
-        ServiceConfiguration configuration = new ServiceConfiguration();
-        configuration.setMetadataStoreUrl("zk:localhost");
-        configuration.setClusterName("clusterName");
-        configuration.setFunctionsWorkerEnabled(false);
-        configuration.setBrokerShutdownTimeoutMs(0L);
-        configuration.setLoadBalancerOverrideBrokerNicSpeedGbps(Optional.of(1.0d));
-        configuration.setBrokerServicePort(Optional.of(0));
-        configuration.setBrokerServicePortTls(Optional.of(0));
-        configuration.setWebServicePort(Optional.of(0));
-        configuration.setWebServicePortTls(Optional.of(0));
-        startBroker(configuration);
+        conf.setFunctionsWorkerEnabled(false);
+        setup();
 
         String errorMessage = "Pulsar Function Worker is not enabled, probably functionsWorkerEnabled is set to false";
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -66,6 +66,7 @@ import org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.admin.ListNamespaceTopicsOptions;
 import org.apache.pulsar.client.admin.Mode;
 import org.apache.pulsar.client.admin.PulsarAdmin;
@@ -319,13 +320,15 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         conf.setWebServicePort(Optional.of(1026));
         conf.setWebServicePortTls(Optional.of(1027));
         @Cleanup
-        PulsarService pulsar2 = startBrokerWithoutAuthorization(conf);
+        PulsarTestContext pulsarTestContext2 = createAdditionalPulsarTestContext(conf);
+        PulsarService pulsar2 = pulsarTestContext2.getPulsarService();
         conf.setBrokerServicePort(Optional.of(2048));
         conf.setBrokerServicePortTls(Optional.of(2049));
         conf.setWebServicePort(Optional.of(2050));
         conf.setWebServicePortTls(Optional.of(2051));
         @Cleanup
-        PulsarService pulsar3 = startBrokerWithoutAuthorization(conf);
+        PulsarTestContext pulsarTestContext3 = createAdditionalPulsarTestContext(conf);
+        PulsarService pulsar3 = pulsarTestContext.getPulsarService();
         @Cleanup
         PulsarAdmin admin2 = PulsarAdmin.builder().serviceHttpUrl(pulsar2.getWebServiceAddress()).build();
         @Cleanup

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaTest.java
@@ -393,7 +393,7 @@ public class AdminApiSchemaTest extends MockedPulsarServiceBaseTest {
             public long getCToken() {
                 return 0;
             }
-        })).when(mockBookKeeper).getLedgerMetadata(anyLong());
+        })).when(pulsarTestContext.getBookKeeperClient()).getLedgerMetadata(anyLong());
         PersistentTopicInternalStats persistentTopicInternalStats = admin.topics().getInternalStats(topicName);
         List<PersistentTopicInternalStats.LedgerInfo> list = persistentTopicInternalStats.schemaLedgers;
         assertEquals(list.size(), 1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -73,6 +73,8 @@ import org.apache.pulsar.broker.loadbalance.LeaderBroker;
 import org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl;
 import org.apache.pulsar.broker.namespace.NamespaceEphemeralData;
 import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.broker.testcontext.PulsarTestContext;
+import org.apache.pulsar.broker.testcontext.SpyConfig;
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -168,6 +170,13 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
     @Override
     public void setup() throws Exception {
         setupConfigAndStart(null);
+    }
+
+    @Override
+    protected void customizeMainPulsarTestContextBuilder(PulsarTestContext.Builder pulsarTestContextBuilder) {
+        pulsarTestContextBuilder.spyConfigCustomizer(
+                // verify(compactor) is used in this test class
+                builder -> builder.compactor(SpyConfig.SpyType.SPY_ALSO_INVOCATIONS));
     }
 
     private void applyDefaultConfig() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -936,13 +936,10 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         AsyncResponse response1 = mock(AsyncResponse.class);
         ArgumentCaptor<RestException> responseCaptor = ArgumentCaptor.forClass(RestException.class);
         NamespaceName namespaceName = NamespaceName.get(property, cluster, namespace);
-        NamespaceService ns = spy(pulsar.getNamespaceService());
-        Field namespaceField = pulsar.getClass().getDeclaredField("nsService");
-        namespaceField.setAccessible(true);
-        namespaceField.set(pulsar, ns);
         CompletableFuture<List<String>> future = new CompletableFuture();
         future.completeExceptionally(new RuntimeException("500 error contains error message"));
-        doReturn(future).when(ns).getListOfTopics(namespaceName, CommandGetTopicsOfNamespace.Mode.ALL);
+        NamespaceService namespaceService = pulsar.getNamespaceService();
+        doReturn(future).when(namespaceService).getListOfTopics(namespaceName, CommandGetTopicsOfNamespace.Mode.ALL);
         persistentTopics.createPartitionedTopic(response1, property, cluster, namespace, partitionedTopicName, 5, false);
         verify(response1, timeout(5000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getResponse().getStatus(), Status.INTERNAL_SERVER_ERROR.getStatusCode());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/BrokerAdminClientTlsAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/BrokerAdminClientTlsAuthTest.java
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.policies.data.BundlesData;
@@ -122,7 +123,8 @@ public class BrokerAdminClientTlsAuthTest extends MockedPulsarServiceBaseTest {
         buildConf(conf);
 
         @Cleanup
-        PulsarService pulsar2 = startBroker(conf);
+        PulsarTestContext pulsarTestContext2 = createAdditionalPulsarTestContext(conf);
+        PulsarService pulsar2 = pulsarTestContext2.getPulsarService();
 
         /***** Broker 2 Started *****/
         try (PulsarAdmin admin = buildAdminClient("superproxy")) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
@@ -42,6 +42,7 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import lombok.AllArgsConstructor;
+import lombok.Cleanup;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.avro.generic.GenericData;
@@ -60,6 +61,7 @@ import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -319,7 +321,13 @@ public class TopicsTest extends MockedPulsarServiceBaseTest {
         URI requestPath = URI.create(pulsar.getWebServiceAddress() + "/topics/my-tenant/my-namespace/my-topic");
         //create topic on one broker
         admin.topics().createNonPartitionedTopic(topicName);
-        PulsarService pulsar2 = startBroker(getDefaultConf());
+        conf.setBrokerServicePort(Optional.of(0));
+        conf.setBrokerServicePortTls(Optional.of(0));
+        conf.setWebServicePort(Optional.of(0));
+        conf.setWebServicePortTls(Optional.of(0));
+        @Cleanup
+        PulsarTestContext pulsarTestContext2 = createAdditionalPulsarTestContext(conf);
+        PulsarService pulsar2 = pulsarTestContext2.getPulsarService();
         doReturn(false).when(topics).isRequestHttps();
         UriInfo uriInfo = mock(UriInfo.class);
         doReturn(requestPath).when(uriInfo).getRequestUri();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
@@ -59,6 +59,8 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.namespace.NamespaceEphemeralData;
 import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.broker.testcontext.PulsarTestContext;
+import org.apache.pulsar.broker.testcontext.SpyConfig;
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -176,6 +178,13 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
         adminTls.close();
         super.internalCleanup();
         mockPulsarSetup.cleanup();
+    }
+
+    @Override
+    protected void customizeMainPulsarTestContextBuilder(PulsarTestContext.Builder pulsarTestContextBuilder) {
+        pulsarTestContextBuilder.spyConfigCustomizer(
+                // verify(compactor) is used in this test class
+                builder -> builder.compactor(SpyConfig.SpyType.SPY_ALSO_INVOCATIONS));
     }
 
     @AfterMethod(alwaysRun = true)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/InvalidBrokerConfigForAuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/InvalidBrokerConfigForAuthorizationTest.java
@@ -32,7 +32,8 @@ public class InvalidBrokerConfigForAuthorizationTest extends MockedPulsarService
         try {
             internalSetup();
             fail("An exception should have been thrown");
-        } catch (Exception e) {
+        } catch (Exception rte) {
+            Throwable e = rte.getCause();
             assertEquals(e.getClass(), PulsarServerException.class);
             assertEquals(e.getCause().getClass(), IllegalStateException.class);
             assertEquals(e.getCause().getMessage(), "Invalid broker configuration. Authentication must be "

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -152,10 +152,18 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         return createNewPulsarClient(clientBuilder);
     }
 
+    /**
+     * Customize the {@link ClientBuilder} before creating a new {@link PulsarClient} instance.
+     * @param clientBuilder
+     */
     protected void customizeNewPulsarClientBuilder(ClientBuilder clientBuilder) {
 
     }
 
+    /**
+     * Customize the {@link BrokerService} just after it has been created.
+     * @param brokerService the {@link BrokerService} instance
+     */
     protected BrokerService customizeNewBrokerService(BrokerService brokerService) {
         return brokerService;
     }
@@ -232,14 +240,31 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
 
     protected abstract void cleanup() throws Exception;
 
+    /**
+     * Customize the PulsarService instance before it is started.
+     * This can be used to add custom mock or spy configuration to PulsarService.
+     *
+     * @param pulsar the PulsarService instance
+     * @throws Exception if an error occurs
+     */
     protected void beforePulsarStart(PulsarService pulsar) throws Exception {
         // No-op
     }
 
-    protected void afterPulsarStart(PulsarService pulsar) throws Exception {
+    /**
+     * Customize the PulsarService instance after it is started.
+     * @param pulsar the PulsarService instance
+     * @throws Exception if an error occurs
+     */
+     protected void afterPulsarStart(PulsarService pulsar) throws Exception {
         // No-op
     }
 
+    /**
+     * Restarts the test broker.
+     *
+     * @throws Exception if an error occurs
+     */
     protected void restartBroker() throws Exception {
         stopBroker();
         startBroker();
@@ -280,10 +305,23 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         admin = spyWithoutRecordingInvocations(pulsarAdminBuilder.build());
     }
 
+    /**
+     * Customize the PulsarAdminBuilder instance before it is used to create a PulsarAdmin instance.
+     *
+     * @param pulsarAdminBuilder the PulsarAdminBuilder instance
+     */
     protected void customizeNewPulsarAdminBuilder(PulsarAdminBuilder pulsarAdminBuilder) {
 
     }
 
+    /**
+     * Creates the PulsarTestContext instance for the main PulsarService instance.
+     *
+     * @see PulsarTestContext
+     * @param conf the ServiceConfiguration instance to use
+     * @return the PulsarTestContext instance
+     * @throws Exception if an error occurs
+     */
     protected PulsarTestContext createMainPulsarTestContext(ServiceConfiguration conf) throws Exception {
         PulsarTestContext.Builder pulsarTestContextBuilder = createPulsarTestContextBuilder(conf);
         if (pulsarTestContext != null) {
@@ -296,10 +334,25 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
                 .build();
     }
 
+    /**
+     * Customize the PulsarTestContext.Builder instance used for creating the PulsarTestContext
+     * for the main PulsarService instance.
+     *
+     * @param pulsarTestContextBuilder the PulsarTestContext.Builder instance to customize
+     */
     protected void customizeMainPulsarTestContextBuilder(PulsarTestContext.Builder pulsarTestContextBuilder) {
 
     }
 
+    /**
+     * Creates a PulsarTestContext.Builder instance that is used for the builder of the main PulsarTestContext and also
+     * for the possible additional PulsarTestContext instances.
+     *
+     * When overriding this method, it is recommended to call the super method and then customize the returned builder.
+     *
+     * @param conf the ServiceConfiguration instance to use
+     * @return a PulsarTestContext.Builder instance
+     */
     protected PulsarTestContext.Builder createPulsarTestContextBuilder(ServiceConfiguration conf) {
         PulsarTestContext.Builder builder = PulsarTestContext.builder()
                 .spyByDefault()
@@ -316,6 +369,14 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         return builder;
     }
 
+    /**
+     * This method can be used in test classes for creating additional PulsarTestContext instances
+     * that share the same mock ZooKeeper and BookKeeper instances as the main PulsarTestContext instance.
+     *
+     * @param conf the ServiceConfiguration instance to use
+     * @return the PulsarTestContext instance
+     * @throws Exception if an error occurs
+     */
     protected PulsarTestContext createAdditionalPulsarTestContext(ServiceConfiguration conf) throws Exception {
         return createPulsarTestContextBuilder(conf)
                 .reuseMockBookkeeperAndMetadataStores(pulsarTestContext)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -18,28 +18,16 @@
  */
 package org.apache.pulsar.broker.auth;
 
-import static org.apache.pulsar.broker.BrokerTestUtil.spyWithClassAndConstructorArgs;
-import static org.apache.pulsar.broker.BrokerTestUtil.spyWithoutRecordingInvocations;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import static org.apache.pulsar.broker.BrokerTestUtil.*;
 import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.MoreExecutors;
-import io.netty.channel.EventLoopGroup;
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -47,23 +35,13 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.TimeoutHandler;
-import org.apache.bookkeeper.client.BookKeeper;
-import org.apache.bookkeeper.client.EnsemblePlacementPolicy;
-import org.apache.bookkeeper.client.PulsarMockBookKeeper;
-import org.apache.bookkeeper.common.util.OrderedExecutor;
-import org.apache.bookkeeper.stats.StatsLogger;
-import org.apache.bookkeeper.util.ZkUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.pulsar.broker.BookKeeperClientFactory;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.broker.intercept.CounterBrokerInterceptor;
-import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.BrokerTestBase;
-import org.apache.pulsar.broker.service.PulsarMetadataEventSynchronizer;
+import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -74,16 +52,9 @@ import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicType;
-import org.apache.pulsar.metadata.api.MetadataStoreConfig;
-import org.apache.pulsar.metadata.api.MetadataStoreException;
-import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
-import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.tests.TestRetrySupport;
 import org.apache.pulsar.utils.ResourceUtils;
-import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.MockZooKeeper;
-import org.apache.zookeeper.MockZooKeeperSession;
-import org.apache.zookeeper.data.ACL;
 import org.mockito.Mockito;
 import org.mockito.internal.util.MockUtil;
 import org.slf4j.Logger;
@@ -120,6 +91,9 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
     protected final String GLOBAL_DUMMY_VALUE = "GLOBAL_DUMMY_VALUE";
 
     protected ServiceConfiguration conf;
+    protected PulsarTestContext pulsarTestContext;
+    protected MockZooKeeper mockZooKeeper;
+    protected MockZooKeeper mockZooKeeperGlobal;
     protected PulsarService pulsar;
     protected PulsarAdmin admin;
     protected PulsarClient pulsarClient;
@@ -130,14 +104,8 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
 
     protected URI lookupUrl;
 
-    protected MockZooKeeper mockZooKeeper;
-    protected MockZooKeeper mockZooKeeperGlobal;
-    protected NonClosableMockBookKeeper mockBookKeeper;
     protected boolean isTcpLookup = false;
     protected static final String configClusterName = "test";
-
-    private SameThreadOrderedSafeExecutor sameThreadOrderedSafeExecutor;
-    private OrderedExecutor bkExecutor;
 
     protected boolean enableBrokerInterceptor = false;
 
@@ -188,6 +156,10 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
 
     }
 
+    protected BrokerService customizeNewBrokerService(BrokerService brokerService) {
+        return brokerService;
+    }
+
     protected PulsarClient createNewPulsarClient(ClientBuilder clientBuilder) throws PulsarClientException {
         return clientBuilder.build();
     }
@@ -223,13 +195,6 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
 
     protected final void init() throws Exception {
         doInitConf();
-        sameThreadOrderedSafeExecutor = new SameThreadOrderedSafeExecutor();
-        bkExecutor = OrderedExecutor.newBuilder().numThreads(1).name("mock-pulsar-bk").build();
-
-        mockZooKeeper = createMockZooKeeper();
-        mockZooKeeperGlobal = createMockZooKeeperGlobal();
-        mockBookKeeper = createMockBookKeeper(bkExecutor);
-
         startBroker();
     }
 
@@ -251,44 +216,11 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         if (brokerGateway != null) {
             brokerGateway.close();
         }
-        if (pulsar != null) {
-            stopBroker();
-            pulsar = null;
+        if (pulsarTestContext != null) {
+            pulsarTestContext.close();
+            pulsarTestContext = null;
         }
         resetConfig();
-        if (mockBookKeeper != null) {
-            mockBookKeeper.reallyShutdown();
-            Mockito.reset(mockBookKeeper);
-            mockBookKeeper = null;
-        }
-        if (mockZooKeeperGlobal != null) {
-            mockZooKeeperGlobal.shutdown();
-            mockZooKeeperGlobal = null;
-        }
-        if (mockZooKeeper != null) {
-            mockZooKeeper.shutdown();
-            mockZooKeeper = null;
-        }
-        if(sameThreadOrderedSafeExecutor != null) {
-            try {
-                sameThreadOrderedSafeExecutor.shutdownNow();
-                sameThreadOrderedSafeExecutor.awaitTermination(5, TimeUnit.SECONDS);
-            } catch (InterruptedException ex) {
-                log.error("sameThreadOrderedSafeExecutor shutdown had error", ex);
-                Thread.currentThread().interrupt();
-            }
-            sameThreadOrderedSafeExecutor = null;
-        }
-        if(bkExecutor != null) {
-            try {
-                bkExecutor.shutdownNow();
-                bkExecutor.awaitTermination(5, TimeUnit.SECONDS);
-            } catch (InterruptedException ex) {
-                log.error("bkExecutor shutdown had error", ex);
-                Thread.currentThread().interrupt();
-            }
-            bkExecutor = null;
-        }
         onCleanup();
     }
 
@@ -300,7 +232,11 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
 
     protected abstract void cleanup() throws Exception;
 
-    protected void beforePulsarStartMocks(PulsarService pulsar) throws Exception {
+    protected void beforePulsarStart(PulsarService pulsar) throws Exception {
+        // No-op
+    }
+
+    protected void afterPulsarStart(PulsarService pulsar) throws Exception {
         // No-op
     }
 
@@ -310,24 +246,23 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
     }
 
     protected void stopBroker() throws Exception {
+        if (pulsar == null) {
+            return;
+        }
         log.info("Stopping Pulsar broker. brokerServiceUrl: {} webServiceAddress: {}", pulsar.getBrokerServiceUrl(),
                 pulsar.getWebServiceAddress());
-        // set shutdown timeout to 0 for forceful shutdown
-        pulsar.getConfiguration().setBrokerShutdownTimeoutMs(0L);
         pulsar.close();
-        if (MockUtil.isMock(pulsar)) {
-            Mockito.reset(pulsar);
-        }
         pulsar = null;
         // Simulate cleanup of ephemeral nodes
         //mockZooKeeper.delete("/loadbalance/brokers/localhost:" + pulsar.getConfiguration().getWebServicePort(), -1);
     }
 
     protected void startBroker() throws Exception {
-        if (this.pulsar != null) {
-            throw new RuntimeException("broker already started!");
-        }
-        this.pulsar = startBroker(conf);
+        this.pulsarTestContext = createMainPulsarTestContext(conf);
+        this.mockZooKeeper = pulsarTestContext.getMockZooKeeper();
+        this.mockZooKeeperGlobal = pulsarTestContext.getMockZooKeeperGlobal();
+        this.pulsar = pulsarTestContext.getPulsarService();
+        afterPulsarStart(pulsar);
 
         brokerUrl = pulsar.getWebServiceAddress() != null ? new URL(pulsar.getWebServiceAddress()) : null;
         brokerUrlTls = pulsar.getWebServiceAddressTls() != null ? new URL(pulsar.getWebServiceAddressTls()) : null;
@@ -349,86 +284,43 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
 
     }
 
-    protected PulsarService startBroker(ServiceConfiguration conf) throws Exception {
-        return startBrokerWithoutAuthorization(conf);
-    }
-
-    protected PulsarService startBrokerWithoutAuthorization(ServiceConfiguration conf) throws Exception {
-        conf.setBrokerShutdownTimeoutMs(0L);
-        PulsarService pulsar = spyWithoutRecordingInvocations(newPulsarService(conf));
-        setupBrokerMocks(pulsar);
-        beforePulsarStartMocks(pulsar);
-        pulsar.start();
-        log.info("Pulsar started. brokerServiceUrl: {} webServiceAddress: {}", pulsar.getBrokerServiceUrl(),
-                pulsar.getWebServiceAddress());
-        return pulsar;
-    }
-
-    protected PulsarService newPulsarService(ServiceConfiguration conf) throws Exception {
-        return new PulsarService(conf);
-    }
-
-    protected void setupBrokerMocks(PulsarService pulsar) throws Exception {
-        // Override default providers with mocked ones
-        doReturn(mockBookKeeperClientFactory).when(pulsar).newBookKeeperClientFactory();
-
-        PulsarMetadataEventSynchronizer synchronizer = StringUtils
-                .isNotBlank(pulsar.getConfig().getMetadataSyncEventTopic())
-                        ? new PulsarMetadataEventSynchronizer(pulsar, pulsar.getConfig().getMetadataSyncEventTopic())
-                        : null;
-        PulsarMetadataEventSynchronizer configSynchronizer = StringUtils
-                .isNotBlank(pulsar.getConfig().getConfigurationMetadataSyncEventTopic())
-                        ? new PulsarMetadataEventSynchronizer(pulsar,
-                                pulsar.getConfig().getConfigurationMetadataSyncEventTopic())
-                        : null;
-        doReturn(synchronizer != null ? createLocalMetadataStore(synchronizer) : createLocalMetadataStore())
-                .when(pulsar).createLocalMetadataStore(any());
-        doReturn(configSynchronizer != null ? createConfigurationMetadataStore(configSynchronizer)
-                : createConfigurationMetadataStore()).when(pulsar).createConfigurationMetadataStore(any());
-
-        Supplier<NamespaceService> namespaceServiceSupplier =
-                () -> spyWithClassAndConstructorArgs(NamespaceService.class, pulsar);
-        doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();
-
-        doReturn(sameThreadOrderedSafeExecutor).when(pulsar).getOrderedExecutor();
-        doReturn(new CounterBrokerInterceptor()).when(pulsar).getBrokerInterceptor();
-
-        doAnswer((invocation) -> spy(invocation.callRealMethod())).when(pulsar).newCompactor();
-        if (enableBrokerInterceptor) {
-            mockConfigBrokerInterceptors(pulsar);
+    protected PulsarTestContext createMainPulsarTestContext(ServiceConfiguration conf) throws Exception {
+        PulsarTestContext.Builder pulsarTestContextBuilder = createPulsarTestContextBuilder(conf);
+        if (pulsarTestContext != null) {
+            pulsarTestContextBuilder.reuseMockBookkeeperAndMetadataStores(pulsarTestContext);
+            pulsarTestContextBuilder.reuseSpyConfig(pulsarTestContext);
+            pulsarTestContextBuilder.chainClosing(pulsarTestContext);
         }
+        customizeMainPulsarTestContextBuilder(pulsarTestContextBuilder);
+        return pulsarTestContextBuilder
+                .build();
     }
 
-    protected MetadataStoreExtended createLocalMetadataStore(PulsarMetadataEventSynchronizer synchronizer) {
-        return new ZKMetadataStore(mockZooKeeper, MetadataStoreConfig.builder()
-                .metadataStoreName(MetadataStoreConfig.METADATA_STORE)
-                .synchronizer(synchronizer).build());
-    }
-
-    protected MetadataStoreExtended createLocalMetadataStore() throws MetadataStoreException {
-        return new ZKMetadataStore(MockZooKeeperSession.newInstance(mockZooKeeper), MetadataStoreConfig.builder()
-                .metadataStoreName(MetadataStoreConfig.METADATA_STORE).build());
-    }
-
-    protected MetadataStoreExtended createConfigurationMetadataStore(PulsarMetadataEventSynchronizer synchronizer) {
-        return new ZKMetadataStore(mockZooKeeperGlobal,
-                MetadataStoreConfig.builder()
-                        .metadataStoreName(MetadataStoreConfig.CONFIGURATION_METADATA_STORE)
-                        .synchronizer(synchronizer).build());
+    protected void customizeMainPulsarTestContextBuilder(PulsarTestContext.Builder pulsarTestContextBuilder) {
 
     }
 
-    protected MetadataStoreExtended createConfigurationMetadataStore() throws MetadataStoreException {
-        return new ZKMetadataStore(MockZooKeeperSession.newInstance(mockZooKeeperGlobal), MetadataStoreConfig.builder()
-                .metadataStoreName(MetadataStoreConfig.CONFIGURATION_METADATA_STORE).build());
+    protected PulsarTestContext.Builder createPulsarTestContextBuilder(ServiceConfiguration conf) {
+        PulsarTestContext.Builder builder = PulsarTestContext.startableBuilder()
+                .spyByDefault()
+                .config(conf)
+                .withMockZookeeper(true)
+                .pulsarServiceCustomizer(pulsarService -> {
+                    try {
+                        beforePulsarStart(pulsarService);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .brokerServiceCustomizer(this::customizeNewBrokerService);
+        return builder;
     }
 
-    private void mockConfigBrokerInterceptors(PulsarService pulsarService) {
-        ServiceConfiguration configuration = spy(conf);
-        Set<String> mockBrokerInterceptors = mock(Set.class);
-        when(mockBrokerInterceptors.isEmpty()).thenReturn(false);
-        when(configuration.getBrokerInterceptors()).thenReturn(mockBrokerInterceptors);
-        when(pulsarService.getConfig()).thenReturn(configuration);
+    protected PulsarTestContext createAdditionalPulsarTestContext(ServiceConfiguration conf) throws Exception {
+        return createPulsarTestContextBuilder(conf)
+                .reuseMockBookkeeperAndMetadataStores(pulsarTestContext)
+                .reuseSpyConfig(pulsarTestContext)
+                .build();
     }
 
     protected void waitForZooKeeperWatchers() {
@@ -450,73 +342,6 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         return new TenantInfoImpl(new HashSet<>(), allowedClusters);
     }
 
-    public static MockZooKeeper createMockZooKeeper() throws Exception {
-        MockZooKeeper zk = MockZooKeeper.newInstance(MoreExecutors.newDirectExecutorService());
-        List<ACL> dummyAclList = new ArrayList<>(0);
-
-        ZkUtils.createFullPathOptimistic(zk, "/ledgers/available/192.168.1.1:" + 5000,
-                "".getBytes(StandardCharsets.UTF_8), dummyAclList, CreateMode.PERSISTENT);
-
-        zk.create("/ledgers/LAYOUT", "1\nflat:1".getBytes(StandardCharsets.UTF_8), dummyAclList,
-                CreateMode.PERSISTENT);
-        return zk;
-    }
-
-    public static MockZooKeeper createMockZooKeeperGlobal() {
-        return  MockZooKeeper.newInstanceForGlobalZK(MoreExecutors.newDirectExecutorService());
-    }
-
-    public static NonClosableMockBookKeeper createMockBookKeeper(OrderedExecutor executor) throws Exception {
-        return spyWithClassAndConstructorArgs(NonClosableMockBookKeeper.class, executor);
-    }
-
-    // Prevent the MockBookKeeper instance from being closed when the broker is restarted within a test
-    public static class NonClosableMockBookKeeper extends PulsarMockBookKeeper {
-
-        public NonClosableMockBookKeeper(OrderedExecutor executor) throws Exception {
-            super(executor);
-        }
-
-        @Override
-        public void close() {
-            // no-op
-        }
-
-        @Override
-        public void shutdown() {
-            // no-op
-        }
-
-        public void reallyShutdown() {
-            super.shutdown();
-        }
-    }
-
-    private final BookKeeperClientFactory mockBookKeeperClientFactory = new BookKeeperClientFactory() {
-
-        @Override
-        public BookKeeper create(ServiceConfiguration conf, MetadataStoreExtended store,
-                                 EventLoopGroup eventLoopGroup,
-                                 Optional<Class<? extends EnsemblePlacementPolicy>> ensemblePlacementPolicyClass,
-                                 Map<String, Object> properties) {
-            // Always return the same instance (so that we don't loose the mock BK content on broker restart
-            return mockBookKeeper;
-        }
-
-        @Override
-        public BookKeeper create(ServiceConfiguration conf, MetadataStoreExtended store,
-                                 EventLoopGroup eventLoopGroup,
-                                 Optional<Class<? extends EnsemblePlacementPolicy>> ensemblePlacementPolicyClass,
-                                 Map<String, Object> properties, StatsLogger statsLogger) {
-            // Always return the same instance (so that we don't loose the mock BK content on broker restart
-            return mockBookKeeper;
-        }
-
-        @Override
-        public void close() {
-            // no-op
-        }
-    };
 
     public static boolean retryStrategically(Predicate<Void> predicate, int retryCount, long intSleepTimeInMillis)
             throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -301,7 +301,7 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
     }
 
     protected PulsarTestContext.Builder createPulsarTestContextBuilder(ServiceConfiguration conf) {
-        PulsarTestContext.Builder builder = PulsarTestContext.startableBuilder()
+        PulsarTestContext.Builder builder = PulsarTestContext.builder()
                 .spyByDefault()
                 .config(conf)
                 .withMockZookeeper(true)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorTest.java
@@ -18,12 +18,25 @@
  */
 package org.apache.pulsar.broker.intercept;
 
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import lombok.Cleanup;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -38,20 +51,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-
-import static org.mockito.ArgumentMatchers.same;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.testng.Assert.assertEquals;
 
 @Test(groups = "broker")
 public class BrokerInterceptorTest extends ProducerConsumerBase {
@@ -88,6 +87,11 @@ public class BrokerInterceptorTest extends ProducerConsumerBase {
         this.enableBrokerInterceptor = true;
         super.internalSetup();
         super.producerBaseSetup();
+    }
+
+    @Override
+    protected void customizeMainPulsarTestContextBuilder(PulsarTestContext.Builder pulsarTestContextBuilder) {
+        pulsarTestContextBuilder.brokerInterceptor(new CounterBrokerInterceptor());
     }
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/CounterBrokerInterceptor.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/CounterBrokerInterceptor.java
@@ -20,9 +20,9 @@ package org.apache.pulsar.broker.intercept;
 
 import io.netty.buffer.ByteBuf;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -81,7 +81,7 @@ public class CounterBrokerInterceptor implements BrokerInterceptor {
         abortedTxnCount.set(0);
     }
 
-    private final List<ResponseEvent> responseList = new ArrayList<>();
+    private final List<ResponseEvent> responseList = new CopyOnWriteArrayList<>();
 
     @Data
     @AllArgsConstructor

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/InterceptFilterOutTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/InterceptFilterOutTest.java
@@ -18,7 +18,19 @@
  */
 package org.apache.pulsar.broker.intercept;
 
-import java.util.HashSet;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import javax.servlet.FilterChain;
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.web.ExceptionHandler;
@@ -29,20 +41,6 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.testng.collections.Sets;
-
-import javax.servlet.FilterChain;
-import javax.servlet.ReadListener;
-import javax.servlet.ServletInputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
-import javax.servlet.http.HttpServletResponse;
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.charset.Charset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests for the the interceptor filter out.
@@ -96,7 +94,7 @@ public class InterceptFilterOutTest {
         Mockito.doReturn(Sets.newHashSet("interceptor")).when(conf).getBrokerInterceptors();
         Mockito.doReturn(conf).when(pulsarService).getConfig();
         //init filter
-        ProcessHandlerFilter filter = new ProcessHandlerFilter(pulsarService);
+        ProcessHandlerFilter filter = new ProcessHandlerFilter(pulsarService.getBrokerInterceptor());
 
         HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
@@ -142,32 +140,6 @@ public class InterceptFilterOutTest {
             filter.doFilter(request, response, chain);
             Assert.assertEquals(interceptor.getCount(), 1);
         }
-    }
-
-    @Test
-    public void testShouldNotInterceptWhenInterceptorDisabled() throws Exception {
-        CounterBrokerInterceptor interceptor = new CounterBrokerInterceptor();
-        PulsarService pulsarService = Mockito.mock(PulsarService.class);
-        Mockito.doReturn("pulsar://127.0.0.1:6650").when(pulsarService).getAdvertisedAddress();
-        Mockito.doReturn(interceptor).when(pulsarService).getBrokerInterceptor();
-        ServiceConfiguration conf = Mockito.mock(ServiceConfiguration.class);
-        // Disable the broker interceptor
-        Mockito.doReturn(new HashSet<>()).when(conf).getBrokerInterceptors();
-        Mockito.doReturn(conf).when(pulsarService).getConfig();
-        ResponseHandlerFilter filter = new ResponseHandlerFilter(pulsarService);
-
-        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-        FilterChain chain = Mockito.mock(FilterChain.class);
-        Mockito.doNothing().when(chain).doFilter(Mockito.any(), Mockito.any());
-        HttpServletRequestWrapper mockInputStream = new MockRequestWrapper(request);
-        Mockito.doReturn(mockInputStream.getInputStream()).when(request).getInputStream();
-        Mockito.doReturn(new StringBuffer("http://127.0.0.1:8080")).when(request).getRequestURL();
-
-        // Should not be intercepted since the broker interceptor disabled.
-        Mockito.doReturn("application/json").when(request).getContentType();
-        filter.doFilter(request, response, chain);
-        Assert.assertEquals(interceptor.getCount(), 0);
     }
 
     private static class MockRequestWrapper extends HttpServletRequestWrapper {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/MultiBrokerLeaderElectionExpirationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/MultiBrokerLeaderElectionExpirationTest.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.pulsar.broker.loadbalance;
 
 import static org.mockito.Mockito.spy;
@@ -30,7 +31,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.MultiBrokerTestZKBaseTest;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.metadata.api.MetadataCacheConfig;
-import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.awaitility.Awaitility;
 import org.testng.annotations.Test;
@@ -58,13 +58,8 @@ public class MultiBrokerLeaderElectionExpirationTest extends MultiBrokerTestZKBa
     }
 
     @Override
-    protected MetadataStoreExtended createLocalMetadataStore() throws MetadataStoreException {
-        return changeDefaultMetadataCacheConfig(super.createLocalMetadataStore());
-    }
-
-    @Override
-    protected MetadataStoreExtended createConfigurationMetadataStore() throws MetadataStoreException {
-        return changeDefaultMetadataCacheConfig(super.createConfigurationMetadataStore());
+    protected MetadataStoreExtended createMetadataStore() {
+        return changeDefaultMetadataCacheConfig(super.createMetadataStore());
     }
 
     MetadataStoreExtended changeDefaultMetadataCacheConfig(MetadataStoreExtended metadataStore) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/MultiBrokerLeaderElectionExpirationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/MultiBrokerLeaderElectionExpirationTest.java
@@ -58,8 +58,8 @@ public class MultiBrokerLeaderElectionExpirationTest extends MultiBrokerTestZKBa
     }
 
     @Override
-    protected MetadataStoreExtended createMetadataStore() {
-        return changeDefaultMetadataCacheConfig(super.createMetadataStore());
+    protected MetadataStoreExtended createMetadataStore(String metadataStoreName) {
+        return changeDefaultMetadataCacheConfig(super.createMetadataStore(metadataStoreName));
     }
 
     MetadataStoreExtended changeDefaultMetadataCacheConfig(MetadataStoreExtended metadataStore) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnerShipForCurrentServerTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnerShipForCurrentServerTestBase.java
@@ -87,7 +87,7 @@ public abstract class OwnerShipForCurrentServerTestBase {
             serviceConfigurationList.add(conf);
 
             PulsarTestContext.Builder testContextBuilder =
-                    PulsarTestContext.startableBuilder()
+                    PulsarTestContext.builder()
                             .config(conf);
             if (i > 0) {
                 testContextBuilder.reuseMockBookkeeperAndMetadataStores(pulsarTestContexts.get(0));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ManagedLedgerCompressionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ManagedLedgerCompressionTest.java
@@ -81,7 +81,8 @@ public class ManagedLedgerCompressionTest extends BrokerTestBase {
         try {
             startBroker();
             Assert.fail("The managedLedgerInfo compression type is invalid, should fail.");
-        } catch (Exception e) {
+        } catch (Exception rte) {
+            Throwable e = rte.getCause();
             Assert.assertEquals(e.getCause().getClass(), IllegalArgumentException.class);
             Assert.assertEquals(
                     "No enum constant org.apache.bookkeeper.mledger.proto.MLDataFormats.CompressionType.INVALID",

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessageCumulativeAckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessageCumulativeAckTest.java
@@ -61,7 +61,7 @@ public class MessageCumulativeAckTest {
 
     @BeforeMethod
     public void setup() throws Exception {
-        pulsarTestContext = PulsarTestContext.builder()
+        pulsarTestContext = PulsarTestContext.builderForNonStartableContext()
                 .build();
 
         serverCnx = pulsarTestContext.createServerCnxSpy();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
@@ -20,11 +20,9 @@ package org.apache.pulsar.broker.service;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
-
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
 import org.apache.pulsar.client.api.Producer;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
@@ -56,7 +54,7 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
                 .create();
          assertEquals(pulsar.getBrokerService().getPausedConnections(), 0);
 
-         mockBookKeeper.addEntryDelay(1, TimeUnit.SECONDS);
+        pulsarTestContext.getMockBookKeeper().addEntryDelay(1, TimeUnit.SECONDS);
 
         // Make sure the producer can publish successfully
         byte[] payload = new byte[1024 * 1024];
@@ -82,7 +80,7 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
 
         assertEquals(pulsar.getBrokerService().getPausedConnections(), 0);
 
-        mockBookKeeper.addEntryDelay(1, TimeUnit.SECONDS);
+        pulsarTestContext.getMockBookKeeper().addEntryDelay(1, TimeUnit.SECONDS);
 
         byte[] payload = new byte[1024 * 1024];
         for (int i = 0; i < 10; i++) {
@@ -115,7 +113,7 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
         Assert.assertNotNull(topicRef);
         assertEquals(pulsar.getBrokerService().getPausedConnections(), 0);
 
-        mockBookKeeper.addEntryDelay(5, TimeUnit.SECONDS);
+        pulsarTestContext.getMockBookKeeper().addEntryDelay(5, TimeUnit.SECONDS);
 
         // Block by publish buffer.
         byte[] payload = new byte[1024 * 1024];

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -104,7 +104,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         svcConfig.setClusterName("pulsar-cluster");
         svcConfig.setSystemTopicEnabled(false);
         svcConfig.setTopicLevelPoliciesEnabled(false);
-        pulsarTestContext = PulsarTestContext.builder()
+        pulsarTestContext = PulsarTestContext.builderForNonStartableContext()
                 .config(svcConfig)
                 .spyByDefault()
                 .build();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -172,7 +172,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         svcConfig.setClusterName("pulsar-cluster");
         svcConfig.setTopicLevelPoliciesEnabled(false);
         svcConfig.setSystemTopicEnabled(false);
-        pulsarTestContext = PulsarTestContext.builder()
+        pulsarTestContext = PulsarTestContext.builderForNonStartableContext()
                 .config(svcConfig)
                 .spyByDefault()
                 .useTestPulsarResources(metadataStore)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxAuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxAuthorizationTest.java
@@ -95,7 +95,7 @@ public class ServerCnxAuthorizationTest {
         properties.setProperty("tokenSecretKey", "data:;base64,"
                 + Base64.getEncoder().encodeToString(SECRET_KEY.getEncoded()));
         svcConfig.setProperties(properties);
-        pulsarTestContext = PulsarTestContext.builder()
+        pulsarTestContext = PulsarTestContext.builderForNonStartableContext()
                 .config(svcConfig)
                 .spyByDefault()
                 .build();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -181,7 +181,7 @@ public class ServerCnxTest {
         svcConfig.setKeepAliveIntervalSeconds(inSec(1, TimeUnit.SECONDS));
         svcConfig.setBacklogQuotaCheckEnabled(false);
         svcConfig.setClusterName("use");
-        pulsarTestContext = PulsarTestContext.builder()
+        pulsarTestContext = PulsarTestContext.builderForNonStartableContext()
                 .config(svcConfig)
                 .spyByDefault()
                 .build();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/DelayedDeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/DelayedDeliveryTest.java
@@ -23,7 +23,6 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -32,9 +31,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
 import lombok.Cleanup;
-
 import org.apache.bookkeeper.client.BKException;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.service.Dispatcher;
@@ -611,7 +608,7 @@ public class DelayedDeliveryTest extends ProducerConsumerBase {
         assertNull(msg);
 
         // Inject failure in BK read
-        this.mockBookKeeper.failNow(BKException.Code.ReadException);
+        pulsarTestContext.getMockBookKeeper().failNow(BKException.Code.ReadException);
 
         Set<String> receivedMsgs = new TreeSet<>();
         for (int i = 0; i < 10; i++) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentSubscriptionTest.java
@@ -18,22 +18,16 @@
  */
 package org.apache.pulsar.broker.service.persistent;
 
-import static org.apache.pulsar.broker.BrokerTestUtil.spyWithClassAndConstructorArgs;
-import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.createMockBookKeeper;
-import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.createMockZooKeeper;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
 import java.lang.reflect.Field;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -45,19 +39,15 @@ import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
-import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorContainer;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.lang3.tuple.MutablePair;
-import org.apache.pulsar.broker.PulsarService;
-import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.resources.NamespaceResources;
-import org.apache.pulsar.broker.resources.PulsarResources;
-import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.Consumer;
+import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.broker.transaction.buffer.impl.InMemTransactionBufferProvider;
 import org.apache.pulsar.broker.transaction.pendingack.PendingAckStore;
 import org.apache.pulsar.broker.transaction.pendingack.TransactionPendingAckStoreProvider;
@@ -68,13 +58,7 @@ import org.apache.pulsar.common.api.proto.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.api.proto.TxnAction;
 import org.apache.pulsar.common.policies.data.Policies;
-import org.apache.pulsar.common.util.GracefulExecutorServicesShutdown;
-import org.apache.pulsar.common.util.netty.EventLoopUtil;
-import org.apache.pulsar.compaction.Compactor;
-import org.apache.pulsar.metadata.api.MetadataStore;
-import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.transaction.common.exception.TransactionConflictException;
-import org.apache.zookeeper.ZooKeeper;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,10 +69,7 @@ import org.testng.annotations.Test;
 @Test(groups = "broker")
 public class PersistentSubscriptionTest {
 
-    private PulsarService pulsarMock;
-    private BrokerService brokerMock;
-    private ManagedLedgerFactory mlFactoryMock;
-    private MetadataStore store;
+    private PulsarTestContext pulsarTestContext;
     private ManagedLedger ledgerMock;
     private ManagedCursorImpl cursorMock;
     private PersistentTopic topic;
@@ -109,23 +90,18 @@ public class PersistentSubscriptionTest {
 
     @BeforeMethod
     public void setup() throws Exception {
-        executor = OrderedExecutor.newBuilder().numThreads(1).name("persistent-subscription-test").build();
-        eventLoopGroup = new NioEventLoopGroup();
+        pulsarTestContext = PulsarTestContext.builder()
+                .spyByDefault()
+                .configCustomizer(config -> config.setTransactionCoordinatorEnabled(true))
+                .useTestPulsarResources()
+                .build();
 
-        ServiceConfiguration svcConfig = new ServiceConfiguration();
-        svcConfig.setBrokerShutdownTimeoutMs(0L);
-        svcConfig.setLoadBalancerOverrideBrokerNicSpeedGbps(Optional.of(1.0d));
-        svcConfig.setTransactionCoordinatorEnabled(true);
-        svcConfig.setClusterName("pulsar-cluster");
-        pulsarMock = spyWithClassAndConstructorArgs(PulsarService.class, svcConfig);
-        PulsarResources pulsarResources = mock(PulsarResources.class);
-        doReturn(pulsarResources).when(pulsarMock).getPulsarResources();
-        NamespaceResources namespaceResources = mock(NamespaceResources.class);
-        doReturn(namespaceResources).when(pulsarResources).getNamespaceResources();
+        NamespaceResources namespaceResources = pulsarTestContext.getPulsarResources().getNamespaceResources();
+        doReturn(Optional.of(new Policies())).when(namespaceResources)
+                .getPoliciesIfCached(any());
 
-        doReturn(Optional.of(new Policies())).when(namespaceResources).getPoliciesIfCached(any());
-
-        doReturn(new InMemTransactionBufferProvider()).when(pulsarMock).getTransactionBufferProvider();
+        doReturn(new InMemTransactionBufferProvider()).when(pulsarTestContext.getPulsarService())
+                .getTransactionBufferProvider();
         doReturn(new TransactionPendingAckStoreProvider() {
             @Override
             public CompletableFuture<PendingAckStore> newPendingAckStore(PersistentSubscription subscription) {
@@ -172,24 +148,7 @@ public class PersistentSubscriptionTest {
             public CompletableFuture<Boolean> checkInitializedBefore(PersistentSubscription subscription) {
                 return CompletableFuture.completedFuture(true);
             }
-        }).when(pulsarMock).getTransactionPendingAckStoreProvider();
-        doReturn(svcConfig).when(pulsarMock).getConfiguration();
-        doReturn(mock(Compactor.class)).when(pulsarMock).getCompactor();
-
-        mlFactoryMock = mock(ManagedLedgerFactory.class);
-        doReturn(mlFactoryMock).when(pulsarMock).getManagedLedgerFactory();
-
-        ZooKeeper zkMock = createMockZooKeeper();
-        doReturn(createMockBookKeeper(executor))
-                .when(pulsarMock).getBookKeeperClient();
-
-        store = new ZKMetadataStore(zkMock);
-        doReturn(store).when(pulsarMock).getLocalMetadataStore();
-        doReturn(store).when(pulsarMock).getConfigurationMetadataStore();
-
-        brokerMock = spyWithClassAndConstructorArgs(BrokerService.class, pulsarMock, eventLoopGroup);
-        doNothing().when(brokerMock).unloadNamespaceBundlesGracefully();
-        doReturn(brokerMock).when(pulsarMock).getBrokerService();
+        }).when(pulsarTestContext.getPulsarService()).getTransactionPendingAckStoreProvider();
 
         ledgerMock = mock(ManagedLedgerImpl.class);
         cursorMock = mock(ManagedCursorImpl.class);
@@ -201,7 +160,7 @@ public class PersistentSubscriptionTest {
         doReturn(managedLedgerConfigMock).when(ledgerMock).getConfig();
         doReturn(false).when(managedLedgerConfigMock).isAutoSkipNonRecoverableData();
 
-        topic = new PersistentTopic(successTopicName, ledgerMock, brokerMock);
+        topic = new PersistentTopic(successTopicName, ledgerMock, pulsarTestContext.getBrokerService());
 
         consumerMock = mock(Consumer.class);
 
@@ -210,14 +169,10 @@ public class PersistentSubscriptionTest {
 
     @AfterMethod(alwaysRun = true)
     public void teardown() throws Exception {
-        brokerMock.close();
-        pulsarMock.close();
-        GracefulExecutorServicesShutdown.initiate()
-                .timeout(Duration.ZERO)
-                .shutdown(executor)
-                .handle().get();
-        EventLoopUtil.shutdownGracefully(eventLoopGroup).get();
-        store.close();
+        if (pulsarTestContext != null) {
+            pulsarTestContext.close();
+            pulsarTestContext = null;
+        }
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentSubscriptionTest.java
@@ -90,7 +90,7 @@ public class PersistentSubscriptionTest {
 
     @BeforeMethod
     public void setup() throws Exception {
-        pulsarTestContext = PulsarTestContext.builder()
+        pulsarTestContext = PulsarTestContext.builderForNonStartableContext()
                 .spyByDefault()
                 .configCustomizer(config -> config.setTransactionCoordinatorEnabled(true))
                 .useTestPulsarResources()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/plugin/EntryFilterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/plugin/EntryFilterTest.java
@@ -42,19 +42,22 @@ public class EntryFilterTest implements EntryFilter {
         String matchValueReject = metadata.getOrDefault("matchValueReject", "REJECT");
         String matchValueReschedule = metadata.getOrDefault("matchValueReschedule", "RESCHEDULE");
         List<KeyValue> list = context.getMsgMetadata().getPropertiesList();
+        String debug =
+                list.stream().filter(kv -> "debug".equalsIgnoreCase(kv.getKey())).findFirst().map(KeyValue::getValue)
+                        .orElse("-");
         // filter by string
         for (KeyValue keyValue : list) {
             if (matchValueAccept.equalsIgnoreCase(keyValue.getKey())) {
-                log.info("metadata {} key {} outcome ACCEPT", metadata, keyValue.getKey());
+                log.info("metadata {} key {} debug '{}' outcome ACCEPT", metadata, keyValue.getKey(), debug);
                 return FilterResult.ACCEPT;
             } else if (matchValueReject.equalsIgnoreCase(keyValue.getKey())){
-                log.info("metadata {} key {} outcome REJECT", metadata, keyValue.getKey());
+                log.info("metadata {} key {} debug '{}' outcome REJECT", metadata, keyValue.getKey(), debug);
                 return FilterResult.REJECT;
             } else if (matchValueReschedule.equalsIgnoreCase(keyValue.getKey())){
-                log.info("metadata {} key {} outcome RESCHEDULE", metadata, keyValue.getKey());
+                log.info("metadata {} key {} debug '{}' outcome RESCHEDULE", metadata, keyValue.getKey(), debug);
                 return FilterResult.RESCHEDULE;
             } else {
-                log.info("metadata {} key {} outcome ??", metadata, keyValue.getKey());
+                log.info("metadata {} key {} debug '{}' outcome ??", metadata, keyValue.getKey(), debug);
             }
         }
         return null;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.broker.stats;
 
 import static org.apache.pulsar.broker.BrokerTestUtil.spyWithClassAndConstructorArgs;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.AssertJUnit.assertEquals;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -43,9 +42,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -373,16 +370,6 @@ public class ConsumerStatsTest extends ProducerConsumerBase {
             Assert.assertTrue(totalRateOut > 0D);
             Assert.assertEquals(totalAckRate, totalRateOut, totalRateOut * 0.1D);
         }
-    }
-
-    @Override
-    protected PulsarService newPulsarService(ServiceConfiguration conf) throws Exception {
-        return new PulsarService(conf) {
-            @Override
-            protected BrokerService newBrokerService(PulsarService pulsar) throws Exception {
-                return spy(new BrokerService(this, ioEventLoopGroup));
-            }
-        };
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionBatchWriterMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionBatchWriterMetricsTest.java
@@ -109,8 +109,8 @@ public class TransactionBatchWriterMetricsTest extends MockedPulsarServiceBaseTe
 
 
     @Override
-    protected PulsarService startBroker(ServiceConfiguration conf) throws Exception {
-        PulsarService pulsar = startBrokerWithoutAuthorization(conf);
+    protected void startBroker() throws Exception {
+        super.startBroker();
         ensureClusterExists(pulsar, clusterName);
         ensureTenantExists(pulsar.getPulsarResources().getTenantResources(), TopicName.PUBLIC_TENANT, clusterName);
         ensureNamespaceExists(pulsar.getPulsarResources().getNamespaceResources(), DEFAULT_NAMESPACE,
@@ -119,7 +119,6 @@ public class TransactionBatchWriterMetricsTest extends MockedPulsarServiceBaseTe
                 clusterName);
         ensureTopicExists(pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources(),
                 SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN, 16);
-        return pulsar;
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/AbstractTestPulsarService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/AbstractTestPulsarService.java
@@ -19,12 +19,10 @@
 
 package org.apache.pulsar.broker.testcontext;
 
-import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.pulsar.broker.BookKeeperClientFactory;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.broker.auth.SameThreadOrderedSafeExecutor;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import org.apache.pulsar.broker.service.PulsarMetadataEventSynchronizer;
 import org.apache.pulsar.compaction.Compactor;
@@ -44,14 +42,12 @@ abstract class AbstractTestPulsarService extends PulsarService {
     protected final Compactor compactor;
     protected final BrokerInterceptor brokerInterceptor;
     protected final BookKeeperClientFactory bookKeeperClientFactory;
-    private final boolean useSameThreadOrderedExecutor;
 
     public AbstractTestPulsarService(SpyConfig spyConfig, ServiceConfiguration config,
                                      MetadataStoreExtended localMetadataStore,
                                      MetadataStoreExtended configurationMetadataStore, Compactor compactor,
                                      BrokerInterceptor brokerInterceptor,
-                                     BookKeeperClientFactory bookKeeperClientFactory,
-                                     boolean useSameThreadOrderedExecutor) {
+                                     BookKeeperClientFactory bookKeeperClientFactory) {
         super(config);
         this.spyConfig = spyConfig;
         this.localMetadataStore =
@@ -61,7 +57,6 @@ abstract class AbstractTestPulsarService extends PulsarService {
         this.compactor = compactor;
         this.brokerInterceptor = brokerInterceptor;
         this.bookKeeperClientFactory = bookKeeperClientFactory;
-        this.useSameThreadOrderedExecutor = useSameThreadOrderedExecutor;
     }
 
     @Override
@@ -103,14 +98,5 @@ abstract class AbstractTestPulsarService extends PulsarService {
     @Override
     public BookKeeperClientFactory newBookKeeperClientFactory() {
         return bookKeeperClientFactory;
-    }
-
-    @Override
-    protected OrderedExecutor newOrderedExecutor() {
-        if (useSameThreadOrderedExecutor) {
-            return new SameThreadOrderedSafeExecutor();
-        } else {
-            return super.newOrderedExecutor();
-        }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/AbstractTestPulsarService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/AbstractTestPulsarService.java
@@ -62,13 +62,18 @@ abstract class AbstractTestPulsarService extends PulsarService {
     @Override
     public MetadataStore createConfigurationMetadataStore(PulsarMetadataEventSynchronizer synchronizer)
             throws MetadataStoreException {
-
+        if (synchronizer != null) {
+            synchronizer.registerSyncListener(configurationMetadataStore::handleMetadataEvent);
+        }
         return configurationMetadataStore;
     }
 
     @Override
     public MetadataStoreExtended createLocalMetadataStore(PulsarMetadataEventSynchronizer synchronizer)
             throws MetadataStoreException, PulsarServerException {
+        if (synchronizer != null) {
+            synchronizer.registerSyncListener(localMetadataStore::handleMetadataEvent);
+        }
         return localMetadataStore;
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/AbstractTestPulsarService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/AbstractTestPulsarService.java
@@ -32,6 +32,11 @@ import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 
+/**
+ * This is an internal class used by {@link PulsarTestContext} as the abstract base class for
+ * {@link PulsarService} implementations for a PulsarService instance used in tests.
+ * Please see {@link PulsarTestContext} for more details.
+ */
 abstract class AbstractTestPulsarService extends PulsarService {
     protected final SpyConfig spyConfig;
     protected final MetadataStoreExtended localMetadataStore;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/MockBookKeeperClientFactory.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/MockBookKeeperClientFactory.java
@@ -28,6 +28,9 @@ import org.apache.pulsar.broker.BookKeeperClientFactory;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 
+/**
+ * A {@link BookKeeperClientFactory} that always returns the same instance of {@link BookKeeper}.
+ */
 class MockBookKeeperClientFactory implements BookKeeperClientFactory {
     private final BookKeeper mockBookKeeper;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/NonClosableMockBookKeeper.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/NonClosableMockBookKeeper.java
@@ -16,12 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.pulsar.broker.testcontext;
 
 import org.apache.bookkeeper.client.PulsarMockBookKeeper;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
 
-// Prevent the MockBookKeeper instance from being closed when the broker is restarted within a test
+/**
+ * An in-memory mock bookkeeper which prevents closing when "close" method is called.
+ * This is an internal class used by {@link PulsarTestContext}
+ *
+ * @see PulsarMockBookKeeper
+ */
 class NonClosableMockBookKeeper extends PulsarMockBookKeeper {
 
     public NonClosableMockBookKeeper(OrderedExecutor executor) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/NonClosingProxyHandler.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/NonClosingProxyHandler.java
@@ -22,6 +22,11 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
+/**
+ * This is a JDK Proxy based handler that wraps an AutoCloseable instance and prevents it from being closed
+ * when the close method is invoked.
+ * The {@link #reallyClose(AutoCloseable)} method can be used to close the delegate instance.
+ */
 public class NonClosingProxyHandler implements InvocationHandler {
     private final AutoCloseable delegate;
 
@@ -29,6 +34,9 @@ public class NonClosingProxyHandler implements InvocationHandler {
         this.delegate = delegate;
     }
 
+    /**
+     * Wraps the given delegate instance with a proxy instance that prevents closing.
+     */
     public static <T extends AutoCloseable> T createNonClosingProxy(T delegate, Class<T> interfaceClass) {
         if (isNonClosingProxy(delegate)) {
             return delegate;
@@ -37,11 +45,22 @@ public class NonClosingProxyHandler implements InvocationHandler {
                 new Class<?>[] {interfaceClass}, new NonClosingProxyHandler(delegate)));
     }
 
+    /**
+     * Returns true if the given instance is a proxy instance created by
+     * {@link #createNonClosingProxy(AutoCloseable, Class)}
+     * @param instance proxy instance
+     * @return true if the given instance is a proxy instance
+     */
     public static boolean isNonClosingProxy(Object instance) {
         return Proxy.isProxyClass(instance.getClass())
                 && Proxy.getInvocationHandler(instance) instanceof NonClosingProxyHandler;
     }
 
+    /**
+     * Returns the delegate instance of the given proxy instance.
+     * @param instance proxy instance
+     * @return delegate instance
+     */
     public static <T extends I, I extends AutoCloseable> I getDelegate(T instance) {
         if (isNonClosingProxy(instance)) {
             return (T) ((NonClosingProxyHandler) Proxy.getInvocationHandler(instance)).getDelegate();
@@ -50,6 +69,12 @@ public class NonClosingProxyHandler implements InvocationHandler {
         }
     }
 
+    /**
+     * Calls close on the delegate instance of a proxy that was created by
+     * {@link #createNonClosingProxy(AutoCloseable, Class)}
+     * @param instance instance to close
+     * @throws Exception if an error occurs
+     */
     public static <T extends AutoCloseable> void reallyClose(T instance) throws Exception {
         if (isNonClosingProxy(instance)) {
             getDelegate(instance).close();
@@ -58,10 +83,17 @@ public class NonClosingProxyHandler implements InvocationHandler {
         }
     }
 
+    /**
+     * Returns the delegate instance.
+     */
     public AutoCloseable getDelegate() {
         return delegate;
     }
 
+    /**
+     * JDK Proxy InvocationHandler implementation.
+     * If the method is close, then it is ignored.
+     */
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         if (method.getName().equals("close")) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/NonStartableTestPulsarService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/NonStartableTestPulsarService.java
@@ -68,11 +68,11 @@ class NonStartableTestPulsarService extends AbstractTestPulsarService {
                                          MetadataStoreExtended configurationMetadataStore,
                                          Compactor compactor, BrokerInterceptor brokerInterceptor,
                                          BookKeeperClientFactory bookKeeperClientFactory,
-                                         boolean useSameThreadOrderedExecutor, PulsarResources pulsarResources,
+                                         PulsarResources pulsarResources,
                                          ManagedLedgerStorage managedLedgerClientFactory,
                                          Function<BrokerService, BrokerService> brokerServiceCustomizer) {
         super(spyConfig, config, localMetadataStore, configurationMetadataStore, compactor, brokerInterceptor,
-                bookKeeperClientFactory, useSameThreadOrderedExecutor);
+                bookKeeperClientFactory);
         this.pulsarResources = pulsarResources;
         this.managedLedgerClientFactory = managedLedgerClientFactory;
         try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/NonStartableTestPulsarService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/NonStartableTestPulsarService.java
@@ -49,11 +49,9 @@ import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 
 /**
- * Subclass of PulsarService that is used for some tests.
- * This was written as a replacement for the previous Mockito Spy over PulsarService solution which caused
- * a flaky test issue https://github.com/apache/pulsar/issues/13620.
+ * This is an internal class used by {@link PulsarTestContext} as the {@link PulsarService} implementation
+ * for a "non-startable" PulsarService. Please see {@link PulsarTestContext} for more details.
  */
-
 class NonStartableTestPulsarService extends AbstractTestPulsarService {
     private final PulsarResources pulsarResources;
     private final ManagedLedgerStorage managedLedgerClientFactory;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
@@ -92,7 +92,7 @@ import org.mockito.internal.util.MockUtil;
  *
  * <h2>Example usage of a PulsarService that is started</h2>
  * <pre>{@code
- * PulsarTestContext testContext = PulsarTestContext.startableBuilder()
+ * PulsarTestContext testContext = PulsarTestContext.builder()
  *     .spyByDefault()
  *     .withMockZooKeeper()
  *     .build();
@@ -106,7 +106,7 @@ import org.mockito.internal.util.MockUtil;
  *
  * <h2>Example usage of a PulsarService that is not started at all</h2>
  * <pre>{@code
- * PulsarTestContext testContext = PulsarTestContext.builder()
+ * PulsarTestContext testContext = PulsarTestContext.builderForNonStartableContext()
  *     .spyByDefault()
  *     .build();
  * PulsarService pulsarService = testContext.getPulsarService();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
@@ -487,7 +487,7 @@ public class PulsarTestContext implements AutoCloseable {
         protected void initializePulsarServices(SpyConfig spyConfig, Builder builder) {
             BookKeeperClientFactory bookKeeperClientFactory =
                     new MockBookKeeperClientFactory(builder.bookKeeperClient);
-            PulsarService pulsarService = spyConfig.getPulsarBroker()
+            PulsarService pulsarService = spyConfig.getPulsarService()
                     .spy(StartableTestPulsarService.class, spyConfig, builder.config, builder.localMetadataStore,
                             builder.configurationMetadataStore, builder.compactor, builder.brokerInterceptor,
                             bookKeeperClientFactory, builder.useSameThreadOrderedExecutor,
@@ -541,7 +541,7 @@ public class PulsarTestContext implements AutoCloseable {
             }
             BookKeeperClientFactory bookKeeperClientFactory =
                     new MockBookKeeperClientFactory(builder.bookKeeperClient);
-            PulsarService pulsarService = spyConfig.getPulsarBroker()
+            PulsarService pulsarService = spyConfig.getPulsarService()
                     .spy(NonStartableTestPulsarService.class, spyConfig, builder.config, builder.localMetadataStore,
                             builder.configurationMetadataStore, builder.compactor, builder.brokerInterceptor,
                             bookKeeperClientFactory, builder.useSameThreadOrderedExecutor, builder.pulsarResources,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
@@ -268,6 +268,30 @@ public class PulsarTestContext implements AutoCloseable {
             if (svcConfig.getNumHttpServerThreads() == unconfiguredDefaults.getNumHttpServerThreads()) {
                 svcConfig.setNumHttpServerThreads(8);
             }
+
+            // change the default value for ports so that a random port is used
+            if (unconfiguredDefaults.getBrokerServicePort().equals(svcConfig.getBrokerServicePort())) {
+                svcConfig.setBrokerServicePort(Optional.of(0));
+            }
+            if (unconfiguredDefaults.getWebServicePort().equals(svcConfig.getWebServicePort())) {
+                svcConfig.setWebServicePort(Optional.of(0));
+            }
+
+            // change the default value for nic speed
+            if (unconfiguredDefaults.getLoadBalancerOverrideBrokerNicSpeedGbps()
+                    .equals(svcConfig.getLoadBalancerOverrideBrokerNicSpeedGbps())) {
+                svcConfig.setLoadBalancerOverrideBrokerNicSpeedGbps(Optional.of(1.0d));
+            }
+
+            // set the cluster name if it's unset
+            if (svcConfig.getClusterName() == null) {
+                svcConfig.setClusterName("test");
+            }
+
+            // adjust managed ledger cache size
+            if (svcConfig.getManagedLedgerCacheSizeMB() == unconfiguredDefaults.getManagedLedgerCacheSizeMB()) {
+                svcConfig.setManagedLedgerCacheSizeMB(8);
+            }
         }
 
         /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
@@ -114,11 +114,11 @@ public class PulsarTestContext implements AutoCloseable {
         return PulsarMockBookKeeper.class.cast(bookKeeperClient);
     }
 
-    public static Builder startableBuilder() {
+    public static Builder builder() {
         return new StartableCustomBuilder();
     }
 
-    public static Builder builder() {
+    public static Builder builderForNonStartableContext() {
         return new NonStartableCustomBuilder();
     }
 
@@ -160,6 +160,8 @@ public class PulsarTestContext implements AutoCloseable {
             return this;
         }
 
+        // these are default values that are overridden in all provided configurations
+        // set `.configCustomizer(null)` to disable this behavior
         protected void defaultOverrideServiceConfiguration(ServiceConfiguration svcConfig) {
             svcConfig.setBrokerShutdownTimeoutMs(0L);
             svcConfig.setNumIOThreads(4);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
@@ -303,6 +303,9 @@ public class PulsarTestContext implements AutoCloseable {
             if (configOverrideCustomizer != null) {
                 configOverrideCustomizer.accept(super.config);
             }
+            if (super.brokerInterceptor != null) {
+                super.config.setDisableBrokerInterceptors(false);
+            }
             initializeCommonPulsarServices(spyConfig);
             initializePulsarServices(spyConfig, this);
             if (pulsarServiceCustomizer != null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
@@ -228,8 +228,6 @@ public class PulsarTestContext implements AutoCloseable {
          */
         protected ServiceConfiguration initializeConfig() {
             ServiceConfiguration svcConfig = new ServiceConfiguration();
-            svcConfig.setLoadBalancerOverrideBrokerNicSpeedGbps(Optional.of(1.0d));
-            svcConfig.setClusterName("pulsar-cluster");
             defaultOverrideServiceConfiguration(svcConfig);
             return svcConfig;
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/SpyConfig.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/SpyConfig.java
@@ -21,16 +21,32 @@ package org.apache.pulsar.broker.testcontext;
 
 import lombok.Value;
 import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.PulsarService;
 import org.mockito.Mockito;
 import org.mockito.internal.creation.instance.ConstructorInstantiator;
 
+/**
+ * Configuration for what kind of Mockito spy to use on collaborator objects
+ * of the PulsarService managed by {@link PulsarTestContext}.
+ *
+ * This configuration is applied using {@link PulsarTestContext.Builder#spyConfig(SpyConfig)} or by
+ * calling {@link PulsarTestContext.Builder#spyByDefault()} to enable spying for all configurable collaborator
+ * objects.
+ *
+ * For verifying interactions with Mockito's {@link Mockito#verify(Object)} method, the spy type must be set to
+ * {@link SpyType#SPY_ALSO_INVOCATIONS}. This is because the default spy type {@link SpyType#SPY}
+ * does not record invocations.
+ */
 @lombok.Builder(builderClassName = "Builder", toBuilder = true)
 @Value
 public class SpyConfig {
+    /**
+     * Type of spy to use.
+     */
     public enum SpyType {
-        NONE,
-        SPY,
-        SPY_ALSO_INVOCATIONS;
+        NONE, // No spy
+        SPY, // Spy without recording invocations
+        SPY_ALSO_INVOCATIONS; // Spy and record invocations
 
         public <T> T spy(T object) {
             if (object == null) {
@@ -63,20 +79,51 @@ public class SpyConfig {
         }
     }
 
-    private final SpyType pulsarBroker;
+    /**
+     * Spy configuration for {@link PulsarTestContext#getPulsarService()}.
+     */
+    private final SpyType pulsarService;
+    /**
+     * Spy configuration for {@link PulsarService#getPulsarResources()}.
+     */
     private final SpyType pulsarResources;
+    /**
+     * Spy configuration for {@link PulsarService#getBrokerService()}.
+     */
     private final SpyType brokerService;
+    /**
+     * Spy configuration for {@link PulsarService#getBookKeeperClient()}.
+     * In the test context, this is the same as {@link PulsarTestContext#getBookKeeperClient()} .
+     * It is a client that wraps an in-memory mock bookkeeper implementation.
+     */
     private final SpyType bookKeeperClient;
+    /**
+     * Spy configuration for {@link PulsarService#getCompactor()}.
+     */
     private final SpyType compactor;
+    /**
+     * Spy configuration for {@link PulsarService#getNamespaceService()}.
+     */
     private final SpyType namespaceService;
 
+    /**
+     * Create a builder for SpyConfig with no spies by default.
+     *
+     * @return a builder
+     */
     public static Builder builder() {
         return builder(SpyType.NONE);
     }
 
+    /**
+     * Create a builder for SpyConfig with the given spy type for all configurable collaborator objects.
+     *
+     * @param defaultSpyType the spy type to use for all configurable collaborator objects
+     * @return a builder
+     */
     public static Builder builder(SpyType defaultSpyType) {
         Builder spyConfigBuilder = new Builder();
-        spyConfigBuilder.pulsarBroker(defaultSpyType);
+        spyConfigBuilder.pulsarService(defaultSpyType);
         spyConfigBuilder.pulsarResources(defaultSpyType);
         spyConfigBuilder.brokerService(defaultSpyType);
         spyConfigBuilder.bookKeeperClient(defaultSpyType);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/SpyConfig.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/SpyConfig.java
@@ -67,6 +67,8 @@ public class SpyConfig {
     private final SpyType pulsarResources;
     private final SpyType brokerService;
     private final SpyType bookKeeperClient;
+    private final SpyType compactor;
+    private final SpyType namespaceService;
 
     public static Builder builder() {
         return builder(SpyType.NONE);
@@ -78,6 +80,8 @@ public class SpyConfig {
         spyConfigBuilder.pulsarResources(defaultSpyType);
         spyConfigBuilder.brokerService(defaultSpyType);
         spyConfigBuilder.bookKeeperClient(defaultSpyType);
+        spyConfigBuilder.compactor(defaultSpyType);
+        spyConfigBuilder.namespaceService(defaultSpyType);
         return spyConfigBuilder;
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/StartableTestPulsarService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/StartableTestPulsarService.java
@@ -31,6 +31,10 @@ import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.compaction.Compactor;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 
+/**
+ * This is an internal class used by {@link PulsarTestContext} as the {@link PulsarService} implementation
+ * for a "startable" PulsarService. Please see {@link PulsarTestContext} for more details.
+ */
 class StartableTestPulsarService extends AbstractTestPulsarService {
     private final Function<BrokerService, BrokerService> brokerServiceCustomizer;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/StartableTestPulsarService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/StartableTestPulsarService.java
@@ -44,10 +44,9 @@ class StartableTestPulsarService extends AbstractTestPulsarService {
                                       Compactor compactor,
                                       BrokerInterceptor brokerInterceptor,
                                       BookKeeperClientFactory bookKeeperClientFactory,
-                                      boolean useSameThreadOrderedExecutor,
                                       Function<BrokerService, BrokerService> brokerServiceCustomizer) {
         super(spyConfig, config, localMetadataStore, configurationMetadataStore, compactor, brokerInterceptor,
-                bookKeeperClientFactory, useSameThreadOrderedExecutor);
+                bookKeeperClientFactory);
         this.brokerServiceCustomizer = brokerServiceCustomizer;
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
@@ -149,7 +149,7 @@ public abstract class TransactionTestBase extends TestRetrySupport {
             serviceConfigurationList.add(conf);
 
             PulsarTestContext.Builder testContextBuilder =
-                    PulsarTestContext.startableBuilder()
+                    PulsarTestContext.builder()
                             .brokerInterceptor(new CounterBrokerInterceptor())
                             .spyByDefault()
                             .config(conf);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
@@ -18,38 +18,22 @@
  */
 package org.apache.pulsar.broker.transaction;
 
-import static org.apache.pulsar.broker.BrokerTestUtil.spyWithClassAndConstructorArgs;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.MoreExecutors;
-import io.netty.channel.EventLoopGroup;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.bookkeeper.client.BookKeeper;
-import org.apache.bookkeeper.client.EnsemblePlacementPolicy;
-import org.apache.bookkeeper.client.PulsarMockBookKeeper;
-import org.apache.bookkeeper.common.util.OrderedExecutor;
-import org.apache.bookkeeper.stats.StatsLogger;
-import org.apache.bookkeeper.util.ZkUtils;
-import org.apache.pulsar.broker.BookKeeperClientFactory;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
-import org.apache.pulsar.broker.auth.SameThreadOrderedSafeExecutor;
 import org.apache.pulsar.broker.intercept.CounterBrokerInterceptor;
-import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.naming.NamespaceName;
@@ -59,34 +43,22 @@ import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
-import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
-import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.tests.TestRetrySupport;
-import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.MockZooKeeper;
-import org.apache.zookeeper.MockZooKeeperSession;
-import org.apache.zookeeper.data.ACL;
 
 @Slf4j
 public abstract class TransactionTestBase extends TestRetrySupport {
-
     public static final String CLUSTER_NAME = "test";
 
     @Setter
     private int brokerCount = 3;
-
-    private final List<SameThreadOrderedSafeExecutor> orderedExecutorList = new ArrayList<>();
     @Getter
     private final List<ServiceConfiguration> serviceConfigurationList = new ArrayList<>();
     @Getter
     protected final List<PulsarService> pulsarServiceList = new ArrayList<>();
+    protected List<PulsarTestContext> pulsarTestContexts = new ArrayList<>();
 
     protected PulsarAdmin admin;
     protected PulsarClient pulsarClient;
-
-    private MockZooKeeper mockZooKeeper;
-    private OrderedExecutor bkExecutor;
-    private NonClosableMockBookKeeper mockBookKeeper;
 
     public static final String TENANT = "tnx";
     protected static final String NAMESPACE1 = TENANT + "/ns1";
@@ -108,13 +80,6 @@ public abstract class TransactionTestBase extends TestRetrySupport {
     }
 
     private void init() throws Exception {
-        mockZooKeeper = createMockZooKeeper();
-
-        bkExecutor = OrderedExecutor.newBuilder()
-                .numThreads(1)
-                .name("mock-pulsar-bk")
-                .build();
-        mockBookKeeper = createMockBookKeeper(bkExecutor);
         startBroker();
     }
     protected void setUpBase(int numBroker,int numPartitionsOfTC, String topic, int numPartitions) throws Exception{
@@ -183,96 +148,24 @@ public abstract class TransactionTestBase extends TestRetrySupport {
             conf.setTransactionBufferSnapshotMinTimeInMillis(2000);
             serviceConfigurationList.add(conf);
 
-            PulsarService pulsar = spyWithClassAndConstructorArgs(PulsarService.class, conf);
-
-            setupBrokerMocks(pulsar);
-            pulsar.start();
+            PulsarTestContext.Builder testContextBuilder =
+                    PulsarTestContext.startableBuilder()
+                            .brokerInterceptor(new CounterBrokerInterceptor())
+                            .spyByDefault()
+                            .config(conf);
+            if (i > 0) {
+                testContextBuilder.reuseMockBookkeeperAndMetadataStores(pulsarTestContexts.get(0));
+            } else {
+                testContextBuilder.withMockZookeeper();
+            }
+            PulsarTestContext pulsarTestContext = testContextBuilder
+                    .build();
+            PulsarService pulsar = pulsarTestContext.getPulsarService();
             pulsarServiceList.add(pulsar);
+            pulsarTestContexts.add(pulsarTestContext);
         }
     }
 
-    protected void setupBrokerMocks(PulsarService pulsar) throws Exception {
-        // Override default providers with mocked ones
-        doReturn(mockBookKeeperClientFactory).when(pulsar).newBookKeeperClientFactory();
-
-        MockZooKeeperSession mockZooKeeperSession = MockZooKeeperSession.newInstance(mockZooKeeper);
-        doReturn(new ZKMetadataStore(mockZooKeeperSession)).when(pulsar).createLocalMetadataStore(null);
-        doReturn(new ZKMetadataStore(mockZooKeeperSession)).when(pulsar).createConfigurationMetadataStore(null);
-        Supplier<NamespaceService> namespaceServiceSupplier =
-                () -> spyWithClassAndConstructorArgs(NamespaceService.class, pulsar);
-        doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();
-
-        SameThreadOrderedSafeExecutor executor = new SameThreadOrderedSafeExecutor();
-        orderedExecutorList.add(executor);
-        doReturn(executor).when(pulsar).getOrderedExecutor();
-        doReturn(new CounterBrokerInterceptor()).when(pulsar).getBrokerInterceptor();
-
-        doAnswer((invocation) -> spy(invocation.callRealMethod())).when(pulsar).newCompactor();
-    }
-
-    public static MockZooKeeper createMockZooKeeper() throws Exception {
-        MockZooKeeper zk = MockZooKeeper.newInstance(MoreExecutors.newDirectExecutorService());
-        List<ACL> dummyAclList = new ArrayList<>(0);
-
-        ZkUtils.createFullPathOptimistic(zk, "/ledgers/available/192.168.1.1:" + 5000,
-                "".getBytes(StandardCharsets.UTF_8), dummyAclList, CreateMode.PERSISTENT);
-
-        zk.create("/ledgers/LAYOUT", "1\nflat:1".getBytes(StandardCharsets.UTF_8), dummyAclList,
-                CreateMode.PERSISTENT);
-        return zk;
-    }
-
-    public static TransactionTestBase.NonClosableMockBookKeeper createMockBookKeeper(OrderedExecutor executor) throws Exception {
-        return spy(new TransactionTestBase.NonClosableMockBookKeeper(executor));
-    }
-
-    // Prevent the MockBookKeeper instance from being closed when the broker is restarted within a test
-    public static class NonClosableMockBookKeeper extends PulsarMockBookKeeper {
-
-        public NonClosableMockBookKeeper(OrderedExecutor executor) throws Exception {
-            super(executor);
-        }
-
-        @Override
-        public void close() {
-            // no-op
-        }
-
-        @Override
-        public void shutdown() {
-            // no-op
-        }
-
-        public void reallyShutdown() {
-            super.shutdown();
-        }
-    }
-
-    private final BookKeeperClientFactory mockBookKeeperClientFactory = new BookKeeperClientFactory() {
-
-        @Override
-        public BookKeeper create(ServiceConfiguration conf, MetadataStoreExtended store,
-                                 EventLoopGroup eventLoopGroup,
-                                 Optional<Class<? extends EnsemblePlacementPolicy>> ensemblePlacementPolicyClass,
-                                 Map<String, Object> properties) {
-            // Always return the same instance (so that we don't loose the mock BK content on broker restart
-            return mockBookKeeper;
-        }
-
-        @Override
-        public BookKeeper create(ServiceConfiguration conf, MetadataStoreExtended store,
-                                 EventLoopGroup eventLoopGroup,
-                                 Optional<Class<? extends EnsemblePlacementPolicy>> ensemblePlacementPolicyClass,
-                                 Map<String, Object> properties, StatsLogger statsLogger) {
-            // Always return the same instance (so that we don't loose the mock BK content on broker restart
-            return mockBookKeeper;
-        }
-
-        @Override
-        public void close() {
-            // no-op
-        }
-    };
 
     protected final void internalCleanup() {
         markCurrentSetupNumberCleaned();
@@ -287,45 +180,15 @@ public abstract class TransactionTestBase extends TestRetrySupport {
                 pulsarClient.shutdown();
                 pulsarClient = null;
             }
-            if (pulsarServiceList.size() > 0) {
-                for (PulsarService pulsarService : pulsarServiceList) {
-                    pulsarService.close();
+            if (pulsarTestContexts.size() > 0) {
+                for(int i = pulsarTestContexts.size() - 1; i >= 0; i--) {
+                    pulsarTestContexts.get(i).close();
                 }
-                pulsarServiceList.clear();
+                pulsarTestContexts.clear();
             }
+            pulsarServiceList.clear();
             if (serviceConfigurationList.size() > 0) {
                 serviceConfigurationList.clear();
-            }
-            if (mockBookKeeper != null) {
-                mockBookKeeper.reallyShutdown();
-            }
-            if (mockZooKeeper != null) {
-                mockZooKeeper.shutdown();
-            }
-            if (orderedExecutorList.size() > 0) {
-                for (int i = 0; i < orderedExecutorList.size(); i++) {
-                    SameThreadOrderedSafeExecutor sameThreadOrderedSafeExecutor = orderedExecutorList.get(i);
-                    if(sameThreadOrderedSafeExecutor != null) {
-                        try {
-                            sameThreadOrderedSafeExecutor.shutdownNow();
-                            sameThreadOrderedSafeExecutor.awaitTermination(5, TimeUnit.SECONDS);
-                        } catch (InterruptedException ex) {
-                            log.error("sameThreadOrderedSafeExecutor shutdown had error", ex);
-                            Thread.currentThread().interrupt();
-                        }
-                        orderedExecutorList.set(i, null);
-                    }
-                }
-            }
-            if(bkExecutor != null) {
-                try {
-                    bkExecutor.shutdownNow();
-                    bkExecutor.awaitTermination(5, TimeUnit.SECONDS);
-                } catch (InterruptedException ex) {
-                    log.error("bkExecutor shutdown had error", ex);
-                    Thread.currentThread().interrupt();
-                }
-                bkExecutor = null;
             }
         } catch (Exception e) {
             log.warn("Failed to clean up mocked pulsar service:", e);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckPersistentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckPersistentTest.java
@@ -444,7 +444,7 @@ public class PendingAckPersistentTest extends TransactionTestBase {
         assertFalse(topics.contains(topic));
     }
 
-    @Test
+    @Test(groups = "quarantine")
     public void testDeleteUselessLogDataWhenSubCursorMoved() throws Exception {
         getPulsarServiceList().get(0).getConfig().setTransactionPendingAckLogIndexMinLag(5);
         getPulsarServiceList().get(0).getConfiguration().setManagedLedgerDefaultMarkDeleteRateLimit(5);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/ProcessHandlerFilterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/ProcessHandlerFilterTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.broker.web;
 
 import java.io.IOException;
-import java.util.HashSet;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -45,7 +44,7 @@ public class ProcessHandlerFilterTest {
         Mockito.doReturn(spyInterceptor).when(mockPulsarService).getBrokerInterceptor();
         Mockito.doReturn(config).when(mockPulsarService).getConfig();
         config.setBrokerInterceptors(Sets.newHashSet("Interceptor1", "Interceptor2"));
-        ProcessHandlerFilter processHandlerFilter = new ProcessHandlerFilter(mockPulsarService);
+        ProcessHandlerFilter processHandlerFilter = new ProcessHandlerFilter(mockPulsarService.getBrokerInterceptor());
         processHandlerFilter.doFilter(mockHttpServletRequest, mockHttpServletResponse, mockFilterChain);
         Mockito.verify(spyInterceptor).onFilter(mockHttpServletRequest, mockHttpServletResponse, mockFilterChain);
     }
@@ -59,18 +58,12 @@ public class ProcessHandlerFilterTest {
         FilterChain spyFilterChain = Mockito.spy(FilterChain.class);
         Mockito.doReturn(spyInterceptor).when(mockPulsarService).getBrokerInterceptor();
         Mockito.doReturn(config).when(mockPulsarService).getConfig();
-        config.setBrokerInterceptors(new HashSet<>());
-        // empty interceptor list
-        HttpServletRequest mockHttpServletRequest = Mockito.mock(HttpServletRequest.class);
-        ProcessHandlerFilter processHandlerFilter = new ProcessHandlerFilter(mockPulsarService);
-        processHandlerFilter.doFilter(mockHttpServletRequest, mockHttpServletResponse, spyFilterChain);
-        Mockito.verify(spyFilterChain).doFilter(mockHttpServletRequest, mockHttpServletResponse);
-        Mockito.clearInvocations(spyFilterChain);
         // request has MULTIPART_FORM_DATA content-type
         config.setBrokerInterceptors(Sets.newHashSet("Interceptor1","Interceptor2"));
+        config.setDisableBrokerInterceptors(false);
         HttpServletRequest mockHttpServletRequest2 = Mockito.mock(HttpServletRequest.class);
         Mockito.doReturn(MediaType.MULTIPART_FORM_DATA).when(mockHttpServletRequest2).getContentType();
-        ProcessHandlerFilter processHandlerFilter2 = new ProcessHandlerFilter(mockPulsarService);
+        ProcessHandlerFilter processHandlerFilter2 = new ProcessHandlerFilter(mockPulsarService.getBrokerInterceptor());
         processHandlerFilter2.doFilter(mockHttpServletRequest2, mockHttpServletResponse, spyFilterChain);
         Mockito.verify(spyFilterChain).doFilter(mockHttpServletRequest2, mockHttpServletResponse);
         Mockito.clearInvocations(spyFilterChain);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
@@ -417,7 +417,7 @@ public class WebServiceTest {
             config.setHttpRequestsMaxPerSecond(rateLimit);
         }
 
-        pulsarTestContext = PulsarTestContext.startableBuilder()
+        pulsarTestContext = PulsarTestContext.builder()
                 .spyByDefault()
                 .config(config)
                 .build();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pulsar.broker.web;
 
-import static org.apache.pulsar.broker.BrokerTestUtil.spyWithClassAndConstructorArgs;
-import static org.mockito.Mockito.doReturn;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -51,12 +49,11 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import lombok.Cleanup;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.pulsar.broker.MockedBookKeeperClientFactory;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.stats.PrometheusMetricsTest;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
+import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.admin.PulsarAdminException.ConflictException;
@@ -66,8 +63,6 @@ import org.apache.pulsar.common.policies.data.ClusterDataImpl;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.common.util.SecurityUtility;
-import org.apache.pulsar.metadata.impl.ZKMetadataStore;
-import org.apache.zookeeper.MockZooKeeper;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.BoundRequestBuilder;
 import org.asynchttpclient.DefaultAsyncHttpClient;
@@ -85,6 +80,7 @@ import org.testng.annotations.Test;
 @Test(groups = "broker")
 public class WebServiceTest {
 
+    private PulsarTestContext pulsarTestContext;
     private PulsarService pulsar;
     private String BROKER_LOOKUP_URL;
     private String BROKER_LOOKUP_URL_TLS;
@@ -96,7 +92,7 @@ public class WebServiceTest {
 
     @Test
     public void testWebExecutorMetrics() throws Exception {
-        setupEnv(true, "1.0", true, false, false, false, -1, false);
+        setupEnv(true, false, false, false, -1, false);
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
         String metricsStr = statsOut.toString();
@@ -137,7 +133,7 @@ public class WebServiceTest {
      */
     @Test
     public void testDefaultClientVersion() throws Exception {
-        setupEnv(true, "1.0", true, false, false, false, -1, false);
+        setupEnv(true, false, false, false, -1, false);
 
         try {
             // Make an HTTP request to lookup a namespace. The request should
@@ -155,7 +151,7 @@ public class WebServiceTest {
      */
     @Test
     public void testTlsEnabled() throws Exception {
-        setupEnv(false, "1.0", false, true, false, false, -1, false);
+        setupEnv(false, true, false, false, -1, false);
 
         // Make requests both HTTP and HTTPS. The requests should succeed
         try {
@@ -177,7 +173,7 @@ public class WebServiceTest {
      */
     @Test
     public void testTlsDisabled() throws Exception {
-        setupEnv(false, "1.0", false, false, false, false, -1, false);
+        setupEnv(false, false, false, false, -1, false);
 
         // Make requests both HTTP and HTTPS. Only the HTTP request should succeed
         try {
@@ -201,7 +197,7 @@ public class WebServiceTest {
      */
     @Test
     public void testTlsAuthAllowInsecure() throws Exception {
-        setupEnv(false, "1.0", false, true, true, true, -1, false);
+        setupEnv(false, true, true, true, -1, false);
 
         // Only the request with client certificate should succeed
         try {
@@ -224,7 +220,7 @@ public class WebServiceTest {
      */
     @Test
     public void testTlsAuthDisallowInsecure() throws Exception {
-        setupEnv(false, "1.0", false, true, true, false, -1, false);
+        setupEnv(false, true, true, false, -1, false);
 
         // Only the request with trusted client certificate should succeed
         try {
@@ -242,7 +238,7 @@ public class WebServiceTest {
 
     @Test
     public void testRateLimiting() throws Exception {
-        setupEnv(false, "1.0", false, false, false, false, 10.0, false);
+        setupEnv(false, false, false, false, 10.0, false);
 
         // Make requests without exceeding the max rate
         for (int i = 0; i < 5; i++) {
@@ -269,7 +265,7 @@ public class WebServiceTest {
 
     @Test
     public void testDisableHttpTraceAndTrackMethods() throws Exception {
-        setupEnv(true, "1.0", true, false, false, false, -1, true);
+        setupEnv(true, false, false, false, -1, true);
 
         String url = pulsar.getWebServiceAddress() + "/admin/v2/tenants/my-tenant" + System.currentTimeMillis();
 
@@ -293,7 +289,7 @@ public class WebServiceTest {
 
     @Test
     public void testMaxRequestSize() throws Exception {
-        setupEnv(true, "1.0", true, false, false, false, -1, false);
+        setupEnv(true, false, false, false, -1, false);
 
         String url = pulsar.getWebServiceAddress() + "/admin/v2/tenants/my-tenant" + System.currentTimeMillis();
 
@@ -337,7 +333,7 @@ public class WebServiceTest {
 
     @Test
     public void testBrokerReady() throws Exception {
-        setupEnv(true, "1.0", true, false, false, false, -1, false);
+        setupEnv(true, false, false, false, -1, false);
 
         String url = pulsar.getWebServiceAddress() + "/admin/v2/brokers/ready";
 
@@ -382,9 +378,8 @@ public class WebServiceTest {
         }
     }
 
-    private void setupEnv(boolean enableFilter, String minApiVersion, boolean allowUnversionedClients,
-            boolean enableTls, boolean enableAuth, boolean allowInsecure, double rateLimit,
-            boolean disableTrace) throws Exception {
+    private void setupEnv(boolean enableFilter, boolean enableTls, boolean enableAuth, boolean allowInsecure,
+                          double rateLimit, boolean disableTrace) throws Exception {
         if (pulsar != null) {
             throw new Exception("broker already started");
         }
@@ -421,19 +416,13 @@ public class WebServiceTest {
             config.setHttpRequestsLimitEnabled(true);
             config.setHttpRequestsMaxPerSecond(rateLimit);
         }
-        pulsar = spyWithClassAndConstructorArgs(PulsarService.class, config);
-     // mock zk
-        MockZooKeeper mockZooKeeper = MockedPulsarServiceBaseTest.createMockZooKeeper();
-        doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createConfigurationMetadataStore(null);
-        doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createLocalMetadataStore(null);
-        doReturn(new MockedBookKeeperClientFactory()).when(pulsar).newBookKeeperClientFactory();
-        pulsar.start();
 
-        try {
-            pulsar.getLocalMetadataStore().delete("/minApiVersion", Optional.empty()).join();
-        } catch (Exception ex) {
-        }
-        pulsar.getLocalMetadataStore().put("/minApiVersion", minApiVersion.getBytes(), Optional.of(-1L)).join();
+        pulsarTestContext = PulsarTestContext.startableBuilder()
+                .spyByDefault()
+                .config(config)
+                .build();
+
+        pulsar = pulsarTestContext.getPulsarService();
 
         String BROKER_URL_BASE = "http://localhost:" + pulsar.getListenPortHTTP().get();
         String BROKER_URL_BASE_TLS = "https://localhost:" + pulsar.getListenPortHTTPS().orElse(-1);
@@ -469,14 +458,15 @@ public class WebServiceTest {
 
     @AfterMethod(alwaysRun = true)
     void teardown() {
-        if (pulsar != null) {
+        if (pulsarTestContext != null) {
             try {
-                pulsar.close();
-                pulsar = null;
+                pulsarTestContext.close();
+                pulsarTestContext = null;
             } catch (Exception e) {
                 Assert.fail("Got exception while closing the pulsar instance ", e);
             }
         }
+        pulsar = null;
     }
 
     private static final Logger log = LoggerFactory.getLogger(WebServiceTest.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/MultiBrokerMetadataConsistencyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/MultiBrokerMetadataConsistencyTest.java
@@ -22,12 +22,15 @@ import static org.testng.Assert.assertTrue;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.MultiBrokerBaseTest;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.metadata.TestZKServer;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.jetbrains.annotations.NotNull;
 import org.testng.annotations.Test;
 
 @Slf4j
@@ -59,13 +62,20 @@ public class MultiBrokerMetadataConsistencyTest extends MultiBrokerBaseTest {
     }
 
     @Override
-    protected MetadataStoreExtended createLocalMetadataStore() throws MetadataStoreException {
-        return MetadataStoreExtended.create(testZKServer.getConnectionString(), MetadataStoreConfig.builder().build());
+    protected PulsarTestContext.Builder createPulsarTestContextBuilder(ServiceConfiguration conf) {
+        return super.createPulsarTestContextBuilder(conf)
+                .localMetadataStore(createMetadataStore())
+                .configurationMetadataStore(createMetadataStore());
     }
 
-    @Override
-    protected MetadataStoreExtended createConfigurationMetadataStore() throws MetadataStoreException {
-        return MetadataStoreExtended.create(testZKServer.getConnectionString(), MetadataStoreConfig.builder().build());
+    @NotNull
+    protected MetadataStoreExtended createMetadataStore()  {
+        try {
+            return MetadataStoreExtended.create(testZKServer.getConnectionString(),
+                    MetadataStoreConfig.builder().build());
+        } catch (MetadataStoreException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -78,6 +78,7 @@ import org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper;
 import org.apache.pulsar.broker.loadbalance.impl.SimpleResourceUnit;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.ServiceUnitId;
 import org.apache.pulsar.common.naming.TopicName;
@@ -150,7 +151,8 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         conf2.setConfigurationMetadataStoreUrl("zk:localhost:3181");
 
         @Cleanup
-        PulsarService pulsar2 = startBroker(conf2);
+        PulsarTestContext pulsarTestContext2 = createAdditionalPulsarTestContext(conf2);
+        PulsarService pulsar2 = pulsarTestContext2.getPulsarService();
         pulsar.getLoadManager().get().writeLoadReportOnZookeeper();
         pulsar2.getLoadManager().get().writeLoadReportOnZookeeper();
 
@@ -277,7 +279,8 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         admin.namespaces().createNamespace(property + "/" + newCluster + "/my-ns");
 
         @Cleanup
-        PulsarService pulsar2 = startBroker(conf2);
+        PulsarTestContext pulsarTestContext2 = createAdditionalPulsarTestContext(conf2);
+        PulsarService pulsar2 = pulsarTestContext2.getPulsarService();
         pulsar.getLoadManager().get().writeLoadReportOnZookeeper();
         pulsar2.getLoadManager().get().writeLoadReportOnZookeeper();
 
@@ -361,7 +364,8 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         conf2.setConfigurationMetadataStoreUrl("zk:localhost:3181");
 
         @Cleanup
-        PulsarService pulsar2 = startBroker(conf2);
+        PulsarTestContext pulsarTestContext2 = createAdditionalPulsarTestContext(conf2);
+        PulsarService pulsar2 = pulsarTestContext2.getPulsarService();
         pulsar.getLoadManager().get().writeLoadReportOnZookeeper();
         pulsar2.getLoadManager().get().writeLoadReportOnZookeeper();
 
@@ -445,7 +449,8 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         conf2.setConfigurationMetadataStoreUrl("zk:localhost:3181");
 
         @Cleanup
-        PulsarService pulsar2 = startBroker(conf2);
+        PulsarTestContext pulsarTestContext2 = createAdditionalPulsarTestContext(conf2);
+        PulsarService pulsar2 = pulsarTestContext2.getPulsarService();
 
         // restart broker1 with tls enabled
         conf.setBrokerServicePortTls(Optional.of(0));
@@ -555,7 +560,8 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         conf2.setConfigurationMetadataStoreUrl("zk:localhost:3181");
 
         @Cleanup
-        PulsarService pulsar2 = startBroker(conf2);
+        PulsarTestContext pulsarTestContext2 = createAdditionalPulsarTestContext(conf2);
+        PulsarService pulsar2 = pulsarTestContext2.getPulsarService();
         pulsar.getLoadManager().get().writeLoadReportOnZookeeper();
         pulsar2.getLoadManager().get().writeLoadReportOnZookeeper();
 
@@ -671,7 +677,8 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
             startBroker();
 
             @Cleanup
-            PulsarService pulsar2 = startBroker(conf2);
+            PulsarTestContext pulsarTestContext2 = createAdditionalPulsarTestContext(conf2);
+            PulsarService pulsar2 = pulsarTestContext2.getPulsarService();
 
             pulsar.getLoadManager().get().writeLoadReportOnZookeeper();
             pulsar2.getLoadManager().get().writeLoadReportOnZookeeper();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonDurableSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonDurableSubscriptionTest.java
@@ -18,6 +18,11 @@
  */
 package org.apache.pulsar.client.api;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
 import java.lang.reflect.Field;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -25,7 +30,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
-import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.PulsarChannelInitializer;
 import org.apache.pulsar.broker.service.ServerCnx;
@@ -38,12 +42,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.AssertJUnit.assertFalse;
-import static org.testng.AssertJUnit.assertNull;
-import static org.testng.AssertJUnit.assertTrue;
 
 @Test(groups = "broker-api")
 @Slf4j
@@ -68,31 +66,23 @@ public class NonDurableSubscriptionTest  extends ProducerConsumerBase {
     }
 
     @Override
-    protected PulsarService newPulsarService(ServiceConfiguration conf) throws Exception {
-        return new PulsarService(conf) {
+    protected BrokerService customizeNewBrokerService(BrokerService brokerService) {
+        brokerService.setPulsarChannelInitializerFactory((_pulsar, opts) -> {
+            return new PulsarChannelInitializer(_pulsar, opts) {
+                @Override
+                protected ServerCnx newServerCnx(PulsarService pulsar, String listenerName) throws Exception {
+                    return new ServerCnx(pulsar) {
 
-            @Override
-            protected BrokerService newBrokerService(PulsarService pulsar) throws Exception {
-                BrokerService broker = new BrokerService(this, ioEventLoopGroup);
-                broker.setPulsarChannelInitializerFactory(
-                        (_pulsar, opts) -> {
-                            return new PulsarChannelInitializer(_pulsar, opts) {
-                                @Override
-                                protected ServerCnx newServerCnx(PulsarService pulsar, String listenerName) throws Exception {
-                                    return new ServerCnx(pulsar) {
-
-                                        @Override
-                                        protected void handleFlow(CommandFlow flow) {
-                                            super.handleFlow(flow);
-                                            numFlow.incrementAndGet();
-                                        }
-                                    };
-                                }
-                            };
-                        });
-                return broker;
-            }
-        };
+                        @Override
+                        protected void handleFlow(CommandFlow flow) {
+                            super.handleFlow(flow);
+                            numFlow.incrementAndGet();
+                        }
+                    };
+                }
+            };
+        });
+        return brokerService;
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -1075,8 +1075,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     }
 
     @Override
-    protected void beforePulsarStartMocks(PulsarService pulsar) throws Exception {
-        super.beforePulsarStartMocks(pulsar);
+    protected void beforePulsarStart(PulsarService pulsar) throws Exception {
+        super.beforePulsarStart(pulsar);
         doAnswer(i0 -> {
             ManagedLedgerFactory factory = (ManagedLedgerFactory) spy(i0.callRealMethod());
             doAnswer(i1 -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerTest.java
@@ -614,8 +614,8 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
     }
 
     @Override
-    protected void beforePulsarStartMocks(PulsarService pulsar) throws Exception {
-        super.beforePulsarStartMocks(pulsar);
+    protected void beforePulsarStart(PulsarService pulsar) throws Exception {
+        super.beforePulsarStart(pulsar);
         doAnswer(i0 -> {
             ManagedLedgerFactory factory = (ManagedLedgerFactory) spy(i0.callRealMethod());
             doAnswer(i1 -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BatchMessageIndexAckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BatchMessageIndexAckTest.java
@@ -18,6 +18,15 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.api.DigestType;
@@ -38,17 +47,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doReturn;
 
 @Slf4j
 @Test(groups = "broker-impl")
@@ -150,7 +148,7 @@ public class BatchMessageIndexAckTest extends ProducerConsumerBase {
             public long getCToken() {
                 return 0;
             }
-        })).when(mockBookKeeper).getLedgerMetadata(anyLong());
+        })).when(pulsarTestContext.getBookKeeperClient()).getLedgerMetadata(anyLong());
     }
 
     @AfterMethod(alwaysRun = true)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -824,7 +824,7 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
 
         // capture opened ledgers
         Set<Long> ledgersOpened = Sets.newConcurrentHashSet();
-        when(mockBookKeeper.newOpenLedgerOp()).thenAnswer(
+        when(pulsarTestContext.getBookKeeperClient().newOpenLedgerOp()).thenAnswer(
                 (invocation) -> {
                     OpenBuilder builder = (OpenBuilder)spy(invocation.callRealMethod());
                     when(builder.withLedgerId(anyLong())).thenAnswer(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionE2ESecurityTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionE2ESecurityTest.java
@@ -27,7 +27,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
-
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -124,7 +123,7 @@ public class PulsarFunctionE2ESecurityTest {
         bkEnsemble = new LocalBookkeeperEnsemble(3, 0, () -> 0);
         bkEnsemble.start();
 
-        config = spy(ServiceConfiguration.class);
+        config = new ServiceConfiguration();
         config.setClusterName("use");
         Set<String> superUsers = Sets.newHashSet(ADMIN_SUBJECT);
         config.setSuperUserRoles(superUsers);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
@@ -200,7 +200,7 @@ public class PulsarFunctionLocalRunTest {
         bkEnsemble = new LocalBookkeeperEnsemble(3, 0, () -> 0);
         bkEnsemble.start();
 
-        config = spy(ServiceConfiguration.class);
+        config = new ServiceConfiguration();
         config.setSystemTopicEnabled(false);
         config.setTopicLevelPoliciesEnabled(false);
         config.setClusterName(CLUSTER);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionPublishTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionPublishTest.java
@@ -25,7 +25,6 @@ import static org.apache.pulsar.functions.worker.PulsarFunctionLocalRunTest.getP
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
-
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.io.File;
@@ -120,7 +119,7 @@ public class PulsarFunctionPublishTest {
         bkEnsemble = new LocalBookkeeperEnsemble(3, 0, () -> 0);
         bkEnsemble.start();
 
-        config = spy(ServiceConfiguration.class);
+        config = new ServiceConfiguration();
         config.setClusterName("use");
         Set<String> superUsers = Sets.newHashSet("superUser", "admin");
         config.setSuperUserRoles(superUsers);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarWorkerAssignmentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarWorkerAssignmentTest.java
@@ -22,7 +22,6 @@ import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.retryStr
 import static org.apache.pulsar.functions.worker.PulsarFunctionLocalRunTest.getPulsarApiExamplesJar;
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
-
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
@@ -87,7 +86,7 @@ public class PulsarWorkerAssignmentTest {
         bkEnsemble = new LocalBookkeeperEnsemble(3, 0, () -> 0);
         bkEnsemble.start();
 
-        config = spy(ServiceConfiguration.class);
+        config = new ServiceConfiguration();
         config.setClusterName("use");
         final Set<String> superUsers = Sets.newHashSet("superUser", "admin");
         config.setSuperUserRoles(superUsers);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/AbstractPulsarE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/AbstractPulsarE2ETest.java
@@ -26,7 +26,7 @@ import static org.apache.pulsar.functions.worker.PulsarFunctionLocalRunTest.getP
 import static org.apache.pulsar.functions.worker.PulsarFunctionLocalRunTest.getPulsarIODataGeneratorNar;
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertTrue;
-
+import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -38,7 +38,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.ServiceConfigurationUtils;
@@ -71,8 +70,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.Sets;
 
 public abstract class AbstractPulsarE2ETest {
 
@@ -112,7 +109,7 @@ public abstract class AbstractPulsarE2ETest {
         bkEnsemble = new LocalBookkeeperEnsemble(3, 0, () -> 0);
         bkEnsemble.start();
 
-        config = spy(ServiceConfiguration.class);
+        config = new ServiceConfiguration();
         config.setClusterName("use");
         Set<String> superUsers = Sets.newHashSet("superUser", "admin");
         config.setSuperUserRoles(superUsers);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionAdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionAdminTest.java
@@ -93,7 +93,7 @@ public class PulsarFunctionAdminTest {
         bkEnsemble = new LocalBookkeeperEnsemble(3, 0, () -> 0);
         bkEnsemble.start();
 
-        config = spy(ServiceConfiguration.class);
+        config = new ServiceConfiguration();
         config.setClusterName("use");
         Set<String> superUsers = Sets.newHashSet("superUser", "admin");
         config.setSuperUserRoles(superUsers);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionTlsTest.java
@@ -107,7 +107,7 @@ public class PulsarFunctionTlsTest {
         bkEnsemble = new LocalBookkeeperEnsemble(3, 0, () -> 0);
         bkEnsemble.start();
 
-        config = spy(ServiceConfiguration.class);
+        config = new ServiceConfiguration();
         config.setBrokerShutdownTimeoutMs(0L);
         config.setLoadBalancerOverrideBrokerNicSpeedGbps(Optional.of(1.0d));
         config.setClusterName("use");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
@@ -510,7 +510,7 @@ public class SchemaCompatibilityCheckTest extends MockedPulsarServiceBaseTest {
             producer.close();
         }
         // The other ledgers are about 5.
-        Assert.assertTrue(mockBookKeeper.getLedgerMap().values().stream()
+        Assert.assertTrue(pulsarTestContext.getMockBookKeeper().getLedgerMap().values().stream()
                 .filter(ledger -> !ledger.isFenced())
                 .collect(Collectors.toList()).size() < 20);
         admin.topics().delete(topicName, true);

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/extended/MetadataStoreExtended.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/extended/MetadataStoreExtended.java
@@ -22,6 +22,7 @@ import java.util.EnumSet;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import org.apache.pulsar.metadata.api.MetadataEvent;
 import org.apache.pulsar.metadata.api.MetadataEventSynchronizer;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
@@ -81,5 +82,15 @@ public interface MetadataStoreExtended extends MetadataStore {
      */
     default Optional<MetadataEventSynchronizer> getMetadataEventSynchronizer() {
         return Optional.empty();
+    }
+
+    /**
+     * Handles a metadata synchronizer event.
+     *
+     * @param event
+     * @return completed future when the event is handled
+     */
+    default CompletableFuture<Void> handleMetadataEvent(MetadataEvent event) {
+        return CompletableFuture.completedFuture(null);
     }
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -136,44 +136,45 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
         this.metadataStoreStats = new MetadataStoreStats(metadataStoreName);
     }
 
-    protected void registerSyncLister(Optional<MetadataEventSynchronizer> synchronizer) {
-        if (synchronizer.isPresent()) {
-            synchronizer.get().registerSyncListener(event -> {
-                CompletableFuture<Void> result = new CompletableFuture<>();
-                get(event.getPath()).thenApply(res -> {
-                    Set<CreateOption> options = event.getOptions() != null ? event.getOptions()
-                            : Collections.emptySet();
-                    if (res.isPresent()) {
-                        GetResult existingValue = res.get();
-                        if (shouldIgnoreEvent(event, existingValue)) {
-                            result.complete(null);
-                            return result;
-                        }
-                    }
-                    // else update the event
-                    CompletableFuture<?> updateResult = (event.getType() == NotificationType.Deleted)
-                            ? deleteInternal(event.getPath(), Optional.ofNullable(event.getExpectedVersion()))
-                            : putInternal(event.getPath(), event.getValue(),
-                                    Optional.ofNullable(event.getExpectedVersion()), options);
-                    updateResult.thenApply(stat -> {
-                        if (log.isDebugEnabled()) {
-                            log.debug("successfully updated {}", event.getPath());
-                        }
-                        return result.complete(null);
-                    }).exceptionally(ex -> {
-                        log.warn("Failed to update metadata {}", event.getPath(), ex.getCause());
-                        if (ex.getCause() instanceof MetadataStoreException.BadVersionException) {
-                            result.complete(null);
-                        } else {
-                            result.completeExceptionally(ex);
-                        }
-                        return false;
-                    });
+    @Override
+    public CompletableFuture<Void> handleMetadataEvent(MetadataEvent event) {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        get(event.getPath()).thenApply(res -> {
+            Set<CreateOption> options = event.getOptions() != null ? event.getOptions()
+                    : Collections.emptySet();
+            if (res.isPresent()) {
+                GetResult existingValue = res.get();
+                if (shouldIgnoreEvent(event, existingValue)) {
+                    result.complete(null);
                     return result;
-                });
-                return result;
+                }
+            }
+            // else update the event
+            CompletableFuture<?> updateResult = (event.getType() == NotificationType.Deleted)
+                    ? deleteInternal(event.getPath(), Optional.ofNullable(event.getExpectedVersion()))
+                    : putInternal(event.getPath(), event.getValue(),
+                    Optional.ofNullable(event.getExpectedVersion()), options);
+            updateResult.thenApply(stat -> {
+                if (log.isDebugEnabled()) {
+                    log.debug("successfully updated {}", event.getPath());
+                }
+                return result.complete(null);
+            }).exceptionally(ex -> {
+                log.warn("Failed to update metadata {}", event.getPath(), ex.getCause());
+                if (ex.getCause() instanceof MetadataStoreException.BadVersionException) {
+                    result.complete(null);
+                } else {
+                    result.completeExceptionally(ex);
+                }
+                return false;
             });
-        }
+            return result;
+        });
+        return result;
+    }
+
+    protected void registerSyncLister(Optional<MetadataEventSynchronizer> synchronizer) {
+        synchronizer.ifPresent(s -> s.registerSyncListener(this::handleMetadataEvent));
     }
 
     @VisibleForTesting

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/FaultInjectionMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/FaultInjectionMetadataStore.java
@@ -34,6 +34,7 @@ import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataCacheConfig;
+import org.apache.pulsar.metadata.api.MetadataEvent;
 import org.apache.pulsar.metadata.api.MetadataSerde;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.Notification;
@@ -179,6 +180,11 @@ public class FaultInjectionMetadataStore implements MetadataStoreExtended {
     public void registerSessionListener(Consumer<SessionEvent> listener) {
         store.registerSessionListener(listener);
         sessionListeners.add(listener);
+    }
+
+    @Override
+    public CompletableFuture<Void> handleMetadataEvent(MetadataEvent event) {
+        return store.handleMetadataEvent(event);
     }
 
     @Override

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
@@ -46,12 +46,19 @@ public class MockZooKeeperSession extends ZooKeeper {
 
     private static final AtomicInteger sessionIdGenerator = new AtomicInteger(1000);
 
+    private boolean closeMockZooKeeperOnClose;
+
     public static MockZooKeeperSession newInstance(MockZooKeeper mockZooKeeper) {
+        return newInstance(mockZooKeeper, true);
+    }
+
+    public static MockZooKeeperSession newInstance(MockZooKeeper mockZooKeeper, boolean closeMockZooKeeperOnClose) {
         ObjectInstantiator<MockZooKeeperSession> instantiator = objenesis.getInstantiatorOf(MockZooKeeperSession.class);
         MockZooKeeperSession mockZooKeeperSession = instantiator.newInstance();
 
         mockZooKeeperSession.mockZooKeeper = mockZooKeeper;
         mockZooKeeperSession.sessionId = sessionIdGenerator.getAndIncrement();
+        mockZooKeeperSession.closeMockZooKeeperOnClose = closeMockZooKeeperOnClose;
         return mockZooKeeperSession;
     }
 
@@ -212,11 +219,15 @@ public class MockZooKeeperSession extends ZooKeeper {
 
     @Override
     public void close() throws InterruptedException {
-        mockZooKeeper.close();
+        if (closeMockZooKeeperOnClose) {
+            mockZooKeeper.close();
+        }
     }
 
     public void shutdown() throws InterruptedException {
-        mockZooKeeper.shutdown();
+        if (closeMockZooKeeperOnClose) {
+            mockZooKeeper.shutdown();
+        }
     }
 
     Optional<KeeperException.Code> programmedFailure(MockZooKeeper.Op op, String path) {


### PR DESCRIPTION
### Motivation

This PR continues changes made in previous PRs (#19337, #19326, #19323) to refactor Pulsar unit tests to reduce mocking which causes flakiness since Mockito isn't thread safe.

One key motivation for this PR is to extend PulsarTestContext features so that most tests can be migrated to use it to reduce the use of Mockito spies in the way that causes flakiness. Mockito Spies aren't completely removed, but it moves to a better direction.

### Modifications

- add missing features to PulsarTestContext
- Improve MetadataStoreExtended so that it's simpler to add MetadataEventSynchronizer in tests
- reduce unnecessary spies for ServiceConfiguration
- migrate tests to use PulsarTestContext
- Disable FilterEntryTest.testEntryFilterRescheduleMessageDependingOnConsumerSharedSubscription
  - this test is very flaky and the behavior depends on the number of threads in thread pool
- Quarantine a very flaky test PendingAckPersistentTest.testDeleteUselessLogDataWhenSubCursorMoved
- Improved Javadocs

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/139