### PR TITLE
[fix][client] Cache empty schema version in ProducerImpl schemaCache.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MockBrokerService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MockBrokerService.java
@@ -96,7 +96,8 @@ public class MockBrokerService {
         private final Pattern multiPartPattern = Pattern.compile(".*/multi-part-.*");
 
         @Override
-        public void handle(String s, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+        public void handle(String s, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+                throws IOException, ServletException {
             String responseString;
             log.info("Received HTTP request {}", baseRequest.getRequestURI());
             if (baseRequest.getRequestURI().startsWith(lookupURI)) {
@@ -165,7 +166,8 @@ public class MockBrokerService {
                 return;
             }
             // default
-            ctx.writeAndFlush(Commands.newLookupResponse(getBrokerAddress(), null, true, LookupType.Connect, lookup.getRequestId(), false));
+            ctx.writeAndFlush(Commands.newLookupResponse(getBrokerAddress(), null, true,
+                    LookupType.Connect, lookup.getRequestId(), false));
         }
 
         @Override
@@ -305,7 +307,8 @@ public class MockBrokerService {
             startMockBrokerService();
             log.info("Started mock Pulsar service on {}", getBrokerAddress());
 
-            lookupData = new LookupData(getBrokerAddress(), null, getHttpAddress(), null);
+            lookupData = new LookupData(getBrokerAddress(), null,
+                    getHttpAddress(), null);
         } catch (Exception e) {
             log.error("Error starting mock service", e);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MockBrokerServiceHooks.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MockBrokerServiceHooks.java
@@ -26,6 +26,7 @@ import org.apache.pulsar.common.api.proto.CommandCloseConsumer;
 import org.apache.pulsar.common.api.proto.CommandCloseProducer;
 import org.apache.pulsar.common.api.proto.CommandConnect;
 import org.apache.pulsar.common.api.proto.CommandFlow;
+import org.apache.pulsar.common.api.proto.CommandGetOrCreateSchema;
 import org.apache.pulsar.common.api.proto.CommandLookupTopic;
 import org.apache.pulsar.common.api.proto.CommandPartitionedTopicMetadata;
 import org.apache.pulsar.common.api.proto.CommandProducer;
@@ -76,5 +77,9 @@ public interface MockBrokerServiceHooks {
 
     interface CommandCloseConsumerHook {
         void apply(ChannelHandlerContext ctx, CommandCloseConsumer closeConsumer);
+    }
+
+    interface CommandGetOrCreateSchemaHook {
+        void apply(ChannelHandlerContext ctx, CommandGetOrCreateSchema closeConsumer);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerEmptySchemaCacheTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerEmptySchemaCacheTest.java
@@ -1,0 +1,70 @@
+package org.apache.pulsar.client.impl;
+
+import lombok.Cleanup;
+import org.apache.pulsar.client.api.MockBrokerService;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.protocol.Commands;
+import org.apache.pulsar.common.protocol.schema.SchemaVersion;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.testng.Assert.assertEquals;
+
+public class ProducerEmptySchemaCacheTest {
+
+    MockBrokerService mockBrokerService;
+
+    @BeforeClass(alwaysRun = true)
+    public void setup() {
+        mockBrokerService = new MockBrokerService();
+        mockBrokerService.start();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown() {
+        if (mockBrokerService != null) {
+            mockBrokerService.stop();
+            mockBrokerService = null;
+        }
+    }
+
+    @org.testng.annotations.Test
+    public void testConsumerUnsubscribeReference() throws Exception {
+        @Cleanup
+        PulsarClientImpl client = (PulsarClientImpl) PulsarClient.builder()
+                .serviceUrl(mockBrokerService.getBrokerAddress())
+                .build();
+
+        AtomicLong counter = new AtomicLong(0);
+
+        mockBrokerService.setHandleGetOrCreateSchema((ctx, commandGetOrCreateSchema) -> {
+            counter.incrementAndGet();
+            ctx.writeAndFlush(
+                    Commands.newGetOrCreateSchemaResponse(commandGetOrCreateSchema.getRequestId(),
+                            SchemaVersion.Empty));
+        });
+
+        // this schema mode is used in consumer retry and dlq Producer
+        // when the origin consumer has Schema.BYTES schema
+        // and when retry message or dlq message is send
+        // will use typed message builder set Schema.Bytes to send message.
+
+        @Cleanup
+        Producer<byte[]> producer = client.newProducer(Schema.AUTO_PRODUCE_BYTES(Schema.BYTES))
+                .topic("testAutoProduceBytesSchemaShouldCache")
+                .sendTimeout(5, TimeUnit.SECONDS)
+                .maxPendingMessages(0)
+                .enableBatching(false)
+                .create();
+
+        producer.newMessage(Schema.BYTES).value("hello".getBytes()).send();
+
+
+        assertEquals(counter.get(), 1);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerEmptySchemaCacheTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerEmptySchemaCacheTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.client.impl;
 
 import lombok.Cleanup;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1705,8 +1705,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 requestId).thenAccept(response -> {
                     String producerName = response.getProducerName();
                     long lastSequenceId = response.getLastSequenceId();
-                    schemaVersion = Optional.ofNullable(response.getSchemaVersion());  // 这里记录当前这个producer的 schemaVersion
-                    schemaVersion.ifPresent(v -> schemaCache.put(SchemaHash.of(schema), v));  // 这里记录了schemaCache到schema的缓存
+                    schemaVersion = Optional.ofNullable(response.getSchemaVersion());
+                    schemaVersion.ifPresent(v -> schemaCache.put(SchemaHash.of(schema), v));
 
                     // We are now reconnected to broker and clear to send messages. Re-send all pending messages and
                     // set the cnx pointer so that new messages will be sent immediately

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -738,7 +738,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         byte[] schemaVersion = schemaCache.get(msg.getSchemaHash());
         if (schemaVersion != null) {
             if (schemaVersion != SchemaVersion.Empty.bytes()) {
-                msg.getMessageBuilder().setSchemaVersion(schemaVersion);
+                msgMetadataBuilder.setSchemaVersion(schemaVersion);
             }
 
             msg.setSchemaState(MessageImpl.SchemaState.Ready);


### PR DESCRIPTION

Fixes #19928

### Motivation

When use Schema.BYTES consumer and enable retry and dlq policy.

need cache the empty schema version to avoid send a lot of GetOrCreateSchema request to retrieve the schema version.

### Modifications

1. Cache empty schema version in ProducerImpl schemaCache.

2. When read from schemaCache, check if the schema version means empty.


### Verifying this change

- [ ] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
