### PR TITLE
[improve][ml] Add Read cache misses metric for ledger

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerMXBean.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerMXBean.java
@@ -100,6 +100,11 @@ public interface ManagedLedgerMXBean {
      */
     long getReadEntriesErrors();
 
+    /**
+     * @return the number of readEntries requests that cache miss Rate
+     */
+    double getReadEntriesOpsCacheMissesRate();
+
     // Entry size statistics
 
     double getEntrySizeAverage();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMBeanImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMBeanImpl.java
@@ -39,6 +39,7 @@ public class ManagedLedgerMBeanImpl implements ManagedLedgerMXBean {
     private final Rate addEntryOpsFailed = new Rate();
     private final Rate readEntriesOps = new Rate();
     private final Rate readEntriesOpsFailed = new Rate();
+    private final Rate readEntriesOpsCacheMisses = new Rate();
     private final Rate markDeleteOps = new Rate();
 
     private final LongAdder dataLedgerOpenOp = new LongAdder();
@@ -72,6 +73,7 @@ public class ManagedLedgerMBeanImpl implements ManagedLedgerMXBean {
         addEntryOpsFailed.calculateRate(seconds);
         readEntriesOps.calculateRate(seconds);
         readEntriesOpsFailed.calculateRate(seconds);
+        readEntriesOpsCacheMisses.calculateRate(seconds);
         markDeleteOps.calculateRate(seconds);
 
         addEntryLatencyStatsUsec.refresh();
@@ -96,6 +98,10 @@ public class ManagedLedgerMBeanImpl implements ManagedLedgerMXBean {
 
     public void recordReadEntriesError() {
         readEntriesOpsFailed.recordEvent();
+    }
+
+    public void recordReadEntriesOpsCacheMisses() {
+        readEntriesOpsCacheMisses.recordEvent();
     }
 
     public void addAddEntryLatencySample(long latency, TimeUnit unit) {
@@ -226,6 +232,11 @@ public class ManagedLedgerMBeanImpl implements ManagedLedgerMXBean {
     @Override
     public long getReadEntriesErrors() {
         return readEntriesOpsFailed.getCount();
+    }
+
+    @Override
+    public double getReadEntriesOpsCacheMissesRate() {
+        return readEntriesOpsCacheMisses.getRate();
     }
 
     @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/EntryCacheDisabled.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/EntryCacheDisabled.java
@@ -93,6 +93,7 @@ public class EntryCacheDisabled implements EntryCache {
                     } finally {
                         ledgerEntries.close();
                     }
+                    ml.getMbean().recordReadEntriesOpsCacheMisses();
                     ml.getFactory().getMbean().recordCacheMiss(entries.size(), totalSize);
                     ml.getMbean().addReadEntriesSample(entries.size(), totalSize);
 
@@ -120,6 +121,7 @@ public class EntryCacheDisabled implements EntryCache {
                             LedgerEntry ledgerEntry = iterator.next();
                             EntryImpl returnEntry = RangeEntryCacheManagerImpl.create(ledgerEntry, interceptor);
 
+                            ml.getMbean().recordReadEntriesOpsCacheMisses();
                             ml.getFactory().getMbean().recordCacheMiss(1, returnEntry.getLength());
                             ml.getMbean().addReadEntriesSample(1, returnEntry.getLength());
                             callback.readEntryComplete(returnEntry, ctx);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -256,6 +256,7 @@ public class RangeEntryCacheImpl implements EntryCache {
                                 LedgerEntry ledgerEntry = iterator.next();
                                 EntryImpl returnEntry = RangeEntryCacheManagerImpl.create(ledgerEntry, interceptor);
 
+                                ml.getMbean().recordReadEntriesOpsCacheMisses();
                                 manager.mlFactoryMBean.recordCacheMiss(1, returnEntry.getLength());
                                 ml.getMbean().addReadEntriesSample(1, returnEntry.getLength());
                                 callback.readEntryComplete(returnEntry, ctx);
@@ -449,6 +450,7 @@ public class RangeEntryCacheImpl implements EntryCache {
                                     }
                                 }
 
+                                ml.getMbean().recordReadEntriesOpsCacheMisses();
                                 manager.mlFactoryMBean.recordCacheMiss(entriesToReturn.size(), totalSize);
                                 ml.getMbean().addReadEntriesSample(entriesToReturn.size(), totalSize);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerMetrics.java
@@ -108,6 +108,8 @@ public class ManagedLedgerMetrics extends AbstractMetrics {
                         (double) lStats.getReadEntriesErrors());
                 populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ml_ReadEntriesRate",
                         lStats.getReadEntriesRate());
+                populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ml_ReadEntriesOpsCacheMissesRate",
+                        lStats.getReadEntriesOpsCacheMissesRate());
                 populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ml_ReadEntriesSucceeded",
                         (double) lStats.getReadEntriesSucceeded());
                 populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ml_StoredMessagesSize",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedBrokerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedBrokerStats.java
@@ -31,6 +31,7 @@ public class AggregatedBrokerStats {
     public long storageLogicalSize;
     public double storageWriteRate;
     public double storageReadRate;
+    public double storageReadCacheMissesRate;
     public long msgBacklog;
 
     void updateStats(TopicStats stats) {
@@ -46,6 +47,7 @@ public class AggregatedBrokerStats {
         storageLogicalSize += stats.managedLedgerStats.storageLogicalSize;
         storageWriteRate += stats.managedLedgerStats.storageWriteRate;
         storageReadRate += stats.managedLedgerStats.storageReadRate;
+        storageReadCacheMissesRate += stats.managedLedgerStats.storageReadCacheMissesRate;
         msgBacklog += stats.msgBacklog;
     }
 
@@ -62,6 +64,7 @@ public class AggregatedBrokerStats {
         storageLogicalSize = 0;
         storageWriteRate = 0;
         storageReadRate = 0;
+        storageReadCacheMissesRate = 0;
         msgBacklog = 0;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedNamespaceStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedNamespaceStats.java
@@ -107,6 +107,7 @@ public class AggregatedNamespaceStats {
 
         managedLedgerStats.storageWriteRate += stats.managedLedgerStats.storageWriteRate;
         managedLedgerStats.storageReadRate += stats.managedLedgerStats.storageReadRate;
+        managedLedgerStats.storageReadCacheMissesRate += stats.managedLedgerStats.storageReadCacheMissesRate;
 
         msgBacklog += stats.msgBacklog;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/ManagedLedgerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/ManagedLedgerStats.java
@@ -34,11 +34,13 @@ public class ManagedLedgerStats {
 
     double storageWriteRate;
     double storageReadRate;
+    double storageReadCacheMissesRate;
 
     public void reset() {
         storageSize = 0;
         storageWriteRate = 0;
         storageReadRate = 0;
+        storageReadCacheMissesRate = 0;
         backlogSize = 0;
         offloadedStorageUsed = 0;
         storageLogicalSize = 0;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -190,6 +190,7 @@ public class NamespaceStatsAggregator {
 
             stats.managedLedgerStats.storageWriteRate = mlStats.getAddEntryMessagesRate();
             stats.managedLedgerStats.storageReadRate = mlStats.getReadEntriesRate();
+            stats.managedLedgerStats.storageReadCacheMissesRate = mlStats.getReadEntriesOpsCacheMissesRate();
         }
         TopicStatsImpl tStatus = topic.getStats(getPreciseBacklog, subscriptionBacklogSize, false);
         stats.msgInCounter = tStatus.msgInCounter;
@@ -331,6 +332,8 @@ public class NamespaceStatsAggregator {
         writeMetric(stream, "pulsar_broker_storage_logical_size", brokerStats.storageLogicalSize, cluster);
         writeMetric(stream, "pulsar_broker_storage_write_rate", brokerStats.storageWriteRate, cluster);
         writeMetric(stream, "pulsar_broker_storage_read_rate", brokerStats.storageReadRate, cluster);
+        writeMetric(stream, "pulsar_broker_storage_read_cache_misses_rate",
+                brokerStats.storageReadCacheMissesRate, cluster);
         writeMetric(stream, "pulsar_broker_msg_backlog", brokerStats.msgBacklog, cluster);
     }
 
@@ -376,6 +379,8 @@ public class NamespaceStatsAggregator {
                 cluster, namespace);
         writeMetric(stream, "pulsar_storage_read_rate", stats.managedLedgerStats.storageReadRate,
                 cluster, namespace);
+        writeMetric(stream, "pulsar_storage_read_cache_misses_rate",
+                stats.managedLedgerStats.storageReadCacheMissesRate, cluster, namespace);
 
         writeMetric(stream, "pulsar_subscription_delayed", stats.msgDelayed, cluster, namespace);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
@@ -152,6 +152,9 @@ class TopicStats {
                 cluster, namespace, topic, splitTopicAndPartitionIndexLabel);
         writeMetric(stream, "pulsar_storage_read_rate", stats.managedLedgerStats.storageReadRate,
                 cluster, namespace, topic, splitTopicAndPartitionIndexLabel);
+        writeMetric(stream, "pulsar_storage_read_cache_misses_rate",
+                stats.managedLedgerStats.storageReadCacheMissesRate,
+                cluster, namespace, topic, splitTopicAndPartitionIndexLabel);
         writeMetric(stream, "pulsar_storage_backlog_size", stats.managedLedgerStats.backlogSize,
                 cluster, namespace, topic, splitTopicAndPartitionIndexLabel);
         writeMetric(stream, "pulsar_publish_rate_limit_times", stats.publishRateLimitedTimes,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -58,6 +58,7 @@ import java.util.stream.Collectors;
 import javax.crypto.SecretKey;
 import javax.naming.AuthenticationException;
 import lombok.Cleanup;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -84,6 +85,7 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker")
@@ -538,6 +540,111 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         assertEquals(cm.get(0).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic1");
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
         assertEquals(cm.get(0).tags.get("subscription"), "test");
+    }
+
+    @DataProvider(name = "cacheEnable")
+    public static Object[][] cacheEnable() {
+        return new Object[][] { { Boolean.TRUE }, { Boolean.FALSE } };
+    }
+
+    @Test(dataProvider = "cacheEnable")
+    public void testStorageReadCacheMissesRate(boolean cacheEnable) throws Exception {
+        cleanup();
+        conf.setManagedLedgerStatsPeriodSeconds(Integer.MAX_VALUE);
+        conf.setManagedLedgerCacheEvictionTimeThresholdMillis(Long.MAX_VALUE);
+        conf.setCacheEvictionByMarkDeletedPosition(true);
+        if (cacheEnable) {
+            conf.setManagedLedgerCacheSizeMB(1);
+        } else {
+            conf.setManagedLedgerCacheSizeMB(0);
+        }
+        setup();
+        String ns = "prop/ns-abc1";
+        admin.namespaces().createNamespace(ns);
+        String topic = "persistent://" + ns + "/testStorageReadCacheMissesRate" + UUID.randomUUID();
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().enableBatching(false).topic(topic).create();
+        @Cleanup
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionName("test")
+                .subscribe();
+        byte[] msg = new byte[2 * 1024 * 1024];
+        new Random().nextBytes(msg);
+        producer.send(msg);
+        consumer.receive();
+        // when cacheEnable, the second msg will read cache miss
+        producer.send(msg);
+        consumer.receive();
+
+        PersistentTopic persistentTopic =
+                (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topic).get().get();
+        ManagedLedgerImpl managedLedger = ((ManagedLedgerImpl) persistentTopic.getManagedLedger());
+        managedLedger.getMbean().refreshStats(1, TimeUnit.SECONDS);
+
+        // includeTopicMetric true
+        ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
+        PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
+        String metricsStr = statsOut.toString();
+        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+
+        metrics.entries().forEach(e -> System.out.println(e.getKey() + ": " + e.getValue()));
+
+        List<Metric> cm = (List<Metric>) metrics.get("pulsar_storage_read_cache_misses_rate");
+        assertEquals(cm.size(), 1);
+        if (cacheEnable) {
+            assertEquals(cm.get(0).value, 1.0);
+        } else {
+            assertEquals(cm.get(0).value, 2.0);
+        }
+
+        assertEquals(cm.get(0).tags.get("topic"), topic);
+        assertEquals(cm.get(0).tags.get("namespace"), ns);
+        assertEquals(cm.get(0).tags.get("cluster"), "test");
+
+        List<Metric> brokerMetric = (List<Metric>) metrics.get("pulsar_broker_storage_read_cache_misses_rate");
+        assertEquals(brokerMetric.size(), 1);
+        if (cacheEnable) {
+            assertEquals(brokerMetric.get(0).value, 1.0);
+        } else {
+            assertEquals(brokerMetric.get(0).value, 2.0);
+        }
+
+        assertEquals(brokerMetric.get(0).tags.get("cluster"), "test");
+        assertNull(brokerMetric.get(0).tags.get("namespace"));
+        assertNull(brokerMetric.get(0).tags.get("topic"));
+
+        // includeTopicMetric false
+        ByteArrayOutputStream statsOut2 = new ByteArrayOutputStream();
+        PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut2);
+        String metricsStr2 = statsOut2.toString();
+        Multimap<String, Metric> metrics2 = parseMetrics(metricsStr2);
+
+        metrics2.entries().forEach(e -> System.out.println(e.getKey() + ": " + e.getValue()));
+
+        List<Metric> cm2 = (List<Metric>) metrics2.get("pulsar_storage_read_cache_misses_rate");
+        assertEquals(cm2.size(), 1);
+        if (cacheEnable) {
+            assertEquals(cm2.get(0).value, 1.0);
+        } else {
+            assertEquals(cm2.get(0).value, 2.0);
+        }
+
+        assertNull(cm2.get(0).tags.get("topic"));
+        assertEquals(cm2.get(0).tags.get("namespace"), ns);
+        assertEquals(cm2.get(0).tags.get("cluster"), "test");
+
+        List<Metric> brokerMetric2 = (List<Metric>) metrics.get("pulsar_broker_storage_read_cache_misses_rate");
+        assertEquals(brokerMetric2.size(), 1);
+        if (cacheEnable) {
+            assertEquals(brokerMetric2.get(0).value, 1.0);
+        } else {
+            assertEquals(brokerMetric2.get(0).value, 2.0);
+        }
+        assertEquals(brokerMetric2.get(0).tags.get("cluster"), "test");
+        assertNull(brokerMetric2.get(0).tags.get("namespace"));
+        assertNull(brokerMetric2.get(0).tags.get("topic"));
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -645,6 +645,17 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         assertEquals(brokerMetric2.get(0).tags.get("cluster"), "test");
         assertNull(brokerMetric2.get(0).tags.get("namespace"));
         assertNull(brokerMetric2.get(0).tags.get("topic"));
+
+        // test ManagedLedgerMetrics
+        List<Metric> mlMetric = ((List<Metric>) metrics.get("pulsar_ml_ReadEntriesOpsCacheMissesRate"));
+        assertEquals(mlMetric.size(), 1);
+        if (cacheEnable) {
+            assertEquals(mlMetric.get(0).value, 1.0);
+        } else {
+            assertEquals(mlMetric.get(0).value, 2.0);
+        }
+        assertEquals(mlMetric.get(0).tags.get("cluster"), "test");
+        assertEquals(mlMetric.get(0).tags.get("namespace"), ns + "/persistent");
     }
 
     @Test


### PR DESCRIPTION
### Motivation

When there are too many read request to bookie server,  we need find out which ledger is reading without cache.  So here we add  a `storage_read_cache_misses_rate` for ledger level.

### Modifications

Add a metric `storage_read_cache_misses_rate` for ledger level.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
- Add UT `org.apache.pulsar.broker.stats.PrometheusMetricsTest#testStorageReadCacheMissesRate` to verify it

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/AnonHxy/pulsar/pull/34
