### PR TITLE
[fix][client] Fix typo in Java doc for ClientConfigurationData

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -170,7 +170,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
 
     @ApiModelProperty(
             name = "tlsHostnameVerificationEnable",
-            value = "Whether the hostname is validated when the proxy creates a TLS connection with brokers."
+            value = "Whether the hostname is validated when the client creates a TLS connection with brokers."
     )
     private boolean tlsHostnameVerificationEnable = false;
     @ApiModelProperty(


### PR DESCRIPTION
### Motivation

A minor typo fix.

### Modifications

Update `ClientConfigurationData` by replacing `proxy` with `client`.

### Documentation

- [x] `doc`

This is a doc change.