### PR TITLE
[fix][broker] Fix the thread safety issue of BrokerData#getTimeAverageData access

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -589,7 +589,9 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
             }
 
             // Using the newest data, update the aggregated time-average data for the current broker.
-            brokerData.getTimeAverageData().reset(statsMap.keySet(), bundleData, defaultStats);
+            TimeAverageBrokerData timeAverageData = new TimeAverageBrokerData();
+            timeAverageData.reset(statsMap.keySet(), bundleData, defaultStats);
+            brokerData.setTimeAverageData(timeAverageData);
             final ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>> namespaceToBundleRange =
                     brokerToNamespaceToBundleRange
                             .computeIfAbsent(broker, k ->


### PR DESCRIPTION
### Motivation
In the updateBundleData method, when the following code is executed:
https://github.com/apache/pulsar/blob/30d2469086fea989ac8baf059df8e69c66a68d89/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java#L591-L592

In the reset method, information such as longTermMsgRateIn will be recalculated:
<img width="1145" alt="image" src="https://user-images.githubusercontent.com/19296967/226811566-330033f9-1752-4697-b108-a41cac74615f.png">

At this time, if brokerData.getTimeAverageData() is called in the LeastLongTermMessageRate#getScore method, the calculated score will be inaccurate：
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/19296967/226811780-4e3dc0c2-65ef-4e2d-ba8a-689cdc67a460.png">


### Modifications

Create a new TimeAverageBrokerData object and perform a reset update. After the update is complete, call setTimeAverageData:
```
TimeAverageBrokerData timeAverageData = new TimeAverageBrokerData();
timeAverageData.reset(statsMap.keySet(), bundleData, defaultStats);
brokerData.setTimeAverageData(timeAverageData);
```


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lordcheng10/pulsar/pull/45
