### PR TITLE
[fix] [broker] Make the service name resolver cache of PulsarWebResource expire after access

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -103,7 +103,7 @@ public abstract class PulsarWebResource {
     private static final Logger log = LoggerFactory.getLogger(PulsarWebResource.class);
 
     private static final LoadingCache<String, PulsarServiceNameResolver> SERVICE_NAME_RESOLVER_CACHE =
-            Caffeine.newBuilder().expireAfterWrite(Duration.ofMinutes(5)).build(
+            Caffeine.newBuilder().expireAfterAccess(Duration.ofMinutes(5)).build(
                     new CacheLoader<>() {
                         @Override
                         public @Nullable PulsarServiceNameResolver load(@NonNull String serviceUrl) throws Exception {


### PR DESCRIPTION
### Motivation

see https://github.com/apache/pulsar/pull/19505#discussion_r1107373967

`PulsarServiceNameResolver` is used to randomly select a service name from multiple service names, the logic is:
- select a random index of the service name list
- if the previous service name can not work, use `{previous index} + 1`

But when the cache of`PulsarServiceNameResolver` refreshes, it will create a new `PulsarServiceNameResolver` instance, which will break the logic "if the previous service name can not work, use `{previous index} + 1`"

### Modifications

Make the service name resolver cache of PulsarWebResource expire after access

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 

- https://github.com/poorbarcode/pulsar/pull/69
