### PR TITLE
[fix][build] Suppress Guava CVE-2020-8908 in OWASP dependency check

### DIFF
--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -463,5 +463,12 @@
         <cve>CVE-2020-17516</cve>
         <cve>CVE-2021-44521</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+       The vulnerable method is deprecated in Guava, but isn't removed. It's necessary to suppress this CVE.
+       See https://github.com/google/guava/issues/4011
+       ]]></notes>
+        <cve>CVE-2020-8908</cve>
+    </suppress>
 
 </suppressions>


### PR DESCRIPTION
### Motivation

- Fix OWASP dependency check for master branch
- The vulnerable method is deprecated in Guava, but isn't removed. It's necessary to suppress this CVE. See https://github.com/google/guava/issues/4011

### Modifications

- suppress CVE-2020-8908

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->