### PR TITLE
[fix][meta] Follow up #19817, Fix race condition between ResourceLock update and invalidation

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -182,7 +183,12 @@ public class FutureUtil {
         public static <T> Sequencer<T> create() {
             return new Sequencer<>(false);
         }
+
+        /**
+         * @throws NullPointerException NPE when param is null
+         */
         public synchronized CompletableFuture<T> sequential(Supplier<CompletableFuture<T>> newTask) {
+            Objects.requireNonNull(newTask);
             if (sequencerFuture.isDone()) {
                 if (sequencerFuture.isCompletedExceptionally() && allowExceptionBreakChain) {
                     return sequencerFuture;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
@@ -177,8 +177,8 @@ public class FutureUtil {
             this.allowExceptionBreakChain = allowExceptionBreakChain;
         }
 
-        public static <T> Sequencer<T> create(boolean allowExceptionBreakLink) {
-            return new Sequencer<>(allowExceptionBreakLink);
+        public static <T> Sequencer<T> create(boolean allowExceptionBreakChain) {
+            return new Sequencer<>(allowExceptionBreakChain);
         }
         public static <T> Sequencer<T> create() {
             return new Sequencer<>(false);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
@@ -193,8 +193,7 @@ public class FutureUtil {
                 if (sequencerFuture.isCompletedExceptionally() && allowExceptionBreakChain) {
                     return sequencerFuture;
                 }
-                // Break the link chain
-                sequencerFuture = CompletableFuture.completedFuture(null);
+                return sequencerFuture = newTask.get();
             }
             return sequencerFuture = allowExceptionBreakChain
                     ? sequencerFuture.thenCompose(__ -> newTask.get())

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
@@ -31,7 +31,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 import lombok.Cleanup;
-import org.apache.commons.lang.mutable.MutableInt;
 import org.assertj.core.util.Lists;
 import org.awaitility.Awaitility;
 import org.testng.Assert;

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.common.util;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -30,8 +31,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 import lombok.Cleanup;
+import org.apache.commons.lang.mutable.MutableInt;
 import org.assertj.core.util.Lists;
 import org.awaitility.Awaitility;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -50,8 +53,9 @@ public class FutureUtilTest {
         timeoutException.printStackTrace(new PrintWriter(stringWriter, true));
         assertEquals(stringWriter.toString(),
                 "org.apache.pulsar.common.util.FutureUtil$LowOverheadTimeoutException: "
-                + "hello world" + System.lineSeparator()
-                + "\tat org.apache.pulsar.common.util.FutureUtilTest.test(...)(Unknown Source)" + System.lineSeparator());
+                        + "hello world" + System.lineSeparator()
+                        + "\tat org.apache.pulsar.common.util.FutureUtilTest.test(...)(Unknown Source)" +
+                        System.lineSeparator());
     }
 
     @Test
@@ -149,7 +153,8 @@ public class FutureUtilTest {
         f2.complete("2");
         f3.complete("3");
         f4.complete("4");
-        CompletableFuture<Optional<Object>> ret = FutureUtil.waitForAny(Lists.newArrayList(f1, f2, f3, f4), p -> p.equals("3"));
+        CompletableFuture<Optional<Object>> ret =
+                FutureUtil.waitForAny(Lists.newArrayList(f1, f2, f3, f4), p -> p.equals("3"));
         assertEquals(ret.join().get(), "3");
         // test not matched predicate result
         CompletableFuture<String> f5 = new CompletableFuture<>();
@@ -176,6 +181,76 @@ public class FutureUtilTest {
             fail("Should have failed");
         } catch (CompletionException ex) {
             assertTrue(ex.getCause() instanceof RuntimeException);
+        }
+    }
+
+    @Test
+    public void testSequencer() {
+        int concurrentNum = 1000;
+        final ScheduledExecutorService executor = Executors.newScheduledThreadPool(concurrentNum);
+        final FutureUtil.Sequencer<Void> sequencer = FutureUtil.Sequencer.create();
+        // normal case -- allowExceptionBreakChain=false
+        final List<Integer> list = new ArrayList<>();
+        final List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (int i = 0; i < concurrentNum; i++) {
+            int finalI = i;
+            futures.add(sequencer.sequential(() -> CompletableFuture.runAsync(() -> {
+                list.add(finalI);
+            }, executor)));
+        }
+        FutureUtil.waitForAll(futures).join();
+        for (int i = 0; i < list.size(); i++) {
+            Assert.assertEquals(list.get(i), (Integer) i);
+        }
+
+        // exception case -- allowExceptionBreakChain=false
+        final List<Integer> list2 = new ArrayList<>();
+        final List<CompletableFuture<Void>> futures2 = new ArrayList<>();
+        for (int i = 0; i < concurrentNum; i++) {
+            int finalI = i;
+            futures2.add(sequencer.sequential(() -> CompletableFuture.runAsync(() -> {
+                if (finalI == 2) {
+                    throw new IllegalStateException();
+                }
+                list2.add(finalI);
+            }, executor)));
+        }
+        try {
+            FutureUtil.waitForAll(futures2).join();
+        } catch (Throwable ignore) {
+
+        }
+        for (int i = 0; i < concurrentNum - 1; i++) {
+            if (i >= 2) {
+                Assert.assertEquals(list2.get(i), i + 1);
+            } else {
+                Assert.assertEquals(list2.get(i), (Integer) i);
+            }
+        }
+        // allowExceptionBreakChain=true
+        final FutureUtil.Sequencer<Void> sequencer2 = FutureUtil.Sequencer.create(true);
+        final List<Integer> list3 = new ArrayList<>();
+        final List<CompletableFuture<Void>> futures3 = new ArrayList<>();
+        for (int i = 0; i < concurrentNum; i++) {
+            int finalI = i;
+            futures3.add(sequencer2.sequential(() -> CompletableFuture.runAsync(() -> {
+                if (finalI == 2) {
+                    throw new IllegalStateException();
+                }
+                list3.add(finalI);
+            }, executor)));
+        }
+        try {
+            FutureUtil.waitForAll(futures3).join();
+        } catch (Throwable ignore) {
+
+        }
+        for (int i = 2; i < concurrentNum; i++) {
+            Assert.assertTrue(futures3.get(i).isCompletedExceptionally());
+        }
+
+        for (int i = 0; i < 2; i++) {
+            Assert.assertEquals(list3.get(i), (Integer) i);
         }
     }
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/FutureUtilTest.java
@@ -53,9 +53,8 @@ public class FutureUtilTest {
         timeoutException.printStackTrace(new PrintWriter(stringWriter, true));
         assertEquals(stringWriter.toString(),
                 "org.apache.pulsar.common.util.FutureUtil$LowOverheadTimeoutException: "
-                        + "hello world" + System.lineSeparator()
-                        + "\tat org.apache.pulsar.common.util.FutureUtilTest.test(...)(Unknown Source)" +
-                        System.lineSeparator());
+                + "hello world" + System.lineSeparator()
+                + "\tat org.apache.pulsar.common.util.FutureUtilTest.test(...)(Unknown Source)" + System.lineSeparator());
     }
 
     @Test
@@ -153,8 +152,7 @@ public class FutureUtilTest {
         f2.complete("2");
         f3.complete("3");
         f4.complete("4");
-        CompletableFuture<Optional<Object>> ret =
-                FutureUtil.waitForAny(Lists.newArrayList(f1, f2, f3, f4), p -> p.equals("3"));
+        CompletableFuture<Optional<Object>> ret = FutureUtil.waitForAny(Lists.newArrayList(f1, f2, f3, f4), p -> p.equals("3"));
         assertEquals(ret.join().get(), "3");
         // test not matched predicate result
         CompletableFuture<String> f5 = new CompletableFuture<>();

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
@@ -124,7 +124,7 @@ class LockManagerImpl<T> implements LockManager<T> {
             if (se == SessionEvent.SessionReestablished) {
                 log.info("Metadata store session has been re-established. Revalidating all the existing locks.");
                 for (ResourceLockImpl<T> lock : locks.values()) {
-                    futures.add(lock.revalidate(lock.getValue(), true, true));
+                    futures.add(lock.silentRevalidateOnce());
                 }
 
             } else if (se == SessionEvent.Reconnected) {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
@@ -77,7 +77,7 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
         if (pendingOperationFuture.isDone()) {
             pendingOperationFuture = CompletableFuture.completedFuture(null);
         }
-        return pendingOperationFuture = pendingOperationFuture.thenCompose(__ -> {
+        pendingOperationFuture.thenCompose(__ -> {
                     synchronized (ResourceLockImpl.this) {
                         if (state != State.Valid) {
                             return CompletableFuture.failedFuture(
@@ -86,6 +86,7 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
                         return acquire(newValue);
                     }
                 });
+        return pendingOperationFuture;
     }
 
     @Override

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
@@ -197,7 +197,7 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
 
     synchronized CompletableFuture<Void> revalidateIfNeededAfterReconnection() {
         if (revalidateAfterReconnection) {
-            ResourceLockImpl.this.revalidateAfterReconnection = false;
+            revalidateAfterReconnection = false;
             log.warn("Revalidate lock at {} after reconnection", path);
             return silentRevalidateOnce();
         } else {
@@ -251,7 +251,7 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
                             // We failed to revalidate the lock due to connectivity issue
                             // Continue assuming we hold the lock, until we can revalidate it, either
                             // on Reconnected or SessionReestablished events.
-                            ResourceLockImpl.this.revalidateAfterReconnection = true;
+                            revalidateAfterReconnection = true;
                             log.warn("Failed to revalidate the lock at {}. Retrying later on reconnection {}", path,
                                     realCause.getMessage());
                         }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
@@ -75,7 +75,7 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
         // If there is an operation in progress, we're going to let it complete before attempting to
         // update the value
         return pendingOperationFuture = pendingOperationFuture.exceptionally(ex -> null) // ignore all the exception
-                .thenCompose(v -> {
+                .thenCompose(__ -> {
                     synchronized (ResourceLockImpl.this) {
                         if (state != State.Valid) {
                             return CompletableFuture.failedFuture(

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
@@ -84,6 +84,7 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
                             return CompletableFuture.failedFuture(
                                     new IllegalStateException("Lock was not in valid state: " + state));
                         }
+
                         return acquire(newValue);
                     }
                 });

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
@@ -222,8 +222,8 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
             trackFuture = revalidate(value);
         } else {
             if (log.isDebugEnabled()) {
-                log.debug("Previous revalidating is not finished while revalidate newValue={}, value={}, version={}",
-                        value, value, version);
+                log.debug("Previous revalidating is not finished while revalidate value={}, version={}",
+                        value, version);
             }
             trackFuture = pendingOperationFuture.exceptionally(ex -> null)
                     .thenCompose(__ -> revalidate(value));

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
@@ -77,6 +77,7 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
         if (pendingOperationFuture.isDone()) {
             pendingOperationFuture = CompletableFuture.completedFuture(null);
         }
+
         pendingOperationFuture = pendingOperationFuture.thenCompose(__ -> {
                     synchronized (ResourceLockImpl.this) {
                         if (state != State.Valid) {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/ResourceLockImpl.java
@@ -77,7 +77,7 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
         if (pendingOperationFuture.isDone()) {
             pendingOperationFuture = CompletableFuture.completedFuture(null);
         }
-        pendingOperationFuture.thenCompose(__ -> {
+        pendingOperationFuture = pendingOperationFuture.thenCompose(__ -> {
                     synchronized (ResourceLockImpl.this) {
                         if (state != State.Valid) {
                             return CompletableFuture.failedFuture(
@@ -86,6 +86,7 @@ public class ResourceLockImpl<T> implements ResourceLock<T> {
                         return acquire(newValue);
                     }
                 });
+
         return pendingOperationFuture;
     }
 


### PR DESCRIPTION
### Motivation

This PR is following up the PR #19817.  It includes three parts as follows:
1. Fix the previous PR's incompletable future problem.
2. Split `revalidate` into two methods to eliminate some flags. 
3. Add strict revalidation state check to avoid revalidating expired lock.

### Modifications

1. Fix the previous PR's incompletable future problem.
2. Split `revalidate` into two methods to eliminate some flags. 
3. Add strict revalidation state check to avoid revalidating expired lock.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->