### PR TITLE
[improve][cli] topic offline internal-info provide schema ledger info

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.github.zafarkhaja.semver.Version;
 import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.netty.buffer.ByteBuf;
 import java.io.IOException;
@@ -82,6 +83,8 @@ import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentReplicator;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage;
+import org.apache.pulsar.broker.stats.TopicInternalInfo;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
 import org.apache.pulsar.client.admin.OffloadProcessStatus;
@@ -1433,6 +1436,7 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
     protected void internalGetManagedLedgerInfoForNonPartitionedTopic(AsyncResponse asyncResponse) {
+        CompletableFuture<ManagedLedgerInfo> mlFuture = new CompletableFuture<>();
         validateTopicOperationAsync(topicName, TopicOperation.GET_STATS)
                 .thenAccept(__ -> {
                     String managedLedger = topicName.getPersistenceNamingEncoding();
@@ -1440,13 +1444,11 @@ public class PersistentTopicsBase extends AdminResource {
                             .asyncGetManagedLedgerInfo(managedLedger, new ManagedLedgerInfoCallback() {
                         @Override
                         public void getInfoComplete(ManagedLedgerInfo info, Object ctx) {
-                            asyncResponse.resume((StreamingOutput) output -> {
-                                objectWriter().writeValue(output, info);
-                            });
+                            mlFuture.complete(info);
                         }
                         @Override
                         public void getInfoFailed(ManagedLedgerException exception, Object ctx) {
-                            asyncResponse.resume(exception);
+                            mlFuture.completeExceptionally(exception);
                         }
                     }, null);
                 }).exceptionally(ex -> {
@@ -1454,6 +1456,22 @@ public class PersistentTopicsBase extends AdminResource {
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
+
+        // Schema store ledgers
+        CompletableFuture<List<Long>> schemaFuture = ((BookkeeperSchemaStorage) pulsar().getSchemaStorage())
+                .getStoreLedgerIdsBySchemaId(topicName.getSchemaName());
+
+        FutureUtil.waitForAll(Lists.newArrayList(mlFuture, schemaFuture)).handle((res, ex) -> {
+            if (ex != null) {
+                asyncResponse.resume(ex);
+                return null;
+            }
+            TopicInternalInfo info = new TopicInternalInfo(mlFuture.getNow(null), schemaFuture.getNow(null));
+            asyncResponse.resume((StreamingOutput) output -> {
+                objectWriter().writeValue(output, info);
+            });
+            return null;
+        });
 
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/TopicInternalInfo.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/TopicInternalInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats;
+
+import java.util.List;
+import org.apache.bookkeeper.mledger.ManagedLedgerInfo;
+
+/**
+ * Persistent topic internal statistics.
+ */
+public class TopicInternalInfo extends ManagedLedgerInfo {
+
+    public List<Long> schemaLedgers;
+
+    public TopicInternalInfo() {
+        super();
+    }
+
+    public TopicInternalInfo(ManagedLedgerInfo info, List<Long> schemaLedgers) {
+        this.schemaLedgers = schemaLedgers;
+        if (info != null) {
+            version = info.version;
+            creationDate = info.creationDate;
+            modificationDate = info.modificationDate;
+            ledgers = info.ledgers;
+            terminatedPosition = info.terminatedPosition;
+            cursors = info.cursors;
+            properties = info.properties;
+        }
+    }
+
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/ClientGetSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/ClientGetSchemaTest.java
@@ -22,6 +22,7 @@ import static org.apache.pulsar.common.naming.TopicName.PUBLIC_TENANT;
 import static org.apache.pulsar.schema.compatibility.SchemaCompatibilityCheckTest.randomName;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +31,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import lombok.Cleanup;
 
+import org.apache.pulsar.broker.stats.TopicInternalInfo;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
@@ -40,12 +42,14 @@ import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.schema.Schemas;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
 
 @Test(groups = "broker")
@@ -176,5 +180,52 @@ public class ClientGetSchemaTest extends ProducerConsumerBase {
 
         producer.close();
         consumer.close();
+    }
+
+    /**
+     * Test verifies that broker should be able to handle non-recoverable error while deleting topic if topic's schema
+     * ledger doesn't exist.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testDeletedSchemaLedgerTopic() throws Exception {
+        final String tenant = PUBLIC_TENANT;
+        final String namespace = "test-namespace-" + randomName(16);
+        final String topicOne = "test-schema-info";
+        String fqtnOne = TopicName.get(TopicDomain.persistent.value(), tenant, namespace, topicOne).toString();
+
+        admin.namespaces().createNamespace(tenant + "/" + namespace, Sets.newHashSet("test"));
+
+        // (1) create topic with schema
+        Producer<Schemas.PersonTwo> producer = pulsarClient
+                .newProducer(Schema.AVRO(SchemaDefinition.<Schemas.PersonTwo> builder().withAlwaysAllowNull(false)
+                        .withSupportSchemaVersioning(true).withPojo(Schemas.PersonTwo.class).build()))
+                .topic(fqtnOne).create();
+
+        Consumer<Schemas.PersonTwo> consumer = pulsarClient
+                .newConsumer(Schema.AVRO(SchemaDefinition.<Schemas.PersonTwo> builder().withAlwaysAllowNull(false)
+                        .withSupportSchemaVersioning(true).withPojo(Schemas.PersonTwo.class).build()))
+                .subscriptionName("test").topic(fqtnOne).subscribe();
+
+        consumer.close();
+
+        String key = TopicName.get(fqtnOne).getSchemaName();
+        BookkeeperSchemaStorage schemaStrogate = (BookkeeperSchemaStorage) pulsar.getSchemaStorage();
+        long schemaLedgerId = schemaStrogate.getSchemaLedgerList(key).get(0);
+
+        // (2) break schema locator by deleting schema-ledger
+        schemaStrogate.getBookKeeper().deleteLedger(schemaLedgerId);
+
+        pulsar.getBrokerService().unloadNamespaceBundlesGracefully();
+
+        // fetch internal info with schema
+        String info = admin.topics().getInternalInfo(fqtnOne);
+
+        ObjectMapper objectMapper = ObjectMapperFactory.getMapper().getObjectMapper();
+        TopicInternalInfo infoObj = objectMapper.readValue(info, TopicInternalInfo.class);
+        assertFalse(infoObj.schemaLedgers.isEmpty());
+
+        producer.close();
     }
 }


### PR DESCRIPTION
### Motivation

There are many cases when a broker is not able to load the topic successfully and it requires examining the metadata of topic/schema/managed-ledger etc for example: https://github.com/apache/pulsar/pull/19882 . But all such metadata is stored in binary in metadata/zk and it really requires to broker admin API to fetch internal info of the topic. Therefore, issue like in PR# 19882 requires users to retrieve schema ledger metadata for further debugging even if topic is not successfully loaded. so, add topic's schema metadata into topic's internal-info API which doesn't depend on loaded topic.

### Modifications

Add schema ledger metadata into topics' offline internal-metadata api.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
