### PR TITLE
[fix][broker] Copy command fields and fix potential thread-safety in ServerCnx

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -2545,7 +2545,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         final String checkOwner = getPrincipal();
         return service.pulsar().getTransactionMetadataStoreService()
                 .verifyTxnOwnership(txnID, checkOwner)
-                .thenComposeAsync(isOwner -> {
+                .thenCompose(isOwner -> {
                     if (isOwner) {
                         return CompletableFuture.completedFuture(true);
                     }
@@ -2556,7 +2556,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     } else {
                         return CompletableFuture.completedFuture(false);
                     }
-                }, ctx.executor());
+                });
     }
 
     @Override


### PR DESCRIPTION
### Motivation

In https://github.com/apache/pulsar/pull/19467 we introduced a couple of possible issues about thread-safety of the `BaseCommand` and `ServerCnx` instances.

Original comments from @michaeljmarshall :
- https://github.com/apache/pulsar/pull/19467#discussion_r1101827289
- https://github.com/apache/pulsar/pull/19467#discussion_r1101815870

### Modifications

* Get the auth fields in the same thread of the connection
* Copy partitionList instead of reading it in another thread
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
