### PR TITLE
[fix] [txn] update txn status concurrently throw exception

### DIFF
--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
@@ -400,6 +400,14 @@ public class MLTransactionMetadataStore
                             appendLogCount.increment();
                             try {
                                 synchronized (txnMetaListPair.getLeft()) {
+                                    if (txnMetaListPair.getLeft().status() == newStatus) {
+                                        transactionLog.deletePosition(Collections.singletonList(position));
+                                        log.info("TxnID : {} has update txn status to {} repeatedly.",
+                                                txnMetaListPair.getLeft().id().toString(),
+                                                txnMetaListPair.getLeft().status().name());
+                                        promise.complete(null);
+                                        return;
+                                    }
                                     txnMetaListPair.getLeft().updateTxnStatus(newStatus, expectedStatus);
                                     txnMetaListPair.getRight().add(position);
                                 }

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/MLTransactionMetadataStoreTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/MLTransactionMetadataStoreTest.java
@@ -143,6 +143,71 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
         }
     }
 
+    @Test
+    public void testUpdateTxnStatusConcurrently() throws Exception {
+        TxnLogBufferedWriterConfig disabled = new TxnLogBufferedWriterConfig();
+        disabled.setBatchEnabled(false);
+
+        ManagedLedgerFactoryConfig factoryConf = new ManagedLedgerFactoryConfig();
+        factoryConf.setMaxCacheSize(0);
+
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(metadataStore, bkc, factoryConf);
+        TransactionCoordinatorID transactionCoordinatorID = new TransactionCoordinatorID(1);
+        ManagedLedgerConfig managedLedgerConfig = new ManagedLedgerConfig();
+        MLTransactionSequenceIdGenerator mlTransactionSequenceIdGenerator = new MLTransactionSequenceIdGenerator();
+        managedLedgerConfig.setManagedLedgerInterceptor(mlTransactionSequenceIdGenerator);
+        MLTransactionLogImpl mlTransactionLog = new MLTransactionLogImpl(transactionCoordinatorID, factory,
+                managedLedgerConfig, disabled, transactionTimer, DISABLED_BUFFERED_WRITER_METRICS);
+        mlTransactionLog.initialize().get(2, TimeUnit.SECONDS);
+        MLTransactionMetadataStore transactionMetadataStore =
+                new MLTransactionMetadataStore(transactionCoordinatorID, mlTransactionLog,
+                        new TransactionTimeoutTrackerImpl(),
+                        mlTransactionSequenceIdGenerator, 0L);
+        transactionMetadataStore.init(new TransactionRecoverTrackerImpl()).get();
+
+        if (transactionMetadataStore.checkIfReady()) {
+            TxnID txnID = transactionMetadataStore.newTransaction(5000, null).get();
+            assertEquals(transactionMetadataStore.getTxnStatus(txnID).get(), TxnStatus.OPEN);
+
+            List<String> partitions = new ArrayList<>();
+            partitions.add("pt-1");
+            partitions.add("pt-2");
+            transactionMetadataStore.addProducedPartitionToTxn(txnID, partitions).get();
+            assertEquals(transactionMetadataStore.getTxnMeta(txnID).get().producedPartitions(), partitions);
+
+            // update txn status OPEN->COMMITTING concurrently
+            List<CompletableFuture<Void>> list = new ArrayList<>();
+            list.add(transactionMetadataStore.updateTxnStatus(txnID, TxnStatus.COMMITTING, TxnStatus.OPEN, false));
+            list.add(transactionMetadataStore.updateTxnStatus(txnID, TxnStatus.COMMITTING, TxnStatus.OPEN, false));
+
+            try {
+                FutureUtil.waitForAll(list).get();
+            } catch (ExecutionException e) {
+                fail();
+            }
+            Assert.assertEquals(transactionMetadataStore.getTxnStatus(txnID).get(), TxnStatus.COMMITTING);
+
+            // update txn status COMMITTING->COMMITTED concurrently
+            List<CompletableFuture<Void>> list2 = new ArrayList<>();
+            list2.add(transactionMetadataStore.updateTxnStatus(txnID, TxnStatus.COMMITTED, TxnStatus.COMMITTING, false));
+            list2.add(transactionMetadataStore.updateTxnStatus(txnID, TxnStatus.COMMITTED, TxnStatus.COMMITTING, false));
+
+            try {
+                FutureUtil.waitForAll(list2).get();
+            } catch (ExecutionException e) {
+                fail();
+            }
+
+            try {
+                transactionMetadataStore.getTxnMeta(txnID).get();
+                fail();
+            } catch (ExecutionException e) {
+                Assert.assertTrue(e.getCause() instanceof TransactionNotFoundException);
+            }
+        }
+    }
+
     @DataProvider(name = "isUseManagedLedgerProperties")
     public Object[][] versions() {
         return new Object[][] { { true }, { false }};


### PR DESCRIPTION
### Motivation

When MLTransactionMetadataStore#updateTxnStatus concurrently, there is a case only one request succeed, other requests throw exception. 

### Modifications

If the newStatus == txnMeta.status(), it should not throw exception to client. Which is the same as https://github.com/apache/pulsar/blob/7ea8741af265bd8554e7a52a29a4ed59cb749dea/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java#L385-L388

1. judge "txnMetaListPair.getLeft().status() == newStatus" again after synchronize
2. add test


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/TakaHiR07/pulsar/pull/4

