### PR TITLE
[fix][broker] Fix NPE when update topic policy.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -240,7 +240,9 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
         topicPolicies.getDispatchRate().updateTopicValue(DispatchRateImpl.normalize(data.getDispatchRate()));
         topicPolicies.getSchemaValidationEnforced().updateTopicValue(data.getSchemaValidationEnforced());
         topicPolicies.getEntryFilters().updateTopicValue(data.getEntryFilters());
-        this.subscriptionPolicies = data.getSubscriptionPolicies();
+        if (data.getSubscriptionPolicies() != null) {
+            this.subscriptionPolicies = data.getSubscriptionPolicies();
+        }
 
         updateEntryFilters();
     }


### PR DESCRIPTION
### Motivation

```
Failed to create consumer: consumerId=30, Cannot invoke "java.util.Map.get(Object)" because "this.subscriptionPolicies" is null
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

