### PR TITLE
[cleanup] [broker] cleanup the lib which may lead to the OWASP Dependency Check faul

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -879,6 +879,12 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk15on</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.yahoo.athenz</groupId>
         <artifactId>athenz-zts-java-client-core</artifactId>
         <version>${athenz.version}</version>


### PR DESCRIPTION
### Motivation

[CVE 2020 26939](https://github.com/bcgit/bc-java/wiki/CVE-2020-26939) reports a vulnerability in the project [bc-java](https://github.com/bcgit/bc-java) and suggestion using `1.61 or later` instead of `1.60`, but there is a test type dependency in the project.

```
[INFO] org.apache.pulsar:tiered-storage-file-system:jar:3.0.0-SNAPSHOT
[INFO] \- org.apache.hadoop:hadoop-minicluster:jar:3.3.3:test
[INFO]    \- org.apache.hadoop:hadoop-yarn-server-web-proxy:jar:3.3.3:test
[INFO]       +- org.bouncycastle:bcprov-jdk15on:jar:1.60:test
[INFO]       \- org.bouncycastle:bcpkix-jdk15on:jar:1.60:test
[INFO]          \- (org.bouncycastle:bcprov-jdk15on:jar:1.60:test - omitted for duplicate)
```

<img width="529" alt="截屏2023-03-09 18 23 46" src="https://user-images.githubusercontent.com/25195800/223995448-86b4baf9-c266-499b-b2ac-b8203c95e72b.png">


### Modifications

make the version of project BC unify into `1.69`


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- x
