### PR TITLE
[fix][sec] Upgrade kafka client to 3.4.0 to fix CVE-2023-25194

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@ flexible messaging model and an intuitive client API.</description>
     <hbc-core.version>2.2.0</hbc-core.version>
     <cassandra.version>3.11.2</cassandra.version>
     <aerospike-client.version>4.4.20</aerospike-client.version>
-    <kafka-client.version>2.8.2</kafka-client.version>
+    <kafka-client.version>3.4.0</kafka-client.version>
     <rabbitmq-client.version>5.5.3</rabbitmq-client.version>
     <aws-sdk.version>1.12.262</aws-sdk.version>
     <avro.version>1.10.2</avro.version>


### PR DESCRIPTION
### Motivation

OWASP dependency checks are currently failing on some other PRs (e.g. https://github.com/apache/pulsar/actions/runs/4180151982/jobs/7241507184).
```
Error:  Failed to execute goal org.owasp:dependency-check-maven:8.0.1:aggregate (default) on project pulsar: 
Error:  
Error:  One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '7.0': 
Error:  
Error:  kafka-clients-2.8.2.jar: CVE-2023-25194(8.8)
Error:  
Error:  See the dependency-check report for more details.
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
Error:  
Error:  After correcting the problems, you can resume the build with the command
Error:    mvn <args> -rf :pulsar
Error: Process completed with exit code 1.
```
Apparently `kafka-clients-2.8.2` seems to have a high level security vulnerability.

### Modifications

Upgraded `kafka-clients` to 3.4.0, the latest version. This is a major version upgrade, but I don't know if there are other things to fix.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->