### PR TITLE
[fix] [test] fix flaky test BucketDelayedDeliveryTrackerTest. testWithBkException

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
@@ -308,10 +308,6 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
 
         assertEquals(110, tracker.getNumberOfDelayedMessages());
 
-        int size = tracker.getImmutableBuckets().asMapOfRanges().size();
-
-        assertEquals(10, size);
-
         tracker.addMessage(111, 1011, 111 * 10);
 
         MutableLong delayedMessagesInSnapshot = new MutableLong();


### PR DESCRIPTION
fixes: #19720

### Motivation

This test sets the maximum number of buckets to 10, then creates multiple buckets by writing, then uses the merge mechanism to make the final number of buckets less than or equal to 10.

But `BucketDelayedDeliveryTracker` doesn't guarantee that every merger operation will work, these cases will make the operation fail:
- the last persistention of the bucket has not finished.
- all buckets are full.

### Modifications

- If a maximum of 10 buckets is not guaranteed, then this validation should be removed(which this PR does)
- If want to guarantee a maximum of 10 buckets, then this is a bug that needs to be fixed(should close this PR and create a new PR to fix it)


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- x
