### PR TITLE
[fix][io] Update Elasticsearch sink idle cnx timeout to 30s

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
@@ -215,7 +215,7 @@ public class ElasticSearchConfig implements Serializable {
     @FieldDoc(
             required = false,
             defaultValue = "30000",
-            help = "Idle connection timeout to prevent a connection timeouts."
+            help = "Idle connection timeout to prevent a connection timeout due to inactivity."
     )
     private int connectionIdleTimeoutInMs = 30000;
 

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfig.java
@@ -214,10 +214,10 @@ public class ElasticSearchConfig implements Serializable {
 
     @FieldDoc(
             required = false,
-            defaultValue = "5",
-            help = "Idle connection timeout to prevent a read timeout."
+            defaultValue = "30000",
+            help = "Idle connection timeout to prevent a connection timeouts."
     )
-    private int connectionIdleTimeoutInMs = 5;
+    private int connectionIdleTimeoutInMs = 30000;
 
     @FieldDoc(
             required = false,

--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/RestClient.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/RestClient.java
@@ -83,7 +83,6 @@ public abstract class RestClient implements Closeable {
         // idle+expired connection evictor thread
         this.executorService = Executors.newSingleThreadScheduledExecutor();
         this.executorService.scheduleAtFixedRate(() -> {
-                    configCallback.connectionManager.closeExpiredConnections();
                     configCallback.connectionManager.closeIdleConnections(
                             config.getConnectionIdleTimeoutInMs(), TimeUnit.MILLISECONDS);
                 },

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfigTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchConfigTests.java
@@ -92,7 +92,7 @@ public class ElasticSearchConfigTests {
         assertEquals(config.isCompressionEnabled(), false);
         assertEquals(config.getConnectTimeoutInMs(), 5000L);
         assertEquals(config.getConnectionRequestTimeoutInMs(), 1000L);
-        assertEquals(config.getConnectionIdleTimeoutInMs(), 5L);
+        assertEquals(config.getConnectionIdleTimeoutInMs(), 30000L);
         assertEquals(config.getSocketTimeoutInMs(), 60000);
 
         assertEquals(config.isStripNulls(), true);


### PR DESCRIPTION
### Motivation

The current Elasticsearch sink has a setting named `connectionIdleTimeoutInMs`. This setting closes expired and idle http connections opened by the Elasticsearch Rest Client. The current default is 5 milliseconds. With this value, I observed connection issues both for timeouts trying to connect to elasticsearch and errors like "connection reset by peer". When overriding the default to 5 seconds, all errors disappeared. I propose we change it to 30 seconds since even 5 seconds is a little low.

### Modifications

* Change default value for `connectionIdleTimeoutInMs` from 5 millis to 30000 millis
* Remove unnecessary call to `closeExpiredConnections`. This call is unnecessary because the `closeIdleConnections` also closes expired connections. Based on looking at the source code, we iterate over connections for each method call, so relying on the `closeIdleConnections` lets us iterate over connections once instead of twice. Source: https://hc.apache.org/httpcomponents-asyncclient-4.1.x/current/httpasyncclient/apidocs/org/apache/http/nio/conn/NHttpClientConnectionManager.html#closeIdleConnections(long,%20java.util.concurrent.TimeUnit)

```java
    /**
     * Closes idle connections in the pool.
     * <p>
     * Open connections in the pool that have not been used for the
     * timespan given by the argument will be closed.
     * Currently allocated connections are not subject to this method.
     * Times will be checked with milliseconds precision
     *
     * All expired connections will also be closed.
     *
     * @param idletime  the idle time of connections to be closed
     * @param tunit     the unit for the {@code idletime}
     *
     * @see #closeExpiredConnections()
     */
    void closeIdleConnections(long idletime, TimeUnit tunit);
```

### Verifying this change

This is a trivial change. 

### Does this pull request potentially affect one of the following parts:

- [x] The default values of configurations

This PR changes a default value for a sink. The current default is problematic.

### Documentation

- [x] `doc-not-needed`

We generate the docs for this sink, so we don't need to update any site docs. We should include this update on the release notes.

### Matching PR in forked repository

PR in forked repository: https://github.com/michaeljmarshall/pulsar/pull/22