### PR TITLE
[fix][broker] Embed stringified exception in placeholder in log message

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -388,7 +388,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         if (state != State.Failed) {
             // No need to report stack trace for known exceptions that happen in disconnections
             log.warn("[{}] Got exception {}", remoteAddress,
-                    ClientCnx.isKnownException(cause) ? cause : ExceptionUtils.getStackTrace(cause));
+                    ClientCnx.isKnownException(cause) ? cause.toString() : ExceptionUtils.getStackTrace(cause));
             state = State.Failed;
             if (log.isDebugEnabled()) {
                 log.debug("[{}] connect state change to : [{}]", remoteAddress, State.Failed.name());
@@ -398,7 +398,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             // failed
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Got exception {}", remoteAddress,
-                        ClientCnx.isKnownException(cause) ? cause : ExceptionUtils.getStackTrace(cause));
+                        ClientCnx.isKnownException(cause) ? cause.toString() : ExceptionUtils.getStackTrace(cause));
             }
         }
         ctx.close();


### PR DESCRIPTION
### Motivation

I noticed the following warn log output on a broker server.
```
14:03:44.580 [pulsar-io-24-26] WARN  o.a.pulsar.broker.service.ServerCnx  - [/xxx.xxx.xxx.xxx:35144] Got exception {}
io.netty.channel.unix.Errors$NativeIoException: readAddress(..) failed: Connection reset by peer
```

I think the expected behavior is that the summary of the exception `cause` is embedded in the placeholder `{}`, but actually the stacktrace is printed.
https://github.com/apache/pulsar/blob/6d3e483bab0f960b21cb521fb3908eccd55993b6/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java#L389-L391

Apparently, exceptions are embedded when log4j2 is used, but not when logback is used.

### Modifications

Stringify `cause` to embed it in the placeholder.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->