### PR TITLE
[fix][broker] Filter system topic when getting topic list by binary proto.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -2182,8 +2182,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     getBrokerService().pulsar().getNamespaceService().getListOfTopics(namespaceName, mode)
                         .thenAccept(topics -> {
                             boolean filterTopics = false;
-                            // filter transaction internal topic
-                            List<String> filteredTopics = TopicList.filterTransactionInternalName(topics);
+                            // filter system topic
+                            List<String> filteredTopics = TopicList.filterSystemTopic(topics);
 
                             if (enableSubscriptionPatternEvaluation && topicsPattern.isPresent()) {
                                 if (topicsPattern.get().length() <= maxSubscriptionPatternLength) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicList.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicList.java
@@ -57,9 +57,9 @@ public class TopicList {
                 .collect(Collectors.toList());
     }
 
-    public static List<String> filterTransactionInternalName(List<String> original) {
+    public static List<String> filterSystemTopic(List<String> original) {
         return original.stream()
-                .filter(topic -> !SystemTopicNames.isTransactionInternalName(TopicName.get(topic)))
+                .filter(topic -> !SystemTopicNames.isSystemTopic(TopicName.get(topic)))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
### Motivation

In v2.11.0, the system topic [enables by default](https://github.com/apache/pulsar/pull/15619). This causes the `GET_TOPICS_OF_NAMESPACE ` command to return the system topic redundantly.

And, If the transaction is enabled, the transaction-related system topic will return by the client(`__transaction_buffer_snapshot, __transaction_buffer_snapshot_segments, __transaction_buffer_snapshot_indexes`). This [PR](https://github.com/apache/pulsar/pull/16533) filters some transaction-related topics,  but these are missing.

This causes some incompatibility issues: If consumers use pattern subscribe and the pattern is `/tenant/namespace/.*`, it will subscribe to these system topics.

Discuss mail: https://lists.apache.org/thread/qhm0zbfw0wfd1m5vj977w002qmkr5lt9

### Modifications
- Filter system topic when getting topic list by binary proto.

### Verifying this change
- `testBinaryProtoSubscribeAllTopicOfNamespace` will cover the don't subscribe system topic.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/shibd/pulsar/pull/21

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
