### PR TITLE
[fix][broker] Fix tenant admin authorization bug.

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -186,7 +186,7 @@ public class AuthorizationService {
             if (isSuperUser) {
                 return CompletableFuture.completedFuture(true);
             } else {
-                return provider.canProduceAsync(topicName, role, authenticationData);
+                return provider.allowTopicOperationAsync(topicName, role, TopicOperation.PRODUCE, authenticationData);
             }
         });
     }
@@ -211,7 +211,7 @@ public class AuthorizationService {
             if (isSuperUser) {
                 return CompletableFuture.completedFuture(true);
             } else {
-                return provider.canConsumeAsync(topicName, role, authenticationData, subscription);
+                return provider.allowTopicOperationAsync(topicName, role, TopicOperation.CONSUME, authenticationData);
             }
         });
     }
@@ -293,7 +293,7 @@ public class AuthorizationService {
             if (isSuperUser) {
                 return CompletableFuture.completedFuture(true);
             } else {
-                return provider.canLookupAsync(topicName, role, authenticationData);
+                return provider.allowTopicOperationAsync(topicName, role, TopicOperation.LOOKUP, authenticationData);
             }
         });
     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSubscription;
 import org.apache.pulsar.broker.authentication.AuthenticationParameters;
 import org.apache.pulsar.broker.resources.PulsarResources;
 import org.apache.pulsar.common.naming.NamespaceName;
@@ -182,13 +183,7 @@ public class AuthorizationService {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
-        return provider.isSuperUser(role, authenticationData, conf).thenComposeAsync(isSuperUser -> {
-            if (isSuperUser) {
-                return CompletableFuture.completedFuture(true);
-            } else {
-                return provider.allowTopicOperationAsync(topicName, role, TopicOperation.PRODUCE, authenticationData);
-            }
-        });
+        return provider.allowTopicOperationAsync(topicName, role, TopicOperation.PRODUCE, authenticationData);
     }
 
     /**
@@ -207,13 +202,9 @@ public class AuthorizationService {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
-        return provider.isSuperUser(role, authenticationData, conf).thenComposeAsync(isSuperUser -> {
-            if (isSuperUser) {
-                return CompletableFuture.completedFuture(true);
-            } else {
-                return provider.allowTopicOperationAsync(topicName, role, TopicOperation.CONSUME, authenticationData);
-            }
-        });
+
+        return provider.allowTopicOperationAsync(topicName, role, TopicOperation.CONSUME,
+                new AuthenticationDataSubscription(authenticationData, subscription));
     }
 
     public boolean canProduce(TopicName topicName, String role, AuthenticationDataSource authenticationData)
@@ -289,13 +280,7 @@ public class AuthorizationService {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
-        return provider.isSuperUser(role, authenticationData, conf).thenComposeAsync(isSuperUser -> {
-            if (isSuperUser) {
-                return CompletableFuture.completedFuture(true);
-            } else {
-                return provider.allowTopicOperationAsync(topicName, role, TopicOperation.LOOKUP, authenticationData);
-            }
-        });
+        return provider.allowTopicOperationAsync(topicName, role, TopicOperation.LOOKUP, authenticationData);
     }
 
     public CompletableFuture<Boolean> allowFunctionOpsAsync(NamespaceName namespaceName, String role,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -85,9 +85,9 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
     public CompletableFuture<Boolean> canProduceAsync(TopicName topicName, String role,
             AuthenticationDataSource authenticationData) {
         return validateTenantAdminAccess(topicName.getTenant(), role, authenticationData)
-                .thenComposeAsync(isSuperUserOrAdmin -> {
+                .thenCompose(isSuperUserOrAdmin -> {
                     if (log.isDebugEnabled()) {
-                        log.debug("Verify if role {} is allowed to consume topic {}: isSuperUserOrAdmin={}",
+                        log.debug("Verify if role {} is allowed to produce topic {}: isSuperUserOrAdmin={}",
                                 role, topicName, isSuperUserOrAdmin);
                     }
                     if (isSuperUserOrAdmin) {
@@ -112,57 +112,59 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
     @Override
     public CompletableFuture<Boolean> canConsumeAsync(TopicName topicName, String role,
             AuthenticationDataSource authenticationData, String subscription) {
-        return validateTenantAdminAccess(topicName.getTenant(), role, authenticationData).exceptionally(ex -> {
-            log.warn("Client with Role - {} failed to check tenant admin for topic - {}. {}", role, topicName,
-                    ex.getMessage());
-            return false;
-        }).thenComposeAsync(isSuperUserOrAdmin -> {
-            if (log.isDebugEnabled()) {
-                log.debug("Verify if role {} is allowed to consume topic {}: isSuperUserOrAdmin={}",
-                        role, topicName, isSuperUserOrAdmin);
-            }
-            if (isSuperUserOrAdmin) {
-                return CompletableFuture.completedFuture(true);
-            } else {
-                return pulsarResources.getNamespaceResources().getPoliciesAsync(topicName.getNamespaceObject())
-                        .thenCompose(policies -> {
-                            if (!policies.isPresent()) {
-                                if (log.isDebugEnabled()) {
-                                    log.debug("Policies node couldn't be found for topic : {}", topicName);
-                                }
-                            } else {
-                                if (isNotBlank(subscription)) {
-                                    // validate if role is authorized to access subscription. (skip validation if authorization
-                                    // list is empty)
-                                    Set<String> roles = policies.get().auth_policies
-                                            .getSubscriptionAuthentication().get(subscription);
-                                    if (roles != null && !roles.isEmpty() && !roles.contains(role)) {
-                                        log.warn("[{}] is not authorized to subscribe on {}-{}", role, topicName, subscription);
-                                        return CompletableFuture.completedFuture(false);
-                                    }
+        return validateTenantAdminAccess(topicName.getTenant(), role, authenticationData)
+                .thenCompose(isSuperUserOrAdmin -> {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Verify if role {} is allowed to consume topic {}: isSuperUserOrAdmin={}",
+                                role, topicName, isSuperUserOrAdmin);
+                    }
+                    if (isSuperUserOrAdmin) {
+                        return CompletableFuture.completedFuture(true);
+                    } else {
+                        return pulsarResources.getNamespaceResources().getPoliciesAsync(topicName.getNamespaceObject())
+                                .thenCompose(policies -> {
+                                    if (!policies.isPresent()) {
+                                        if (log.isDebugEnabled()) {
+                                            log.debug("Policies node couldn't be found for topic : {}", topicName);
+                                        }
+                                    } else {
+                                        if (isNotBlank(subscription)) {
+                                            // validate if role is authorized to access subscription.
+                                            // (skip validation if authorization list is empty)
+                                            Set<String> roles = policies.get().auth_policies
+                                                    .getSubscriptionAuthentication().get(subscription);
+                                            if (roles != null && !roles.isEmpty() && !roles.contains(role)) {
+                                                log.warn("[{}] is not authorized to subscribe on {}-{}",
+                                                        role, topicName, subscription);
+                                                return CompletableFuture.completedFuture(false);
+                                            }
 
-                                    // validate if subscription-auth mode is configured
-                                    if (policies.get().subscription_auth_mode != null) {
-                                        switch (policies.get().subscription_auth_mode) {
-                                            case Prefix:
-                                                if (!subscription.startsWith(role)) {
-                                                    PulsarServerException ex = new PulsarServerException(String.format(
-                                                            "Failed to create consumer - The subscription name needs to be"
-                                                                    + " prefixed by the authentication role, like %s-xxxx for topic: %s",
-                                                            role, topicName));
-                                                    return FutureUtil.failedFuture(ex);
+                                            // validate if subscription-auth mode is configured
+                                            if (policies.get().subscription_auth_mode != null) {
+                                                switch (policies.get().subscription_auth_mode) {
+                                                    case Prefix:
+                                                        if (!subscription.startsWith(role)) {
+                                                            PulsarServerException ex =
+                                                                    new PulsarServerException(String.format(
+                                                                            "Failed to create consumer - The "
+                                                                                    + "subscription name needs to be"
+                                                                                    + " prefixed by the "
+                                                                                    + "authentication role, like "
+                                                                                    + "%s-xxxx for topic: %s",
+                                                                            role, topicName));
+                                                            return FutureUtil.failedFuture(ex);
+                                                        }
+                                                        break;
+                                                    default:
+                                                        break;
                                                 }
-                                                break;
-                                            default:
-                                                break;
+                                            }
                                         }
                                     }
-                                }
-                            }
-                            return checkAuthorization(topicName, role, AuthAction.consume);
-                        });
-            }
-        });
+                                    return checkAuthorization(topicName, role, AuthAction.consume);
+                                });
+                    }
+                });
     }
 
     /**

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -84,7 +84,18 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
     @Override
     public CompletableFuture<Boolean> canProduceAsync(TopicName topicName, String role,
             AuthenticationDataSource authenticationData) {
-        return checkAuthorization(topicName, role, AuthAction.produce);
+        return validateTenantAdminAccess(topicName.getTenant(), role, authenticationData)
+                .thenComposeAsync(isSuperUserOrAdmin -> {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Verify if role {} is allowed to consume topic {}: isSuperUserOrAdmin={}",
+                                role, topicName, isSuperUserOrAdmin);
+                    }
+                    if (isSuperUserOrAdmin) {
+                        return CompletableFuture.completedFuture(true);
+                    } else {
+                        return checkAuthorization(topicName, role, AuthAction.produce);
+                    }
+                });
     }
 
     /**
@@ -101,43 +112,57 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
     @Override
     public CompletableFuture<Boolean> canConsumeAsync(TopicName topicName, String role,
             AuthenticationDataSource authenticationData, String subscription) {
-        return pulsarResources.getNamespaceResources().getPoliciesAsync(topicName.getNamespaceObject())
-                .thenCompose(policies -> {
-                    if (!policies.isPresent()) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Policies node couldn't be found for topic : {}", topicName);
-                        }
-                    } else {
-                        if (isNotBlank(subscription)) {
-                            // validate if role is authorized to access subscription. (skip validation if authorization
-                            // list is empty)
-                            Set<String> roles = policies.get().auth_policies
-                                    .getSubscriptionAuthentication().get(subscription);
-                            if (roles != null && !roles.isEmpty() && !roles.contains(role)) {
-                                log.warn("[{}] is not authorized to subscribe on {}-{}", role, topicName, subscription);
-                                return CompletableFuture.completedFuture(false);
-                            }
+        return validateTenantAdminAccess(topicName.getTenant(), role, authenticationData).exceptionally(ex -> {
+            log.warn("Client with Role - {} failed to check tenant admin for topic - {}. {}", role, topicName,
+                    ex.getMessage());
+            return false;
+        }).thenComposeAsync(isSuperUserOrAdmin -> {
+            if (log.isDebugEnabled()) {
+                log.debug("Verify if role {} is allowed to consume topic {}: isSuperUserOrAdmin={}",
+                        role, topicName, isSuperUserOrAdmin);
+            }
+            if (isSuperUserOrAdmin) {
+                return CompletableFuture.completedFuture(true);
+            } else {
+                return pulsarResources.getNamespaceResources().getPoliciesAsync(topicName.getNamespaceObject())
+                        .thenCompose(policies -> {
+                            if (!policies.isPresent()) {
+                                if (log.isDebugEnabled()) {
+                                    log.debug("Policies node couldn't be found for topic : {}", topicName);
+                                }
+                            } else {
+                                if (isNotBlank(subscription)) {
+                                    // validate if role is authorized to access subscription. (skip validation if authorization
+                                    // list is empty)
+                                    Set<String> roles = policies.get().auth_policies
+                                            .getSubscriptionAuthentication().get(subscription);
+                                    if (roles != null && !roles.isEmpty() && !roles.contains(role)) {
+                                        log.warn("[{}] is not authorized to subscribe on {}-{}", role, topicName, subscription);
+                                        return CompletableFuture.completedFuture(false);
+                                    }
 
-                            // validate if subscription-auth mode is configured
-                            if (policies.get().subscription_auth_mode != null) {
-                                switch (policies.get().subscription_auth_mode) {
-                                    case Prefix:
-                                        if (!subscription.startsWith(role)) {
-                                            PulsarServerException ex = new PulsarServerException(String.format(
-                                                 "Failed to create consumer - The subscription name needs to be"
-                                                 + " prefixed by the authentication role, like %s-xxxx for topic: %s",
-                                                 role, topicName));
-                                            return FutureUtil.failedFuture(ex);
+                                    // validate if subscription-auth mode is configured
+                                    if (policies.get().subscription_auth_mode != null) {
+                                        switch (policies.get().subscription_auth_mode) {
+                                            case Prefix:
+                                                if (!subscription.startsWith(role)) {
+                                                    PulsarServerException ex = new PulsarServerException(String.format(
+                                                            "Failed to create consumer - The subscription name needs to be"
+                                                                    + " prefixed by the authentication role, like %s-xxxx for topic: %s",
+                                                            role, topicName));
+                                                    return FutureUtil.failedFuture(ex);
+                                                }
+                                                break;
+                                            default:
+                                                break;
                                         }
-                                        break;
-                                    default:
-                                        break;
+                                    }
                                 }
                             }
-                        }
-                    }
-                    return checkAuthorization(topicName, role, AuthAction.consume);
-                });
+                            return checkAuthorization(topicName, role, AuthAction.consume);
+                        });
+            }
+        });
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
@@ -82,7 +82,8 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
         assertFalse(auth.canLookup(TopicName.get("persistent://p1/c1/ns1/ds1"), "my-role", null));
 
         admin.clusters().createCluster("c1", ClusterData.builder().build());
-        admin.tenants().createTenant("p1", new TenantInfoImpl(Sets.newHashSet("role1"), Sets.newHashSet("c1")));
+        String tenantAdmin = "role1";
+        admin.tenants().createTenant("p1", new TenantInfoImpl(Sets.newHashSet(tenantAdmin), Sets.newHashSet("c1")));
         waitForChange();
         admin.namespaces().createNamespace("p1/c1/ns1");
         waitForChange();
@@ -215,20 +216,21 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
                 SubscriptionAuthMode.Prefix);
         waitForChange();
 
-        assertTrue(auth.canLookup(TopicName.get("persistent://p1/c1/ns1/ds1"), "role1", null));
+        assertTrue(auth.canLookup(TopicName.get("persistent://p1/c1/ns1/ds1"), tenantAdmin, null));
         assertTrue(auth.canLookup(TopicName.get("persistent://p1/c1/ns1/ds1"), "role2", null));
-        try {
-            assertFalse(auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), "role1", null, "sub1"));
-            fail();
-        } catch (Exception ignored) {}
+        // tenant admin can consume all topics, even if SubscriptionAuthMode.Prefix mode
+        assertTrue(auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), tenantAdmin, null, "sub1"));
         try {
             assertFalse(auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), "role2", null, "sub2"));
             fail();
         } catch (Exception ignored) {}
 
-        assertTrue(auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), "role1", null, "role1-sub1"));
+        assertTrue(auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), tenantAdmin, null, "role1-sub1"));
         assertTrue(auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), "role2", null, "role2-sub2"));
         assertTrue(auth.canConsume(TopicName.get("persistent://p1/c1/ns1/ds1"), "pulsar.super_user", null, "role3-sub1"));
+
+        // tenant admin can produce all topics
+        assertTrue(auth.canProduce(TopicName.get("persistent://p1/c1/ns1/ds1"), tenantAdmin, null));
 
         admin.namespaces().deleteNamespace("p1/c1/ns1");
         admin.tenants().deleteTenant("p1");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
@@ -79,8 +79,10 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
     public void simple() throws Exception {
         AuthorizationService auth = pulsar.getBrokerService().getAuthorizationService();
 
-        assertFalse(auth.canLookup(TopicName.get("persistent://p1/c1/ns1/ds1"), "my-role", null));
-
+        try {
+            assertFalse(auth.canLookup(TopicName.get("persistent://p1/c1/ns1/ds1"), "my-role", null));
+            fail("Should throw exception while tenant not exist");
+        } catch (Exception ignored) {}
         admin.clusters().createCluster("c1", ClusterData.builder().build());
         String tenantAdmin = "role1";
         admin.tenants().createTenant("p1", new TenantInfoImpl(Sets.newHashSet(tenantAdmin), Sets.newHashSet("c1")));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
@@ -81,7 +81,7 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
 
         try {
             assertFalse(auth.canLookup(TopicName.get("persistent://p1/c1/ns1/ds1"), "my-role", null));
-            fail("Should throw exception while tenant not exist");
+            fail("Should throw exception when tenant not exist");
         } catch (Exception ignored) {}
         admin.clusters().createCluster("c1", ClusterData.builder().build());
         String tenantAdmin = "role1";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -1036,6 +1036,22 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
         }
 
         @Override
+        public CompletableFuture<Boolean> allowTopicOperationAsync(TopicName topic, String role,
+                                                                   TopicOperation operation,
+                                                                   AuthenticationDataSource authData) {
+            switch (operation) {
+
+                case PRODUCE:
+                    return canProduceAsync(topic, role, authData);
+                case CONSUME:
+                    return canConsumeAsync(topic, role, authData, authData.getSubscription());
+                case LOOKUP:
+                    return canLookupAsync(topic, role, authData);
+            }
+            return super.allowTopicOperationAsync(topic, role, operation, authData);
+        }
+
+        @Override
         public CompletableFuture<Void> grantPermissionAsync(NamespaceName namespace, Set<AuthAction> actions,
                 String role, String authData) {
             this.authDataJson = authData;


### PR DESCRIPTION
Fixes #20066 

### Motivation

Fixes the bug that producers/consumers will all disconnect while using tenant admin to produce/consume.

The root cause is that the permission check logic is not the same bewteen `org.apache.pulsar.broker.service.ServerCnx` and `org.apache.pulsar.broker.service.persistent.PersistentTopic#onPoliciesUpdate`.

In `org.apache.pulsar.broker.service.ServerCnx`, while `handleProducer` and `handleSubscribe`, the permission check will go to `isTopicOperationAllowed` and finally be processed by `org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider#allowTopicOperationAsync`, which will `validateTenantAdminAccess`. Everything is fine.

In `org.apache.pulsar.broker.service.persistent.PersistentTopic#onPoliciesUpdate`, it checks the permission by `producer.checkPermissionsAsync` and `consumer.checkPermissionsAsync`. Let's take the processing logic of the producer as an example. It will be processed by `org.apache.pulsar.broker.authorization.AuthorizationService#canProduceAsync` and finally `org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider#canProduceAsync`. The tenant admin can not pass the check.

### Modifications

Update `org.apache.pulsar.broker.authorization.AuthorizationProvider#canProduceAsync` to `org.apache.pulsar.broker.authorization.AuthorizationProvider#allowTopicOperationAsync` in `org.apache.pulsar.broker.authorization.AuthorizationService#canProduceAsync`. So do `org.apache.pulsar.broker.authorization.AuthorizationService#canConsumeAsync` and ``org.apache.pulsar.broker.authorization.AuthorizationService#canLookupAsync``

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - *Added and fixed the test in `org.apache.pulsar.broker.auth.AuthorizationTest#simple`*
  - *Added and fixed the test in `org.apache.pulsar.websocket.proxy.ProxyAuthorizationTest`*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dragonls/pulsar/pull/7

