### PR TITLE
[fix][broker] Fix overloadedBroker and underloadedBroker to select the wrong broker for UniformLoadShedder

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
@@ -73,12 +73,17 @@ public class UniformLoadShedder implements LoadSheddingStrategy {
             double msgRate = data.getLocalData().getMsgRateIn() + data.getLocalData().getMsgRateOut();
             double throughputRate = data.getLocalData().getMsgThroughputIn()
                     + data.getLocalData().getMsgThroughputOut();
-            if (msgRate > maxMsgRate.getValue() || throughputRate > maxThroughputRate.getValue()) {
+            if ( ((conf.getLoadBalancerMsgRateDifferenceShedderThreshold() > 0)
+                    && (msgRate > maxMsgRate.getValue())) ||
+                    ((conf.getLoadBalancerMsgThroughputMultiplierDifferenceShedderThreshold() > 0)
+                            && (throughputRate > maxThroughputRate.getValue()))) {
                 overloadedBroker.setValue(broker);
                 maxMsgRate.setValue(msgRate);
                 maxThroughputRate.setValue(throughputRate);
             }
-            if (msgRate < minMsgRate.getValue() || throughputRate < minThroughputRate.getValue()) {
+            if (((conf.getLoadBalancerMsgRateDifferenceShedderThreshold() > 0) && (msgRate < minMsgRate.getValue()))
+                    || ((conf.getLoadBalancerMsgThroughputMultiplierDifferenceShedderThreshold() > 0)
+                    && (throughputRate < minThroughputRate.getValue()))) {
                 underloadedBroker.setValue(broker);
                 minMsgRate.setValue(msgRate);
                 minThroughputRate.setValue(throughputRate);


### PR DESCRIPTION
fix #21016
### Motivation
The configuration is as follows:
```
loadBalancerMsgThroughputMultiplierDifferenceShedderThreshold=0
loadBalancerMsgRateDifferenceShedderThreshold=50
```

I hope that the balance only considers msgRate, but as a result, when selecting overloadedBroker and underloadedBroker, the broker with the largest and smallest msgRate will never be selected;
for example:
```
broker1 msgRate=10 throughputRate=20
broker2 msgRate=30 throughputRate=10
broker3 msgRate=10 throughputRate=40
```

The final selected overloadedBroker=broker3 underloadedBroker=broker3;


If the order of traversing brokers is changed, the selection results are completely different:
```
broker3 msgRate=10 throughputRate=40
broker2 msgRate=30 throughputRate=10
broker1 msgRate=10 throughputRate=20
```
The final selected overloadedBroker=broker1 underloadedBroker=broker1;

When overloadedBroker and underloadedBroker are selected, loadBalancerMsgRateDifferenceShedderThreshold and loadBalancerMsgThroughputMultiplierDifferenceShedderThreshold configurations are not considered：
https://github.com/apache/pulsar/blob/30d2469086fea989ac8baf059df8e69c66a68d89/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java#L72-L86


### Modifications
When selecting overloadedBroker and underloadedBroker, you need to consider the configuration of loadBalancerMsgRateDifferenceShedderThreshold and loadBalancerMsgThroughputMultiplierDifferenceShedderThreshold:
```
brokersData.forEach((broker, data) -> {
            double msgRate = data.getLocalData().getMsgRateIn() + data.getLocalData().getMsgRateOut();
            double throughputRate = data.getLocalData().getMsgThroughputIn()
                    + data.getLocalData().getMsgThroughputOut();
            if ( ((conf.getLoadBalancerMsgRateDifferenceShedderThreshold() > 0)
                    && (msgRate > maxMsgRate.getValue())) ||
                    ((conf.getLoadBalancerMsgThroughputMultiplierDifferenceShedderThreshold() > 0)
                            && (throughputRate > maxThroughputRate.getValue()))) {
                overloadedBroker.setValue(broker);
                maxMsgRate.setValue(msgRate);
                maxThroughputRate.setValue(throughputRate);
            }
            if (((conf.getLoadBalancerMsgRateDifferenceShedderThreshold() > 0) && (msgRate < minMsgRate.getValue()))
                    || ((conf.getLoadBalancerMsgThroughputMultiplierDifferenceShedderThreshold() > 0)
                    && (throughputRate < minThroughputRate.getValue()))) {
                underloadedBroker.setValue(broker);
                minMsgRate.setValue(msgRate);
                minThroughputRate.setValue(throughputRate);
            }
        });
```


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lordcheng10/pulsar/pull/46
