### PR TITLE
[fix][broker] Make ServerCnx#originalAuthData volatile

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -195,7 +195,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     // In case of proxy, if the authentication credentials are forwardable,
     // it will hold the credentials of the original client
     private AuthenticationState originalAuthState;
-    private AuthenticationDataSource originalAuthData;
+    private volatile AuthenticationDataSource originalAuthData;
     // Keep temporarily in order to verify after verifying proxy's authData
     private AuthData originalAuthDataCopy;
     private boolean pendingAuthChallengeResponse = false;


### PR DESCRIPTION
Fixes #19431 

### Motivation

`authenticationData` is already `volatile`. We use `originalAuthData` when set, so we should match the style. In #19431, I proposed that we find a way to not use `volatile`. I still think this might be a "better" approach, but it will be a larger change, and since we already use `volatile` for `authenticationData`, I think this is the right change for now.

It's possible that this is not a bug, given that the `originalAuthData` does not change frequently. However, we always want to use up to date values for authorization.

### Modifications

* Add `volatile` keyword to `ServerCnx#originalAuthData`.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation
- [x] `doc-not-needed`

### Matching PR in forked repository

PR in forked repository: skipping test in fork.