### PR TITLE
[improve] [admin] pulsar admin support get exact or whole batch message by id

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1667,7 +1667,9 @@ public interface Topics {
      * @throws PulsarAdminException
      *            Unexpected error
      */
-    Message<byte[]> getMessageById(String topic, long ledgerId, long entryId) throws PulsarAdminException;
+    default Message<byte[]> getMessageById(String topic, long ledgerId, long entryId) throws PulsarAdminException {
+        return getMessageById(topic, ledgerId, entryId, -1);
+    };
 
     /**
      * Get a message by its messageId via a topic subscription asynchronously.
@@ -1679,7 +1681,65 @@ public interface Topics {
      *            Entry id
      * @return a future that can be used to track when the message is returned
      */
-    CompletableFuture<Message<byte[]>> getMessageByIdAsync(String topic, long ledgerId, long entryId);
+    default CompletableFuture<Message<byte[]>> getMessageByIdAsync(String topic, long ledgerId, long entryId) throws PulsarAdminException {
+        return getMessageByIdAsync(topic, ledgerId, entryId, -1);
+    };
+
+    /**
+     * Get a message by its messageId via a topic subscription.
+     * @param topic
+     *            Topic name
+     * @param ledgerId
+     *            Ledger id
+     * @param entryId
+     *            Entry id
+     * @param batchIndex
+     *            Batch Index
+     * @return the message indexed by the messageId
+     * @throws PulsarAdminException
+     *            Unexpected error
+     */
+    Message<byte[]> getMessageById(String topic, long ledgerId, long entryId, int batchIndex) throws PulsarAdminException;
+
+    /**
+     * Get a message by its messageId via a topic subscription asynchronously.
+     * @param topic
+     *            Topic name
+     * @param ledgerId
+     *            Ledger id
+     * @param entryId
+     *            Entry id
+     * @param batchIndex
+     *            Batch Index
+     * @return a future that can be used to track when the message is returned
+     */
+    CompletableFuture<Message<byte[]>> getMessageByIdAsync(String topic, long ledgerId, long entryId, int batchIndex);
+
+    /**
+     * Get whole batch messages by its messageId via a topic subscription.
+     * @param topic
+     *            Topic name
+     * @param ledgerId
+     *            Ledger id
+     * @param entryId
+     *            Entry id
+     * @return the whole batch messages indexed by the messageId
+     * @throws PulsarAdminException
+     *            Unexpected error
+     */
+    List<Message<byte[]>> getBatchMessagesById(String topic, long ledgerId, long entryId) throws PulsarAdminException;
+
+    /**
+     * Get whole batch messages by its messageId via a topic subscription asynchronously.
+     * @param topic
+     *            Topic name
+     * @param ledgerId
+     *            Ledger id
+     * @param entryId
+     *            Entry id
+     * @return a future that can be used to track when the batch messages is returned
+     */
+    CompletableFuture<List<Message<byte[]>>> getBatchMessagesByIdAsync(String topic, long ledgerId, long entryId);
 
     /**
      * Get message ID published at or just after this absolute timestamp (in ms).

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -1798,7 +1798,10 @@ public class PulsarAdminToolTest {
         verify(mockTopics).setMaxMessageSize("persistent://myprop/clust/ns1/ds1", 99);
 
         cmdTopics.run(split("get-message-by-id persistent://myprop/clust/ns1/ds1 -l 10 -e 2"));
-        verify(mockTopics).getMessageById("persistent://myprop/clust/ns1/ds1", 10,2);
+        verify(mockTopics).getMessageById("persistent://myprop/clust/ns1/ds1", 10,2, -1);
+
+        cmdTopics.run(split("get-batch-messages-by-id persistent://myprop/clust/ns1/ds1 -l 10 -e 2"));
+        verify(mockTopics).getBatchMessagesById("persistent://myprop/clust/ns1/ds1", 10,2);
 
         cmdTopics.run(split("get-dispatch-rate persistent://myprop/clust/ns1/ds1 -ap"));
         verify(mockTopics).getDispatchRate("persistent://myprop/clust/ns1/ds1", true);


### PR DESCRIPTION
### Motivation

If we enable batch message, sometimes we need to get the exact message in a batch or get the whole batch messages to help find out some problems.  But now the admin getMessageById() method can only get the first message in a batch. 

### Modifications

1. implement getBatchMessagesById() to get the whole batch messages in a entry
2. implement get the exact batch message in the previous getMessageById() methods, and ensure the compatibility with previous behaviour
3. add unittest for these implementation

### Verifying this change

This change added tests and can be verified as follows:


### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [x] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

