### PR TITLE
[fix] Fix UnsupportedException for NonPersistentTopic when there are EntryFilters

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -199,7 +199,9 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             // entry internally retains data so, duplicateBuffer should be release here
             duplicateBuffer.release();
             if (subscription.getDispatcher() != null) {
-                subscription.getDispatcher().sendMessages(Collections.singletonList(entry));
+                List<Entry> entries = new ArrayList<>(1);
+                entries.add(entry);
+                subscription.getDispatcher().sendMessages(entries);
             } else {
                 // it happens when subscription is created but dispatcher is not created as consumer is not added
                 // yet

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -26,7 +26,6 @@ import com.carrotsearch.hppc.ObjectObjectHashMap;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
### Motivation

In NonPersistentTopic, we dispatch messages to Consumers by using
```
               subscription.getDispatcher().sendMessages(Collections.singletonList(entry));
```

but Collections.SingleList.class didn't override `void set(int i, T element)` method,
it extends `void set(int i, T element)` from AbstractList, and AbstractList.set(int i, T element)
throws `UnsupportedException`.

So the following usage will lead to `UnsupportedException`:
```
List<Object> objs = Collections.singletonList(new Object());
objs.set(0, null);
```

But in [AbstractBaseDispatcher#filterEntriesForConsumer](https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java#L153), if the filter result is REJECT/RESCHEDULE, it will filter out the entry by calling 
```
entries.set(i, null);
```
and it will throw `UnsupportedException`, the exception will caught by [ServerCnx#exceptionCaught](https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java#L387).

The producer will be closed and try to reconnect.

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dao-jun/pulsar/pull/3
