### PR TITLE
[cherry-pick][branch-2.11] KCA: picking fixes from master

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.io.kafka.connect;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -30,7 +32,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.runtime.TaskConfig;
+import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 import org.apache.kafka.connect.source.SourceTaskContext;
@@ -55,6 +59,7 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
 
     // kafka connect related variables
     private SourceTaskContext sourceTaskContext;
+    private SourceConnector connector;
     @Getter
     private SourceTask sourceTask;
     public Converter keyConverter;
@@ -71,6 +76,8 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
     // number of outstandingRecords that have been polled but not been acked
     private final AtomicInteger outstandingRecords = new AtomicInteger(0);
 
+    public static final String CONNECTOR_CLASS = "kafkaConnectorSourceClass";
+
     @Override
     public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
         Map<String, String> stringConfig = new HashMap<>();
@@ -79,12 +86,6 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
                 stringConfig.put(key, (String) value);
             }
         });
-
-        // get the source class name from config and create source task from reflection
-        sourceTask = Class.forName(stringConfig.get(TaskConfig.TASK_CLASS_CONFIG))
-                .asSubclass(SourceTask.class)
-                .getDeclaredConstructor()
-                .newInstance();
 
         topicNamespace = stringConfig.get(PulsarKafkaWorkerConfig.TOPIC_NAMESPACE_CONFIG);
 
@@ -129,8 +130,36 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
 
         sourceTaskContext = new PulsarIOSourceTaskContext(offsetReader, pulsarKafkaWorkerConfig);
 
+        final Map<String, String> taskConfig;
+        if (config.get(CONNECTOR_CLASS) != null) {
+            String kafkaConnectorFQClassName = config.get(CONNECTOR_CLASS).toString();
+            Class<?> clazz = Class.forName(kafkaConnectorFQClassName);
+            connector = (SourceConnector) clazz.getConstructor().newInstance();
+
+            Class<? extends Task> taskClass = connector.taskClass();
+            sourceTask = (SourceTask) taskClass.getConstructor().newInstance();
+
+            connector.initialize(new PulsarKafkaSinkContext());
+            connector.start(stringConfig);
+
+            List<Map<String, String>> configs = connector.taskConfigs(1);
+            checkNotNull(configs);
+            checkArgument(configs.size() == 1);
+            taskConfig = configs.get(0);
+        } else {
+            // for backward compatibility with old configuration
+            // that use the task directly
+
+            // get the source class name from config and create source task from reflection
+            sourceTask = Class.forName(stringConfig.get(TaskConfig.TASK_CLASS_CONFIG))
+                    .asSubclass(SourceTask.class)
+                    .getDeclaredConstructor()
+                    .newInstance();
+            taskConfig = stringConfig;
+        }
+
         sourceTask.initialize(sourceTaskContext);
-        sourceTask.start(stringConfig);
+        sourceTask.start(taskConfig);
     }
 
     @Override
@@ -176,6 +205,11 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
         if (sourceTask != null) {
             sourceTask.stop();
             sourceTask = null;
+        }
+
+        if (connector != null) {
+            connector.stop();
+            connector = null;
         }
 
         if (offsetStore != null) {

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSink.java
@@ -96,6 +96,12 @@ public class KafkaConnectSink implements Sink<GenericObject> {
             CacheBuilder.newBuilder().maximumSize(1000)
                     .expireAfterAccess(30, TimeUnit.MINUTES).build();
 
+    // Can't really safely expire these entries.  If we do, we could end up with
+    // a sanitized topic name that used in e.g. resume() after a long pause but can't be
+    // // re-resolved into a form usable for Pulsar.
+    private final Cache<String, String> desanitizedTopicCache =
+            CacheBuilder.newBuilder().build();
+
     private int maxBatchBitsForOffset = 12;
     private boolean useIndexAsOffset = true;
 
@@ -185,7 +191,18 @@ public class KafkaConnectSink implements Sink<GenericObject> {
         });
         task = (SinkTask) taskClass.getConstructor().newInstance();
         taskContext =
-                new PulsarKafkaSinkTaskContext(configs.get(0), ctx, task::open);
+                new PulsarKafkaSinkTaskContext(configs.get(0), ctx, task::open, kafkaName -> {
+                    if (sanitizeTopicName) {
+                        String pulsarTopicName = desanitizedTopicCache.getIfPresent(kafkaName);
+                        if (log.isDebugEnabled()) {
+                            log.debug("desanitizedTopicCache got: kafkaName: {}, pulsarTopicName: {}",
+                                    kafkaName, pulsarTopicName);
+                        }
+                        return pulsarTopicName != null ? pulsarTopicName : kafkaName;
+                    } else {
+                        return kafkaName;
+                    }
+                });
         task.initialize(taskContext);
         task.start(configs.get(0));
 
@@ -487,6 +504,9 @@ public class KafkaConnectSink implements Sink<GenericObject> {
                 if (sanitizedName.matches("^[^a-zA-Z_].*")) {
                     sanitizedName = "_" + sanitizedName;
                 }
+                // do this once, sanitize() can be called on already sanitized name
+                // so avoid replacing with (sanitizedName -> sanitizedName).
+                desanitizedTopicCache.get(sanitizedName, () -> name);
                 return sanitizedName;
             });
         } catch (ExecutionException e) {

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaSinkTaskContext.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarKafkaSinkTaskContext.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -50,6 +51,7 @@ public class PulsarKafkaSinkTaskContext implements SinkTaskContext {
     private final SinkContext ctx;
 
     private final OffsetBackingStore offsetStore;
+    private Function<String, String> desanitizeTopicName;
     private final String topicNamespace;
     private final Consumer<Collection<TopicPartition>> onPartitionChange;
     private final AtomicBoolean runRepartition = new AtomicBoolean(false);
@@ -58,11 +60,13 @@ public class PulsarKafkaSinkTaskContext implements SinkTaskContext {
 
     public PulsarKafkaSinkTaskContext(Map<String, String> config,
                                       SinkContext ctx,
-                                      Consumer<Collection<TopicPartition>> onPartitionChange) {
+                                      Consumer<Collection<TopicPartition>> onPartitionChange,
+                                      Function<String, String> desanitizeTopicName) {
         this.config = config;
         this.ctx = ctx;
 
         offsetStore = new PulsarOffsetBackingStore(ctx.getPulsarClient());
+        this.desanitizeTopicName = desanitizeTopicName;
         PulsarKafkaWorkerConfig pulsarKafkaWorkerConfig = new PulsarKafkaWorkerConfig(config);
         offsetStore.configure(pulsarKafkaWorkerConfig);
         offsetStore.start();
@@ -145,7 +149,9 @@ public class PulsarKafkaSinkTaskContext implements SinkTaskContext {
 
     private void seekAndUpdateOffset(TopicPartition topicPartition, long offset) {
         try {
-            ctx.seek(topicPartition.topic(), topicPartition.partition(), MessageIdUtils.getMessageId(offset));
+            ctx.seek(desanitizeTopicName.apply(topicPartition.topic()),
+                    topicPartition.partition(),
+                    MessageIdUtils.getMessageId(offset));
         } catch (PulsarClientException e) {
             log.error("Failed to seek topic {} partition {} offset {}",
                     topicPartition.topic(), topicPartition.partition(), offset, e);
@@ -203,7 +209,7 @@ public class PulsarKafkaSinkTaskContext implements SinkTaskContext {
     public void pause(TopicPartition... topicPartitions) {
         for (TopicPartition tp: topicPartitions) {
             try {
-                ctx.pause(tp.topic(), tp.partition());
+                ctx.pause(desanitizeTopicName.apply(tp.topic()), tp.partition());
             } catch (PulsarClientException e) {
                 log.error("Failed to pause topic {} partition {}", tp.topic(), tp.partition(), e);
                 throw new RuntimeException("Failed to pause topic " + tp.topic() + " partition " + tp.partition(), e);
@@ -215,7 +221,7 @@ public class PulsarKafkaSinkTaskContext implements SinkTaskContext {
     public void resume(TopicPartition... topicPartitions) {
         for (TopicPartition tp: topicPartitions) {
             try {
-                ctx.resume(tp.topic(), tp.partition());
+                ctx.resume(desanitizeTopicName.apply(tp.topic()), tp.partition());
             } catch (PulsarClientException e) {
                 log.error("Failed to resume topic {} partition {}", tp.topic(), tp.partition(), e);
                 throw new RuntimeException("Failed to resume topic " + tp.topic() + " partition " + tp.partition(), e);

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSinkTest.java
@@ -314,6 +314,50 @@ public class KafkaConnectSinkTest extends ProducerConsumerBase {
         sink.close();
     }
 
+    @Test
+    public void seekPauseResumeWithSanitizeTest() throws Exception {
+        KafkaConnectSink sink = new KafkaConnectSink();
+        props.put("sanitizeTopicName", "true");
+        sink.open(props, context);
+
+        String pulsarTopicName = "persistent://a-b/c-d/fake-topic.a";
+
+        final GenericRecord rec = getGenericRecord("value", Schema.STRING);
+        Message msg = mock(MessageImpl.class);
+        when(msg.getValue()).thenReturn(rec);
+        final MessageId msgId = new MessageIdImpl(10, 10, 0);
+        when(msg.getMessageId()).thenReturn(msgId);
+
+        final AtomicInteger status = new AtomicInteger(0);
+        Record<GenericObject> record = PulsarRecord.<String>builder()
+                .topicName(pulsarTopicName)
+                .message(msg)
+                .ackFunction(status::incrementAndGet)
+                .failFunction(status::decrementAndGet)
+                .schema(Schema.STRING)
+                .build();
+
+        sink.write(record);
+        sink.flush();
+
+        assertEquals(status.get(), 1);
+
+        final TopicPartition tp = new TopicPartition(sink.sanitizeNameIfNeeded(pulsarTopicName, true), 0);
+        assertNotEquals(MessageIdUtils.getOffset(msgId), 0);
+        assertEquals(sink.currentOffset(tp.topic(), tp.partition()), MessageIdUtils.getOffset(msgId));
+
+        sink.taskContext.offset(tp, 0);
+        verify(context, times(1)).seek(pulsarTopicName,
+                tp.partition(), MessageIdUtils.getMessageId(0));
+        assertEquals(sink.currentOffset(tp.topic(), tp.partition()), 0);
+
+        sink.taskContext.pause(tp);
+        verify(context, times(1)).pause(pulsarTopicName, tp.partition());
+        sink.taskContext.resume(tp);
+        verify(context, times(1)).resume(pulsarTopicName, tp.partition());
+
+        sink.close();
+    }
 
     @Test
     public void subscriptionTypeTest() throws Exception {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/coordination/impl/LeaderElectionImplTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/coordination/impl/LeaderElectionImplTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information


### PR DESCRIPTION
### Motivation

Cherry-picking from master

```
Author: Andrey Yegorov <8622884+dlg99@users.noreply.github.com>
Date:   Fri Mar 10 01:58:40 2023 -0800

    [fix][io] KCA: Option to use kafka connector's SourceConnector class to create task and task config (#19772)

    (cherry picked from commit 90b0f0a17579d22d413853ed4941d81debbe0cbe)

Author: Andrey Yegorov <8622884+dlg99@users.noreply.github.com>
Date:   Thu Mar 9 01:09:34 2023 -0800

    [fix][io] KCA: 'desanitize' topic name for the pulsar's ctx calls (#19756)

    (cherry picked from commit d4930a31c052dd8fcd5982b649898967a24f8961)
```

### Modifications

cherry-picks

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

NO

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: n/a

