### PR TITLE
[improve] Upgrade to zk 3.8.1

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -474,9 +474,9 @@ The Apache Software License, Version 2.0
     - io.vertx-vertx-web-3.9.8.jar
     - io.vertx-vertx-web-common-3.9.8.jar
   * Apache ZooKeeper
-    - org.apache.zookeeper-zookeeper-3.8.0.jar
-    - org.apache.zookeeper-zookeeper-jute-3.8.0.jar
-    - org.apache.zookeeper-zookeeper-prometheus-metrics-3.8.0.jar
+    - org.apache.zookeeper-zookeeper-3.8.1.jar
+    - org.apache.zookeeper-zookeeper-jute-3.8.1.jar
+    - org.apache.zookeeper-zookeeper-prometheus-metrics-3.8.1.jar
   * Snappy Java
     - org.xerial.snappy-snappy-java-1.1.8.4.jar
   * Google HTTP Client

--- a/pom.xml
+++ b/pom.xml
@@ -2432,14 +2432,5 @@ flexible messaging model and an intuitive client API.</description>
         <enabled>false</enabled>
       </snapshots>
     </repository>
-    <repository>
-      <id>zk-staging</id>
-      <name>zk-staging</name>
-      <url>https://repository.apache.org/content/repositories/orgapachezookeeper-1088/</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
   </repositories>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2435,7 +2435,7 @@ flexible messaging model and an intuitive client API.</description>
     <repository>
       <id>zk-staging</id>
       <name>zk-staging</name>
-      <url>https://repository.apache.org/content/repositories/orgapachezookeeper-1085/</url>
+      <url>https://repository.apache.org/content/repositories/orgapachezookeeper-1088/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ flexible messaging model and an intuitive client API.</description>
     <commons-compress.version>1.21</commons-compress.version>
 
     <bookkeeper.version>4.15.3</bookkeeper.version>
-    <zookeeper.version>3.8.0</zookeeper.version>
+    <zookeeper.version>3.8.1</zookeeper.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <commons-text.version>1.10.0</commons-text.version>
     <snappy.version>1.1.8.4</snappy.version> <!-- ZooKeeper server -->
@@ -2428,6 +2428,14 @@ flexible messaging model and an intuitive client API.</description>
       <id>maven.restlet.org</id>
       <name>maven.restlet.org</name>
       <url>https://maven.restlet.talend.com</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>zk-staging</id>
+      <name>zk-staging</name>
+      <url>https://repository.apache.org/content/repositories/orgapachezookeeper-1085/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -462,8 +462,8 @@ The Apache Software License, Version 2.0
     - memory-0.8.3.jar
     - sketches-core-0.8.3.jar
   * Apache Zookeeper
-    - zookeeper-3.8.0.jar
-    - zookeeper-jute-3.8.0.jar
+    - zookeeper-3.8.1.jar
+    - zookeeper-jute-3.8.1.jar
   * Apache Yetus Audience Annotations
     - audience-annotations-0.12.0.jar
   * Swagger


### PR DESCRIPTION
### Motivation

Upgrade to zk 3.8.1

Release notes: https://zookeeper.apache.org/doc/r3.8.1/releasenotes.html
Among other changes it includes improvement to "Reduce the performance impact of Prometheus metrics".

### Modifications

ZK upgrade

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [x] **Dependencies (add or upgrade a dependency)**
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dlg99/pulsar/pull/8
