### PR TITLE
[improve][authorization] Uniformly use allowTopicOperationAsync to check permissions

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProvider.java
@@ -200,50 +200,6 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
         return FutureUtil.waitForAny(futures, ret -> (boolean) ret).thenApply(v -> v.isPresent());
     }
 
-    /**
-     * Check if the specified role has permission to send messages to the specified fully qualified topic name.
-     *
-     * @param topicName the fully qualified topic name associated with the topic.
-     * @param role      the app id used to send messages to the topic.
-     */
-    @Override
-    public CompletableFuture<Boolean> canProduceAsync(TopicName topicName, String role,
-                                                      AuthenticationDataSource authenticationData) {
-        return authorize(authenticationData, r -> super.canProduceAsync(topicName, r, authenticationData));
-    }
-
-    /**
-     * Check if the specified role has permission to receive messages from the specified fully qualified topic
-     * name.
-     *
-     * @param topicName    the fully qualified topic name associated with the topic.
-     * @param role         the app id used to receive messages from the topic.
-     * @param subscription the subscription name defined by the client
-     */
-    @Override
-    public CompletableFuture<Boolean> canConsumeAsync(TopicName topicName, String role,
-                                                      AuthenticationDataSource authenticationData,
-                                                      String subscription) {
-        return authorize(authenticationData, r -> super.canConsumeAsync(topicName, r, authenticationData,
-                subscription));
-    }
-
-    /**
-     * Check whether the specified role can perform a lookup for the specified topic.
-     * <p>
-     * For that the caller needs to have producer or consumer permission.
-     *
-     * @param topicName
-     * @param role
-     * @return
-     * @throws Exception
-     */
-    @Override
-    public CompletableFuture<Boolean> canLookupAsync(TopicName topicName, String role,
-                                                     AuthenticationDataSource authenticationData) {
-        return authorize(authenticationData, r -> super.canLookupAsync(topicName, r, authenticationData));
-    }
-
     @Override
     public CompletableFuture<Boolean> allowFunctionOpsAsync(NamespaceName namespaceName, String role,
                                                             AuthenticationDataSource authenticationData) {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -81,9 +81,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
      * @param role
      *            the app id used to send messages to the topic.
      */
-    @Override
-    public CompletableFuture<Boolean> canProduceAsync(TopicName topicName, String role,
-            AuthenticationDataSource authenticationData) {
+    private CompletableFuture<Boolean> checkProduceAsync(TopicName topicName, String role) {
         return checkAuthorization(topicName, role, AuthAction.produce);
     }
 
@@ -95,12 +93,18 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
      *            the fully qualified topic name associated with the topic.
      * @param role
      *            the app id used to receive messages from the topic.
-     * @param subscription
-     *            the subscription name defined by the client
+     * @param authData
+     *            is used for get the subscription name defined by the client
      */
-    @Override
-    public CompletableFuture<Boolean> canConsumeAsync(TopicName topicName, String role,
-            AuthenticationDataSource authenticationData, String subscription) {
+    private CompletableFuture<Boolean> checkConsumeAsync(TopicName topicName, String role,
+                                                         AuthenticationDataSource authData) {
+        String subscription;
+        if (authData != null) {
+            subscription = authData.getSubscription();
+        } else {
+            subscription = null;
+        }
+
         return pulsarResources.getNamespaceResources().getPoliciesAsync(topicName.getNamespaceObject())
                 .thenCompose(policies -> {
                     if (!policies.isPresent()) {
@@ -154,15 +158,14 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
      * @return
      * @throws Exception
      */
-    @Override
-    public CompletableFuture<Boolean> canLookupAsync(TopicName topicName, String role,
+    private CompletableFuture<Boolean> checkLookupAsync(TopicName topicName, String role,
             AuthenticationDataSource authenticationData) {
-        return canProduceAsync(topicName, role, authenticationData)
+        return checkProduceAsync(topicName, role)
                 .thenCompose(canProduce -> {
                     if (canProduce) {
                         return CompletableFuture.completedFuture(true);
                     }
-                    return canConsumeAsync(topicName, role, authenticationData, null);
+                    return checkConsumeAsync(topicName, role, authenticationData);
                 }).exceptionally(ex -> {
                     if (log.isDebugEnabled()) {
                         log.debug("Topic [{}] Role [{}] exception occurred while trying to check produce/consume"
@@ -531,9 +534,9 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                             case LOOKUP:
                             case GET_STATS:
                             case GET_METADATA:
-                                return canLookupAsync(topicName, role, authData);
+                                return checkLookupAsync(topicName, role, authData);
                             case PRODUCE:
-                                return canProduceAsync(topicName, role, authData);
+                                return checkProduceAsync(topicName, role);
                             case GET_SUBSCRIPTIONS:
                             case CONSUME:
                             case SUBSCRIBE:
@@ -545,7 +548,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                             case GET_BACKLOG_SIZE:
                             case SET_REPLICATED_SUBSCRIPTION_STATUS:
                             case GET_REPLICATED_SUBSCRIPTION_STATUS:
-                                return canConsumeAsync(topicName, role, authData, authData.getSubscription());
+                                return checkConsumeAsync(topicName, role, authData);
                             case TERMINATE:
                             case COMPACT:
                             case OFFLOAD:

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pulsar.broker.auth;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.common.collect.Sets;
@@ -73,7 +75,9 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
     public void simple() throws Exception {
         AuthorizationService auth = pulsar.getBrokerService().getAuthorizationService();
 
-        assertFalse(auth.canLookup(TopicName.get("persistent://p1/c1/ns1/ds1"), "my-role", null));
+        assertThatThrownBy(
+                () -> auth.canLookup(TopicName.get("persistent://p1/c1/ns1/ds1"), "my-role", null)).hasMessageContaining(
+                "404");
 
         admin.clusters().createCluster("c1", ClusterData.builder().build());
         admin.tenants().createTenant("p1", new TenantInfoImpl(Sets.newHashSet("role1"), Sets.newHashSet("c1")));
@@ -209,20 +213,19 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
                 SubscriptionAuthMode.Prefix);
         waitForChange();
 
+        // role1 is tenant's superuser
         assertTrue(auth.canLookup(TopicName.get("persistent://p1/c1/ns1/ds1"), "role1", null));
-        assertTrue(auth.canLookup(TopicName.get("persistent://p1/c1/ns1/ds1"), "role2", null));
-        try {
-            assertFalse(auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), "role1", null, "sub1"));
-            fail();
-        } catch (Exception ignored) {}
-        try {
-            assertFalse(auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), "role2", null, "sub2"));
-            fail();
-        } catch (Exception ignored) {}
-
+        assertTrue(auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), "role1", null, "sub1"));
         assertTrue(auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), "role1", null, "role1-sub1"));
+
+        // role2
+        assertTrue(auth.canLookup(TopicName.get("persistent://p1/c1/ns1/ds1"), "role2", null));
         assertTrue(auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), "role2", null, "role2-sub2"));
-        assertTrue(auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), "pulsar.super_user", null, "role3-sub1"));
+        assertTrue(
+                auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), "pulsar.super_user", null, "role3-sub1"));
+
+        assertThrows(() -> auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), "role2", null, "sub2"));
+        assertThrows(() -> auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), "role2", null, "sub1"));
 
         admin.namespaces().deleteNamespace("p1/c1/ns1");
         admin.tenants().deleteTenant("p1");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 import com.google.common.collect.Sets;
 import java.util.EnumSet;
 import org.apache.pulsar.broker.authorization.AuthorizationService;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -936,20 +936,6 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
         }
 
         @Override
-        public CompletableFuture<Boolean> allowTopicOperationAsync(
-            TopicName topic, String role, TopicOperation operation, AuthenticationDataSource authData) {
-            CompletableFuture<Boolean> isAuthorizedFuture;
-
-            if (role.equals("plugbleRole")) {
-                isAuthorizedFuture = CompletableFuture.completedFuture(true);
-            } else {
-                isAuthorizedFuture = CompletableFuture.completedFuture(false);
-            }
-
-            return isAuthorizedFuture;
-        }
-
-        @Override
         public Boolean allowTopicOperation(
             TopicName topicName, String role, TopicOperation operation, AuthenticationDataSource authData) {
             try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthorizationTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.websocket.proxy;
 
 import static org.apache.pulsar.broker.BrokerTestUtil.spyWithClassAndConstructorArgs;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -83,7 +84,8 @@ public class ProxyAuthorizationTest extends MockedPulsarServiceBaseTest {
     public void test() throws Exception {
         AuthorizationService auth = service.getAuthorizationService();
 
-        assertFalse(auth.canLookup(TopicName.get("persistent://p1/c1/ns1/ds1"), "my-role", null));
+        assertThatThrownBy(() -> auth.canLookup(TopicName.get("persistent://p1/c1/ns1/ds1"), "my-role",
+                null)).hasMessageContaining("404");
 
         admin.clusters().createCluster(configClusterName, ClusterData.builder().build());
         admin.tenants().createTenant("p1", new TenantInfoImpl(Sets.newHashSet("role1"), Sets.newHashSet("c1")));


### PR DESCRIPTION
### Motivation

#6428 adds `allowTopicOperationAsync()` to check the topic authz abilities, it is a good solution, but this PR doesn't deprecate the old methods:

- canProduceAsync
- canConsumeAsync
- canLookupAsync

When users customize their own `AuthorizationProvider`,  they will be confused, so I decided to deprecate the old methods.

### Modifications

- Deprecate `canProduceAsync`, `canConsumeAsync`, and `canLookupAsync` in the `AuthorizationProvider`, and add a default implementation
-  Add back compatibility  to `allowTopicOperationAsync` to call the deprecated method
- Uniformly use `allowTopicOperationAsync` to check permissions in the `AuthorizationService`
- Fix failure tests

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
