### PR TITLE
[fix][ml] Reset individualDeletedMessagesSerializedSize after acked all messages.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2912,6 +2912,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         lock.readLock().lock();
         try {
             if (individualDeletedMessages.isEmpty()) {
+                this.individualDeletedMessagesSerializedSize = 0;
                 return Collections.emptyList();
             }
 


### PR DESCRIPTION
### Motivation

We should reset `individualDeletedMessagesSerializedSize` if all the message is acknowledged. (no more individualDeletedMessages)

### Modifications

- Reset `individualDeletedMessagesSerializedSize=0` when the `individualDeletedMessages.isEmpty()`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation
- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->