### PR TITLE
[fix][client] Shade com.fasterxml.jackson.datatype.* to prevent ClassNotFoundException

### DIFF
--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -123,7 +123,7 @@
                   <include>com.google.protobuf:protobuf-java</include>
                   <include>com.google.guava:guava</include>
                   <include>com.google.code.gson:gson</include>
-                  <include>com.fasterxml.jackson.core</include>
+                  <include>com.fasterxml.jackson.*:*</include>
                   <include>io.netty:*</include>
                   <include>io.netty.incubator:*</include>
                   <include>org.apache.pulsar:pulsar-common</include>
@@ -133,7 +133,6 @@
                   <include>javax.ws.rs:*</include>
                   <include>jakarta.annotation:*</include>
                   <include>org.glassfish.hk2*:*</include>
-                  <include>com.fasterxml.jackson.*:*</include>
                   <include>io.grpc:*</include>
                   <include>io.perfmark:*</include>
                   <include>com.yahoo.datasketches:*</include>

--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -149,6 +149,9 @@
                   <!-- Issue #6834, Since Netty ByteBuf shaded, we need also shade this module -->
                   <include>org.apache.pulsar:pulsar-client-messagecrypto-bc</include>
                 </includes>
+                <excludes>
+                  <exclude>com.fasterxml.jackson.core:jackson-annotations</exclude>
+                </excludes>
               </artifactSet>
               <filters>
                 <filter>
@@ -191,6 +194,9 @@
                 <relocation>
                   <pattern>com.fasterxml.jackson</pattern>
                   <shadedPattern>org.apache.pulsar.shade.com.fasterxml.jackson</shadedPattern>
+                  <excludes>
+                    <exclude>com.fasterxml.jackson.annotation.*</exclude>
+                  </excludes>
                 </relocation>
                 <relocation>
                   <pattern>io.netty</pattern>

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -151,10 +151,7 @@
                   <include>com.google.errorprone:*</include>
                   <include>com.google.j2objc:*</include>
                   <include>com.google.code.gson:gson</include>
-                  <include>com.fasterxml.jackson.core</include>
-                  <include>com.fasterxml.jackson.module</include>
-                  <include>com.fasterxml.jackson.core:jackson-core</include>
-                  <include>com.fasterxml.jackson.dataformat</include>
+                  <include>com.fasterxml.jackson.*:*</include>
                   <include>io.netty:netty</include>
                   <include>io.netty:netty-all</include>
                   <include>io.netty:netty-tcnative-boringssl-static</include>
@@ -171,7 +168,6 @@
                   <include>javax.ws.rs:*</include>
                   <include>jakarta.annotation:*</include>
                   <include>org.glassfish.hk2*:*</include>
-                  <include>com.fasterxml.jackson.*:*</include>
                   <include>io.grpc:*</include>
                   <include>io.perfmark:*</include>
                   <include>com.yahoo.datasketches:*</include>

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -190,6 +190,9 @@
                   <!-- Issue #6834, Since Netty ByteBuf shaded, we need also shade this module -->
                   <include>org.apache.pulsar:pulsar-client-messagecrypto-bc</include>
                 </includes>
+                <excludes>
+                  <exclude>com.fasterxml.jackson.core:jackson-annotations</exclude>
+                </excludes>
               </artifactSet>
               <filters>
                 <filter>
@@ -226,6 +229,9 @@
                 <relocation>
                   <pattern>com.fasterxml.jackson</pattern>
                   <shadedPattern>org.apache.pulsar.shade.com.fasterxml.jackson</shadedPattern>
+                  <excludes>
+                    <exclude>com.fasterxml.jackson.annotation.*</exclude>
+                  </excludes>
                 </relocation>
                 <relocation>
                   <pattern>io.netty</pattern>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -168,6 +168,9 @@
                   <!-- Issue #6834, Since Netty ByteBuf shaded, we need also shade this module -->
                   <include>org.apache.pulsar:pulsar-client-messagecrypto-bc</include>
                 </includes>
+                <excludes>
+                  <exclude>com.fasterxml.jackson.core:jackson-annotations</exclude>
+                </excludes>
               </artifactSet>
               <filters>
                 <filter>
@@ -204,6 +207,9 @@
                 <relocation>
                   <pattern>com.fasterxml.jackson</pattern>
                   <shadedPattern>org.apache.pulsar.shade.com.fasterxml.jackson</shadedPattern>
+                  <excludes>
+                    <exclude>com.fasterxml.jackson.annotation.*</exclude>
+                  </excludes>
                 </relocation>
                 <relocation>
                   <pattern>io.netty</pattern>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -145,10 +145,7 @@
                   <include>com.google.errorprone:*</include>
                   <include>com.google.j2objc:*</include>
                   <include>com.google.code.gson:gson</include>
-                  <include>com.fasterxml.jackson.core</include>
-                  <include>com.fasterxml.jackson.module</include>
-                  <include>com.fasterxml.jackson.core:jackson-core</include>
-                  <include>com.fasterxml.jackson.dataformat</include>
+                  <include>com.fasterxml.jackson.*:*</include>
                   <include>io.netty:*</include>
                   <include>io.netty.incubator:*</include>
                   <include>io.perfmark:*</include>


### PR DESCRIPTION
### Motivation

I tried to use the latest Java client with the authentication plugin, but it threw the following exception:
```
Exception in thread "main" org.apache.pulsar.client.api.PulsarClientException$UnsupportedAuthenticationException: java.lang.NoClassDefFoundError: org/apache/pulsar/shade/com/fasterxml/jackson/datatype/jdk8/Jdk8Module
        at org.apache.pulsar.client.api.AuthenticationFactory.create(AuthenticationFactory.java:110)
        at org.apache.pulsar.client.impl.ClientBuilderImpl.authentication(ClientBuilderImpl.java:138)
        at SampleConsumer.main(SampleConsumer.java:42)
Caused by: java.lang.NoClassDefFoundError: org/apache/pulsar/shade/com/fasterxml/jackson/datatype/jdk8/Jdk8Module
        at org.apache.pulsar.client.impl.AuthenticationUtil.<clinit>(AuthenticationUtil.java:35)
        at org.apache.pulsar.client.impl.PulsarClientImplementationBindingImpl.createAuthentication(PulsarClientImplementationBindingImpl.java:132)
        at org.apache.pulsar.client.api.AuthenticationFactory.create(AuthenticationFactory.java:108)
        ... 2 more
Caused by: java.lang.ClassNotFoundException: org.apache.pulsar.shade.com.fasterxml.jackson.datatype.jdk8.Jdk8Module
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
        ... 5 more
```
This is because the `com.fasterxml.jackson.datatype.*` classes are not shaded in `pulsar-client`.

### Modifications

Fixed shade settings to use wildcards to specify Jackson classes to include. This also shades the `com.fasterxml.jackson.datatype.*` classes.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->