### PR TITLE
[fix][authentication] Store the original authentication data

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -737,15 +737,15 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 // 2. an authentication refresh, in which case we need to refresh authenticationData
                 AuthenticationState authState = useOriginalAuthState ? originalAuthState : this.authState;
                 String newAuthRole = authState.getAuthRole();
+                AuthenticationDataSource newAuthDataSource = authState.getAuthDataSource();
 
-                // Refresh the auth data.
-                this.authenticationData = authState.getAuthDataSource();
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Auth data refreshed for role={}", remoteAddress, this.authRole);
-                }
-
+                // Refresh the auth data and role.
                 if (!useOriginalAuthState) {
                     this.authRole = newAuthRole;
+                    this.authenticationData = newAuthDataSource;
+                } else {
+                    this.originalAuthData = newAuthDataSource;
+                    this.originalPrincipal = newAuthRole;
                 }
 
                 if (log.isDebugEnabled()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -739,29 +739,30 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 String newAuthRole = authState.getAuthRole();
                 AuthenticationDataSource newAuthDataSource = authState.getAuthDataSource();
 
-                // Refresh the auth data and role.
-                if (!useOriginalAuthState) {
-                    this.authRole = newAuthRole;
-                    this.authenticationData = newAuthDataSource;
-                } else {
-                    this.originalAuthData = newAuthDataSource;
-                    this.originalPrincipal = newAuthRole;
-                }
-
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Client successfully authenticated with {} role {} and originalPrincipal {}",
-                            remoteAddress, authMethod, this.authRole, originalPrincipal);
-                }
-
                 if (state != State.Connected) {
+                    // Set the auth data and auth role
+                    if (!useOriginalAuthState) {
+                        this.authRole = newAuthRole;
+                        this.authenticationData = newAuthDataSource;
+                    }
                     // First time authentication is done
                     if (originalAuthState != null) {
                         // We only set originalAuthState when we are going to use it.
                         authenticateOriginalData(clientProtocolVersion, clientVersion);
                     } else {
                         completeConnect(clientProtocolVersion, clientVersion);
+                        if (log.isDebugEnabled()) {
+                            log.debug("[{}] Client successfully authenticated with {} role {} and originalPrincipal {}",
+                                    remoteAddress, authMethod, this.authRole, originalPrincipal);
+                        }
                     }
                 } else {
+                    // Refresh the auth data
+                    if (!useOriginalAuthState) {
+                        this.authenticationData = newAuthDataSource;
+                    } else {
+                        this.originalAuthData = newAuthDataSource;
+                    }
                     // If the connection was already ready, it means we're doing a refresh
                     if (!StringUtils.isEmpty(authRole)) {
                         if (!authRole.equals(newAuthRole)) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthenticationProvider.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthenticationProvider.java
@@ -18,17 +18,11 @@
  */
 package org.apache.pulsar.broker.auth;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.IOException;
-import java.net.SocketAddress;
 import javax.naming.AuthenticationException;
-import javax.net.ssl.SSLSession;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.broker.authentication.AuthenticationDataCommand;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
-import org.apache.pulsar.broker.authentication.AuthenticationState;
-import org.apache.pulsar.common.api.AuthData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,41 +65,4 @@ public class MockAuthenticationProvider implements AuthenticationProvider {
                 "Not a valid principle. Should be [pass|fail|error].[pass|fail|error], found " + principal);
     }
 
-    @Override
-    public AuthenticationState newAuthState(AuthData authData, SocketAddress remoteAddress, SSLSession sslSession)
-            throws AuthenticationException {
-        return new MockAuthState(this);
-    }
-
-    private static class MockAuthState implements AuthenticationState {
-        private String authRole = null;
-        private AuthenticationDataSource dataSource = null;
-        private final MockAuthenticationProvider provider;
-
-        public MockAuthState(MockAuthenticationProvider provider) {
-            this.provider = provider;
-        }
-
-        @Override
-        public String getAuthRole() {
-            return authRole;
-        }
-
-        @Override
-        public AuthData authenticate(AuthData authData) throws AuthenticationException {
-            this.dataSource = new AuthenticationDataCommand(new String(authData.getBytes(), UTF_8));
-            this.authRole = provider.authenticate(this.dataSource);
-            return null;
-        }
-
-        @Override
-        public AuthenticationDataSource getAuthDataSource() {
-            return dataSource;
-        }
-
-        @Override
-        public boolean isComplete() {
-            return true;
-        }
-    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockMutableAuthenticationProvider.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockMutableAuthenticationProvider.java
@@ -18,19 +18,15 @@
  */
 package org.apache.pulsar.broker.auth;
 
-import org.apache.pulsar.broker.authentication.AuthenticationProvider;
+import org.apache.pulsar.broker.authentication.AuthenticationState;
+import org.apache.pulsar.common.api.AuthData;
+import javax.net.ssl.SSLSession;
+import java.net.SocketAddress;
 
-/**
- * Class to use when verifying the behavior around expired authentication data because it will always return
- * true when isExpired is called.
- */
-public class MockAlwaysExpiredAuthenticationState extends MockMutableAuthenticationState {
-    MockAlwaysExpiredAuthenticationState(AuthenticationProvider provider) {
-        super(provider);
-    }
-
-    @Override
-    public boolean isExpired() {
-        return true;
+public class MockMutableAuthenticationProvider extends MockAuthenticationProvider {
+    public AuthenticationState newAuthState(AuthData authData,
+                                            SocketAddress remoteAddress,
+                                            SSLSession sslSession) {
+        return new MockMutableAuthenticationState(this);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockMutableAuthenticationState.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockMutableAuthenticationState.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.auth;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import javax.naming.AuthenticationException;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.broker.authentication.AuthenticationDataCommand;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.broker.authentication.AuthenticationProvider;
+import org.apache.pulsar.broker.authentication.AuthenticationState;
+import org.apache.pulsar.common.api.AuthData;
+
+// MockMutableAuthenticationState always update the authentication data source and auth role.
+public class MockMutableAuthenticationState implements AuthenticationState {
+    final AuthenticationProvider provider;
+    AuthenticationDataSource authenticationDataSource;
+    volatile String authRole;
+
+    MockMutableAuthenticationState(AuthenticationProvider provider) {
+        this.provider = provider;
+    }
+
+    @Override
+    public String getAuthRole() throws AuthenticationException {
+        if (authRole == null) {
+            throw new AuthenticationException("Must authenticate first.");
+        }
+        return authRole;
+    }
+
+    @Override
+    public AuthData authenticate(AuthData authData) throws AuthenticationException {
+        return null;
+    }
+
+    /**
+     * This authentication is always single stage, so it returns immediately
+     */
+    @Override
+    public CompletableFuture<AuthData> authenticateAsync(AuthData authData) {
+        authenticationDataSource = new AuthenticationDataCommand(new String(authData.getBytes(), UTF_8));
+        return provider
+                .authenticateAsync(authenticationDataSource)
+                .thenApply(role -> {
+                    authRole = role;
+                    return null;
+                });
+    }
+
+    @Override
+    public AuthenticationDataSource getAuthDataSource() {
+        return authenticationDataSource;
+    }
+
+    @Override
+    public boolean isComplete() {
+        return true;
+    }
+
+    @Override
+    public boolean isExpired() {
+        return false;
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -75,6 +75,7 @@ import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.MockAlwaysExpiredAuthenticationProvider;
+import org.apache.pulsar.broker.auth.MockMutableAuthenticationProvider;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSubscription;
 import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.broker.TransactionMetadataStoreService;
@@ -1033,7 +1034,7 @@ public class ServerCnxTest {
     @Test
     public void testRefreshOriginalPrincipalWithAuthDataForwardedFromProxy() throws Exception {
         AuthenticationService authenticationService = mock(AuthenticationService.class);
-        AuthenticationProvider authenticationProvider = new MockAuthenticationProvider();
+        AuthenticationProvider authenticationProvider = new MockMutableAuthenticationProvider();
         String authMethodName = authenticationProvider.getAuthMethodName();
         when(brokerService.getAuthenticationService()).thenReturn(authenticationService);
         when(authenticationService.getAuthenticationProvider(authMethodName)).thenReturn(authenticationProvider);
@@ -1059,11 +1060,11 @@ public class ServerCnxTest {
         assertEquals(serverCnx.getAuthRole(), proxyRole);
         assertEquals(serverCnx.getAuthState().getAuthRole(), proxyRole);
 
-        String newClientRole = "pass.RefreshOriginAuthData";
         // Request refreshing the original auth.
         // Expected:
         // 1. Original role and original data equals to "pass.RefreshOriginAuthData".
         // 2. The broker disconnects the client, because the new role doesn't equal the old role.
+        String newClientRole = "pass.RefreshOriginAuthData";
         ByteBuf refreshAuth = Commands.newAuthResponse(authMethodName,
                 AuthData.of(newClientRole.getBytes(StandardCharsets.UTF_8)), 0, "test");
         channel.writeInbound(refreshAuth);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -1071,7 +1071,6 @@ public class ServerCnxTest {
 
         assertEquals(serverCnx.getOriginalAuthData().getCommandData(), newClientRole);
         assertEquals(serverCnx.getOriginalAuthState().getAuthRole(), newClientRole);
-        assertEquals(serverCnx.getOriginalPrincipal(), newClientRole);
         assertEquals(serverCnx.getAuthData().getCommandData(), proxyRole);
         assertEquals(serverCnx.getAuthRole(), proxyRole);
         assertEquals(serverCnx.getAuthState().getAuthRole(), proxyRole);


### PR DESCRIPTION
### Motivation

In the authentication:

- With the proxy, the broker stores the client authentication to the `originalAuthData` and `originalPrincipal`, and stores the proxy authentication to the `authenticationData` and `authRole`.
- Without the proxy, the broker stores the authentication to the `authenticationData` and `authRole`


When with the proxy, the broker only checks whether `originalAuthData` is expired. If true, the broker sends `AuthChallenge` to the client, then the client sends `CommandAuthResponse`.

In `handleAuthResponse` logic, the broker always stores the authentication to `authenticationData` and `authRole`, without considering the proxy case. When the authorization provider checks the role and authentication data, it is unmatched, this is incorrect behavior, so we need to distinguish whether have the proxy and then store the authentication data and role correctly.

More context: https://github.com/apache/pulsar/pull/18130

### Modifications

- Fix storing the authentication in the `authChallengeSuccessCallback` 
- Add `MockMutableAuthenticationProvider` and `MockMutableAuthenticationState` to refresh the role and datasource
- Make `MockAlwaysExpiredAuthenticationState` extends  `MockMutableAuthenticationState` to avoid the code duplication, and override the `isExpired` 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

Added `testRefreshOriginalPrincipalWithAuthDataForwardedFromProxy` test

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
