### PR TITLE
[fix][broker]: validation for at least one TlsUrl / nonTlsUrl is present for cluster creation/update

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
@@ -164,6 +164,9 @@ public class ClustersBase extends AdminResource {
                     NamedEntity.checkName(cluster);
                     try {
                         clusterData.checkPropertiesIfPresent();
+                        if (!cluster.equals("global")) {
+                            clusterData.checkNeededUrlExist();
+                        }
                     } catch (IllegalArgumentException ex) {
                         throw new RestException(Status.BAD_REQUEST, ex.getMessage());
                     }
@@ -225,6 +228,9 @@ public class ClustersBase extends AdminResource {
                 .thenCompose(__ -> {
                     try {
                         clusterData.checkPropertiesIfPresent();
+                        if (cluster != "global") {
+                            clusterData.checkNeededUrlExist();
+                        }
                     } catch (IllegalArgumentException ex) {
                         throw new RestException(Status.BAD_REQUEST, ex.getMessage());
                     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/EmbeddedPulsarCluster.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/EmbeddedPulsarCluster.java
@@ -78,7 +78,8 @@ public class EmbeddedPulsarCluster implements AutoCloseable {
                 .serviceHttpUrl(adminUrl)
                 .build();
 
-        admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().brokerServiceUrl(serviceUrl).build());
+        admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder()
+                .serviceUrl(adminUrl).brokerServiceUrl(serviceUrl).build());
         admin.tenants().createTenant("public",
                 TenantInfo.builder().allowedClusters(Collections.singleton(CLUSTER_NAME)).build());
         admin.namespaces().createNamespace("public/default", Collections.singleton(CLUSTER_NAME));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/SLAMonitoringTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/SLAMonitoringTest.java
@@ -100,7 +100,8 @@ public class SLAMonitoringTest {
 
         Thread.sleep(100);
 
-        createTenant(pulsarAdmins[BROKER_COUNT - 1]);
+        createTenant(pulsarAdmins[BROKER_COUNT - 1], pulsarServices[BROKER_COUNT - 1].getWebServiceAddress(),
+                pulsarServices[BROKER_COUNT - 1].getBrokerServiceUrl());
         for (int i = 0; i < BROKER_COUNT; i++) {
             String topic = String.format("%s/%s/%s:%s", NamespaceService.SLA_NAMESPACE_PROPERTY, "my-cluster",
                     pulsarServices[i].getAdvertisedAddress(), brokerWebServicePorts[i]);
@@ -108,10 +109,11 @@ public class SLAMonitoringTest {
         }
     }
 
-    private void createTenant(PulsarAdmin pulsarAdmin)
+    private void createTenant(PulsarAdmin pulsarAdmin, String serviceUrl, String brokerServiceUrl)
             throws PulsarAdminException {
         ClusterData clusterData = ClusterData.builder()
-                .serviceUrl(pulsarAdmin.getServiceUrl())
+                .serviceUrl(serviceUrl)
+                .brokerServiceUrl(brokerServiceUrl)
                 .build();
         pulsarAdmins[0].clusters().createCluster("my-cluster", clusterData);
         Set<String> allowedClusters = new HashSet<>();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -190,7 +190,8 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
     }
 
     private void setupClusters() throws PulsarAdminException {
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("test"));
         admin.tenants().createTenant("prop-xyz", tenantInfo);
         admin.namespaces().createNamespace("prop-xyz/ns1", Set.of("test"));
@@ -337,7 +338,8 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         cleanup();
         setup();
         admin.clusters().updateCluster("test",
-                ClusterData.builder().serviceUrl((pulsar.getWebServiceAddress() + ",localhost:1026," + "localhost:2050")).build());
+                ClusterData.builder().serviceUrl((pulsar.getWebServiceAddress() + ",localhost:1026," + "localhost:2050"))
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("test"));
         admin.tenants().createTenant("prop-xyz2", tenantInfo);
         admin.namespaces().createNamespace("prop-xyz2/ns1", Set.of("test"));
@@ -751,13 +753,17 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
     @Test
     public void testPeerCluster() throws Exception {
         admin.clusters().createCluster("us-west1",
-                ClusterData.builder().serviceUrl("http://broker.messaging.west1.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.west1.example.com:8080")
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.clusters().createCluster("us-west2",
-                ClusterData.builder().serviceUrl("http://broker.messaging.west2.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.west2.example.com:8080")
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.clusters().createCluster("us-east1",
-                ClusterData.builder().serviceUrl("http://broker.messaging.east1.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.east1.example.com:8080")
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.clusters().createCluster("us-east2",
-                ClusterData.builder().serviceUrl("http://broker.messaging.east2.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.east2.example.com:8080")
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         admin.clusters().updatePeerClusterNames("us-west1", new LinkedHashSet<>(List.of("us-west2")));
         assertEquals(admin.clusters().getCluster("us-west1").getPeerClusterNames(), Set.of("us-west2"));
@@ -796,17 +802,23 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
     @Test
     public void testReplicationPeerCluster() throws Exception {
         admin.clusters().createCluster("us-west1",
-                ClusterData.builder().serviceUrl("http://broker.messaging.west1.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.west1.example.com:8080")
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.clusters().createCluster("us-west2",
-                ClusterData.builder().serviceUrl("http://broker.messaging.west2.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.west2.example.com:8080")
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.clusters().createCluster("us-west3",
-                ClusterData.builder().serviceUrl("http://broker.messaging.west2.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.west2.example.com:8080")
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.clusters().createCluster("us-west4",
-                ClusterData.builder().serviceUrl("http://broker.messaging.west2.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.west2.example.com:8080")
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.clusters().createCluster("us-east1",
-                ClusterData.builder().serviceUrl("http://broker.messaging.east1.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.east1.example.com:8080")
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.clusters().createCluster("us-east2",
-                ClusterData.builder().serviceUrl("http://broker.messaging.east2.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.east2.example.com:8080")
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.clusters().createCluster("global", ClusterData.builder().build());
 
         List<String> allClusters = admin.clusters().getClusters();
@@ -1983,7 +1995,8 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testUpdateClusterWithProxyUrl() throws Exception {
-        ClusterData cluster = ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build();
+        ClusterData cluster = ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build();
         String clusterName = "test2";
         admin.clusters().createCluster(clusterName, cluster);
         Assert.assertEquals(admin.clusters().getCluster(clusterName), cluster);
@@ -1991,6 +2004,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         // update
         cluster = ClusterData.builder()
                 .serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl())
                 .proxyServiceUrl("pulsar://example.com")
                 .proxyProtocol(ProxyProtocol.SNI)
                 .build();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiClusterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiClusterTest.java
@@ -46,7 +46,8 @@ public class AdminApiClusterTest extends MockedPulsarServiceBaseTest {
     public void setup() throws Exception {
         super.internalSetup();
         admin.clusters()
-                .createCluster(CLUSTER, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                .createCluster(CLUSTER, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
     }
 
     @AfterMethod(alwaysRun = true)
@@ -79,7 +80,8 @@ public class AdminApiClusterTest extends MockedPulsarServiceBaseTest {
         String cluster = "test-exist-cluster-" + UUID.randomUUID();
 
         admin.clusters()
-                .createCluster(cluster, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                .createCluster(cluster, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         Awaitility.await().untilAsserted(() -> assertNotNull(admin.clusters().getCluster(cluster)));
 
         admin.clusters().deleteCluster(cluster);
@@ -124,18 +126,6 @@ public class AdminApiClusterTest extends MockedPulsarServiceBaseTest {
                 .serviceUrlTls("https://pulsar.app:8443")
                 .brokerServiceUrl("")
                 .brokerServiceUrlTls("pulsar+ssl://pulsar.app:6651")
-                .build());
-        clusterDataList.add(ClusterData.builder()
-                .serviceUrl("")
-                .serviceUrlTls("")
-                .brokerServiceUrl("")
-                .brokerServiceUrlTls("")
-                .build());
-        clusterDataList.add(ClusterData.builder()
-                .serviceUrl(null)
-                .serviceUrlTls(null)
-                .brokerServiceUrl(null)
-                .brokerServiceUrlTls(null)
                 .build());
         for (int i = 0; i < clusterDataList.size(); i++) {
             admin.clusters().createCluster("cluster-test-" + i, clusterDataList.get(i));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiDelayedDeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiDelayedDeliveryTest.java
@@ -46,7 +46,8 @@ public class AdminApiDelayedDeliveryTest extends MockedPulsarServiceBaseTest {
     public void setup() throws Exception {
         super.internalSetup();
 
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("test"));
         admin.tenants().createTenant("delayed-delivery-messages", tenantInfo);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiGetLastMessageIdTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiGetLastMessageIdTest.java
@@ -63,7 +63,8 @@ public class AdminApiGetLastMessageIdTest extends MockedPulsarServiceBaseTest {
     @BeforeMethod
     protected void setup() throws Exception {
         super.internalSetup();
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("prop",
                 new TenantInfoImpl(Set.of("appid1"), Set.of("test")));
         admin.namespaces().createNamespace("prop/ns-abc");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiHealthCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiHealthCheckTest.java
@@ -54,7 +54,8 @@ public class AdminApiHealthCheckTest extends MockedPulsarServiceBaseTest {
     public void setup() throws Exception {
         super.internalSetup();
         admin.clusters().createCluster("test",
-                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(
                 Set.of("role1", "role2"), Set.of("test"));
         admin.tenants().createTenant("pulsar", tenantInfo);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMaxUnackedMessagesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMaxUnackedMessagesTest.java
@@ -50,7 +50,8 @@ public class AdminApiMaxUnackedMessagesTest extends MockedPulsarServiceBaseTest 
     public void setup() throws Exception {
         super.internalSetup();
 
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("test"));
         admin.tenants().createTenant("max-unacked-messages", tenantInfo);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
@@ -94,7 +94,8 @@ public class AdminApiOffloadTest extends MockedPulsarServiceBaseTest {
         super.internalSetup();
 
         // Setup namespaces
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("test"));
         admin.tenants().createTenant(testTenant, tenantInfo);
         admin.namespaces().createNamespace(myNamespace, Set.of("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaAutoUpdateTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaAutoUpdateTest.java
@@ -44,7 +44,8 @@ public class AdminApiSchemaAutoUpdateTest extends MockedPulsarServiceBaseTest {
         super.internalSetup();
 
         // Setup namespaces
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("test"));
         admin.tenants().createTenant("prop-xyz", tenantInfo);
         admin.namespaces().createNamespace("prop-xyz/ns1", Set.of("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaTest.java
@@ -77,7 +77,8 @@ public class AdminApiSchemaTest extends MockedPulsarServiceBaseTest {
         super.internalSetup();
 
         // Setup namespaces
-        admin.clusters().createCluster(cluster, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster(cluster, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("test"));
         admin.tenants().createTenant("schematest", tenantInfo);
         admin.namespaces().createNamespace("schematest/test", Set.of("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaValidationEnforcedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaValidationEnforcedTest.java
@@ -49,7 +49,8 @@ public class AdminApiSchemaValidationEnforcedTest extends MockedPulsarServiceBas
     public void setup() throws Exception {
         super.internalSetup();
 
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("test"));
         admin.tenants().createTenant("schema-validation-enforced", tenantInfo);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaWithAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaWithAuthTest.java
@@ -84,7 +84,8 @@ public class AdminApiSchemaWithAuthTest extends MockedPulsarServiceBaseTest {
         admin = Mockito.spy(pulsarAdminBuilder.build());
 
         // Setup namespaces
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("test"));
         admin.tenants().createTenant("schematest", tenantInfo);
         admin.namespaces().createNamespace("schematest/test", Set.of("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTenantTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTenantTest.java
@@ -43,7 +43,8 @@ public class AdminApiTenantTest extends MockedPulsarServiceBaseTest {
     public void setup() throws Exception {
         super.internalSetup();
         admin.clusters()
-                .createCluster(CLUSTER, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                .createCluster(CLUSTER, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
     }
 
     @BeforeClass(alwaysRun = true)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -240,7 +240,8 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
     }
 
     private void setupClusters() throws PulsarAdminException {
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("test"));
         admin.tenants().createTenant("prop-xyz", tenantInfo);
         admin.namespaces().createNamespace("prop-xyz/ns1", Set.of("test"));
@@ -288,30 +289,36 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
     @Test
     public void clusters() throws Exception {
         admin.clusters().createCluster("usw",
-                ClusterData.builder().serviceUrl("http://broker.messaging.use.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.use.example.com:8080")
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         // "test" cluster is part of config-default cluster and it's znode gets created when PulsarService creates
         // failure-domain znode of this default cluster
         assertEquals(admin.clusters().getClusters(), List.of("test", "usw"));
 
         assertEquals(admin.clusters().getCluster("test"),
-                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         admin.clusters().updateCluster("usw",
-                ClusterData.builder().serviceUrl("http://new-broker.messaging.usw.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://new-broker.messaging.usw.example.com:8080")
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         assertEquals(admin.clusters().getClusters(), List.of("test", "usw"));
         assertEquals(admin.clusters().getCluster("usw"),
-                ClusterData.builder().serviceUrl("http://new-broker.messaging.usw.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://new-broker.messaging.usw.example.com:8080")
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         admin.clusters().updateCluster("usw",
                 ClusterData.builder()
                         .serviceUrl("http://new-broker.messaging.usw.example.com:8080")
                         .serviceUrlTls("https://new-broker.messaging.usw.example.com:4443")
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl())
                         .build());
         assertEquals(admin.clusters().getClusters(), List.of("test", "usw"));
         assertEquals(admin.clusters().getCluster("usw"),
                 ClusterData.builder()
                         .serviceUrl("http://new-broker.messaging.usw.example.com:8080")
                         .serviceUrlTls("https://new-broker.messaging.usw.example.com:4443")
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl())
                         .build());
 
         admin.clusters().deleteCluster("usw");
@@ -324,7 +331,8 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
         // Check name validation
         try {
-            admin.clusters().createCluster("bf!", ClusterData.builder().serviceUrl("http://dummy.messaging.example.com").build());
+            admin.clusters().createCluster("bf!", ClusterData.builder().serviceUrl("http://dummy.messaging.example.com")
+                    .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
             fail("should have failed");
         } catch (PulsarAdminException e) {
             assertTrue(e instanceof PreconditionFailedException);
@@ -793,7 +801,9 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void namespaces() throws Exception {
-        admin.clusters().createCluster("usw", ClusterData.builder().build());
+        admin.clusters().createCluster("usw", ClusterData.builder()
+                .serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"),
                 Set.of("test", "usw"));
         admin.tenants().updateTenant("prop-xyz", tenantInfo);
@@ -3036,7 +3046,9 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testTopicBundleRangeLookup() throws PulsarAdminException, PulsarServerException, Exception {
-        admin.clusters().createCluster("usw", ClusterData.builder().build());
+        admin.clusters().createCluster("usw", ClusterData.builder()
+                .serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"),
                 Set.of("test", "usw"));
         admin.tenants().updateTenant("prop-xyz", tenantInfo);
@@ -3229,7 +3241,9 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testCreateAndDeleteNamespaceWithBundles() throws Exception {
-        admin.clusters().createCluster("usw", ClusterData.builder().build());
+        admin.clusters().createCluster("usw", ClusterData.builder()
+                .serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"),
                 Set.of("test", "usw"));
         admin.tenants().updateTenant("prop-xyz", tenantInfo);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTlsAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTlsAuthTest.java
@@ -95,7 +95,8 @@ public class AdminApiTlsAuthTest extends MockedPulsarServiceBaseTest {
         super.internalSetup();
 
         PulsarAdmin admin = buildAdminClient("admin");
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.close();
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminRestTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminRestTest.java
@@ -106,7 +106,8 @@ public class AdminRestTest extends MockedPulsarServiceBaseTest {
     protected void setup() throws Exception {
         super.internalSetup();
         // Create tenant, namespace, topic
-        admin.clusters().createCluster(clusterName, ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster(clusterName, ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant(tenantName,
                 new TenantInfoImpl(Collections.singleton("a"), Collections.singleton(clusterName)));
         admin.namespaces().createNamespace(namespaceName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -258,7 +258,8 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         verify(clusters, never()).validateSuperUserAccessAsync();
 
         asyncRequests(ctx -> clusters.createCluster(ctx,
-                "use", ClusterDataImpl.builder().serviceUrl("http://broker.messaging.use.example.com:8080").build()));
+                "use", ClusterDataImpl.builder().serviceUrl("http://broker.messaging.use.example.com:8080")
+                        .brokerServiceUrl("pulsar://broker.messaging.use.example.com:6650").build()));
         // ensure to read from ZooKeeper directly
         //clusters.clustersListCache().clear();
         assertEquals(asyncRequests(ctx -> clusters.getClusters(ctx)), Set.of("use"));
@@ -266,7 +267,8 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         // Check creating existing cluster
         try {
             asyncRequests(ctx -> clusters.createCluster(ctx, "use",
-                    ClusterDataImpl.builder().serviceUrl("http://broker.messaging.use.example.com:8080").build()));
+                    ClusterDataImpl.builder().serviceUrl("http://broker.messaging.use.example.com:8080")
+                            .brokerServiceUrl("pulsar://broker.messaging.use.example.com:6650").build()));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.CONFLICT.getStatusCode());
@@ -281,13 +283,16 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         }
 
         assertEquals(asyncRequests(ctx -> clusters.getCluster(ctx, "use")),
-                ClusterDataImpl.builder().serviceUrl("http://broker.messaging.use.example.com:8080").build());
+                ClusterDataImpl.builder().serviceUrl("http://broker.messaging.use.example.com:8080")
+                        .brokerServiceUrl("pulsar://broker.messaging.use.example.com:6650").build());
 
         asyncRequests(ctx -> clusters.updateCluster(ctx, "use",
-                ClusterDataImpl.builder().serviceUrl("http://new-broker.messaging.use.example.com:8080").build()));
+                ClusterDataImpl.builder().serviceUrl("http://new-broker.messaging.use.example.com:8080")
+                        .brokerServiceUrl("pulsar://new-broker.messaging.use.example.com:6650").build()));
 
         assertEquals(asyncRequests(ctx -> clusters.getCluster(ctx, "use")),
-                ClusterData.builder().serviceUrl("http://new-broker.messaging.use.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://new-broker.messaging.use.example.com:8080")
+                        .brokerServiceUrl("pulsar://new-broker.messaging.use.example.com:6650").build());
 
         try {
             asyncRequests(ctx -> clusters.getNamespaceIsolationPolicies(ctx, "use"));
@@ -334,7 +339,9 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         }
 
         try {
-            asyncRequests(ctx -> clusters.updateCluster(ctx, "use", ClusterDataImpl.builder().build()));
+            asyncRequests(ctx -> clusters.updateCluster(ctx, "use", ClusterDataImpl.builder()
+                    .serviceUrl(pulsar.getWebServiceAddress())
+                    .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build()));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), 404);
@@ -373,7 +380,8 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
             });
         try {
             asyncRequests(ctx -> clusters.createCluster(ctx, "test",
-                    ClusterDataImpl.builder().serviceUrl("http://broker.messaging.test.example.com:8080").build()));
+                    ClusterDataImpl.builder().serviceUrl("http://broker.messaging.test.example.com:8080")
+                            .brokerServiceUrl("pulsar://broker.messaging.test.example.com:6650").build()));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.INTERNAL_SERVER_ERROR.getStatusCode());
@@ -387,7 +395,8 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         store.invalidateAll();
         try {
             asyncRequests(ctx -> clusters.updateCluster(ctx, "test",
-                    ClusterDataImpl.builder().serviceUrl("http://broker.messaging.test.example.com").build()));
+                    ClusterDataImpl.builder().serviceUrl("http://broker.messaging.test.example.com")
+                            .brokerServiceUrl("pulsar://broker.messaging.test.example.com").build()));
             fail("should have failed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.INTERNAL_SERVER_ERROR.getStatusCode());
@@ -434,7 +443,8 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         // Check name validations
         try {
             asyncRequests(ctx -> clusters.createCluster(ctx, "bf@",
-                    ClusterDataImpl.builder().serviceUrl("http://dummy.messaging.example.com").build()));
+                    ClusterDataImpl.builder().serviceUrl("http://dummy.messaging.example.com")
+                            .brokerServiceUrl("pulsar://dummy.messaging.example.com").build()));
             fail("should have filed");
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
@@ -466,7 +476,9 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         verify(properties, times(1)).validateSuperUserAccessAsync();
 
         // create local cluster
-        asyncRequests(ctx -> clusters.createCluster(ctx, configClusterName, ClusterDataImpl.builder().build()));
+        asyncRequests(ctx -> clusters.createCluster(ctx, configClusterName, ClusterDataImpl.builder()
+                .serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build()));
 
         Set<String> allowedClusters = new HashSet<>();
         allowedClusters.add(configClusterName);
@@ -709,6 +721,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         asyncRequests(ctx -> clusters.createCluster(ctx, "use", ClusterDataImpl.builder()
                 .serviceUrl("http://broker.messaging.use.example.com")
                 .serviceUrlTls("https://broker.messaging.use.example.com:4443")
+                .brokerServiceUrl("pulsar://broker.messaging.use.example.com")
                 .build()));
 
         URI requestUri = new URI(
@@ -773,7 +786,8 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         TenantInfoImpl admin = TenantInfoImpl.builder()
                 .allowedClusters(Collections.singleton(cluster))
                 .build();
-        ClusterDataImpl clusterData = ClusterDataImpl.builder().serviceUrl("http://example.pulsar").build();
+        ClusterDataImpl clusterData = ClusterDataImpl.builder().serviceUrl("http://example.pulsar")
+                .brokerServiceUrl("pulsar://example.pulsar").build();
         asyncRequests(ctx -> clusters.createCluster(ctx, cluster, clusterData ));
         asyncRequests(ctx -> properties.createTenant(ctx, property, admin));
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/BrokerAdminClientTlsAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/BrokerAdminClientTlsAuthTest.java
@@ -128,7 +128,8 @@ public class BrokerAdminClientTlsAuthTest extends MockedPulsarServiceBaseTest {
 
         /***** Broker 2 Started *****/
         try (PulsarAdmin admin = buildAdminClient("superproxy")) {
-            admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+            admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                    .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
             admin.tenants().createTenant("tenant",
                                          new TenantInfoImpl(Set.of("admin"),
                                                  Set.of("test")));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/IncrementPartitionsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/IncrementPartitionsTest.java
@@ -61,7 +61,8 @@ public class IncrementPartitionsTest extends MockedPulsarServiceBaseTest {
         mockPulsarSetup.setup();
 
         // Setup namespaces
-        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("use"));
         admin.tenants().createTenant("prop-xyz", tenantInfo);
         admin.namespaces().createNamespace("prop-xyz/use/ns1");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -215,9 +215,12 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         doReturn(null).when(namespaces).clientAuthData();
         doReturn(Set.of("use", "usw", "usc", "global")).when(namespaces).clusters();
 
-        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl("http://broker-use.com:8080").build());
-        admin.clusters().createCluster("usw", ClusterData.builder().serviceUrl("http://broker-usw.com:8080").build());
-        admin.clusters().createCluster("usc", ClusterData.builder().serviceUrl("http://broker-usc.com:8080").build());
+        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl("http://broker-use.com:8080")
+                .brokerServiceUrl("pulsar://broker-use.com:6650").build());
+        admin.clusters().createCluster("usw", ClusterData.builder().serviceUrl("http://broker-usw.com:8080")
+                .brokerServiceUrl("pulsar://broker-usw.com:6650").build());
+        admin.clusters().createCluster("usc", ClusterData.builder().serviceUrl("http://broker-usc.com:8080")
+                .brokerServiceUrl("pulsar://broker-usc.com:6650").build());
         admin.tenants().createTenant(this.testTenant,
                 new TenantInfoImpl(Set.of("role1", "role2"), Set.of("use", "usc", "usw")));
         admin.tenants().createTenant(this.testOtherTenant,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesV2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesV2Test.java
@@ -97,9 +97,12 @@ public class NamespacesV2Test extends MockedPulsarServiceBaseTest {
         doReturn(null).when(namespaces).clientAuthData();
         doReturn(Set.of("use", "usw", "usc", "global")).when(namespaces).clusters();
 
-        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl("http://broker-use.com:8080").build());
-        admin.clusters().createCluster("usw", ClusterData.builder().serviceUrl("http://broker-usw.com:8080").build());
-        admin.clusters().createCluster("usc", ClusterData.builder().serviceUrl("http://broker-usc.com:8080").build());
+        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl("http://broker-use.com:8080")
+                .brokerServiceUrl("pulsar://broker-use.com:6650").build());
+        admin.clusters().createCluster("usw", ClusterData.builder().serviceUrl("http://broker-usw.com:8080")
+                .brokerServiceUrl("pulsar://broker-usw.com:6650").build());
+        admin.clusters().createCluster("usc", ClusterData.builder().serviceUrl("http://broker-usc.com:8080")
+                .brokerServiceUrl("pulsar://broker-usc.com:6650").build());
         admin.tenants().createTenant(this.testTenant,
                 new TenantInfoImpl(Set.of("role1", "role2"), Set.of("use", "usc", "usw")));
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -163,8 +163,10 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         doReturn(spy(new TopicResources(pulsar.getLocalMetadataStore()))).when(resources).getTopicResources();
         doReturn(resources).when(pulsar).getPulsarResources();
 
-        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl("http://broker-use.com:8080").build());
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl("http://broker-use.com:8080").build());
+        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl("http://broker-use.com:8080")
+                .brokerServiceUrl("pulsar://broker-use.com:6650").build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl("http://broker-use.com:8080")
+                .brokerServiceUrl("pulsar://broker-use.com:6650").build());
         admin.tenants().createTenant(this.testTenant,
                 new TenantInfoImpl(Set.of("role1", "role2"), Set.of(testLocalCluster, "test")));
         admin.tenants().createTenant("pulsar",

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/ResourceGroupsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/ResourceGroupsTest.java
@@ -172,7 +172,8 @@ public class ResourceGroupsTest extends MockedPulsarServiceBaseTest {
 
     private void prepareData() throws PulsarAdminException {
         admin.clusters()
-                .createCluster(testCluster, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                .createCluster(testCluster, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant(
                 testTenant,
                 new TenantInfoImpl(Set.of("role1", "role2"), Set.of(testCluster))

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
@@ -51,7 +51,8 @@ public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
         this.conf.setTtlDurationDefaultInSeconds(3600);
         super.internalSetup();
 
-        admin.clusters().createCluster(testCluster, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster(testCluster, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of(testCluster));
         admin.tenants().createTenant(this.testTenant, tenantInfo);
         admin.namespaces().createNamespace(testTenant + "/" + testNamespace, Set.of(testCluster));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesDisableTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesDisableTest.java
@@ -54,7 +54,8 @@ public class TopicPoliciesDisableTest extends MockedPulsarServiceBaseTest {
         this.conf.setTopicLevelPoliciesEnabled(false);
         super.internalSetup();
 
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("test"));
         admin.tenants().createTenant(this.testTenant, tenantInfo);
         admin.namespaces().createNamespace(testTenant + "/" + testNamespace, Set.of("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -116,7 +116,8 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         this.conf.setDefaultNumberOfNamespaceBundles(1);
         super.internalSetup();
 
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("test"));
         admin.tenants().createTenant(this.testTenant, tenantInfo);
         admin.namespaces().createNamespace(testTenant + "/" + testNamespace, Set.of("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsAuthTest.java
@@ -43,7 +43,7 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import org.apache.pulsar.client.impl.schema.StringSchema;
 import org.apache.pulsar.common.policies.data.AuthAction;
-import org.apache.pulsar.common.policies.data.ClusterDataImpl;
+import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.websocket.data.ProducerMessage;
@@ -90,7 +90,9 @@ public class TopicsAuthTest extends MockedPulsarServiceBaseTest {
                 .authentication(AuthenticationToken.class.getName(),
                         ADMIN_TOKEN);
         admin = Mockito.spy(pulsarAdminBuilder.build());
-        admin.clusters().createCluster(testLocalCluster, new ClusterDataImpl());
+        admin.clusters().createCluster(testLocalCluster, ClusterData.builder()
+                .serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant(testTenant, new TenantInfoImpl(Set.of("role1", "role2"),
                 Set.of(testLocalCluster)
         ));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
@@ -81,7 +81,7 @@ import org.apache.pulsar.client.impl.schema.generic.GenericJsonRecord;
 import org.apache.pulsar.client.impl.schema.generic.GenericJsonSchema;
 import org.apache.pulsar.client.impl.schema.generic.GenericSchemaImpl;
 import org.apache.pulsar.common.naming.TopicDomain;
-import org.apache.pulsar.common.policies.data.ClusterDataImpl;
+import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
@@ -114,7 +114,9 @@ public class TopicsTest extends MockedPulsarServiceBaseTest {
         doReturn(TopicDomain.persistent.value()).when(topics).domain();
         doReturn("test-app").when(topics).clientAppId();
         doReturn(mock(AuthenticationDataHttps.class)).when(topics).clientAuthData();
-        admin.clusters().createCluster(testLocalCluster, new ClusterDataImpl());
+        admin.clusters().createCluster(testLocalCluster, ClusterData.builder()
+                .serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant(testTenant, new TenantInfoImpl(Set.of("role1", "role2"), Set.of(testLocalCluster)));
         admin.namespaces().createNamespace(testTenant + "/" + testNamespace,
                                            Set.of(testLocalCluster));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApi2Test.java
@@ -90,7 +90,8 @@ public class V1_AdminApi2Test extends MockedPulsarServiceBaseTest {
         mockPulsarSetup.setup();
 
         // Setup namespaces
-        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("use"));
         admin.tenants().createTenant("prop-xyz", tenantInfo);
         admin.namespaces().createNamespace("prop-xyz/use/ns1");
@@ -545,13 +546,17 @@ public class V1_AdminApi2Test extends MockedPulsarServiceBaseTest {
     @Test
     public void testPeerCluster() throws Exception {
         admin.clusters().createCluster("us-west1",
-                ClusterData.builder().serviceUrl("http://broker.messaging.west1.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.west1.example.com:8080")
+                        .brokerServiceUrl("pulsar://broker.messaging.west1.example.com:6650").build());
         admin.clusters().createCluster("us-west2",
-                ClusterData.builder().serviceUrl("http://broker.messaging.west2.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.west2.example.com:8080")
+                        .brokerServiceUrl("pulsar://broker.messaging.west2.example.com:6650").build());
         admin.clusters().createCluster("us-east1",
-                ClusterData.builder().serviceUrl("http://broker.messaging.east1.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.east1.example.com:8080")
+                        .brokerServiceUrl("pulsar://broker.messaging.east1.example.com:6650").build());
         admin.clusters().createCluster("us-east2",
-                ClusterData.builder().serviceUrl("http://broker.messaging.east2.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.east2.example.com:8080")
+                        .brokerServiceUrl("pulsar://broker.messaging.east2.example.com:6650").build());
 
         admin.clusters().updatePeerClusterNames("us-west1", Sets.newLinkedHashSet(List.of("us-west2")));
         assertEquals(admin.clusters().getCluster("us-west1").getPeerClusterNames(), List.of("us-west2"));
@@ -590,17 +595,23 @@ public class V1_AdminApi2Test extends MockedPulsarServiceBaseTest {
     @Test
     public void testReplicationPeerCluster() throws Exception {
         admin.clusters().createCluster("us-west1",
-                ClusterData.builder().serviceUrl("http://broker.messaging.west1.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.west1.example.com:8080")
+                        .brokerServiceUrl("pulsar://broker.messaging.west1.example.com:6650").build());
         admin.clusters().createCluster("us-west2",
-                ClusterData.builder().serviceUrl("http://broker.messaging.west2.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.west2.example.com:8080")
+                        .brokerServiceUrl("pulsar://broker.messaging.west2.example.com:6650").build());
         admin.clusters().createCluster("us-west3",
-                ClusterData.builder().serviceUrl("http://broker.messaging.west2.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.west3.example.com:8080")
+                        .brokerServiceUrl("pulsar://broker.messaging.west3.example.com:6650").build());
         admin.clusters().createCluster("us-west4",
-                ClusterData.builder().serviceUrl("http://broker.messaging.west2.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.west4.example.com:8080")
+                        .brokerServiceUrl("pulsar://broker.messaging.west4.example.com:6650").build());
         admin.clusters().createCluster("us-east1",
-                ClusterData.builder().serviceUrl("http://broker.messaging.east1.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.east1.example.com:8080")
+                        .brokerServiceUrl("pulsar://broker.messaging.east1.example.com:6650").build());
         admin.clusters().createCluster("us-east2",
-                ClusterData.builder().serviceUrl("http://broker.messaging.east2.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.east2.example.com:8080")
+                        .brokerServiceUrl("pulsar://broker.messaging.east2.example.com:6650").build());
         admin.clusters().createCluster("global", ClusterData.builder().build());
 
         final String property = "peer-prop";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApi2Test.java
@@ -658,6 +658,8 @@ public class V1_AdminApi2Test extends MockedPulsarServiceBaseTest {
                 ClusterData.builder()
                         .serviceUrl(pulsar.getSafeWebServiceAddress())
                         .serviceUrlTls(pulsar.getWebServiceAddressTls())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl())
+                        .brokerServiceUrlTls(pulsar.getBrokerServiceUrlTls())
                         .build());
         // create
         FailureDomain domain = FailureDomain.builder()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
@@ -166,7 +166,8 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
         otheradmin = mockPulsarSetup.getAdmin();
 
         // Setup namespaces
-        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("use"));
         admin.tenants().createTenant("prop-xyz", tenantInfo);
         admin.namespaces().createNamespace("prop-xyz/use/ns1");
@@ -202,7 +203,8 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
 
         if (!admin.clusters().getClusters().contains("use")) {
             admin.clusters().createCluster("use",
-                    ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                    ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                            .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         }
 
         if (!admin.tenants().getTenants().contains("prop-xyz")) {
@@ -235,30 +237,36 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
     @Test
     public void clusters() throws Exception {
         admin.clusters().createCluster("usw",
-                ClusterData.builder().serviceUrl("http://broker.messaging.use.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://broker.messaging.use.example.com:8080")
+                        .brokerServiceUrl("pulsar://broker.messaging.use.example.com:6650").build());
         // "test" cluster is part of config-default cluster and it's znode gets created when PulsarService creates
         // failure-domain znode of this default cluster
         assertEquals(admin.clusters().getClusters(), List.of("use", "usw"));
 
         assertEquals(admin.clusters().getCluster("use"),
-                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         admin.clusters().updateCluster("usw",
-                ClusterData.builder().serviceUrl("http://new-broker.messaging.use.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://new-broker.messaging.usw.example.com:8080")
+                        .brokerServiceUrl("pulsar://new-broker.messaging.use.example.com:6650").build());
         assertEquals(admin.clusters().getClusters(), List.of("use", "usw"));
         assertEquals(admin.clusters().getCluster("usw"),
-                ClusterData.builder().serviceUrl("http://new-broker.messaging.use.example.com:8080").build());
+                ClusterData.builder().serviceUrl("http://new-broker.messaging.usw.example.com:8080")
+                        .brokerServiceUrl("pulsar://new-broker.messaging.usw.example.com:6650").build());
 
         admin.clusters().updateCluster("usw",
                 ClusterData.builder()
                         .serviceUrl("http://new-broker.messaging.usw.example.com:8080")
                         .serviceUrlTls("https://new-broker.messaging.usw.example.com:4443")
+                        .brokerServiceUrl("pulsar://broker.messaging.usw.example.com:6650")
                         .build());
         assertEquals(admin.clusters().getClusters(), List.of("use", "usw"));
         assertEquals(admin.clusters().getCluster("usw"),
                 ClusterData.builder()
                         .serviceUrl("http://new-broker.messaging.usw.example.com:8080")
                         .serviceUrlTls("https://new-broker.messaging.usw.example.com:4443")
+                        .brokerServiceUrl("pulsar://broker.messaging.usw.example.com:6650")
                         .build());
 
         admin.clusters().deleteCluster("usw");
@@ -272,7 +280,8 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
 
         // Check name validation
         try {
-            admin.clusters().createCluster("bf!", ClusterData.builder().serviceUrl("http://dummy.messaging.example.com").build());
+            admin.clusters().createCluster("bf!", ClusterData.builder().serviceUrl("http://dummy.messaging.example.com")
+                    .brokerServiceUrl("pulsar://dummy.messaging.example.com:6650").build());
             fail("should have failed");
         } catch (PulsarAdminException e) {
             assertTrue(e instanceof PreconditionFailedException);
@@ -658,7 +667,9 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void namespaces() throws Exception {
-        admin.clusters().createCluster("usw", ClusterData.builder().build());
+        admin.clusters().createCluster("usw", ClusterData.builder()
+                .serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"),
                 Set.of("use", "usw"));
         admin.tenants().updateTenant("prop-xyz", tenantInfo);
@@ -2052,7 +2063,9 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testTopicBundleRangeLookup() throws Exception {
-        admin.clusters().createCluster("usw", ClusterData.builder().build());
+        admin.clusters().createCluster("usw", ClusterData.builder()
+                .serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"),
                 Set.of("use", "usw"));
         admin.tenants().updateTenant("prop-xyz", tenantInfo);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v1/V1_AdminApiTest.java
@@ -249,7 +249,7 @@ public class V1_AdminApiTest extends MockedPulsarServiceBaseTest {
 
         admin.clusters().updateCluster("usw",
                 ClusterData.builder().serviceUrl("http://new-broker.messaging.usw.example.com:8080")
-                        .brokerServiceUrl("pulsar://new-broker.messaging.use.example.com:6650").build());
+                        .brokerServiceUrl("pulsar://new-broker.messaging.usw.example.com:6650").build());
         assertEquals(admin.clusters().getClusters(), List.of("use", "usw"));
         assertEquals(admin.clusters().getCluster("usw"),
                 ClusterData.builder().serviceUrl("http://new-broker.messaging.usw.example.com:8080")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -96,7 +96,8 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("test"));
         admin.tenants().createTenant("pulsar", tenantInfo);
         admin.namespaces().createNamespace("pulsar/system", Set.of("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthLogsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthLogsTest.java
@@ -65,7 +65,8 @@ public class AuthLogsTest extends MockedPulsarServiceBaseTest {
         try (PulsarAdmin admin = PulsarAdmin.builder()
              .authentication(new MockAuthentication("pass.pass"))
              .serviceHttpUrl(brokerUrl.toString()).build()) {
-            admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+            admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                    .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
             admin.tenants().createTenant("public",
                                          new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
             admin.namespaces().createNamespace("public/default");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
@@ -81,7 +81,9 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
 
         assertFalse(auth.canLookup(TopicName.get("persistent://p1/c1/ns1/ds1"), "my-role", null));
 
-        admin.clusters().createCluster("c1", ClusterData.builder().build());
+        admin.clusters().createCluster("c1", ClusterData.builder()
+                .serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("p1", new TenantInfoImpl(Sets.newHashSet("role1"), Sets.newHashSet("c1")));
         waitForChange();
         admin.namespaces().createNamespace("p1/c1/ns1");
@@ -277,7 +279,9 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
         String tenant = "p1";
         String namespaceV1 = "p1/global/ns1";
         String namespaceV2 = "p1/ns2";
-        admin.clusters().createCluster("c1", ClusterData.builder().build());
+        admin.clusters().createCluster("c1", ClusterData.builder()
+                .serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant(tenant, new TenantInfoImpl(Sets.newHashSet("role1"), Sets.newHashSet("c1")));
         admin.namespaces().createNamespace(namespaceV1, Sets.newHashSet("c1"));
         admin.namespaces().grantPermissionOnNamespace(namespaceV1, "pass.pass2", EnumSet.of(AuthAction.produce));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -403,7 +403,9 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
     protected TenantInfoImpl createDefaultTenantInfo() throws PulsarAdminException {
         // create local cluster if not exist
         if (!admin.clusters().getClusters().contains(configClusterName)) {
-            admin.clusters().createCluster(configClusterName, ClusterData.builder().build());
+            admin.clusters().createCluster(configClusterName, ClusterData.builder()
+                    .serviceUrl(pulsar.getWebServiceAddress())
+                    .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         }
         Set<String> allowedClusters = new HashSet<>();
         allowedClusters.add(configClusterName);
@@ -459,7 +461,8 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
 
         if (!admin.clusters().getClusters().contains(configClusterName)) {
             admin.clusters().createCluster(configClusterName,
-                    ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                    ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                            .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         }
 
         if (!admin.tenants().getTenants().contains(tenant)) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LeaderElectionServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LeaderElectionServiceTest.java
@@ -89,7 +89,8 @@ public class LeaderElectionServiceTest {
         final String namespace = "ns";
         @Cleanup
         PulsarAdmin adminClient = PulsarAdmin.builder().serviceHttpUrl(pulsar.getWebServiceAddress()).build();
-        adminClient.clusters().createCluster(clusterName, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        adminClient.clusters().createCluster(clusterName, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         adminClient.tenants().createTenant(tenant, new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"),
                 Sets.newHashSet(clusterName)));
         adminClient.namespaces().createNamespace(tenant + "/" + namespace, 16);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
@@ -318,7 +318,8 @@ public class ModularLoadManagerImplTest {
         final String cluster = "test";
         String namespace = tenant + "/" + cluster + "/" + "test";
         String topic = "persistent://" + namespace + "/my-topic1";
-        admin1.clusters().createCluster(cluster, ClusterData.builder().serviceUrl("http://" + pulsar1.getAdvertisedAddress()).build());
+        admin1.clusters().createCluster(cluster, ClusterData.builder().serviceUrl(pulsar1.getWebServiceAddress())
+                .brokerServiceUrl(pulsar1.getBrokerServiceUrl()).build());
         admin1.tenants().createTenant(tenant,
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet(cluster)));
         admin1.namespaces().createNamespace(namespace, 16);
@@ -562,7 +563,8 @@ public class ModularLoadManagerImplTest {
         final String broker1Address = pulsar1.getAdvertisedAddress() + "0";
         final String broker2Address = pulsar2.getAdvertisedAddress() + "1";
         final String sharedBroker = "broker3";
-        admin1.clusters().createCluster(cluster, ClusterData.builder().serviceUrl("http://" + pulsar1.getAdvertisedAddress()).build());
+        admin1.clusters().createCluster(cluster, ClusterData.builder().serviceUrl(pulsar1.getWebServiceAddress())
+                .brokerServiceUrl(pulsar1.getBrokerServiceUrl()).build());
         admin1.tenants().createTenant(tenant,
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet(cluster)));
         admin1.namespaces().createNamespace(tenant + "/" + cluster + "/" + namespace);
@@ -661,7 +663,8 @@ public class ModularLoadManagerImplTest {
         final String brokerAddress = pulsar1.getAdvertisedAddress();
         final String broker1Address = pulsar1.getAdvertisedAddress() + 1;
 
-        admin1.clusters().createCluster(cluster, ClusterData.builder().serviceUrl("http://" + pulsar1.getAdvertisedAddress()).build());
+        admin1.clusters().createCluster(cluster, ClusterData.builder().serviceUrl(pulsar1.getWebServiceAddress())
+                .brokerServiceUrl(pulsar1.getBrokerServiceUrl()).build());
         admin1.tenants().createTenant(tenant,
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet(cluster)));
         admin1.namespaces().createNamespace(namespace);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -153,7 +153,8 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
         setSecondaryLoadManager();
 
         admin.clusters().createCluster(this.conf.getClusterName(),
-                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("public",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"),
                         Sets.newHashSet(this.conf.getClusterName())));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
@@ -84,9 +84,12 @@ public class HttpTopicLookupv2Test {
         clusters.add("use");
         clusters.add("usc");
         clusters.add("usw");
-        ClusterData useData = ClusterData.builder().serviceUrl("http://broker.messaging.use.example.com:8080").build();
-        ClusterData uscData = ClusterData.builder().serviceUrl("http://broker.messaging.usc.example.com:8080").build();
-        ClusterData uswData = ClusterData.builder().serviceUrl("http://broker.messaging.usw.example.com:8080").build();
+        ClusterData useData = ClusterData.builder().serviceUrl("http://broker.messaging.use.example.com:8080")
+                .brokerServiceUrl("pulsar:broker.messaging.use.example.com:6650").build();
+        ClusterData uscData = ClusterData.builder().serviceUrl("http://broker.messaging.usc.example.com:8080")
+                .brokerServiceUrl("pulsar:broker.messaging.usc.example.com:6650").build();
+        ClusterData uswData = ClusterData.builder().serviceUrl("http://broker.messaging.usw.example.com:8080")
+                .brokerServiceUrl("pulsar:broker.messaging.usw.example.com:6650").build();
         doReturn(config).when(pulsar).getConfiguration();
 
         ClusterResources clusters = mock(ClusterResources.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnerShipCacheForCurrentServerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnerShipCacheForCurrentServerTest.java
@@ -47,7 +47,9 @@ public class OwnerShipCacheForCurrentServerTest extends OwnerShipForCurrentServe
         internalSetup();
         String[] brokerServiceUrlArr = getPulsarServiceList().get(0).getBrokerServiceUrl().split(":");
         String webServicePort = brokerServiceUrlArr[brokerServiceUrlArr.length -1];
-        admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().serviceUrl("http://localhost:" + webServicePort).build());
+        admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder()
+                .serviceUrl(getPulsarServiceList().get(0).getWebServiceAddress())
+                .brokerServiceUrl(getPulsarServiceList().get(0).getBrokerServiceUrl()).build());
         admin.tenants().createTenant(TENANT,
                 new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet(CLUSTER_NAME)));
         admin.namespaces().createNamespace(NAMESPACE);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/RGUsageMTAggrWaitForAllMsgsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/RGUsageMTAggrWaitForAllMsgsTest.java
@@ -881,7 +881,8 @@ public class RGUsageMTAggrWaitForAllMsgsTest extends ProducerConsumerBase {
     private void prepareForOps() throws PulsarAdminException {
         this.conf.setResourceUsageTransportPublishIntervalInSecs(PUBLISH_INTERVAL_SECS);
         this.conf.setAllowAutoTopicCreation(true);
-        admin.clusters().createCluster(clusterName, ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster(clusterName, ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
     }
 
     // Set up of RG/tenant/namespaces/topic names, and checking of the test parameters.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupConfigListenerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupConfigListenerTest.java
@@ -280,7 +280,8 @@ public class ResourceGroupConfigListenerTest extends MockedPulsarServiceBaseTest
     }
 
     private void prepareData() throws PulsarAdminException {
-        admin.clusters().createCluster(clusterName, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster(clusterName, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         testAddRg.setPublishRateInBytes(10000L);
         testAddRg.setPublishRateInMsgs(100);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupServiceTest.java
@@ -273,6 +273,7 @@ public class ResourceGroupServiceTest extends MockedPulsarServiceBaseTest {
     private static final int PUBLISH_INTERVAL_SECS = 500;
     private void prepareData() throws PulsarAdminException {
         this.conf.setResourceUsageTransportPublishIntervalInSecs(PUBLISH_INTERVAL_SECS);
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupUsageAggregationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupUsageAggregationTest.java
@@ -275,7 +275,8 @@ public class ResourceGroupUsageAggregationTest extends ProducerConsumerBase {
         this.conf.setAllowAutoTopicCreation(true);
 
         final String clusterName = "test";
-        admin.clusters().createCluster(clusterName, ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster(clusterName, ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
             admin.tenants().createTenant(TenantName,
                     new TenantInfoImpl(Sets.newHashSet("fakeAdminRole"), Sets.newHashSet(clusterName)));
         admin.namespaces().createNamespace(TenantAndNsName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceUsageTransportManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceUsageTransportManagerTest.java
@@ -118,7 +118,8 @@ public class ResourceUsageTransportManagerTest extends MockedPulsarServiceBaseTe
     private void prepareData() throws PulsarServerException, PulsarAdminException, PulsarClientException {
         this.conf.setResourceUsageTransportClassName("org.apache.pulsar.broker.resourcegroup.ResourceUsageTopicTransportManager");
         this.conf.setResourceUsageTransportPublishIntervalInSecs(PUBLISH_INTERVAL_SECS);
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         tManager = new ResourceUsageTopicTransportManager(pulsar);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -137,7 +137,8 @@ public class BacklogQuotaManagerTest {
             adminUrl = new URL("http://127.0.0.1" + ":" + pulsar.getListenPortHTTP().get());
             admin = PulsarAdmin.builder().serviceHttpUrl(adminUrl.toString()).build();
 
-            admin.clusters().createCluster("usc", ClusterData.builder().serviceUrl(adminUrl.toString()).build());
+            admin.clusters().createCluster("usc", ClusterData.builder().serviceUrl(adminUrl.toString())
+                    .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
             admin.tenants().createTenant("prop",
                     new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet("usc")));
         } catch (Throwable t) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BkEnsemblesTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BkEnsemblesTestBase.java
@@ -102,7 +102,8 @@ public abstract class BkEnsemblesTestBase extends TestRetrySupport {
 
             admin = PulsarAdmin.builder().serviceHttpUrl(pulsar.getWebServiceAddress()).build();
 
-            admin.clusters().createCluster("usc", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+            admin.clusters().createCluster("usc", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                    .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
             admin.tenants().createTenant("prop",
                     new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet("usc")));
         } catch (Throwable t) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
@@ -173,7 +173,8 @@ public class BrokerBookieIsolationTest {
 
         PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(pulsarService.getWebServiceAddress()).build();
 
-        ClusterData clusterData = ClusterData.builder().serviceUrl(pulsarService.getWebServiceAddress()).build();
+        ClusterData clusterData = ClusterData.builder().serviceUrl(pulsarService.getWebServiceAddress())
+                .brokerServiceUrl(pulsarService.getBrokerServiceUrl()).build();
         admin.clusters().createCluster(cluster, clusterData);
         TenantInfoImpl tenantInfo = new TenantInfoImpl(null, Sets.newHashSet(cluster));
         admin.tenants().createTenant(tenant1, tenantInfo);
@@ -326,7 +327,8 @@ public class BrokerBookieIsolationTest {
 
         PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(pulsarService.getWebServiceAddress()).build();
 
-        ClusterData clusterData = ClusterData.builder().serviceUrl(pulsarService.getWebServiceAddress()).build();
+        ClusterData clusterData = ClusterData.builder().serviceUrl(pulsarService.getWebServiceAddress())
+                .brokerServiceUrl(pulsarService.getBrokerServiceUrl()).build();
         admin.clusters().createCluster(cluster, clusterData);
         TenantInfoImpl tenantInfo = new TenantInfoImpl(null, Sets.newHashSet(cluster));
         admin.tenants().createTenant(tenant1, tenantInfo);
@@ -470,7 +472,8 @@ public class BrokerBookieIsolationTest {
 
         PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(pulsarService.getWebServiceAddress()).build();
 
-        ClusterData clusterData = ClusterData.builder().serviceUrl(pulsarService.getWebServiceAddress()).build();
+        ClusterData clusterData = ClusterData.builder().serviceUrl(pulsarService.getWebServiceAddress())
+                .brokerServiceUrl(pulsarService.getBrokerServiceUrl()).build();
         admin.clusters().createCluster(cluster, clusterData);
         TenantInfoImpl tenantInfo = new TenantInfoImpl(null, Sets.newHashSet(cluster));
         admin.tenants().createTenant(tenant1, tenantInfo);
@@ -625,7 +628,8 @@ public class BrokerBookieIsolationTest {
 
         PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(pulsarService.getWebServiceAddress()).build();
 
-        ClusterData clusterData = ClusterData.builder().serviceUrl(pulsarService.getWebServiceAddress()).build();
+        ClusterData clusterData = ClusterData.builder().serviceUrl(pulsarService.getWebServiceAddress())
+                .brokerServiceUrl(pulsarService.getBrokerServiceUrl()).build();
         admin.clusters().createCluster(cluster, clusterData);
         TenantInfoImpl tenantInfo = new TenantInfoImpl(null, Sets.newHashSet(cluster));
         admin.tenants().createTenant(tenant1, tenantInfo);
@@ -763,7 +767,8 @@ public class BrokerBookieIsolationTest {
 
         PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(pulsarService.getWebServiceAddress()).build();
 
-        ClusterData clusterData = ClusterData.builder().serviceUrl(pulsarService.getWebServiceAddress()).build();
+        ClusterData clusterData = ClusterData.builder().serviceUrl(pulsarService.getWebServiceAddress())
+                .brokerServiceUrl(pulsarService.getBrokerServiceUrl()).build();
         admin.clusters().createCluster(cluster, clusterData);
         TenantInfoImpl tenantInfo = new TenantInfoImpl(null, Sets.newHashSet(cluster));
         admin.tenants().createTenant(tenant1, tenantInfo);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerInternalClientConfigurationOverrideTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerInternalClientConfigurationOverrideTest.java
@@ -72,7 +72,8 @@ public class BrokerInternalClientConfigurationOverrideTest extends BrokerTestBas
     @Test
     public void testBrokerServicePulsarClientConfiguration() {
         // This data only needs to have the service url for this test.
-        ClusterData data = ClusterData.builder().serviceUrl("http://localhost:8080").build();
+        ClusterData data = ClusterData.builder().serviceUrl("http://localhost:8080")
+                .brokerServiceUrl("pulsar://localhost:6650").build();
 
         // Set the configs and set some configs that won't apply
         Properties config = pulsar.getConfiguration().getProperties();
@@ -94,7 +95,8 @@ public class BrokerInternalClientConfigurationOverrideTest extends BrokerTestBas
     @Test
     public void testNamespaceServicePulsarClientConfiguration() {
         // This data only needs to have the service url for this test.
-        ClusterDataImpl data = (ClusterDataImpl) ClusterData.builder().serviceUrl("http://localhost:8080").build();
+        ClusterDataImpl data = (ClusterDataImpl) ClusterData.builder().serviceUrl("http://localhost:8080")
+                .brokerServiceUrl("pulsar://localhost:6650").build();
 
         // Set the configs and set some configs that won't apply
         Properties config = pulsar.getConfiguration().getProperties();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerTestBase.java
@@ -52,7 +52,8 @@ public abstract class BrokerTestBase extends MockedPulsarServiceBaseTest {
     }
 
     private void baseSetupCommon() throws Exception {
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("prop",
                 new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet("test")));
         admin.namespaces().createNamespace("prop/ns-abc");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MaxMessageSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MaxMessageSizeTest.java
@@ -78,7 +78,8 @@ public class MaxMessageSizeTest {
 
             String url = "http://127.0.0.1:" + pulsar.getListenPortHTTP().get();
             admin = PulsarAdmin.builder().serviceHttpUrl(url).build();
-            admin.clusters().createCluster("max_message_test", ClusterData.builder().serviceUrl(url).build());
+            admin.clusters().createCluster("max_message_test", ClusterData.builder().serviceUrl(url)
+                    .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
             admin.tenants()
                     .createTenant("test",
                             new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet("max_message_test")));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -236,7 +236,8 @@ public class ReplicatorTest extends ReplicatorTestBase {
 
         String cluster2ServiceUrls = String.format("%s,localhost:1234,localhost:5678,localhost:5677,localhost:5676",
                 pulsar2.getWebServiceAddress());
-        ClusterData cluster2Data = ClusterData.builder().serviceUrl(cluster2ServiceUrls).build();
+        ClusterData cluster2Data = ClusterData.builder().serviceUrl(cluster2ServiceUrls)
+                .brokerServiceUrl(pulsar2.getBrokerServiceUrl()).build();
         String cluster2 = "activeCLuster2";
         admin2.clusters().createCluster(cluster2, cluster2Data);
         Awaitility.await().until(()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
@@ -280,7 +280,8 @@ public class SystemTopicBasedTopicPoliciesServiceTest extends MockedPulsarServic
 
 
     private void prepareData() throws PulsarAdminException {
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("system-topic",
                 new TenantInfoImpl(new HashSet<>(), Set.of("test")));
         admin.namespaces().createNamespace(NAMESPACE1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
@@ -106,7 +106,8 @@ public class TopicOwnerTest {
         leaderAdmin = pulsarAdmins[0];
         Thread.sleep(1000);
 
-        pulsarAdmins[0].clusters().createCluster(testCluster, ClusterData.builder().serviceUrl(pulsarServices[0].getWebServiceAddress()).build());
+        pulsarAdmins[0].clusters().createCluster(testCluster, ClusterData.builder().serviceUrl(pulsarServices[0].getWebServiceAddress())
+                .brokerServiceUrl(pulsarServices[0].getBrokerServiceUrl()).build());
         TenantInfo tenantInfo = TenantInfo.builder()
                 .allowedClusters(Sets.newHashSet(testCluster))
                 .build();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/NamespaceEventsSystemTopicServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/NamespaceEventsSystemTopicServiceTest.java
@@ -164,7 +164,8 @@ public class NamespaceEventsSystemTopicServiceTest extends MockedPulsarServiceBa
     }
 
     private void prepareData() throws PulsarAdminException {
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("system-topic",
             new TenantInfoImpl(new HashSet<>(), Sets.newHashSet("test")));
         admin.namespaces().createNamespace(NAMESPACE1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
@@ -73,7 +73,7 @@ public class TransactionConsumeTest extends TransactionTestBase {
         String[] brokerServiceUrlArr = getPulsarServiceList().get(0).getBrokerServiceUrl().split(":");
         String webServicePort = brokerServiceUrlArr[brokerServiceUrlArr.length -1];
         admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().serviceUrl("http://localhost:" + webServicePort)
-                .brokerServiceUrl(brokerServiceUrlArr[0]).build());
+                .brokerServiceUrl(getPulsarServiceList().get(0).getBrokerServiceUrl()).build());
         admin.tenants().createTenant("public",
                 new TenantInfoImpl(new HashSet<>(), Sets.newHashSet(CLUSTER_NAME)));
         admin.namespaces().createNamespace("public/txn", 10);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
@@ -72,7 +72,8 @@ public class TransactionConsumeTest extends TransactionTestBase {
 
         String[] brokerServiceUrlArr = getPulsarServiceList().get(0).getBrokerServiceUrl().split(":");
         String webServicePort = brokerServiceUrlArr[brokerServiceUrlArr.length -1];
-        admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().serviceUrl("http://localhost:" + webServicePort).build());
+        admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().serviceUrl("http://localhost:" + webServicePort)
+                .brokerServiceUrl(brokerServiceUrlArr[0]).build());
         admin.tenants().createTenant("public",
                 new TenantInfoImpl(new HashSet<>(), Sets.newHashSet(CLUSTER_NAME)));
         admin.namespaces().createNamespace("public/txn", 10);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
@@ -109,7 +109,7 @@ public abstract class TransactionTestBase extends TestRetrySupport {
         String webServicePort = brokerServiceUrlArr[brokerServiceUrlArr.length -1];
         admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().serviceUrl("http://localhost:"
                 + webServicePort)
-                .brokerServiceUrl(brokerServiceUrlArr[0]).build());
+                .brokerServiceUrl(getPulsarServiceList().get(0).getBrokerServiceUrl()).build());
 
         admin.tenants().createTenant(NamespaceName.SYSTEM_NAMESPACE.getTenant(),
                 new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet(CLUSTER_NAME)));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
@@ -108,7 +108,8 @@ public abstract class TransactionTestBase extends TestRetrySupport {
         String[] brokerServiceUrlArr = getPulsarServiceList().get(0).getBrokerServiceUrl().split(":");
         String webServicePort = brokerServiceUrlArr[brokerServiceUrlArr.length -1];
         admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().serviceUrl("http://localhost:"
-                + webServicePort).build());
+                + webServicePort)
+                .brokerServiceUrl(brokerServiceUrlArr[0]).build());
 
         admin.tenants().createTenant(NamespaceName.SYSTEM_NAMESPACE.getTenant(),
                 new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet(CLUSTER_NAME)));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
@@ -87,7 +87,7 @@ public class TransactionBufferClientTest extends TransactionTestBase {
         String[] brokerServiceUrlArr = getPulsarServiceList().get(0).getBrokerServiceUrl().split(":");
         String webServicePort = brokerServiceUrlArr[brokerServiceUrlArr.length -1];
         admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().serviceUrl("http://localhost:" + webServicePort)
-                .brokerServiceUrl(brokerServiceUrlArr[0]).build());
+                .brokerServiceUrl(getPulsarServiceList().get(0).getBrokerServiceUrl()).build());
         admin.tenants().createTenant("public",
                 new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet(CLUSTER_NAME)));
         admin.namespaces().createNamespace(namespace, 10);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
@@ -86,7 +86,8 @@ public class TransactionBufferClientTest extends TransactionTestBase {
         internalSetup();
         String[] brokerServiceUrlArr = getPulsarServiceList().get(0).getBrokerServiceUrl().split(":");
         String webServicePort = brokerServiceUrlArr[brokerServiceUrlArr.length -1];
-        admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().serviceUrl("http://localhost:" + webServicePort).build());
+        admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().serviceUrl("http://localhost:" + webServicePort)
+                .brokerServiceUrl(brokerServiceUrlArr[0]).build());
         admin.tenants().createTenant("public",
                 new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet(CLUSTER_NAME)));
         admin.namespaces().createNamespace(namespace, 10);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
@@ -448,7 +448,8 @@ public class WebServiceTest {
 
         try {
             pulsarAdmin.clusters().createCluster(config.getClusterName(),
-                    ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                    ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                            .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         } catch (ConflictException ce) {
             // This is OK.
         } finally {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ZooKeeperSessionExpireRecoveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ZooKeeperSessionExpireRecoveryTest.java
@@ -53,7 +53,8 @@ public class ZooKeeperSessionExpireRecoveryTest extends MockedPulsarServiceBaseT
     @Test
     public void testSessionExpired() throws Exception {
         admin.clusters().createCluster("my-cluster", ClusterData.builder()
-                .serviceUrl("http://test-url").build());
+                .serviceUrl("http://test-url")
+                .brokerServiceUrl("pulsar://test-url").build());
 
         assertTrue(Sets.newHashSet(admin.clusters().getClusters()).contains("my-cluster"));
 
@@ -66,13 +67,13 @@ public class ZooKeeperSessionExpireRecoveryTest extends MockedPulsarServiceBaseT
 
         try {
             admin.clusters().createCluster("my-cluster-2", ClusterData.builder()
-                    .serviceUrl("http://test-url").build());
+                    .serviceUrl("http://test-url").brokerServiceUrl("pulsar://test-url").build());
             fail("Should have failed, because global zk is down");
         } catch (PulsarAdminException e) {
             // Ok
         }
 
         admin.clusters().createCluster("cluster-2", ClusterData.builder()
-                .serviceUrl("http://test-url").build());
+                .serviceUrl("http://test-url").brokerServiceUrl("pulsar://test-url").build());
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthenticatedProducerConsumerTest.java
@@ -194,7 +194,8 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
         authTls.configure(authParams);
         internalSetup(authTls);
 
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
@@ -212,7 +213,8 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
         authPassword.configure("{\"userId\":\"superUser\",\"password\":\"supepass\"}");
         internalSetup(authPassword);
 
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(new HashSet<>(), Sets.newHashSet("test")));
@@ -230,7 +232,8 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
         authPassword.configure("{\"userId\":\"superUser2\",\"password\":\"superpassword\"}");
         internalSetup(authPassword);
 
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(new HashSet<>(), Sets.newHashSet("test")));
@@ -368,7 +371,9 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
         authTls.configure(authParams);
         internalSetup(authTls);
 
-        admin.clusters().createCluster("test", ClusterData.builder().build());
+        admin.clusters().createCluster("test", ClusterData.builder()
+                .serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("p1",
                 new TenantInfoImpl(Collections.emptySet(), new HashSet<>(admin.clusters().getClusters())));
         admin.namespaces().createNamespace("p1/ns1");
@@ -447,7 +452,8 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
         final String topicName = "persistent://my-property/my-ns/my-topic-1";
 
         internalSetup(new AuthenticationToken(ADMIN_TOKEN));
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(new HashSet<>(), Sets.newHashSet("test")));
         admin.namespaces().createNamespace("my-property/my-ns", Sets.newHashSet("test"));
@@ -476,7 +482,8 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
         authTls.configure(authParams);
         internalSetup(authTls);
 
-        admin.clusters().createCluster("test", ClusterData.builder().build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).
+                brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("p1",
                 new TenantInfoImpl(Collections.emptySet(), new HashSet<>(admin.clusters().getClusters())));
         admin.namespaces().createNamespace("p1/ns1");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -142,7 +142,8 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
                 .operationTimeout(1000, TimeUnit.MILLISECONDS)
                 .authentication(authenticationInvalidRole).build();
 
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
@@ -210,7 +211,8 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
 
         Authentication authentication = new ClientAuthentication(subscriptionRole);
 
-        superAdmin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        superAdmin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         superAdmin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet(tenantRole), Sets.newHashSet("test")));
@@ -396,7 +398,7 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
                 .authentication(subAdminAuthentication).build());
 
         superAdmin.clusters().createCluster("test",
-                ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+                ClusterData.builder().serviceUrl(brokerUrl.toString()).brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         superAdmin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet(tenantRole), Sets.newHashSet("test")));
         superAdmin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
@@ -493,7 +495,7 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
                 .authentication(generalAdminAuthentication).build());
 
         superAdmin.clusters().createCluster("test",
-                ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+                ClusterData.builder().serviceUrl(brokerUrl.toString()).brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         superAdmin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet(tenantRole), Sets.newHashSet("test")));
         superAdmin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
@@ -578,7 +580,7 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
                 .authentication(generalAuthentication).build());
 
         superAdmin.clusters().createCluster("test",
-                ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+                ClusterData.builder().serviceUrl(brokerUrl.toString()).brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         superAdmin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet(tenantRole), Sets.newHashSet("test")));
         superAdmin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
@@ -625,7 +627,8 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
                 .authentication(authentication));
 
 
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         admin.tenants().createTenant("prop-prefix",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
@@ -711,7 +714,8 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
         PulsarAdmin admin =
                 PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString()).authentication(adminAuthentication).build();
 
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
         admin.namespaces().createNamespace("my-property/my-ns", Sets.newHashSet("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -791,7 +791,8 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         final int totalPartitions = 10;
         final TopicName dest = TopicName.get("persistent", property, cluster, namespace, topicName);
         admin.clusters().createCluster(cluster,
-                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant(property,
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet(cluster)));
         admin.namespaces().createNamespace(property + "/" + cluster + "/" + namespace);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientDeduplicationFailureTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientDeduplicationFailureTest.java
@@ -109,7 +109,8 @@ public class ClientDeduplicationFailureTest {
         primaryHost = pulsar.getWebServiceAddress();
 
         // update cluster metadata
-        ClusterData clusterData = ClusterData.builder().serviceUrl(url.toString()).build();
+        ClusterData clusterData = ClusterData.builder().serviceUrl(url.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build();
         admin.clusters().createCluster(config.getClusterName(), clusterData);
 
         if (pulsarClient != null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiRolesTokenAuthorizationProviderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiRolesTokenAuthorizationProviderTest.java
@@ -112,6 +112,7 @@ public class MultiRolesTokenAuthorizationProviderTest extends MockedPulsarServic
         admin.clusters().createCluster(configClusterName,
                 ClusterData.builder()
                         .serviceUrl(brokerUrl.toString())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl())
                         .build()
         );
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerConsumerBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerConsumerBase.java
@@ -45,7 +45,8 @@ public abstract class ProducerConsumerBase extends MockedPulsarServiceBaseTest {
     }
 
     protected void producerBaseSetup() throws Exception {
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
         admin.namespaces().createNamespace("my-property/my-ns");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
@@ -119,7 +119,8 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
     }
     @Test
     public void testFindBrokerWithListenerName() throws Exception {
-        admin.clusters().createCluster("localhost", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("localhost", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfo tenantInfo = TenantInfo.builder()
                 .allowedClusters(Collections.singleton("localhost"))
                 .build();
@@ -160,7 +161,8 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
 
     @Test
     public void testHttpLookupRedirect() throws Exception {
-        admin.clusters().createCluster("localhost", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("localhost", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfo tenantInfo = TenantInfo.builder()
                 .allowedClusters(Collections.singleton("localhost"))
                 .build();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TenantTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TenantTest.java
@@ -47,7 +47,8 @@ public class TenantTest extends MockedPulsarServiceBaseTest {
     public void testMaxTenant() throws Exception {
         conf.setMaxTenants(2);
         super.internalSetup();
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Sets.newHashSet("role1", "role2"), Sets.newHashSet("test"));
         admin.tenants().createTenant("testTenant1", tenantInfo);
         admin.tenants().createTenant("testTenant2", tenantInfo);
@@ -61,7 +62,8 @@ public class TenantTest extends MockedPulsarServiceBaseTest {
         super.internalCleanup();
         conf.setMaxTenants(0);
         super.internalSetup();
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         for (int i = 0; i < 10; i++) {
             admin.tenants().createTenant("testTenant-unlimited" + i, tenantInfo);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenAuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenAuthenticatedProducerConsumerTest.java
@@ -157,7 +157,8 @@ public class TokenAuthenticatedProducerConsumerTest extends ProducerConsumerBase
         clientSetup();
 
         // test rest by admin
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
         admin.namespaces().createNamespace("my-property/my-ns", Sets.newHashSet("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenOauth2AuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenOauth2AuthenticatedProducerConsumerTest.java
@@ -161,7 +161,8 @@ public class TokenOauth2AuthenticatedProducerConsumerTest extends ProducerConsum
         clientSetup();
 
         // test rest by admin
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
         admin.namespaces().createNamespace("my-property/my-ns", Sets.newHashSet("test"));
@@ -178,7 +179,8 @@ public class TokenOauth2AuthenticatedProducerConsumerTest extends ProducerConsum
         clientSetup();
 
         // test rest by admin
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-property",
             new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
         admin.namespaces().createNamespace("my-property/my-ns", Sets.newHashSet("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerBase.java
@@ -38,7 +38,8 @@ public abstract class V1_ProducerConsumerBase extends MockedPulsarServiceBaseTes
     }
 
     public void producerBaseSetup() throws Exception {
-        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("use")));
         admin.namespaces().createNamespace("my-property/use/my-ns");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AdminApiKeyStoreTlsAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AdminApiKeyStoreTlsAuthTest.java
@@ -169,7 +169,8 @@ public class AdminApiKeyStoreTlsAuthTest extends ProducerConsumerBase {
     @Test
     public void testSuperUserCanListTenants() throws Exception {
         try (PulsarAdmin admin = buildAdminClient()) {
-            admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+            admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                    .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
             admin.tenants().createTenant("tenant1",
                                          new TenantInfoImpl(Set.of("foobar"),
                                                         Set.of("test")));
@@ -180,7 +181,8 @@ public class AdminApiKeyStoreTlsAuthTest extends ProducerConsumerBase {
     @Test
     public void testSuperUserCanListNamespaces() throws Exception {
         try (PulsarAdmin admin = buildAdminClient()) {
-            admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+            admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                    .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
             admin.tenants().createTenant("tenant1",
                                          new TenantInfoImpl(Set.of(""),
                                                         Set.of("test")));
@@ -192,7 +194,8 @@ public class AdminApiKeyStoreTlsAuthTest extends ProducerConsumerBase {
     @Test
     public void testAuthorizedUserAsOriginalPrincipal() throws Exception {
         try (PulsarAdmin admin = buildAdminClient()) {
-            admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+            admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                    .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
             admin.tenants().createTenant("tenant1",
                                          new TenantInfoImpl(Set.of("proxy", "user1"),
                                                         Set.of("test")));
@@ -211,7 +214,8 @@ public class AdminApiKeyStoreTlsAuthTest extends ProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
 
         try (PulsarAdmin admin = buildAdminClient()) {
-            admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+            admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                    .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
             admin.tenants().createTenant("tenant1",
                     new TenantInfoImpl(Set.of("foobar"),
                             Set.of("test")));
@@ -256,7 +260,8 @@ public class AdminApiKeyStoreTlsAuthTest extends ProducerConsumerBase {
                 .allowTlsInsecureConnection(false)
                 .build();
 
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("tenant1",
                 new TenantInfoImpl(Set.of("foobar"),
                         Set.of("test")));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConTXTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConTXTest.java
@@ -81,7 +81,9 @@ public class AutoCloseUselessClientConTXTest extends AutoCloseUselessClientConSu
     protected PulsarClient createNewPulsarClient(ClientBuilder clientBuilder) throws PulsarClientException {
         try {
             if (!admin.clusters().getClusters().contains("test")){
-                admin.clusters().createCluster("test", ClusterData.builder().build());
+                admin.clusters().createCluster("test", ClusterData.builder()
+                        .serviceUrl(pulsar.getBrokerServiceUrl())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
             }
             if (!admin.tenants().getTenants().contains("pulsar")){
                 admin.tenants().createTenant("pulsar",

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConTXTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConTXTest.java
@@ -82,7 +82,7 @@ public class AutoCloseUselessClientConTXTest extends AutoCloseUselessClientConSu
         try {
             if (!admin.clusters().getClusters().contains("test")){
                 admin.clusters().createCluster("test", ClusterData.builder()
-                        .serviceUrl(pulsar.getBrokerServiceUrl())
+                        .serviceUrl(pulsar.getWebServiceAddress())
                         .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
             }
             if (!admin.tenants().getTenants().contains("pulsar")){

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -674,7 +674,9 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
     public void testCleanProducer() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        admin.clusters().createCluster("global", ClusterData.builder().build());
+        admin.clusters().createCluster("global", ClusterData.builder()
+                .serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.namespaces().createNamespace("my-property/global/lookup");
 
         final int operationTimeOut = 500;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -674,9 +674,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
     public void testCleanProducer() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        admin.clusters().createCluster("global", ClusterData.builder()
-                .serviceUrl(pulsar.getWebServiceAddress())
-                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
+        admin.clusters().createCluster("global", ClusterData.builder().build());
         admin.namespaces().createNamespace("my-property/global/lookup");
 
         final int operationTimeOut = 500;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ClientCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ClientCnxTest.java
@@ -50,7 +50,8 @@ public class ClientCnxTest extends MockedPulsarServiceBaseTest {
     protected void setup() throws Exception {
         super.internalSetup();
         admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder()
-                .serviceUrl(pulsar.getWebServiceAddress()).build());
+                .serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant(TENANT,
                 new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet(CLUSTER_NAME)));
         admin.namespaces().createNamespace(NAMESPACE);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/CompactionReaderImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/CompactionReaderImplTest.java
@@ -49,7 +49,8 @@ public class CompactionReaderImplTest extends MockedPulsarServiceBaseTest {
     public void setup() throws Exception {
         super.internalSetup();
         admin.clusters().createCluster("test",
-                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
         admin.namespaces().createNamespace("my-property/my-ns", Sets.newHashSet("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerConfigurationTest.java
@@ -39,7 +39,8 @@ public class ConsumerConfigurationTest extends MockedPulsarServiceBaseTest {
     public void setup() throws Exception {
         super.internalSetup();
 
-        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("use")));
         admin.namespaces().createNamespace("my-property/use/my-ns");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/LookupRetryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/LookupRetryTest.java
@@ -60,7 +60,8 @@ public class LookupRetryTest extends MockedPulsarServiceBaseTest {
         super.internalSetup();
 
         admin.clusters().createCluster("test",
-                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("public",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
         admin.namespaces().createNamespace("public/default", Sets.newHashSet("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageParserTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageParserTest.java
@@ -52,7 +52,8 @@ public class MessageParserTest extends MockedPulsarServiceBaseTest {
     public void setup() throws Exception {
         super.internalSetup();
 
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-tenant",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
         admin.namespaces().createNamespace("my-tenant/my-ns", Sets.newHashSet("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MultiTopicsReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MultiTopicsReaderTest.java
@@ -77,7 +77,8 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
         super.internalSetup();
 
         admin.clusters().createCluster("test",
-                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
         Policies policies = new Policies();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplAuthTest.java
@@ -147,7 +147,8 @@ public class PatternTopicsConsumerImplAuthTest extends ProducerConsumerBase {
                 .authentication(authenticationInvalidRole).build();
 
         // 1. create partition and grant permissions
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawReaderTest.java
@@ -60,7 +60,8 @@ public class RawReaderTest extends MockedPulsarServiceBaseTest {
         super.internalSetup();
 
         admin.clusters().createCluster("test",
-                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
         admin.namespaces().createNamespace("my-property/my-ns", Sets.newHashSet("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ReaderTest.java
@@ -80,7 +80,8 @@ public class ReaderTest extends MockedPulsarServiceBaseTest {
         super.internalSetup();
 
         admin.clusters().createCluster("test",
-                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
         admin.namespaces().createNamespace("my-property/my-ns", Sets.newHashSet("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SchemaDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SchemaDeleteTest.java
@@ -49,7 +49,8 @@ public class SchemaDeleteTest extends MockedPulsarServiceBaseTest {
         this.conf.setBrokerDeleteInactiveTopicsFrequencySeconds(5);
 
         admin.clusters().createCluster("test",
-                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
         admin.namespaces().createNamespace("my-property/my-ns", Sets.newHashSet("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
@@ -70,7 +70,8 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
         super.internalSetup(conf);
 
         admin.clusters().createCluster("test",
-                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         // so that clients can test short names
         admin.tenants().createTenant("public",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -1049,7 +1049,8 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         final String topicName = "persistent://" + namespace + "/expiry";
         final String subName = "expiredSub";
 
-        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         admin.tenants().createTenant("prop", new TenantInfoImpl(null, Sets.newHashSet("use")));
         admin.namespaces().createNamespace(namespace);
@@ -1183,7 +1184,8 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         topics.add("persistent://prop/use/ns-abc/topic-1");
         topics.add("persistent://prop/use/ns-abc/topic-2");
         topics.add("persistent://prop/use/ns-abc1/topic-3");
-        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("prop", new TenantInfoImpl(null, Sets.newHashSet("use")));
         admin.namespaces().createNamespace("prop/use/ns-abc");
         admin.namespaces().createNamespace("prop/use/ns-abc1");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/processor/MessagePayloadProcessorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/processor/MessagePayloadProcessorTest.java
@@ -57,7 +57,8 @@ public class MessagePayloadProcessorTest extends ProducerConsumerBase {
     protected void setup() throws Exception {
         super.internalSetup();
         admin.clusters().createCluster("test",
-                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("public",
                 new TenantInfoImpl(Sets.newHashSet("appid"), Sets.newHashSet("test")));
         admin.namespaces().createNamespace("public/default", Sets.newHashSet("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicTest.java
@@ -91,7 +91,8 @@ public class CompactedTopicTest extends MockedPulsarServiceBaseTest {
         super.internalSetup();
 
         admin.clusters().createCluster("use",
-                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("use")));
         admin.namespaces().createNamespace("my-property/use/my-ns");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionRetentionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionRetentionTest.java
@@ -66,7 +66,8 @@ public class CompactionRetentionTest extends MockedPulsarServiceBaseTest {
         conf.setManagedLedgerMaxEntriesPerLedger(2);
         super.internalSetup();
 
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-tenant",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
         admin.namespaces().createNamespace("my-tenant/my-ns", Collections.singleton("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -102,7 +102,8 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
     public void setup() throws Exception {
         super.internalSetup();
 
-        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("use")));
         admin.namespaces().createNamespace("my-property/use/my-ns");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
@@ -72,7 +72,8 @@ public class CompactorTest extends MockedPulsarServiceBaseTest {
         super.internalSetup();
 
         admin.clusters().createCluster("use",
-                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("use")));
         admin.namespaces().createNamespace("my-property/use/my-ns");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/ServiceUnitStateCompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/ServiceUnitStateCompactionTest.java
@@ -141,7 +141,8 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
     public void setup() throws Exception {
         super.internalSetup();
 
-        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("use", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("use")));
         admin.namespaces().createNamespace("my-property/use/my-ns");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionE2ESecurityTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionE2ESecurityTest.java
@@ -172,7 +172,8 @@ public class PulsarFunctionE2ESecurityTest {
         primaryHost = pulsar.getWebServiceAddress();
 
         // update cluster metadata
-        ClusterData clusterData = ClusterData.builder().serviceUrl(brokerWebServiceUrl.toString()).build();
+        ClusterData clusterData = ClusterData.builder().serviceUrl(brokerWebServiceUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build();
         superUserAdmin.clusters().updateCluster(config.getClusterName(), clusterData);
 
         ClientBuilder clientBuilder = PulsarClient.builder().serviceUrl(this.workerConfig.getPulsarServiceUrl())

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
@@ -272,7 +272,8 @@ public class PulsarFunctionLocalRunTest {
         primaryHost = pulsar.getWebServiceAddress();
 
         // create cluster metadata
-        ClusterData clusterData = ClusterData.builder().serviceUrlTls(urlTls.toString()).build();
+        ClusterData clusterData = ClusterData.builder().serviceUrlTls(urlTls.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build();
         admin.clusters().createCluster(config.getClusterName(), clusterData);
 
         ClientBuilder clientBuilder = PulsarClient.builder()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionPublishTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionPublishTest.java
@@ -178,7 +178,8 @@ public class PulsarFunctionPublishTest {
         primaryHost = pulsar.getWebServiceAddress();
 
         // update cluster metadata
-        ClusterData clusterData = ClusterData.builder().serviceUrlTls(urlTls.toString()).build();
+        ClusterData clusterData = ClusterData.builder().serviceUrlTls(urlTls.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build();
         admin.clusters().updateCluster(config.getClusterName(), clusterData);
 
         ClientBuilder clientBuilder = PulsarClient.builder().serviceUrl(this.workerConfig.getPulsarServiceUrl());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarWorkerAssignmentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarWorkerAssignmentTest.java
@@ -109,7 +109,8 @@ public class PulsarWorkerAssignmentTest {
         primaryHost = pulsar.getWebServiceAddress();
 
         // update cluster metadata
-        final ClusterData clusterData = ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build();
+        final ClusterData clusterData = ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build();
         admin.clusters().updateCluster(config.getClusterName(), clusterData);
 
         final ClientBuilder clientBuilder = PulsarClient.builder().serviceUrl(this.workerConfig.getPulsarServiceUrl());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionAdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionAdminTest.java
@@ -140,7 +140,8 @@ public class PulsarFunctionAdminTest {
         primaryHost = pulsar.getWebServiceAddress();
 
         // update cluster metadata
-        ClusterData clusterData = ClusterData.builder().serviceUrl(urlTls.toString()).build();
+        ClusterData clusterData = ClusterData.builder().serviceUrl(urlTls.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build();
         admin.clusters().updateCluster(config.getClusterName(), clusterData);
 
         ClientBuilder clientBuilder = PulsarClient.builder().serviceUrl(this.workerConfig.getPulsarServiceUrl());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/PartitionedTopicSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/PartitionedTopicSchemaTest.java
@@ -51,7 +51,8 @@ public class PartitionedTopicSchemaTest extends MockedPulsarServiceBaseTest {
         isTcpLookup = true;
         super.internalSetup();
 
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
         admin.namespaces().createNamespace("my-property/my-ns");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -100,7 +100,8 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         super.internalSetup();
 
         // Setup namespaces
-        admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfo tenantInfo = TenantInfo.builder()
                 .allowedClusters(Collections.singleton(CLUSTER_NAME))
                 .build();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
@@ -63,7 +63,8 @@ public class SchemaCompatibilityCheckTest extends MockedPulsarServiceBaseTest {
         super.internalSetup();
 
         // Setup namespaces
-        admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfo tenantInfo = TenantInfo.builder()
                 .allowedClusters(Collections.singleton(CLUSTER_NAME))
                 .build();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaTypeCompatibilityCheckOnTopicLevelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaTypeCompatibilityCheckOnTopicLevelTest.java
@@ -56,7 +56,7 @@ public class SchemaTypeCompatibilityCheckOnTopicLevelTest extends MockedPulsarSe
 
         // Setup namespaces
         admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
-                .build());
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         TenantInfo tenantInfo = TenantInfo.builder()
                 .allowedClusters(Collections.singleton(CLUSTER_NAME))

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaTypeCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaTypeCompatibilityCheckTest.java
@@ -61,7 +61,8 @@ public class SchemaTypeCompatibilityCheckTest extends MockedPulsarServiceBaseTes
         super.internalSetup();
 
         // Setup namespaces
-        admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster(CLUSTER_NAME, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         TenantInfo tenantInfo = TenantInfo.builder()
                 .allowedClusters(Collections.singleton(CLUSTER_NAME))

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthorizationTest.java
@@ -85,7 +85,8 @@ public class ProxyAuthorizationTest extends MockedPulsarServiceBaseTest {
 
         assertFalse(auth.canLookup(TopicName.get("persistent://p1/c1/ns1/ds1"), "my-role", null));
 
-        admin.clusters().createCluster(configClusterName, ClusterData.builder().build());
+        admin.clusters().createCluster(configClusterName, ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("p1", new TenantInfoImpl(Sets.newHashSet("role1"), Sets.newHashSet("c1")));
         waitForChange();
         admin.namespaces().createNamespace("p1/c1/ns1");

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.ProxyProtocol;
 import org.apache.pulsar.common.util.URIPreconditions;
 
@@ -410,6 +411,19 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
      * @throws IllegalArgumentException exist illegal property.
      */
     public void checkPropertiesIfPresent() throws IllegalArgumentException {
+
+        if (StringUtils.isEmpty(getServiceUrl()) && StringUtils.isEmpty(getServiceUrlTls())) {
+            throw new IllegalArgumentException("Service url not found, "
+                    + "please provide either service url, example: http://pulsar.example.com:8080 "
+                    + "or service tls url, example: https://pulsar.example.com:8443");
+        }
+
+        if (StringUtils.isEmpty(getBrokerServiceUrl()) && StringUtils.isEmpty(getBrokerServiceUrlTls())) {
+            throw new IllegalArgumentException("Broker service url not found, "
+                    + "please provide either broker service url, example: pulsar://pulsar.example.com:6650 "
+                    + "or broker service tls url, example: pulsar+ssl://pulsar.example.com:6651");
+        }
+
         URIPreconditions.checkURIIfPresent(getServiceUrl(),
                 uri -> Objects.equals(uri.getScheme(), "http"),
                 "Illegal service url, example: http://pulsar.example.com:8080");

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
@@ -412,18 +412,6 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
      */
     public void checkPropertiesIfPresent() throws IllegalArgumentException {
 
-        if (StringUtils.isEmpty(getServiceUrl()) && StringUtils.isEmpty(getServiceUrlTls())) {
-            throw new IllegalArgumentException("Service url not found, "
-                    + "please provide either service url, example: http://pulsar.example.com:8080 "
-                    + "or service tls url, example: https://pulsar.example.com:8443");
-        }
-
-        if (StringUtils.isEmpty(getBrokerServiceUrl()) && StringUtils.isEmpty(getBrokerServiceUrlTls())) {
-            throw new IllegalArgumentException("Broker service url not found, "
-                    + "please provide either broker service url, example: pulsar://pulsar.example.com:6650 "
-                    + "or broker service tls url, example: pulsar+ssl://pulsar.example.com:6651");
-        }
-
         URIPreconditions.checkURIIfPresent(getServiceUrl(),
                 uri -> Objects.equals(uri.getScheme(), "http"),
                 "Illegal service url, example: http://pulsar.example.com:8080");
@@ -441,5 +429,20 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
                         || Objects.equals(uri.getScheme(), "pulsar+ssl"),
                 "Illegal proxy service url, example: pulsar+ssl://ats-proxy.example.com:4443 "
                         + "or pulsar://ats-proxy.example.com:4080");
+    }
+
+    public void checkNeededUrlExist() throws IllegalArgumentException {
+
+        if (StringUtils.isEmpty(getServiceUrl()) && StringUtils.isEmpty(getServiceUrlTls())) {
+            throw new IllegalArgumentException("Service url not found, "
+                    + "please provide either service url, example: http://pulsar.example.com:8080 "
+                    + "or service tls url, example: https://pulsar.example.com:8443");
+        }
+
+        if (StringUtils.isEmpty(getBrokerServiceUrl()) && StringUtils.isEmpty(getBrokerServiceUrlTls())) {
+            throw new IllegalArgumentException("Broker service url not found, "
+                    + "please provide either broker service url, example: pulsar://pulsar.example.com:6650 "
+                    + "or broker service tls url, example: pulsar+ssl://pulsar.example.com:6651");
+        }
     }
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataTest.java
@@ -20,11 +20,18 @@ package org.apache.pulsar.common.policies.data;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
-
+import lombok.extern.slf4j.Slf4j;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+@Slf4j
 public class ClusterDataTest {
+
+    String httpProtocolUrl = "http://broker.messaging.c2.example.com:8080";
+    String httpsProtocolUrl = "https://broker.messaging.c2.example.com:8080";
+    String pulsarProtocolUrl = "pulsar://broker.messaging.c2.example.com:8080";
+    String pulsarOverSslProtocolUrl = "pulsar+ssl://broker.messaging.c2.example.com:8080";
 
     @Test
     public void simple() {
@@ -121,6 +128,20 @@ public class ClusterDataTest {
         String url6 = "http://broker.messaging.c2.example.com:8080";
         String url7 = "https://broker.messaging.c2.example.com:8080";
 
+        ClusterDataImpl.builder()
+                .serviceUrl(httpProtocolUrl)
+                .brokerServiceUrl(pulsarProtocolUrl)
+                .proxyServiceUrl(pulsarProtocolUrl)
+                .build()
+                .checkPropertiesIfPresent();
+
+        ClusterDataImpl.builder()
+                .serviceUrlTls(httpsProtocolUrl)
+                .brokerServiceUrlTls(pulsarOverSslProtocolUrl)
+                .proxyServiceUrl(pulsarOverSslProtocolUrl)
+                .build()
+                .checkPropertiesIfPresent();
+
         Assert.assertThrows(IllegalArgumentException.class, () ->
                 ClusterDataImpl.builder().serviceUrl(url1).build().checkPropertiesIfPresent());
         Assert.assertThrows(IllegalArgumentException.class, () ->
@@ -155,19 +176,14 @@ public class ClusterDataTest {
                 ClusterDataImpl.builder().serviceUrl(url4).build().checkPropertiesIfPresent());
         Assert.assertThrows(IllegalArgumentException.class, () ->
                 ClusterDataImpl.builder().serviceUrlTls(url4).build().checkPropertiesIfPresent());
-        ClusterDataImpl.builder().brokerServiceUrl(url4).build().checkPropertiesIfPresent();
         Assert.assertThrows(IllegalArgumentException.class, () ->
                 ClusterDataImpl.builder().brokerServiceUrlTls(url4).build().checkPropertiesIfPresent());
-        ClusterDataImpl.builder().proxyServiceUrl(url4).build().checkPropertiesIfPresent();
         Assert.assertThrows(IllegalArgumentException.class, () ->
                 ClusterDataImpl.builder().serviceUrl(url5).build().checkPropertiesIfPresent());
         Assert.assertThrows(IllegalArgumentException.class, () ->
                 ClusterDataImpl.builder().serviceUrlTls(url5).build().checkPropertiesIfPresent());
         Assert.assertThrows(IllegalArgumentException.class, () ->
                 ClusterDataImpl.builder().brokerServiceUrl(url5).build().checkPropertiesIfPresent());
-        ClusterDataImpl.builder().brokerServiceUrlTls(url5).build().checkPropertiesIfPresent();
-        ClusterDataImpl.builder().proxyServiceUrl(url5).build().checkPropertiesIfPresent();
-        ClusterDataImpl.builder().serviceUrl(url6).build().checkPropertiesIfPresent();
         Assert.assertThrows(IllegalArgumentException.class, () ->
                 ClusterDataImpl.builder().serviceUrlTls(url6).build().checkPropertiesIfPresent());
         Assert.assertThrows(IllegalArgumentException.class, () ->
@@ -178,12 +194,199 @@ public class ClusterDataTest {
                 ClusterDataImpl.builder().proxyServiceUrl(url6).build().checkPropertiesIfPresent());
         Assert.assertThrows(IllegalArgumentException.class, () ->
                 ClusterDataImpl.builder().serviceUrl(url7).build().checkPropertiesIfPresent());
-        ClusterDataImpl.builder().serviceUrlTls(url7).build().checkPropertiesIfPresent();
         Assert.assertThrows(IllegalArgumentException.class, () ->
                 ClusterDataImpl.builder().brokerServiceUrl(url7).build().checkPropertiesIfPresent());
         Assert.assertThrows(IllegalArgumentException.class, () ->
                 ClusterDataImpl.builder().brokerServiceUrlTls(url7).build().checkPropertiesIfPresent());
         Assert.assertThrows(IllegalArgumentException.class, () ->
                 ClusterDataImpl.builder().proxyServiceUrl(url7).build().checkPropertiesIfPresent());
+    }
+
+    @DataProvider(name = "test-service-url")
+    public Object[][] dataProviderForServiceUrlTest() {
+        /*
+         *      1. testArgumentDetails      String
+         *      2. testSubject              ClusterDataImpl
+         *      3. isExceptionExpected      Boolean
+         *      4. expectedExceptionClass   Class
+         * */
+        return new Object[][]{
+                {
+                        "valid ServiceUrl and ServiceUrlTls as null",
+                        ClusterDataImpl.builder()
+                                .serviceUrl(httpProtocolUrl)
+                                .serviceUrlTls(null)
+                                .brokerServiceUrl(pulsarProtocolUrl)
+                                .proxyServiceUrl(pulsarProtocolUrl)
+                                .build(),
+                        false,
+                        null
+                },
+                {
+                        "ServiceUrl as null and valid ServiceUrlTls",
+                        ClusterDataImpl.builder()
+                                .serviceUrl(null)
+                                .serviceUrlTls(httpsProtocolUrl)
+                                .brokerServiceUrl(pulsarProtocolUrl)
+                                .proxyServiceUrl(pulsarProtocolUrl)
+                                .build(),
+                        false,
+                        null
+                },
+                {
+                        "Both ServiceURL and ServiceUrlTls as null.",
+                        ClusterDataImpl.builder()
+                                .serviceUrl(null)
+                                .serviceUrlTls(null)
+                                .brokerServiceUrl(pulsarProtocolUrl)
+                                .proxyServiceUrl(pulsarProtocolUrl)
+                                .build(),
+                        true,
+                        IllegalArgumentException.class
+                },
+                {
+                        "Both ServiceURL and ServiceUrlTls as empty string.",
+                        ClusterDataImpl.builder()
+                                .serviceUrl("")
+                                .serviceUrlTls("")
+                                .brokerServiceUrl(pulsarProtocolUrl)
+                                .proxyServiceUrl(pulsarProtocolUrl)
+                                .build(),
+                        true,
+                        IllegalArgumentException.class
+                },
+                {
+                        "invalid ServiceURL and ServiceUrlTls as null.",
+                        ClusterDataImpl.builder()
+                                .serviceUrl("broker.messaging.c2.example.com:8080")
+                                .serviceUrlTls(null)
+                                .brokerServiceUrl(pulsarProtocolUrl)
+                                .proxyServiceUrl(pulsarProtocolUrl)
+                                .build(),
+                        true,
+                        IllegalArgumentException.class
+                },
+                {
+                        "ServiceURL as null and invalid ServiceUrlTls.",
+                        ClusterDataImpl.builder()
+                                .serviceUrl(null)
+                                .serviceUrlTls("broker.messaging.c2.example.com:8080")
+                                .brokerServiceUrl(pulsarProtocolUrl)
+                                .proxyServiceUrl(pulsarProtocolUrl)
+                                .build(),
+                        true,
+                        IllegalArgumentException.class
+                }
+        };
+    }
+
+    @Test(dataProvider = "test-service-url")
+    public void testServiceUrl(Object[] args) {
+        String testDetail = (String) args[0];
+        ClusterDataImpl clusterDataImpl = (ClusterDataImpl) args[1];
+        Boolean isExceptionExpected = (Boolean) args[2];
+        Class expectedException = (Class) args[3];
+
+        log.debug("Test : testServiceUrl where " + testDetail);
+
+        if (isExceptionExpected) {
+            Assert.assertThrows(expectedException, () -> clusterDataImpl.checkPropertiesIfPresent());
+        } else {
+            clusterDataImpl.checkPropertiesIfPresent();
+        }
+    }
+
+    @DataProvider(name = "test-broker-service-url")
+    public Object[][] dataProviderForBrokerServiceUrlTest() {
+        /*
+         *      1. testArgumentDetails      String
+         *      2. testSubject              ClusterDataImpl
+         *      3. isExceptionExpected      Boolean
+         *      4. expectedExceptionClass   Class
+         * */
+        return new Object[][]{
+                {
+                        "valid BrokerServiceUrl and BrokerServiceUrlTls as null",
+                        ClusterDataImpl.builder()
+                                .brokerServiceUrl(pulsarProtocolUrl)
+                                .brokerServiceUrlTls(null)
+                                .serviceUrl(httpProtocolUrl)
+                                .proxyServiceUrl(pulsarProtocolUrl)
+                                .build(),
+                        false,
+                        null
+                },
+                {
+                        "BrokerServiceUrl as null and valid BrokerServiceUrlTls",
+                        ClusterDataImpl.builder()
+                                .brokerServiceUrl(null)
+                                .brokerServiceUrlTls(pulsarOverSslProtocolUrl)
+                                .serviceUrlTls(httpsProtocolUrl)
+                                .proxyServiceUrl(pulsarProtocolUrl)
+                                .build(),
+                        false,
+                        null
+                },
+                {
+                        "Both BrokerServiceURL and BrokerServiceUrlTls as null.",
+                        ClusterDataImpl.builder()
+                                .brokerServiceUrl(null)
+                                .brokerServiceUrlTls(null)
+                                .serviceUrlTls(pulsarProtocolUrl)
+                                .proxyServiceUrl(pulsarProtocolUrl)
+                                .build(),
+                        true,
+                        IllegalArgumentException.class
+                },
+                {
+                        "Both BrokerServiceURL and BrokerServiceUrlTls as empty string.",
+                        ClusterDataImpl.builder()
+                                .brokerServiceUrl("")
+                                .brokerServiceUrlTls("")
+                                .serviceUrl(httpProtocolUrl)
+                                .proxyServiceUrl(pulsarProtocolUrl)
+                                .build(),
+                        true,
+                        IllegalArgumentException.class
+                },
+                {
+                        "invalid BrokerServiceURL and BrokerServiceUrlTls as null.",
+                        ClusterDataImpl.builder()
+                                .brokerServiceUrl("broker.messaging.c2.example.com:8080")
+                                .brokerServiceUrlTls(null)
+                                .serviceUrlTls(httpsProtocolUrl)
+                                .proxyServiceUrl(pulsarProtocolUrl)
+                                .build(),
+                        true,
+                        IllegalArgumentException.class
+                },
+                {
+                        "BrokerServiceURL as null and invalid BrokerServiceUrlTls.",
+                        ClusterDataImpl.builder()
+                                .brokerServiceUrl(null)
+                                .brokerServiceUrlTls("broker.messaging.c2.example.com:8080")
+                                .serviceUrlTls(httpsProtocolUrl)
+                                .proxyServiceUrl(pulsarProtocolUrl)
+                                .build(),
+                        true,
+                        IllegalArgumentException.class
+                }
+        };
+    }
+
+    @Test(dataProvider = "test-broker-service-url")
+    public void testBrokerServiceUrl(Object[] args) {
+        String testDetail = (String) args[0];
+        ClusterDataImpl clusterDataImpl = (ClusterDataImpl) args[1];
+        Boolean isExceptionExpected = (Boolean) args[2];
+        Class expectedException = (Class) args[3];
+
+        log.debug("Test : testBrokerServiceUrl where " + testDetail);
+
+        if (isExceptionExpected) {
+            Assert.assertThrows(expectedException, () -> clusterDataImpl.checkPropertiesIfPresent());
+        } else {
+            clusterDataImpl.checkPropertiesIfPresent();
+        }
     }
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataTest.java
@@ -254,28 +254,6 @@ public class ClusterDataTest {
                                 .build(),
                         true,
                         IllegalArgumentException.class
-                },
-                {
-                        "invalid ServiceURL and ServiceUrlTls as null.",
-                        ClusterDataImpl.builder()
-                                .serviceUrl("broker.messaging.c2.example.com:8080")
-                                .serviceUrlTls(null)
-                                .brokerServiceUrl(pulsarProtocolUrl)
-                                .proxyServiceUrl(pulsarProtocolUrl)
-                                .build(),
-                        true,
-                        IllegalArgumentException.class
-                },
-                {
-                        "ServiceURL as null and invalid ServiceUrlTls.",
-                        ClusterDataImpl.builder()
-                                .serviceUrl(null)
-                                .serviceUrlTls("broker.messaging.c2.example.com:8080")
-                                .brokerServiceUrl(pulsarProtocolUrl)
-                                .proxyServiceUrl(pulsarProtocolUrl)
-                                .build(),
-                        true,
-                        IllegalArgumentException.class
                 }
         };
     }
@@ -290,9 +268,9 @@ public class ClusterDataTest {
         log.debug("Test : testServiceUrl where " + testDetail);
 
         if (isExceptionExpected) {
-            Assert.assertThrows(expectedException, () -> clusterDataImpl.checkPropertiesIfPresent());
+            Assert.assertThrows(expectedException, () -> clusterDataImpl.checkNeededUrlExist());
         } else {
-            clusterDataImpl.checkPropertiesIfPresent();
+            clusterDataImpl.checkNeededUrlExist();
         }
     }
 
@@ -348,28 +326,6 @@ public class ClusterDataTest {
                                 .build(),
                         true,
                         IllegalArgumentException.class
-                },
-                {
-                        "invalid BrokerServiceURL and BrokerServiceUrlTls as null.",
-                        ClusterDataImpl.builder()
-                                .brokerServiceUrl("broker.messaging.c2.example.com:8080")
-                                .brokerServiceUrlTls(null)
-                                .serviceUrlTls(httpsProtocolUrl)
-                                .proxyServiceUrl(pulsarProtocolUrl)
-                                .build(),
-                        true,
-                        IllegalArgumentException.class
-                },
-                {
-                        "BrokerServiceURL as null and invalid BrokerServiceUrlTls.",
-                        ClusterDataImpl.builder()
-                                .brokerServiceUrl(null)
-                                .brokerServiceUrlTls("broker.messaging.c2.example.com:8080")
-                                .serviceUrlTls(httpsProtocolUrl)
-                                .proxyServiceUrl(pulsarProtocolUrl)
-                                .build(),
-                        true,
-                        IllegalArgumentException.class
                 }
         };
     }
@@ -384,9 +340,9 @@ public class ClusterDataTest {
         log.debug("Test : testBrokerServiceUrl where " + testDetail);
 
         if (isExceptionExpected) {
-            Assert.assertThrows(expectedException, () -> clusterDataImpl.checkPropertiesIfPresent());
+            Assert.assertThrows(expectedException, () -> clusterDataImpl.checkNeededUrlExist());
         } else {
-            clusterDataImpl.checkPropertiesIfPresent();
+            clusterDataImpl.checkNeededUrlExist();
         }
     }
 }

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AuthedAdminProxyHandlerTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/AuthedAdminProxyHandlerTest.java
@@ -157,7 +157,8 @@ public class AuthedAdminProxyHandlerTest extends MockedPulsarServiceBaseTest {
                 // expected
             }
 
-            brokerAdmin.clusters().createCluster(configClusterName, ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+            brokerAdmin.clusters().createCluster(configClusterName, ClusterData.builder().serviceUrl(brokerUrl.toString())
+                    .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
             brokerAdmin.tenants().createTenant("tenant1",
                                                new TenantInfoImpl(ImmutableSet.of("user1"),

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyRefreshAuthTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyRefreshAuthTest.java
@@ -99,7 +99,8 @@ public class ProxyRefreshAuthTest extends ProducerConsumerBase {
                         () -> AuthTokenUtils.createToken(SECRET_KEY, "client", Optional.empty()))).build();
         String namespaceName = "my-tenant/my-ns";
         admin.clusters().createCluster("proxy-authorization",
-                ClusterData.builder().serviceUrlTls(brokerUrlTls.toString()).build());
+                ClusterData.builder().serviceUrlTls(brokerUrlTls.toString())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("my-tenant",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("proxy-authorization")));
         admin.namespaces().createNamespace(namespaceName);

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationNegTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationNegTest.java
@@ -171,7 +171,8 @@ public class ProxyWithAuthorizationNegTest extends ProducerConsumerBase {
 
         String namespaceName = "my-property/proxy-authorization-neg/my-ns";
 
-        admin.clusters().createCluster("proxy-authorization-neg", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("proxy-authorization-neg", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("proxy-authorization-neg")));

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
@@ -559,7 +559,8 @@ public class ProxyWithAuthorizationTest extends ProducerConsumerBase {
 
     private void initializeCluster(PulsarAdmin adminClient, String namespaceName) throws Exception {
         adminClient.clusters().createCluster("proxy-authorization", ClusterData.builder()
-                .serviceUrlTls(brokerUrlTls.toString()).build());
+                .serviceUrlTls(brokerUrlTls.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         adminClient.tenants().createTenant("my-tenant",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("proxy-authorization")));

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
@@ -560,7 +560,7 @@ public class ProxyWithAuthorizationTest extends ProducerConsumerBase {
     private void initializeCluster(PulsarAdmin adminClient, String namespaceName) throws Exception {
         adminClient.clusters().createCluster("proxy-authorization", ClusterData.builder()
                 .serviceUrlTls(brokerUrlTls.toString())
-                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
+                .brokerServiceUrlTls(pulsar.getBrokerServiceUrlTls()).build());
 
         adminClient.tenants().createTenant("my-tenant",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("proxy-authorization")));

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithJwtAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithJwtAuthorizationTest.java
@@ -160,7 +160,8 @@ public class ProxyWithJwtAuthorizationTest extends ProducerConsumerBase {
 
         String namespaceName = "my-property/proxy-authorization/my-ns";
 
-        admin.clusters().createCluster("proxy-authorization", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("proxy-authorization", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("proxy-authorization")));
@@ -244,7 +245,8 @@ public class ProxyWithJwtAuthorizationTest extends ProducerConsumerBase {
         String topicName = "persistent://my-property/my-ns/my-topic1";
         String subscriptionName = "my-subscriber-name";
 
-        admin.clusters().createCluster(clusterName, ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster(clusterName, ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(new HashSet<>(), Sets.newHashSet(clusterName)));
@@ -357,7 +359,8 @@ public class ProxyWithJwtAuthorizationTest extends ProducerConsumerBase {
 
         String namespaceName = "my-property/proxy-authorization/my-ns";
 
-        admin.clusters().createCluster("proxy-authorization", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("proxy-authorization", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         admin.tenants().createTenant("my-property",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("proxy-authorization")));

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithoutServiceDiscoveryTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithoutServiceDiscoveryTest.java
@@ -162,7 +162,8 @@ public class ProxyWithoutServiceDiscoveryTest extends ProducerConsumerBase {
         @Cleanup
         PulsarClient proxyClient = createPulsarClient(authTls, proxyService.getServiceUrlTls());
 
-        admin.clusters().createCluster("without-service-discovery", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("without-service-discovery", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         admin.tenants().createTenant("my-property", new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"),
                 Sets.newHashSet("without-service-discovery")));

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/SuperUserAuthedAdminProxyHandlerTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/SuperUserAuthedAdminProxyHandlerTest.java
@@ -134,7 +134,8 @@ public class SuperUserAuthedAdminProxyHandlerTest extends MockedPulsarServiceBas
     @Test
     public void testAuthenticatedProxyAsAdmin() throws Exception {
         try (PulsarAdmin adminAdmin = getAdminClient("admin")) {
-            adminAdmin.clusters().createCluster(configClusterName, ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+            adminAdmin.clusters().createCluster(configClusterName, ClusterData.builder().serviceUrl(brokerUrl.toString())
+                    .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
             adminAdmin.tenants().createTenant("tenant1",
                                               new TenantInfoImpl(ImmutableSet.of("randoUser"),
                                                              ImmutableSet.of(configClusterName)));
@@ -152,7 +153,8 @@ public class SuperUserAuthedAdminProxyHandlerTest extends MockedPulsarServiceBas
             } catch (PulsarAdminException.NotAuthorizedException e) {
                 // expected
             }
-            adminAdmin.clusters().createCluster(configClusterName, ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+            adminAdmin.clusters().createCluster(configClusterName, ClusterData.builder().serviceUrl(brokerUrl.toString())
+                    .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
             adminAdmin.tenants().createTenant("tenant1",
                                               new TenantInfoImpl(ImmutableSet.of("unknownUser"),
                                                              ImmutableSet.of(configClusterName)));

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestCacheSizeAllocator.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestCacheSizeAllocator.java
@@ -61,7 +61,8 @@ public class TestCacheSizeAllocator extends MockedPulsarServiceBaseTest {
     public void setup() throws Exception {
         super.internalSetup();
 
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         // so that clients can test short names
         admin.tenants().createTenant("public",

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarAuth.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarAuth.java
@@ -65,7 +65,9 @@ public class TestPulsarAuth extends MockedPulsarServiceBaseTest {
         conf.setClusterName("c1");
         internalSetup();
 
-        admin.clusters().createCluster("c1", ClusterData.builder().build());
+        admin.clusters().createCluster("c1", ClusterData.builder()
+                .serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant("p1", new TenantInfoImpl(Sets.newHashSet(SUPER_USER_ROLE), Sets.newHashSet("c1")));
         waitForChange();
         admin.namespaces().createNamespace("p1/c1/ns1");

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestReadChunkedMessages.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestReadChunkedMessages.java
@@ -80,7 +80,8 @@ public class TestReadChunkedMessages extends MockedPulsarServiceBaseTest {
         conf.setManagedLedgerMinLedgerRolloverTimeMinutes(0);
         internalSetup();
 
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
 
         // so that clients can test short names
         admin.tenants().createTenant("public",

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/Oauth2PerformanceTransactionTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/Oauth2PerformanceTransactionTest.java
@@ -141,7 +141,8 @@ public class Oauth2PerformanceTransactionTest extends ProducerConsumerBase {
 
         // Setup namespaces
         admin.clusters().createCluster("test",
-                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                        .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant(NamespaceName.SYSTEM_NAMESPACE.getTenant(),
                 new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet("test")));
         admin.namespaces().createNamespace(myNamespace, Sets.newHashSet("test"));

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
@@ -61,7 +61,8 @@ public class PerformanceProducerTest extends MockedPulsarServiceBaseTest {
             }
         });
         // Setup namespaces
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Sets.newHashSet("role1", "role2"), Sets.newHashSet("test"));
         admin.tenants().createTenant(testTenant, tenantInfo);
         admin.namespaces().createNamespace(myNamespace, Sets.newHashSet("test"));

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceTransactionTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceTransactionTest.java
@@ -71,7 +71,8 @@ public class PerformanceTransactionTest extends MockedPulsarServiceBaseTest {
             }
         });
         // Setup namespaces
-        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl()).build());
         admin.tenants().createTenant(NamespaceName.SYSTEM_NAMESPACE.getTenant(),
                 new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet("test")));
         admin.namespaces().createNamespace(myNamespace, Sets.newHashSet("test"));


### PR DESCRIPTION
Fixes #19866 


### Motivation

Verify either TlsUrl or nonTlsUrl is provided as part of Cluster create and update operation.
This validation is not applicable for "global" cluster create / update operation.

### Modifications

- Added validation either serviceUrl or serviceUrlTls is set as part of cluster creation and update API. 
- Added validation either brokerServiceUrl or brokerServiceUrlTls is set as part of cluster creation and update API. 
- Added unit test cases.
- Fixed old test-cases.


Core changes are only in two files [ClustersBase.java](https://github.com/apache/pulsar/pull/19965/files#diff-714966d12f914572a5ac289654f21efbf6ef1ae0f35ba1876179fd645961ced6), [ClusterDataImpl.java](https://github.com/apache/pulsar/pull/19965/files#diff-d7836029dc49b4e9f42bb0ee927c538f31d15e0ce64fe4972d268d0230be8257), added unit test w.r.t same in [ClusterDataTest.java](https://github.com/apache/pulsar/pull/19965/files#diff-abc908f47297f5d5c41f2c719ff5e115cb152967207ea80644f34b486bd3f06a)
rest 115 file diff is because of patching existing test cases.  

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added  can be verified as follows: 

- unit tests added
- fixed old test cases 

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
