### PR TITLE
[improve][broker] Log resource usage rate of brokers that need to be offloaded in ThresholdShedder

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
@@ -79,7 +79,8 @@ public class ThresholdShedder implements LoadSheddingStrategy {
             final double currentUsage = brokerAvgResourceUsage.getOrDefault(broker, 0.0);
             if (currentUsage < avgUsage + threshold) {
                 if (log.isDebugEnabled()) {
-                    log.debug("[{}] broker is not overloaded, ignoring at this point", broker);
+                    log.debug("[{}] broker is not overloaded, ignoring at this point ({})", broker,
+                            localData.printResourceUsage());
                 }
                 return;
             }
@@ -92,17 +93,19 @@ public class ThresholdShedder implements LoadSheddingStrategy {
             if (minimumThroughputToOffload < minThroughputThreshold) {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] broker is planning to shed throughput {} MByte/s less than "
-                                    + "minimumThroughputThreshold {} MByte/s, skipping bundle unload.",
-                            broker, minimumThroughputToOffload / MB, minThroughputThreshold / MB);
+                                    + "minimumThroughputThreshold {} MByte/s, skipping bundle unload ({})",
+                            broker, minimumThroughputToOffload / MB, minThroughputThreshold / MB,
+                            localData.printResourceUsage());
                 }
                 return;
             }
 
             log.info(
-                    "Attempting to shed load on {}, which has max resource usage above avgUsage  and threshold {}%"
-                            + " > {}% + {}% -- Offloading at least {} MByte/s of traffic, left throughput {} MByte/s",
+                    "Attempting to shed load on {}, which has max resource usage above avgUsage and threshold {}%"
+                            + " > {}% + {}% -- Offloading at least {} MByte/s of traffic,"
+                                    + " left throughput {} MByte/s ({})",
                     broker, 100 * currentUsage, 100 * avgUsage, 100 * threshold, minimumThroughputToOffload / MB,
-                    (brokerCurrentThroughput - minimumThroughputToOffload) / MB);
+                    (brokerCurrentThroughput - minimumThroughputToOffload) / MB, localData.printResourceUsage());
 
             if (localData.getBundles().size() > 1) {
                 filterAndSelectBundle(loadData, recentlyUnloadedBundles, broker, localData, minimumThroughputToOffload);


### PR DESCRIPTION
### Motivation

When `ThresholdShedder` unloads namespace bundles from an overloaded broker, it would be useful to log resource usage of that broker. This is the same change I made to `OverloadShedder` earlier: https://github.com/apache/pulsar/pull/6152

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
