### PR TITLE
[improve][broker] Use consumer's startMessageId as readPosition

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
@@ -662,6 +662,14 @@ public interface ManagedCursor {
     void asyncResetCursor(Position position, boolean forceReset, AsyncCallbacks.ResetCursorCallback callback);
 
     /**
+     * Move the current read position of the cursor specified position only if it is newer.
+     *
+     * @param position
+     *            position to move the cursor to, as long as the position is after the current read position
+     */
+    void moveReadPositionForward(Position position);
+
+    /**
      * Read the specified set of positions from ManagedLedger.
      *
      * @param positions

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1380,6 +1380,19 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
     @Override
+    public void moveReadPositionForward(Position newPos) {
+        checkArgument(newPos instanceof PositionImpl);
+        final PositionImpl newReadPosition = (PositionImpl) newPos;
+        READ_POSITION_UPDATER.updateAndGet(this, (oldReadPosition) -> {
+            if (oldReadPosition.compareTo(newReadPosition) > 0) {
+                return newReadPosition;
+            } else {
+                return oldReadPosition;
+            }
+        });
+    }
+
+    @Override
     public void resetCursor(Position newPos) throws ManagedLedgerException, InterruptedException {
         class Result {
             ManagedLedgerException exception = null;


### PR DESCRIPTION
PIP: #19864  

### Motivation

This is a draft PR to show one potential way that we could use feedback from the client to influence how an exclusive and a failover consumer reconnect to the broker. The PR hastily put together, so it doesn't necessarily cover all edge cases.

Further, I think the `startMessageId` sent by the client could easily be the newest message in the `incomingMessages` queue since there is no need to resend those messages in this scenario.

Note that this PR does not include logic to handle the case where the client was forcefully disconnected from the broker. That is a case where we would not want to use the provided `startMessageId`.

### Documentation
- [x] `doc-not-needed`