### PR TITLE
[improve][broker][PIP-195] Make bucket merge operation asynchronous

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
@@ -90,6 +90,8 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
     private final Table<Long, Long, ImmutableBucket> snapshotSegmentLastIndexTable;
 
+    private static final Long INVALID_BUCKET_ID = -1L;
+
     public BucketDelayedDeliveryTracker(PersistentDispatcherMultipleConsumers dispatcher,
                                  Timer timer, long tickTimeMillis,
                                  boolean isDelayedDeliveryDeliverAtTimeStrict,
@@ -246,12 +248,12 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                     immutableBucket);
 
             immutableBucket.getSnapshotCreateFuture().ifPresent(createFuture -> {
-                CompletableFuture<Long> future = createFuture.whenComplete((__, ex) -> {
+                CompletableFuture<Long> future = createFuture.handle((bucketId, ex) -> {
                     if (ex == null) {
                         immutableBucket.setSnapshotSegments(null);
                         log.info("[{}] Creat bucket snapshot finish, bucketKey: {}", dispatcher.getName(),
                                 immutableBucket.bucketKey());
-                        return;
+                        return bucketId;
                     }
 
                     //TODO Record create snapshot failed
@@ -277,6 +279,7 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                         snapshotSegmentLastIndexTable.remove(lastDelayedIndex.getLedgerId(),
                                 lastDelayedIndex.getTimestamp());
                     }
+                    return INVALID_BUCKET_ID;
                 });
                 immutableBucket.setSnapshotCreateFuture(future);
             });
@@ -308,12 +311,7 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
             lastMutableBucket.resetLastMutableBucketRange();
 
             if (immutableBuckets.asMapOfRanges().size() > maxNumBuckets) {
-                try {
-                    asyncMergeBucketSnapshot().get(2 * AsyncOperationTimeoutSeconds * MaxRetryTimes, TimeUnit.SECONDS);
-                } catch (Exception e) {
-                    // Ignore exception to merge bucket on the next schedule.
-                    log.error("[{}] An exception occurs when merge bucket snapshot.", dispatcher.getName(), e);
-                }
+                asyncMergeBucketSnapshot();
             }
         }
 
@@ -341,18 +339,24 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
     private synchronized CompletableFuture<Void> asyncMergeBucketSnapshot() {
         List<ImmutableBucket> values = immutableBuckets.asMapOfRanges().values().stream().toList();
         long minNumberMessages = Long.MAX_VALUE;
+        long minScheduleTimestampSum = Long.MAX_VALUE;
         int minIndex = -1;
         for (int i = 0; i + 1 < values.size(); i++) {
             ImmutableBucket bucketL = values.get(i);
             ImmutableBucket bucketR = values.get(i + 1);
-            long numberMessages = bucketL.numberBucketDelayedMessages + bucketR.numberBucketDelayedMessages;
-            if (numberMessages < minNumberMessages) {
-                minNumberMessages = (int) numberMessages;
-                if (bucketL.lastSegmentEntryId > bucketL.getCurrentSegmentEntryId()
-                        && bucketR.lastSegmentEntryId > bucketR.getCurrentSegmentEntryId()
-                        && bucketL.getSnapshotCreateFuture().orElse(NULL_LONG_PROMISE).isDone()
-                        && bucketR.getSnapshotCreateFuture().orElse(NULL_LONG_PROMISE).isDone()) {
-                    minIndex = i;
+            if (bucketL.lastSegmentEntryId > bucketL.getCurrentSegmentEntryId()
+                    && bucketR.lastSegmentEntryId > bucketR.getCurrentSegmentEntryId()
+                    && !bucketL.merging && !bucketR.merging){
+                long scheduleTimestampSum =
+                        Math.min(bucketL.firstScheduleTimestamps.get(bucketL.currentSegmentEntryId + 1),
+                                bucketR.firstScheduleTimestamps.get(bucketR.currentSegmentEntryId + 1));
+                long numberMessages = bucketL.numberBucketDelayedMessages + bucketR.numberBucketDelayedMessages;
+                if (scheduleTimestampSum <= minScheduleTimestampSum) {
+                    minScheduleTimestampSum = scheduleTimestampSum;
+                    if (numberMessages < minNumberMessages) {
+                        minNumberMessages = numberMessages;
+                        minIndex = i;
+                    }
                 }
             }
         }
@@ -369,7 +373,14 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
             log.info("[{}] Merging bucket snapshot, bucketAKey: {}, bucketBKey: {}", dispatcher.getName(),
                     immutableBucketA.bucketKey(), immutableBucketB.bucketKey());
         }
+
+        immutableBucketA.merging = true;
+        immutableBucketB.merging = true;
         return asyncMergeBucketSnapshot(immutableBucketA, immutableBucketB).whenComplete((__, ex) -> {
+            synchronized (this) {
+                immutableBucketA.merging = false;
+                immutableBucketB.merging = false;
+            }
             if (ex != null) {
                 log.error("[{}] Failed to merge bucket snapshot, bucketAKey: {}, bucketBKey: {}",
                         dispatcher.getName(), immutableBucketA.bucketKey(), immutableBucketB.bucketKey(), ex);
@@ -382,46 +393,58 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
     private synchronized CompletableFuture<Void> asyncMergeBucketSnapshot(ImmutableBucket bucketA,
                                                                           ImmutableBucket bucketB) {
-        CompletableFuture<List<DelayedMessageIndexBucketSnapshotFormat.SnapshotSegment>> futureA =
-                bucketA.getRemainSnapshotSegment();
-        CompletableFuture<List<DelayedMessageIndexBucketSnapshotFormat.SnapshotSegment>> futureB =
-                bucketB.getRemainSnapshotSegment();
-        return futureA.thenCombine(futureB, CombinedSegmentDelayedIndexQueue::wrap)
-                .thenAccept(combinedDelayedIndexQueue -> {
-                    Pair<ImmutableBucket, DelayedIndex> immutableBucketDelayedIndexPair =
-                            lastMutableBucket.createImmutableBucketAndAsyncPersistent(
-                                    timeStepPerBucketSnapshotSegmentInMillis, maxIndexesPerBucketSnapshotSegment,
-                                    sharedBucketPriorityQueue, combinedDelayedIndexQueue, bucketA.startLedgerId,
-                                    bucketB.endLedgerId);
+        CompletableFuture<Long> createAFuture = bucketA.getSnapshotCreateFuture().orElse(NULL_LONG_PROMISE);
+        CompletableFuture<Long> createBFuture = bucketB.getSnapshotCreateFuture().orElse(NULL_LONG_PROMISE);
 
-                    // Merge bit map to new bucket
-                    Map<Long, RoaringBitmap> delayedIndexBitMapA = bucketA.getDelayedIndexBitMap();
-                    Map<Long, RoaringBitmap> delayedIndexBitMapB = bucketB.getDelayedIndexBitMap();
-                    Map<Long, RoaringBitmap> delayedIndexBitMap = new HashMap<>(delayedIndexBitMapA);
-                    delayedIndexBitMapB.forEach((ledgerId, bitMapB) -> {
-                        delayedIndexBitMap.compute(ledgerId, (k, bitMapA) -> {
-                            if (bitMapA == null) {
-                                return bitMapB;
-                            }
+        return CompletableFuture.allOf(createAFuture, createBFuture).thenCompose(bucketId -> {
+            if (INVALID_BUCKET_ID.equals(createAFuture.join()) || INVALID_BUCKET_ID.equals(createBFuture.join())) {
+                return FutureUtil.failedFuture(new RuntimeException("Can't merge buckets due to bucket create failed"));
+            }
 
-                            bitMapA.or(bitMapB);
-                            return bitMapA;
-                        });
+            CompletableFuture<List<DelayedMessageIndexBucketSnapshotFormat.SnapshotSegment>> futureA =
+                    bucketA.getRemainSnapshotSegment();
+            CompletableFuture<List<DelayedMessageIndexBucketSnapshotFormat.SnapshotSegment>> futureB =
+                    bucketB.getRemainSnapshotSegment();
+            return futureA.thenCombine(futureB, CombinedSegmentDelayedIndexQueue::wrap)
+                    .thenAccept(combinedDelayedIndexQueue -> {
+                        synchronized (BucketDelayedDeliveryTracker.this) {
+                            Pair<ImmutableBucket, DelayedIndex> immutableBucketDelayedIndexPair =
+                                    lastMutableBucket.createImmutableBucketAndAsyncPersistent(
+                                            timeStepPerBucketSnapshotSegmentInMillis,
+                                            maxIndexesPerBucketSnapshotSegment,
+                                            sharedBucketPriorityQueue, combinedDelayedIndexQueue, bucketA.startLedgerId,
+                                            bucketB.endLedgerId);
+
+                            // Merge bit map to new bucket
+                            Map<Long, RoaringBitmap> delayedIndexBitMapA = bucketA.getDelayedIndexBitMap();
+                            Map<Long, RoaringBitmap> delayedIndexBitMapB = bucketB.getDelayedIndexBitMap();
+                            Map<Long, RoaringBitmap> delayedIndexBitMap = new HashMap<>(delayedIndexBitMapA);
+                            delayedIndexBitMapB.forEach((ledgerId, bitMapB) -> {
+                                delayedIndexBitMap.compute(ledgerId, (k, bitMapA) -> {
+                                    if (bitMapA == null) {
+                                        return bitMapB;
+                                    }
+
+                                    bitMapA.or(bitMapB);
+                                    return bitMapA;
+                                });
+                            });
+                            immutableBucketDelayedIndexPair.getLeft().setDelayedIndexBitMap(delayedIndexBitMap);
+
+                            afterCreateImmutableBucket(immutableBucketDelayedIndexPair);
+
+                            immutableBucketDelayedIndexPair.getLeft().getSnapshotCreateFuture()
+                                    .orElse(NULL_LONG_PROMISE).thenCompose(___ -> {
+                                        CompletableFuture<Void> removeAFuture = bucketA.asyncDeleteBucketSnapshot();
+                                        CompletableFuture<Void> removeBFuture = bucketB.asyncDeleteBucketSnapshot();
+                                        return CompletableFuture.allOf(removeAFuture, removeBFuture);
+                                    });
+
+                            immutableBuckets.remove(Range.closed(bucketA.startLedgerId, bucketA.endLedgerId));
+                            immutableBuckets.remove(Range.closed(bucketB.startLedgerId, bucketB.endLedgerId));
+                        }
                     });
-                    immutableBucketDelayedIndexPair.getLeft().setDelayedIndexBitMap(delayedIndexBitMap);
-
-                    afterCreateImmutableBucket(immutableBucketDelayedIndexPair);
-
-                    immutableBucketDelayedIndexPair.getLeft().getSnapshotCreateFuture()
-                            .orElse(NULL_LONG_PROMISE).thenCompose(___ -> {
-                        CompletableFuture<Void> removeAFuture = bucketA.asyncDeleteBucketSnapshot();
-                        CompletableFuture<Void> removeBFuture = bucketB.asyncDeleteBucketSnapshot();
-                        return CompletableFuture.allOf(removeAFuture, removeBFuture);
-                    });
-
-                    immutableBuckets.remove(Range.closed(bucketA.startLedgerId, bucketA.endLedgerId));
-                    immutableBuckets.remove(Range.closed(bucketB.startLedgerId, bucketB.endLedgerId));
-                });
+        });
     }
 
     @Override
@@ -477,6 +500,12 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
             ImmutableBucket bucket = snapshotSegmentLastIndexTable.get(ledgerId, entryId);
             if (bucket != null && immutableBuckets.asMapOfRanges().containsValue(bucket)) {
+                if (bucket.merging) {
+                    log.info("[{}] Skip load to wait for bucket snapshot merge finish, bucketKey:{}",
+                            dispatcher.getName(), bucket.bucketKey());
+                    break;
+                }
+
                 final int preSegmentEntryId = bucket.currentSegmentEntryId;
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Loading next bucket snapshot segment, bucketKey: {}, nextSegmentEntryId: {}",
@@ -525,7 +554,6 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                                     dispatcher.getName(), bucket.bucketKey(), bucket.currentSegmentEntryId);
                         }
                     }).get(AsyncOperationTimeoutSeconds * MaxRetryTimes, TimeUnit.SECONDS);
-                    snapshotSegmentLastIndexTable.remove(ledgerId, entryId);
                 } catch (Exception e) {
                     // Ignore exception to reload this segment on the next schedule.
                     log.error("[{}] An exception occurs when load next bucket snapshot, bucketKey:{}",
@@ -533,6 +561,7 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                     break;
                 }
             }
+            snapshotSegmentLastIndexTable.remove(ledgerId, entryId);
 
             positions.add(new PositionImpl(ledgerId, entryId));
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/ImmutableBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/ImmutableBucket.java
@@ -166,8 +166,10 @@ class ImmutableBucket extends Bucket {
             return bucketSnapshotStorage.getBucketSnapshotSegment(getAndUpdateBucketId(), nextSegmentEntryId,
                     lastSegmentEntryId).whenComplete((__, ex) -> {
                 if (ex != null) {
-                    log.warn("[{}] Failed to get remain bucket snapshot segment, bucketKey: {}.",
-                            dispatcherName, bucketKey(), ex);
+                    log.warn(
+                            "[{}] Failed to get remain bucket snapshot segment, bucketKey: {},"
+                                    + " nextSegmentEntryId: {}, lastSegmentEntryId: {}",
+                            dispatcherName, bucketKey(), nextSegmentEntryId, lastSegmentEntryId, ex);
                 }
             });
         }, BucketSnapshotPersistenceException.class, MaxRetryTimes);

--- a/pulsar-broker/src/main/proto/DelayedMessageIndexBucketSnapshotFormat.proto
+++ b/pulsar-broker/src/main/proto/DelayedMessageIndexBucketSnapshotFormat.proto
@@ -31,6 +31,7 @@ message DelayedIndex {
 message SnapshotSegmentMetadata {
     map<uint64, bytes> delayed_index_bit_map = 1;
     required uint64 max_schedule_timestamp = 2;
+    required uint64 min_schedule_timestamp = 3;
 }
 
 message SnapshotSegment {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/BookkeeperBucketSnapshotStorageTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/BookkeeperBucketSnapshotStorageTest.java
@@ -73,6 +73,7 @@ public class BookkeeperBucketSnapshotStorageTest extends MockedPulsarServiceBase
     public void testGetSnapshot() throws ExecutionException, InterruptedException {
         DelayedMessageIndexBucketSnapshotFormat.SnapshotSegmentMetadata segmentMetadata =
                 DelayedMessageIndexBucketSnapshotFormat.SnapshotSegmentMetadata.newBuilder()
+                        .setMinScheduleTimestamp(System.currentTimeMillis())
                         .setMaxScheduleTimestamp(System.currentTimeMillis())
                         .putDelayedIndexBitMap(100L, ByteString.copyFrom(new byte[1])).build();
 
@@ -122,6 +123,7 @@ public class BookkeeperBucketSnapshotStorageTest extends MockedPulsarServiceBase
         DelayedMessageIndexBucketSnapshotFormat.SnapshotSegmentMetadata segmentMetadata =
                 DelayedMessageIndexBucketSnapshotFormat.SnapshotSegmentMetadata.newBuilder()
                         .setMaxScheduleTimestamp(timeMillis)
+                        .setMinScheduleTimestamp(timeMillis)
                         .putAllDelayedIndexBitMap(map).build();
 
         DelayedMessageIndexBucketSnapshotFormat.SnapshotMetadata snapshotMetadata =
@@ -172,6 +174,7 @@ public class BookkeeperBucketSnapshotStorageTest extends MockedPulsarServiceBase
     public void testGetBucketSnapshotLength() throws ExecutionException, InterruptedException {
         DelayedMessageIndexBucketSnapshotFormat.SnapshotSegmentMetadata segmentMetadata =
                 DelayedMessageIndexBucketSnapshotFormat.SnapshotSegmentMetadata.newBuilder()
+                        .setMinScheduleTimestamp(System.currentTimeMillis())
                         .setMaxScheduleTimestamp(System.currentTimeMillis())
                         .putDelayedIndexBitMap(100L, ByteString.copyFrom(new byte[1])).build();
 


### PR DESCRIPTION
PIP: #16763 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/wiki/proposals/PIP.md -->
### Motivation & Modifications

* Make bucket merge operation asynchronous.
* Optimize the logic of selecting bucket, find two adjacent buckets with the min schedule time and the least number of indexes to merge, avoid preload indexes that have not expired for a long time.
* Add min_schedule_timestamp in SnapshotSegmentMetadata (It is also used later to implement lazy load)
* Fix leak in snapshotSegmentLastIndexTable

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 