### PR TITLE
[improve][test] Use channel.advanceTimeBy instead of Thread.sleep

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -307,7 +307,7 @@ public class ServerCnxTest {
         // Connection will be closed in 2 seconds, in the meantime give chance to run the cleanup logic
         for (int i = 0; i < 3; i++) {
             channel.runPendingTasks();
-            Thread.sleep(1000);
+            channel.advanceTimeBy(1, TimeUnit.SECONDS);
         }
 
         assertFalse(channel.isActive());
@@ -334,7 +334,7 @@ public class ServerCnxTest {
         // Connection will *not* be closed in 2 seconds
         for (int i = 0; i < 3; i++) {
             channel.runPendingTasks();
-            Thread.sleep(1000);
+            channel.advanceTimeBy(1, TimeUnit.SECONDS);
         }
         assertTrue(channel.isActive());
 
@@ -352,7 +352,7 @@ public class ServerCnxTest {
         // Connection will be closed in 2 seconds, in the meantime give chance to run the cleanup logic
         for (int i = 0; i < 3; i++) {
             channel.runPendingTasks();
-            Thread.sleep(1000);
+            channel.advanceTimeBy(1, TimeUnit.SECONDS);
         }
 
         assertFalse(channel.isActive());


### PR DESCRIPTION
### Motivation

We have several `Thread.sleep` calls in the `ServerCnxTest` class. Some of them are pretty trivial to remove, and speed the tests up by about 9 seconds when I run on them on my laptop.

### Modifications

* Replace `Thread.sleep(1000)` with `channel.advanceTimeBy(1, TimeUnit.SECONDS);`

### Verifying this change

This is a change to tests. The tests pass.

### Documentation

- [x] `doc-not-needed`
### Matching PR in forked repository

PR in forked repository: Skipping because this is a test PR and all modified tests pass on my laptop.
