### PR TITLE
[branch-2.11][improve][doc] Improve Pulsar function document

### DIFF
--- a/distribution/server/src/assemble/bin.xml
+++ b/distribution/server/src/assemble/bin.xml
@@ -116,6 +116,11 @@
       <destName>example-window-function-config.yaml</destName>
       <outputDirectory>examples</outputDirectory>
     </file>
+    <file>
+      <source>${basedir}/../../pulsar-functions/java-examples/src/main/resources/example-stateful-function-config.yaml</source>
+      <destName>example-stateful-function-config.yaml</destName>
+      <outputDirectory>examples</outputDirectory>
+    </file>
   </files>
   <dependencySets>
     <dependencySet>

--- a/pulsar-functions/java-examples/src/main/resources/example-function-config.yaml
+++ b/pulsar-functions/java-examples/src/main/resources/example-function-config.yaml
@@ -22,9 +22,6 @@ namespace: "test-namespace"
 name: "example"
 className: "org.apache.pulsar.functions.api.examples.ExclamationFunction"
 inputs: ["test_src"]
-userConfig:
-  "PublishTopic": "test_result"
-
 output: "test_result"
 autoAck: true
 parallelism: 1

--- a/pulsar-functions/java-examples/src/main/resources/example-stateful-function-config.yaml
+++ b/pulsar-functions/java-examples/src/main/resources/example-stateful-function-config.yaml
@@ -19,12 +19,10 @@
 
 tenant: "test"
 namespace: "test-namespace"
-name: "stateful-example"
+name: "word_count"
 className: "org.apache.pulsar.functions.api.examples.WordCountFunction"
 inputs: ["test_stateful_src"]
-userConfig:
-  "PublishTopic": "test_stateful_result"
-
-output: "test_stateful_result"
+inputs: ["test_wordcount_src"]
+output: "test_wordcount_result"
 autoAck: true
 parallelism: 1

--- a/pulsar-functions/java-examples/src/main/resources/example-window-function-config.yaml
+++ b/pulsar-functions/java-examples/src/main/resources/example-window-function-config.yaml
@@ -22,9 +22,6 @@ namespace: "test-namespace"
 name: "example"
 className: "org.apache.pulsar.functions.api.examples.AddWindowFunction"
 inputs: ["test_src"]
-userConfig:
-  "PublishTopic": "test_result"
-
 output: "test_result"
 autoAck: true
 parallelism: 1


### PR DESCRIPTION
Cherry-pick some parts from #18601.

As #18601 is not cherry-picked to branch-2.11, and causes #20063.  


### Motivation

Most of the changes are style improvements.

Some key changes are below:

1. Request users to set `functionsWorkerEnabled=true` before playing with Pulsar function.
2. For clarity, always use yaml file to create functions instead of CLI parameters, and remove the redundant `UserConfig` field in the example yaml file.
3. Rewrite the document for window function. The original document for window function is wrong.
4. Move `example-stateful-function-config.yaml` to `examples` folder when compile.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

