### PR TITLE
[fix][test]testRedirectOfGetCoordinatorInternalStats

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionMultiBrokerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionMultiBrokerTest.java
@@ -59,12 +59,13 @@ public class AdminApiTransactionMultiBrokerTest extends TransactionTestBase {
      */
     @Test
     public void testRedirectOfGetCoordinatorInternalStats() throws Exception {
-        Map<String, String> map = admin.lookups()
+        PulsarAdmin localAdmin = this.admin;
+        Map<String, String> map = localAdmin.lookups()
                 .lookupPartitionedTopic(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN.toString());
 
         for (int i = 0; map.containsValue(getPulsarServiceList().get(i).getBrokerServiceUrl()); i++) {
             if (!map.containsValue(getPulsarServiceList().get(i + 1).getBrokerServiceUrl()))
-                admin = spy(createNewPulsarAdmin(PulsarAdmin.builder()
+                localAdmin = spy(createNewPulsarAdmin(PulsarAdmin.builder()
                         .serviceHttpUrl(pulsarServiceList.get(i + 1).getWebServiceAddress())));
         }
         if (pulsarClient != null) {
@@ -77,7 +78,7 @@ public class AdminApiTransactionMultiBrokerTest extends TransactionTestBase {
                 .enableTransaction(true)
                 .build();
         for (int i = 0; i < NUM_PARTITIONS; i++) {
-            admin.transactions().getCoordinatorInternalStats(i, false);
+            localAdmin.transactions().getCoordinatorInternalStats(i, false);
         }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionMultiBrokerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionMultiBrokerTest.java
@@ -18,13 +18,14 @@
  */
 package org.apache.pulsar.broker.admin.v3;
 
+import static org.mockito.Mockito.spy;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.transaction.TransactionTestBase;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.naming.SystemTopicNames;
-import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -46,21 +47,25 @@ public class AdminApiTransactionMultiBrokerTest extends TransactionTestBase {
         super.internalCleanup();
     }
 
+    /**
+     * This test is used to verify the redirect request of `getCoordinatorInternalStats`.
+     * <p>
+     *     1. Set up 16 broker and create 3 transaction coordinator topic.
+     *     2. The 3 transaction coordinator topic will be assigned to these brokers through some kind of
+     *     load-balancing strategy. (In current implementations, they tend to be assigned to a broker.)
+     *     3. Find a broker x which is not the owner of the transaction coordinator topic.
+     *     4. Create a admin connected to broker x, and use the admin to call ` getCoordinatorInternalStats`.
+     * </p>
+     */
     @Test
     public void testRedirectOfGetCoordinatorInternalStats() throws Exception {
         Map<String, String> map = admin.lookups()
                 .lookupPartitionedTopic(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN.toString());
-        while (map.containsValue(getPulsarServiceList().get(0).getBrokerServiceUrl())) {
-            pulsarServiceList.get(0).getPulsarResources()
-                    .getNamespaceResources()
-                    .getPartitionedTopicResources()
-                            .deletePartitionedTopicAsync(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN);
-            pulsarServiceList.get(0).getPulsarResources()
-                    .getNamespaceResources()
-                    .getPartitionedTopicResources()
-                    .createPartitionedTopic(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN,
-                            new PartitionedTopicMetadata(NUM_PARTITIONS));
-            map = admin.lookups().lookupPartitionedTopic(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN.toString());
+
+        for (int i = 0; map.containsValue(getPulsarServiceList().get(i).getBrokerServiceUrl()); i++) {
+            if (!map.containsValue(getPulsarServiceList().get(i + 1).getBrokerServiceUrl()))
+                admin = spy(createNewPulsarAdmin(PulsarAdmin.builder()
+                        .serviceHttpUrl(pulsarServiceList.get(i + 1).getWebServiceAddress())));
         }
         if (pulsarClient != null) {
             pulsarClient.shutdown();


### PR DESCRIPTION
Fix https://github.com/apache/pulsar/issues/18600

### Motivation

Reason for test failure:
1. Create 16 brokers and 3 transaction coordinator topics. 
2. The 3 transaction coordinator topics are assigned to broker-0.
3. Because the admin is connected to broker-0, we do not hope the topics are assigned to broker-0.
4. Recreate the 3 transaction coordinator topics.
5. The topics are assigned to broker-0 again.
6. Repeat execute steps 3,4,5
7. Timeout

### Modifications
Do not recreate the transaction coordinator topics.
Recreate an admin connect the broker which is not the owner of the transaction coordinator topics.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
