### PR TITLE
[branch-2.10] [fix] [ml] Change the modifier of some variables in ManagedLedgerImpl to default to resolve compilation errors

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -215,9 +215,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     private final CallbackMutex offloadMutex = new CallbackMutex();
     private static final CompletableFuture<PositionImpl> NULL_OFFLOAD_PROMISE = CompletableFuture
             .completedFuture(PositionImpl.LATEST);
-    private volatile LedgerHandle currentLedger;
-    private long currentLedgerEntries = 0;
-    private long currentLedgerSize = 0;
+    volatile LedgerHandle currentLedger;
+    volatile long currentLedgerEntries = 0;
+    volatile long currentLedgerSize = 0;
     private long lastLedgerCreatedTimestamp = 0;
     private long lastLedgerCreationFailureTimestamp = 0;
     private long lastLedgerCreationInitiationTimestamp = 0;


### PR DESCRIPTION
### Motivation
The modifier of variables `currentLedgerEntries`, `currentLedgerSize` and `currentLedger` in `ManagedLedegrImpl` changed to `protected` in PR #18265, this PR is for new features, so there is no cherry picking to branch `2.10`.

PR #19404 fixes the problem of the managed ledger, and is already cherry-picked into branch `2.10`, but this PR uses the above change( The modifier changes of some variables ), so the compilation of branch `2.10` errors now.

### Modifications

change modifier of variables `currentLedgerEntries`, `currentLedgerSize` and `currentLedger` to `default`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

