### PR TITLE
[fix][client] fix receive dumplicated messages after seek to a timestamp in MultiTo…

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -629,6 +629,15 @@ public interface ConsumerBuilder<T> extends Cloneable {
     ConsumerBuilder<T> autoUpdatePartitionsInterval(int interval, TimeUnit unit);
 
     /**
+     * Sets the interval of checking whether seek is complete interval.
+     *
+     * @param interval
+     *            the interval of check ticket.
+     * @return the consumer builder instance
+     */
+    ConsumerBuilder<T> seekCompleteCheckTicketMs(int interval);
+
+    /**
      * Sets KeyShared subscription policy for consumer.
      *
      * <p>By default, KeyShared subscriptions use auto split hash ranges to maintain consumers. If you want to

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -633,9 +633,11 @@ public interface ConsumerBuilder<T> extends Cloneable {
      *
      * @param interval
      *            the interval of check ticket.
+     * @param unit
+     *            the time unit of the interval.
      * @return the consumer builder instance
      */
-    ConsumerBuilder<T> seekCompleteCheckTicketMs(int interval);
+    ConsumerBuilder<T> receiveTaskIntervalMsDuringSeek(int interval, TimeUnit unit);
 
     /**
      * Sets KeyShared subscription policy for consumer.

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -495,6 +495,22 @@ public class PulsarClientException extends IOException {
     }
 
     /**
+     * Seek conflict exception thrown by Pulsar client.
+     */
+    public static class SeekConflictException extends PulsarClientException {
+        /**
+         * Constructs a {@code SeekConflictException} with the specified detail message.
+         *
+         * @param msg
+         *        The detail message (which is saved for later retrieval
+         *        by the {@link #getMessage()} method)
+         */
+        public SeekConflictException(String msg) {
+            super(msg);
+        }
+    }
+
+    /**
      * Authentication exception thrown by Pulsar client.
      */
     public static class AuthenticationException extends PulsarClientException {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -462,8 +462,8 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     }
 
     @Override
-    public ConsumerBuilder<T> seekCompleteCheckTicketMs(int interval) {
-       conf.setSeekCompleteCheckTicketMs(interval);
+    public ConsumerBuilder<T> receiveTaskIntervalMsDuringSeek(int interval, TimeUnit unit) {
+       conf.setReceiveTaskIntervalMsDuringSeek(interval, unit);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -462,7 +462,12 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     }
 
     @Override
+    public ConsumerBuilder<T> seekCompleteCheckTicketMs(int interval) {
+       conf.setSeekCompleteCheckTicketMs(interval);
+        return this;
+    }
 
+    @Override
     public ConsumerBuilder<T> startMessageIdInclusive() {
         conf.setResetIncludeHead(true);
         return this;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -790,7 +790,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     public CompletableFuture<Void> seekAsync(long timestamp) {
         List<CompletableFuture<Void>> futures = new ArrayList<>(consumers.size());
         consumers.values().forEach(consumer -> futures.add(consumer.seekAsync(timestamp)));
-        return FutureUtil.waitForAll(futures).thenApply( f -> {
+        return FutureUtil.waitForAll(futures).thenApply(f -> {
                     clearIncomingMessages();
                     return null;
                 });

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -790,7 +790,10 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     public CompletableFuture<Void> seekAsync(long timestamp) {
         List<CompletableFuture<Void>> futures = new ArrayList<>(consumers.size());
         consumers.values().forEach(consumer -> futures.add(consumer.seekAsync(timestamp)));
-        return FutureUtil.waitForAll(futures);
+        return FutureUtil.waitForAll(futures).thenApply( f -> {
+                    clearIncomingMessages();
+                    return null;
+                });
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -400,7 +400,7 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
 
     private List<TopicConsumerConfigurationData> topicConfigurations = new ArrayList<>();
 
-    private long seekCompleteCheckTicketMs = 1;
+    private long receiveTaskIntervalMsDuringSeek = 10;
 
     public TopicConsumerConfigurationData getMatchingTopicConfiguration(String topicName) {
         return topicConfigurations.stream()
@@ -417,6 +417,11 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
     public void setAutoUpdatePartitionsIntervalSeconds(int interval, TimeUnit timeUnit) {
         checkArgument(interval > 0, "interval needs to be > 0");
         this.autoUpdatePartitionsIntervalSeconds = timeUnit.toSeconds(interval);
+    }
+
+    public void setReceiveTaskIntervalMsDuringSeek(int interval, TimeUnit timeUnit) {
+        checkArgument(interval > 0, "interval needs to be > 0");
+        this.receiveTaskIntervalMsDuringSeek = timeUnit.toMillis(interval);
     }
 
     @JsonIgnore

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -400,6 +400,8 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
 
     private List<TopicConsumerConfigurationData> topicConfigurations = new ArrayList<>();
 
+    private long seekCompleteCheckTicketMs = 1;
+
     public TopicConsumerConfigurationData getMatchingTopicConfiguration(String topicName) {
         return topicConfigurations.stream()
                 .filter(topicConf -> topicConf.getTopicNameMatcher().matches(topicName))


### PR DESCRIPTION
### Motivation

For `MultiTopicConsumerImpl`, after seeking a timestamp, the consumer may receive duplicated messages.

### Modifications

Clearing the `incommingQueue` for `MultiTopicConsumerImpl` after seeking a timestamp success

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->


### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
https://github.com/aloyszhang/pulsar/pull/13

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
