### PR TITLE
[improve][doc] Changing subject prefix for PIPs in the mailing list

### DIFF
--- a/wiki/proposals/PIP.md
+++ b/wiki/proposals/PIP.md
@@ -80,7 +80,7 @@ The process works in the following way:
 1. The author(s) of the proposal will create a GitHub issue ticket choosing the
    template for PIP proposals.
 2. The author(s) will send a note to the dev@pulsar.apache.org mailing list
-   to start the discussion, using subject prefix `[PIP] xxx`. The discussion
+   to start the discussion, using subject prefix `[DISCUSS] PIP-xxx: `. The discussion
    need to happen in the mailing list. Please avoid discussing it using
    GitHub comments in the PIP GitHub issue, as it creates two tracks 
    of feedback.


### PR DESCRIPTION
### Motivation

Mailing list discussion seems to use the prefix "[DISCUSS] PIP-xxx: ", so it makes sense to update the PIP wiki accordingly.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

