### PR TITLE
[improve][txn] PIP-251: Add snapshot stats in TransactionBufferStats

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/AbortedTxnProcessor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/AbortedTxnProcessor.java
@@ -68,7 +68,7 @@ public interface AbortedTxnProcessor {
     /**
      * Get the snapshot stats form the processor.
      */
-    void getSnapshotStats(TransactionBufferStats stats);
+    void generateSnapshotStats(TransactionBufferStats stats);
 
     CompletableFuture<Void> closeAsync();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/AbortedTxnProcessor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/AbortedTxnProcessor.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.transaction.buffer;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.client.api.transaction.TxnID;
+import org.apache.pulsar.common.policies.data.TransactionBufferStats;
 
 
 public interface AbortedTxnProcessor {
@@ -65,10 +66,9 @@ public interface AbortedTxnProcessor {
     CompletableFuture<Void> takeAbortedTxnsSnapshot(PositionImpl maxReadPosition);
 
     /**
-     * Get the lastSnapshotTimestamps.
-     * @return the lastSnapshotTimestamps.
+     * Get the snapshot stats form the processor.
      */
-    long getLastSnapshotTimestamps();
+    void getSnapshotStats(TransactionBufferStats stats);
 
     CompletableFuture<Void> closeAsync();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
@@ -37,6 +37,7 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.TransactionBufferStats;
 import org.apache.pulsar.common.util.FutureUtil;
 
 @Slf4j
@@ -170,8 +171,8 @@ public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcesso
     }
 
     @Override
-    public long getLastSnapshotTimestamps() {
-        return this.lastSnapshotTimestamps;
+    public void getSnapshotStats(TransactionBufferStats stats) {
+        stats.lastSnapshotTimestamps = this.lastSnapshotTimestamps;
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
@@ -171,7 +171,7 @@ public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcesso
     }
 
     @Override
-    public void getSnapshotStats(TransactionBufferStats stats) {
+    public void generateSnapshotStats(TransactionBufferStats stats) {
         stats.lastSnapshotTimestamps = this.lastSnapshotTimestamps;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -388,7 +388,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
     public void generateSnapshotStats(TransactionBufferStats stats) {
         stats.lastSnapshotTimestamps = this.lastSnapshotTimestamps;
         TransactionBufferStats.SnapshotStats snapshotStats = new TransactionBufferStats.SnapshotStats();
-        snapshotStats.segmentsSize = this.indexes.size();
+        snapshotStats.segmentsSize = this.segmentIndex.size();
         snapshotStats.unsealedAbortTxnIDs = this.unsealedTxnIds.size();
         stats.snapshotStats = snapshotStats;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -59,6 +59,7 @@ import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.TransactionBufferStats;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.util.FutureUtil;
 
@@ -384,8 +385,12 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
     }
 
     @Override
-    public long getLastSnapshotTimestamps() {
-        return this.lastSnapshotTimestamps;
+    public void getSnapshotStats(TransactionBufferStats stats) {
+        stats.lastSnapshotTimestamps = this.lastSnapshotTimestamps;
+        TransactionBufferStats.SnapshotStats snapshotStats = new TransactionBufferStats.SnapshotStats();
+        snapshotStats.segmentsSize = this.indexes.size();
+        snapshotStats.unsealedAbortTxnIDs = this.unsealedTxnIds.size();
+        stats.snapshotStats = snapshotStats;
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -385,7 +385,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
     }
 
     @Override
-    public void getSnapshotStats(TransactionBufferStats stats) {
+    public void generateSnapshotStats(TransactionBufferStats stats) {
         stats.lastSnapshotTimestamps = this.lastSnapshotTimestamps;
         TransactionBufferStats.SnapshotStats snapshotStats = new TransactionBufferStats.SnapshotStats();
         snapshotStats.segmentsSize = this.indexes.size();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -511,9 +511,9 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
     @Override
     public TransactionBufferStats getStats(boolean lowWaterMarks) {
         TransactionBufferStats transactionBufferStats = new TransactionBufferStats();
-        transactionBufferStats.lastSnapshotTimestamps = this.snapshotAbortedTxnProcessor.getLastSnapshotTimestamps();
         transactionBufferStats.state = this.getState().name();
         transactionBufferStats.maxReadPosition = this.maxReadPosition.toString();
+        snapshotAbortedTxnProcessor.getSnapshotStats(transactionBufferStats);
         if (lowWaterMarks) {
             transactionBufferStats.lowWaterMarks = this.lowWaterMarks;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -513,7 +513,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
         TransactionBufferStats transactionBufferStats = new TransactionBufferStats();
         transactionBufferStats.state = this.getState().name();
         transactionBufferStats.maxReadPosition = this.maxReadPosition.toString();
-        snapshotAbortedTxnProcessor.getSnapshotStats(transactionBufferStats);
+        snapshotAbortedTxnProcessor.generateSnapshotStats(transactionBufferStats);
         if (lowWaterMarks) {
             transactionBufferStats.lowWaterMarks = this.lowWaterMarks;
         }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TransactionBufferStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TransactionBufferStats.java
@@ -44,4 +44,19 @@ public class TransactionBufferStats {
     public long recoverStartTime;
     //End timestamp of transaction buffer recovery. 0L means no startup.
     public long recoverEndTime;
+    /**
+     *  The stats of snapshots that only exist when enabling multiple snapshot segments.
+     */
+    public SnapshotStats snapshotStats;
+
+    public static class SnapshotStats {
+        /**
+         * The transaction snapshot segment size stored for this topic transaction buffer.
+         */
+        public long segmentsSize;
+        /**
+         * The unsealed aborted transaction IDs size stored in the snapshot processor.
+         */
+        public long unsealedAbortTxnIDs;
+    }
 }


### PR DESCRIPTION
Master https://github.com/apache/pulsar/issues/19628

### Motivation

Modify the admin tool to get the stats of the transaction buffer snapshot segment when the transaction buffer snapshot segment is enabled.



### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/liangyepianzhou/pulsar/pull/23
