### PR TITLE
[fix][txn] return success when try to commit txn committed.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
@@ -340,11 +340,11 @@ public class TransactionMetadataStoreService {
                     if (txnMeta.status() == TxnStatus.OPEN) {
                         return updateTxnStatus(txnID, newStatus, TxnStatus.OPEN, isTimeout)
                                 .thenCompose(__ -> endTxnInTransactionBuffer(txnID, txnAction));
-                    } else if (txnMeta.status() == TxnStatus.COMMITTED &&
-                            txnAction == TxnAction.COMMIT_VALUE) {
+                    } else if (txnMeta.status() == TxnStatus.COMMITTED
+                            && txnAction == TxnAction.COMMIT_VALUE) {
                         future.complete(null);
-                    } else if (txnMeta.status() == TxnStatus.ABORTED &&
-                            txnAction == TxnAction.ABORT_VALUE) {
+                    } else if (txnMeta.status() == TxnStatus.ABORTED
+                            && txnAction == TxnAction.ABORT_VALUE) {
                         future.complete(null);
                     }
                     return fakeAsyncCheckTxnStatus(txnMeta.status(), txnAction, txnID, newStatus)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
@@ -340,6 +340,12 @@ public class TransactionMetadataStoreService {
                     if (txnMeta.status() == TxnStatus.OPEN) {
                         return updateTxnStatus(txnID, newStatus, TxnStatus.OPEN, isTimeout)
                                 .thenCompose(__ -> endTxnInTransactionBuffer(txnID, txnAction));
+                    } else if (txnMeta.status() == TxnStatus.COMMITTED &&
+                            txnAction == TxnAction.COMMIT_VALUE) {
+                        future.complete(null);
+                    } else if (txnMeta.status() == TxnStatus.ABORTED &&
+                            txnAction == TxnAction.ABORT_VALUE) {
+                        future.complete(null);
                     }
                     return fakeAsyncCheckTxnStatus(txnMeta.status(), txnAction, txnID, newStatus)
                             .thenCompose(__ -> endTxnInTransactionBuffer(txnID, txnAction));


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->

Fixes #19629

### Motivation
when client try to commit a transaction which have been committed already, the broker will return exception. The client will regard that it fail to commit the transaction and resend the messages in this transaction, which will result into message duplication.
It should be emphasized that, there is retry logic in the internal logic of pulsar `tcClient`. We will meet problem above though we commit only once. For example, if broker restart, commit request may arrive to broker twice though we only commit once.

### Modifications
do not return exception when client try to commit a transaction which have been committed already.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/14

