### PR TITLE
[fix] [broker] Topic close failure leaves subscription in a permanent fence state

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -929,7 +929,7 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
     public synchronized void resumeAfterFence() {
         // If "fenceFuture" is null, it means that "disconnect" has never been called.
         if (fenceFuture != null) {
-            fenceFuture.whenComplete((ignore, closeFail) -> {
+            fenceFuture.whenComplete((ignore, ignoreEx) -> {
                 synchronized (PersistentSubscription.this) {
                     try {
                         if (IS_FENCED_UPDATER.compareAndSet(this, TRUE, FALSE)) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -898,10 +898,7 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
      */
     @Override
     public synchronized CompletableFuture<Void> disconnect() {
-        if (fenceFuture != null && !fenceFuture.isDone()){
-            return fenceFuture;
-        }
-        if (fenceFuture != null && fenceFuture.isDone() && !fenceFuture.isCompletedExceptionally()){
+        if (fenceFuture != null){
             return fenceFuture;
         }
         fenceFuture = new CompletableFuture<>();
@@ -939,7 +936,7 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
                         }
                         fenceFuture = null;
                     } catch (Exception ex) {
-                        log.error("[{}] Resume subscription[{}] failure: {}", topicName, subName, ex.getMessage(), ex);
+                        log.error("[{}] Resume subscription [{}] failure", topicName, subName, ex);
                     }
                 }
             });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -931,7 +931,6 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
         if (fenceFuture != null) {
             fenceFuture.whenComplete((ignore, closeFail) -> {
                 synchronized (PersistentSubscription.this) {
-                    // If "closeFail" is null, the status will be replied by "disconnect".
                     if (closeFail != null) {
                         return;
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -931,9 +931,6 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
         if (fenceFuture != null) {
             fenceFuture.whenComplete((ignore, closeFail) -> {
                 synchronized (PersistentSubscription.this) {
-                    if (closeFail != null) {
-                        return;
-                    }
                     try {
                         if (IS_FENCED_UPDATER.compareAndSet(this, TRUE, FALSE)) {
                             if (dispatcher != null) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -937,7 +937,7 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
             return CompletableFuture.completedFuture(null);
         } else {
             fenceFuture.whenComplete((ignore, closeFail) -> {
-                synchronized (this) {
+                synchronized (PersistentSubscription.this) {
                     // If "closeFail" is null, the status will be replied by "disconnect".
                     if (closeFail != null) {
                         result.complete(null);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3234,6 +3234,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     private void unfenceTopicToResume() {
+        subscriptions.values().forEach(sub -> sub.resumeAfterFence());
         isFenced = false;
         isClosingOrDeleting = false;
     }


### PR DESCRIPTION
### Motivation
After a Topic close failure or a delete failure, the fence state will be reset to get the topic back to work,but it will not reset the fence state of the subscription, which will result in the consumer never being able to connect to the broker.

![image](https://user-images.githubusercontent.com/25195800/222391415-4446b8d4-7856-4064-ae7d-fafb446b021e.png)


### Modifications
Reset the fence state of subscriptions if the operation of topic close is failed.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- https://github.com/poorbarcode/pulsar/pull/73
