### PR TITLE
[feat][ci] Enable assertions when running tests in CI

### DIFF
--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -36,7 +36,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAVEN_OPTS: -Xss1500k -Xmx1024m -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  MAVEN_OPTS: -Xss1500k -Xmx1024m -enableassertions:org.apache.pulsar... -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
   # defines the retention period for the intermediate build artifacts needed for rerunning a failed build job
   # it's possible to rerun individual failed jobs when the build artifacts are available
   # if the artifacts have already been expired, the complete workflow can be rerun by closing and reopening the PR or by rebasing the PR

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -36,7 +36,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAVEN_OPTS: -Xss1500k -Xmx1024m -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  MAVEN_OPTS: -Xss1500k -Xmx1024m -enableassertions:org.apache.pulsar... -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
   # defines the retention period for the intermediate build artifacts needed for rerunning a failed build job
   # it's possible to rerun individual failed jobs when the build artifacts are available
   # if the artifacts have already been expired, the complete workflow can be rerun by closing and reopening the PR or by rebasing the PR


### PR DESCRIPTION
### Motivation

I noticed recently that Netty uses asserts to ensure that certain methods are run on the correct thread. This seems like a reasonable usage to me given that this kind of thing is hard to verify with a test and easy to verify at runtime. Here are some Netty usage references:

https://github.com/netty/netty/blob/d34212439068091bcec29a8fad4df82f0a82c638/transport/src/main/java/io/netty/channel/PendingWriteQueue.java#L68

https://github.com/netty/netty/blob/c18fc2bc68c08805b2553336a3bf02f0c8c50972/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java#L210

https://github.com/netty/netty/blob/00905d64c817b87aa37dee1c2bc3292b874b47a6/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java#L179

And [many more](https://github.com/netty/netty/search?q=assert+inEventLoop) that might change over time.

As such, I recently committed some assertions to the Pulsar code base:

https://github.com/apache/pulsar/blob/de43ad0340f9fa857394449b7bfdbc4a339dcc92/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java#L838-L839

If we want to use these assertions, I think we must enable them in our CI pipeline to ensure the assertions are actually verified.

### Modifications

* Update CI maven options `MAVEN_OPTS` to include the flag that will enable assertions for all `org.apache.pulsar` sub packages.

### Verifying this change

I am not exactly sure how to verify this with a test, so I'll need to figure that out.

### Documentation

- [x] `doc-not-needed`

I don't think we need docs yet, but if we want to make an official stance on when to use `assert`, maybe we should document it.

### Matching PR in forked repository

This should not break tests.