### PR TITLE
[fix][meta] deadlock of zkSessionWatcher when zkConnection loss

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
@@ -81,7 +81,7 @@ public class ZKSessionWatcher implements AutoCloseable, Watcher {
     }
 
     // task that runs every TICK_TIME to check zk connection
-    private synchronized void checkConnectionStatus() {
+    private void checkConnectionStatus() {
         try {
             CompletableFuture<Watcher.Event.KeeperState> future = new CompletableFuture<>();
             zk.exists("/", false, (StatCallback) (rc, path, ctx, stat) -> {
@@ -126,7 +126,7 @@ public class ZKSessionWatcher implements AutoCloseable, Watcher {
         currentStatus = SessionEvent.SessionLost;
     }
 
-    private void checkState(Watcher.Event.KeeperState zkClientState) {
+    private synchronized void checkState(Watcher.Event.KeeperState zkClientState) {
         switch (zkClientState) {
         case Expired:
             if (currentStatus != SessionEvent.SessionLost) {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
@@ -18,15 +18,8 @@
  */
 package org.apache.pulsar.metadata.impl;
 
+import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
 import io.netty.util.concurrent.DefaultThreadFactory;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.metadata.api.extended.SessionEvent;
-import org.apache.zookeeper.AsyncCallback.StatCallback;
-import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.WatchedEvent;
-import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.ZooKeeper;
-
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -35,8 +28,13 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-
-import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.metadata.api.extended.SessionEvent;
+import org.apache.zookeeper.AsyncCallback.StatCallback;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooKeeper;
 
 /**
  * Monitor the ZK session state every few seconds and send notifications.
@@ -84,8 +82,9 @@ public class ZKSessionWatcher implements AutoCloseable, Watcher {
 
     // task that runs every TICK_TIME to check zk connection
     // NOT ThreadSafe:
-    //  If zk client can't ensure the order, it may lead to problems.
-    //  Currently,we can it in single thread, it will be fine. but we shouldn't leave any potential problems in the future.
+    // If zk client can't ensure the order, it may lead to problems.
+    // Currently,we can it in single thread, it will be fine. but we shouldn't leave any potential problems
+    // in the future.
     private void checkConnectionStatus() {
         try {
             CompletableFuture<Watcher.Event.KeeperState> future = new CompletableFuture<>();

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
@@ -83,7 +83,7 @@ public class ZKSessionWatcher implements AutoCloseable, Watcher {
     // task that runs every TICK_TIME to check zk connection
     // NOT ThreadSafe:
     // If zk client can't ensure the order, it may lead to problems.
-    // Currently,we can it in single thread, it will be fine. but we shouldn't leave any potential problems
+    // Currently,we only use it in single thread, it will be fine. but we shouldn't leave any potential problems
     // in the future.
     private void checkConnectionStatus() {
         try {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.metadata.impl;
 
 import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
+
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
@@ -81,6 +83,7 @@ public class ZKSessionWatcher implements AutoCloseable, Watcher {
     }
 
     // task that runs every TICK_TIME to check zk connection
+    @VisibleForTesting
     private void checkConnectionStatus() {
         try {
             CompletableFuture<Watcher.Event.KeeperState> future = new CompletableFuture<>();


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #[20105](https://github.com/apache/pulsar/issues/20105)

### Motivation

The deadlock is caused by the different acquiring lock order in zkwatcher callback and connection check thread in zkSessionWatcher. Meanwhile, the lock of ZkSessionWatch is intending to  project the currentStatus field,  no need  to perform a lock operation when executing checkConnectionStatus method.  

### Modifications

1. don't perform a lock operation in ZKSessionWatcher.checkConnectionStatus method, which runs in single thread.
2. perform a lock operation in ZKSessionWatcher.checkStatus method.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
