### PR TITLE
[fix][admin] Include non persistent partitioned topics while retreiving topics list (#19316)

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -2980,6 +2980,62 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         producer2.close();
     }
 
+    @Test
+    public void testGetTopicsWithPartitions() throws Exception {
+        final String namespace = "prop-xyz/ns1";
+
+        final String persistentTopicName = TopicName
+                .get("persistent", NamespaceName.get(namespace), "get_topics_mode_" + UUID.randomUUID().toString())
+                .toString();
+
+        final String nonPersistentTopicName = TopicName
+                .get("non-persistent", NamespaceName.get(namespace), "get_topics_mode_" + UUID.randomUUID().toString())
+                .toString();
+
+        final String persistentPartitionedTopicName = TopicName
+                .get("persistent", NamespaceName.get(namespace), "get_topics_mode_" + UUID.randomUUID().toString())
+                .toString();
+        admin.topics().createPartitionedTopic(persistentPartitionedTopicName, 4);
+
+        final String nonPersistentPartitionedTopicName = TopicName
+                .get("non-persistent", NamespaceName.get(namespace), "get_topics_mode_" + UUID.randomUUID().toString())
+                .toString();
+        admin.topics().createPartitionedTopic(nonPersistentPartitionedTopicName, 4);
+
+
+        Producer<byte[]> producer1 = pulsarClient.newProducer().topic(persistentTopicName).create();
+        Producer<byte[]> producer2 = pulsarClient.newProducer().topic(nonPersistentTopicName).create();
+        Producer<byte[]> producer3 = pulsarClient.newProducer().topic(persistentPartitionedTopicName).create();
+        Producer<byte[]> producer4 = pulsarClient.newProducer().topic(nonPersistentPartitionedTopicName).create();
+
+        List<String> topics = new ArrayList<>(admin.topics().getList(namespace));
+        assertEquals(topics.size(), 10);
+        assertTrue(topics.contains(persistentTopicName));
+        assertTrue(topics.contains(nonPersistentTopicName));
+
+        topics.clear();
+
+        topics.addAll(admin.topics().getList(namespace, TopicDomain.persistent));
+        assertEquals(topics.size(), 5);
+        assertTrue(topics.contains(persistentTopicName));
+
+        topics.clear();
+
+        topics.addAll(admin.topics().getList(namespace, TopicDomain.non_persistent));
+        assertEquals(topics.size(), 5);
+        assertTrue(topics.contains(nonPersistentTopicName));
+
+        try {
+            admin.topics().getList(namespace, TopicDomain.getEnum("none"));
+            fail("Should failed with invalid get topic mode.");
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid topic domain: 'none'");
+        }
+
+        producer1.close();
+        producer2.close();
+    }
+
     @Test(dataProvider = "isV1")
     public void testNonPartitionedTopic(boolean isV1) throws Exception {
         String tenant = "prop-xyz";


### PR DESCRIPTION
…ng topics list (#19316)

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #19316

<!-- or this PR is one task of an issue -->

Master Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/wiki/proposals/PIP.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
While retrieving the list of topics, non-persistent partitioned topics are not listed in the given list

### Modifications
From the code, non persistent partitioned topics were include to the getListAsync
- retrieve non persistent partition topics with get request of /admin/v2/non-persistent/public/default/partitioned
- retrieve metadata for each non persistent topic data with get request of /admin/v2/non-persistent/public/default/{topic}/partitions
- iterate over partition and form full topicname 
- append future list to the existing non persistent list

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:
Added new test case to test whether the partitioned topics retrieved properly along with non partitioned topics
*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [x] The REST endpoints
- [x] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
