### PR TITLE
[improve][broker] PIP-192 Switched Assigning and Releasing state order in the transfer protocol

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitState.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitState.java
@@ -47,9 +47,9 @@ public enum ServiceUnitState {
             // when the topic is compacted in the middle of assign, transfer or split.
             Init, Set.of(Free, Owned, Assigning, Releasing, Splitting, Deleted),
             Free, Set.of(Assigning, Init),
-            Owned, Set.of(Assigning, Splitting, Releasing),
-            Assigning, Set.of(Owned, Releasing),
-            Releasing, Set.of(Owned, Free),
+            Owned, Set.of(Splitting, Releasing),
+            Assigning, Set.of(Owned),
+            Releasing, Set.of(Assigning, Free),
             Splitting, Set.of(Deleted),
             Deleted, Set.of(Init)
     );
@@ -67,4 +67,7 @@ public enum ServiceUnitState {
         return inFlightStates.contains(state);
     }
 
+    public static boolean isActiveState(ServiceUnitState state) {
+        return inFlightStates.contains(state) || state == Owned;
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateCompactionStrategy.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateCompactionStrategy.java
@@ -71,22 +71,21 @@ public class ServiceUnitStateCompactionStrategy implements TopicCompactionStrate
             switch (prevState) {
                 case Owned:
                     switch (state) {
-                        case Assigning:
-                            return invalidTransfer(from, to);
                         case Splitting:
+                            return isNotBlank(to.dstBroker())
+                                    || !from.dstBroker().equals(to.sourceBroker());
                         case Releasing:
-                            return isNotBlank(to.sourceBroker()) || targetNotEquals(from, to);
+                            return invalidUnload(from, to);
                     }
                 case Assigning:
                     switch (state) {
-                        case Releasing:
-                            return isBlank(to.sourceBroker()) || notEquals(from, to);
                         case Owned:
-                            return isNotBlank(to.sourceBroker()) || targetNotEquals(from, to);
+                            return notEquals(from, to);
                     }
                 case Releasing:
                     switch (state) {
-                        case Owned:
+                        case Assigning:
+                            return isBlank(to.dstBroker()) || notEquals(from, to);
                         case Free:
                             return notEquals(from, to);
                     }
@@ -98,24 +97,21 @@ public class ServiceUnitStateCompactionStrategy implements TopicCompactionStrate
                 case Free:
                     switch (state) {
                         case Assigning:
-                            return isNotBlank(to.sourceBroker());
+                            return isNotBlank(to.sourceBroker()) || isBlank(to.dstBroker());
                     }
             }
         }
         return false;
     }
 
-    private boolean targetNotEquals(ServiceUnitStateData from, ServiceUnitStateData to) {
-        return !from.broker().equals(to.broker());
-    }
-
     private boolean notEquals(ServiceUnitStateData from, ServiceUnitStateData to) {
-        return !from.broker().equals(to.broker())
+        return !StringUtils.equals(from.dstBroker(), to.dstBroker())
                 || !StringUtils.equals(from.sourceBroker(), to.sourceBroker());
     }
 
-    private boolean invalidTransfer(ServiceUnitStateData from, ServiceUnitStateData to) {
-        return !from.broker().equals(to.sourceBroker())
-                || from.broker().equals(to.broker());
+    private boolean invalidUnload(ServiceUnitStateData from, ServiceUnitStateData to) {
+        return isBlank(to.sourceBroker())
+                || !from.dstBroker().equals(to.sourceBroker())
+                || from.dstBroker().equals(to.dstBroker());
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateData.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateData.java
@@ -27,25 +27,25 @@ import org.apache.commons.lang3.StringUtils;
  */
 
 public record ServiceUnitStateData(
-        ServiceUnitState state, String broker, String sourceBroker, boolean force, long timestamp, long versionId) {
+        ServiceUnitState state, String dstBroker, String sourceBroker, boolean force, long timestamp, long versionId) {
 
     public ServiceUnitStateData {
         Objects.requireNonNull(state);
-        if (StringUtils.isBlank(broker)) {
+        if (StringUtils.isBlank(dstBroker) && StringUtils.isBlank(sourceBroker)) {
             throw new IllegalArgumentException("Empty broker");
         }
     }
 
-    public ServiceUnitStateData(ServiceUnitState state, String broker, String sourceBroker, long versionId) {
-        this(state, broker, sourceBroker, false, System.currentTimeMillis(), versionId);
+    public ServiceUnitStateData(ServiceUnitState state, String dstBroker, String sourceBroker, long versionId) {
+        this(state, dstBroker, sourceBroker, false, System.currentTimeMillis(), versionId);
     }
 
-    public ServiceUnitStateData(ServiceUnitState state, String broker, long versionId) {
-        this(state, broker, null, false, System.currentTimeMillis(), versionId);
+    public ServiceUnitStateData(ServiceUnitState state, String dstBroker, long versionId) {
+        this(state, dstBroker, null, false, System.currentTimeMillis(), versionId);
     }
 
-    public ServiceUnitStateData(ServiceUnitState state, String broker, boolean force, long versionId) {
-        this(state, broker, null, force, System.currentTimeMillis(), versionId);
+    public ServiceUnitStateData(ServiceUnitState state, String dstBroker, boolean force, long versionId) {
+        this(state, dstBroker, null, force, System.currentTimeMillis(), versionId);
     }
 
     public static ServiceUnitState state(ServiceUnitStateData data) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateCompactionStrategyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateCompactionStrategyTest.java
@@ -71,19 +71,19 @@ public class ServiceUnitStateCompactionStrategyTest {
 
         assertFalse(strategy.shouldKeepLeft(
                 new ServiceUnitStateData(Owned, dst, src, 10),
-                new ServiceUnitStateData(Assigning, "broker2", dst, 11)));
+                new ServiceUnitStateData(Releasing, "broker2", dst, 11)));
 
         assertFalse(strategy.shouldKeepLeft(
                 new ServiceUnitStateData(Owned, dst, src, Long.MAX_VALUE),
-                new ServiceUnitStateData(Assigning, "broker2", dst, Long.MAX_VALUE + 1)));
+                new ServiceUnitStateData(Releasing, "broker2", dst, Long.MAX_VALUE + 1)));
 
         assertFalse(strategy.shouldKeepLeft(
                 new ServiceUnitStateData(Owned, dst, src, Long.MAX_VALUE + 1),
-                new ServiceUnitStateData(Assigning, "broker2", dst, Long.MAX_VALUE + 2)));
+                new ServiceUnitStateData(Releasing, "broker2", dst, Long.MAX_VALUE + 2)));
 
         assertTrue(strategy.shouldKeepLeft(
                 new ServiceUnitStateData(Owned, dst, src, 10),
-                new ServiceUnitStateData(Assigning, "broker2", dst, 5)));
+                new ServiceUnitStateData(Releasing, "broker2", dst, 5)));
 
     }
 
@@ -133,41 +133,42 @@ public class ServiceUnitStateCompactionStrategyTest {
         assertTrue(strategy.shouldKeepLeft(data(Assigning, "dst1"), data2(Owned, "dst2")));
         assertTrue(strategy.shouldKeepLeft(data(Assigning, dst), data2(Owned, src, dst)));
         assertFalse(strategy.shouldKeepLeft(data(Assigning, dst), data2(Owned, dst)));
+        assertFalse(strategy.shouldKeepLeft(data(Assigning, src, dst), data2(Owned, src, dst)));
         assertTrue(strategy.shouldKeepLeft(data(Assigning, src, dst), data2(Releasing, dst)));
-        assertTrue(strategy.shouldKeepLeft(data(Assigning, src, "dst1"), data2(Releasing, src, "dst2")));
-        assertTrue(strategy.shouldKeepLeft(data(Assigning, "src1", dst), data2(Releasing, "src2", dst)));
-        assertFalse(strategy.shouldKeepLeft(data(Assigning, src, dst), data2(Releasing, src, dst)));
+        assertTrue(strategy.shouldKeepLeft(data(Assigning, src, dst), data2(Releasing, src, dst)));
         assertTrue(strategy.shouldKeepLeft(data(Assigning), data2(Splitting, dst)));
         assertTrue(strategy.shouldKeepLeft(data(Assigning), data2(Deleted, dst)));
 
         assertTrue(strategy.shouldKeepLeft(data(Owned), data2(Init)));
         assertTrue(strategy.shouldKeepLeft(data(Owned), data2(Free)));
-        assertTrue(strategy.shouldKeepLeft(data(Owned, src, "dst1"), data2(Assigning, src, "dst2")));
-        assertTrue(strategy.shouldKeepLeft(data(Owned, src, dst), data2(Assigning, dst)));
-        assertTrue(strategy.shouldKeepLeft(data(Owned, src, dst), data2(Assigning, src, dst)));
-        assertTrue(strategy.shouldKeepLeft(data(Owned, src, dst), data2(Assigning, dst, dst)));
-        assertFalse(strategy.shouldKeepLeft(data(Owned, src, dst), data2(Assigning, dst, "dst1")));
+        assertTrue(strategy.shouldKeepLeft(data(Owned), data2(Assigning)));
         assertTrue(strategy.shouldKeepLeft(data(Owned), data2(Owned)));
         assertTrue(strategy.shouldKeepLeft(data(Owned), data2(Releasing, dst)));
         assertTrue(strategy.shouldKeepLeft(data(Owned, src, "dst1"), data2(Releasing, src, "dst2")));
         assertTrue(strategy.shouldKeepLeft(data(Owned, "dst1"), data2(Releasing, "dst2")));
-        assertFalse(strategy.shouldKeepLeft(data(Owned, dst), data2(Releasing, dst)));
-        assertFalse(strategy.shouldKeepLeft(data(Owned, src, dst), data2(Releasing, dst)));
+        assertTrue(strategy.shouldKeepLeft(data(Owned, dst), data2(Releasing, dst)));
+        assertTrue(strategy.shouldKeepLeft(data(Owned, src, dst), data2(Releasing, null, dst)));
+        assertTrue(strategy.shouldKeepLeft(data(Owned, src, dst), data2(Releasing, src, null)));
+        assertFalse(strategy.shouldKeepLeft(data(Owned, src, dst), data2(Releasing, dst, null)));
+        assertTrue(strategy.shouldKeepLeft(data(Owned, src, "dst1"), data2(Releasing, src, "dst2")));
+        assertTrue(strategy.shouldKeepLeft(data(Owned, "src1", dst), data2(Releasing, "src2", dst)));
+        assertTrue(strategy.shouldKeepLeft(data(Owned, src, dst), data2(Releasing, src, dst)));
+        assertFalse(strategy.shouldKeepLeft(data(Owned, src, dst), data2(Releasing, dst, "dst2")));
         assertTrue(strategy.shouldKeepLeft(data(Owned, src, "dst1"), data2(Splitting, src, "dst2")));
         assertTrue(strategy.shouldKeepLeft(data(Owned, "dst1"), data2(Splitting, "dst2")));
-        assertFalse(strategy.shouldKeepLeft(data(Owned, dst), data2(Splitting, dst)));
-        assertFalse(strategy.shouldKeepLeft(data(Owned, src, dst), data2(Splitting, dst)));
+        assertFalse(strategy.shouldKeepLeft(data(Owned, dst), data2(Splitting, dst, null)));
+        assertFalse(strategy.shouldKeepLeft(data(Owned, src, dst), data2(Splitting, dst, null)));
         assertTrue(strategy.shouldKeepLeft(data(Owned), data2(Deleted, dst)));
 
         assertTrue(strategy.shouldKeepLeft(data(Releasing), data2(Init)));
         assertFalse(strategy.shouldKeepLeft(data(Releasing), data2(Free)));
         assertTrue(strategy.shouldKeepLeft(data(Releasing, "dst1"), data2(Free, "dst2")));
         assertTrue(strategy.shouldKeepLeft(data(Releasing, "src1", dst), data2(Free, "src2", dst)));
-        assertTrue(strategy.shouldKeepLeft(data(Releasing), data2(Assigning)));
-        assertTrue(strategy.shouldKeepLeft(data(Releasing, "dst1"), data2(Owned, "dst2")));
-        assertTrue(strategy.shouldKeepLeft(data(Releasing, src, "dst1"), data2(Owned, src, "dst2")));
-        assertTrue(strategy.shouldKeepLeft(data(Releasing, "src1", dst), data2(Owned, "src2", dst)));
-        assertFalse(strategy.shouldKeepLeft(data(Releasing, src, dst), data2(Owned, src, dst)));
+        assertTrue(strategy.shouldKeepLeft(data(Releasing, src, "dst1"), data2(Assigning, src, "dst2")));
+        assertTrue(strategy.shouldKeepLeft(data(Releasing, src, "dst1"), data2(Assigning, src, "dst2")));
+        assertTrue(strategy.shouldKeepLeft(data(Releasing, "src1", dst), data2(Assigning, "src2", dst)));
+        assertFalse(strategy.shouldKeepLeft(data(Releasing, src, dst), data2(Assigning, src, dst)));
+        assertTrue(strategy.shouldKeepLeft(data(Releasing), data2(Owned)));
         assertTrue(strategy.shouldKeepLeft(data(Releasing), data2(Releasing)));
         assertTrue(strategy.shouldKeepLeft(data(Releasing), data2(Splitting)));
         assertTrue(strategy.shouldKeepLeft(data(Releasing), data2(Deleted, dst)));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateDataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateDataTest.java
@@ -35,16 +35,15 @@ public class ServiceUnitStateDataTest {
     public void testConstructors() throws InterruptedException {
         ServiceUnitStateData data1 = new ServiceUnitStateData(Owned, "A", 1);
         assertEquals(data1.state(), Owned);
-        assertEquals(data1.broker(), "A");
+        assertEquals(data1.dstBroker(), "A");
         assertNull(data1.sourceBroker());
         assertThat(data1.timestamp()).isGreaterThan(0);
-        ;
 
         Thread.sleep(10);
 
         ServiceUnitStateData data2 = new ServiceUnitStateData(Assigning, "A", "B", 1);
         assertEquals(data2.state(), Assigning);
-        assertEquals(data2.broker(), "A");
+        assertEquals(data2.dstBroker(), "A");
         assertEquals(data2.sourceBroker(), "B");
         assertThat(data2.timestamp()).isGreaterThan(data1.timestamp());
     }
@@ -55,13 +54,13 @@ public class ServiceUnitStateDataTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testNullBroker() {
-        new ServiceUnitStateData(Owned, null, 1);
+    public void testNullBrokers() {
+        new ServiceUnitStateData(Owned, null, null, 1);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testEmptyBroker() {
-        new ServiceUnitStateData(Owned, "", 1);
+    public void testEmptyBrokers() {
+        new ServiceUnitStateData(Owned, "", "", 1);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTest.java
@@ -43,6 +43,17 @@ public class ServiceUnitStateTest {
     }
 
     @Test
+    public void testActive() {
+        assertFalse(ServiceUnitState.isActiveState(Init));
+        assertFalse(ServiceUnitState.isActiveState(Free));
+        assertTrue(ServiceUnitState.isActiveState(Owned));
+        assertTrue(ServiceUnitState.isActiveState(Assigning));
+        assertTrue(ServiceUnitState.isActiveState(Releasing));
+        assertTrue(ServiceUnitState.isActiveState(Splitting));
+        assertFalse(ServiceUnitState.isActiveState(Deleted));
+    }
+
+    @Test
     public void testTransitions() {
 
         assertFalse(ServiceUnitState.isValidTransition(Init, Init));
@@ -65,13 +76,13 @@ public class ServiceUnitStateTest {
         assertFalse(ServiceUnitState.isValidTransition(Assigning, Free));
         assertFalse(ServiceUnitState.isValidTransition(Assigning, Assigning));
         assertTrue(ServiceUnitState.isValidTransition(Assigning, Owned));
-        assertTrue(ServiceUnitState.isValidTransition(Assigning, Releasing));
+        assertFalse(ServiceUnitState.isValidTransition(Assigning, Releasing));
         assertFalse(ServiceUnitState.isValidTransition(Assigning, Splitting));
         assertFalse(ServiceUnitState.isValidTransition(Assigning, Deleted));
 
         assertFalse(ServiceUnitState.isValidTransition(Owned, Init));
         assertFalse(ServiceUnitState.isValidTransition(Owned, Free));
-        assertTrue(ServiceUnitState.isValidTransition(Owned, Assigning));
+        assertFalse(ServiceUnitState.isValidTransition(Owned, Assigning));
         assertFalse(ServiceUnitState.isValidTransition(Owned, Owned));
         assertTrue(ServiceUnitState.isValidTransition(Owned, Releasing));
         assertTrue(ServiceUnitState.isValidTransition(Owned, Splitting));
@@ -79,8 +90,8 @@ public class ServiceUnitStateTest {
 
         assertFalse(ServiceUnitState.isValidTransition(Releasing, Init));
         assertTrue(ServiceUnitState.isValidTransition(Releasing, Free));
-        assertFalse(ServiceUnitState.isValidTransition(Releasing, Assigning));
-        assertTrue(ServiceUnitState.isValidTransition(Releasing, Owned));
+        assertTrue(ServiceUnitState.isValidTransition(Releasing, Assigning));
+        assertFalse(ServiceUnitState.isValidTransition(Releasing, Owned));
         assertFalse(ServiceUnitState.isValidTransition(Releasing, Releasing));
         assertFalse(ServiceUnitState.isValidTransition(Releasing, Splitting));
         assertFalse(ServiceUnitState.isValidTransition(Releasing, Deleted));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/ServiceUnitStateCompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/ServiceUnitStateCompactionTest.java
@@ -570,12 +570,12 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
         long versionId = 1;
         producer.newMessage().key(bundle).value(new ServiceUnitStateData(Owned, src, versionId++)).send();
         for (int i = 0; i < 3; i++) {
-            var assignedStateData = new ServiceUnitStateData(Assigning, dst, src, versionId++);
-            producer.newMessage().key(bundle).value(assignedStateData).send();
-            producer.newMessage().key(bundle).value(assignedStateData).send();
             var releasedStateData = new ServiceUnitStateData(Releasing, dst, src, versionId++);
             producer.newMessage().key(bundle).value(releasedStateData).send();
             producer.newMessage().key(bundle).value(releasedStateData).send();
+            var assignedStateData = new ServiceUnitStateData(Assigning, dst, src, versionId++);
+            producer.newMessage().key(bundle).value(assignedStateData).send();
+            producer.newMessage().key(bundle).value(assignedStateData).send();
             var ownedStateData = new ServiceUnitStateData(Owned, dst, src, versionId++);
             producer.newMessage().key(bundle).value(ownedStateData).send();
             producer.newMessage().key(bundle).value(ownedStateData).send();
@@ -726,7 +726,7 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
                 .subscriptionName("sub1").readCompacted(true).subscribe()) {
             Message<ServiceUnitStateData> message = consumer.receive();
             Assert.assertEquals(message.getKey(), "key1");
-            Assert.assertEquals(new String(message.getValue().broker()), "my-message-4");
+            Assert.assertEquals(new String(message.getValue().dstBroker()), "my-message-4");
         }
     }
 
@@ -860,7 +860,7 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
             Message<ServiceUnitStateData> m1 = consumer.receive();
             assertNotNull(m1);
             assertEquals(m1.getKey(), key);
-            assertEquals(m1.getValue().broker(), "19");
+            assertEquals(m1.getValue().dstBroker(), "19");
             Message<ServiceUnitStateData> none = consumer.receive(2, TimeUnit.SECONDS);
             assertNull(none);
         }
@@ -908,7 +908,7 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
                 Message<ServiceUnitStateData> received = consumer.receive();
                 assertNotNull(received);
                 assertEquals(received.getKey(), key);
-                assertEquals(received.getValue().broker(), i + 9 + "");
+                assertEquals(received.getValue().dstBroker(), i + 9 + "");
                 consumer.acknowledge(received);
             }
             Message<ServiceUnitStateData> none = consumer.receive(2, TimeUnit.SECONDS);
@@ -946,7 +946,7 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
                 Message<ServiceUnitStateData> received = consumer.receive();
                 assertNotNull(received);
                 assertEquals(received.getKey(), key);
-                assertEquals(received.getValue().broker(), i + 20 + "");
+                assertEquals(received.getValue().dstBroker(), i + 20 + "");
                 consumer.acknowledge(received);
             }
             Message<ServiceUnitStateData> none = consumer.receive(2, TimeUnit.SECONDS);


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->



<!-- or this PR is one task of an issue -->

Master Issue: https://github.com/apache/pulsar/issues/16691

### Motivation

As part of the PIP implementation: https://github.com/apache/pulsar/issues/16691

I propose switching `Assigning` and `Releasing` state order in the transfer protocol to the following.

Before:
Owned -> Assigning -> Releasing -> Owned

After:
Owned -> Releasing -> Assigning -> Owned

Reasoning:
- The broker states in the assigning state are consistent in both transfer and assign commands in that the dst broker acks the ownership by publishing own message.
- In the future, it will be easier to make the transfer command 2pc (Owned -> Releasing -> Owned) to optimize the transfer protocol latency, if required. For the 2pc, with this change, we can make the src broker publish `Own` message right after `Releasing`(optimistically assuming the dst broker is available).


### Modifications
This PR 
- Switched `Assigning` and `Releasing` state order in the transfer protocol.

Before:
Owned -> Assigning -> Releasing -> Owned

After:
Owned -> Releasing -> Assigning -> Owned

![Bundle States](https://user-images.githubusercontent.com/103456639/222288039-07aaaf90-63c7-469e-977c-3a8332eb1f82.png)


- Renamed BrokerLoadData.broker to BrokerLoadData.dstBroker to clarify the role of dst brokers, and accordingly updated the code.

<!-- Describe the modifications you've done. -->


### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - *Updaated unit tests.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

We will have separate PRs to update the Doc later.

### Matching PR in forked repository

PR in forked repository: https://github.com/heesung-sn/pulsar/pull/35

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
