### PR TITLE
PIP-188: Support option to disconnect clients that not support cluster migration feature 

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -302,6 +302,12 @@ isAllowAutoUpdateSchemaEnabled=true
 # Enable check for minimum allowed client library version
 clientLibraryVersionCheckEnabled=false
 
+# Minimum client version allowed by broker else broker will reject connection.
+# (It's useful when client lib doesn't support specific feature and feature 
+# might be required by broker to apply globally on all topics.
+# (eg: all clients must be on V20 to perform cloud migration)
+clientMinVersionAllowed=-1
+
 # Path for the file used to determine the rotation status for the broker when responding
 # to service discovery health checks
 statusFilePath=

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -191,6 +191,12 @@ isAllowAutoUpdateSchemaEnabled=true
 # Enable check for minimum allowed client library version
 clientLibraryVersionCheckEnabled=false
 
+# Minimum client version allowed by broker else broker will reject connection.
+# (It's useful when client lib doesn't support specific feature and feature 
+# might be required by broker to apply globally on all topics.
+# (eg: all clients must be on V20 to perform cloud migration)
+clientMinVersionAllowed=-1
+
 # Path for the file used to determine the rotation status for the broker when responding
 # to service discovery health checks
 statusFilePath=/usr/local/apache/htdocs

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -205,6 +205,12 @@ maxTopicsPerNamespace=0
 # Enable check for minimum allowed client library version
 clientLibraryVersionCheckEnabled=false
 
+# Minimum client version allowed by broker else broker will reject connection.
+# (It's useful when client lib doesn't support specific feature and feature 
+# might be required by broker to apply globally on all topics.
+# (eg: all clients must be on V20 to perform cloud migration)
+clientMinVersionAllowed=-1
+
 # Path for the file used to determine the rotation status for the broker when responding
 # to service discovery health checks
 statusFilePath=

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -850,6 +850,17 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Enable check for minimum allowed client library version"
     )
     private boolean clientLibraryVersionCheckEnabled = false;
+
+    @FieldContext(
+        category = CATEGORY_SERVER,
+        dynamic = true,
+        doc = "Minimum client version allowed by broker else broker will reject connection."
+              + "(It's useful when client lib doesn't support specific feature and feature "
+              + "might be required by broker to apply globally on all topics."
+              + "(eg: all clients must be on V20 to perform cloud migration)"
+    )
+    private int clientMinVersionAllowed = -1;
+
     @FieldContext(
         category = CATEGORY_SERVER,
         doc = "Path for the file used to determine the rotation status for the broker"


### PR DESCRIPTION
### Motivation

As discussed at [PIP-188](https://github.com/apache/pulsar/issues/16551) and in PR #19605
In ordered to achieve cluster migration, all clients need to be upgraded to the version which handles cluster migration redirection. So, Broker can't complete migration if clients are not upgrade to the supported version. Therefore, it's really important to find out if any unsupported client is connected or don't allow any unsupported client to connect if we want to start the cluster migration process. Therefore, we will add a flag to allow the broker to reject all client connections which are initiated from unsupported clients. The broker will not allow connection from clients which don't support cluster migration redirection handling if the `clientMinVersionAllowed` broker flag is enabled.

### Modifications

Add flag `clientMinVersionAllowed` to allow brokers to ocreate connections with only those clients that support cluster migration handling feature to avoid incomplete cluster migration process.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
