### PR TITLE
[fix][test] Fix ProxyRefreshAuthTest.testAuthDataRefresh

### DIFF
--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyRefreshAuthTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyRefreshAuthTest.java
@@ -86,7 +86,7 @@ public class ProxyRefreshAuthTest extends ProducerConsumerBase {
         conf.setClusterName("proxy-authorization");
         conf.setNumExecutorThreadPoolSize(5);
 
-        conf.setAuthenticationRefreshCheckSeconds(1);
+        conf.setAuthenticationRefreshCheckSeconds(2);
     }
 
     @BeforeClass
@@ -154,7 +154,7 @@ public class ProxyRefreshAuthTest extends ProducerConsumerBase {
 
         AuthenticationToken authenticationToken = new AuthenticationToken(() -> {
             Calendar calendar = Calendar.getInstance();
-            calendar.add(Calendar.SECOND, 1);
+            calendar.add(Calendar.SECOND, 2);
             return AuthTokenUtils.createToken(SECRET_KEY, "client", Optional.of(calendar.getTime()));
         });
 
@@ -169,7 +169,7 @@ public class ProxyRefreshAuthTest extends ProducerConsumerBase {
         PulsarClientImpl pulsarClientImpl = (PulsarClientImpl) pulsarClient;
         Set<CompletableFuture<ClientCnx>> connections = pulsarClientImpl.getCnxPool().getConnections();
 
-        Awaitility.await().during(4, SECONDS).untilAsserted(() -> {
+        Awaitility.await().during(6, SECONDS).untilAsserted(() -> {
             pulsarClient.getPartitionsForTopic(topic).get();
             assertTrue(connections.stream().allMatch(n -> {
                 try {


### PR DESCRIPTION
Fixes #19400

### Motivation

I suggest `authenticationRefreshCheckSeconds`, and the token expiration time is too short.

### Modifications

- Increasing `authenticationRefreshCheckSeconds`, and the token expiration time

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
