### PR TITLE
[fix] [cli] Fix Broker crashed by too much memory usage of pulsar tools

### DIFF
--- a/conf/pulsar_tools_env.sh
+++ b/conf/pulsar_tools_env.sh
@@ -45,10 +45,11 @@
 # Discard parameter "-Xms" of $PULSAR_MEM, which tends to be the Broker's minimum memory, to avoid using too much
 # memory by tools.
 if [ -n "$PULSAR_MEM" ]; then
+  PULSAR_MEM_ARR=("${PULSAR_MEM}")
   PULSAR_MEM_REWRITE=""
-  for i in $PULSAR_MEM
+  for i in ${PULSAR_MEM_ARR}
   do
-    if [ "${i:0:4}" != "-Xms" ];then
+    if [ "${i:0:4}" != "-Xms" ]; then
        PULSAR_MEM_REWRITE="$PULSAR_MEM_REWRITE $i";
     fi
   done

--- a/conf/pulsar_tools_env.sh
+++ b/conf/pulsar_tools_env.sh
@@ -42,6 +42,18 @@
 # PULSAR_GLOBAL_ZK_CONF=
 
 # Extra options to be passed to the jvm
+# Discard parameter "-Xms" of $PULSAR_MEM, which tends to be the Broker's minimum memory, to avoid using too much
+# memory by tools.
+if [ -n "$PULSAR_MEM" ]; then
+  PULSAR_MEM_REWRITE=""
+  for i in $PULSAR_MEM
+  do
+    if [ "${i:0:4}" != "-Xms" ];then
+       PULSAR_MEM_REWRITE="$PULSAR_MEM_REWRITE $i";
+    fi
+  done
+  PULSAR_MEM=${PULSAR_MEM_REWRITE}
+fi
 PULSAR_MEM=${PULSAR_MEM:-"-Xmx128m -XX:MaxDirectMemorySize=128m"}
 
 # Garbage collection options


### PR DESCRIPTION
### Motivation
After #15868, we allow `PULSAR_MEM` & `PULSAR_GC` to be overridden in `pulsar_tool_env.sh`.

Many users set `-Xms` to `2G` or larger in `PULSAR_MEM`, this will make the tools(such as `pulsar-admin`) cost a lot of memory, and if users execute `pulsar-admin` or another tool on the machine where the Broker is deployed, the current device will not have enough memory to allocate, resulting in a broker crash.

### Modifications

When `PULSAR_MEM` is overridden  in `pulsar_tool_env.sh`, delete parameter `-Xms`


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- https://github.com/poorbarcode/pulsar/pull/85