### PR TITLE
[fix][test] Fix flaky test: PendingAckPersistentTest.testDeleteUselessLogDataWhenSubCursorMoved

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckPersistentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckPersistentTest.java
@@ -89,7 +89,7 @@ public class PendingAckPersistentTest extends TransactionTestBase {
 
     private static final int NUM_PARTITIONS = 16;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void setup() throws Exception {
         setUpBase(1, NUM_PARTITIONS, PENDING_ACK_REPLAY_TOPIC, 0);
     }


### PR DESCRIPTION
Fixes #19437

### Motivation

The `beforeMethod` doesn't have `alwaysRun=true` so it might happens that the setup is not called, especially in this case since the test class is in `broker` group and the test is in the `quarantine` one

This is probably caused by https://github.com/apache/pulsar/pull/19376/files#diff-ef1ad820ecc095be19dccf2d98e2e3ecd642ca6288d574efc1ee1b643da9e437

### Modifications

* Set `alwaysRun=true`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
