### PR TITLE
[fix][broker]: make log4j2 delete strategy work

### DIFF
--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -78,7 +78,7 @@ Configuration:
             basePath: ${sys:pulsar.log.dir}
             maxDepth: 2
             IfFileName:
-              glob: "*/${sys:pulsar.log.file}*log.gz"
+              glob: "${sys:pulsar.log.file}*log.gz"
             IfLastModified:
               age: 30d
 
@@ -120,7 +120,7 @@ Configuration:
                             basePath: ${sys:pulsar.log.dir}
                             maxDepth: 2
                             IfFileName:
-                              glob: "*/${sys:pulsar.log.file}*log.gz"
+                              glob: "${sys:pulsar.log.file}*log.gz"
                             IfLastModified:
                               age: 30d
                   - ref: "${sys:pulsar.routing.appender.default}"


### PR DESCRIPTION
Fixes #19494

### Motivation

when we use RollingFile, we found  log4j2 delete strategy does not work, because the configuration item `IfFileName:
              glob: "*/${sys:pulsar.log.file}*log.gz"`  in log4j2.yaml  has wrong dir path,  "*/" of IfFileName should be removed  to make log4j2 delete strategy work.  

in the log4j2.yaml :
```
fileName: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}
 DefaultRolloverStrategy:
          Delete:
            basePath: ${sys:pulsar.log.dir}
            maxDepth: 2
            IfFileName:
              glob: "*/${sys:pulsar.log.file}*log.gz"
            IfLastModified:
              age: 30d
```
DefaultRolloverStrategy's IfFileName  has different dir path with  log fileName,  the "*/" of  IfFileName  in should be removed, when we change it into  `glob: "${sys:pulsar.log.file}*log.gz"`, delete strategy works!

### Modifications
remove  "*/"  of IfFileName in log4j2.yaml

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

