### PR TITLE
[improve] [txn] respond to client when txn update status to committing or aborting

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedTransactionCoordinatorStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedTransactionCoordinatorStats.java
@@ -32,6 +32,8 @@ public class AggregatedTransactionCoordinatorStats {
 
     public long appendLogCount;
 
+    public long nonRetryableCount;
+
     public long[] executionLatency;
 
     public void reset() {
@@ -41,6 +43,7 @@ public class AggregatedTransactionCoordinatorStats {
         createdCount = 0;
         timeoutCount = 0;
         appendLogCount = 0;
+        nonRetryableCount = 0;
         executionLatency = null;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
@@ -96,6 +96,8 @@ public class TransactionAggregator {
                             transactionMetadataStoreStats.getTimeoutCount();
                     transactionCoordinatorStats.appendLogCount =
                             transactionMetadataStoreStats.getAppendLogCount();
+                    transactionCoordinatorStats.nonRetryableCount =
+                            transactionMetadataStoreStats.getNonRetryableCount();
                     transactionMetadataStoreStats.executionLatencyBuckets.refresh();
                     transactionCoordinatorStats.executionLatency =
                             transactionMetadataStoreStats.executionLatencyBuckets.getBuckets();
@@ -250,6 +252,8 @@ public class TransactionAggregator {
         writeMetric(stream, "pulsar_txn_timeout_total", stats.timeoutCount, cluster,
                 coordinatorId);
         writeMetric(stream, "pulsar_txn_append_log_total", stats.appendLogCount, cluster,
+                coordinatorId);
+        writeMetric(stream, "pulsar_txn_non_retryable_total", stats.nonRetryableCount, cluster,
                 coordinatorId);
         long[] latencyBuckets = stats.executionLatency;
         writeMetric(stream, "pulsar_txn_execution_latency_le_10", latencyBuckets[0], cluster, coordinatorId);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionMetricsTest.java
@@ -227,6 +227,10 @@ public class TransactionMetricsTest extends BrokerTestBase {
         assertEquals(metric.size(), 1);
         metric.forEach(item -> assertEquals(item.value, txnCount * 4 + 3));
 
+        metric = metrics.get("pulsar_txn_non_retryable_total");
+        assertEquals(metric.size(), 1);
+        metric.forEach(item -> assertEquals(item.value, 0));
+
         metric = metrics.get("pulsar_txn_execution_latency_le_5000");
         assertEquals(metric.size(), 1);
         metric.forEach(item -> assertEquals(item.value, 1));

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStore.java
@@ -139,4 +139,6 @@ public interface TransactionMetadataStore {
      * @return {@link TxnMeta} the txnMetas of slow transactions
      */
     List<TxnMeta> getSlowTransactions(long timeout);
+
+    void incrementNonRetryableCount();
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/InMemTransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/InMemTransactionMetadataStore.java
@@ -48,6 +48,7 @@ class InMemTransactionMetadataStore implements TransactionMetadataStore {
     private final LongAdder commitTransactionCount;
     private final LongAdder abortTransactionCount;
     private final LongAdder transactionTimeoutCount;
+    private final LongAdder nonRetryableCount;
 
     InMemTransactionMetadataStore(TransactionCoordinatorID tcID) {
         this.tcID = tcID;
@@ -58,7 +59,7 @@ class InMemTransactionMetadataStore implements TransactionMetadataStore {
         this.commitTransactionCount = new LongAdder();
         this.abortTransactionCount = new LongAdder();
         this.transactionTimeoutCount = new LongAdder();
-
+        this.nonRetryableCount = new LongAdder();
     }
 
     @Override
@@ -164,5 +165,10 @@ class InMemTransactionMetadataStore implements TransactionMetadataStore {
     @Override
     public List<TxnMeta> getSlowTransactions(long timeout) {
         return null;
+    }
+
+    @Override
+    public void incrementNonRetryableCount() {
+        nonRetryableCount.increment();
     }
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
@@ -78,6 +78,7 @@ public class MLTransactionMetadataStore
     private final LongAdder abortedTransactionCount;
     private final LongAdder transactionTimeoutCount;
     private final LongAdder appendLogCount;
+    private final LongAdder nonRetryableCount;
     private final MLTransactionSequenceIdGenerator sequenceIdGenerator;
     private final ExecutorService internalPinnedExecutor;
     public final RecoverTimeRecord recoverTime = new RecoverTimeRecord();
@@ -100,6 +101,7 @@ public class MLTransactionMetadataStore
         this.committedTransactionCount = new LongAdder();
         this.abortedTransactionCount = new LongAdder();
         this.transactionTimeoutCount = new LongAdder();
+        this.nonRetryableCount = new LongAdder();
         this.appendLogCount = new LongAdder();
         DefaultThreadFactory threadFactory = new DefaultThreadFactory("transaction_coordinator_"
                 + tcID.toString() + "thread_factory");
@@ -465,6 +467,11 @@ public class MLTransactionMetadataStore
         return transactionCoordinatorstats;
     }
 
+    @Override
+    public void incrementNonRetryableCount() {
+        nonRetryableCount.increment();
+    }
+
     private CompletableFuture<Pair<TxnMeta, List<Position>>> getTxnPositionPair(TxnID txnID) {
         CompletableFuture<Pair<TxnMeta, List<Position>>> completableFuture = new CompletableFuture<>();
         Pair<TxnMeta, List<Position>> txnMetaListPair = txnMetaMap.get(txnID.getLeastSigBits());
@@ -507,6 +514,7 @@ public class MLTransactionMetadataStore
         this.transactionMetadataStoreStats.setAbortedCount(this.abortedTransactionCount.longValue());
         this.transactionMetadataStoreStats.setTimeoutCount(this.transactionTimeoutCount.longValue());
         this.transactionMetadataStoreStats.setAppendLogCount(this.appendLogCount.longValue());
+        this.transactionMetadataStoreStats.setNonRetryableCount(this.nonRetryableCount.longValue());
         return transactionMetadataStoreStats;
     }
 

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/TransactionMetadataStoreStats.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/TransactionMetadataStoreStats.java
@@ -51,6 +51,9 @@ public class TransactionMetadataStoreStats {
     /** The timeout out transaction count of this transaction coordinator. */
     public long timeoutCount;
 
+    /** The non retryable exception count of this transaction coordinator. */
+    public long nonRetryableCount;
+
     /** The transaction execution latency. */
     public StatsBuckets executionLatencyBuckets = new StatsBuckets(TRANSACTION_EXECUTION_BUCKETS);
 


### PR DESCRIPTION
Master Issue: #19747 

### Motivation

Related to issue, endTxn behave as kafka. 

When txn status update to committing/aborting, respond success to client.

### Modifications

1. finish future when update txn status to committing/aborting successfully, then asynchronously process committing->committed
2. retry committing->committed when occur retryable exception
3. In case of failing to process committing->committed, add a metric to record unexpected nonRetryable exception count when tc is still available

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/TakaHiR07/pulsar/pull/6

