### PR TITLE
[fix] [test] fix flaky test MetadataStoreStatsTest.testMetadataStoreStats

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -207,6 +207,8 @@ public abstract class BookKeeperClusterTestCase {
         }
         // stop zookeeper service
         try {
+            // cleanup for metrics.
+            metadataStore.close();
             stopZKCluster();
         } catch (Exception e) {
             LOG.error("Got Exception while trying to stop ZKCluster", e);
@@ -226,8 +228,6 @@ public abstract class BookKeeperClusterTestCase {
         if (tearDownException != null) {
             throw tearDownException;
         }
-        // cleanup for metrics.
-        metadataStore.close();
     }
 
     /**

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -226,6 +226,8 @@ public abstract class BookKeeperClusterTestCase {
         if (tearDownException != null) {
             throw tearDownException;
         }
+        // cleanup for metrics.
+        metadataStore.close();
     }
 
     /**

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/CounterTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/CounterTest.java
@@ -87,6 +87,7 @@ public class CounterTest extends BaseMetadataStoreTest {
         // Delete all the empty container nodes
         zks.checkContainers();
 
+        @Cleanup
         MetadataStoreExtended store2 = MetadataStoreExtended.create(metadataUrl, MetadataStoreConfig.builder().build());
         @Cleanup
         CoordinationService cs2 = new CoordinationServiceImpl(store2);
@@ -95,8 +96,6 @@ public class CounterTest extends BaseMetadataStoreTest {
         assertNotEquals(l1, l4);
         assertNotEquals(l2, l4);
         assertNotEquals(l3, l4);
-
-        store2.close();
     }
 
     @Test(dataProvider = "impl")

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/CounterTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/CounterTest.java
@@ -95,6 +95,8 @@ public class CounterTest extends BaseMetadataStoreTest {
         assertNotEquals(l1, l4);
         assertNotEquals(l2, l4);
         assertNotEquals(l3, l4);
+
+        store2.close();
     }
 
     @Test(dataProvider = "impl")

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/MetadataStoreFactoryImplTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/MetadataStoreFactoryImplTest.java
@@ -55,11 +55,13 @@ public class MetadataStoreFactoryImplTest {
 
 
     @Test
-    public void testCreate() throws MetadataStoreException{
+    public void testCreate() throws Exception{
         MetadataStore instance = MetadataStoreFactoryImpl.create(
                 "custom://localhost",
                 MetadataStoreConfig.builder().build());
         assertTrue(instance instanceof MyMetadataStore);
+        // cleanup.
+        instance.close();
     }
 
 

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/MetadataStoreFactoryImplTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/MetadataStoreFactoryImplTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.metadata.impl;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import lombok.Cleanup;
 import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
@@ -56,12 +57,11 @@ public class MetadataStoreFactoryImplTest {
 
     @Test
     public void testCreate() throws Exception{
+        @Cleanup
         MetadataStore instance = MetadataStoreFactoryImpl.create(
                 "custom://localhost",
                 MetadataStoreConfig.builder().build());
         assertTrue(instance instanceof MyMetadataStore);
-        // cleanup.
-        instance.close();
     }
 
 

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/MockedBookKeeperTestCase.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/MockedBookKeeperTestCase.java
@@ -131,6 +131,7 @@ public abstract class MockedBookKeeperTestCase {
     }
 
     protected void stopMetadataStore() throws Exception {
+        metadataStore.close();
         metadataStore.setAlwaysFail(new MetadataStoreException("error"));
     }
 


### PR DESCRIPTION
### Motivation

We can see that this is a flaky test:

- https://github.com/apache/pulsar/actions/runs/4084265136/jobs/7040983653

When the test is executed, it can be seen from the log that multiple metrics of class `MetadataStoreStats` are registered, and there is one named blank string. So I guess it is caused by other tests not closing `MetadataStoreStats` which is named blank string.

```

pulsar_metadata_store_ops_latency_ms_count{cluster="test",name="",type="get",status="success"} 7.0
pulsar_metadata_store_ops_latency_ms_sum{cluster="test",name="",type="get",status="success"} 0.0
pulsar_metadata_store_ops_latency_ms_created{cluster="test",name="",type="get",status="success"} 1.675430236619E9
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="fail",le="1.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="fail",le="3.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="fail",le="5.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="fail",le="10.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="fail",le="20.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="fail",le="50.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="fail",le="100.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="fail",le="200.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="fail",le="500.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="fail",le="1000.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="fail",le="2000.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="fail",le="5000.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="fail",le="+Inf"} 0.0
pulsar_metadata_store_ops_latency_ms_count{cluster="test",name="",type="put",status="fail"} 0.0
pulsar_metadata_store_ops_latency_ms_sum{cluster="test",name="",type="put",status="fail"} 0.0
pulsar_metadata_store_ops_latency_ms_created{cluster="test",name="",type="put",status="fail"} 1.675430236619E9
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="fail",le="1.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="fail",le="3.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="fail",le="5.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="fail",le="10.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="fail",le="20.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="fail",le="50.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="fail",le="100.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="fail",le="200.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="fail",le="500.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="fail",le="1000.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="fail",le="2000.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="fail",le="5000.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="fail",le="+Inf"} 0.0
pulsar_metadata_store_ops_latency_ms_count{cluster="test",name="",type="del",status="fail"} 0.0
pulsar_metadata_store_ops_latency_ms_sum{cluster="test",name="",type="del",status="fail"} 0.0
pulsar_metadata_store_ops_latency_ms_created{cluster="test",name="",type="del",status="fail"} 1.675430236619E9
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="fail",le="1.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="fail",le="3.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="fail",le="5.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="fail",le="10.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="fail",le="20.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="fail",le="50.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="fail",le="100.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="fail",le="200.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="fail",le="500.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="fail",le="1000.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="fail",le="2000.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="fail",le="5000.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="fail",le="+Inf"} 0.0
pulsar_metadata_store_ops_latency_ms_count{cluster="test",name="metadata-store",type="put",status="fail"} 0.0
pulsar_metadata_store_ops_latency_ms_sum{cluster="test",name="metadata-store",type="put",status="fail"} 0.0
pulsar_metadata_store_ops_latency_ms_created{cluster="test",name="metadata-store",type="put",status="fail"} 1.675430399313E9
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="success",le="1.0"} 1.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="success",le="3.0"} 5.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="success",le="5.0"} 27.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="success",le="10.0"} 28.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="success",le="20.0"} 28.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="success",le="50.0"} 28.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="success",le="100.0"} 28.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="success",le="200.0"} 28.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="success",le="500.0"} 28.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="success",le="1000.0"} 28.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="success",le="2000.0"} 28.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="success",le="5000.0"} 28.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="success",le="+Inf"} 28.0
pulsar_metadata_store_ops_latency_ms_count{cluster="test",name="metadata-store",type="get",status="success"} 28.0
pulsar_metadata_store_ops_latency_ms_sum{cluster="test",name="metadata-store",type="get",status="success"} 124.0
pulsar_metadata_store_ops_latency_ms_created{cluster="test",name="metadata-store",type="get",status="success"} 1.675430399313E9
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="fail",le="1.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="fail",le="3.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="fail",le="5.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="fail",le="10.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="fail",le="20.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="fail",le="50.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="fail",le="100.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="fail",le="200.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="fail",le="500.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="fail",le="1000.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="fail",le="2000.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="fail",le="5000.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="get",status="fail",le="+Inf"} 0.0
pulsar_metadata_store_ops_latency_ms_count{cluster="test",name="metadata-store",type="get",status="fail"} 0.0
pulsar_metadata_store_ops_latency_ms_sum{cluster="test",name="metadata-store",type="get",status="fail"} 0.0
pulsar_metadata_store_ops_latency_ms_created{cluster="test",name="metadata-store",type="get",status="fail"} 1.675430399313E9
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="success",le="1.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="success",le="3.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="success",le="5.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="success",le="10.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="success",le="20.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="success",le="50.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="success",le="100.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="success",le="200.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="success",le="500.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="success",le="1000.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="success",le="2000.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="success",le="5000.0"} 0.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="del",status="success",le="+Inf"} 0.0
pulsar_metadata_store_ops_latency_ms_count{cluster="test",name="",type="del",status="success"} 0.0
pulsar_metadata_store_ops_latency_ms_sum{cluster="test",name="",type="del",status="success"} 0.0
pulsar_metadata_store_ops_latency_ms_created{cluster="test",name="",type="del",status="success"} 1.675430236619E9
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="success",le="1.0"} 4.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="success",le="3.0"} 10.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="success",le="5.0"} 14.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="success",le="10.0"} 15.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="success",le="20.0"} 15.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="success",le="50.0"} 15.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="success",le="100.0"} 15.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="success",le="200.0"} 15.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="success",le="500.0"} 15.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="success",le="1000.0"} 15.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="success",le="2000.0"} 15.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="success",le="5000.0"} 15.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="metadata-store",type="put",status="success",le="+Inf"} 15.0
pulsar_metadata_store_ops_latency_ms_count{cluster="test",name="metadata-store",type="put",status="success"} 15.0
pulsar_metadata_store_ops_latency_ms_sum{cluster="test",name="metadata-store",type="put",status="success"} 41.0
pulsar_metadata_store_ops_latency_ms_created{cluster="test",name="metadata-store",type="put",status="success"} 1.675430399313E9
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="success",le="1.0"} 49.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="success",le="3.0"} 51.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="success",le="5.0"} 52.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="success",le="10.0"} 52.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="success",le="20.0"} 52.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="success",le="50.0"} 52.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="success",le="100.0"} 52.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="success",le="200.0"} 52.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="success",le="500.0"} 52.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="success",le="1000.0"} 52.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="success",le="2000.0"} 52.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="success",le="5000.0"} 52.0
pulsar_metadata_store_ops_latency_ms_bucket{cluster="test",name="",type="put",status="success",le="+Inf"} 52.0
pulsar_metadata_store_ops_latency_ms_count{cluster="test",name="",type="put",status="success"} 52.0
pulsar_metadata_store_ops_latency_ms_sum{cluster="test",name="",type="put",status="success"} 9.0
pulsar_metadata_store_ops_latency_ms_created{cluster="test",name="",type="put",status="success"} 1.675430236619E9
```

### Modifications

Close `MetadataStore` after tests.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- https://github.com/poorbarcode/pulsar/pull/64