### PR TITLE
[branch-2.10] [fix] [auth] fix not forward compatible config saslJaasServerRoleTokenSignerSecretPath after cherry-pick #15121

### DIFF
--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderSasl.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderSasl.java
@@ -41,6 +41,7 @@ import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -106,8 +107,8 @@ public class AuthenticationProviderSasl implements AuthenticationProvider {
         if (StringUtils.isNotBlank(saslJaasServerRoleTokenSignerSecretPath)) {
             secret = readSecretFromUrl(saslJaasServerRoleTokenSignerSecretPath);
         } else {
-            String msg = "saslJaasServerRoleTokenSignerSecretPath parameter is empty";
-            throw new IllegalArgumentException(msg);
+            secret = Long.toString(new Random().nextLong()).getBytes();
+            log.info("JAAS authentication provider using random secret.");
         }
         this.signer = new SaslRoleTokenSigner(secret);
     }


### PR DESCRIPTION
### Motivation

This is A follow-up for cherry-pick #15121

After [DIscuss: Cherry-pick #15121 into branch-2.10 to solve the issue sasl authentication failure](https://lists.apache.org/thread/pv65nq9y4ohy9yw4h4nqrz4g50gtft56), we will do a follow-up process to keep the new configuration `saslJaasServerRoleTokenSignerSecretPath` forward compatible: make this config optinal.

### Modifications

Make the config `saslJaasServerRoleTokenSignerSecretPath` optinal


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- 
