### PR TITLE
[fix][client] Fix async completion in ConsumerImpl#processPossibleToDLQ

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2020,6 +2020,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                                         log.warn("[{}] [{}] [{}] Failed to acknowledge the message {} of the original"
                                                         + " topic but send to the DLQ successfully.",
                                                 topicName, subscription, consumerName, finalMessageId, ex);
+                                        result.complete(false);
                                     } else {
                                         result.complete(true);
                                     }


### PR DESCRIPTION
### Motivation

- the possible failure of acknowledging the message isn't handled in ConsumerImpl#processPossibleToDLQ

The `exceptionally` handler in the code below this particular location doesn't get executed, since it's in a different call chain than the `acknowledgeAsync` call. Perhaps that was the author's expectation that the failure would be handled by the `exceptionally` handler.

### Modifications

- complete the future with `false` when there are failures.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->