### PR TITLE
[branch-2.11] [fix] [broker] Fix estimateBacklogFromPosition if position is greater than the greatest ledgerId

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -113,6 +113,8 @@ public class ManagedCursorImpl implements ManagedCursor {
             return e1.getEntryId() < e2.getEntryId() ? -1 : 1;
         }
 
+
+
         return 0;
     };
     protected final BookKeeper bookkeeper;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -113,8 +113,6 @@ public class ManagedCursorImpl implements ManagedCursor {
             return e1.getEntryId() < e2.getEntryId() ? -1 : 1;
         }
 
-
-
         return 0;
     };
     protected final BookKeeper bookkeeper;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1255,18 +1255,16 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     long estimateBacklogFromPosition(PositionImpl pos) {
         synchronized (this) {
+            long sizeBeforePosLedger = ledgers.headMap(pos.getLedgerId()).values()
+                    .stream().mapToLong(LedgerInfo::getSize).sum();
             LedgerInfo ledgerInfo = ledgers.get(pos.getLedgerId());
+            long sizeAfter = getTotalSize() - sizeBeforePosLedger;
             if (ledgerInfo == null) {
-                return getTotalSize(); // position no longer in managed ledger, so return total size
-            }
-            long sizeBeforePosLedger = ledgers.values().stream().filter(li -> li.getLedgerId() < pos.getLedgerId())
-                    .mapToLong(LedgerInfo::getSize).sum();
-            long size = getTotalSize() - sizeBeforePosLedger;
-
-            if (pos.getLedgerId() == currentLedger.getId()) {
-                return size - consumedLedgerSize(currentLedgerSize, currentLedgerEntries, pos.getEntryId());
+                return sizeAfter;
+            } else if (pos.getLedgerId() == currentLedger.getId()) {
+                return sizeAfter - consumedLedgerSize(currentLedgerSize, currentLedgerEntries, pos.getEntryId());
             } else {
-                return size - consumedLedgerSize(ledgerInfo.getSize(), ledgerInfo.getEntries(), pos.getEntryId());
+                return sizeAfter - consumedLedgerSize(ledgerInfo.getSize(), ledgerInfo.getEntries(), pos.getEntryId());
             }
         }
     }
@@ -1275,7 +1273,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (ledgerEntries <= 0) {
             return 0;
         }
-        if (ledgerEntries == (consumedEntries + 1)) {
+        if (ledgerEntries <= (consumedEntries + 1)) {
             return ledgerSize;
         } else {
             long averageSize = ledgerSize / ledgerEntries;


### PR DESCRIPTION
Cherry-pick #19017

In release 2.11.1, I found that `testGetEstimatedBacklogSize` was failed, and then I found that the logic of the #19017 change did not reach branch2.11, but the test did. So cherry pick this to branch-2.11

### Motivation

- Fix bug: If the input paramter `position` is greater than the greatest ledgerId in `ManagedLedgerImpl#ledgers`,  the `estimateBacklogFromPosition` should return 0,  instead of `getTotalSize()`
- Improve: Using `java.util.NavigableMap#tailMap(K)` to calculate the `size`, which will avoid traversal the whole `ManagedLedgerImpl#ledgers`


### Verifying this change

- [x] Make sure that the change passes the CI checks.
- Add ut `ManagedLedgerTest#testGetEstimatedBacklogSize` to test this change

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
