### PR TITLE
[fix][broker] Fix LedgerOffloaderStatsImpl singleton close method

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LedgerOffloaderStatsImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LedgerOffloaderStatsImpl.java
@@ -276,17 +276,19 @@ public final class LedgerOffloaderStatsImpl implements LedgerOffloaderStats, Run
     }
 
     @Override
-    public void close() throws Exception {
+    public synchronized void close() throws Exception {
         if (instance == this && this.closed.compareAndSet(false, true)) {
             CollectorRegistry.defaultRegistry.unregister(this.offloadError);
             CollectorRegistry.defaultRegistry.unregister(this.offloadRate);
             CollectorRegistry.defaultRegistry.unregister(this.readLedgerLatency);
             CollectorRegistry.defaultRegistry.unregister(this.writeStorageError);
             CollectorRegistry.defaultRegistry.unregister(this.readOffloadError);
+            CollectorRegistry.defaultRegistry.unregister(this.readOffloadBytes);
             CollectorRegistry.defaultRegistry.unregister(this.readOffloadRate);
             CollectorRegistry.defaultRegistry.unregister(this.readOffloadIndexLatency);
             CollectorRegistry.defaultRegistry.unregister(this.readOffloadDataLatency);
-            this.offloadAndReadOffloadBytesMap.clear();
+            CollectorRegistry.defaultRegistry.unregister(this.deleteOffloadOps);
+            instance = null;
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.broker.stats;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
@@ -20,14 +20,12 @@ package org.apache.pulsar.broker.stats;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.bookkeeper.mledger.impl.LedgerOffloaderStatsImpl;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.BrokerTestBase;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
@@ -20,19 +20,21 @@ package org.apache.pulsar.broker.stats;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+
 import org.apache.bookkeeper.mledger.impl.LedgerOffloaderStatsImpl;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
-public class LedgerOffloaderMetricsTest  extends BrokerTestBase {
+public class LedgerOffloaderMetricsTest extends BrokerTestBase {
 
     @Override
     protected void setup() throws Exception {
@@ -60,7 +62,7 @@ public class LedgerOffloaderMetricsTest  extends BrokerTestBase {
 
         String ns1 = "prop/ns-abc1";
         admin.namespaces().createNamespace(ns1);
-        String []topics = new String[3];
+        String[] topics = new String[3];
 
         LedgerOffloaderStatsImpl offloaderStats = (LedgerOffloaderStatsImpl) pulsar.getOffloaderStats();
         for (int i = 0; i < 3; i++) {
@@ -80,10 +82,10 @@ public class LedgerOffloaderMetricsTest  extends BrokerTestBase {
 
         for (String topicName : topics) {
             assertEquals(offloaderStats.getOffloadError(topicName), 2);
-            assertEquals(offloaderStats.getOffloadBytes(topicName) , 100);
+            assertEquals(offloaderStats.getOffloadBytes(topicName), 100);
             assertEquals((long) offloaderStats.getReadLedgerLatency(topicName).sum, 1);
             assertEquals(offloaderStats.getReadOffloadError(topicName), 2);
-            assertEquals((long) offloaderStats.getReadOffloadIndexLatency(topicName).sum ,1000);
+            assertEquals((long) offloaderStats.getReadOffloadIndexLatency(topicName).sum, 1000);
             assertEquals(offloaderStats.getReadOffloadBytes(topicName), 100000);
             assertEquals(offloaderStats.getWriteStorageError(topicName), 2);
         }
@@ -126,13 +128,13 @@ public class LedgerOffloaderMetricsTest  extends BrokerTestBase {
             List<String> topics = entry.getValue();
             String topicName = topics.get(0);
 
-            assertTrue(offloaderStats.getOffloadError(topicName) >= 1);
-            assertTrue(offloaderStats.getOffloadBytes(topicName) >= 100);
-            assertTrue((long) offloaderStats.getReadLedgerLatency(topicName).sum >= 1);
-            assertTrue(offloaderStats.getReadOffloadError(topicName) >= 1);
-            assertTrue((long) offloaderStats.getReadOffloadIndexLatency(topicName).sum >= 1000);
-            assertTrue(offloaderStats.getReadOffloadBytes(topicName) >= 100000);
-            assertTrue(offloaderStats.getWriteStorageError(topicName) >= 1);
+            assertEquals(offloaderStats.getOffloadError(topicName), 6);
+            assertEquals(offloaderStats.getOffloadBytes(topicName), 600);
+            assertEquals((long) offloaderStats.getReadLedgerLatency(topicName).sum, 6);
+            assertEquals(offloaderStats.getReadOffloadError(topicName), 6);
+            assertEquals((long) offloaderStats.getReadOffloadIndexLatency(topicName).sum, 6000);
+            assertEquals(offloaderStats.getReadOffloadBytes(topicName), 600000);
+            assertEquals(offloaderStats.getWriteStorageError(topicName), 6);
         }
     }
 


### PR DESCRIPTION
### Motivation

The `LedgerOffloaderStatsImpl` singleton close method can't be called twice due to wrong condition in the close method.
Also not every metric is unregistered from the prometheus collector.
Also there might be concurrency issues while closing.

I've noticed that the test `LedgerOffloaderMetricsTest` often fails if the topic test method is executed after the namespace one.
This is because the assertions in the namespace test are not strict enough to catch the error. 

### Modifications

* Set the singleton instance to null after closing
* Unregister all the metrics
* Add `synchronized` to the close method which makes sense since the creation method is synchronized too
* Fix assertion in LedgerOffloaderMetricsTest to be more precise


### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

