### PR TITLE
[fix][fn] Revert change to deprecation since it broke the master branch

### DIFF
--- a/pulsar-function-go/pb/Function.pb.go
+++ b/pulsar-function-go/pb/Function.pb.go
@@ -579,7 +579,6 @@ type FunctionDetails struct {
 	Runtime              FunctionDetails_Runtime `protobuf:"varint,8,opt,name=runtime,proto3,enum=proto.FunctionDetails_Runtime" json:"runtime,omitempty"`
 	// Deprecated since, see https://github.com/apache/pulsar/issues/15560
 	//
-	// Deprecated: Do not use.
 	AutoAck              bool                          `protobuf:"varint,9,opt,name=autoAck,proto3" json:"autoAck,omitempty"`
 	Parallelism          int32                         `protobuf:"varint,10,opt,name=parallelism,proto3" json:"parallelism,omitempty"`
 	Source               *SourceSpec                   `protobuf:"bytes,11,opt,name=source,proto3" json:"source,omitempty"`


### PR DESCRIPTION
### Motivation

Master branch build fails with this error message:
```
Error: pf/instance.go:158:15: SA1019: gi.context.instanceConf.funcDetails.AutoAck is deprecated: Do not use.  (staticcheck)
			autoAck := gi.context.instanceConf.funcDetails.AutoAck
			           ^
Error: pf/instance.go:364:[13](https://github.com/apache/pulsar/actions/runs/4497924735/jobs/7913997105?pr=19903#step:7:14): SA1019: gi.context.instanceConf.funcDetails.AutoAck is deprecated: Do not use.  (staticcheck)
	autoAck := gi.context.instanceConf.funcDetails.AutoAck
	           ^
Error: pf/instanceConf.go:105:6: SA1019: instanceConf.funcDetails.AutoAck is deprecated: Do not use.  (staticcheck)
	if !instanceConf.funcDetails.AutoAck &&
	    ^
Error: Process completed with exit code 1.
```
- change was made in #19470
- it was possible to merge the change because of this bug in Pulsar CI: #19905

### Modifications

Revert change to deprecation

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->