### PR TITLE
[fix][authorization] Fix the return value of canConsumeAsync

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -140,7 +140,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                 }).exceptionally(ex -> {
                     log.warn("Client with Role - {} failed to get permissions for topic - {}. {}", role, topicName,
                             ex.getMessage());
-                    return null;
+                    throw FutureUtil.wrapToCompletionException(ex);
                 });
     }
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -137,10 +137,6 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                         }
                     }
                     return checkAuthorization(topicName, role, AuthAction.consume);
-                }).exceptionally(ex -> {
-                    log.warn("Client with Role - {} failed to get permissions for topic - {}. {}", role, topicName,
-                            ex.getMessage());
-                    throw FutureUtil.wrapToCompletionException(ex);
                 });
     }
 
@@ -163,13 +159,6 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                         return CompletableFuture.completedFuture(true);
                     }
                     return canConsumeAsync(topicName, role, authenticationData, null);
-                }).exceptionally(ex -> {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Topic [{}] Role [{}] exception occurred while trying to check produce/consume"
-                                + " permissions. {}", topicName.toString(), role, ex.getMessage());
-
-                    }
-                    throw FutureUtil.wrapToCompletionException(ex);
                 });
     }
 


### PR DESCRIPTION
### Motivation

When an exception occurs in the `canConsumeAsync` method, we should throw that.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->