### PR TITLE
[fix][broker] Terminate the async call chain when the condition isn't met for resetCursor

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2672,7 +2672,7 @@ public class PersistentTopicsBase extends AdminResource {
                         if (topicMetadata.partitions > 0) {
                             log.warn("[{}] Not supported operation on partitioned-topic {} {}",
                                     clientAppId(), topicName, subName);
-                            asyncResponse.resume(new RestException(Status.METHOD_NOT_ALLOWED,
+                            throw new CompletionException(new RestException(Status.METHOD_NOT_ALLOWED,
                                     "Reset-cursor at position is not allowed for partitioned-topic"));
                         }
                         return CompletableFuture.completedFuture(null);


### PR DESCRIPTION
### Motivation

- resetCursor isn't supported for partitioned topics. However, in the previous async call solution made by #19015, the async call chain wasn't terminated when the condition failed.

### Modifications

- throw the exception instead of completing the async request
- add a test case

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->