### PR TITLE
[improve][ci] Extend cache action timeout to 10 minutes

### DIFF
--- a/.github/workflows/ci-maven-cache-update.yaml
+++ b/.github/workflows/ci-maven-cache-update.yaml
@@ -96,7 +96,7 @@ jobs:
         if: ${{ github.event_name == 'schedule' || steps.changes.outputs.poms == 'true' }}
         id: cache
         uses: actions/cache@v3
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           path: |
             ~/.m2/repository/*/*/*

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           path: |
             ~/.m2/repository/*/*/*

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           path: |
             ~/.m2/repository/*/*/*

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -226,7 +226,7 @@ jobs:
 
       - name: Cache Maven dependencies
         uses: actions/cache@v3
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -330,7 +330,7 @@ jobs:
 
       - name: Cache Maven dependencies
         uses: actions/cache@v3
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -413,7 +413,7 @@ jobs:
 
       - name: Cache Maven dependencies
         uses: actions/cache@v3
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -528,7 +528,7 @@ jobs:
 
       - name: Cache Maven dependencies
         uses: actions/cache@v3
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -644,7 +644,7 @@ jobs:
 
       - name: Cache Maven dependencies
         uses: actions/cache@v3
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -764,7 +764,7 @@ jobs:
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -900,7 +900,7 @@ jobs:
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -1011,7 +1011,7 @@ jobs:
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -1112,7 +1112,7 @@ jobs:
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -1239,7 +1239,7 @@ jobs:
 
       - name: Cache Maven dependencies
         uses: actions/cache@v3
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -1285,7 +1285,7 @@ jobs:
 
       - name: Cache Maven dependencies
         uses: actions/cache@v3
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           path: |
             ~/.m2/repository/*/*/*


### PR DESCRIPTION
This closes https://github.com/apache/pulsar/issues/19953.

### Motivation

We now cache a large maven dependencies set, 5 minutes are not enough for personal CI.

### Modifications

AS IS

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->

cc @devinbost 
