### PR TITLE
[fix] [ml] make the result of delete cursor is success if cursor is deleted

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -309,8 +309,7 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
                         callback.operationComplete(null, null);
                         return null;
                     }
-                    executor.executeOrdered(ledgerName, SafeRunnable.safeRun(() -> callback
-                            .operationFailed(getException(ex))));
+                    SafeRunnable.safeRun(() -> callback.operationFailed(getException(ex));
                     return null;
                 }, executor.chooseThread(ledgerName));
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -47,6 +47,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.compression.CompressionCodec;
 import org.apache.pulsar.common.compression.CompressionCodecProvider;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.Notification;
@@ -292,7 +293,7 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
     @Override
     public void asyncRemoveCursor(String ledgerName, String cursorName, MetaStoreCallback<Void> callback) {
         String path = PREFIX + ledgerName + "/" + cursorName;
-        log.info("[{}] Remove consumer={}", ledgerName, cursorName);
+        log.info("[{}] Remove cursor={}", ledgerName, cursorName);
 
         store.delete(path, Optional.empty())
                 .thenAcceptAsync(v -> {
@@ -301,11 +302,17 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
                     }
                     callback.operationComplete(null, null);
                 }, executor.chooseThread(ledgerName))
-                .exceptionally(ex -> {
+                .exceptionallyAsync(ex -> {
+                    Throwable actEx = FutureUtil.unwrapCompletionException(ex);
+                    if (actEx instanceof MetadataStoreException.NotFoundException){
+                        log.info("[{}] [{}] cursor delete done because it did not exist.", ledgerName, cursorName);
+                        callback.operationComplete(null, null);
+                        return null;
+                    }
                     executor.executeOrdered(ledgerName, SafeRunnable.safeRun(() -> callback
                             .operationFailed(getException(ex))));
                     return null;
-                });
+                }, executor.chooseThread(ledgerName));
     }
 
     @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -309,7 +309,7 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
                         callback.operationComplete(null, null);
                         return null;
                     }
-                    SafeRunnable.safeRun(() -> callback.operationFailed(getException(ex));
+                    SafeRunnable.safeRun(() -> callback.operationFailed(getException(ex)));
                     return null;
                 }, executor.chooseThread(ledgerName));
     }


### PR DESCRIPTION
### Motivation
If the same cursor is deleted concurrently due to multiple tasks, it will return a failure even if the deletion succeeded. Such a task has these: 
- cancel geo-replication will trigger the delete operation of the cursor `rep.x`
- cancel the dedup task will trigger the delete operation of the cursor `dedup`
- unsubscribe
- delete topic

If the task `delete topic` and the above three tasks are concurrently executing, it will fail.

### Modifications

When deleting the zk node of the cursor, if exception `MetadataStoreException.NotFoundException`  occurs, the deletion is considered successful


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- https://github.com/poorbarcode/pulsar/pull/77
