### PR TITLE
[imporve][broker] use shortTermMsgRate and shortTermThroughput for UniformLoadShedder

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
@@ -72,10 +72,10 @@ public class UniformLoadShedder implements LoadSheddingStrategy {
         MutableDouble minThroughputRate = new MutableDouble(Integer.MAX_VALUE);
         brokersData.forEach((broker, data) -> {
             TimeAverageBrokerData timeAverageData = data.getTimeAverageData();
-            double msgRate = timeAverageData.getLongTermMsgRateIn()
-                    + timeAverageData.getLongTermMsgRateOut();
-            double throughputRate = timeAverageData.getLongTermMsgThroughputIn()
-                    + timeAverageData.getLongTermMsgThroughputOut();
+            double msgRate = timeAverageData.getShortTermMsgRateIn()
+                    + timeAverageData.getShortTermMsgRateOut();
+            double throughputRate = timeAverageData.getShortTermMsgThroughputIn()
+                    + timeAverageData.getShortTermMsgThroughputOut();
             if (msgRate > maxMsgRate.getValue() || throughputRate > maxThroughputRate.getValue()) {
                 overloadedBroker.setValue(broker);
                 maxMsgRate.setValue(msgRate);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.broker.loadbalance.LoadSheddingStrategy;
 import org.apache.pulsar.policies.data.loadbalancer.BrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.BundleData;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
+import org.apache.pulsar.policies.data.loadbalancer.TimeAverageBrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.TimeAverageMessageData;
 
 /**
@@ -70,9 +71,11 @@ public class UniformLoadShedder implements LoadSheddingStrategy {
         MutableDouble minMsgRate = new MutableDouble(Integer.MAX_VALUE);
         MutableDouble minThroughputRate = new MutableDouble(Integer.MAX_VALUE);
         brokersData.forEach((broker, data) -> {
-            double msgRate = data.getLocalData().getMsgRateIn() + data.getLocalData().getMsgRateOut();
-            double throughputRate = data.getLocalData().getMsgThroughputIn()
-                    + data.getLocalData().getMsgThroughputOut();
+            TimeAverageBrokerData timeAverageData = data.getTimeAverageData();
+            double msgRate = timeAverageData.getLongTermMsgRateIn()
+                    + timeAverageData.getLongTermMsgRateOut();
+            double throughputRate = timeAverageData.getLongTermMsgThroughputIn()
+                    + timeAverageData.getLongTermMsgThroughputOut();
             if (msgRate > maxMsgRate.getValue() || throughputRate > maxThroughputRate.getValue()) {
                 overloadedBroker.setValue(broker);
                 maxMsgRate.setValue(msgRate);


### PR DESCRIPTION
### Motivation
In UniformLoadShedder, when selecting overloadedBroker and underloadedBroker, use shortTermThroughput and shortTermMsgRate.



### Modifications

In UniformLoadShedder, when selecting overloadedBroker and underloadedBroker, use shortTermThroughput and shortTermMsgRate.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository:  
