### PR TITLE
Revert "[improve] configure whether function consumer should skip to latest (#17214)"

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
@@ -131,8 +131,6 @@ public class FunctionConfig {
     private Integer maxPendingAsyncRequests;
     // Whether the pulsar admin client exposed to function context, default is disabled.
     private Boolean exposePulsarAdminClientEnabled;
-    // Whether the consumer should skip to latest position in case of failure recovery
-    private Boolean skipToLatest;
 
     @Builder.Default
     private SubscriptionInitialPosition subscriptionPosition = SubscriptionInitialPosition.Latest;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -325,9 +325,6 @@ public class CmdFunctions extends CmdBase {
         @Parameter(names = "--subs-position", description = "Pulsar source subscription position if user wants to "
                 + "consume messages from the specified location #Java")
         protected SubscriptionInitialPosition subsPosition;
-        @Parameter(names = "--skip-to-latest", description = "Whether or not the consumer skip to latest message "
-            + "upon function instance restart", arity = 1)
-        protected Boolean skipToLatest;
         @Parameter(names = "--parallelism", description = "The parallelism factor of a Pulsar Function "
                 + "(i.e. the number of function instances to run) #Java")
         protected Integer parallelism;
@@ -549,10 +546,6 @@ public class CmdFunctions extends CmdBase {
 
             if (null != subsPosition) {
                 functionConfig.setSubscriptionPosition(subsPosition);
-            }
-
-            if (null != skipToLatest) {
-                functionConfig.setSkipToLatest(skipToLatest);
             }
 
             if (null != userConfigString) {

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -789,12 +789,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                     convertFromFunctionDetailsSubscriptionPosition(sourceSpec.getSubscriptionPosition())
             );
 
-            pulsarSourceConfig.setSkipToLatest(
-                sourceSpec.getSkipToLatest()
-            );
-
             Objects.requireNonNull(contextImpl.getSubscriptionType());
-
             pulsarSourceConfig.setSubscriptionType(contextImpl.getSubscriptionType());
 
             pulsarSourceConfig.setTypeClassName(sourceSpec.getTypeClassName());

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/MultiConsumerPulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/MultiConsumerPulsarSource.java
@@ -27,7 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageListener;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -67,11 +66,6 @@ public class MultiConsumerPulsarSource<T> extends PushPulsarSource<T> implements
             cb.messageListener(this);
 
             Consumer<T> consumer = cb.subscribeAsync().join();
-
-            if (pulsarSourceConfig.getSkipToLatest() != null && pulsarSourceConfig.getSkipToLatest()) {
-                consumer.seek(MessageId.latest);
-            }
-
             inputConsumers.add(consumer);
         }
     }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSourceConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSourceConfig.java
@@ -30,8 +30,7 @@ public abstract class PulsarSourceConfig {
     SubscriptionType subscriptionType;
     private String subscriptionName;
     private SubscriptionInitialPosition subscriptionPosition;
-    // Whether call consumer.seek(latest) to skip contents between last ask message and the latest message
-    private Boolean skipToLatest;
+    // Whether the subscriptions the functions created/used should be deleted when the functions is deleted
     private Integer maxMessageRetries = -1;
     private String deadLetterTopic;
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/SingleConsumerPulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/SingleConsumerPulsarSource.java
@@ -27,7 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.util.Reflections;
 import org.apache.pulsar.functions.api.Record;
@@ -74,11 +73,6 @@ public class SingleConsumerPulsarSource<T> extends PulsarSource<T> {
 
         ConsumerBuilder<T> cb = createConsumeBuilder(topic, pulsarSourceConsumerConfig);
         consumer = cb.subscribeAsync().join();
-
-        if (this.pulsarSourceConfig.getSkipToLatest() != null && this.pulsarSourceConfig.getSkipToLatest()) {
-            consumer.seek(MessageId.latest);
-        }
-
         inputConsumers.add(consumer);
     }
 

--- a/pulsar-functions/proto/src/main/proto/Function.proto
+++ b/pulsar-functions/proto/src/main/proto/Function.proto
@@ -165,7 +165,6 @@ message SourceSpec {
     bool cleanupSubscription = 11;
     SubscriptionPosition subscriptionPosition = 12;
     uint64 negativeAckRedeliveryDelayMs = 13;
-    bool skipToLatest = 14;
 }
 
 message SinkSpec {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -198,12 +198,6 @@ public class FunctionConfigUtils {
             sourceSpecBuilder.setSubscriptionPosition(subPosition);
         }
 
-        if (functionConfig.getSkipToLatest() != null) {
-            sourceSpecBuilder.setSkipToLatest(functionConfig.getSkipToLatest());
-        } else {
-            sourceSpecBuilder.setSkipToLatest(false);
-        }
-
         if (extractedDetails.getTypeArg0() != null) {
             sourceSpecBuilder.setTypeClassName(extractedDetails.getTypeArg0());
         } else if (StringUtils.isNotEmpty(functionConfig.getInputTypeClassName())) {


### PR DESCRIPTION
This reverts commit bf982f4995e624659021191982f7fedc13fc3ba0.

### Motivation

In #17214, we added a new protobuf field without a PIP. In order to ensure this code is not released, I propose that we revert this commit now and only move forward once it has been accepted through a PIP (or a discussion on the mailing list if a PIP is deemed unnecessary).

### Documentation

- [x] `doc-not-needed` 

This is just reverting a commit, and there were no external docs merged for that commit, so no docs need to be updated.