### PR TITLE
[improve][broker] PIP-192 Use msg property to mark compacted msgs from strategic compaction

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitState.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitState.java
@@ -66,9 +66,7 @@ public enum ServiceUnitState {
     Splitting; // the service unit(e.g. bundle) is in the process of splitting.
 
     private static Map<ServiceUnitState, Set<ServiceUnitState>> validTransitions = Map.of(
-            // (Free -> Released | Splitting) transitions are required
-            // when the topic is compacted in the middle of transfer or split.
-            Free, Set.of(Owned, Assigned, Released, Splitting),
+            Free, Set.of(Owned, Assigned),
             Owned, Set.of(Assigned, Splitting, Free),
             Assigned, Set.of(Owned, Released, Free),
             Released, Set.of(Owned, Free),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateCompactionStrategy.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateCompactionStrategy.java
@@ -18,13 +18,10 @@
  */
 package org.apache.pulsar.broker.loadbalance.extensions.channel;
 
-import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Assigned;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Free;
-import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Owned;
-import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Released;
-import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Splitting;
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.topics.TopicCompactionStrategy;
 
@@ -57,33 +54,45 @@ public class ServiceUnitStateCompactionStrategy implements TopicCompactionStrate
         }
 
         if (checkBrokers) {
-            if (prevState == Free && (state == Assigned || state == Owned)) {
-                // Free -> Assigned || Owned broker check
-                return StringUtils.isBlank(to.broker());
-            } else if (prevState == Owned && state == Assigned) {
-                // Owned -> Assigned(transfer) broker check
-                return !StringUtils.equals(from.broker(), to.sourceBroker())
-                        || StringUtils.isBlank(to.broker())
-                        || StringUtils.equals(from.broker(), to.broker());
-            } else if (prevState == Assigned && state == Released) {
-                // Assigned -> Released(transfer) broker check
-                return !StringUtils.equals(from.broker(), to.broker())
-                        || !StringUtils.equals(from.sourceBroker(), to.sourceBroker());
-            } else if (prevState == Released && state == Owned) {
-                // Released -> Owned(transfer) broker check
-                return !StringUtils.equals(from.broker(), to.broker())
-                        || !StringUtils.equals(from.sourceBroker(), to.sourceBroker());
-            } else if (prevState == Assigned && state == Owned) {
-                // Assigned -> Owned broker check
-                return !StringUtils.equals(from.broker(), to.broker())
-                        || !StringUtils.equals(from.sourceBroker(), to.sourceBroker());
-            } else if (prevState == Owned && state == Splitting) {
-                // Owned -> Splitting broker check
-                return !StringUtils.equals(from.broker(), to.broker());
+            switch (prevState) {
+                case Free:
+                    switch (state) {
+                        case Assigned:
+                        case Owned:
+                            return isNotBlank(to.sourceBroker());
+                    }
+                case Owned:
+                    switch (state) {
+                        case Assigned:
+                            return invalidTransfer(from, to);
+                        case Splitting:
+                            return !from.broker().equals(to.broker());
+                    }
+                case Assigned:
+                    switch (state) {
+                        case Released:
+                        case Owned:
+                            return notEquals(from, to);
+                    }
+                case Released:
+                    switch (state) {
+                        case Owned:
+                            return notEquals(from, to);
+                    }
+                case Splitting:
+                    return false;
             }
         }
-
         return false;
     }
 
+    private boolean notEquals(ServiceUnitStateData from, ServiceUnitStateData to) {
+        return !from.broker().equals(to.broker())
+                || !StringUtils.equals(from.sourceBroker(), to.sourceBroker());
+    }
+
+    private boolean invalidTransfer(ServiceUnitStateData from, ServiceUnitStateData to) {
+        return !from.broker().equals(to.sourceBroker())
+                || from.broker().equals(to.broker());
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateData.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateData.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.loadbalance.extensions.channel;
 
 
 import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Defines data for the service unit state changes.
@@ -30,7 +31,9 @@ public record ServiceUnitStateData(ServiceUnitState state, String broker, String
 
     public ServiceUnitStateData {
         Objects.requireNonNull(state);
-        Objects.requireNonNull(broker);
+        if (StringUtils.isBlank(broker)) {
+            throw new IllegalArgumentException("Empty broker");
+        }
     }
 
     public ServiceUnitStateData(ServiceUnitState state, String broker, String sourceBroker) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateCompactionStrategyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateCompactionStrategyTest.java
@@ -47,11 +47,11 @@ public class ServiceUnitStateCompactionStrategyTest {
         String dst = "dst";
         assertTrue(strategy.shouldKeepLeft(data(Free), data(Free)));
         assertFalse(strategy.shouldKeepLeft(data(Free), data(Assigned)));
-        assertTrue(strategy.shouldKeepLeft(data(Free), data(Assigned, "")));
+        assertTrue(strategy.shouldKeepLeft(data(Free), data(Assigned, dst)));
         assertFalse(strategy.shouldKeepLeft(data(Free), data(Owned)));
-        assertTrue(strategy.shouldKeepLeft(data(Free), data(Owned, "")));
-        assertFalse(strategy.shouldKeepLeft(data(Free), data(Released)));
-        assertFalse(strategy.shouldKeepLeft(data(Free), data(Splitting)));
+        assertTrue(strategy.shouldKeepLeft(data(Free), data(Owned, dst)));
+        assertTrue(strategy.shouldKeepLeft(data(Free), data(Released)));
+        assertTrue(strategy.shouldKeepLeft(data(Free), data(Splitting)));
 
         assertFalse(strategy.shouldKeepLeft(data(Assigned), data(Free)));
         assertTrue(strategy.shouldKeepLeft(data(Assigned), data(Assigned)));
@@ -65,7 +65,7 @@ public class ServiceUnitStateCompactionStrategyTest {
 
         assertFalse(strategy.shouldKeepLeft(data(Owned), data(Free)));
         assertTrue(strategy.shouldKeepLeft(data(Owned), data(Assigned)));
-        assertTrue(strategy.shouldKeepLeft(data(Owned), data(Assigned, "")));
+        assertTrue(strategy.shouldKeepLeft(data(Owned), data(Assigned, "broker")));
         assertTrue(strategy.shouldKeepLeft(data(Owned), data(Assigned, "src", dst)));
         assertFalse(strategy.shouldKeepLeft(data(Owned), data(Assigned, dst)));
         assertTrue(strategy.shouldKeepLeft(data(Owned), data(Owned)));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateDataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateDataTest.java
@@ -53,11 +53,14 @@ public class ServiceUnitStateDataTest {
         new ServiceUnitStateData(null, "A");
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testNullBroker() {
         new ServiceUnitStateData(Owned, null);
     }
-
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testEmptyBroker() {
+        new ServiceUnitStateData(Owned, "");
+    }
     @Test
     public void jsonWriteAndReadTest() throws JsonProcessingException {
         ObjectMapper mapper = ObjectMapperFactory.create();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTest.java
@@ -36,8 +36,8 @@ public class ServiceUnitStateTest {
         assertFalse(ServiceUnitState.isValidTransition(Free, Free));
         assertTrue(ServiceUnitState.isValidTransition(Free, Assigned));
         assertTrue(ServiceUnitState.isValidTransition(Free, Owned));
-        assertTrue(ServiceUnitState.isValidTransition(Free, Released));
-        assertTrue(ServiceUnitState.isValidTransition(Free, Splitting));
+        assertFalse(ServiceUnitState.isValidTransition(Free, Released));
+        assertFalse(ServiceUnitState.isValidTransition(Free, Splitting));
 
         assertTrue(ServiceUnitState.isValidTransition(Assigned, Free));
         assertFalse(ServiceUnitState.isValidTransition(Assigned, Assigned));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static org.apache.pulsar.common.topics.TopicCompactionStrategy.SYSTEM_COMPACTION_MSG_PROPERTY_KEY;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -191,7 +192,9 @@ public class TableViewImpl<T> implements TableView<T> {
                 boolean update = true;
                 if (compactionStrategy != null) {
                     T prev = data.get(key);
-                    update = !compactionStrategy.shouldKeepLeft(prev, cur);
+                    update = !compactionStrategy.shouldKeepLeft(prev, cur)
+                            // Initially, compacted messages are considered as valid transitions.
+                            || (prev == null && msg.hasProperty(SYSTEM_COMPACTION_MSG_PROPERTY_KEY));
                 }
 
                 if (update) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicCompactionStrategy.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicCompactionStrategy.java
@@ -44,6 +44,8 @@ import org.apache.pulsar.client.api.Schema;
  *                 .create();
  */
 public interface TopicCompactionStrategy<T> {
+    // Messages will have a metadata property with this key after compaction.
+    String SYSTEM_COMPACTION_MSG_PROPERTY_KEY = "__sys_comp";
 
     /**
      * Returns the schema object for this strategy.


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->



<!-- or this PR is one task of an issue -->

Master Issue: https://github.com/apache/pulsar/issues/16691

### Motivation

There is a possible edge case where bundle ownership could be in an invalid state in the new load balancer.

Let's say strategic compaction happened in the middle of the bundle transfer.
Owned->Transfer_Assigned // compaction happened.

After the compaction, when a tableview joins and builds its cache from the compacted topic, it will first see a transition, `null -> Transfer_Assigned`. However, because this is invalid, the tableview will skip this msg, causing an inconsistent view. 

To avoid this issue,  this transition(`null -> Transfer_Assigned`) has been changed to a valid transition in the state diagram, but I realized that this could bring another wrong state when transfer and split occur concurrently.

**Racing condition**
leader : Owned -> Transfer_Assigned -> Released -> Owned
Broker-2 : Owned -> Splitting -> null(parent-bundle)

**Wrong state**: a parent bundle is owned by another broker after the split.
Owned -> Splitting -> **null -> Transfer_Assigned** -> Released -> Owned

Ideally, we need to mark if messages are compacted or not. Then, TableView can know (`null -> compacted_messages`) are valid transitions.

null -> Transfer_Assigned(compacted) // valid transition.
null -> Transfer_Assigned(non-compacted) // invalid transition.


### Modifications
This PR added a system property to compacted msgs from strategic compaction. 

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - *Updaated unit tests.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

We will have separate PRs to update the Doc later.

### Matching PR in forked repository

PR in forked repository: https://github.com/heesung-sn/pulsar/pull/31

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
