### PR TITLE
[fix][client] Fix load the trust store file

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/keystoretls/KeyStoreSSLContext.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/keystoretls/KeyStoreSSLContext.java
@@ -34,6 +34,7 @@ import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -150,27 +151,30 @@ public class KeyStoreSSLContext {
         }
 
         // trust store
-        TrustManagerFactory trustManagerFactory;
+        TrustManagerFactory trustManagerFactory = null;
         if (this.allowInsecureConnection) {
             trustManagerFactory = InsecureTrustManagerFactory.INSTANCE;
         } else {
-            trustManagerFactory = provider != null
-                    ? TrustManagerFactory.getInstance(tmfAlgorithm, provider)
-                    : TrustManagerFactory.getInstance(tmfAlgorithm);
-            KeyStore trustStore = KeyStore.getInstance(trustStoreTypeString);
-            char[] passwordChars = trustStorePassword.toCharArray();
             if (!Strings.isNullOrEmpty(trustStorePath)) {
+                trustManagerFactory = provider != null
+                        ? TrustManagerFactory.getInstance(tmfAlgorithm, provider)
+                        : TrustManagerFactory.getInstance(tmfAlgorithm);
+                KeyStore trustStore = KeyStore.getInstance(trustStoreTypeString);
+                char[] passwordChars = trustStorePassword.toCharArray();
                 try (FileInputStream inputStream = new FileInputStream(trustStorePath)) {
                     trustStore.load(inputStream, passwordChars);
                 }
+                trustManagerFactory.init(trustStore);
             }
-            trustManagerFactory.init(trustStore);
+        }
+
+        TrustManager[] trustManagers = null;
+        if (trustManagerFactory != null) {
+            trustManagers = SecurityUtility.processConscryptTrustManagers(trustManagerFactory.getTrustManagers());
         }
 
         // init
-        sslContext.init(keyManagers, SecurityUtility
-                        .processConscryptTrustManagers(trustManagerFactory.getTrustManagers()),
-                new SecureRandom());
+        sslContext.init(keyManagers, trustManagers, new SecureRandom());
         this.sslContext = sslContext;
         return sslContext;
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/keystoretls/KeyStoreSSLContext.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/keystoretls/KeyStoreSSLContext.java
@@ -159,8 +159,10 @@ public class KeyStoreSSLContext {
                     : TrustManagerFactory.getInstance(tmfAlgorithm);
             KeyStore trustStore = KeyStore.getInstance(trustStoreTypeString);
             char[] passwordChars = trustStorePassword.toCharArray();
-            try (FileInputStream inputStream = new FileInputStream(trustStorePath)) {
-                trustStore.load(inputStream, passwordChars);
+            if (!Strings.isNullOrEmpty(trustStorePath)) {
+                try (FileInputStream inputStream = new FileInputStream(trustStorePath)) {
+                    trustStore.load(inputStream, passwordChars);
+                }
             }
             trustManagerFactory.init(trustStore);
         }


### PR DESCRIPTION
### Motivation

When the trust store file is empty, we can skip loading the trust store file, because there is using the trust store file from the operating system.

### Modifications

- Add check and load the `tlsTrustStorePath` to the `KeyStoreSSLContext`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->