### PR TITLE
[improve][broker] PIP-192: Filter the transfer dest broker

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/AntiAffinityGroupPolicyFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/AntiAffinityGroupPolicyFilter.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.broker.loadbalance.extensions.filter;
 
 import java.util.Map;
-import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.loadbalance.extensions.policies.AntiAffinityGroupPolicyHelper;
@@ -49,10 +48,5 @@ public class AntiAffinityGroupPolicyFilter implements BrokerFilter {
     @Override
     public String name() {
         return FILTER_NAME;
-    }
-
-    @Override
-    public void initialize(PulsarService pulsar) {
-        return;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerFilter.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.broker.loadbalance.extensions.filter;
 
 import java.util.Map;
-import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
@@ -34,11 +33,6 @@ public interface BrokerFilter {
      * The broker filter name.
      */
     String name();
-
-    /**
-     * Initialize this broker filter using the given pulsar service.
-     */
-    void initialize(PulsarService pulsar);
 
     /**
      * Filter out unqualified brokers based on implementation.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerIsolationPoliciesFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerIsolationPoliciesFilter.java
@@ -21,12 +21,10 @@ package org.apache.pulsar.broker.loadbalance.extensions.filter;
 import java.util.Map;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.loadbalance.extensions.policies.IsolationPoliciesHelper;
-import org.apache.pulsar.broker.loadbalance.impl.SimpleResourceAllocationPolicies;
 import org.apache.pulsar.common.naming.ServiceUnitId;
 
 
@@ -37,14 +35,13 @@ public class BrokerIsolationPoliciesFilter implements BrokerFilter {
 
     private IsolationPoliciesHelper isolationPoliciesHelper;
 
-    @Override
-    public String name() {
-        return FILTER_NAME;
+    public BrokerIsolationPoliciesFilter(IsolationPoliciesHelper helper) {
+        this.isolationPoliciesHelper = helper;
     }
 
     @Override
-    public void initialize(PulsarService pulsar) {
-        this.isolationPoliciesHelper = new IsolationPoliciesHelper(new SimpleResourceAllocationPolicies(pulsar));
+    public String name() {
+        return FILTER_NAME;
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerMaxTopicCountFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerMaxTopicCountFilter.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.broker.loadbalance.extensions.filter;
 
 import java.util.Map;
 import java.util.Optional;
-import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLoadData;
@@ -34,11 +33,6 @@ public class BrokerMaxTopicCountFilter implements BrokerFilter {
     @Override
     public String name() {
         return FILTER_NAME;
-    }
-
-    @Override
-    public void initialize(PulsarService pulsar) {
-        // No-op
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerVersionFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerVersionFilter.java
@@ -22,7 +22,6 @@ import com.github.zafarkhaja.semver.Version;
 import java.util.Iterator;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.BrokerFilterBadVersionException;
 import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
@@ -147,10 +146,5 @@ public class BrokerVersionFilter implements BrokerFilter {
     @Override
     public String name() {
         return FILTER_NAME;
-    }
-
-    @Override
-    public void initialize(PulsarService pulsar) {
-        // No-op
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/policies/AntiAffinityGroupPolicyHelper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/policies/AntiAffinityGroupPolicyHelper.java
@@ -87,6 +87,16 @@ public class AntiAffinityGroupPolicyHelper {
         }
     }
 
+    public boolean hasAntiAffinityGroupPolicy(String bundle) {
+        try {
+            return LoadManagerShared.getNamespaceAntiAffinityGroup(
+                    pulsar, LoadManagerShared.getNamespaceNameFromBundleName(bundle)).isPresent();
+        } catch (MetadataStoreException e) {
+            log.error("Failed to check unload candidates. Assumes that bundle:{} cannot unload ", bundle, e);
+            return false;
+        }
+    }
+
     public void listenFailureDomainUpdate() {
         LoadManagerShared.refreshBrokerToFailureDomainMap(pulsar, brokerToFailureDomainMap);
         // register listeners for domain changes

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/policies/AntiAffinityGroupPolicyHelper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/policies/AntiAffinityGroupPolicyHelper.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.broker.loadbalance.extensions.policies;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannel;
@@ -47,44 +46,6 @@ public class AntiAffinityGroupPolicyHelper {
         LoadManagerShared.filterAntiAffinityGroupOwnedBrokers(pulsar, bundle,
                 brokers.keySet(),
                 channel.getOwnershipEntrySet(), brokerToFailureDomainMap);
-    }
-
-    public boolean canUnload(
-            Map<String, BrokerLookupData> brokers,
-            String bundle,
-            String srcBroker,
-            Optional<String> dstBroker) {
-
-        try {
-            var antiAffinityGroupOptional = LoadManagerShared.getNamespaceAntiAffinityGroup(
-                    pulsar, LoadManagerShared.getNamespaceNameFromBundleName(bundle));
-            if (antiAffinityGroupOptional.isEmpty()) {
-                return true;
-            }
-
-            // bundle has anti-affinityGroup
-            if (!pulsar.getConfiguration().isLoadBalancerSheddingBundlesWithPoliciesEnabled()) {
-                return false;
-            }
-
-            // copy to retain the input brokers
-            Map<String, BrokerLookupData> candidates = new HashMap<>(brokers);
-
-            filter(candidates, bundle);
-
-            candidates.remove(srcBroker);
-
-            // unload case
-            if (dstBroker.isEmpty()) {
-                return !candidates.isEmpty();
-            }
-
-            // transfer case
-            return candidates.containsKey(dstBroker.get());
-        } catch (MetadataStoreException e) {
-            log.error("Failed to check unload candidates. Assumes that bundle:{} cannot unload ", bundle, e);
-            return false;
-        }
     }
 
     public boolean hasAntiAffinityGroupPolicy(String bundle) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/policies/IsolationPoliciesHelper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/policies/IsolationPoliciesHelper.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared;
 import org.apache.pulsar.broker.loadbalance.impl.SimpleResourceAllocationPolicies;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.ServiceUnitId;
 
 @Slf4j
@@ -63,6 +64,10 @@ public class IsolationPoliciesHelper {
                     }
                 });
         return brokerCandidateCache;
+    }
+
+    public boolean hasIsolationPolicy(NamespaceName namespaceName) {
+        return policies.areIsolationPoliciesPresent(namespaceName);
     }
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedder.java
@@ -691,13 +691,15 @@ public class TransferShedder implements NamespaceUnloadStrategy {
         }
 
         Map<String, BrokerLookupData> candidates = new HashMap<>(availableBrokers);
-        brokerFilterPipeline.forEach(filter -> {
+        for (var filter : brokerFilterPipeline) {
             try {
                 filter.filter(candidates, namespaceBundle, context);
             } catch (BrokerFilterException e) {
                 log.error("Failed to filter brokers with filter: {}", filter.getClass().getName(), e);
+                return false;
             }
-        });
+        }
+
         if (dstBroker.isPresent()) {
             if (!candidates.containsKey(dstBroker.get())) {
                 return false;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedder.java
@@ -723,7 +723,6 @@ public class TransferShedder implements NamespaceUnloadStrategy {
             return context.brokerConfiguration().isLoadBalancerSheddingBundlesWithPoliciesEnabled();
         }
 
-        String bundle = namespaceBundle.toString();
         if (antiAffinityGroupPolicyHelper != null
                 && antiAffinityGroupPolicyHelper.hasAntiAffinityGroupPolicy(namespaceBundle.toString())) {
             return context.brokerConfiguration().isLoadBalancerSheddingBundlesWithPoliciesEnabled();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedder.java
@@ -32,6 +32,7 @@ import static org.apache.pulsar.broker.loadbalance.extensions.models.UnloadDecis
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +47,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannel;
@@ -53,6 +55,7 @@ import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateC
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLoadData;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.loadbalance.extensions.data.TopBundlesLoadData;
+import org.apache.pulsar.broker.loadbalance.extensions.filter.BrokerFilter;
 import org.apache.pulsar.broker.loadbalance.extensions.models.Unload;
 import org.apache.pulsar.broker.loadbalance.extensions.models.UnloadCounter;
 import org.apache.pulsar.broker.loadbalance.extensions.models.UnloadDecision;
@@ -60,7 +63,6 @@ import org.apache.pulsar.broker.loadbalance.extensions.policies.AntiAffinityGrou
 import org.apache.pulsar.broker.loadbalance.extensions.policies.IsolationPoliciesHelper;
 import org.apache.pulsar.broker.loadbalance.extensions.store.LoadDataStore;
 import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared;
-import org.apache.pulsar.broker.loadbalance.impl.SimpleResourceAllocationPolicies;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,9 +98,10 @@ public class TransferShedder implements NamespaceUnloadStrategy {
     private static final String CANNOT_UNLOAD_BUNDLE_MSG = "Can't unload bundle:%s.";
     private final LoadStats stats = new LoadStats();
     private PulsarService pulsar;
-    private SimpleResourceAllocationPolicies allocationPolicies;
     private IsolationPoliciesHelper isolationPoliciesHelper;
     private AntiAffinityGroupPolicyHelper antiAffinityGroupPolicyHelper;
+    private List<BrokerFilter> brokerFilterPipeline;
+
     private Set<UnloadDecision> decisionCache;
     @Getter
     private UnloadCounter counter;
@@ -109,7 +112,6 @@ public class TransferShedder implements NamespaceUnloadStrategy {
     public TransferShedder(UnloadCounter counter){
         this.pulsar = null;
         this.decisionCache = new HashSet<>();
-        this.allocationPolicies = null;
         this.counter = counter;
         this.isolationPoliciesHelper = null;
         this.antiAffinityGroupPolicyHelper = null;
@@ -117,26 +119,28 @@ public class TransferShedder implements NamespaceUnloadStrategy {
 
     public TransferShedder(PulsarService pulsar,
                            UnloadCounter counter,
+                           List<BrokerFilter> brokerFilterPipeline,
+                           IsolationPoliciesHelper isolationPoliciesHelper,
                            AntiAffinityGroupPolicyHelper antiAffinityGroupPolicyHelper){
         this.pulsar = pulsar;
         this.decisionCache = new HashSet<>();
-        this.allocationPolicies = new SimpleResourceAllocationPolicies(pulsar);
         this.counter = counter;
-        this.isolationPoliciesHelper = new IsolationPoliciesHelper(allocationPolicies);
-        this.channel = ServiceUnitStateChannelImpl.get(pulsar);
+        this.isolationPoliciesHelper = isolationPoliciesHelper;
         this.antiAffinityGroupPolicyHelper = antiAffinityGroupPolicyHelper;
+        this.channel = ServiceUnitStateChannelImpl.get(pulsar);
+        this.brokerFilterPipeline = brokerFilterPipeline;
     }
 
     @Override
     public void initialize(PulsarService pulsar){
         this.pulsar = pulsar;
         this.decisionCache = new HashSet<>();
-        this.allocationPolicies = new SimpleResourceAllocationPolicies(pulsar);
         var manager = ExtensibleLoadManagerImpl.get(pulsar.getLoadManager().get());
         this.counter = manager.getUnloadCounter();
-        this.isolationPoliciesHelper = new IsolationPoliciesHelper(allocationPolicies);
-        this.channel = ServiceUnitStateChannelImpl.get(pulsar);
+        this.isolationPoliciesHelper = manager.getIsolationPoliciesHelper();
         this.antiAffinityGroupPolicyHelper = manager.getAntiAffinityGroupPolicyHelper();
+        this.channel = ServiceUnitStateChannelImpl.get(pulsar);
+        this.brokerFilterPipeline = manager.getBrokerFilterPipeline();
     }
 
 
@@ -673,7 +677,7 @@ public class TransferShedder implements NamespaceUnloadStrategy {
                                    String bundle,
                                    String srcBroker,
                                    Optional<String> dstBroker) {
-        if (pulsar == null || allocationPolicies == null) {
+        if (pulsar == null) {
             return true;
         }
 
@@ -682,54 +686,49 @@ public class TransferShedder implements NamespaceUnloadStrategy {
         NamespaceBundle namespaceBundle =
                 pulsar.getNamespaceService().getNamespaceBundleFactory().getBundle(namespace, bundleRange);
 
-        if (!canTransferWithIsolationPoliciesToBroker(
-                context, availableBrokers, namespaceBundle, srcBroker, dstBroker)) {
+        if (!isLoadBalancerSheddingBundlesWithPoliciesEnabled(context, namespaceBundle)) {
             return false;
         }
 
-        if (antiAffinityGroupPolicyHelper != null
-                && !antiAffinityGroupPolicyHelper.canUnload(availableBrokers, bundle, srcBroker, dstBroker)) {
-            return false;
+        Map<String, BrokerLookupData> candidates = new HashMap<>(availableBrokers);
+        brokerFilterPipeline.forEach(filter -> {
+            try {
+                filter.filter(candidates, namespaceBundle, context);
+            } catch (BrokerFilterException e) {
+                log.error("Failed to filter brokers with filter: {}", filter.getClass().getName(), e);
+            }
+        });
+        if (dstBroker.isPresent()) {
+            if (!candidates.containsKey(dstBroker.get())) {
+                return false;
+            }
         }
-        return true;
-    }
-
-    /**
-     * Check the gave bundle and broker can be transfer or unload with isolation policies applied.
-     *
-     * @param context The load manager context.
-     * @param availableBrokers The available brokers.
-     * @param namespaceBundle The bundle try to unload or transfer.
-     * @param currentBroker The current broker.
-     * @param targetBroker The broker will be transfer to.
-     * @return Can be transfer/unload or not.
-     */
-    private boolean canTransferWithIsolationPoliciesToBroker(LoadManagerContext context,
-                                                             Map<String, BrokerLookupData> availableBrokers,
-                                                             NamespaceBundle namespaceBundle,
-                                                             String currentBroker,
-                                                             Optional<String> targetBroker) {
-        if (isolationPoliciesHelper == null
-                || !allocationPolicies.areIsolationPoliciesPresent(namespaceBundle.getNamespaceObject())) {
-            return true;
-        }
-
-        // bundle has isolation policies.
-        if (!context.brokerConfiguration().isLoadBalancerSheddingBundlesWithPoliciesEnabled()) {
-            return false;
-        }
-
-        boolean transfer = context.brokerConfiguration().isLoadBalancerTransferEnabled();
-        Set<String> candidates = isolationPoliciesHelper.applyIsolationPolicies(availableBrokers, namespaceBundle);
 
         // Remove the current bundle owner broker.
-        candidates.remove(currentBroker);
+        candidates.remove(srcBroker);
+        boolean transfer = context.brokerConfiguration().isLoadBalancerTransferEnabled();
 
         // Unload: Check if there are any more candidates available for selection.
-        if (targetBroker.isEmpty() || !transfer) {
+        if (dstBroker.isEmpty() || !transfer) {
             return !candidates.isEmpty();
         }
         // Transfer: Check if this broker is among the candidates.
-        return candidates.contains(targetBroker.get());
+        return candidates.containsKey(dstBroker.get());
+    }
+
+    protected boolean isLoadBalancerSheddingBundlesWithPoliciesEnabled(LoadManagerContext context,
+                                                                       NamespaceBundle namespaceBundle) {
+        if (isolationPoliciesHelper != null
+                && isolationPoliciesHelper.hasIsolationPolicy(namespaceBundle.getNamespaceObject())) {
+            return context.brokerConfiguration().isLoadBalancerSheddingBundlesWithPoliciesEnabled();
+        }
+
+        String bundle = namespaceBundle.toString();
+        if (antiAffinityGroupPolicyHelper != null
+                && antiAffinityGroupPolicyHelper.hasAntiAffinityGroupPolicy(namespaceBundle.toString())) {
+            return context.brokerConfiguration().isLoadBalancerSheddingBundlesWithPoliciesEnabled();
+        }
+
+        return true;
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/AntiAffinityNamespaceGroupExtensionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/AntiAffinityNamespaceGroupExtensionTest.java
@@ -22,8 +22,6 @@ import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUni
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -84,83 +82,7 @@ public class AntiAffinityNamespaceGroupExtensionTest extends AntiAffinityNamespa
     }
 
     protected void verifyLoadSheddingWithAntiAffinityNamespace(String namespace, String bundle) {
-        try {
-            String namespaceBundle = namespace + "/" + bundle;
-            var antiAffinityGroupPolicyHelper =
-                    (AntiAffinityGroupPolicyHelper)
-                            FieldUtils.readDeclaredField(
-                                    primaryLoadManager, "antiAffinityGroupPolicyHelper", true);
-            var brokerRegistry =
-                    (BrokerRegistry)
-                            FieldUtils.readDeclaredField(
-                                    primaryLoadManager, "brokerRegistry", true);
-            var brokers = brokerRegistry
-                    .getAvailableBrokerLookupDataAsync().get(5, TimeUnit.SECONDS);
-            var serviceUnitStateChannel = (ServiceUnitStateChannel)
-                    FieldUtils.readDeclaredField(
-                            primaryLoadManager, "serviceUnitStateChannel", true);
-            var srcBroker = serviceUnitStateChannel.getOwnerAsync(namespaceBundle)
-                    .get(5, TimeUnit.SECONDS).get();
-            var brokersCopy = new HashMap<>(brokers);
-            brokersCopy.remove(srcBroker);
-            var dstBroker = brokersCopy.entrySet().iterator().next().getKey();
-
-            // test setLoadBalancerSheddingBundlesWithPoliciesEnabled = true
-            conf.setLoadBalancerSheddingBundlesWithPoliciesEnabled(true);
-            assertTrue(antiAffinityGroupPolicyHelper.canUnload(brokers,
-                    "not-enabled-" + namespace + "/" + bundle,
-                    srcBroker, Optional.of(dstBroker)));
-
-            assertTrue(antiAffinityGroupPolicyHelper.canUnload(brokers,
-                    "not-enabled-" + namespace + "/" + bundle,
-                    srcBroker, Optional.empty()));
-
-            assertTrue(antiAffinityGroupPolicyHelper.canUnload(brokers,
-                    namespaceBundle,
-                    srcBroker, Optional.of(dstBroker)));
-
-            assertFalse(antiAffinityGroupPolicyHelper.canUnload(brokers,
-                    namespaceBundle,
-                    dstBroker, Optional.of(srcBroker)));
-
-            assertTrue(antiAffinityGroupPolicyHelper.canUnload(brokers,
-                    namespaceBundle,
-                    srcBroker, Optional.empty()));
-
-            assertFalse(antiAffinityGroupPolicyHelper.canUnload(brokers,
-                    namespaceBundle,
-                    dstBroker, Optional.empty()));
-
-            // test setLoadBalancerSheddingBundlesWithPoliciesEnabled = false
-            conf.setLoadBalancerSheddingBundlesWithPoliciesEnabled(false);
-            assertTrue(antiAffinityGroupPolicyHelper.canUnload(brokers,
-                    "not-enabled-" + namespace + "/" + bundle,
-                    srcBroker, Optional.of(dstBroker)));
-
-            assertTrue(antiAffinityGroupPolicyHelper.canUnload(brokers,
-                    "not-enabled-" + namespace + "/" + bundle,
-                    srcBroker, Optional.empty()));
-
-            assertFalse(antiAffinityGroupPolicyHelper.canUnload(brokers,
-                    namespaceBundle,
-                    srcBroker, Optional.of(dstBroker)));
-
-            assertFalse(antiAffinityGroupPolicyHelper.canUnload(brokers,
-                    namespaceBundle,
-                    dstBroker, Optional.of(srcBroker)));
-
-            assertFalse(antiAffinityGroupPolicyHelper.canUnload(brokers,
-                    namespaceBundle,
-                    srcBroker, Optional.empty()));
-
-            assertFalse(antiAffinityGroupPolicyHelper.canUnload(brokers,
-                    namespaceBundle,
-                    dstBroker, Optional.empty()));
-
-
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        // No-op
     }
 
     protected boolean isLoadManagerUpdatedDomainCache(Object loadManager) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -285,11 +285,6 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
             }
 
             @Override
-            public void initialize(PulsarService pulsar) {
-                // No-op
-            }
-
-            @Override
             public Map<String, BrokerLookupData> filter(Map<String, BrokerLookupData> brokers,
                                                         ServiceUnitId serviceUnit,
                                                         LoadManagerContext context) throws BrokerFilterException {
@@ -819,11 +814,6 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
         @Override
         public String name() {
             return "Mock-broker-filter";
-        }
-
-        @Override
-        public void initialize(PulsarService pulsar) {
-            // No-op
         }
 
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerIsolationPoliciesFilterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerIsolationPoliciesFilterTest.java
@@ -31,7 +31,6 @@ import static org.testng.Assert.assertTrue;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.lang.reflect.FieldUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
@@ -71,13 +70,13 @@ public class BrokerIsolationPoliciesFilterTest {
         var namespace = "my-tenant/my-ns";
         NamespaceName namespaceName = NamespaceName.get(namespace);
 
-        BrokerIsolationPoliciesFilter filter = new BrokerIsolationPoliciesFilter();
         var policies = mock(SimpleResourceAllocationPolicies.class);
 
         // 1. Namespace: primary=broker1, secondary=broker2, shared=broker3, min_limit = 1
         setIsolationPolicies(policies, namespaceName, Set.of("broker1"), Set.of("broker2"), Set.of("broker3"), 1);
         IsolationPoliciesHelper isolationPoliciesHelper = new IsolationPoliciesHelper(policies);
-        FieldUtils.writeDeclaredField(filter, "isolationPoliciesHelper", isolationPoliciesHelper, true);
+
+        BrokerIsolationPoliciesFilter filter = new BrokerIsolationPoliciesFilter(isolationPoliciesHelper);
 
         // a. available-brokers: broker1, broker2, broker3 => result: broker1
         Map<String, BrokerLookupData> result = filter.filter(new HashMap<>(Map.of(
@@ -128,13 +127,14 @@ public class BrokerIsolationPoliciesFilterTest {
         doReturn(true).when(namespaceBundle).hasNonPersistentTopic();
         doReturn(namespaceName).when(namespaceBundle).getNamespaceObject();
 
-        BrokerIsolationPoliciesFilter filter = new BrokerIsolationPoliciesFilter();
-
         var policies = mock(SimpleResourceAllocationPolicies.class);
         doReturn(false).when(policies).areIsolationPoliciesPresent(eq(namespaceName));
         doReturn(true).when(policies).isSharedBroker(any());
         IsolationPoliciesHelper isolationPoliciesHelper = new IsolationPoliciesHelper(policies);
-        FieldUtils.writeDeclaredField(filter, "isolationPoliciesHelper", isolationPoliciesHelper, true);
+
+        BrokerIsolationPoliciesFilter filter = new BrokerIsolationPoliciesFilter(isolationPoliciesHelper);
+
+
 
         Map<String, BrokerLookupData> result = filter.filter(new HashMap<>(Map.of(
                 "broker1", getLookupData(),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedderTest.java
@@ -40,13 +40,16 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
@@ -69,6 +72,9 @@ import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateC
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLoadData;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.loadbalance.extensions.data.TopBundlesLoadData;
+import org.apache.pulsar.broker.loadbalance.extensions.filter.AntiAffinityGroupPolicyFilter;
+import org.apache.pulsar.broker.loadbalance.extensions.filter.BrokerFilter;
+import org.apache.pulsar.broker.loadbalance.extensions.filter.BrokerIsolationPoliciesFilter;
 import org.apache.pulsar.broker.loadbalance.extensions.models.TopKBundles;
 import org.apache.pulsar.broker.loadbalance.extensions.models.Unload;
 import org.apache.pulsar.broker.loadbalance.extensions.models.UnloadCounter;
@@ -108,6 +114,7 @@ public class TransferShedderTest {
     ExtensibleLoadManagerImpl loadManager;
     ServiceUnitStateChannel channel;
     ServiceConfiguration conf;
+    IsolationPoliciesHelper isolationPoliciesHelper;
     AntiAffinityGroupPolicyHelper antiAffinityGroupPolicyHelper;
     LocalPoliciesResources localPoliciesResources;
     String bundleD1 = "my-tenant/my-namespaceD/0x00000000_0x0FFFFFFF";
@@ -129,6 +136,7 @@ public class TransferShedderTest {
         var factory = mock(NamespaceBundleFactory.class);
         namespaceService = mock(NamespaceService.class);
         localPoliciesResources = mock(LocalPoliciesResources.class);
+        isolationPoliciesHelper = mock(IsolationPoliciesHelper.class);
         antiAffinityGroupPolicyHelper = mock(AntiAffinityGroupPolicyHelper.class);
         doReturn(conf).when(pulsar).getConfiguration();
         doReturn(namespaceService).when(pulsar).getNamespaceService();
@@ -157,8 +165,6 @@ public class TransferShedderTest {
 
     public LoadManagerContext setupContext(){
         var ctx = getContext();
-
-
 
         var topBundlesLoadDataStore = ctx.topBundleLoadDataStore();
         topBundlesLoadDataStore.pushAsync("broker1", getTopBundlesLoad("my-tenant/my-namespaceA", 1000000, 2000000));
@@ -389,18 +395,25 @@ public class TransferShedderTest {
 
         BrokerRegistry brokerRegistry = mock(BrokerRegistry.class);
         doReturn(CompletableFuture.completedFuture(Map.of(
-                "broker1", mock(BrokerLookupData.class),
-                "broker2", mock(BrokerLookupData.class),
-                "broker3", mock(BrokerLookupData.class),
-                "broker4", mock(BrokerLookupData.class),
-                "broker5", mock(BrokerLookupData.class)
-        )))
-                .when(brokerRegistry).getAvailableBrokerLookupDataAsync();
+                "broker1", getMockBrokerLookupData(),
+                "broker2", getMockBrokerLookupData(),
+                "broker3", getMockBrokerLookupData(),
+                "broker4", getMockBrokerLookupData(),
+                "broker5", getMockBrokerLookupData()
+        ))).when(brokerRegistry).getAvailableBrokerLookupDataAsync();
         doReturn(conf).when(ctx).brokerConfiguration();
         doReturn(brokerLoadDataStore).when(ctx).brokerLoadDataStore();
         doReturn(topBundleLoadDataStore).when(ctx).topBundleLoadDataStore();
         doReturn(brokerRegistry).when(ctx).brokerRegistry();
         return ctx;
+    }
+
+
+    BrokerLookupData getMockBrokerLookupData() {
+        BrokerLookupData brokerLookupData = mock(BrokerLookupData.class);
+        doReturn(true).when(brokerLookupData).persistentTopicsEnabled();
+        doReturn(true).when(brokerLookupData).nonPersistentTopicsEnabled();
+        return brokerLookupData;
     }
 
     @Test
@@ -524,12 +537,12 @@ public class TransferShedderTest {
     @Test
     public void testGetAvailableBrokersFailed() {
         UnloadCounter counter = new UnloadCounter();
-        AntiAffinityGroupPolicyHelper affinityGroupPolicyHelper = mock(AntiAffinityGroupPolicyHelper.class);
-        TransferShedder transferShedder = new TransferShedder(pulsar, counter, affinityGroupPolicyHelper);
+        TransferShedder transferShedder = new TransferShedder(pulsar, counter, null,
+                isolationPoliciesHelper, antiAffinityGroupPolicyHelper);
         var ctx = setupContext();
         BrokerRegistry registry = ctx.brokerRegistry();
         doReturn(FutureUtil.failedFuture(new TimeoutException())).when(registry).getAvailableBrokerLookupDataAsync();
-        var res = transferShedder.findBundlesForUnloading(ctx, Map.of(), Map.of());
+        transferShedder.findBundlesForUnloading(ctx, Map.of(), Map.of());
         assertEquals(counter.getBreakdownCounters().get(Failure).get(Unknown).get(), 1);
         assertEquals(counter.getLoadAvg(), 0.0);
         assertEquals(counter.getLoadStd(), 0.0);
@@ -537,18 +550,21 @@ public class TransferShedderTest {
 
     @Test(timeOut = 30 * 1000)
     public void testBundlesWithIsolationPolicies() throws IllegalAccessException {
-        doReturn(true).when(antiAffinityGroupPolicyHelper).canUnload(any(), any(), any(), any());
-        UnloadCounter counter = new UnloadCounter();
-        TransferShedder transferShedder = spy(new TransferShedder(pulsar, counter, antiAffinityGroupPolicyHelper));
-        var allocationPoliciesSpy = (SimpleResourceAllocationPolicies)
-                spy(FieldUtils.readDeclaredField(transferShedder, "allocationPolicies", true));
-        FieldUtils.writeDeclaredField(transferShedder, "allocationPolicies", allocationPoliciesSpy, true);
+        List<BrokerFilter> filters = new ArrayList<>();
+        var allocationPoliciesSpy = mock(SimpleResourceAllocationPolicies.class);
         IsolationPoliciesHelper isolationPoliciesHelper = new IsolationPoliciesHelper(allocationPoliciesSpy);
-        FieldUtils.writeDeclaredField(transferShedder, "isolationPoliciesHelper", isolationPoliciesHelper, true);
+        BrokerIsolationPoliciesFilter filter = new BrokerIsolationPoliciesFilter(isolationPoliciesHelper);
+        filters.add(filter);
+        UnloadCounter counter = new UnloadCounter();
+        TransferShedder transferShedder = spy(new TransferShedder(pulsar, counter, null,
+                isolationPoliciesHelper, antiAffinityGroupPolicyHelper));
+        FieldUtils.writeDeclaredField(transferShedder, "allocationPolicies", allocationPoliciesSpy, true);
 
         setIsolationPolicies(allocationPoliciesSpy, "my-tenant/my-namespaceE",
                 Set.of("broker5"), Set.of(), Set.of(), 1);
         var ctx = setupContext();
+        ctx.brokerConfiguration().setLoadBalancerSheddingBundlesWithPoliciesEnabled(true);
+        doReturn(ctx.brokerConfiguration()).when(pulsar).getConfiguration();
         var res = transferShedder.findBundlesForUnloading(ctx, Map.of(), Map.of());
         var expected = new HashSet<UnloadDecision>();
         expected.add(new UnloadDecision(new Unload("broker4", bundleD1, Optional.of("broker1")),
@@ -641,22 +657,25 @@ public class TransferShedderTest {
 
 
     @Test
-    public void testBundlesWithAntiAffinityGroup() throws IllegalAccessException, MetadataStoreException {
+    public void testBundlesWithAntiAffinityGroup() throws MetadataStoreException {
+        var filters = new ArrayList<BrokerFilter>();
+        AntiAffinityGroupPolicyFilter filter = new AntiAffinityGroupPolicyFilter(antiAffinityGroupPolicyHelper);
+        filters.add(filter);
         var counter = new UnloadCounter();
-        TransferShedder transferShedder = new TransferShedder(pulsar, counter, antiAffinityGroupPolicyHelper);
-        var allocationPoliciesSpy = (SimpleResourceAllocationPolicies)
-                spy(FieldUtils.readDeclaredField(transferShedder, "allocationPolicies", true));
-        doReturn(false).when(allocationPoliciesSpy).areIsolationPoliciesPresent(any());
-        FieldUtils.writeDeclaredField(transferShedder, "allocationPolicies", allocationPoliciesSpy, true);
+        TransferShedder transferShedder = new TransferShedder(pulsar, counter, filters,
+                isolationPoliciesHelper, antiAffinityGroupPolicyHelper);
 
         LocalPolicies localPolicies = new LocalPolicies(null, null, "namespaceAntiAffinityGroup");
         doReturn(Optional.of(localPolicies)).when(localPoliciesResources).getLocalPolicies(any());
 
         var ctx = setupContext();
-        var antiAffinityGroupPolicyHelperSpy = (AntiAffinityGroupPolicyHelper)
-                spy(FieldUtils.readDeclaredField(transferShedder, "antiAffinityGroupPolicyHelper", true));
-        doReturn(false).when(antiAffinityGroupPolicyHelperSpy).canUnload(any(), any(), any(), any());
-        FieldUtils.writeDeclaredField(transferShedder, "antiAffinityGroupPolicyHelper", antiAffinityGroupPolicyHelperSpy, true);
+        ctx.brokerConfiguration().setLoadBalancerSheddingBundlesWithPoliciesEnabled(true);
+
+        doAnswer(invocationOnMock -> {
+            Map<String, BrokerLookupData> brokers = invocationOnMock.getArgument(0);
+            brokers.clear();
+            return brokers;
+        }).when(antiAffinityGroupPolicyHelper).filter(any(), any());
         var res = transferShedder.findBundlesForUnloading(ctx, Map.of(), Map.of());
 
         assertTrue(res.isEmpty());
@@ -664,8 +683,16 @@ public class TransferShedderTest {
         assertEquals(counter.getLoadAvg(), setupLoadAvg);
         assertEquals(counter.getLoadStd(), setupLoadStd);
 
+        doAnswer(invocationOnMock -> {
+            Map<String, BrokerLookupData> brokers = invocationOnMock.getArgument(0);
+            String bundle = invocationOnMock.getArgument(1, String.class);
 
-        doReturn(true).when(antiAffinityGroupPolicyHelperSpy).canUnload(any(), eq(bundleE1), any(), any());
+            if (bundle.equalsIgnoreCase(bundleE1)) {
+                return brokers;
+            }
+            brokers.clear();
+            return brokers;
+        }).when(antiAffinityGroupPolicyHelper).filter(any(), any());
         var res2 = transferShedder.findBundlesForUnloading(ctx, Map.of(), Map.of());
         var expected2 = new HashSet<>();
         expected2.add(new UnloadDecision(new Unload("broker5", bundleE1, Optional.of("broker1")),
@@ -673,6 +700,23 @@ public class TransferShedderTest {
         assertEquals(res2, expected2);
         assertEquals(counter.getLoadAvg(), setupLoadAvg);
         assertEquals(counter.getLoadStd(), setupLoadStd);
+    }
+
+    @Test
+    public void testIsLoadBalancerSheddingBundlesWithPoliciesEnabled() {
+        var counter = new UnloadCounter();
+        TransferShedder transferShedder = new TransferShedder(pulsar, counter, new ArrayList<>(),
+                isolationPoliciesHelper, antiAffinityGroupPolicyHelper);
+
+        var ctx = setupContext();
+
+        ctx.brokerConfiguration().setLoadBalancerSheddingBundlesWithPoliciesEnabled(false);
+        NamespaceBundle namespaceBundle = mock(NamespaceBundle.class);
+        doReturn("bundle").when(namespaceBundle).toString();
+        assertFalse(transferShedder.isLoadBalancerSheddingBundlesWithPoliciesEnabled(ctx, namespaceBundle));
+
+
+
     }
 
     @Test


### PR DESCRIPTION
Master Issue: https://github.com/apache/pulsar/issues/16691

### Motivation

The PIP-192 introduced transfer to transfer the bundle from ower broker to a specific broker without unloading,
But the dest broker is not filtered by the broker filter.

### Modifications

* Filter out the dest broker by broker filter.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->