### PR TITLE
[fix][test] InactiveTopicDeleteTest#testDeleteWhenNoSubscriptionsWithMultiConfig

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -307,7 +307,8 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         }
         Awaitility.await()
                 .untilAsserted(() -> Assert.assertFalse(admin.topics().getList(namespace).contains(topic)));
-        Assert.assertFalse(admin.topics().getList(namespace3).contains(topic3));
+        Awaitility.await()
+                .untilAsserted(() -> Assert.assertFalse(admin.topics().getList(namespace3).contains(topic3)));
     }
 
     @Test


### PR DESCRIPTION

<!-- Either this PR fixes an issue, -->

Fixes #19379 

<!-- or this PR is one task of an issue -->



<!-- If the PR belongs to a PIP, please add the PIP link here -->



<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/wiki/proposals/PIP.md -->

### Modifications

The two topics will be deleted due to `delete_when_no_subscriptions`, but may not be at the same time. So use `Awaitility` to ensure they are deleted at the end.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
