### PR TITLE
[fix][client] Fix typo in ConsumerStats

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerStats.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerStats.java
@@ -92,7 +92,7 @@ public interface ConsumerStats extends Serializable {
     /**
      * @return Total number of messages batch receive failures
      */
-    long getTotaBatchReceivedFailed();
+    long getTotalBatchReceivedFailed();
 
     /**
      * @return Total number of message acknowledgments sent by this consumer

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsDisabled.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsDisabled.java
@@ -100,7 +100,7 @@ public class ConsumerStatsDisabled implements ConsumerStatsRecorder {
     }
 
     @Override
-    public long getTotaBatchReceivedFailed() {
+    public long getTotalBatchReceivedFailed() {
         return 0;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
@@ -230,7 +230,7 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
         totalMsgsReceived.add(stats.getTotalMsgsReceived());
         totalBytesReceived.add(stats.getTotalBytesReceived());
         totalReceiveFailed.add(stats.getTotalReceivedFailed());
-        totalBatchReceiveFailed.add(stats.getTotaBatchReceivedFailed());
+        totalBatchReceiveFailed.add(stats.getTotalBatchReceivedFailed());
         totalAcksSent.add(stats.getTotalAcksSent());
         totalAcksFailed.add(stats.getTotalAcksFailed());
     }
@@ -301,7 +301,7 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
     }
 
     @Override
-    public long getTotaBatchReceivedFailed() {
+    public long getTotalBatchReceivedFailed() {
         return totalBatchReceiveFailed.longValue();
     }
 


### PR DESCRIPTION

### Motivation

This is a minor typo fix.


### Modifications
`getTotaBatchReceivedFailed`-> `getTotalBatchReceivedFailed`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

