### PR TITLE
[fix][fn] Make /version return correct version

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/ConfigurationResource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/ConfigurationResource.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.functions.worker.rest;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -28,7 +29,7 @@ import org.apache.pulsar.PulsarVersion;
 @Path("/")
 public class ConfigurationResource {
 
-    private final static String VERSION = "{\"version\":\"" + PulsarVersion.getVersion() + "\"}";
+    private static final String VERSION = "{\"version\":\"" + PulsarVersion.getVersion() + "\"}";
 
     @Path("version")
     @GET

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/ConfigurationResource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/ConfigurationResource.java
@@ -26,23 +26,21 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 
 @Path("/")
 public class ConfigurationResource {
+
+    private final static String VERSION = "{\"version\":\"" + PulsarVersion.getVersion() + "\"}";
+
     @Path("version")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response release() throws JsonProcessingException {
-        final ObjectMapper mapper = ObjectMapperFactory.getMapper().getObjectMapper();
-        final ObjectNode node = mapper.createObjectNode();
-        node.put("version", "version.number");
-
         return Response.ok()
                 .type(MediaType.APPLICATION_JSON)
-                .entity(mapper
-                        .writerWithDefaultPrettyPrinter()
-                        .writeValueAsString(node))
+                .entity(VERSION)
                 .build();
     }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/ConfigurationResource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/ConfigurationResource.java
@@ -18,16 +18,12 @@
  */
 package org.apache.pulsar.functions.worker.rest;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.pulsar.PulsarVersion;
-import org.apache.pulsar.common.util.ObjectMapperFactory;
 
 @Path("/")
 public class ConfigurationResource {


### PR DESCRIPTION
### Motivation

The `/version` endpoint for functions currently returns `{"version":"version.number"}` instead of an actual version number. This PR fixes that.

One observation is that the broker's `/version` endpoint returns a plain string:

https://github.com/apache/pulsar/blob/82237d3684fe506bcb6426b3b23f413422e6e4fb/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java#L527-L535

### Modifications

* Return the actual version.
* Use a static field to decrease the cost of this endpoint.

### Verifying this change

This is a trivial change.

### Documentation

- [x] `doc-not-needed`

This fixes an endpoint, no docs are needed.

### Matching PR in forked repository

PR in forked repository: Skipping PR since this is so trivial