### PR TITLE
[fix][meta] Fix notification thread block causes double owner.

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
@@ -127,7 +127,7 @@ class LockManagerImpl<T> implements LockManager<T> {
             if (se == SessionEvent.SessionReestablished) {
                 log.info("Metadata store session has been re-established. Revalidating all the existing locks.");
                 for (ResourceLockImpl<T> lock : locks.values()) {
-                    futures.add(lock.revalidateOnce(lock.getValue()));
+                    futures.add(lock.silentRevalidateOnce(lock.getValue()));
                 }
             } else if (se == SessionEvent.Reconnected) {
                 log.info("Metadata store connection has been re-established. Revalidating locks that were pending.");

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
@@ -146,7 +146,7 @@ class LockManagerImpl<T> implements LockManager<T> {
                 log.warn("Got timeout exception when execute revalidate");
                 for (final CompletableFuture<Void> future : futures) {
                     if (!future.isDone()) {
-                        if(!future.cancel(true)) {
+                        if (!future.cancel(true)) {
                             log.warn("Failed to cancel the revalidation future {}", future);
                         }
                     }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
@@ -22,6 +22,7 @@ import java.util.EnumSet;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.pulsar.common.util.FutureUtil;
@@ -33,7 +34,6 @@ import org.apache.pulsar.metadata.api.MetadataStoreException.LockBusyException;
 import org.apache.pulsar.metadata.api.coordination.ResourceLock;
 import org.apache.pulsar.metadata.api.extended.CreateOption;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
-import javax.annotation.Nonnull;
 
 @Slf4j
 public class ResourceLockImpl<T> implements ResourceLock<T> {
@@ -231,8 +231,8 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
     }
 
     /**
-     * This method designed for background notification usage,it will auto mark the lock is released if revalidation
-     * operation got one of exceptions as follows:
+     * This method designed for background notification usage.
+     * It will auto mark the lock is released if revalidation operation got one of exceptions as follows:
      * - LockBusyException
      * - BadVersionException
      * - CancellationException


### PR DESCRIPTION
### Motivation

This is a namespace bundle double-owners problem. We found it in the memory dumps.

The memory dumps show that the notification thread has been blocked for a long time. And many notifications are blocked in the executor queue. This causes we can't to revalidate the locks, and they are still thinking them working well.

Honestly, we have to figure out why those futures didn't complete. Maybe it is blocked by other places, or the developers forgot to complete this future in the corner place. But I still think giving it protection(timeout) here is good, and I will continue investigating.

For private reasons, I can't share the namespace bundle snapshot, but the blocked thread easily explains it.

<img width="1061" alt="image" src="https://user-images.githubusercontent.com/74767115/223670419-c4319f44-f1e1-4361-8c79-04c7f0dabe3c.png">
^^ blocked thread

<img width="949" alt="image" src="https://user-images.githubusercontent.com/74767115/223672000-fb4ce22c-6a45-4cb6-9d23-c36e3afbc93a.png">

^^ executor queue


### Modifications

- I added timeout protection to the `CompletableFuture#get` method.
- Split `revalidate` to `revalidateOnce` and `revalidate` methods to make it understandable easily.
- Give up the lock in memory when we revalidate timeout to ensure the final consensus.
- Avoid revalidating the released lock since the expireFuture has been completed.
- Avoid revalidating the released lock.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
