### PR TITLE
[fix][sec] Fix transitive critical CVEs in file-system tiered storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,8 +180,8 @@ flexible messaging model and an intuitive client API.</description>
     <clickhouse-jdbc.version>0.3.2-patch11</clickhouse-jdbc.version>
     <mariadb-jdbc.version>2.7.5</mariadb-jdbc.version>
     <openmldb-jdbc.version>0.4.4-hotfix1</openmldb-jdbc.version>
-    <hdfs-offload-version3>3.3.3</hdfs-offload-version3>
-    <json-smart.version>2.4.7</json-smart.version>
+    <hdfs-offload-version3>3.3.5</hdfs-offload-version3>
+    <json-smart.version>2.4.10</json-smart.version>
     <opensearch.version>1.2.4</opensearch.version>
     <elasticsearch-java.version>8.5.2</elasticsearch-java.version>
     <trino.version>363</trino.version>
@@ -257,7 +257,7 @@ flexible messaging model and an intuitive client API.</description>
     <objenesis.version>3.1</objenesis.version>
     <awaitility.version>4.2.0</awaitility.version>
     <reload4j.version>1.2.22</reload4j.version>
-    <jettison.version>1.5.3</jettison.version>
+    <jettison.version>1.5.4</jettison.version>
     <woodstox.version>5.4.0</woodstox.version>
     <wiremock.version>2.33.2</wiremock.version>
 
@@ -835,11 +835,11 @@ flexible messaging model and an intuitive client API.</description>
         <scope>import</scope>
       </dependency>
 
-      <dependency>
-        <groupId>org.codehaus.jettison</groupId>
-        <artifactId>jettison</artifactId>
-        <version>${jettison.version}</version>
-      </dependency>
+<!--      <dependency>-->
+<!--        <groupId>org.codehaus.jettison</groupId>-->
+<!--        <artifactId>jettison</artifactId>-->
+<!--        <version>${jettison.version}</version>-->
+<!--      </dependency>-->
 
       <dependency>
         <groupId>com.fasterxml.woodstox</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -835,11 +835,11 @@ flexible messaging model and an intuitive client API.</description>
         <scope>import</scope>
       </dependency>
 
-<!--      <dependency>-->
-<!--        <groupId>org.codehaus.jettison</groupId>-->
-<!--        <artifactId>jettison</artifactId>-->
-<!--        <version>${jettison.version}</version>-->
-<!--      </dependency>-->
+      <dependency>
+        <groupId>org.codehaus.jettison</groupId>
+        <artifactId>jettison</artifactId>
+        <version>${jettison.version}</version>
+      </dependency>
 
       <dependency>
         <groupId>com.fasterxml.woodstox</groupId>

--- a/tiered-storage/file-system/pom.xml
+++ b/tiered-storage/file-system/pom.xml
@@ -54,31 +54,6 @@
         </dependency>
         <!-- fix hadoop-commons vulnerable dependencies -->
         <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-json</artifactId>
-            <!-- same version used by hadoop-common-->
-            <version>1.19</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.codehaus.jackson</groupId>
-                    <artifactId>jackson-core-asl</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.jackson</groupId>
-                    <artifactId>jackson-mapper-asl</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.jackson</groupId>
-                    <artifactId>jackson-jaxrs</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.jackson</groupId>
-                    <artifactId>jackson-xc</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- fix hadoop-commons vulnerable dependencies -->
-        <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <version>${avro.version}</version>


### PR DESCRIPTION
### Motivation

Currently the file-system tiered storages brings in the following CVEs:
- CVE-2023-1436 (from jettison)
- CVE-2023-1370 (from json-smart)
- sonatype-2022-5820 (from hadoop 3.3.3)

### Modifications

All the above are depending from hadoop.
- Upgraded hadoop from 3.3.3 to 3.3.5 - removed the jersey-json override since the dependency has changed (https://issues.apache.org/jira/browse/HADOOP-15983)
- Upgraded jettison from 1.5.3 to 1.5.4
- Upgraded json-smart from 2.4.7 to 2.4.10

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository
