### PR TITLE
[fix][admin] Add javax.xml.bind:jaxb-api to shade

### DIFF
--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -131,6 +131,7 @@
                   <include>com.yahoo.datasketches:sketches-core</include>
                   <include>org.glassfish.jersey*:*</include>
                   <include>javax.ws.rs:*</include>
+                  <include>javax.xml.bind:jaxb-api</include>
                   <include>jakarta.annotation:*</include>
                   <include>org.glassfish.hk2*:*</include>
                   <include>io.grpc:*</include>
@@ -229,6 +230,10 @@
                 <relocation>
                   <pattern>javax.annotation</pattern>
                   <shadedPattern>org.apache.pulsar.shade.javax.annotation</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.xml.bind</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.javax.xml.bind</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>jersey</pattern>

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -182,6 +182,7 @@
                   <include>com.yahoo.datasketches:sketches-core</include>
                   <include>org.glassfish.jersey*:*</include>
                   <include>javax.ws.rs:*</include>
+                  <include>javax.xml.bind:jaxb-api</include>
                   <include>jakarta.annotation:*</include>
                   <include>org.glassfish.hk2*:*</include>
                   <include>io.grpc:*</include>
@@ -284,6 +285,10 @@
                 <relocation>
                   <pattern>javax.annotation</pattern>
                   <shadedPattern>org.apache.pulsar.shade.javax.annotation</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.xml.bind</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.javax.xml.bind</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>jersey</pattern>


### PR DESCRIPTION
Fixes #19856

### Motivation

`javax.xml.bind:jaxb-api` didn't package into the shade package.

Add a context, why add `javax.xml.bind:jaxb-api` to the admin module, see https://www.jesperdj.com/2018/09/30/jaxb-on-java-9-10-11-and-beyond/

### Modifications

Add `javax.xml.bind:jaxb-api` to  `pulsar-client-admin-shaded/pom.xml`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->