### PR TITLE
[fix] [ml] Fix uncompleted future when remove cursor

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -303,18 +303,20 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
                     callback.operationComplete(null, null);
                 }, executor.chooseThread(ledgerName))
                 .exceptionallyAsync(ex -> {
-                    Throwable actEx = FutureUtil.unwrapCompletionException(ex);
-                    if (actEx instanceof MetadataStoreException.NotFoundException){
-                        log.info("[{}] [{}] cursor delete done because it did not exist.", ledgerName, cursorName);
-                        callback.operationComplete(null, null);
+                    try {
+                        Throwable actEx = FutureUtil.unwrapCompletionException(ex);
+                        if (actEx instanceof MetadataStoreException.NotFoundException){
+                            log.info("[{}] [{}] cursor delete done because it did not exist.", ledgerName, cursorName);
+                            callback.operationComplete(null, null);
+                            return null;
+                        }
+                        callback.operationFailed(getException(ex));
+                        return null;
+                    } catch (Exception ex2){
+                        // do try-catch is just for print log and do not throw error to "executor".
+                        log.error("Unexpected throwable caught when executing callback of async remove cursor", ex2);
                         return null;
                     }
-                    try {
-                        callback.operationFailed(getException(ex));
-                    } catch (Exception ex2){
-                        log.error("Unexpected throwable caught when executing callback of async remove cursor", ex2);
-                    }
-                    return null;
                 }, executor.chooseThread(ledgerName));
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -308,6 +308,7 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
                         if (actEx instanceof MetadataStoreException.NotFoundException){
                             log.info("[{}] [{}] cursor delete done because it did not exist.", ledgerName, cursorName);
                             callback.operationComplete(null, null);
+                            return;
                         }
                         callback.operationFailed(getException(ex));
                     }));

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -309,7 +309,11 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
                         callback.operationComplete(null, null);
                         return null;
                     }
-                    SafeRunnable.safeRun(() -> callback.operationFailed(getException(ex)));
+                    try {
+                        callback.operationFailed(getException(ex));
+                    } catch (Exception ex2){
+                        log.error("Unexpected throwable caught when executing callback of async remove cursor", ex2);
+                    }
                     return null;
                 }, executor.chooseThread(ledgerName));
     }


### PR DESCRIPTION
### Motivation

In the method `MetaStoreImpl. asyncRemoveCursor`: 
```java
SafeRunnable.safeRun(() -> callback.operationFailed(getException(ex))); 
```
just creates a runnable but will not execute it.

### Modifications
 do run the task

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- https://github.com/poorbarcode/pulsar/pull/86