### PR TITLE
[improve][doc] Clarify where to grab the number for the PIP

### DIFF
--- a/wiki/proposals/PIP.md
+++ b/wiki/proposals/PIP.md
@@ -78,7 +78,9 @@ A PIP proposal can be in these states:
 The process works in the following way:
 
 1. The author(s) of the proposal will create a GitHub issue ticket choosing the
-   template for PIP proposals.
+   template for PIP proposals. The issue title should be "PIP-xxx: title", where
+   the "xxx" number should be chosen to be the next number from the existing PIP 
+   issues, listed [here]([url](https://github.com/apache/pulsar/labels/PIP)).
 2. The author(s) will send a note to the dev@pulsar.apache.org mailing list
    to start the discussion, using subject prefix `[PIP] xxx`. The discussion
    need to happen in the mailing list. Please avoid discussing it using
@@ -89,12 +91,12 @@ The process works in the following way:
 4. Once some consensus is reached, there will be a vote to formally approve
    the proposal.
    The vote will be held on the dev@pulsar.apache.org mailing list. Everyone
-   is welcome to vote on the proposal, though it will considered to be binding
+   is welcome to vote on the proposal, though it will be considered to be binding
    only the vote of PMC members.
    I would be required to have a lazy majority of at least 3 binding +1s votes.
    The vote should stay open for at least 48 hours.
 5. When the vote is closed, if the outcome is positive, the state of the
-   proposal is updated and the Pull Requests associated with this proposal can
+   proposal is updated, and the Pull Requests associated with this proposal can
    start to get merged into the master branch.
 
 All the Pull Requests that are created, should always reference the


### PR DESCRIPTION
### Motivation

Clarify in the PIP process where to take the number from.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

