### PR TITLE
[fix] [client] fix memory leak if enabled pooled messages

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -948,7 +948,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         assertNotEquals(payload.refCnt(), 0);
         consumer.redeliverUnacknowledgedMessages();
         Awaitility.await().untilAsserted(() -> {
-            assertEquals(consumer.incomingMessages.size(), 100);
+            assertTrue(consumer.incomingMessages.size() >=100);
         });
         consumer.close();
         producer.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -947,9 +947,14 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         ByteBuf payload = ((MessageImpl) msg).getPayload();
         assertNotEquals(payload.refCnt(), 0);
         consumer.redeliverUnacknowledgedMessages();
-        assertEquals(payload.refCnt(), 0);
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(consumer.incomingMessages.size(), 100);
+        });
         consumer.close();
         producer.close();
+        admin.topics().delete(topic, false);
+        assertEquals(consumer.incomingMessages.size(), 0);
+        assertEquals(payload.refCnt(), 0);
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -948,7 +948,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         assertNotEquals(payload.refCnt(), 0);
         consumer.redeliverUnacknowledgedMessages();
         Awaitility.await().untilAsserted(() -> {
-            assertTrue(consumer.incomingMessages.size() >=100);
+            assertTrue(consumer.incomingMessages.size() >= 100);
         });
         consumer.close();
         producer.close();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -82,7 +82,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     protected final ExecutorService externalPinnedExecutor;
     protected final ExecutorService internalPinnedExecutor;
     protected UnAckedMessageTracker unAckedMessageTracker;
-    final BlockingQueue<Message<T>> incomingMessages;
+    final GrowableArrayBlockingQueue<Message<T>> incomingMessages;
     protected ConcurrentOpenHashMap<MessageIdImpl, MessageIdImpl[]> unAckedChunkedMessageIdSequenceMap;
     protected final ConcurrentLinkedQueue<CompletableFuture<Message<T>>> pendingReceives;
     protected final int maxReceiverQueueSize;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -50,7 +50,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -1077,42 +1076,16 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         negativeAcksTracker.close();
         stats.getStatTimeout().ifPresent(Timeout::cancel);
         if (poolMessages) {
-            releasePooledMessages();
+            releasePooledMessagesAndStopAcceptNew();
         }
     }
 
     /**
-     * If enabled pooled messages, we should release the messages after closing consumer.
-     *   1. Call "clearIncomingMessages" regardless of whether "internalPinnedExecutor" has shutdown or not.
-     *   2. Increment epoch will auto release all messages which received after close.
-     *   3. Call "clearIncomingMessages" in "internalPinnedExecutor" is used to clear messages in flight.
+     * If enabled pooled messages, we should release the messages after closing consumer and stop accept the new
+     * messages.
      */
-    private void releasePooledMessages() {
-        // Increment epoch.
-        CONSUMER_EPOCH.incrementAndGet(this);
-        // Try clear the incoming queue in internalPinnedExecutor-thread.
-        boolean executorIsShutdown;
-        try {
-            if (!(executorIsShutdown = internalPinnedExecutor.isShutdown())) {
-                internalPinnedExecutor.execute(this::clearIncomingMessages);
-            }
-        } catch (RejectedExecutionException rejectedExecutionException) {
-            executorIsShutdown = true;
-        }
-        // If internalPinnedExecutor is shutdown, try await termination and clear the incoming queue.
-        if (executorIsShutdown) {
-            boolean awaitTerminationSuccess = false;
-            try {
-                awaitTerminationSuccess = internalPinnedExecutor.awaitTermination(1, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
-                // Current thread is interrupted, so awaitTerminationSuccess will be false.
-            }
-            if (!awaitTerminationSuccess){
-                log.warn("[{}] [{}] Failed to wait for in-flight messages, there is a small probability that client"
-                        + " memory leaks will occur", topicName, subscription);
-            }
-        }
-        // Call "clearIncomingMessages" regardless of whether "internalPinnedExecutor" has shutdown or not.
+    private void releasePooledMessagesAndStopAcceptNew() {
+        incomingMessages.terminate(message -> message.release());
         clearIncomingMessages();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1004,6 +1004,10 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     public CompletableFuture<Void> closeAsync() {
         CompletableFuture<Void> closeFuture = new CompletableFuture<>();
 
+        if (poolMessages) {
+            clearIncomingMessages();
+        }
+
         if (getState() == State.Closing || getState() == State.Closed) {
             closeConsumerTasks();
             failPendingReceive().whenComplete((r, t) -> closeFuture.complete(null));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1091,7 +1091,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         // Increment epoch.
         CONSUMER_EPOCH.incrementAndGet(this);
         // Try clear the incoming queue in internalPinnedExecutor-thread.
-        boolean executorIsShutdown = false;
+        boolean executorIsShutdown;
         try {
             if (!(executorIsShutdown = internalPinnedExecutor.isShutdown())) {
                 internalPinnedExecutor.execute(this::clearIncomingMessages);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1077,8 +1077,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         stats.getStatTimeout().ifPresent(Timeout::cancel);
         // Execute "clearIncomingMessages" regardless of whether "internalPinnedExecutor" has shutdown or not.
         // Call "clearIncomingMessages" in "internalPinnedExecutor" is used to clear messages in flight.
-        clearIncomingMessages();
-        internalPinnedExecutor.execute(this::clearIncomingMessages);
+        if (!internalPinnedExecutor.isShutdown()) {
+            internalPinnedExecutor.execute(this::clearIncomingMessages);
+        } else {
+            clearIncomingMessages();
+        }
     }
 
     void activeConsumerChanged(boolean isActive) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1076,7 +1076,9 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         }
         negativeAcksTracker.close();
         stats.getStatTimeout().ifPresent(Timeout::cancel);
-        releaseMsgIfEnabledPooledMsg();
+        if (poolMessages) {
+            releasePooledMessages();
+        }
     }
 
     /**
@@ -1085,10 +1087,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
      *   2. Increment epoch will auto release all messages which received after close.
      *   3. Call "clearIncomingMessages" in "internalPinnedExecutor" is used to clear messages in flight.
      */
-    private void releaseMsgIfEnabledPooledMsg() {
-        if (!poolMessages) {
-            return;
-        }
+    private void releasePooledMessages() {
         // Increment epoch.
         CONSUMER_EPOCH.incrementAndGet(this);
         // Try clear the incoming queue in internalPinnedExecutor-thread.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1077,10 +1077,9 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         stats.getStatTimeout().ifPresent(Timeout::cancel);
         // Execute "clearIncomingMessages" regardless of whether "internalPinnedExecutor" has shutdown or not.
         // Call "clearIncomingMessages" in "internalPinnedExecutor" is used to clear messages in flight.
+        clearIncomingMessages();
         if (!internalPinnedExecutor.isShutdown()) {
             internalPinnedExecutor.execute(this::clearIncomingMessages);
-        } else {
-            clearIncomingMessages();
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1093,7 +1093,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         // Try clear the incoming queue in internalPinnedExecutor-thread.
         boolean executorIsShutdown = false;
         try {
-            if (!internalPinnedExecutor.isShutdown()) {
+            if (!(executorIsShutdown = internalPinnedExecutor.isShutdown())) {
                 internalPinnedExecutor.execute(this::clearIncomingMessages);
             }
         } catch (RejectedExecutionException rejectedExecutionException) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueue.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueue.java
@@ -422,6 +422,9 @@ public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements B
         if (itemAfterTerminatedHandler != null) {
             this.itemAfterTerminatedHandler = itemAfterTerminatedHandler;
         }
+        // After wait for the in-flight item enqueue, it means the operation of terminate is finished.
+        long stamp = tailLock.writeLock();
+        tailLock.unlockWrite(stamp);
     }
 
     public boolean isTerminated() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueue.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueue.java
@@ -418,13 +418,16 @@ public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements B
      * by {@param itemAfterTerminatedHandler}.
      */
     public void terminate(@Nullable Consumer<T> itemAfterTerminatedHandler) {
-        terminated = true;
-        if (itemAfterTerminatedHandler != null) {
-            this.itemAfterTerminatedHandler = itemAfterTerminatedHandler;
-        }
         // After wait for the in-flight item enqueue, it means the operation of terminate is finished.
         long stamp = tailLock.writeLock();
-        tailLock.unlockWrite(stamp);
+        try {
+            terminated = true;
+            if (itemAfterTerminatedHandler != null) {
+                this.itemAfterTerminatedHandler = itemAfterTerminatedHandler;
+            }
+        } finally {
+            tailLock.unlockWrite(stamp);
+        }
     }
 
     public boolean isTerminated() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueue.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueue.java
@@ -132,18 +132,18 @@ public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements B
 
     @Override
     public void put(T e) {
-        if (terminated){
-            if (itemAfterTerminatedHandler != null) {
-                itemAfterTerminatedHandler.accept(e);
-            }
-            return;
-        }
-
         long stamp = tailLock.writeLock();
 
         boolean wasEmpty = false;
 
         try {
+            if (terminated){
+                if (itemAfterTerminatedHandler != null) {
+                    itemAfterTerminatedHandler.accept(e);
+                }
+                return;
+            }
+
             if (SIZE_UPDATER.get(this) == data.length) {
                 expandArray();
             }


### PR DESCRIPTION
### Motivation

#### <strong>1. Memory leak if enabled pooled messages</strong>
If enabled pooled messages of a consumer, the the passed payload of messages will use the `ByteBuf` which is coming from network and is backed by a direct buffer. But it will not release the buffers in the incoming queue when consumer is closing.

----

#### <strong>2. flaky test `BrokerClientIntegrationTest.testPooledMessageWithAckTimeout`</strong>
see: https://github.com/apache/pulsar/actions/runs/4231062918/jobs/7349401610

Cause: If enabled pooled messages, the ByteBuf named `payload` in `MessageImpl` will be reused if released. So the expression `payload.refCnt()` will not be `0` if it it used by another place.

----

### Modifications
- release the messages in the incoming queue when consumer is closing
- fix flaky test BrokerClientIntegrationTest.testPooledMessageWithAckTimeout


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository:
- https://github.com/poorbarcode/pulsar/pull/72
