### PR TITLE
[improve][broker] introduce consistent hash ring to distribute the load of multiple topics subscription

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.broker.service;
 
 import static com.google.common.base.Preconditions.checkArgument;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.broker.service;
 
 import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -153,7 +155,7 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
                 hashRing.put(hash, i);
             }
         }
-        return hashRing;
+        return Collections.unmodifiableNavigableMap(hashRing);
     }
 
     public synchronized void addConsumer(Consumer consumer) throws BrokerServiceException {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
@@ -20,7 +20,10 @@ package org.apache.pulsar.broker.service;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Objects;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -30,7 +33,9 @@ import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.BrokerServiceException.ConsumerBusyException;
 import org.apache.pulsar.broker.service.BrokerServiceException.ServerMetadataException;
+import org.apache.pulsar.client.impl.Murmur3Hash32;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
+import org.apache.pulsar.common.util.Murmur3_32Hash;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,6 +62,7 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
     private volatile int isClosed = FALSE;
 
     protected boolean isFirstRead = true;
+    private static final int CONSUMER_CONSISTENT_HASH_REPLICAS = 100;
 
     public AbstractDispatcherSingleActiveConsumer(SubType subscriptionType, int partitionIndex,
                                                   String topicName, Subscription subscription,
@@ -93,35 +99,31 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
      */
     protected boolean pickAndScheduleActiveConsumer() {
         checkArgument(!consumers.isEmpty());
-        // By default always pick the first connected consumer for non partitioned topic.
-        int index = 0;
+        AtomicBoolean hasPriorityConsumer = new AtomicBoolean(false);
+        consumers.sort((c1, c2) -> {
+            int priority = c1.getPriorityLevel() - c2.getPriorityLevel();
+            if (priority != 0) {
+                hasPriorityConsumer.set(true);
+                return priority;
+            }
+            return c1.consumerName().compareTo(c2.consumerName());
+        });
 
-        // If it's a partitioned topic, sort consumers based on priority level then consumer name.
-        if (partitionIndex >= 0) {
-            AtomicBoolean hasPriorityConsumer = new AtomicBoolean(false);
-            consumers.sort((c1, c2) -> {
-                int priority = c1.getPriorityLevel() - c2.getPriorityLevel();
-                if (priority != 0) {
-                    hasPriorityConsumer.set(true);
-                    return priority;
-                }
-                return c1.consumerName().compareTo(c2.consumerName());
-            });
-
-            int consumersSize = consumers.size();
-            // find number of consumers which are having the highest priorities. so partitioned-topic assignment happens
-            // evenly across highest priority consumers
-            if (hasPriorityConsumer.get()) {
-                int highestPriorityLevel = consumers.get(0).getPriorityLevel();
-                for (int i = 0; i < consumers.size(); i++) {
-                    if (highestPriorityLevel != consumers.get(i).getPriorityLevel()) {
-                        consumersSize = i;
-                        break;
-                    }
+        int consumersSize = consumers.size();
+        // find number of consumers which are having the highest priorities. so partitioned-topic assignment happens
+        // evenly across highest priority consumers
+        if (hasPriorityConsumer.get()) {
+            int highestPriorityLevel = consumers.get(0).getPriorityLevel();
+            for (int i = 0; i < consumers.size(); i++) {
+                if (highestPriorityLevel != consumers.get(i).getPriorityLevel()) {
+                    consumersSize = i;
+                    break;
                 }
             }
-            index = partitionIndex % consumersSize;
         }
+        int index = partitionIndex >= 0
+                ? partitionIndex % consumersSize
+                : peekConsumerIndexFromHashRing(makeHashRing(consumersSize));
 
         Consumer prevConsumer = ACTIVE_CONSUMER_UPDATER.getAndSet(this, consumers.get(index));
 
@@ -134,6 +136,24 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
             scheduleReadOnActiveConsumer();
             return true;
         }
+    }
+
+    private int peekConsumerIndexFromHashRing(NavigableMap<Integer, Integer> hashRing) {
+        int hash = Murmur3Hash32.getInstance().makeHash(topicName);
+        Map.Entry<Integer, Integer> ceilingEntry = hashRing.ceilingEntry(hash);
+        return ceilingEntry != null ? ceilingEntry.getValue() : hashRing.firstEntry().getValue();
+    }
+
+    private NavigableMap<Integer, Integer> makeHashRing(int consumerSize) {
+        NavigableMap<Integer, Integer> hashRing = new TreeMap<>();
+        for (int i = 0; i < consumerSize; i++) {
+            for (int j = 0; j < CONSUMER_CONSISTENT_HASH_REPLICAS; j++) {
+                String key = consumers.get(i).consumerName() + j;
+                int hash = Murmur3_32Hash.getInstance().makeHash(key.getBytes());
+                hashRing.put(hash, i);
+            }
+        }
+        return hashRing;
     }
 
     public synchronized void addConsumer(Consumer consumer) throws BrokerServiceException {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ResendRequestTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ResendRequestTest.java
@@ -707,12 +707,19 @@ public class ResendRequestTest extends BrokerTestBase {
                 receivedConsumer1 += 1;
             }
         } while (message1 != null);
+        do {
+            message2 = consumer2.receive(500, TimeUnit.MILLISECONDS);
+            if (message2 != null) {
+                log.info("Consumer 2 Received: " + new String(message2.getData()));
+                receivedConsumer2 += 1;
+            }
+        } while (message2 != null);
         log.info("Consumer 1 receives = " + receivedConsumer1);
         log.info("Consumer 2 receives = " + receivedConsumer2);
         log.info("Total receives = " + (receivedConsumer2 + receivedConsumer1));
         assertEquals(receivedConsumer2 + receivedConsumer1, totalMessages);
         // Consumer 2 is on Stand By
-        assertEquals(receivedConsumer2, 0);
+        assertEquals(receivedConsumer1, 0);
 
         // 5. Consumer 2 asks for a redelivery but the request is ignored
         log.info("Consumer 2 asks for resend");
@@ -722,7 +729,7 @@ public class ResendRequestTest extends BrokerTestBase {
         message1 = consumer1.receive(500, TimeUnit.MILLISECONDS);
         message2 = consumer2.receive(500, TimeUnit.MILLISECONDS);
         assertNull(message1);
-        assertNull(message2);
+        assertNotNull(message2);
     }
 
     @SuppressWarnings("unchecked")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -1331,7 +1331,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         log.info("Topics are distributed to consumers as {}", eventListener.getActiveConsumers());
         Map<String, Integer> assigned = new HashMap<>();
         eventListener.getActiveConsumers().forEach((k, v) -> assigned.compute(v, (t, c) -> c == null ? 1 : ++ c));
-        assertEquals(assigned.size(), 10);
+        assertEquals(assigned.size(), consumers);
         for (Consumer<?> consumer : consumerList) {
             consumer.close();
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -30,6 +30,7 @@ import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerEventListener;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageRouter;
@@ -1302,6 +1303,57 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
             Assert.assertEquals(consumer.getPartitionsOfTheTopicMap(), 10);
             Assert.assertEquals(consumer.allTopicPartitionsNumber.intValue(), 10);
         });
+    }
+
+    @Test
+    public void testTopicsDistribution() throws Exception {
+        final String topic = "topics-distribution";
+        final int topicCount = 100;
+        final int consumers = 10;
+
+        for (int i = 0; i < topicCount; i++) {
+            admin.topics().createNonPartitionedTopic(topic + "-" + i);
+        }
+
+        CustomizedConsumerEventListener eventListener = new CustomizedConsumerEventListener();
+
+        List<Consumer<?>> consumerList = new ArrayList<>(consumers);
+        for (int i = 0; i < consumers; i++) {
+            consumerList.add(pulsarClient.newConsumer()
+                    .topics(IntStream.range(0, topicCount).mapToObj(j -> topic + "-" + j).toList())
+                    .subscriptionType(SubscriptionType.Failover)
+                    .subscriptionName("my-sub")
+                    .consumerName("consumer-" + i)
+                    .consumerEventListener(eventListener)
+                    .subscribe());
+        }
+
+        log.info("Topics are distributed to consumers as {}", eventListener.getActiveConsumers());
+        Map<String, Integer> assigned = new HashMap<>();
+        eventListener.getActiveConsumers().forEach((k, v) -> assigned.compute(v, (t, c) -> c == null ? 1 : ++ c));
+        assertEquals(assigned.size(), 10);
+        for (Consumer<?> consumer : consumerList) {
+            consumer.close();
+        }
+    }
+
+    private static class CustomizedConsumerEventListener implements ConsumerEventListener {
+
+        private final Map<String, String> activeConsumers = new HashMap<>();
+
+        @Override
+        public void becameActive(Consumer<?> consumer, int partitionId) {
+            activeConsumers.put(consumer.getTopic(), consumer.getConsumerName());
+        }
+
+        @Override
+        public void becameInactive(Consumer<?> consumer, int partitionId) {
+            //no-op
+        }
+
+        public Map<String, String> getActiveConsumers() {
+            return activeConsumers;
+        }
     }
 
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
@@ -240,9 +240,7 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
         ConsumerImpl<byte[]> consumer1 = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topicName)
                 .subscriptionName(subscriptionName).receiverQueueSize(0).subscriptionType(SubscriptionType.Failover)
                 .consumerName("consumer-1").subscribe();
-        ConsumerImpl<byte[]> consumer2 = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topicName)
-                .subscriptionName(subscriptionName).receiverQueueSize(0).subscriptionType(SubscriptionType.Failover)
-                .consumerName("consumer-2").subscribe();
+
 
         // 4. Produce Messages
         for (int i = 0; i < totalMessages; i++) {
@@ -259,6 +257,10 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
             assertEquals(consumer1.numMessagesInQueue(), 0);
             log.info("Consumer received : " + new String(message.getData()));
         }
+
+        ConsumerImpl<byte[]> consumer2 = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topicName)
+                .subscriptionName(subscriptionName).receiverQueueSize(0).subscriptionType(SubscriptionType.Failover)
+                .consumerName("consumer-2").subscribe();
 
         // 6. Trigger redelivery
         consumer1.redeliverUnacknowledgedMessages();


### PR DESCRIPTION
### Motivation

We cannot distribute the load of multiple topics to multiple consumers for the Failover subscription because only the first consumer will be taken if the topic is not partitioned.

https://github.com/apache/pulsar/blob/950ff441da28e144bdfb71c317a9bc339d4f05b7/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java#L96-L97

So, if you subscribe with the topic list or topic regex, the first connected consumer will be the active consumer of all the topics. Kafka has a [consumer group coordinator](https://developer.confluent.io/learn-kafka/architecture/consumer-group-protocol/), which can rebalance the load. 

For Pulsar, we don't have a consumer group coordinator. So this PR tries to introduce a consistent hash mechanism to peek the active consumer of a topic based on the consumer name hash and the topic name hash (note: the client will use the same consumer name to subscribe to all the topics that it wants).

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
