### PR TITLE
[fix] Upgrade Vertx to match BK's version (otherwise BK does not work)

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -470,11 +470,11 @@ The Apache Software License, Version 2.0
   * JCTools - Java Concurrency Tools for the JVM
     - org.jctools-jctools-core-2.1.2.jar
   * Vertx
-    - io.vertx-vertx-auth-common-3.9.8.jar
-    - io.vertx-vertx-bridge-common-3.9.8.jar
-    - io.vertx-vertx-core-3.9.8.jar
-    - io.vertx-vertx-web-3.9.8.jar
-    - io.vertx-vertx-web-common-3.9.8.jar
+    - io.vertx-vertx-auth-common-4.3.2.jar
+    - io.vertx-vertx-bridge-common-4.3.2.jar
+    - io.vertx-vertx-core-4.3.2.jar
+    - io.vertx-vertx-web-4.3.2.jar
+    - io.vertx-vertx-web-common-4.3.2.jar
   * Apache ZooKeeper
     - org.apache.zookeeper-zookeeper-3.8.1.jar
     - org.apache.zookeeper-zookeeper-jute-3.8.1.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -470,11 +470,11 @@ The Apache Software License, Version 2.0
   * JCTools - Java Concurrency Tools for the JVM
     - org.jctools-jctools-core-2.1.2.jar
   * Vertx
-    - io.vertx-vertx-auth-common-4.3.2.jar
-    - io.vertx-vertx-bridge-common-4.3.2.jar
-    - io.vertx-vertx-core-4.3.2.jar
-    - io.vertx-vertx-web-4.3.2.jar
-    - io.vertx-vertx-web-common-4.3.2.jar
+    - io.vertx-vertx-auth-common-4.3.8.jar
+    - io.vertx-vertx-bridge-common-4.3.8.jar
+    - io.vertx-vertx-core-4.3.8.jar
+    - io.vertx-vertx-web-4.3.8.jar
+    - io.vertx-vertx-web-common-4.3.8.jar
   * Apache ZooKeeper
     - org.apache.zookeeper-zookeeper-3.8.1.jar
     - org.apache.zookeeper-zookeeper-jute-3.8.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ flexible messaging model and an intuitive client API.</description>
     <jersey.version>2.34</jersey.version>
     <athenz.version>1.10.50</athenz.version>
     <prometheus.version>0.16.0</prometheus.version>
-    <vertx.version>3.9.8</vertx.version>
+    <vertx.version>4.3.2</vertx.version>
     <rocksdb.version>6.29.4.1</rocksdb.version>
     <slf4j.version>1.7.32</slf4j.version>
     <commons.collections4.version>4.4</commons.collections4.version>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ flexible messaging model and an intuitive client API.</description>
     <jersey.version>2.34</jersey.version>
     <athenz.version>1.10.50</athenz.version>
     <prometheus.version>0.16.0</prometheus.version>
-    <vertx.version>4.3.2</vertx.version>
+    <vertx.version>4.3.8</vertx.version>
     <rocksdb.version>6.29.4.1</rocksdb.version>
     <slf4j.version>1.7.32</slf4j.version>
     <commons.collections4.version>4.4</commons.collections4.version>


### PR DESCRIPTION
### Motivation

BK deployed with Pulsar fail on start with
```
ERROR org.apache.bookkeeper.common.component.AbstractLifecycleComponent - Failed to start Component: http-service
java.lang.NoSuchMethodError: 'io.vertx.core.Future io.vertx.core.Vertx.deployVerticle(io.vertx.core.Verticle)'
	at org.apache.bookkeeper.http.vertx.VertxHttpServer.startServer(VertxHttpServer.java:93) ~[org.apache.bookkeeper.http-vertx-http-server-4.16.0.jar:4.16.0]
	at org.apache.bookkeeper.server.service.HttpService.doStart(HttpService.java:62) ~[org.apache.bookkeeper-bookkeeper-server-4.16.0.jar:4.16.0]
	at org.apache.bookkeeper.common.component.AbstractLifecycleComponent.start(AbstractLifecycleComponent.java:83) ~[org.apache.bookkeeper-bookkeeper-common-4.16.0.jar:4.16.0]
	at org.apache.bookkeeper.common.component.LifecycleComponentStack.lambda$start$4(LifecycleComponentStack.java:144) ~[org.apache.bookkeeper-bookkeeper-common-4.16.0.jar:4.16.0]
	at com.google.common.collect.ImmutableList.forEach(ImmutableList.java:422) ~[com.google.guava-guava-31.0.1-jre.jar:?]
	at org.apache.bookkeeper.common.component.LifecycleComponentStack.start(LifecycleComponentStack.java:144) ~[org.apache.bookkeeper-bookkeeper-common-4.16.0.jar:4.16.0]
	at org.apache.bookkeeper.common.component.ComponentStarter.startComponent(ComponentStarter.java:84) ~[org.apache.bookkeeper-bookkeeper-common-4.16.0.jar:4.16.0]
	at org.apache.bookkeeper.server.Main.doMain(Main.java:224) ~[org.apache.bookkeeper-bookkeeper-server-4.16.0.jar:4.16.0]
	at org.apache.bookkeeper.server.Main.main(Main.java:199) ~[org.apache.bookkeeper-bookkeeper-server-4.16.0.jar:4.16.0]

```

The root cause is that BK upgraded to 4.16.0 and needs newer version of vertx that introduced API changes https://github.com/apache/bookkeeper/pull/3435

Pulsar forces older version of dependency.

### Modifications

Upgrade Vertx to the same version as BK

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

Update standalone configuration:
```
diff --git a/conf/standalone.conf b/conf/standalone.conf
index f141946c29f..c7bbe8fdbb6 100644
--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -17,6 +17,11 @@
 # under the License.
 #

+
+httpServerEnabled=true
+httpServerPort=8000
+httpServerClass=org.apache.bookkeeper.http.vertx.VertxHttpServer
+
 ### --- General broker settings --- ###

 # The metadata store URL
@@ -51,7 +56,7 @@ advertisedAddress=
 haProxyProtocolEnabled=false

 # Number of threads to use for Netty IO. Default is set to 2 * Runtime.getRuntime().availableProcessors()
-numIOThreads=
+#numIOThreads=

 # Number of threads to use for ordered executor. The ordered executor is used to operate with zookeeper,
 # such as init zookeeper client, get namespace policies from zookeeper etc. It also used to split bundle. Default is 8
```

and run `bin/pulsar standalone`
Without the fix it fails with "Not enough non-faulty bookies available"

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [x] **Dependencies (add or upgrade a dependency)**
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dlg99/pulsar/pull/14
