### PR TITLE
[fix][ci] Fix pulsar shell bin file name

### DIFF
--- a/src/stage-release.sh
+++ b/src/stage-release.sh
@@ -35,8 +35,8 @@ popd
 cp $PULSAR_PATH/target/apache-pulsar-$VERSION-src.tar.gz $DEST_PATH
 cp $PULSAR_PATH/distribution/server/target/apache-pulsar-$VERSION-bin.tar.gz $DEST_PATH
 cp $PULSAR_PATH/distribution/offloaders/target/apache-pulsar-offloaders-$VERSION-bin.tar.gz $DEST_PATH
-cp $PULSAR_PATH/distribution/shell/target/apache-pulsar-shell-$VERSION-shell-bin.tar.gz $DEST_PATH
-cp $PULSAR_PATH/distribution/shell/target/apache-pulsar-shell-$VERSION-shell-bin.zip $DEST_PATH
+cp $PULSAR_PATH/distribution/shell/target/apache-pulsar-shell-$VERSION-bin.tar.gz $DEST_PATH
+cp $PULSAR_PATH/distribution/shell/target/apache-pulsar-shell-$VERSION-bin.zip $DEST_PATH
 
 cp -r $PULSAR_PATH/distribution/io/target/apache-pulsar-io-connectors-$VERSION-bin $DEST_PATH/connectors
 

--- a/src/stage-release.sh
+++ b/src/stage-release.sh
@@ -35,8 +35,8 @@ popd
 cp $PULSAR_PATH/target/apache-pulsar-$VERSION-src.tar.gz $DEST_PATH
 cp $PULSAR_PATH/distribution/server/target/apache-pulsar-$VERSION-bin.tar.gz $DEST_PATH
 cp $PULSAR_PATH/distribution/offloaders/target/apache-pulsar-offloaders-$VERSION-bin.tar.gz $DEST_PATH
-cp $PULSAR_PATH/distribution/shell/target/apache-pulsar-shell-$VERSION-shell.tar.gz $DEST_PATH
-cp $PULSAR_PATH/distribution/shell/target/apache-pulsar-shell-$VERSION-shell.zip $DEST_PATH
+cp $PULSAR_PATH/distribution/shell/target/apache-pulsar-shell-$VERSION-shell-bin.tar.gz $DEST_PATH
+cp $PULSAR_PATH/distribution/shell/target/apache-pulsar-shell-$VERSION-shell-bin.zip $DEST_PATH
 
 cp -r $PULSAR_PATH/distribution/io/target/apache-pulsar-io-connectors-$VERSION-bin $DEST_PATH/connectors
 


### PR DESCRIPTION
### Motivation

The shell distribution files' name are like `apache-pulsar-shell-$VERSION-shell-bin.tar.gz` and `apache-pulsar-shell-$VERSION-shell-bin.zip` which are incorrect in `stage-release.sh`.

<img width="496" alt="image" src="https://user-images.githubusercontent.com/10069311/215854629-8763c754-d846-4b95-a5f6-54e33202f098.png">


### Modifications

Add suffix `-bin`

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/yaalsn/pulsar/pull/17