### PR TITLE
[fix][broker] Fixed history load not releasing

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadSheddingStrategy.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadSheddingStrategy.java
@@ -43,5 +43,5 @@ public interface LoadSheddingStrategy {
      *
      * @param activeBrokers active Brokers
      */
-    default void onBrokerChange(Set<String> activeBrokers) {}
+    default void onActiveBrokersChange(Set<String> activeBrokers) {}
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadSheddingStrategy.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadSheddingStrategy.java
@@ -39,7 +39,7 @@ public interface LoadSheddingStrategy {
     Multimap<String, String> findBundlesForUnloading(LoadData loadData, ServiceConfiguration conf);
 
     /**
-     * Triggered when active broker changes
+     * Triggered when active broker changes.
      *
      * @param activeBrokers active Brokers
      */

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadSheddingStrategy.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadSheddingStrategy.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.loadbalance;
 
 import com.google.common.collect.Multimap;
+import java.util.Set;
 import org.apache.pulsar.broker.ServiceConfiguration;
 
 /**
@@ -36,4 +37,11 @@ public interface LoadSheddingStrategy {
      * @return A map from all selected bundles to the brokers on which they reside.
      */
     Multimap<String, String> findBundlesForUnloading(LoadData loadData, ServiceConfiguration conf);
+
+    /**
+     * Triggered when active broker changes
+     *
+     * @param activeBrokers active Brokers
+     */
+    default void onBrokerChange(Set<String> activeBrokers) {}
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -490,7 +490,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                 && pulsar.getLeaderElectionService().isLeader()) {
             deadBrokers.forEach(this::deleteTimeAverageDataFromMetadataStoreAsync);
             for (LoadSheddingStrategy loadSheddingStrategy : loadSheddingPipeline) {
-                loadSheddingStrategy.onBrokerChange(activeBrokers);
+                loadSheddingStrategy.onActiveBrokersChange(activeBrokers);
             }
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -489,6 +489,9 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         if (pulsar.getLeaderElectionService() != null
                 && pulsar.getLeaderElectionService().isLeader()) {
             deadBrokers.forEach(this::deleteTimeAverageDataFromMetadataStoreAsync);
+            for (LoadSheddingStrategy loadSheddingStrategy : loadSheddingPipeline) {
+                loadSheddingStrategy.onBrokerChange(activeBrokers);
+            }
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
@@ -60,7 +60,8 @@ public class ThresholdShedder implements LoadSheddingStrategy {
     private final Map<String, Double> brokerAvgResourceUsage = new HashMap<>();
 
     @Override
-    public synchronized Multimap<String, String> findBundlesForUnloading(final LoadData loadData, final ServiceConfiguration conf) {
+    public synchronized Multimap<String, String> findBundlesForUnloading(final LoadData loadData,
+                                                                         final ServiceConfiguration conf) {
         selectedBundlesCache.clear();
         final double threshold = conf.getLoadBalancerBrokerThresholdShedderPercentage() / 100.0;
         final Map<String, Long> recentlyUnloadedBundles = loadData.getRecentlyUnloadedBundles();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
@@ -20,11 +20,9 @@ package org.apache.pulsar.broker.loadbalance.impl;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableDouble;
 import org.apache.commons.lang3.tuple.Pair;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
@@ -238,7 +238,7 @@ public class ThresholdShedder implements LoadSheddingStrategy {
         return Pair.of(hasBrokerBelowLowerBound, maxUsageBrokerName);
     }
     @Override
-    public void onBrokerChange(Set<String> newBrokers) {
+    public void onActiveBrokersChange(Set<String> newBrokers) {
         synchronized (activeBrokers) {
             activeBrokers.clear();
             activeBrokers.addAll(newBrokers);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedderTest.java
@@ -23,7 +23,10 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import java.lang.reflect.Field;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.LoadData;
@@ -55,6 +58,18 @@ public class ThresholdShedderTest {
     public void testNoBrokers() {
         LoadData loadData = new LoadData();
         assertTrue(thresholdShedder.findBundlesForUnloading(loadData, conf).isEmpty());
+    }
+
+    @Test
+    public void testCleanCache() throws Exception {
+        testBrokerReachThreshold();
+        Field field = ThresholdShedder.class.getDeclaredField("brokerAvgResourceUsage");
+        field.setAccessible(true);
+        Map<String, Double> map = (Map<String, Double>) field.get(thresholdShedder);
+        assertFalse(map.isEmpty());
+        thresholdShedder.onBrokerChange(new HashSet<>());
+        map = (Map<String, Double>) field.get(thresholdShedder);
+        assertTrue(map.isEmpty());
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedderTest.java
@@ -67,7 +67,10 @@ public class ThresholdShedderTest {
         field.setAccessible(true);
         Map<String, Double> map = (Map<String, Double>) field.get(thresholdShedder);
         assertFalse(map.isEmpty());
-        thresholdShedder.onBrokerChange(new HashSet<>());
+        HashSet<String> activeBrokers = new HashSet<>();
+        activeBrokers.add("leader");
+        thresholdShedder.onBrokerChange(activeBrokers);
+        thresholdShedder.findBundlesForUnloading(new LoadData(), conf);
         map = (Map<String, Double>) field.get(thresholdShedder);
         assertTrue(map.isEmpty());
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedderTest.java
@@ -69,7 +69,7 @@ public class ThresholdShedderTest {
         assertFalse(map.isEmpty());
         HashSet<String> activeBrokers = new HashSet<>();
         activeBrokers.add("leader");
-        thresholdShedder.onBrokerChange(activeBrokers);
+        thresholdShedder.onActiveBrokersChange(activeBrokers);
         thresholdShedder.findBundlesForUnloading(new LoadData(), conf);
         map = (Map<String, Double>) field.get(thresholdShedder);
         assertTrue(map.isEmpty());


### PR DESCRIPTION
### Motivation
When a broker in the cluster is not active, its load still remain in the memory of the Leader. 
If deployed in a container, brokers will scale up and down frequently, and the memory of the Leader gradually increase

### Modifications
When a broker is no longer active, delete its load information

### Verifying this change
https://github.com/315157973/pulsar/pull/6

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

