### PR TITLE
[feat][txn] Support for idempotent commit and abort, Solution1.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/recover/TransactionRecoverTrackerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/recover/TransactionRecoverTrackerImpl.java
@@ -163,12 +163,12 @@ public class TransactionRecoverTrackerImpl implements TransactionRecoverTracker 
 
     @Override
     public void handleCommittingAndAbortingTransaction() {
-            committingTransactions.forEach((k, v) ->
-                    transactionMetadataStoreService.endTransaction(new TxnID(tcId, k), TxnAction.COMMIT_VALUE,
-                            false));
+        committingTransactions.forEach((k, v) ->
+                transactionMetadataStoreService.endTransaction(new TxnID(tcId, k), TxnAction.COMMIT_VALUE,
+                        false));
 
-            abortingTransactions.forEach((k, v) ->
-                    transactionMetadataStoreService.endTransaction(new TxnID(tcId, k), TxnAction.ABORT_VALUE,
-                            false));
+        abortingTransactions.forEach((k, v) ->
+                transactionMetadataStoreService.endTransaction(new TxnID(tcId, k), TxnAction.ABORT_VALUE,
+                        false));
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/recover/TransactionRecoverTrackerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/recover/TransactionRecoverTrackerImpl.java
@@ -151,13 +151,13 @@ public class TransactionRecoverTrackerImpl implements TransactionRecoverTracker 
 
     @Override
     public void handleCommittedAbortedTransaction(
-            long sequenceId, TxnStatus txnStatus, long unavailableDuration, Map txnMetaMap) {
+            long sequenceId, TxnStatus txnStatus, long unavailableDuration, Map terminatedTxnMetaMap) {
         // transaction in terminatedTransactions is ordered by added time.
         synchronized (this) {
             while (!terminatedTransactions.isEmpty() && terminatedTransactions.get(terminatedTransactions.firstKey())
                     + unavailableDuration > System.currentTimeMillis()) {
                 long firstKey = terminatedTransactions.firstKey();
-                txnMetaMap.remove(firstKey);
+                terminatedTxnMetaMap.remove(firstKey);
                 terminatedTransactions.remove(firstKey);
             }
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/recover/TransactionRecoverTrackerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/recover/TransactionRecoverTrackerImpl.java
@@ -142,9 +142,6 @@ public class TransactionRecoverTrackerImpl implements TransactionRecoverTracker 
         committingTransactions.forEach(timeoutTracker::replayAddTransaction);
         abortingTransactions.forEach(timeoutTracker::replayAddTransaction);
         terminatedTransactions.forEach(timeoutTracker::replayAddTransaction);
-        committingTransactions.clear();
-        abortingTransactions.clear();
-        terminatedTransactions.clear();
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/recover/TransactionRecoverTrackerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/recover/TransactionRecoverTrackerImpl.java
@@ -148,13 +148,11 @@ public class TransactionRecoverTrackerImpl implements TransactionRecoverTracker 
     public void handleCommittedAbortedTransaction(
             long sequenceId, TxnStatus txnStatus, long unavailableDuration, Map terminatedTxnMetaMap) {
         // transaction in terminatedTransactions is ordered by added time.
-        synchronized (this) {
-            while (!terminatedTransactions.isEmpty() && terminatedTransactions.get(terminatedTransactions.firstKey())
-                    + unavailableDuration > System.currentTimeMillis()) {
-                long firstKey = terminatedTransactions.firstKey();
-                terminatedTxnMetaMap.remove(firstKey);
-                terminatedTransactions.remove(firstKey);
-            }
+        while (!terminatedTransactions.isEmpty() && terminatedTransactions.get(terminatedTransactions.firstKey())
+                + unavailableDuration > System.currentTimeMillis()) {
+            long firstKey = terminatedTransactions.firstKey();
+            terminatedTxnMetaMap.remove(firstKey);
+            terminatedTransactions.remove(firstKey);
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/recover/TransactionRecoverTrackerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/recover/TransactionRecoverTrackerImpl.java
@@ -19,9 +19,7 @@
 package org.apache.pulsar.broker.transaction.recover;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.map.LinkedMap;
 import org.apache.pulsar.broker.TransactionMetadataStoreService;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMetadataStoreServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMetadataStoreServiceTest.java
@@ -342,7 +342,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
 
     @Test(dataProvider = "txnStatus")
     public void testEndTransactionOpRetry(TxnStatus txnStatus) throws Exception {
-        int timeOut = 3000;
+        int timeOut = 5000;
         pulsar.getTransactionMetadataStoreService().handleTcClientConnect(TransactionCoordinatorID.get(0));
         Awaitility.await()
                 .until(() -> pulsar.getTransactionMetadataStoreService()
@@ -353,7 +353,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
 
         checkTransactionMetadataStoreReady(transactionMetadataStore);
 
-        TxnID txnID = newTransactionWithTimeoutOf(timeOut - 2000);
+        TxnID txnID = newTransactionWithTimeoutOf(timeOut);
         TxnMeta txnMeta = transactionMetadataStore.getTxnMeta(txnID).get();
         txnMeta.updateTxnStatus(txnStatus, TxnStatus.OPEN);
 
@@ -364,7 +364,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
         try {
             completableFuture = pulsar.getTransactionMetadataStoreService().endTransaction(txnID, TxnAction.COMMIT.getValue(),
                     false);
-            completableFuture.get(5, TimeUnit.SECONDS);
+            completableFuture.get(3, TimeUnit.SECONDS);
             fail();
         } catch (Exception e) {
             if (txnStatus == TxnStatus.OPEN || txnStatus == TxnStatus.COMMITTING) {
@@ -385,7 +385,7 @@ public class TransactionMetadataStoreServiceTest extends BrokerTestBase {
             pulsar.getTransactionMetadataStoreService()
                     .endTransaction(txnID, TxnAction.ABORT.getValue(), false).get();
         }
-        Awaitility.await().atMost(timeOut, TimeUnit.MILLISECONDS).until(() -> {
+        Awaitility.await().atMost(timeOut + 1000, TimeUnit.MILLISECONDS).until(() -> {
             try {
                 transactionMetadataStore.getTxnMeta(txnID).get();
                 return false;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -854,7 +854,7 @@ public class TransactionTest extends TransactionTestBase {
         field.set(mlTransactionLog, persistentTopic.getManagedLedger());
 
         TransactionRecoverTracker transactionRecoverTracker = mock(TransactionRecoverTracker.class);
-        doNothing().when(transactionRecoverTracker).appendOpenTransactionToTimeoutTracker();
+        doNothing().when(transactionRecoverTracker).appendTransactionToTimeoutTracker(0l);
         doNothing().when(transactionRecoverTracker).handleCommittingAndAbortingTransaction();
         TransactionTimeoutTracker timeoutTracker = mock(TransactionTimeoutTracker.class);
         doNothing().when(timeoutTracker).start();
@@ -926,6 +926,75 @@ public class TransactionTest extends TransactionTestBase {
         commitTxn.commit().get();
         Awaitility.await().untilAsserted(() -> assertEquals(listener.getCommittedTxnCount(),1));
     }
+
+    @Test
+    public void testConcurrentCommit() throws Exception {
+        String topic = NAMESPACE1 + "/testConcurrentCommit";
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient
+                .newProducer(Schema.BYTES)
+                .topic(topic)
+                .enableBatching(true)
+                // ensure that batch message is sent
+                .batchingMaxPublishDelay(3, TimeUnit.SECONDS)
+                .sendTimeout(0, TimeUnit.SECONDS)
+                .create();
+        Transaction txn = pulsarClient.newTransaction()
+                .withTransactionTimeout(10, TimeUnit.MINUTES).build().get();
+
+        // send batch message, the size is 5
+        for (int i = 0; i < 5; i++) {
+            producer.newMessage(txn).value(("test" + i).getBytes());
+        }
+        producer.flush();
+
+        CompletableFuture future = new CompletableFuture();
+        // try to commit many times.
+        while (!txn.getState().equals(Transaction.State.COMMITTED)) {
+            txn.commit().exceptionally(e -> {
+                future.completeExceptionally(e);
+                return null;
+            });
+        }
+        assertTrue(!future.isCompletedExceptionally());
+
+        txn.commit().get();
+    }
+
+    @Test
+    public void testConcurrentAbort() throws Exception {
+        String topic = NAMESPACE1 + "/testConcurrentCommit";
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient
+                .newProducer(Schema.BYTES)
+                .topic(topic)
+                .enableBatching(true)
+                // ensure that batch message is sent
+                .batchingMaxPublishDelay(3, TimeUnit.SECONDS)
+                .sendTimeout(0, TimeUnit.SECONDS)
+                .create();
+        Transaction txn = pulsarClient.newTransaction()
+                .withTransactionTimeout(10, TimeUnit.MINUTES).build().get();
+
+        // send batch message, the size is 5
+        for (int i = 0; i < 5; i++) {
+            producer.newMessage(txn).value(("test" + i).getBytes());
+        }
+        producer.flush();
+
+        CompletableFuture future = new CompletableFuture();
+        // try to abort many times.
+        while (!txn.getState().equals(Transaction.State.ABORTED)) {
+            txn.abort().exceptionally(e -> {
+                future.completeExceptionally(e);
+                return null;
+            });
+        }
+        assertTrue(!future.isCompletedExceptionally());
+
+        txn.abort().get();
+    }
+
 
     @Test
     public void testNoEntryCanBeReadWhenRecovery() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -1665,7 +1665,7 @@ public class TransactionTest extends TransactionTestBase {
         transaction = pulsarClient.newTransaction().withTransactionTimeout(1, TimeUnit.SECONDS)
                 .build().get();
         pulsarServiceList.get(0).getTransactionMetadataStoreService()
-                .endTransaction(transaction.getTxnID(), 0, false);
+                .endTransaction(transaction.getTxnID(), 1, false);
         transaction.commit();
         Transaction errorTxn = transaction;
         Awaitility.await().until(() -> errorTxn.getState() == Transaction.State.ERROR);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionLowWaterMarkTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionLowWaterMarkTest.java
@@ -139,9 +139,8 @@ public class TransactionLowWaterMarkTest extends TransactionTestBase {
         producer.newMessage(txn).value(TEST2.getBytes()).send();
         try {
             txn.commit().get();
-            Assert.fail("The commit operation should be failed.");
         } catch (Exception e){
-            Assert.assertTrue(e.getCause() instanceof TransactionCoordinatorClientException.TransactionNotFoundException);
+            Assert.fail("The commit operation should be successful.");
         }
 
         PartitionedTopicMetadata partitionedTopicMetadata =

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionLowWaterMarkTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionLowWaterMarkTest.java
@@ -47,7 +47,6 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.transaction.Transaction;
-import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClientException;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.transaction.TransactionImpl;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/recover/TransactionRecoverTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/recover/TransactionRecoverTrackerTest.java
@@ -63,7 +63,7 @@ public class TransactionRecoverTrackerTest {
         TripleLongPriorityQueue priorityQueue = (TripleLongPriorityQueue) field.get(timeoutTracker);
         assertEquals(priorityQueue.size(), 0);
 
-        recoverTracker.appendOpenTransactionToTimeoutTracker();
+        recoverTracker.appendTransactionToTimeoutTracker(0l);
         assertEquals(priorityQueue.size(), 2);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/recover/TransactionRecoverTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/recover/TransactionRecoverTrackerTest.java
@@ -100,18 +100,18 @@ public class TransactionRecoverTrackerTest {
 
         field = TransactionRecoverTrackerImpl.class.getDeclaredField("committingTransactions");
         field.setAccessible(true);
-        Set<Long> commitSet = (Set<Long>) field.get(recoverTracker);
+        Map<Long,Long> commitSet = (Map<Long, Long>) field.get(recoverTracker);
 
         assertEquals(commitSet.size(), 1);
-        assertTrue(commitSet.contains(committingSequenceId));
-        assertFalse(commitSet.contains(committedSequenceId));
+        assertTrue(commitSet.containsKey(committingSequenceId));
+        assertFalse(commitSet.containsKey(committedSequenceId));
 
         field = TransactionRecoverTrackerImpl.class.getDeclaredField("abortingTransactions");
         field.setAccessible(true);
-        Set<Long> abortSet = (Set<Long>) field.get(recoverTracker);
+        Map<Long,Long> abortSet = (Map<Long, Long>) field.get(recoverTracker);
 
         assertEquals(1, abortSet.size());
-        assertTrue(abortSet.contains(abortingSequenceId));
-        assertFalse(abortSet.contains(abortedSequenceId));
+        assertTrue(abortSet.containsKey(abortingSequenceId));
+        assertFalse(abortSet.containsKey(abortedSequenceId));
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/recover/TransactionRecoverTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/recover/TransactionRecoverTrackerTest.java
@@ -30,7 +30,6 @@ import org.testng.annotations.Test;
 
 import java.lang.reflect.Field;
 import java.util.Map;
-import java.util.Set;
 
 import static org.mockito.Mockito.mock;
 import static org.testng.AssertJUnit.assertEquals;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -547,12 +547,8 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             field.set(commitTxn, TransactionImpl.State.OPEN);
             try {
                 commitTxn.commit().get();
-                fail("recommit one transaction should be failed.");
             } catch (Exception reCommitError) {
-                // recommit one transaction should be failed
-                log.info("expected exception for recommit one transaction.");
-                Assert.assertNotNull(reCommitError);
-                Assert.assertTrue(reCommitError.getCause() instanceof TransactionNotFoundException);
+                fail("recommit one transaction should be successfully.");
             }
         }
 
@@ -790,12 +786,8 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             field.set(commitTxn, TransactionImpl.State.OPEN);
             try {
                 commitTxn.commit().get();
-                fail("recommit one transaction should be failed.");
             } catch (Exception reCommitError) {
-                // recommit one transaction should be failed
-                log.info("expected exception for recommit one transaction.");
-                Assert.assertNotNull(reCommitError);
-                Assert.assertTrue(reCommitError.getCause() instanceof TransactionNotFoundException);
+                fail("recommit one transaction should be successfully.");
             }
 
             message = consumer.receive(300, TimeUnit.MILLISECONDS);
@@ -951,9 +943,8 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         try {
             produceTxn.commit().get();
-            fail();
         } catch (Exception e) {
-            assertTrue(e.getCause() instanceof TransactionCoordinatorClientException.InvalidTxnStatusException);
+            fail();
         }
 
 
@@ -969,9 +960,8 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         try {
             consumeTxn.commit().get();
-            fail();
         } catch (Exception e) {
-            assertTrue(e.getCause() instanceof TransactionCoordinatorClientException.InvalidTxnStatusException);
+            fail();
         }
 
         Transaction timeoutTxn = pulsarClient

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
@@ -186,6 +186,9 @@ public class TransactionImpl implements Transaction , TimerTask {
     @Override
     public CompletableFuture<Void> commit() {
         timeout.cancel();
+        if (state == State.COMMITTED) {
+            return CompletableFuture.completedFuture(null);
+        }
         return checkIfOpenOrCommitting().thenCompose((value) -> {
             CompletableFuture<Void> commitFuture = new CompletableFuture<>();
             this.state = State.COMMITTING;
@@ -216,6 +219,9 @@ public class TransactionImpl implements Transaction , TimerTask {
     @Override
     public CompletableFuture<Void> abort() {
         timeout.cancel();
+        if (state == State.ABORTED) {
+            return CompletableFuture.completedFuture(null);
+        }
         return checkIfOpenOrAborting().thenCompose(value -> {
             CompletableFuture<Void> abortFuture = new CompletableFuture<>();
             this.state = State.ABORTING;

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStore.java
@@ -139,4 +139,11 @@ public interface TransactionMetadataStore {
      * @return {@link TxnMeta} the txnMetas of slow transactions
      */
     List<TxnMeta> getSlowTransactions(long timeout);
+
+
+    /**
+     * remove the txnMeta when the transaction is terminated.
+     * @param transactionId
+     */
+    void removeTerminatedTxnMeta(long transactionId);
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionRecoverTracker.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionRecoverTracker.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.transaction.coordinator;
 
+import java.util.Map;
 import org.apache.pulsar.transaction.coordinator.exceptions.CoordinatorException;
 import org.apache.pulsar.transaction.coordinator.proto.TxnStatus;
 
@@ -42,9 +43,15 @@ public interface TransactionRecoverTracker {
     void handleOpenStatusTransaction(long sequenceId, long timeout);
 
     /**
-     * Handle the transaction in open status append to transaction timeout tracker.
+     * Handle the transaction append to transaction timeout tracker.
      */
-    void appendOpenTransactionToTimeoutTracker();
+    void appendTransactionToTimeoutTracker(long unavailableDuration);
+
+    /**
+     * Handle the transaction in committed or aborted status.
+     */
+    void handleCommittedAbortedTransaction(long sequenceId, TxnStatus txnStatus,
+                                           long unavailableDuration, Map txnMetaMap);
 
     /**
      * Handle the transaction in committing and aborting status.

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionRecoverTracker.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionRecoverTracker.java
@@ -51,7 +51,7 @@ public interface TransactionRecoverTracker {
      * Handle the transaction in committed or aborted status.
      */
     void handleCommittedAbortedTransaction(long sequenceId, TxnStatus txnStatus,
-                                           long unavailableDuration, Map txnMetaMap);
+                                           long unavailableDuration, Map terminatedTxnMetaMap);
 
     /**
      * Handle the transaction in committing and aborting status.

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/InMemTransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/InMemTransactionMetadataStore.java
@@ -165,4 +165,9 @@ class InMemTransactionMetadataStore implements TransactionMetadataStore {
     public List<TxnMeta> getSlowTransactions(long timeout) {
         return null;
     }
+
+    @Override
+    public void removeTerminatedTxnMeta(long transactionId) {
+
+    }
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
@@ -72,7 +72,8 @@ public class MLTransactionMetadataStore
     @VisibleForTesting
     final ConcurrentSkipListMap<Long, Pair<TxnMeta, List<Position>>> txnMetaMap = new ConcurrentSkipListMap<>();
 
-    final ConcurrentSkipListMap<Long, Pair<TxnMeta, List<Position>>> terminatedTxnMetaMap = new ConcurrentSkipListMap<>();
+    final ConcurrentSkipListMap<Long, Pair<TxnMeta, List<Position>>> terminatedTxnMetaMap =
+            new ConcurrentSkipListMap<>();
 
     private final TransactionTimeoutTracker timeoutTracker;
     private final TransactionMetadataStoreStats transactionMetadataStoreStats;
@@ -203,8 +204,8 @@ public class MLTransactionMetadataStore
                                             // if openTimeStamp + timeout + unavailableDuration > currentTime,
                                             // we will remove txnMeta from terminatedTxnMetaMap.
                                             long unavailableDuration = System.currentTimeMillis() - shutdownTime;
-                                            recoverTracker.handleCommittedAbortedTransaction(
-                                                    transactionId, newStatus, unavailableDuration, terminatedTxnMetaMap);
+                                            recoverTracker.handleCommittedAbortedTransaction(transactionId,
+                                                    newStatus, unavailableDuration, terminatedTxnMetaMap);
                                         });
                                     }
                                 }
@@ -420,7 +421,7 @@ public class MLTransactionMetadataStore
                                     if (txnMetaListPair.getLeft().status() == newStatus) {
                                         transactionLog.deletePosition(Collections.singletonList(position));
                                         promise.complete(null);
-                                        return ;
+                                        return;
                                     }
                                     txnMetaListPair.getLeft().updateTxnStatus(newStatus, expectedStatus);
                                     txnMetaListPair.getRight().add(position);

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
@@ -197,13 +197,14 @@ public class MLTransactionMetadataStore
                                     if (newStatus == TxnStatus.COMMITTED || newStatus == TxnStatus.ABORTED) {
                                         transactionLog.deletePosition(txnMetaMap
                                                 .get(transactionId).getRight()).thenAccept(v -> {
+                                            terminatedTxnMetaMap.put(transactionId, txnMetaMap.remove(transactionId));
                                             // unavailableDuration decrements as TC scans the tc and shutdownTime
                                             // increments.
                                             // if openTimeStamp + timeout + unavailableDuration > currentTime,
-                                            // we will remove txnMeta from txnMetaMap.
+                                            // we will remove txnMeta from terminatedTxnMetaMap.
                                             long unavailableDuration = System.currentTimeMillis() - shutdownTime;
                                             recoverTracker.handleCommittedAbortedTransaction(
-                                                    transactionId, newStatus, unavailableDuration, txnMetaMap);
+                                                    transactionId, newStatus, unavailableDuration, terminatedTxnMetaMap);
                                         });
                                     }
                                 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
@@ -204,8 +204,8 @@ public class MLTransactionMetadataStore
                                             // if openTimeStamp + timeout + unavailableDuration > currentTime,
                                             // we will remove txnMeta from terminatedTxnMetaMap.
                                             long unavailableDuration = System.currentTimeMillis() - shutdownTime;
-                                            recoverTracker.handleCommittedAbortedTransaction(transactionId,
-                                                    newStatus, unavailableDuration, terminatedTxnMetaMap);
+                                            internalPinnedExecutor.execute(() -> recoverTracker.handleCommittedAbortedTransaction(
+                                                            transactionId, newStatus, unavailableDuration, terminatedTxnMetaMap));
                                         });
                                     }
                                 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
@@ -204,8 +204,9 @@ public class MLTransactionMetadataStore
                                             // if openTimeStamp + timeout + unavailableDuration > currentTime,
                                             // we will remove txnMeta from terminatedTxnMetaMap.
                                             long unavailableDuration = System.currentTimeMillis() - shutdownTime;
-                                            internalPinnedExecutor.execute(() -> recoverTracker.handleCommittedAbortedTransaction(
-                                                            transactionId, newStatus, unavailableDuration, terminatedTxnMetaMap));
+                                            internalPinnedExecutor.execute(() ->
+                                                    recoverTracker.handleCommittedAbortedTransaction(transactionId,
+                                                            newStatus, unavailableDuration, terminatedTxnMetaMap));
                                         });
                                     }
                                 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
@@ -418,6 +418,7 @@ public class MLTransactionMetadataStore
                             try {
                                 synchronized (txnMetaListPair.getLeft()) {
                                     if (txnMetaListPair.getLeft().status() == newStatus) {
+                                        transactionLog.deletePosition(Collections.singletonList(position));
                                         promise.complete(null);
                                         return ;
                                     }

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/MLTransactionMetadataStoreTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/MLTransactionMetadataStoreTest.java
@@ -133,9 +133,10 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
 
                 try {
                     transactionMetadataStore.getTxnMeta(txnID).get();
-                    fail();
                 } catch (ExecutionException e) {
-                    Assert.assertTrue(e.getCause() instanceof TransactionNotFoundException);
+                    // as we do not start the timeoutTracker, terminated txnMeta will not
+                    // be removed in terminatedTxnMetaMap.
+                    fail();
                 }
                 break;
             } else {
@@ -317,16 +318,18 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
                                 .updateTxnStatus(txnID2, TxnStatus.COMMITTED, TxnStatus.COMMITTING, false).get();
                         try {
                             transactionMetadataStoreTest.getTxnMeta(txnID1).get();
-                            fail();
                         } catch (ExecutionException e) {
-                            Assert.assertTrue(e.getCause() instanceof TransactionNotFoundException);
+                            // as we do not start the timeoutTracker, terminated txnMeta will not
+                            // be removed in terminatedTxnMetaMap.
+                            fail();
                         }
 
                         try {
                             transactionMetadataStoreTest.getTxnMeta(txnID2).get();
-                            fail();
                         } catch (ExecutionException e) {
-                            Assert.assertTrue(e.getCause() instanceof TransactionNotFoundException);
+                            // as we do not start the timeoutTracker, terminated txnMeta will not
+                            // be removed in terminatedTxnMetaMap.
+                            fail();
                         }
                         TxnID txnID = transactionMetadataStoreTest.newTransaction(1000, null).get();
                         assertEquals(txnID.getLeastSigBits(), 2L);

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/MLTransactionMetadataStoreTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/MLTransactionMetadataStoreTest.java
@@ -35,7 +35,6 @@ import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.transaction.coordinator.exceptions.CoordinatorException;
-import org.apache.pulsar.transaction.coordinator.exceptions.CoordinatorException.TransactionNotFoundException;
 import org.apache.pulsar.transaction.coordinator.impl.MLTransactionLogImpl;
 import org.apache.pulsar.transaction.coordinator.impl.MLTransactionSequenceIdGenerator;
 import org.apache.pulsar.transaction.coordinator.impl.MLTransactionMetadataStore;

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/MLTransactionMetadataStoreTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/MLTransactionMetadataStoreTest.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.transaction.coordinator;
 
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.concurrent.DefaultThreadFactory;
+
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.ManagedCursor;
@@ -538,7 +540,12 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
         }
 
         @Override
-        public void appendOpenTransactionToTimeoutTracker() {
+        public void appendTransactionToTimeoutTracker(long unavailableDuration) {
+
+        }
+
+        @Override
+        public void handleCommittedAbortedTransaction(long sequenceId, TxnStatus txnStatus, long unavailableDuration, Map txnMetaMap) {
 
         }
 


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->

Fixes #19629
PIP: https://github.com/apache/pulsar/issues/19744

**WARN: this PR implement Solution1 in PIP-255, which may be deprecated. Solution2 may be a better solution.**

### Motivation
when client try to commit a transaction which have been committed already, the broker will return exception. The client will regard that it fail to commit the transaction and resend the messages in this transaction, which will result into message duplication.
It should be emphasized that, there is retry logic in the internal logic of pulsar `tcClient`. We will meet problem above though we commit only once. For example, if broker restart, commit request may arrive to broker twice though we only commit once.
As a result, we should avoid throwing exceptions to client when the transaction is committed successfully.  
One of exceptions `Expect Txn `(7,24726)` to be in COMMITTING status but it is in COMMITTED status` is resulted by race condition.

### Modifications
- fix the race condition to avoid throwing exceptions like `Expect Txn `(7,24726)` to be in COMMITTING status but it is in COMMITTED status` .
- persist txnMeta for `transactionTimeout` to avoid `TransactionNotFound`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
- [ ] The REST endpoints

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/15

