### PR TITLE
[improve] [broker] Support expose metadataStore zookeeper client metrics.

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2808,7 +2808,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private boolean exposeMetadataStoreZookeeperStatsInPrometheus = false;
 
     /**
-     * the transient field here is for pass statsProvider to `ManagedLedgerClientFactory`
+     * the transient field here is for pass statsProvider to `ManagedLedgerClientFactory`.
      */
     private transient StatsProvider statsProvider = new NullStatsProvider();
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -35,6 +35,8 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.apache.bookkeeper.client.api.DigestType;
+import org.apache.bookkeeper.stats.NullStatsProvider;
+import org.apache.bookkeeper.stats.StatsProvider;
 import org.apache.bookkeeper.util.BookKeeperConstants;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider;
@@ -2798,6 +2800,17 @@ public class ServiceConfiguration implements PulsarConfiguration {
                 + " this would be more efficient but may be inaccurate. Default is false."
     )
     private boolean exposePreciseBacklogInPrometheus = false;
+
+    @FieldContext(
+        category = CATEGORY_METRICS,
+        doc = "Enable expose the metadata store zookeeper client stats."
+    )
+    private boolean exposeMetadataStoreZookeeperStatsInPrometheus = false;
+
+    /**
+     * the transient field here is for pass statsProvider to `ManagedLedgerClientFactory`
+     */
+    private transient StatsProvider statsProvider = new NullStatsProvider();
 
     @FieldContext(
         category = CATEGORY_METRICS,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -73,15 +73,8 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
         managedLedgerFactoryConfig.setStatsPeriodSeconds(conf.getManagedLedgerStatsPeriodSeconds());
         managedLedgerFactoryConfig.setManagedCursorInfoCompressionType(conf.getManagedCursorInfoCompressionType());
 
-        Configuration configuration = new ClientConfiguration();
-        if (conf.isBookkeeperClientExposeStatsToPrometheus()) {
-            configuration.addProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_LATENCY_ROLLOVER_SECONDS,
-                    conf.getManagedLedgerPrometheusStatsLatencyRolloverSeconds());
-            configuration.addProperty(PrometheusMetricsProvider.CLUSTER_NAME, conf.getClusterName());
-            statsProvider = new PrometheusMetricsProvider();
-        }
+        this.statsProvider = conf.getStatsProvider();
 
-        statsProvider.start(configuration);
         StatsLogger statsLogger = statsProvider.getStatsLogger("pulsar_managedLedger_client");
 
         this.defaultBkClient =

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -70,7 +70,9 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
         managedLedgerFactoryConfig.setStatsPeriodSeconds(conf.getManagedLedgerStatsPeriodSeconds());
         managedLedgerFactoryConfig.setManagedCursorInfoCompressionType(conf.getManagedCursorInfoCompressionType());
 
-        this.statsProvider = conf.getStatsProvider();
+        if (conf.isBookkeeperClientExposeStatsToPrometheus()) {
+            this.statsProvider = conf.getStatsProvider();
+        }
 
         StatsLogger statsLogger = statsProvider.getStatsLogger("pulsar_managedLedger_client");
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RejectedExecutionException;
 import org.apache.bookkeeper.client.BookKeeper;
-import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactoryConfig;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
@@ -34,8 +33,6 @@ import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl.BookkeeperFac
 import org.apache.bookkeeper.stats.NullStatsProvider;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.stats.StatsProvider;
-import org.apache.commons.configuration.Configuration;
-import org.apache.pulsar.broker.stats.prometheus.metrics.PrometheusMetricsProvider;
 import org.apache.pulsar.broker.storage.ManagedLedgerStorage;
 import org.apache.pulsar.common.policies.data.EnsemblePlacementPolicyConfig;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -764,8 +764,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             // Now we are ready to start services
             this.bkClientFactory = newBookKeeperClientFactory();
 
-            if (config.isBookkeeperClientExposeStatsToPrometheus() ||
-                    config.isExposeMetadataStoreZookeeperStatsInPrometheus()) {
+            if (config.isBookkeeperClientExposeStatsToPrometheus()
+                    || config.isExposeMetadataStoreZookeeperStatsInPrometheus()) {
                 Configuration configuration = new ClientConfiguration();
                 configuration.addProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_LATENCY_ROLLOVER_SECONDS,
                         config.getManagedLedgerPrometheusStatsLatencyRolloverSeconds());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -75,6 +75,7 @@ import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.impl.NullLedgerOffloader;
 import org.apache.bookkeeper.mledger.offload.Offloaders;
 import org.apache.bookkeeper.mledger.offload.OffloadersCache;
+import org.apache.bookkeeper.stats.NullStatsProvider;
 import org.apache.bookkeeper.stats.StatsProvider;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.lang3.StringUtils;
@@ -207,7 +208,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     private ResourceUsageTransportManager resourceUsageTransportManager;
     private ResourceGroupService resourceGroupServiceManager;
 
-    private StatsProvider statsProvider;
+    private StatsProvider statsProvider = new NullStatsProvider();
 
     private final ScheduledExecutorService executor;
     private final ScheduledExecutorService cacheExecutor;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -311,7 +311,7 @@ public class PrometheusMetricsGenerator {
 
     private static void generateManagedLedgerBookieClientMetrics(PulsarService pulsar, SimpleTextOutputStream stream) {
         StatsProvider statsProvider = pulsar.getStatsProvider();
-        if (statsProvider instanceof NullStatsProvider) {
+        if (statsProvider == null || statsProvider instanceof NullStatsProvider) {
             return;
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -310,7 +310,7 @@ public class PrometheusMetricsGenerator {
     }
 
     private static void generateManagedLedgerBookieClientMetrics(PulsarService pulsar, SimpleTextOutputStream stream) {
-        StatsProvider statsProvider = pulsar.getManagedLedgerClientFactory().getStatsProvider();
+        StatsProvider statsProvider = pulsar.getStatsProvider();
         if (statsProvider instanceof NullStatsProvider) {
             return;
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
@@ -227,7 +227,7 @@ public class ServiceConfigurationTest {
         try (FileInputStream stream = new FileInputStream("../conf/broker.conf")) {
             final ServiceConfiguration javaConfig = PulsarConfigurationLoader.create(new Properties(), ServiceConfiguration.class);
             final ServiceConfiguration fileConfig = PulsarConfigurationLoader.create(stream, ServiceConfiguration.class);
-            List<String> toSkip = Arrays.asList("properties", "class", "metadataStoreBackedByZookeeper");
+            List<String> toSkip = Arrays.asList("properties", "class", "metadataStoreBackedByZookeeper", "statsProvider");
             for (PropertyDescriptor pd : Introspector.getBeanInfo(ServiceConfiguration.class).getPropertyDescriptors()) {
                 if (pd.getReadMethod() == null || toSkip.contains(pd.getName())) {
                     continue;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreConfig.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreConfig.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.metadata.api;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.stats.StatsLogger;
 
 /**
  * The configuration builder for a {@link MetadataStore} config.
@@ -92,4 +94,10 @@ public class MetadataStoreConfig {
      * separate clusters.
      */
     private MetadataEventSynchronizer synchronizer;
+
+    /**
+     * StatsLogger for expose zookeeper operation relate metrics.
+     */
+    @Builder.Default
+    private final StatsLogger statsLogger = NullStatsLogger.INSTANCE;
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/AbstractMetadataDriver.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/AbstractMetadataDriver.java
@@ -54,7 +54,8 @@ public abstract class AbstractMetadataDriver implements Closeable {
     protected String ledgersRootPath;
     protected StatsLogger statsLogger = new NullStatsLogger();
 
-    protected void initialize(AbstractConfiguration conf, StatsLogger statsLogger) throws MetadataException {
+    protected void initialize(AbstractConfiguration conf,
+                              StatsLogger statsLogger) throws MetadataException {
         this.conf = conf;
         this.statsLogger = statsLogger;
         this.ledgersRootPath = resolveLedgersRootPath();

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarMetadataBookieDriver.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarMetadataBookieDriver.java
@@ -36,13 +36,13 @@ public class PulsarMetadataBookieDriver extends AbstractMetadataDriver implement
     }
 
     @Override
-    protected void initialize(AbstractConfiguration serverConfiguration) throws MetadataException {
-        super.initialize(serverConfiguration);
+    protected void initialize(AbstractConfiguration serverConfiguration, StatsLogger statsLogger) throws MetadataException {
+        super.initialize(serverConfiguration, statsLogger);
     }
 
     @Override
     public MetadataBookieDriver initialize(ServerConfiguration conf, StatsLogger statsLogger) throws MetadataException {
-        super.initialize(conf);
+        super.initialize(conf, statsLogger);
         return this;
     }
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarMetadataBookieDriver.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarMetadataBookieDriver.java
@@ -36,12 +36,14 @@ public class PulsarMetadataBookieDriver extends AbstractMetadataDriver implement
     }
 
     @Override
-    protected void initialize(AbstractConfiguration serverConfiguration, StatsLogger statsLogger) throws MetadataException {
+    protected void initialize(AbstractConfiguration serverConfiguration,
+                              StatsLogger statsLogger) throws MetadataException {
         super.initialize(serverConfiguration, statsLogger);
     }
 
     @Override
-    public MetadataBookieDriver initialize(ServerConfiguration conf, StatsLogger statsLogger) throws MetadataException {
+    public MetadataBookieDriver initialize(ServerConfiguration conf,
+                                           StatsLogger statsLogger) throws MetadataException {
         super.initialize(conf, statsLogger);
         return this;
     }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarMetadataClientDriver.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarMetadataClientDriver.java
@@ -46,7 +46,7 @@ public class PulsarMetadataClientDriver extends AbstractMetadataDriver implement
                                            ScheduledExecutorService scheduledExecutorService,
                                            StatsLogger statsLogger,
                                            Optional<Object> optionalCtx) throws MetadataException {
-        super.initialize(clientConfiguration);
+        super.initialize(clientConfiguration, statsLogger);
         return this;
     }
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -97,6 +97,7 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
             isZkManaged = true;
             zkc = PulsarZooKeeperClient.newBuilder().connectString(zkConnectString)
                     .connectRetryPolicy(new BoundExponentialBackoffRetryPolicy(100, 60_000, Integer.MAX_VALUE))
+                    .statsLogger(metadataStoreConfig.getStatsLogger())
                     .allowReadOnlyMode(metadataStoreConfig.isAllowReadOnlyOperations())
                     .sessionTimeoutMs(metadataStoreConfig.getSessionTimeoutMillis())
                     .watchers(Collections.singleton(this::processSessionWatcher))


### PR DESCRIPTION
fix #19713

### Motivation
expose metadataStore zookeeper metrics in prometheus.

### Modifications
set prometheusMetricProvider in MetadataStoreConfig.


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.



### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
