### PR TITLE
[fix][broker] Revert : Forbid uploading BYTES schema with admin API (#18995)

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
@@ -114,10 +114,6 @@ public class SchemasResourceBase extends AdminResource {
     }
 
     public CompletableFuture<SchemaVersion> postSchemaAsync(PostSchemaPayload payload, boolean authoritative) {
-        if (SchemaType.BYTES.name().equals(payload.getType())) {
-            return CompletableFuture.failedFuture(new RestException(Response.Status.NOT_ACCEPTABLE,
-                    "Do not upload a BYTES schema, because it's the default schema type"));
-        }
         return validateOwnershipAndOperationAsync(authoritative, TopicOperation.PRODUCE)
                 .thenCompose(__ -> getSchemaCompatibilityStrategyAsyncWithoutAuth())
                 .thenCompose(schemaCompatibilityStrategy -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaTest.java
@@ -185,17 +185,6 @@ public class AdminApiSchemaTest extends MockedPulsarServiceBaseTest {
 
     }
 
-    @Test
-    public void testCreateBytesSchema() {
-        // forbid admin api creating BYTES schema to be consistent with client side
-        try {
-            testSchemaInfoApi(Schema.BYTES, "schematest/test/test-BYTES");
-            fail("should fail");
-        } catch (Exception e) {
-            assertTrue(e.getMessage().contains("Do not upload a BYTES schema"));
-        }
-    }
-
     @Test(dataProvider = "version")
     public void testPostSchemaCompatibilityStrategy(ApiVersion version) throws PulsarAdminException {
         String namespace = format("%s%s%s", "schematest", (ApiVersion.V1.equals(version) ? "/" + cluster + "/" : "/"),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -513,17 +513,13 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         admin.topics().createPartitionedTopic(topic, 2);
 
         // set schema
-        if (!schema.equals(SchemaType.BYTES)) {
-            // don't upload bytes schema with admin API
-            // because null schema means the BYTES schema
-            SchemaInfo schemaInfo = SchemaInfoImpl
-                    .builder()
-                    .schema(new byte[0])
-                    .name("dummySchema")
-                    .type(schema)
-                    .build();
-            admin.schemas().createSchema(topic, schemaInfo);
-        }
+        SchemaInfo schemaInfo = SchemaInfoImpl
+                .builder()
+                .schema(new byte[0])
+                .name("dummySchema")
+                .type(schema)
+                .build();
+        admin.schemas().createSchema(topic, schemaInfo);
 
         Producer<byte[]> producer = pulsarClient
                 .newProducer()
@@ -548,8 +544,7 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         Message<GenericRecord> message2 = consumer2.receive();
         if (schema == SchemaType.BYTES) {
             assertEquals(schema, message.getReaderSchema().get().getSchemaInfo().getType());
-            // default schema of AUTO_CONSUME is BYTES
-            assertTrue(message2.getReaderSchema().get().toString().contains("BYTES"));
+            assertEquals(schema, message2.getReaderSchema().get().getSchemaInfo().getType());
         } else if (schema == SchemaType.NONE) {
             // schema NONE is always reported as BYTES
             assertEquals(SchemaType.BYTES, message.getReaderSchema().get().getSchemaInfo().getType());


### PR DESCRIPTION
This reverts commit ea4d3b4840ba57cfb8edfcf14b6e28e859fdce9b.

### Motivation

Follow the discussion thread https://lists.apache.org/thread/672zmptfblwjmrf9z8336mk12r7csngf to check the details.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
