### PR TITLE
[fix][broker] Fix create cluster with empty url

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiClusterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiClusterTest.java
@@ -22,6 +22,8 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.fail;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
@@ -106,5 +108,37 @@ public class AdminApiClusterTest extends MockedPulsarServiceBaseTest {
         Awaitility.await().untilAsserted(() -> admin.clusters().getFailureDomain(CLUSTER, domainName));
 
         admin.clusters().deleteFailureDomain(CLUSTER, domainName);
+    }
+
+    @Test
+    public void testCreateCluster() throws PulsarAdminException {
+        List<ClusterData> clusterDataList = new ArrayList<>();
+        clusterDataList.add(ClusterData.builder()
+                .serviceUrl("http://pulsar.app:8080")
+                .serviceUrlTls("")
+                .brokerServiceUrl("pulsar://pulsar.app:6650")
+                .brokerServiceUrlTls("")
+                .build());
+        clusterDataList.add(ClusterData.builder()
+                .serviceUrl("")
+                .serviceUrlTls("https://pulsar.app:8443")
+                .brokerServiceUrl("")
+                .brokerServiceUrlTls("pulsar+ssl://pulsar.app:6651")
+                .build());
+        clusterDataList.add(ClusterData.builder()
+                .serviceUrl("")
+                .serviceUrlTls("")
+                .brokerServiceUrl("")
+                .brokerServiceUrlTls("")
+                .build());
+        clusterDataList.add(ClusterData.builder()
+                .serviceUrl(null)
+                .serviceUrlTls(null)
+                .brokerServiceUrl(null)
+                .brokerServiceUrlTls(null)
+                .build());
+        for (int i = 0; i < clusterDataList.size(); i++) {
+            admin.clusters().createCluster("cluster-test-" + i, clusterDataList.get(i));
+        }
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/URIPreconditions.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/URIPreconditions.java
@@ -67,7 +67,7 @@ public class URIPreconditions {
     public static void checkURIIfPresent(@Nullable String uri,
                                          @Nonnull Predicate<URI> predicate,
                                          @Nullable String errorMessage) throws IllegalArgumentException {
-        if (uri == null) {
+        if (uri == null || uri.length() == 0) {
             return;
         }
         checkURI(uri, predicate, errorMessage);

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/URIPreconditionsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/URIPreconditionsTest.java
@@ -30,6 +30,7 @@ public class URIPreconditionsTest {
         // normal
         checkURI("http://pulsar.apache.org", uri -> true);
         checkURI("http://pulsar.apache.org", uri -> Objects.equals(uri.getScheme(), "http"));
+        checkURI("", uri -> true);
         // illegal
         try {
             checkURI("pulsar.apache.org", uri -> Objects.equals(uri.getScheme(), "http"));
@@ -48,6 +49,7 @@ public class URIPreconditionsTest {
     @Test
     public void testCheckURIIfPresent() {
         checkURIIfPresent(null, uri -> false);
+        checkURIIfPresent("", uri -> false);
         checkURIIfPresent("http://pulsar.apache.org", uri -> true);
         try {
             checkURIIfPresent("http/pulsar.apache.org", uri -> uri.getScheme() != null, "Error");


### PR DESCRIPTION
### Motivation

When creating the cluster, if the `serviceUrlTls` is empty in the `ClusterData`, I got `Illegal service tls url, example: https://pulsar.example.com:8443`. I expect the Pulsar works fine.

#19151 breaks this behavior, see the following code:
```
    public static void checkURIIfPresent(@Nullable String uri,
                                         @Nonnull Predicate<URI> predicate,
                                         @Nullable String errorMessage) throws IllegalArgumentException {
        if (uri == null) {
            return;
        }
        checkURI(uri, predicate, errorMessage);
    }
```

This check should also ignore the empty URL.

### Modifications

- Ignore checking the empty URL

### Verifying this change

- [x] Make sure that the change passes the CI checks.

Added `testCreateCluster` test.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
