### PR TITLE
[fix][broker] Only send AuthChallenge when client supports it

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -480,6 +480,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
+    @Test
     public void testAuthChallengePrincipalChangeFails() throws Exception {
         AuthenticationService authenticationService = mock(AuthenticationService.class);
         AuthenticationProvider authenticationProvider = new MockAlwaysExpiredAuthenticationProvider();
@@ -533,6 +534,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
+    @Test
     public void testAuthChallengeOriginalPrincipalChangeFails() throws Exception {
         AuthenticationService authenticationService = mock(AuthenticationService.class);
         AuthenticationProvider authenticationProvider = new MockAlwaysExpiredAuthenticationProvider();
@@ -551,7 +553,7 @@ public class ServerCnxTest {
         // Don't want the keep alive task affecting which messages are handled
         serverCnx.cancelKeepAliveTask();
 
-        ByteBuf clientCommand = Commands.newConnect(authMethodName, "pass.proxy", 1, null,
+        ByteBuf clientCommand = Commands.newConnect(authMethodName, "pass.proxy", ProtocolVersion.v14.getValue(), null,
                 null, "pass.client", "pass.client", authMethodName);
         channel.writeInbound(clientCommand);
 
@@ -706,7 +708,8 @@ public class ServerCnxTest {
 
         // Trigger another AuthChallenge to verify that code path continues to challenge
         ByteBuf authResponse1 =
-                Commands.newAuthResponse(authMethodName, AuthData.of("challenge.client".getBytes()), 1, "1");
+                Commands.newAuthResponse(authMethodName, AuthData.of("challenge.client".getBytes()),
+                        ProtocolVersion.v14.getValue(), "1");
         channel.writeInbound(authResponse1);
 
         Object challenge2 = getResponse();
@@ -722,6 +725,67 @@ public class ServerCnxTest {
         assertEquals(((CommandError) response3).getMessage(), "Failed to authenticate");
         assertEquals(serverCnx.getState(), State.Failed);
         assertFalse(serverCnx.isActive());
+        channel.finish();
+    }
+
+    @Test
+    public void testAuthChallengeWithOldClientResultsInErrorToClient() throws Exception {
+        AuthenticationService authenticationService = mock(AuthenticationService.class);
+        AuthenticationProvider authenticationProvider = new MockMultiStageAuthenticationProvider();
+        String authMethodName = authenticationProvider.getAuthMethodName();
+
+        when(brokerService.getAuthenticationService()).thenReturn(authenticationService);
+        when(authenticationService.getAuthenticationProvider(authMethodName)).thenReturn(authenticationProvider);
+        svcConfig.setAuthenticationEnabled(true);
+
+        resetChannel();
+        assertTrue(channel.isActive());
+        assertEquals(serverCnx.getState(), State.Start);
+
+        // Trigger connect command to result in AuthChallenge
+        ByteBuf clientCommand = Commands.newConnect(authMethodName, "challenge.client", ProtocolVersion.v13.getValue(),
+                "1", null, null, null, null);
+        channel.writeInbound(clientCommand);
+
+        Object error = getResponse();
+        assertTrue(error instanceof CommandError);
+        assertEquals(serverCnx.getState(), State.Failed);
+        assertFalse(serverCnx.isActive());
+        channel.finish();
+    }
+
+    @Test
+    public void testAuthRefreshWithOldClientResultsClosedConnection() throws Exception {
+        AuthenticationService authenticationService = mock(AuthenticationService.class);
+        AuthenticationProvider authenticationProvider = new MockAlwaysExpiredAuthenticationProvider();
+        String authMethodName = authenticationProvider.getAuthMethodName();
+
+        when(brokerService.getAuthenticationService()).thenReturn(authenticationService);
+        when(authenticationService.getAuthenticationProvider(authMethodName)).thenReturn(authenticationProvider);
+        svcConfig.setAuthenticationEnabled(true);
+        svcConfig.setAuthenticationRefreshCheckSeconds(30);
+
+        resetChannel();
+        assertTrue(channel.isActive());
+        assertEquals(serverCnx.getState(), State.Start);
+        // Don't want the keep alive task affecting which messages are handled
+        serverCnx.cancelKeepAliveTask();
+
+        // Trigger connect command to result in AuthChallenge
+        ByteBuf clientCommand = Commands.newConnect(authMethodName, "pass.client", ProtocolVersion.v13.getValue(),
+                "1", null, null, null, null);
+        channel.writeInbound(clientCommand);
+        Object connected = getResponse();
+        assertTrue(connected instanceof CommandConnected);
+
+        // Trigger the ServerCnx to check if authentication is expired (it is because of our special implementation)
+        // and then force channel to run the task
+        channel.advanceTimeBy(30, TimeUnit.SECONDS);
+        assertTrue(channel.hasPendingTasks(), "This test assumes there are pending tasks to run.");
+        channel.runPendingTasks();
+        assertTrue(channel.outboundMessages().isEmpty());
+        // Then expect channel to close
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> !channel.isActive());
         channel.finish();
     }
 


### PR DESCRIPTION
### Motivation

While reviewing the `ServerCnx`, I noticed the broker and client compatibility could have a missing edge case. In this case, the concept of multi-stage authentication was introduced with version 14 of the protocol by https://github.com/apache/pulsar/pull/3677. However, we send an `AuthChallenge` to the client without verifying it has a sufficient protocol version to support such a challenge.

This change is unlikely to fix any real issues because the `AuthChallenge` was introduced a while ago. However, I think we should add this logic to further support our claim that any version of the client can connect to any version of the broker.

Another reason we might choose not to merge this PR is that it's possible https://github.com/apache/pulsar/pull/3677 introduced mutual authentication in the client and the proxy at the same time, so this case isn't possible. My main response is that the protocol is an open spec, so we should use our versioning system to ensure that there isn't even a third party client library that receives protocol messages it is unable to handle.

### Modifications

* When an old client tries to connect using an authentication provider that generates an auth challenge, send an `AuthenticationError` and close the connection for both broker and proxy.
* Only send the `AuthChallenge` that is triggered by authentication refresh when the client knows how to handle the `AuthChallenge` protocol message. This is arguably covered by the `FeatureFlag`, but given what our protocol versioning means, I think we should cover this unlikely edge case.

### Verifying this change

Includes a test for `ServerCnx` and I created an issue for https://github.com/apache/pulsar/issues/19624 the proxy.

### Does this pull request potentially affect one of the following parts:

This enforces the existing protocol.

### Documentation

- [x] `doc-not-needed`

This is part of the protocol spec.
### Matching PR in forked repository

PR in forked repository: https://github.com/michaeljmarshall/pulsar/pull/32