### PR TITLE
[fixbug] [broker] filter messages in pending ack state.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -141,9 +141,9 @@ public abstract class AbstractBaseDispatcher extends EntryFilterSupport implemen
 
             PositionImpl position = PositionImpl.get(entry.getLedgerId(), entry.getEntryId());
             // filter non batch messages in pending ack state
-            if (subscription instanceof PersistentSubscription &&
-                    msgMetadata.hasNumMessagesInBatch() &&
-                    ((PersistentSubscription) subscription).checkPositionInPendingAckState(position)) {
+            if (subscription instanceof PersistentSubscription
+                    && msgMetadata.hasNumMessagesInBatch()
+                    && ((PersistentSubscription) subscription).checkPositionInPendingAckState(position)) {
                 entries.set(i, null);
                 entry.release();
                 continue;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1295,6 +1295,10 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
         return pendingAckHandle;
     }
 
+    public boolean checkPositionInPendingAckState(PositionImpl position) {
+        return pendingAckHandle.checkPositionInPendingAckState(position);
+    }
+
     public void syncBatchPositionBitSetForPendingAck(PositionImpl position) {
         this.pendingAckHandle.syncBatchPositionAckSetForTransaction(position);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckHandle.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckHandle.java
@@ -166,4 +166,11 @@ public interface PendingAckHandle {
      * @return the stats of the message position.
      */
     PositionInPendingAckStats checkPositionInPendingAckState(PositionImpl position, Integer batchIndex);
+
+
+
+    /**
+     * check whether specific Position is in pending ack state.
+     */
+    boolean checkPositionInPendingAckState(PositionImpl position);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleDisabled.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleDisabled.java
@@ -106,4 +106,9 @@ public class PendingAckHandleDisabled implements PendingAckHandle {
     public PositionInPendingAckStats checkPositionInPendingAckState(PositionImpl position, Integer batchIndex) {
         return null;
     }
+
+    @Override
+    public boolean checkPositionInPendingAckState(PositionImpl position) {
+        return false;
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
@@ -1051,6 +1051,14 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
         }
     }
 
+    @Override
+    public boolean checkPositionInPendingAckState(PositionImpl position) {
+        if (individualAckPositions != null) {
+            return individualAckPositions.containsKey(position);
+        }
+        return false;
+    }
+
     @VisibleForTesting
     public Map<PositionImpl, MutablePair<PositionImpl, Integer>> getIndividualAckPositions() {
         return individualAckPositions;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -1436,7 +1436,7 @@ public class TransactionTest extends TransactionTestBase {
                 .newConsumer(Schema.INT32)
                 .topic(topicName)
                 .subscriptionName("test")
-                .subscriptionType(SubscriptionType.Shared)
+                .subscriptionType(SubscriptionType.Exclusive)
                 .subscribe();
 
         for (int i = 0; i < count; i++) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -64,7 +64,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.swagger.models.auth.In;
 import lombok.Cleanup;
 import lombok.Lombok;
 import lombok.extern.slf4j.Slf4j;


### PR DESCRIPTION
### Motivation
Currently, broker do not filter messages in pending ack state when dispatching messages to client. If messages in pending ack state are delivered to client, `PulsarClientException$TransactionConflictException` will be throwed.
PR #14327 has tried to fix one of cases that broker will dispatch messages in pending ack state. 
But, there are other cases that will trigger this problem. 
For example, if producer send non batch messages, msg1 and msg2. consumer use txn1 ack msg1, use txn2 ack msg2.
then consumer abort txn2, at this time, we should redeliver only msg2. Because msg1 is in pending ack state.

### Modifications

filter non batch messages in pending ack state.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added tests and can be verified.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/13

