### PR TITLE
[improve][broker] Store nonBlank clientVersions that have spaces

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -690,7 +690,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             log.debug("[{}] connect state change to : [{}]", remoteAddress, State.Connected.name());
         }
         setRemoteEndpointProtocolVersion(clientProtoVersion);
-        if (isNotBlank(clientVersion) && !clientVersion.contains(" ") /* ignore default version: pulsar client */) {
+        if (isNotBlank(clientVersion)) {
             this.clientVersion = clientVersion.intern();
         }
         if (brokerInterceptor != null) {


### PR DESCRIPTION
Relates to: https://github.com/apache/pulsar/pull/19540

### Motivation

We currently filter out the `clientVersion` when it has a `" "` in it. As a consequence, we filter out the go client's version because of how it is made:

https://github.com/apache/pulsar-client-go/blob/dedbdc45c63b06e6a12356785418cd906d6bab3c/pulsar/internal/version.go#L43

Given that we do not have any documented restrictions on the `clientVersion`, I think we should not drop clients that have a space in their name.

I propose that we remove the filter logic to store all "valid" versions supplied by the client.

### Modifications

* Update `ServerCnx` to store `clientVersion` when it has a space in its name.

### Verifying this change

A new test is added.

### Does this pull request potentially affect one of the following parts:

This is a backwards compatible change.

### Documentation

- [x] `doc-not-needed`

### Matching PR in forked repository

PR in forked repository: skipping for this minor change that shouldn't make any tests fail