### PR TITLE
[improve] Upgrade lombok to 1.8.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@ flexible messaging model and an intuitive client API.</description>
     <hppc.version>0.9.1</hppc.version>
     <spark-streaming_2.10.version>2.1.0</spark-streaming_2.10.version>
     <assertj-core.version>3.18.1</assertj-core.version>
-    <lombok.version>1.18.24</lombok.version>
+    <lombok.version>1.18.26</lombok.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <jaxb-api>2.3.1</jaxb-api>
     <javax.activation.version>1.2.0</javax.activation.version>


### PR DESCRIPTION
### Motivation

Pulsar build is failing with Java 19 compiler because of an issue in Lombok.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.1:testCompile (default-testCompile) on project pulsar-broker: Compilation failure: Compilation failure:
[ERROR] /Users/mmerli/prg/pulsar/pulsar-broker/src/test/java/org/apache/pulsar/broker/EmbeddedPulsarCluster.java:[38,5] @Builder.Default requires @Builder or @SuperBuilder on the class for it to mean anything.
[ERROR] /Users/mmerli/prg/pulsar/pulsar-broker/src/test/java/org/apache/pulsar/broker/EmbeddedPulsarCluster.java:[41,5] @Builder.Default requires @Builder or @SuperBuilder on the class for it to mean anything.
[ERROR] /Users/mmerli/prg/pulsar/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java:[1762,58] You're assigning an auto-cleanup variable to something else. This is a bad idea.
[ERROR] /Users/mmerli/prg/pulsar/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerTestUtil.java:[75,55] unchecked cast
[ERROR]   required: java.lang.Class<T>
[ERROR]   found:    java.lang.Class<capture#1 of ? extends java.lang.Object>
[ERROR] /Users/mmerli/prg/pulsar/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java:[124,8] auto-closeable resource org.apache.pulsar.broker.testcontext.PulsarTestContext has a member method close() that could throw InterruptedException
[ERROR] -> [Help 1]
```

Upgrading to latest lombok which has support for Java 19.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
