### PR TITLE
[fix][client] Add explicit dependency on athenz-cert-refresher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -891,6 +891,12 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
+        <groupId>com.yahoo.athenz</groupId>
+        <artifactId>athenz-cert-refresher</artifactId>
+        <version>${athenz.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.github.zafarkhaja</groupId>
         <artifactId>java-semver</artifactId>
         <version>${java-semver.version}</version>

--- a/pulsar-client-auth-athenz/pom.xml
+++ b/pulsar-client-auth-athenz/pom.xml
@@ -48,6 +48,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.yahoo.athenz</groupId>
+      <artifactId>athenz-cert-refresher</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>


### PR DESCRIPTION
### Motivation

In https://github.com/apache/pulsar/pull/19445, I added import statements for the `com.oath.auth.*` classes to the `AuthenticationAthenz` class. These classes are in a package named `athenz-cert-refresher`, so we should add a dependency on this package. However, due to the indirect dependency, `athenz-cert-refresher` will be installed without doing this and the build will not fail.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->