### PR TITLE
[fix][admin] Fix delete tenant

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/LocalPoliciesResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/LocalPoliciesResources.java
@@ -85,7 +85,7 @@ public class LocalPoliciesResources extends BaseResources<LocalPolicies> {
     public CompletableFuture<Void> deleteLocalPoliciesTenantAsync(String tenant) {
         final String localPoliciesPath = joinPath(LOCAL_POLICIES_ROOT, tenant);
         CompletableFuture<Void> future = new CompletableFuture<Void>();
-        deleteAsync(localPoliciesPath).whenComplete((ignore, ex) -> {
+        deleteIfExistsAsync(localPoliciesPath).whenComplete((ignore, ex) -> {
             if (ex != null && ex.getCause().getCause() instanceof KeeperException) {
                 future.complete(null);
             } else if (ex != null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTenantTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTenantTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.testng.Assert.*;
+
+@Test(groups = "broker-admin")
+@Slf4j
+public class AdminApiTenantTest extends MockedPulsarServiceBaseTest {
+    private final String CLUSTER = "test";
+
+    @BeforeClass
+    @Override
+    public void setup() throws Exception {
+        super.internalSetup();
+        admin.clusters()
+                .createCluster(CLUSTER, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+    }
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    public void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testListTenant() throws PulsarAdminException {
+        admin.tenants().getTenants();
+    }
+
+    @Test
+    public void testCreateAndDeleteTenant() throws PulsarAdminException {
+        String tenant = "test-tenant-"+ UUID.randomUUID();
+        admin.tenants().createTenant(tenant, TenantInfo.builder().allowedClusters(Collections.singleton(CLUSTER)).build());
+        List<String> tenants = admin.tenants().getTenants();
+        assertTrue(tenants.contains(tenant));
+        admin.tenants().deleteTenant(tenant);
+        tenants = admin.tenants().getTenants();
+        assertFalse(tenants.contains(tenant));
+    }
+
+    @Test
+    public void testDeleteNonExistTenant() {
+        String tenant = "test-non-exist-tenant-" + UUID.randomUUID();
+        assertThrows(PulsarAdminException.NotFoundException.class, () -> admin.tenants().deleteTenant(tenant));
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTenantTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTenantTest.java
@@ -18,6 +18,13 @@
  */
 package org.apache.pulsar.broker.admin;
 
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -25,12 +32,6 @@ import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
-import static org.testng.Assert.*;
 
 @Test(groups = "broker-admin")
 @Slf4j


### PR DESCRIPTION
Fixes #19921

### Motivation

Failed to delete tenant, see log:

```
2023-03-25T18:40:15,174+0800 [pulsar-web-48-12] ERROR org.apache.pulsar.broker.admin.impl.TenantsBase - [null] Failed to delete tenant newtenant
org.apache.pulsar.metadata.api.MetadataStoreException$NotFoundException: path /admin/local-policies/newtenant not found.
        at org.apache.pulsar.metadata.impl.RocksdbMetadataStore.storeDelete(RocksdbMetadataStore.java:480) ~[pulsar-metadata.jar:3.0.0-SNAPSHOT]
        at org.apache.pulsar.metadata.impl.AbstractMetadataStore.deleteInternal(AbstractMetadataStore.java:386) ~[pulsar-metadata.jar:3.0.0-SNAPSHOT]
        at org.apache.pulsar.metadata.impl.AbstractMetadataStore.delete(AbstractMetadataStore.java:373) ~[pulsar-metadata.jar:3.0.0-SNAPSHOT]
        at org.apache.pulsar.metadata.cache.impl.MetadataCacheImpl.delete(MetadataCacheImpl.java:248) ~[pulsar-metadata.jar:3.0.0-SNAPSHOT]
        at org.apache.pulsar.broker.resources.BaseResources.deleteAsync(BaseResources.java:160) ~[pulsar-broker-common.jar:3.0.0-SNAPSHOT]
        at org.apache.pulsar.broker.resources.LocalPoliciesResources.deleteLocalPoliciesTenantAsync(LocalPoliciesResources.java:88) ~[pulsar-broker-common.jar:3.0.0-SNAPSHOT]
        at org.apache.pulsar.broker.admin.impl.TenantsBase.lambda$internalDeleteTenantAsync$33(TenantsBase.java:238) ~[pulsar-broker.jar:3.0.0-SNAPSHOT]
```

When deleting a tenant, we delete a path that does not exist, so throw an exception.

### Modifications

- Check whether the `/admin/local-policies/{tenant}` exists, and then delete it

### Verifying this change

- [x] Make sure that the change passes the CI checks.
Added `AdminApiTenantTest`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->