### PR TITLE
[fix][broker] Fix potential exception cause the policy service init fail.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -343,6 +343,10 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
             if (hasMore) {
                 reader.readNextAsync().thenAccept(msg -> {
                     refreshTopicPoliciesCache(msg);
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] Loop next event reading for system topic.",
+                                reader.getSystemTopic().getTopicName().getNamespaceObject());
+                    }
                     initPolicesCache(reader, future);
                 }).exceptionally(e -> {
                     log.error("[{}] Failed to read event from the system topic.",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -341,20 +341,15 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                 return;
             }
             if (hasMore) {
-                reader.readNextAsync().whenComplete((msg, e) -> {
-                    if (e != null) {
-                        log.error("[{}] Failed to read event from the system topic.",
-                                reader.getSystemTopic().getTopicName(), e);
-                        future.completeExceptionally(e);
-                        cleanCacheAndCloseReader(reader.getSystemTopic().getTopicName().getNamespaceObject(), false);
-                        return;
-                    }
+                reader.readNextAsync().thenAccept(msg -> {
                     refreshTopicPoliciesCache(msg);
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Loop next event reading for system topic.",
-                                reader.getSystemTopic().getTopicName().getNamespaceObject());
-                    }
                     initPolicesCache(reader, future);
+                }).exceptionally(e -> {
+                    log.error("[{}] Failed to read event from the system topic.",
+                            reader.getSystemTopic().getTopicName(), e);
+                    future.completeExceptionally(e);
+                    cleanCacheAndCloseReader(reader.getSystemTopic().getTopicName().getNamespaceObject(), false);
+                    return null;
                 });
             } else {
                 if (log.isDebugEnabled()) {


### PR DESCRIPTION
### Motivation

We find that sometimes we can't get the topic policy all the time. After dumping the broker file, we find the namespace value in `policyCacheInitMap`  is false, but the reader was created successfully.


![image](https://user-images.githubusercontent.com/6297296/223623035-28473096-b37f-4f86-95a3-e513c8ff160d.png)

![image](https://user-images.githubusercontent.com/6297296/223623161-bf494a14-96f6-405f-acad-438649db80c5.png)

I suspect that there may be some exceptions that occurs in the `refreshTopicPoliciesCache`.

### Modifications

Move the `refreshTopicPoliciesCache` to the `thenAccept` block so we can catch any exceptions.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

