### PR TITLE
[improve] [broker] Print warn log if compaction failure

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3020,6 +3020,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             } else {
                 currentCompaction = brokerService.pulsar().getCompactor().compact(topic);
             }
+            currentCompaction.whenComplete((ignore, ex) -> {
+               if (ex != null){
+                   log.warn("[{}] Compaction failure.", topic, ex);
+               }
+            });
         } else {
             throw new AlreadyRunningException("Compaction already in progress");
         }


### PR DESCRIPTION
### Motivation
Now exceptions that happen in the flow of compaction task are collected into variable `currentCompaction` and don't print any log.

When compaction doesn't work, two reasons come to mind:
- the task skipped by rules.
- the task failed.

We can't determine which causing the problem if there has no log, this increases the difficulty of troubleshooting. 

The API `pulsar-admin topics compaction-status <topic>` lets us see what happens when the last compaction executes, But it can not help us know if there were previous missions that failed.


### Modifications

Print warn log if compaction fails.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- https://github.com/poorbarcode/pulsar/pull/63
