### PR TITLE
[improve][broker] PIP-192: Redirect the request to current load manager

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LeaderElectionService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LeaderElectionService.java
@@ -37,7 +37,14 @@ public class LeaderElectionService implements AutoCloseable {
 
     public LeaderElectionService(CoordinationService cs, String localWebServiceAddress,
             Consumer<LeaderElectionState> listener) {
-        this.leaderElection = cs.getLeaderElection(LeaderBroker.class, ELECTION_ROOT, listener);
+        this(cs, localWebServiceAddress, ELECTION_ROOT, listener);
+    }
+
+    public LeaderElectionService(CoordinationService cs,
+                                 String localWebServiceAddress,
+                                 String electionRoot,
+                                 Consumer<LeaderElectionState> listener) {
+        this.leaderElection = cs.getLeaderElection(LeaderBroker.class, electionRoot, listener);
         this.localValue = new LeaderBroker(localWebServiceAddress);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/NoopLoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/NoopLoadManager.java
@@ -65,6 +65,7 @@ public class NoopLoadManager implements LoadManager {
                 pulsar.getWebServiceAddressTls(),
                 pulsar.getBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls(), pulsar.getAdvertisedListeners());
         localData.setProtocols(pulsar.getProtocolDataToAdvertise());
+        localData.setLoadManagerClassName(this.pulsar.getConfig().getLoadManagerClassName());
         String brokerReportPath = LoadManager.LOADBALANCE_BROKERS_ROOT + "/" + lookupServiceAddress;
 
         try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryImpl.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pulsar.broker.loadbalance.extensions;
 
+import static org.apache.pulsar.broker.loadbalance.LoadManager.LOADBALANCE_BROKERS_ROOT;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -50,8 +50,6 @@ import org.apache.pulsar.metadata.api.coordination.ResourceLock;
  */
 @Slf4j
 public class BrokerRegistryImpl implements BrokerRegistry {
-
-    protected static final String LOOKUP_DATA_PATH = "/loadbalance/extension/brokers";
 
     private final PulsarService pulsar;
 
@@ -94,6 +92,8 @@ public class BrokerRegistryImpl implements BrokerRegistry {
                 pulsar.getProtocolDataToAdvertise(),
                 pulsar.getConfiguration().isEnablePersistentTopics(),
                 pulsar.getConfiguration().isEnableNonPersistentTopics(),
+                conf.getLoadManagerClassName(),
+                System.currentTimeMillis(),
                 pulsar.getBrokerVersion());
         this.state = State.Init;
     }
@@ -151,7 +151,7 @@ public class BrokerRegistryImpl implements BrokerRegistry {
     @Override
     public CompletableFuture<List<String>> getAvailableBrokersAsync() {
         this.checkState();
-        return brokerLookupDataLockManager.listLocks(LOOKUP_DATA_PATH).thenApply(Lists::newArrayList);
+        return brokerLookupDataLockManager.listLocks(LOADBALANCE_BROKERS_ROOT).thenApply(ArrayList::new);
     }
 
     @Override
@@ -215,7 +215,7 @@ public class BrokerRegistryImpl implements BrokerRegistry {
                 return;
             }
             this.scheduler.submit(() -> {
-                String brokerId = t.getPath().substring(LOOKUP_DATA_PATH.length() + 1);
+                String brokerId = t.getPath().substring(LOADBALANCE_BROKERS_ROOT.length() + 1);
                 for (BiConsumer<String, NotificationType> listener : listeners) {
                     listener.accept(brokerId, t.getType());
                 }
@@ -227,12 +227,13 @@ public class BrokerRegistryImpl implements BrokerRegistry {
 
     @VisibleForTesting
     protected static boolean isVerifiedNotification(Notification t) {
-       return t.getPath().startsWith(LOOKUP_DATA_PATH + "/") && t.getPath().length() > LOOKUP_DATA_PATH.length() + 1;
+       return t.getPath().startsWith(LOADBALANCE_BROKERS_ROOT + "/")
+               && t.getPath().length() > LOADBALANCE_BROKERS_ROOT.length() + 1;
     }
 
     @VisibleForTesting
     protected static String keyPath(String brokerId) {
-        return String.format("%s/%s", LOOKUP_DATA_PATH, brokerId);
+        return String.format("%s/%s", LOADBALANCE_BROKERS_ROOT, brokerId);
     }
 
     private void checkState() throws IllegalStateException {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupData.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupData.java
@@ -36,6 +36,8 @@ public record BrokerLookupData (String webServiceUrl,
                                 Map<String, String> protocols,
                                 boolean persistentTopicsEnabled,
                                 boolean nonPersistentTopicsEnabled,
+                                String loadManagerClassName,
+                                long startTimestamp,
                                 String brokerVersion) implements ServiceLookupData {
     @Override
     public String getWebServiceUrl() {
@@ -65,6 +67,16 @@ public record BrokerLookupData (String webServiceUrl,
     @Override
     public Optional<String> getProtocol(String protocol) {
         return Optional.ofNullable(this.protocols().get(protocol));
+    }
+
+    @Override
+    public String getLoadManagerClassName() {
+        return this.loadManagerClassName;
+    }
+
+    @Override
+    public long getStartTimestamp() {
+        return this.startTimestamp;
     }
 
     public LookupResult toLookupResult() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerLoadManagerClassFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerLoadManagerClassFilter.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.extensions.filter;
+
+import java.util.Map;
+import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
+import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
+import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
+import org.apache.pulsar.common.naming.ServiceUnitId;
+
+public class BrokerLoadManagerClassFilter implements BrokerFilter {
+
+    public static final String FILTER_NAME = "broker_load_manager_class_filter";
+    @Override
+    public String name() {
+        return FILTER_NAME;
+    }
+
+    @Override
+    public Map<String, BrokerLookupData> filter(
+            Map<String, BrokerLookupData> brokers,
+            ServiceUnitId serviceUnit,
+            LoadManagerContext context)
+            throws BrokerFilterException {
+        if (brokers.isEmpty()) {
+            return brokers;
+        }
+        brokers.entrySet().removeIf(entry -> {
+            BrokerLookupData v = entry.getValue();
+            return !v.getLoadManagerClassName().equals(context.brokerConfiguration().getLoadManagerClassName());
+        });
+        return brokers;
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/manager/RedirectManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/manager/RedirectManager.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.extensions.manager;
+
+import static org.apache.pulsar.broker.loadbalance.LoadManager.LOADBALANCE_BROKERS_ROOT;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
+import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
+import org.apache.pulsar.broker.lookup.LookupResult;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.metadata.api.coordination.LockManager;
+import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
+
+@Slf4j
+public class RedirectManager {
+    private final PulsarService pulsar;
+
+    private final LockManager<BrokerLookupData> brokerLookupDataLockManager;
+
+
+    public RedirectManager(PulsarService pulsar) {
+        this.pulsar = pulsar;
+        this.brokerLookupDataLockManager = pulsar.getCoordinationService().getLockManager(BrokerLookupData.class);
+    }
+
+    public CompletableFuture<Map<String, BrokerLookupData>> getAvailableBrokerLookupDataAsync() {
+        return brokerLookupDataLockManager.listLocks(LOADBALANCE_BROKERS_ROOT).thenCompose(availableBrokers -> {
+            Map<String, BrokerLookupData> map = new ConcurrentHashMap<>();
+            List<CompletableFuture<Void>> futures = new ArrayList<>();
+            for (String brokerId : availableBrokers) {
+                futures.add(this.brokerLookupDataLockManager.readLock(
+                        String.format("%s/%s", LOADBALANCE_BROKERS_ROOT, brokerId)).thenAccept(lookupDataOpt -> {
+                    if (lookupDataOpt.isPresent()) {
+                        map.put(brokerId, lookupDataOpt.get());
+                    } else {
+                        log.warn("Got an empty lookup data, brokerId: {}", brokerId);
+                    }
+                }));
+            }
+
+            return FutureUtil.waitForAll(futures).thenApply(__ -> map);
+        });
+    }
+
+    public CompletableFuture<Optional<LookupResult>> findRedirectLookupResultAsync() {
+        String currentLMClassName = pulsar.getConfiguration().getLoadManagerClassName();
+        boolean debug = ExtensibleLoadManagerImpl.debug(pulsar.getConfig(), log);
+        return getAvailableBrokerLookupDataAsync().thenApply(lookupDataMap -> {
+            if (lookupDataMap.isEmpty()) {
+                String errorMsg = "No available broker found.";
+                log.warn(errorMsg);
+                throw new IllegalStateException(errorMsg);
+            }
+            AtomicReference<ServiceLookupData> latestServiceLookupData = new AtomicReference<>();
+            AtomicLong lastStartTimestamp = new AtomicLong(0L);
+            lookupDataMap.forEach((key, value) -> {
+                if (lastStartTimestamp.get() <= value.getStartTimestamp()) {
+                    lastStartTimestamp.set(value.getStartTimestamp());
+                    latestServiceLookupData.set(value);
+                }
+            });
+            if (latestServiceLookupData.get() == null) {
+                String errorMsg = "No latest service lookup data found.";
+                log.warn(errorMsg);
+                throw new IllegalStateException(errorMsg);
+            }
+            if (latestServiceLookupData.get().getLoadManagerClassName().equals(currentLMClassName)) {
+                if (debug) {
+                    log.info("We don't need to redirect, current load manager class name: {}",
+                            currentLMClassName);
+                }
+                return Optional.empty();
+            }
+            var serviceLookupDataObj = latestServiceLookupData.get();
+            var candidateBrokers = new ArrayList<ServiceLookupData>();
+            lookupDataMap.forEach((key, value) -> {
+                if (value.getLoadManagerClassName().equals(serviceLookupDataObj.getLoadManagerClassName())) {
+                    candidateBrokers.add(value);
+                }
+            });
+            var selectedBroker = candidateBrokers.get((int) (Math.random() * candidateBrokers.size()));
+
+            return Optional.of(new LookupResult(selectedBroker.getWebServiceUrl(),
+                    selectedBroker.getWebServiceUrlTls(),
+                    selectedBroker.getPulsarServiceUrl(),
+                    selectedBroker.getPulsarServiceUrlTls(),
+                    true));
+        });
+    }
+
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BrokerLoadManagerClassFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BrokerLoadManagerClassFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.impl;
+
+import java.util.Set;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.loadbalance.BrokerFilter;
+import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
+import org.apache.pulsar.broker.loadbalance.LoadData;
+import org.apache.pulsar.policies.data.loadbalancer.BundleData;
+
+public class BrokerLoadManagerClassFilter implements BrokerFilter {
+
+    @Override
+    public void filter(Set<String> brokers, BundleData bundleToAssign,
+                       LoadData loadData,
+                       ServiceConfiguration conf) throws BrokerFilterException {
+        loadData.getBrokerData().forEach((key, value) -> {
+            if (!value.getLocalData().getLoadManagerClassName()
+                    .equals(conf.getLoadManagerClassName())) {
+                brokers.remove(key);
+            }
+        });
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -267,6 +267,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
 
         placementStrategy = ModularLoadManagerStrategy.create(conf);
         policies = new SimpleResourceAllocationPolicies(pulsar);
+        filterPipeline.add(new BrokerLoadManagerClassFilter());
         filterPipeline.add(new BrokerVersionFilter());
 
         LoadManagerShared.refreshBrokerToFailureDomainMap(pulsar, brokerToFailureDomainMap);
@@ -960,6 +961,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
             // configure broker-topic mode
             localData.setPersistentTopicsEnabled(pulsar.getConfiguration().isEnablePersistentTopics());
             localData.setNonPersistentTopicsEnabled(pulsar.getConfiguration().isEnableNonPersistentTopics());
+            localData.setLoadManagerClassName(conf.getLoadManagerClassName());
 
             String lookupServiceAddress = pulsar.getLookupServiceAddress();
             brokerZnodePath = LoadManager.LOADBALANCE_BROKERS_ROOT + "/" + lookupServiceAddress;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -1090,6 +1090,8 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                 loadReport.setSystemResourceUsage(systemResourceUsage);
                 loadReport.setBundleStats(pulsar.getBrokerService().getBundleStats());
                 loadReport.setTimestamp(System.currentTimeMillis());
+                loadReport.setLoadManagerClassName(pulsar.getConfig().getLoadManagerClassName());
+                loadReport.setStartTimestamp(System.currentTimeMillis());
 
                 final Set<String> oldBundles = lastLoadReport.getBundles();
                 final Set<String> newBundles = loadReport.getBundles();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -56,6 +56,7 @@ import org.apache.pulsar.broker.loadbalance.LeaderElectionService;
 import org.apache.pulsar.broker.loadbalance.LoadManager;
 import org.apache.pulsar.broker.loadbalance.ResourceUnit;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
+import org.apache.pulsar.broker.loadbalance.extensions.manager.RedirectManager;
 import org.apache.pulsar.broker.lookup.LookupResult;
 import org.apache.pulsar.broker.resources.NamespaceResources;
 import org.apache.pulsar.broker.service.BrokerServiceException.ServiceUnitNotReadyException;
@@ -136,6 +137,7 @@ public class NamespaceService implements AutoCloseable {
     private final ConcurrentOpenHashMap<ClusterDataImpl, PulsarClientImpl> namespaceClients;
 
     private final List<NamespaceBundleOwnershipListener> bundleOwnershipListeners;
+    private final RedirectManager redirectManager;
 
 
     private static final Counter lookupRedirects = Counter.build("pulsar_broker_lookup_redirects", "-").register();
@@ -164,6 +166,7 @@ public class NamespaceService implements AutoCloseable {
                 ConcurrentOpenHashMap.<ClusterDataImpl, PulsarClientImpl>newBuilder().build();
         this.bundleOwnershipListeners = new CopyOnWriteArrayList<>();
         this.localBrokerDataCache = pulsar.getLocalMetadataStore().getMetadataCache(LocalBrokerData.class);
+        this.redirectManager = new RedirectManager(pulsar);
     }
 
     public void initialize() {
@@ -177,12 +180,20 @@ public class NamespaceService implements AutoCloseable {
 
         CompletableFuture<Optional<LookupResult>> future = getBundleAsync(topic)
                 .thenCompose(bundle -> {
-                    if (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(config)) {
-                        return loadManager.get().findBrokerServiceUrl(Optional.of(topic), bundle);
-                    } else {
-                        // TODO: Add unit tests cover it.
-                        return findBrokerServiceUrl(bundle, options);
-                    }
+                    // Do redirection if the cluster is in rollback or deploying.
+                    return redirectManager.findRedirectLookupResultAsync().thenCompose(optResult -> {
+                        if (optResult.isPresent()) {
+                            LOG.info("[{}] Redirect lookup request to {} for topic {}",
+                                    pulsar.getSafeWebServiceAddress(), optResult.get(), topic);
+                            return CompletableFuture.completedFuture(optResult);
+                        }
+                        if (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(config)) {
+                            return loadManager.get().findBrokerServiceUrl(Optional.of(topic), bundle);
+                        } else {
+                            // TODO: Add unit tests cover it.
+                            return findBrokerServiceUrl(bundle, options);
+                        }
+                    });
                 });
 
         future.thenAccept(optResult -> {
@@ -271,22 +282,40 @@ public class NamespaceService implements AutoCloseable {
                                                                       NamespaceBundle bundle,
                                                                       LookupOptions options) {
 
-        return (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(config)
-                ? loadManager.get().findBrokerServiceUrl(topic, bundle) :
-                // TODO: Add unit tests cover it.
-                findBrokerServiceUrl(bundle, options)).thenApply(lookupResult -> {
-            if (lookupResult.isPresent()) {
+        return redirectManager.findRedirectLookupResultAsync().thenCompose(optResult -> {
+            if (optResult.isPresent()) {
+                LOG.info("[{}] Redirect lookup request to {} for topic {}",
+                        pulsar.getSafeWebServiceAddress(), optResult.get(), topic);
                 try {
-                    LookupData lookupData = lookupResult.get().getLookupData();
+                    LookupData lookupData = optResult.get().getLookupData();
                     final String redirectUrl = options.isRequestHttps()
                             ? lookupData.getHttpUrlTls() : lookupData.getHttpUrl();
-                    return Optional.of(new URL(redirectUrl));
+                    return CompletableFuture.completedFuture(Optional.of(new URL(redirectUrl)));
                 } catch (Exception e) {
                     // just log the exception, nothing else to do
                     LOG.warn("internalGetWebServiceUrl [{}]", e.getMessage(), e);
                 }
+                return CompletableFuture.completedFuture(Optional.empty());
             }
-            return Optional.empty();
+            CompletableFuture<Optional<LookupResult>> future =
+                    ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(config)
+                    ? loadManager.get().findBrokerServiceUrl(topic, bundle) :
+                    findBrokerServiceUrl(bundle, options);
+
+            return future.thenApply(lookupResult -> {
+                if (lookupResult.isPresent()) {
+                    try {
+                        LookupData lookupData = lookupResult.get().getLookupData();
+                        final String redirectUrl = options.isRequestHttps()
+                                ? lookupData.getHttpUrlTls() : lookupData.getHttpUrl();
+                        return Optional.of(new URL(redirectUrl));
+                    } catch (Exception e) {
+                        // just log the exception, nothing else to do
+                        LOG.warn("internalGetWebServiceUrl [{}]", e.getMessage(), e);
+                    }
+                }
+                return Optional.empty();
+            });
         });
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.loadbalance.extensions;
 
+import static org.apache.pulsar.broker.loadbalance.LoadManager.LOADBALANCE_BROKERS_ROOT;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
@@ -379,19 +380,19 @@ public class BrokerRegistryTest {
     public void testIsVerifiedNotification() {
         assertFalse(BrokerRegistryImpl.isVerifiedNotification(new Notification(NotificationType.Created, "/")));
         assertFalse(BrokerRegistryImpl.isVerifiedNotification(new Notification(NotificationType.Created,
-                BrokerRegistryImpl.LOOKUP_DATA_PATH + "xyz")));
+                LOADBALANCE_BROKERS_ROOT + "xyz")));
         assertFalse(BrokerRegistryImpl.isVerifiedNotification(new Notification(NotificationType.Created,
-                BrokerRegistryImpl.LOOKUP_DATA_PATH)));
+                LOADBALANCE_BROKERS_ROOT)));
         assertTrue(BrokerRegistryImpl.isVerifiedNotification(
-                new Notification(NotificationType.Created, BrokerRegistryImpl.LOOKUP_DATA_PATH + "/brokerId")));
+                new Notification(NotificationType.Created, LOADBALANCE_BROKERS_ROOT + "/brokerId")));
         assertTrue(BrokerRegistryImpl.isVerifiedNotification(
-                new Notification(NotificationType.Created, BrokerRegistryImpl.LOOKUP_DATA_PATH + "/brokerId/xyz")));
+                new Notification(NotificationType.Created, LOADBALANCE_BROKERS_ROOT + "/brokerId/xyz")));
     }
 
     @Test
     public void testKeyPath() {
         String keyPath = BrokerRegistryImpl.keyPath("brokerId");
-        assertEquals(keyPath, BrokerRegistryImpl.LOOKUP_DATA_PATH + "/brokerId");
+        assertEquals(keyPath, LOADBALANCE_BROKERS_ROOT + "/brokerId");
     }
 
     public BrokerRegistryImpl.State getState(BrokerRegistryImpl brokerRegistry) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupDataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupDataTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.loadbalance.extensions.data;
 
+import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
 import org.apache.pulsar.broker.lookup.LookupResult;
 import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
 import org.junit.Assert;
@@ -41,7 +42,8 @@ public class BrokerLookupDataTest {
         }};
         BrokerLookupData lookupData = new BrokerLookupData(
                 webServiceUrl, webServiceUrlTls, pulsarServiceUrl,
-                pulsarServiceUrlTls, advertisedListeners, protocols, true, true, "3.0");
+                pulsarServiceUrlTls, advertisedListeners, protocols, true, true,
+                ExtensibleLoadManagerImpl.class.getName(), System.currentTimeMillis(),"3.0");
         Assert.assertEquals(webServiceUrl, lookupData.webServiceUrl());
         Assert.assertEquals(webServiceUrlTls, lookupData.webServiceUrlTls());
         Assert.assertEquals(pulsarServiceUrl, lookupData.pulsarServiceUrl());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerFilterTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerFilterTestBase.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLoadData;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
@@ -105,6 +106,10 @@ public class BrokerFilterTestBase {
     }
 
     public BrokerLookupData getLookupData(String version) {
+        return getLookupData(version, ExtensibleLoadManagerImpl.class.getName());
+    }
+
+    public BrokerLookupData getLookupData(String version, String loadManagerClassName) {
         String webServiceUrl = "http://localhost:8080";
         String webServiceUrlTls = "https://localhoss:8081";
         String pulsarServiceUrl = "pulsar://localhost:6650";
@@ -115,6 +120,7 @@ public class BrokerFilterTestBase {
         }};
         return new BrokerLookupData(
                 webServiceUrl, webServiceUrlTls, pulsarServiceUrl,
-                pulsarServiceUrlTls, advertisedListeners, protocols, true, true, version);
+                pulsarServiceUrlTls, advertisedListeners, protocols, true, true,
+                loadManagerClassName, -1, version);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerIsolationPoliciesFilterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerIsolationPoliciesFilterTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
+import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.loadbalance.extensions.policies.IsolationPoliciesHelper;
@@ -211,7 +212,8 @@ public class BrokerIsolationPoliciesFilterTest {
         return new BrokerLookupData(
                 webServiceUrl, webServiceUrlTls, pulsarServiceUrl,
                 pulsarServiceUrlTls, advertisedListeners, protocols,
-                persistentTopicsEnabled, nonPersistentTopicsEnabled, "3.0.0");
+                persistentTopicsEnabled, nonPersistentTopicsEnabled,
+                ExtensibleLoadManagerImpl.class.getName(), System.currentTimeMillis(), "3.0.0");
     }
 
     public LoadManagerContext getContext() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerLoadManagerClassFilterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerLoadManagerClassFilterTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.extensions.filter;
+
+import static org.testng.Assert.assertEquals;
+import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
+import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
+import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
+import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
+import org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl;
+import org.testng.annotations.Test;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Unit test for {@link BrokerLoadManagerClassFilter}.
+ */
+public class BrokerLoadManagerClassFilterTest extends BrokerFilterTestBase {
+
+    @Test
+    public void test() throws BrokerFilterException {
+        LoadManagerContext context = getContext();
+        context.brokerConfiguration().setLoadManagerClassName(ExtensibleLoadManagerImpl.class.getName());
+        BrokerLoadManagerClassFilter filter = new BrokerLoadManagerClassFilter();
+
+        Map<String, BrokerLookupData> originalBrokers = Map.of(
+                "broker1", getLookupData("3.0.0", ExtensibleLoadManagerImpl.class.getName()),
+                "broker2", getLookupData("3.0.0", ExtensibleLoadManagerImpl.class.getName()),
+                "broker3", getLookupData("3.0.0", ModularLoadManagerImpl.class.getName()),
+                "broker4", getLookupData("3.0.0", ModularLoadManagerImpl.class.getName())
+        );
+
+        Map<String, BrokerLookupData> result = filter.filter(new HashMap<>(originalBrokers), null, context);
+        assertEquals(result, Map.of(
+                "broker1", getLookupData("3.0.0", ExtensibleLoadManagerImpl.class.getName()),
+                "broker2", getLookupData("3.0.0", ExtensibleLoadManagerImpl.class.getName())
+        ));
+
+        context.brokerConfiguration().setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
+        result = filter.filter(new HashMap<>(originalBrokers), null, context);
+
+        assertEquals(result, Map.of(
+                "broker3", getLookupData("3.0.0", ModularLoadManagerImpl.class.getName()),
+                "broker4", getLookupData("3.0.0", ModularLoadManagerImpl.class.getName())
+        ));
+
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedderTest.java
@@ -664,7 +664,8 @@ public class TransferShedderTest {
         return new BrokerLookupData(
                 webServiceUrl, webServiceUrlTls, pulsarServiceUrl,
                 pulsarServiceUrlTls, advertisedListeners, protocols,
-                true, true, "3.0.0");
+                true, true,
+                conf.getLoadManagerClassName(), System.currentTimeMillis(), "3.0.0");
     }
 
     private void setIsolationPolicies(SimpleResourceAllocationPolicies policies,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/BrokerLoadManagerClassFilterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/BrokerLoadManagerClassFilterTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.impl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
+import org.apache.pulsar.broker.loadbalance.LoadData;
+import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
+import org.apache.pulsar.policies.data.loadbalancer.BrokerData;
+import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
+import org.testng.annotations.Test;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Unit test for {@link BrokerLoadManagerClassFilter}.
+ */
+public class BrokerLoadManagerClassFilterTest {
+
+    @Test
+    public void test() throws BrokerFilterException {
+        BrokerLoadManagerClassFilter filter = new BrokerLoadManagerClassFilter();
+
+        LoadData loadData = new LoadData();
+        LocalBrokerData localBrokerData = new LocalBrokerData();
+        localBrokerData.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
+
+        LocalBrokerData localBrokerData1 = new LocalBrokerData();
+        localBrokerData1.setLoadManagerClassName(ExtensibleLoadManagerImpl.class.getName());
+        loadData.getBrokerData().put("broker1", new BrokerData(localBrokerData));
+        loadData.getBrokerData().put("broker2", new BrokerData(localBrokerData1));
+
+        ServiceConfiguration conf = new ServiceConfiguration();
+        conf.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
+
+        Set<String> brokers = new HashSet<>(){{
+            add("broker1");
+            add("broker2");
+        }};
+        filter.filter(brokers, null, loadData, conf);
+
+        assertEquals(brokers.size(), 1);
+        assertTrue(brokers.contains("broker1"));
+
+        brokers = new HashSet<>(){{
+            add("broker1");
+            add("broker2");
+        }};
+        conf.setLoadManagerClassName(ExtensibleLoadManagerImpl.class.getName());
+        filter.filter(brokers, null, loadData, conf);
+        assertEquals(brokers.size(), 1);
+        assertTrue(brokers.contains("broker2"));
+    }
+}

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/policies/data/loadbalancer/ServiceLookupData.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/policies/data/loadbalancer/ServiceLookupData.java
@@ -48,4 +48,8 @@ public interface ServiceLookupData {
      */
     Optional<String> getProtocol(String protocol);
 
+    String getLoadManagerClassName();
+
+    long getStartTimestamp();
+
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LoadReport.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LoadReport.java
@@ -55,6 +55,8 @@ public class LoadReport implements LoadManagerReport {
     private int numProducers;
     private int numBundles;
     private Map<String, String> protocols;
+    private String loadManagerClassName;
+    private long startTimestamp;
     // This place-holder requires to identify correct LoadManagerReport type while deserializing
     @SuppressWarnings("checkstyle:ConstantName")
     public static final String loadReportType = LoadReport.class.getSimpleName();
@@ -473,5 +475,23 @@ public class LoadReport implements LoadManagerReport {
     @Override
     public Optional<String> getProtocol(String protocol) {
         return Optional.ofNullable(protocols.get(protocol));
+    }
+
+    @Override
+    public String getLoadManagerClassName() {
+        return this.loadManagerClassName;
+    }
+
+    public void setLoadManagerClassName(String loadManagerClassName) {
+        this.loadManagerClassName = loadManagerClassName;
+    }
+
+    @Override
+    public long getStartTimestamp() {
+        return this.startTimestamp;
+    }
+
+    public void setStartTimestamp(long startTimestamp) {
+        this.startTimestamp = startTimestamp;
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LocalBrokerData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LocalBrokerData.java
@@ -91,6 +91,9 @@ public class LocalBrokerData implements LoadManagerReport {
     //
     private Map<String, AdvertisedListener> advertisedListeners;
 
+    private String loadManagerClassName;
+    private long startTimestamp;
+
     // For JSON only.
     public LocalBrokerData() {
         this(null, null, null, null);
@@ -113,6 +116,7 @@ public class LocalBrokerData implements LoadManagerReport {
         this.pulsarServiceUrlTls = pulsarServiceUrlTls;
         lastStats = new ConcurrentHashMap<>();
         lastUpdate = System.currentTimeMillis();
+        startTimestamp = System.currentTimeMillis();
         cpu = new ResourceUsage();
         memory = new ResourceUsage();
         directMemory = new ResourceUsage();
@@ -528,5 +532,17 @@ public class LocalBrokerData implements LoadManagerReport {
 
     public void setAdvertisedListeners(Map<String, AdvertisedListener> advertisedListeners) {
         this.advertisedListeners = advertisedListeners;
+    }
+
+    public String getLoadManagerClassName() {
+        return this.loadManagerClassName;
+    }
+
+    public void setLoadManagerClassName(String loadManagerClassName) {
+        this.loadManagerClassName = loadManagerClassName;
+    }
+
+    public long getStartTimestamp() {
+        return this.startTimestamp;
     }
 }


### PR DESCRIPTION
PIP: https://github.com/apache/pulsar/issues/16691

### Motivation

Currently, when we are deploying or rollback the load manager, 
we might get a different bundle owner from the old and new broker,
it will cause producer or consumer to fail.

### Modifications

After this PR, when do the lookup, it will check if we are doing deploy or rollback,
and forward the request to the correct broker.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->