### PR TITLE
[improve][broker] PIP-192: Update the lookup data path to support deploy and rollback

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryImpl.java
@@ -51,7 +51,7 @@ import org.apache.pulsar.metadata.api.coordination.ResourceLock;
 @Slf4j
 public class BrokerRegistryImpl implements BrokerRegistry {
 
-    protected static final String LOOKUP_DATA_PATH = "/loadbalance/brokers";
+    protected static final String LOOKUP_DATA_PATH = "/loadbalance/extension/brokers";
 
     private final PulsarService pulsar;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -517,14 +517,12 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testStartOldLoadManager() throws Exception {
-        try {
-            ServiceConfiguration defaultConf = getDefaultConf();
-            defaultConf.setAllowAutoTopicCreation(true);
-            defaultConf.setForceDeleteNamespaceAllowed(true);
-            defaultConf.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
-            defaultConf.setLoadBalancerSheddingEnabled(false);
-            additionalPulsarTestContext = createAdditionalPulsarTestContext(defaultConf);
-
+        ServiceConfiguration defaultConf = getDefaultConf();
+        defaultConf.setAllowAutoTopicCreation(true);
+        defaultConf.setForceDeleteNamespaceAllowed(true);
+        defaultConf.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
+        defaultConf.setLoadBalancerSheddingEnabled(false);
+        try (var additionalPulsarTestContext = createAdditionalPulsarTestContext(defaultConf)) {
             // start pulsar3 with old load manager
             var pulsar3 = additionalPulsarTestContext.getPulsarService();
 
@@ -543,8 +541,6 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
             assertEquals(availableBrokers.size(), 2);
             assertTrue(availableBrokers.contains(pulsar1.getLookupServiceAddress()));
             assertTrue(availableBrokers.contains(pulsar2.getLookupServiceAddress()));
-        } finally {
-            additionalPulsarTestContext.close();
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -43,7 +43,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -205,7 +205,7 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
         this.additionalPulsarTestContext.close();
     }
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     protected void initializeState() throws PulsarAdminException {
         admin.namespaces().unload("public/default");
         reset(primaryLoadManager, secondaryLoadManager);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -529,8 +529,6 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
             var availableBrokers = pulsar3.getLoadManager().get().getAvailableBrokers();
             assertEquals(availableBrokers.size(), 1);
             assertEquals(availableBrokers.iterator().next(), pulsar3.getLookupServiceAddress());
-            assertNotEquals(availableBrokers.iterator().next(), pulsar1.getLookupServiceAddress());
-            assertNotEquals(availableBrokers.iterator().next(), pulsar2.getLookupServiceAddress());
 
             availableBrokers = pulsar1.getLoadManager().get().getAvailableBrokers();
             assertEquals(availableBrokers.size(), 2);


### PR DESCRIPTION
PIP: https://github.com/apache/pulsar/issues/16691

### Motivation

If we deploy the new LB or rollback to the old LB. We need to isolate broker-bundle assignments to those brokers that configure the matching LM.

### Modifications
* Use a new zk path to store the available broker use by the new load manager.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

