### PR TITLE
[improve][broker] Use shrink map for trackerCache

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryRedeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryRedeliveryTracker.java
@@ -27,8 +27,8 @@ import org.apache.pulsar.common.util.collections.ConcurrentLongLongPairHashMap.L
 public class InMemoryRedeliveryTracker implements RedeliveryTracker {
 
     private ConcurrentLongLongPairHashMap trackerCache = ConcurrentLongLongPairHashMap.newBuilder()
-            .concurrencyLevel(2)
-            .expectedItems(128)
+            .concurrencyLevel(1)
+            .expectedItems(256)
             .autoShrink(true)
             .build();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryRedeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryRedeliveryTracker.java
@@ -26,7 +26,7 @@ import org.apache.pulsar.common.util.collections.ConcurrentLongLongPairHashMap.L
 
 public class InMemoryRedeliveryTracker implements RedeliveryTracker {
 
-    private ConcurrentLongLongPairHashMap trackerCache = new ConcurrentLongLongPairHashMap.newBuilder()
+    private ConcurrentLongLongPairHashMap trackerCache = ConcurrentLongLongPairHashMap.newBuilder()
             .concurrencyLevel(2)
             .expectedItems(128)
             .autoShrink(true)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryRedeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/InMemoryRedeliveryTracker.java
@@ -21,12 +21,16 @@ package org.apache.pulsar.broker.service;
 import java.util.List;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
-import org.apache.bookkeeper.util.collections.ConcurrentLongLongPairHashMap;
-import org.apache.bookkeeper.util.collections.ConcurrentLongLongPairHashMap.LongPair;
+import org.apache.pulsar.common.util.collections.ConcurrentLongLongPairHashMap;
+import org.apache.pulsar.common.util.collections.ConcurrentLongLongPairHashMap.LongPair;
 
 public class InMemoryRedeliveryTracker implements RedeliveryTracker {
 
-    private ConcurrentLongLongPairHashMap trackerCache = new ConcurrentLongLongPairHashMap(256, 1);
+    private ConcurrentLongLongPairHashMap trackerCache = new ConcurrentLongLongPairHashMap.newBuilder()
+            .concurrencyLevel(2)
+            .expectedItems(128)
+            .autoShrink(true)
+            .build();
 
     @Override
     public int incrementAndGetRedeliveryCount(Position position) {


### PR DESCRIPTION
### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Currently, the `trackerCache` uses a ConcurrentLongLongPairHashMap that does not shrink, causing `trackerCache` to occupy a large amount of memory and has no way to release it.

By monitoring the market through the JVM, we can see that during that time period, Young GC and Full GC have been frequently triggered, resulting in a large delay in Young GC and Full GC, which in turn affects production and consumption.

![image](https://user-images.githubusercontent.com/20965307/219296488-084a2df0-e4d5-45ed-8888-536515f6d6e0.png)
![image](https://user-images.githubusercontent.com/20965307/219296556-e4173dae-8480-4eeb-b2e0-bc4d4a3bcd6a.png)

But what is interesting is that we can see that after the Young GC and Full GC are triggered many times, the memory in the heap is not reclaimed, so the Young GC and Full GC are triggered frequently.

![image](https://user-images.githubusercontent.com/20965307/219296608-ab32b520-fcf3-4221-a241-130dd9cd3bba.png)

Therefore, based on the above background, we made a memory dump of the Broker node and found that the set of trackerCache occupies most of the memory and this part of memory uses a non-shrink map, which will never be released. For details, refer to the following dump information:

![image](https://user-images.githubusercontent.com/20965307/219295709-ad797b3d-5bcf-479f-b566-84631bc75aa9.png)


### Modifications

- Use shrink map for trackerCache



- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->