### PR TITLE
[fix][ml] Fix ML init fail if ledger file was deleted from disk

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -60,6 +60,7 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
@@ -264,7 +265,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
 
     @Test
     public void testLastEntryReadErrorWhenInitWithManagedLedgerInterceptor() throws Exception {
-        final String ledgerName  = "testLastEntryReadErrorWhenInitWithManagedLedgerInterceptor";
+        final String ledgerName  = "testLastEntryReadErrorWhenInitWithManagedLedgerInterceptor" + UUID.randomUUID();
         ManagedLedgerConfig conf = new ManagedLedgerConfig();
         conf.setMaxEntriesPerLedger(1);
         conf.setManagedLedgerInterceptor(new ManagedLedgerInterceptorImpl(getBrokerEntryMetadataInterceptors(), null));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -264,7 +264,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
 
     @Test
     public void testLastEntryReadErrorWhenInitWithManagedLedgerInterceptor() throws Exception {
-        final String ledgerName  = "testLastEntryReadErrorWhenInit";
+        final String ledgerName  = "testLastEntryReadErrorWhenInitWithManagedLedgerInterceptor";
         ManagedLedgerConfig conf = new ManagedLedgerConfig();
         conf.setMaxEntriesPerLedger(1);
         conf.setManagedLedgerInterceptor(new ManagedLedgerInterceptorImpl(getBrokerEntryMetadataInterceptors(), null));


### PR DESCRIPTION
### Motivation

If we delete the ledger file from the bookkeeper,  we could open the ledger but will read fail.   Then if we restart the broker server to trigger ManagedLedgerImpl initializes,  the `AppendIndexMetadataInterceptor` will try to read the LAC position to recovery the index, which will cause the topic creating fail, see line425

https://github.com/apache/pulsar/blob/cb306c8e6c5da3a05ea312a5e5746eb178d9ab10/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L421-L427

To fix it , we should do the same action as line434~line435 if `BKNoSuchLedgerExistsException` thrown.

https://github.com/apache/pulsar/blob/cb306c8e6c5da3a05ea312a5e5746eb178d9ab10/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L432-L436

### Modifications

Removing the ledger from `ManagedLedgerImpl` and call `initializeBookKeeper()` if  `managedLedgerInterceptor.onManagedLedgerLastLedgerInitialize` throws `BKNoSuchLedgerExistsException`,
instead of callback fail.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
- Add UT `org.apache.pulsar.broker.service.PersistentTopicTest#testLastEntryReadErrorWhenInitWithManagedLedgerInterceptor`



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/AnonHxy/pulsar/pull/29
