### PR TITLE
[fix][cli] Fix Pulsar admin tool is ignoring tls-trust-cert path arg

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.admin.internal;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
@@ -33,6 +34,7 @@ import org.apache.pulsar.client.impl.conf.ConfigurationDataUtils;
 
 public class PulsarAdminBuilderImpl implements PulsarAdminBuilder {
 
+    @Getter
     protected ClientConfigurationData conf;
 
     private ClassLoader clientBuilderClassLoader = null;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminSupplier.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminSupplier.java
@@ -53,7 +53,7 @@ public class PulsarAdminSupplier implements Supplier<PulsarAdmin> {
         }
     }
 
-    private final PulsarAdminBuilder adminBuilder;
+    protected final PulsarAdminBuilder adminBuilder;
     private RootParamsKey currentParamsKey;
     private PulsarAdmin admin;
 
@@ -102,6 +102,9 @@ public class PulsarAdminSupplier implements Supplier<PulsarAdmin> {
         }
         if (isNotBlank(rootParams.tlsProvider)) {
             adminBuilder.sslProvider(rootParams.tlsProvider);
+        }
+        if (isNotBlank(rootParams.tlsTrustCertsFilePath)) {
+            adminBuilder.tlsTrustCertsFilePath(rootParams.tlsTrustCertsFilePath);
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -45,7 +45,7 @@ import org.apache.pulsar.common.util.ShutdownUtil;
 
 public class PulsarAdminTool {
 
-    private static boolean allowSystemExit = true;
+    protected static boolean allowSystemExit = true;
 
     private static int lastExitCode = Integer.MIN_VALUE;
 
@@ -54,7 +54,7 @@ public class PulsarAdminTool {
     protected JCommander jcommander;
     protected RootParams rootParams;
     private final Properties properties;
-    private PulsarAdminSupplier pulsarAdminSupplier;
+    protected PulsarAdminSupplier pulsarAdminSupplier;
 
     @Getter
     public static class RootParams {
@@ -277,11 +277,16 @@ public class PulsarAdminTool {
     }
 
     public static void main(String[] args) throws Exception {
+        execute(args);
+    }
+
+    @VisibleForTesting
+    public static PulsarAdminTool execute(String[] args) throws Exception {
         lastExitCode = 0;
         if (args.length == 0) {
             System.out.println("Usage: pulsar-admin CONF_FILE_PATH [options] [command] [command options]");
             exit(0);
-            return;
+            return null;
         }
         String configFile = args[0];
         Properties properties = new Properties();
@@ -299,6 +304,7 @@ public class PulsarAdminTool {
         } else {
             exit(1);
         }
+        return tool;
     }
 
     private static void exit(int code) {

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestRunMain.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestRunMain.java
@@ -19,9 +19,15 @@
 package org.apache.pulsar.admin.cli;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
+import org.apache.pulsar.client.admin.internal.PulsarAdminBuilderImpl;
 import org.testng.annotations.Test;
 
 public class TestRunMain {
@@ -74,5 +80,34 @@ public class TestRunMain {
                 "--tls-provider", "OPENSSL",
                 "tenants"});
         assertEquals(pulsarAdminTool.rootParams.tlsProvider, "OPENSSL");
+    }
+
+    @Test
+    public void testMainArgs() throws Exception {
+        String tlsTrustCertsFilePathInFile = "ca-file.cert";
+        String tlsTrustCertsFilePathInArg = "ca-arg.cert";
+        File testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
+        if (testConfigFile.exists()) {
+            testConfigFile.delete();
+        }
+        PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)));
+        printWriter.println("tlsTrustCertsFilePath=" + tlsTrustCertsFilePathInFile);
+        printWriter.println("tlsAllowInsecureConnection=" + false);
+        printWriter.println("tlsEnableHostnameVerification=" + false);
+
+        printWriter.close();
+        testConfigFile.deleteOnExit();
+
+        String argStrTemp = "%s %s --admin-url https://url:4443 " + "topics stats persistent://prop/cluster/ns/t1";
+        boolean prevValue = PulsarAdminTool.allowSystemExit;
+        PulsarAdminTool.allowSystemExit = false;
+
+        String argStr = argStr = argStrTemp.format(argStrTemp, testConfigFile.getAbsolutePath(),
+                "--tls-trust-cert-path " + tlsTrustCertsFilePathInArg);
+        PulsarAdminTool tool = PulsarAdminTool.execute(argStr.split(" "));
+        assertNotNull(tool);
+        PulsarAdminBuilderImpl builder = (PulsarAdminBuilderImpl) tool.pulsarAdminSupplier.adminBuilder;
+        assertEquals(builder.getConf().getTlsTrustCertsFilePath(), tlsTrustCertsFilePathInArg);
+        PulsarAdminTool.allowSystemExit = prevValue;
     }
 }


### PR DESCRIPTION
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Motivation

Right now, PulsarAdmin Tool ignores CLI provided arg for tlsTrustStoreCertPath. This PR fixes and validate it with the testcase.

### Modifications

CLI updates trust-cert path if it's provided in CLI arg.