### PR TITLE
[fix][sec] Upgrade hadoop-client  to get rid of CVE-2022-26612

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@ flexible messaging model and an intuitive client API.</description>
     <debezium.mysql.version>8.0.30</debezium.mysql.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
     <opencensus.version>0.28.0</opencensus.version>
-    <hadoop2.version>2.10.2</hadoop2.version>
+    <hadoop2.version>3.2.3</hadoop2.version>
     <hadoop3.version>3.3.4</hadoop3.version>
     <hbase.version>2.4.15</hbase.version>
     <guava.version>31.0.1-jre</guava.version>


### PR DESCRIPTION
### Motivation

This vulnerability is only applicable on Windows operating system

https://github.com/advisories/GHSA-gx2c-fvhc-ph4j


### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/yaalsn/pulsar/pull/18
