### PR TITLE
[fix][client] Fix NPE when acknowledging multiple messages

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -496,8 +496,13 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             }
             topicToMessageIdMap.forEach((topicPartitionName, messageIds) -> {
                 ConsumerImpl<T> consumer = consumers.get(topicPartitionName);
-                resultFutures.add(consumer.doAcknowledgeWithTxn(messageIds, ackType, properties, txn)
-                        .thenAccept((res) -> messageIdList.forEach(unAckedMessageTracker::remove)));
+                if (consumer != null) {
+                    resultFutures.add(consumer.doAcknowledgeWithTxn(messageIds, ackType, properties, txn)
+                            .thenAccept((res) -> messageIdList.forEach(unAckedMessageTracker::remove)));
+                } else {
+                    log.warn("MessageIds whose owner topic is {} will be discard because the consumer is not connected",
+                            topicPartitionName);
+                }
             });
         }
         return CompletableFuture.allOf(resultFutures.toArray(new CompletableFuture[0]));


### PR DESCRIPTION
### Motivation

For a multi-topics consumer, when it acknowledges a single message, it will first find the owner topic from its message ID. If the owner topic is not subscribed by the consumer, `NotConnectedException` will be thrown.

However, when it acknowledges multiple messages, if any of them is the message whose owner topic is not subscribed by the consumer, NPE will happen instead.

### Modifications

When acknowledging multiple messages, if there is any message ID whose owner topic is not subscribed, fail the whole acknowledgment. `testAckMessageInAnotherTopic` is added to cover this case.

### TODO

There are many other places that do not check if `consumers.get` returns `null`, like `doReconsumeLater`, `negativeAcknowledge`, etc. This patch does not cover them.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/BewareMyPower/pulsar/pull/22