### PR TITLE
[fix][meta] Fixed race condition between ResourceLock update and invalidation

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
@@ -124,7 +124,7 @@ class LockManagerImpl<T> implements LockManager<T> {
             if (se == SessionEvent.SessionReestablished) {
                 log.info("Metadata store session has been re-established. Revalidating all the existing locks.");
                 for (ResourceLockImpl<T> lock : locks.values()) {
-                    futures.add(lock.revalidate(lock.getValue(), true));
+                    futures.add(lock.revalidate(lock.getValue(), true, true));
                 }
 
             } else if (se == SessionEvent.Reconnected) {


### PR DESCRIPTION
### Motivation

The test `LockManagerTest.updateValueWhenKeyDisappears()` can having infrequent failures, especially when running with Etcd backend. 

The problem is really in the logic of the `ResourceLock` itself. After a normal lock-acquire operation, the test is triggering 2 events at the same time: 
 1. A deletion of the lock key-value (eg: the ephemeral node might have disappeared)
 2. A `lock.update()` operation to change the value of the lock.

The race condition is due to the fact that operation (1) will trigger a lock revalidation in background and this now happens at the same time as operation (2). 

The result is that it's possible for the ResourceLock to enter into a loop of revalidations and deletions.

eg: 

```
2023-03-14T20:40:40,350 - INFO  - [-8-1:ResourceLockImpl@180] - Acquired resource lock on /key-9166073612375/1
2023-03-14T20:40:40,376 - INFO  - [-8-1:ResourceLockImpl@201] - Lock on resource /key-9166073612375/1 was invalidated
2023-03-14T20:40:40,392 - INFO  - [-8-1:ResourceLockImpl@180] - Acquired resource lock on /key-9166073612375/1
2023-03-14T20:40:40,392 - INFO  - [-8-1:ResourceLockImpl@268] - Successfully re-acquired missing lock at /key-9166073612375/1
2023-03-14T20:40:40,392 - INFO  - [-8-1:ResourceLockImpl@203] - Successfully revalidated the lock on /key-9166073612375/1
2023-03-14T20:40:40,402 - INFO  - [-8-1:ResourceLockImpl@201] - Lock on resource /key-9166073612375/1 was invalidated
2023-03-14T20:40:40,407 - INFO  - [-8-1:ResourceLockImpl@180] - Acquired resource lock on /key-9166073612375/1
2023-03-14T20:40:40,407 - INFO  - [-8-1:ResourceLockImpl@325] - Successfully re-acquired lock at /key-9166073612375/1
2023-03-14T20:40:40,417 - INFO  - [-8-1:ResourceLockImpl@201] - Lock on resource /key-9166073612375/1 was invalidated
2023-03-14T20:40:40,422 - INFO  - [-8-1:ResourceLockImpl@180] - Acquired resource lock on /key-9166073612375/1
2023-03-14T20:40:40,422 - INFO  - [-8-1:ResourceLockImpl@325] - Successfully re-acquired lock at /key-9166073612375/1
2023-03-14T20:40:40,422 - INFO  - [-8-1:ResourceLockImpl@203] - Successfully revalidated the lock on /key-9166073612375/1
2023-03-14T20:40:40,433 - INFO  - [-8-1:ResourceLockImpl@201] - Lock on resource /key-9166073612375/1 was invalidated
2023-03-14T20:40:40,437 - INFO  - [-8-1:ResourceLockImpl@180] - Acquired resource lock on /key-9166073612375/1
2023-03-14T20:40:40,437 - INFO  - [-8-1:ResourceLockImpl@325] - Successfully re-acquired lock at /key-9166073612375/1
2023-03-14T20:40:40,437 - INFO  - [-8-1:ResourceLockImpl@203] - Successfully revalidated the lock on /key-9166073612375/1
2023-03-14T20:40:40,447 - INFO  - [-8-1:ResourceLockImpl@201] - Lock on resource /key-9166073612375/1 was invalidated
2023-03-14T20:40:40,452 - INFO  - [-8-1:ResourceLockImpl@180] - Acquired resource lock on /key-9166073612375/1
2023-03-14T20:40:40,452 - INFO  - [-8-1:ResourceLockImpl@325] - Successfully re-acquired lock at /key-9166073612375/1
2023-03-14T20:40:40,452 - INFO  - [-8-1:ResourceLockImpl@203] - Successfully revalidated the lock on /key-9166073612375/1
2023-03-14T20:40:40,467 - INFO  - [-8-1:ResourceLockImpl@201] - Lock on resource /key-9166073612375/1 was invalidated
2023-03-14T20:40:40,472 - INFO  - [-8-1:ResourceLockImpl@180] - Acquired resource lock on /key-9166073612375/1
2023-03-14T20:40:40,472 - INFO  - [-8-1:ResourceLockImpl@325] - Successfully re-acquired lock at /key-9166073612375/1
2023-03-14T20:40:40,472 - INFO  - [-8-1:ResourceLockImpl@203] - Successfully revalidated the lock on /key-9166073612375/1
2023-03-14T20:40:40,482 - INFO  - [-8-1:ResourceLockImpl@201] - Lock on resource /key-9166073612375/1 was invalidated
2023-03-14T20:40:40,486 - INFO  - [-8-1:ResourceLockImpl@180] - Acquired resource lock on /key-9166073612375/1
2023-03-14T20:40:40,486 - INFO  - [-8-1:ResourceLockImpl@325] - Successfully re-acquired lock at /key-9166073612375/1
2023-03-14T20:40:40,487 - INFO  - [-8-1:ResourceLockImpl@203] - Successfully revalidated the lock on /key-9166073612375/1
2023-03-14T20:40:40,497 - INFO  - [-8-1:ResourceLockImpl@201] - Lock on resource /key-9166073612375/1 was invalidated
....
```

### Modifications

Similarly as to what we're already doing to prevent concurrent revalidate operations, we need to also wait for any existing operations to complete before attempting to do the update.

The same is true if there is an update() operation in progress: the next revalidate should wait.

We then use a single future to signal pending operation and to piggy back and try when it's the right time.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
