### PR TITLE
[improve] [broker] Fix broker restart logic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -467,6 +467,12 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 protocolHandlers = null;
             }
 
+            // cancel loadShedding task and shutdown the loadManager executor before shutting down the broker
+            if (this.loadSheddingTask != null) {
+                this.loadSheddingTask.cancel();
+            }
+            executorServicesShutdown.shutdown(loadManagerExecutor);
+
             List<CompletableFuture<Void>> asyncCloseFutures = new ArrayList<>();
             if (this.brokerService != null) {
                 CompletableFuture<Void> brokerCloseFuture = this.brokerService.closeAsync();
@@ -500,12 +506,6 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 this.leaderElectionService.close();
                 this.leaderElectionService = null;
             }
-
-            // cancel loadShedding task and shutdown the loadManager executor before shutting down the broker
-            if (this.loadSheddingTask != null) {
-                this.loadSheddingTask.cancel();
-            }
-            executorServicesShutdown.shutdown(loadManagerExecutor);
 
             if (adminClient != null) {
                 adminClient.close();


### PR DESCRIPTION
### Motivation

Currently, when we execute the logic of Broker Close, we first shut down the Broker Service, and then close the LoadManagerTask. This will cause the Broker to be assigned to a new bundle during the shutdown of the Broker, resulting in an inelegant shutdown of the Broker. , eventually triggering brokerShutdownTimeoutMs to forcibly shut down the Broker, causing the Client to fail to produce or consume messages over time.


![image](https://user-images.githubusercontent.com/20965307/232401254-dbed0559-f3a6-4c07-a92f-a48515a2e6a7.png)

When shutting down the Broker, we will first remove the temporary node of the current Broker from zookeeper, which is the logic we expect. We expect that the broker will not allocate new bundles during active shutdown of the broker. However, since the task of loadManagerExecutor has been regularly executed to report its own Load information to zookeeper, this will cause the Broker node to be shut down to be re-registered by loadManagerExecutor. At this time, the Leader Broker believes that the Broker node to be shut down can also allocate a new bundle, and will redistribute the new bundle information.

Interestingly, in the code logic of Pulsar Service shutdown, the comments clearly indicate that we expect LoadMangerTask to be closed before Broker Service, but in real code implementation, it is the opposite.
```
 // cancel loadShedding task and shutdown the loadManager executor before shutting down the broker
```

### Modifications

Adjust the order of component shutdown when Broker is shut down so that LoadManagerTask is shut down before Broker Service

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->