### PR TITLE
[fix][broker][branch-2.10] Replace sync method call in async call chain to prevent ZK event thread deadlock

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2421,10 +2421,11 @@ public class PersistentTopicsBase extends AdminResource {
                         if (topicMetadata.partitions > 0) {
                             log.warn("[{}] Not supported operation on partitioned-topic {} {}",
                                     clientAppId(), topicName, subName);
-                            asyncResponse.resume(new RestException(Status.METHOD_NOT_ALLOWED,
+                            throw new CompletionException(new RestException(Status.METHOD_NOT_ALLOWED,
                                     "Reset-cursor at position is not allowed for partitioned-topic"));
+                        } else {
+                            return CompletableFuture.completedFuture(null);
                         }
-                        return CompletableFuture.completedFuture(null);
                     });
         } else {
             ret = CompletableFuture.completedFuture(null);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -609,6 +609,22 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         consumer.close();
     }
 
+    @Test
+    public void shouldNotSupportResetOnPartitionedTopic() throws PulsarAdminException, PulsarClientException {
+        final String partitionedTopicName = "persistent://prop-xyz/ns1/" + BrokerTestUtil.newUniqueName("parttopic");
+        admin.topics().createPartitionedTopic(partitionedTopicName, 4);
+        @Cleanup
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(partitionedTopicName).subscriptionName("my-sub")
+                .subscriptionType(SubscriptionType.Shared).subscribe();
+        try {
+            admin.topics().resetCursor(partitionedTopicName, "my-sub", MessageId.earliest);
+            fail();
+        } catch (PulsarAdminException.NotAllowedException e) {
+            assertTrue(e.getMessage().contains("Reset-cursor at position is not allowed for partitioned-topic"),
+                    "Condition doesn't match. Actual message:" + e.getMessage());
+        }
+    }
+
     private void publishMessagesOnPersistentTopic(String topicName, int messages, int startIdx) throws Exception {
         Producer<byte[]> producer = pulsarClient.newProducer()
             .topic(topicName)


### PR DESCRIPTION
Fixes #19536

### Motivation

Please check #19536 for details about the problem this PR fixes. 


### Modifications

This backports changes from #19015 to branch-2.10 for replacing a sync method call in async call chain.
In addition, there's a test and an improvement to the #19015 solution which would attempt to execute the call
also for partitioned topics. I'll submit a separate PR to fix that issue in master / branch-2.11.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->