### PR TITLE
[improve][ml] Avoid to wrap `CompletionException` in `ManagedLedgerException`

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
@@ -18,11 +18,11 @@
  */
 package org.apache.bookkeeper.mledger;
 
+import javax.annotation.Nonnull;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
-import javax.annotation.Nonnull;
 
 @InterfaceAudience.LimitedPrivate
 @InterfaceStability.Stable

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -578,7 +578,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                 try {
                     positionInfo = PositionInfo.parseFrom(entry.getEntry());
                 } catch (InvalidProtocolBufferException e) {
-                    callback.operationFailed(new ManagedLedgerException(e));
+                    callback.operationFailed(ManagedLedgerException.getManagedLedgerException(e));
                     return;
                 }
 
@@ -1010,7 +1010,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                 callback.readEntriesFailed(new NoMoreEntriesToReadException("Topic was terminated"), ctx);
             }
         } catch (Throwable t) {
-            callback.readEntriesFailed(new ManagedLedgerException(t), ctx);
+            callback.readEntriesFailed(ManagedLedgerException.getManagedLedgerException(t), ctx);
         }
     }
 
@@ -2364,7 +2364,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                 log.debug("[{}] Consumer {} cursor asyncDelete error, counters: consumed {} mdPos {} rdPos {}",
                         ledger.getName(), name, messagesConsumedCounter, markDeletePosition, readPosition);
             }
-            callback.deleteFailed(new ManagedLedgerException(e), ctx);
+            callback.deleteFailed(ManagedLedgerException.getManagedLedgerException(e), ctx);
         }
     }
 
@@ -2605,7 +2605,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     private void persistPositionMetaStore(long cursorsLedgerId, PositionImpl position, Map<String, Long> properties,
             MetaStoreCallback<Void> callback, boolean persistIndividualDeletedMessageRanges) {
         if (state == State.Closed) {
-            ledger.getExecutor().execute(safeRun(() -> callback.operationFailed(new MetaStoreException(
+            ledger.getExecutor().execute(safeRun(() -> callback.operationFailed(MetaStoreException.getException(
                     new CursorAlreadyClosedException(name + " cursor already closed")))));
             return;
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -650,7 +650,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                     bookkeeper.close();
                 }
             } catch (BKException e) {
-                throw new ManagedLedgerException(e);
+                throw ManagedLedgerException.getManagedLedgerException(e);
             }
         }
 
@@ -893,7 +893,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                 Futures.waitForAll(futures).thenRun(() -> {
                     deleteManagedLedgerData(bkc, managedLedgerName, info, mlConfigFuture, callback, ctx);
                 }).exceptionally(ex -> {
-                    callback.deleteLedgerFailed(new ManagedLedgerException(ex), ctx);
+                    callback.deleteLedgerFailed(ManagedLedgerException.getManagedLedgerException(ex), ctx);
                     return null;
                 });
             }
@@ -991,11 +991,11 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
 
                         @Override
                         public void operationFailed(MetaStoreException e) {
-                            callback.deleteLedgerFailed(new ManagedLedgerException(e), ctx);
+                            callback.deleteLedgerFailed(ManagedLedgerException.getManagedLedgerException(e), ctx);
                         }
                     });
                 }).exceptionally(ex -> {
-                    callback.deleteLedgerFailed(new ManagedLedgerException(ex), ctx);
+                    callback.deleteLedgerFailed(ManagedLedgerException.getManagedLedgerException(ex), ctx);
                     return null;
                 });
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -457,7 +457,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 if (e instanceof MetadataNotFoundException) {
                     callback.initializeFailed(new ManagedLedgerNotFoundException(e));
                 } else {
-                    callback.initializeFailed(new ManagedLedgerException(e));
+                    callback.initializeFailed(ManagedLedgerException.getManagedLedgerException(e));
                 }
             }
         });
@@ -507,7 +507,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             @Override
             public void operationFailed(MetaStoreException e) {
                 handleBadVersion(e);
-                callback.initializeFailed(new ManagedLedgerException(e));
+                callback.initializeFailed(ManagedLedgerException.getManagedLedgerException(e));
             }
         };
 
@@ -642,7 +642,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             @Override
             public void operationFailed(MetaStoreException e) {
                 log.warn("[{}] Failed to get the cursors list", name, e);
-                callback.initializeFailed(new ManagedLedgerException(e));
+                callback.initializeFailed(ManagedLedgerException.getManagedLedgerException(e));
             }
         });
     }
@@ -1360,7 +1360,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     public void operationFailed(MetaStoreException e) {
                         log.error("[{}] Failed to terminate managed ledger: {}", name, e.getMessage());
                         handleBadVersion(e);
-                        callback.terminateFailed(new ManagedLedgerException(e), ctx);
+                        callback.terminateFailed(ManagedLedgerException.getManagedLedgerException(e), ctx);
                     }
                 });
             }
@@ -2865,9 +2865,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         truncateFuture.whenComplete((ignore, exc) -> {
             if (exc != null) {
                 log.error("[{}] Error truncating ledger for deletion", name, exc);
-                callback.deleteLedgerFailed(exc instanceof ManagedLedgerException
-                        ? (ManagedLedgerException) exc : new ManagedLedgerException(exc),
-                        ctx);
+                callback.deleteLedgerFailed(ManagedLedgerException.getManagedLedgerException(exc), ctx);
             } else {
                 asyncDeleteInternal(callback, ctx);
             }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -35,7 +35,6 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.function.Consumer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
-import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.MetaStoreException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.MetadataNotFoundException;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
@@ -48,7 +47,6 @@ import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.compression.CompressionCodec;
 import org.apache.pulsar.common.compression.CompressionCodecProvider;
 import org.apache.pulsar.metadata.api.MetadataStore;
-import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.Notification;
 import org.apache.pulsar.metadata.api.NotificationType;
 import org.apache.pulsar.metadata.api.Stat;
@@ -155,7 +153,8 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
                 .exceptionally(ex -> {
                     try {
                         executor.executeOrdered(ledgerName,
-                                SafeRunnable.safeRun(() -> callback.operationFailed(MetaStoreException.getException(ex))));
+                                SafeRunnable.safeRun(() ->
+                                        callback.operationFailed(MetaStoreException.getException(ex))));
                     } catch (RejectedExecutionException e) {
                         //executor maybe shutdown, use common pool to run callback.
                         CompletableFuture.runAsync(() -> callback.operationFailed(MetaStoreException.getException(ex)));

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
@@ -82,7 +82,8 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
                                         ledgers.put(lastLedgerId, info);
                                         future.complete(null);
                                     } else {
-                                        future.completeExceptionally(new ManagedLedgerException(ex));
+                                        future.completeExceptionally(
+                                                ManagedLedgerException.getManagedLedgerException(ex));
                                     }
                                     return null;
                                 });
@@ -95,7 +96,7 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
                                     ledgers.put(lastLedgerId, info);
                                     future.complete(null);
                                 } else {
-                                    future.completeExceptionally(new ManagedLedgerException(ex));
+                                    future.completeExceptionally(ManagedLedgerException.getManagedLedgerException(ex));
                                 }
                                 return null;
                             });
@@ -110,7 +111,7 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
                 if (e instanceof MetadataNotFoundException) {
                     future.completeExceptionally(new ManagedLedgerNotFoundException(e));
                 } else {
-                    future.completeExceptionally(new ManagedLedgerException(e));
+                    future.completeExceptionally(ManagedLedgerException.getManagedLedgerException(e));
                 }
             }
         });

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ShadowManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ShadowManagedLedgerImpl.java
@@ -155,7 +155,7 @@ public class ShadowManagedLedgerImpl extends ManagedLedgerImpl {
                 if (e instanceof ManagedLedgerException.MetadataNotFoundException) {
                     callback.initializeFailed(new ManagedLedgerException.ManagedLedgerNotFoundException(e));
                 } else {
-                    callback.initializeFailed(new ManagedLedgerException(e));
+                    callback.initializeFailed(ManagedLedgerException.getManagedLedgerException(e));
                 }
             }
         });
@@ -197,7 +197,7 @@ public class ShadowManagedLedgerImpl extends ManagedLedgerImpl {
             @Override
             public void operationFailed(ManagedLedgerException.MetaStoreException e) {
                 handleBadVersion(e);
-                callback.initializeFailed(new ManagedLedgerException(e));
+                callback.initializeFailed(ManagedLedgerException.getManagedLedgerException(e));
             }
         });
     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
@@ -519,7 +519,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         try {
             ledger.offloadPrefix(ledger.getLastConfirmedEntry());
         } catch (ManagedLedgerException e) {
-            assertEquals(e.getCause().getClass(), CompletionException.class);
+            assertEquals(e.getCause().getClass(), Exception.class);
         }
 
         assertEquals(ledger.getLedgersInfoAsList().size(), 4);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3232,10 +3232,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                               publishContext.completed((NotAllowedException) throwable, -1, -1);
                               decrementPendingWriteOpsAndCheck();
                               return null;
-                            } else if (!(throwable instanceof ManagedLedgerException)) {
-                                throwable = new ManagedLedgerException(throwable);
                             }
-                            addFailed((ManagedLedgerException) throwable, publishContext);
+                            addFailed(ManagedLedgerException.getManagedLedgerException(throwable), publishContext);
                             return null;
                         });
                 break;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
@@ -144,7 +144,8 @@ public class CompactedTopicImpl implements CompactedTopic {
                             cursor.seek(compactionHorizon.getNext());
                             callback.readEntriesComplete(Collections.emptyList(), readEntriesCtx);
                         } else {
-                            callback.readEntriesFailed(new ManagedLedgerException(exception), readEntriesCtx);
+                            callback.readEntriesFailed(ManagedLedgerException.getManagedLedgerException(exception),
+                                    readEntriesCtx);
                         }
                         return null;
                     });

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
@@ -361,7 +361,7 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
             AsyncCallbacks.AddEntryCallback callback =
                     (AsyncCallbacks.AddEntryCallback) invocation.getArguments()[1];
             ManagedLedgerException managedLedgerException =
-                    new ManagedLedgerException(new Exception("Fail by mock."));
+                    ManagedLedgerException.getManagedLedgerException(new Exception("Fail by mock."));
             callback.addFailed(managedLedgerException, invocation.getArguments()[2]);
             return null;
         }).when(managedLedger).asyncAddEntry(Mockito.any(ByteBuf.class), Mockito.any(), Mockito.any());


### PR DESCRIPTION
### Motivation

When I was investigating a problem, I found a bad exception stack trace. Ii made the exception harder to handle and to do `instanceOf`.

<img width="700" alt="image" src="https://user-images.githubusercontent.com/74767115/215976411-b45ba2e8-fb90-41b3-8a9c-654db52301f3.png">

### Modifications

- Using the static method to help create `ManagedLedgerException` and `MetaStoreException`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->