### PR TITLE
[fix][ml] Remove OpAddEntry from pendingAddEntries if add failure

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -4034,7 +4034,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 log.error("Failed to add entry for ledger {} in time-out {} sec",
                         (opAddEntry.ledger != null ? opAddEntry.ledger.getId() : -1), timeoutSec);
                 opAddEntry.handleAddTimeoutFailure(opAddEntry.ledger, finalAddOpCount);
-                pendingAddEntries.remove(opAddEntry);
             }
         }
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -4034,6 +4034,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 log.error("Failed to add entry for ledger {} in time-out {} sec",
                         (opAddEntry.ledger != null ? opAddEntry.ledger.getId() : -1), timeoutSec);
                 opAddEntry.handleAddTimeoutFailure(opAddEntry.ledger, finalAddOpCount);
+                pendingAddEntries.remove(opAddEntry);
             }
         }
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -326,6 +326,7 @@ public class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallba
         // be marked as failed.
         ManagedLedgerImpl finalMl = this.ml;
         finalMl.mbean.recordAddEntryError();
+        finalMl.pendingAddEntries.remove(this);
 
         finalMl.getExecutor().execute(SafeRun.safeRun(() -> {
             // Force the creation of a new ledger. Doing it in a background thread to avoid acquiring ML lock


### PR DESCRIPTION
### Motivation

We should remove the `OpAddEntry` from `pendingAddEntries` if add failure, e.g.,  add-entry fails or times out. Otherwise the memory will not release in time

### Modifications
Remove the `OpAddEntry` from `pendingAddEntries` when call `handleAddFailure`

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/AnonHxy/pulsar/pull/27
