### PR TITLE
[cleanup][broker] Update deprecation warnings to use 3.0.0

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProvider.java
@@ -114,7 +114,7 @@ public interface AuthenticationProvider extends Closeable {
      * an {@link AuthenticationDataSource} that was added as the {@link AuthenticatedDataAttributeName} attribute to
      * the http request. Removing this method removes an unnecessary step in the authentication flow.</p>
      */
-    @Deprecated(since = "2.12.0")
+    @Deprecated(since = "3.0.0")
     default AuthenticationState newHttpAuthState(HttpServletRequest request)
             throws AuthenticationException {
         return new OneStageAuthenticationState(request, this);

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
@@ -158,7 +158,7 @@ public class AuthenticationService implements Closeable {
     /**
      * @deprecated use {@link #authenticateHttpRequest(HttpServletRequest, HttpServletResponse)}
      */
-    @Deprecated(since = "2.12.0")
+    @Deprecated(since = "3.0.0")
     public String authenticateHttpRequest(HttpServletRequest request, AuthenticationDataSource authData)
             throws AuthenticationException {
         String authMethodName = getAuthMethodName(request);

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/OneStageAuthenticationState.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/OneStageAuthenticationState.java
@@ -106,7 +106,7 @@ public class OneStageAuthenticationState implements AuthenticationState {
     /**
      * @deprecated use {@link #authenticateAsync(AuthData)}
      */
-    @Deprecated(since = "2.12.0")
+    @Deprecated(since = "3.0.0")
     @Override
     public AuthData authenticate(AuthData authData) throws AuthenticationException {
         try {
@@ -120,7 +120,7 @@ public class OneStageAuthenticationState implements AuthenticationState {
      * @deprecated rely on result from {@link #authenticateAsync(AuthData)}. For more information, see the Javadoc
      * for {@link AuthenticationState#isComplete()}.
      */
-    @Deprecated(since = "2.12.0")
+    @Deprecated(since = "3.0.0")
     @Override
     public boolean isComplete() {
         return authRole != null;


### PR DESCRIPTION
### Motivation

With https://github.com/apache/pulsar/pull/19573, we should replace deprecation warnings that were set to 2.12.0 with 3.0.0.

### Modifications

* Update 4 deprecation warnings.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

This is cosmetic.

### Documentation

- [x] `doc`

This is a documentation change.

### Matching PR in forked repository

PR in forked repository: skipping forked PR since this is a trivial change