### PR TITLE
[fix] [admin] Make response code to 400 instead of 500 when delete topic fails due to enabled geo-replication

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1107,7 +1107,7 @@ public class PersistentTopics extends PersistentTopicsBase {
                                 t.getMessage());
                     }
                     if (t instanceof IllegalStateException){
-                        ex = new RestException(Response.Status.BAD_REQUEST, t.getMessage());
+                        ex = new RestException(422/* Unprocessable entity*/, t.getMessage());
                     } else if (isManagedLedgerNotFoundException(t)) {
                         ex = new RestException(Response.Status.NOT_FOUND,
                                 getTopicNotFoundErrorMessage(topicName.toString()));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1106,7 +1106,9 @@ public class PersistentTopics extends PersistentTopicsBase {
                         ex = new RestException(Response.Status.PRECONDITION_FAILED,
                                 t.getMessage());
                     }
-                    if (isManagedLedgerNotFoundException(t)) {
+                    if (t instanceof IllegalStateException){
+                        ex = new RestException(Response.Status.BAD_REQUEST, t.getMessage());
+                    } else if (isManagedLedgerNotFoundException(t)) {
                         ex = new RestException(Response.Status.NOT_FOUND,
                                 getTopicNotFoundErrorMessage(topicName.toString()));
                     } else if (!isRedirectException(ex)) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -880,7 +880,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
             fail("Delete topic should fail if enabled replicator");
         } catch (Exception ex) {
             assertTrue(ex instanceof PulsarAdminException);
-            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), ((PulsarAdminException) ex).getStatusCode());
+            assertEquals(((PulsarAdminException) ex).getStatusCode(), 422/* Unprocessable entity*/);
         }
     }
 
@@ -894,7 +894,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
             fail("Delete topic should fail if enabled replicator");
         } catch (Exception ex) {
             assertTrue(ex instanceof PulsarAdminException);
-            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), ((PulsarAdminException) ex).getStatusCode());
+            assertEquals(((PulsarAdminException) ex).getStatusCode(), 422/* Unprocessable entity*/);
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -52,7 +52,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import javax.ws.rs.core.Response;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;
 import org.apache.bookkeeper.mledger.Entry;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -52,6 +52,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.ws.rs.core.Response;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;
 import org.apache.bookkeeper.mledger.Entry;
@@ -70,6 +71,7 @@ import org.apache.pulsar.broker.service.BrokerServiceException.NamingException;
 import org.apache.pulsar.broker.service.persistent.PersistentReplicator;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
@@ -867,6 +869,33 @@ public class ReplicatorTest extends ReplicatorTestBase {
         field.setAccessible(true);
         ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) field.get(replicator);
         assertNull(producer);
+    }
+
+    @Test
+    public void testDeleteTopicFailure() throws Exception {
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://pulsar/ns/tp_" + UUID.randomUUID());
+        admin1.topics().createNonPartitionedTopic(topicName);
+        try {
+            admin1.topics().delete(topicName);
+            fail("Delete topic should fail if enabled replicator");
+        } catch (Exception ex) {
+            assertTrue(ex instanceof PulsarAdminException);
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), ((PulsarAdminException) ex).getStatusCode());
+        }
+    }
+
+    @Test
+    public void testDeletePartitionedTopicFailure() throws Exception {
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://pulsar/ns/tp_" + UUID.randomUUID());
+        admin1.topics().createPartitionedTopic(topicName, 2);
+        admin1.topics().createSubscription(topicName, "sub1", MessageId.earliest);
+        try {
+            admin1.topics().deletePartitionedTopic(topicName);
+            fail("Delete topic should fail if enabled replicator");
+        } catch (Exception ex) {
+            assertTrue(ex instanceof PulsarAdminException);
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), ((PulsarAdminException) ex).getStatusCode());
+        }
     }
 
     @Test(priority = 4, timeOut = 30000)


### PR DESCRIPTION
### Motivation
As expected, If geo-replication is enabled, a topic cannot be deleted. However deleting that topic returns a 500, and no further info.

```
2023-03-21T18:09:57,909 - INFO  - [pulsar-web-75-16:Slf4jRequestLogWriter@62] - 127.0.0.1 - - [21/3月/2023:18:09:57 +0800] "DELETE /admin/v2/persistent/pulsar/ns/tp_e82c0505-d47f-4e4a-8a62-9fa8d6341b76-d6d75112-fbe3-419d-a2d4-2186707185db?force=false&deleteSchema=true HTTP/1.1" 500 6641 "-" "Pulsar-Java-v3.0.0-SNAPSHOT" 11
```

In this case, we should give an error of 400 instead of 500.

### Modifications

Make response code to 400 instead of 500 when delete topic fails due to enabled geo-replication

```
2023-03-21T18:13:10,840 - WARN  - [AsyncHttpClient-236-1:BaseResource$4@236] - [http://localhost:64881/admin/v2/persistent/pulsar/ns/tp_630d809a-6874-4c1b-99ad-5f5e0147950a-ed229063-2805-4ca6-abfb-b9685a4b93f3?force=false&deleteSchema=true] Failed to perform http delete request: javax.ws.rs.BadRequestException: HTTP 400 {"reason":"Delete forbidden topic is replicated on clusters [r2, r3]"}
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- https://github.com/poorbarcode/pulsar/pull/80
