### PR TITLE
[fix] [test] Wrong mock-fail of the test ManagedLedgerErrorsTest.recoverLongTimeAfterMultipleWriteErrors

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerErrorsTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerErrorsTest.java
@@ -552,7 +552,7 @@ public class ManagedLedgerErrorsTest extends MockedBookKeeperTestCase {
                 fail("The expected behavior is that the first ledger will be deleted, but it still exists.");
             } catch (Exception ledgerDeletedEx){
                 // Expected LedgerNotExistsEx: the first ledger will be deleted after add entry fail.
-                ledgerDeletedEx.printStackTrace();
+                assertTrue(ledgerDeletedEx instanceof BKException.BKNoSuchLedgerExistsException);
             }
         });
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerErrorsTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerErrorsTest.java
@@ -34,6 +34,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
 import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.CloseCallback;
@@ -48,6 +50,7 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.impl.FaultInjectionMetadataStore;
+import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
@@ -511,9 +514,10 @@ public class ManagedLedgerErrorsTest extends MockedBookKeeperTestCase {
     public void recoverLongTimeAfterMultipleWriteErrors() throws Exception {
         ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("recoverLongTimeAfterMultipleWriteErrors");
         ManagedCursor cursor = ledger.openCursor("c1");
+        LedgerHandle firstLedger = ledger.currentLedger;
 
-        bkc.failAfter(0, BKException.Code.BookieHandleNotAvailableException);
-        bkc.failAfter(1, BKException.Code.BookieHandleNotAvailableException);
+        bkc.addEntryFailAfter(0, BKException.Code.BookieHandleNotAvailableException);
+        bkc.addEntryFailAfter(1, BKException.Code.BookieHandleNotAvailableException);
 
         CountDownLatch counter = new CountDownLatch(2);
         AtomicReference<ManagedLedgerException> ex = new AtomicReference<>();
@@ -539,6 +543,18 @@ public class ManagedLedgerErrorsTest extends MockedBookKeeperTestCase {
 
         counter.await();
         assertNull(ex.get());
+
+        Awaitility.await().untilAsserted(() -> {
+            try {
+                bkc.openLedger(firstLedger.getId(),
+                        BookKeeper.DigestType.fromApiDigestType(ledger.getConfig().getDigestType()),
+                        ledger.getConfig().getPassword());
+                fail("The expected behavior is that the first ledger will be deleted, but it still exists.");
+            } catch (Exception ledgerDeletedEx){
+                // Expected LedgerNotExistsEx: the first ledger will be deleted after add entry fail.
+                ledgerDeletedEx.printStackTrace();
+            }
+        });
 
         assertEquals(cursor.getNumberOfEntriesInBacklog(false), 2);
 

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
@@ -168,7 +168,7 @@ public class PulsarMockLedgerHandle extends LedgerHandle {
 
     @Override
     public void asyncAddEntry(final ByteBuf data, final AddCallback cb, final Object ctx) {
-        bk.getProgrammedFailure().thenComposeAsync((res) -> {
+        bk.getAddEntryFailure().thenComposeAsync((res) -> {
                 Long delayMillis = bk.addEntryDelaysMillis.poll();
                 if (delayMillis == null) {
                     delayMillis = 1L;


### PR DESCRIPTION
### Motivation

In the test `ManagedLedgerErrorsTest.recoverLongTimeAfterMultipleWriteErrors`, it mocks two errors of add entries, then verify that the final write succeeds.

But the event of add entry failure triggers two other operations: `delete current ledger` and `create a new ledger`, these two operations have the probability of consuming the error events that were mocked earlier. As a result, the intent of the test is not being performed correctly.  If the error event is consumed by `create a new ledger`, it will make the test unstable， see: https://github.com/apache/pulsar/actions/runs/4195006942/jobs/7274314432

You can reproduce the issue by the test `recoverLongTimeAfterMultipleWriteErrors` in the current PR, adding `sleep(1000)` after line 541 before line 542 increases the probability of reproducing the issue, just like this:

```java
ledger.asyncAddEntry("entry-1".getBytes(), cb, null);
Thread.sleep(1000);
ledger.asyncAddEntry("entry-2".getBytes(), cb, null);
```

### Modifications

Use a specific method when we only need to mock a failed event of add entry.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- https://github.com/poorbarcode/pulsar/pull/70
