### PR TITLE
[improve][monitor] Introduce new metrics related to transaction buffer snapshot segments 

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -710,6 +710,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
 
         private CompletableFuture<Void> updateSnapshotIndex(TransactionBufferSnapshotIndexesMetadata snapshotSegment) {
             TransactionBufferSnapshotIndexes snapshotIndexes = new TransactionBufferSnapshotIndexes();
+            txnSnapshotSegmentStats.setSnapshotSegmentTotal(indexes.size());
             CompletableFuture<Void> res = snapshotIndexWriter.getFuture()
                     .thenCompose((indexesWriter) -> {
                         snapshotIndexes.setIndexList(indexes.values().stream().toList());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.transaction.buffer.impl;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.prometheus.client.CollectorRegistry;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -150,7 +151,8 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                 .getConfiguration().getTransactionBufferSnapshotSegmentSize() - 8 - topic.getName().length()) / 3;
         this.unsealedTxnIds = new LinkedList<>();
         TopicName topicName = TopicName.get(topic.getName());
-        this.txnSnapshotSegmentStats = new TxnSnapshotSegmentStats(topicName.getNamespace(), topicName.getLocalName());
+        this.txnSnapshotSegmentStats = new TxnSnapshotSegmentStats(topicName.getNamespace(), topicName.getLocalName(),
+                CollectorRegistry.defaultRegistry);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -131,7 +131,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
      */
     private final PersistentWorker persistentWorker;
 
-    TxnSnapshotSegmentStats txnSnapshotSegmentStats;
+    private final TxnSnapshotSegmentStats txnSnapshotSegmentStats;
     private static final String SNAPSHOT_PREFIX = "multiple-";
 
     public SnapshotSegmentAbortedTxnProcessorImpl(PersistentTopic topic) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -52,6 +52,7 @@ import org.apache.pulsar.broker.transaction.buffer.metadata.v2.TransactionBuffer
 import org.apache.pulsar.broker.transaction.buffer.metadata.v2.TransactionBufferSnapshotIndexesMetadata;
 import org.apache.pulsar.broker.transaction.buffer.metadata.v2.TransactionBufferSnapshotSegment;
 import org.apache.pulsar.broker.transaction.buffer.metadata.v2.TxnIDData;
+import org.apache.pulsar.broker.transaction.buffer.stats.TxnSnapshotSegmentStats;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.transaction.TxnID;
@@ -129,6 +130,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
      */
     private final PersistentWorker persistentWorker;
 
+    TxnSnapshotSegmentStats txnSnapshotSegmentStats;
     private static final String SNAPSHOT_PREFIX = "multiple-";
 
     public SnapshotSegmentAbortedTxnProcessorImpl(PersistentTopic topic) {
@@ -147,6 +149,8 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
         this.snapshotSegmentCapacity = (topic.getBrokerService().getPulsar()
                 .getConfiguration().getTransactionBufferSnapshotSegmentSize() - 8 - topic.getName().length()) / 3;
         this.unsealedTxnIds = new LinkedList<>();
+        TopicName topicName = TopicName.get(topic.getName());
+        this.txnSnapshotSegmentStats = new TxnSnapshotSegmentStats(topicName.getNamespace(), topicName.getLocalName());
     }
 
     @Override
@@ -238,6 +242,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                         while (reader.hasMoreEvents()) {
                             Message<TransactionBufferSnapshotIndexes> message = reader.readNextAsync()
                                     .get(getSystemClientOperationTimeoutMs(), TimeUnit.MILLISECONDS);
+                            txnSnapshotSegmentStats.recordIndexOpReadSuccess();
                             if (topic.getName().equals(message.getKey())) {
                                 TransactionBufferSnapshotIndexes transactionBufferSnapshotIndexes = message.getValue();
                                 if (transactionBufferSnapshotIndexes != null) {
@@ -249,6 +254,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                             }
                         }
                     } catch (TimeoutException ex) {
+                        txnSnapshotSegmentStats.recordIndexOpReadFail();
                         Throwable t = FutureUtil.unwrapCompletionException(ex);
                         String errorMessage = String.format("[%s] Transaction buffer recover fail by read "
                                 + "transactionBufferSnapshot timeout!", topic.getName());
@@ -288,6 +294,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                                         new AsyncCallbacks.ReadEntryCallback() {
                                             @Override
                                             public void readEntryComplete(Entry entry, Object ctx) {
+                                                txnSnapshotSegmentStats.recordSegmentOpReadSuccess();
                                                 handleSnapshotSegmentEntry(entry);
                                                 indexes.put(new PositionImpl(
                                                                 index.abortedMarkLedgerID,
@@ -310,6 +317,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                                                   the segment can not be read according to the index.
                                                   We update index again if there are invalid indexes.
                                                  */
+                                                txnSnapshotSegmentStats.recordSegmentOpReadFail();
                                                 if (((ManagedLedgerImpl) topic.getManagedLedger())
                                                         .ledgerExists(index.getAbortedMarkLedgerID())) {
                                                     log.error("[{}] Failed to read snapshot segment [{}:{}]",
@@ -612,6 +620,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                                     sealedAbortedTxnIdSegment.size());
                         }
                         this.sequenceID.getAndIncrement();
+                        txnSnapshotSegmentStats.recordSegmentOpAddSuccess();
                     });
             res.exceptionally(e -> {
                 //Just log the error, and the processor will try to take snapshot again when the transactionBuffer
@@ -620,6 +629,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                                 + "for the topic [{}], and the size of the segment is [{}]",
                         this.sequenceID, abortedMarkerPersistentPosition, topic.getName(),
                         sealedAbortedTxnIdSegment.size(), e);
+                txnSnapshotSegmentStats.recordSegmentOpAddFail();
                 return null;
             });
             return res;
@@ -679,6 +689,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                                                 + "whose sequenceId is [{}] and maxReadPosition is [{}]",
                                         this.topic.getName(), this.sequenceID, positionNeedToDelete);
                             }
+                            txnSnapshotSegmentStats.recordSegmentOpDelSuccess();
                             //The index may fail to update but the processor will check
                             //whether the snapshot segment is null, and update the index when recovering.
                             //And if the task is not the newest in the queue, it is no need to update the index.
@@ -689,6 +700,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                     log.warn("[{}] Failed to delete the snapshot segment, "
                                     + "whose sequenceId is [{}] and maxReadPosition is [{}]",
                             this.topic.getName(), this.sequenceID, positionNeedToDelete, e);
+                    txnSnapshotSegmentStats.recordSegmentOpDelFail();
                     return null;
                 });
                 results.add(res);
@@ -703,10 +715,15 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                         snapshotIndexes.setIndexList(indexes.values().stream().toList());
                         snapshotIndexes.setSnapshot(snapshotSegment);
                         snapshotIndexes.setTopicName(topic.getName());
+                        txnSnapshotSegmentStats.observeSnapshotIndexEntryBytes(calculateSize(snapshotIndexes));
                         return indexesWriter.writeAsync(topic.getName(), snapshotIndexes)
                                 .thenCompose(messageId -> CompletableFuture.completedFuture(null));
                     });
-            res.thenRun(() -> lastSnapshotTimestamps = System.currentTimeMillis()).exceptionally(e -> {
+            res.thenRun(() -> {
+                lastSnapshotTimestamps = System.currentTimeMillis();
+                txnSnapshotSegmentStats.recordIndexOpAddSuccess();
+            }).exceptionally(e -> {
+                txnSnapshotSegmentStats.recordIndexOpAddFail();
                 log.error("[{}] Failed to update snapshot segment index", snapshotIndexes.getTopicName(), e);
                 return null;
             });
@@ -717,12 +734,15 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
             CompletableFuture<Void> res = persistentWorker.clearAllSnapshotSegments()
                     .thenCompose((ignore) -> snapshotIndexWriter.getFuture()
                             .thenCompose(indexesWriter -> indexesWriter.writeAsync(topic.getName(), null)))
-                    .thenRun(() ->
-                            log.debug("Successes to clear the snapshot segment and indexes for the topic [{}]",
-                                    topic.getName()));
+                    .thenRun(() -> {
+                        log.debug("Successes to clear the snapshot segment and indexes for the topic [{}]",
+                                topic.getName());
+                        txnSnapshotSegmentStats.recordIndexOpDelSuccess();
+                    });
             res.exceptionally(e -> {
                 log.error("Failed to clear the snapshot segment and indexes for the topic [{}]",
                         topic.getName(), e);
+                txnSnapshotSegmentStats.recordIndexOpDelFail();
                 return null;
             });
             return res;
@@ -751,10 +771,13 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                                         .get(getSystemClientOperationTimeoutMs(), TimeUnit.MILLISECONDS);
                                 if (topic.getName().equals(message.getValue().getTopicName())) {
                                    snapshotSegmentsWriter.getFuture().get().write(message.getKey(), null);
+                                    txnSnapshotSegmentStats.recordSegmentOpDelSuccess();
                                 }
+                                txnSnapshotSegmentStats.recordSegmentOpReadSuccess();
                             }
                             return CompletableFuture.completedFuture(null);
                         } catch (Exception ex) {
+                            txnSnapshotSegmentStats.recordSegmentOpDelFail();
                             log.error("[{}] Transaction buffer clear snapshot segments fail!", topic.getName(), ex);
                             return FutureUtil.failedFuture(ex);
                         } finally {
@@ -786,4 +809,24 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
         return segment;
     }
 
+    private int calculateSize(TransactionBufferSnapshotIndexes indexes) {
+        int size = 0;
+
+        // Calculate the size of topicName
+        size += indexes.getTopicName().getBytes().length;
+
+        // Calculate the size of indexList
+        for (TransactionBufferSnapshotIndex index : indexes.getIndexList()) {
+            size += 6 * Long.BYTES; // As each TransactionBufferSnapshotIndex has 6 long type attributes
+        }
+
+        // Calculate the size of snapshot
+        TransactionBufferSnapshotIndexesMetadata snapshot = indexes.getSnapshot();
+        size += 2 * Long.BYTES; // Size of maxReadPositionLedgerId and maxReadPositionEntryId
+        for (TxnIDData txnIDData : snapshot.getAborts()) {
+            size += 2 * Long.BYTES; // Size of mostSigBits and leastSigBits
+        }
+
+        return size;
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/stats/TxnSnapshotSegmentStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/stats/TxnSnapshotSegmentStats.java
@@ -41,9 +41,9 @@ public final class TxnSnapshotSegmentStats implements AutoCloseable {
             .labelNames(NAMESPACE_LABEL_NAME, TOPIC_NAME_LABEL_NAME, OPERATION_LABEL_NAME, STATUS_LABEL_NAME)
             .register();
 
-    private static final Gauge SNAPSHOT_INDEX_TOTAL = Gauge
+    private static final Gauge SNAPSHOT_SEGMENT_TOTAL = Gauge
             .build(PREFIX + "index_total",
-                    "Number of snapshot indexes maintained in the Pulsar transaction buffer.")
+                    "Number of snapshot segments maintained in the Pulsar transaction buffer.")
             .labelNames("namespace", "topic")
             .register();
 
@@ -66,7 +66,7 @@ public final class TxnSnapshotSegmentStats implements AutoCloseable {
     private final Counter.Child indexOpAddFailedChild;
     private final Counter.Child indexOpDelFailedChild;
     private final Counter.Child indexOpReadFailedChild;
-    private final Gauge.Child snapshotIndexTotalChild;
+    private final Gauge.Child snapshotSegmentTotalChild;
     private final Histogram.Child snapshotIndexEntryBytesChild;
 
     private final String namespace;
@@ -101,7 +101,7 @@ public final class TxnSnapshotSegmentStats implements AutoCloseable {
                 .labels(namespace, topicName, "del", "fail");
         this.indexOpReadFailedChild = SNAPSHOT_INDEX_OP_TOTAL
                 .labels(namespace, topicName, "read", "fail");
-        this.snapshotIndexTotalChild = SNAPSHOT_INDEX_TOTAL
+        this.snapshotSegmentTotalChild = SNAPSHOT_SEGMENT_TOTAL
                 .labels(namespace, topicName);
         this.snapshotIndexEntryBytesChild = SNAPSHOT_INDEX_ENTRY_BYTES
                 .labels(namespace, topicName);
@@ -155,8 +155,8 @@ public final class TxnSnapshotSegmentStats implements AutoCloseable {
         this.indexOpReadFailedChild.inc();
     }
 
-    public void setSnapshotIndexTotal(double value) {
-        snapshotIndexTotalChild.set(value);
+    public void setSnapshotSegmentTotal(double value) {
+        snapshotSegmentTotalChild.set(value);
     }
 
     public void observeSnapshotIndexEntryBytes(double value) {
@@ -168,7 +168,7 @@ public final class TxnSnapshotSegmentStats implements AutoCloseable {
         if (this.closed.compareAndSet(false, true)) {
             SNAPSHOT_SEGMENT_OP_TOTAL.clear();
             SNAPSHOT_INDEX_OP_TOTAL.clear();
-            SNAPSHOT_INDEX_TOTAL.remove(namespace, topicName);
+            SNAPSHOT_SEGMENT_TOTAL.remove(namespace, topicName);
             SNAPSHOT_INDEX_ENTRY_BYTES.remove(namespace, topicName);
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/stats/TxnSnapshotSegmentStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/stats/TxnSnapshotSegmentStats.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction.buffer.stats;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class TxnSnapshotSegmentStats implements AutoCloseable {
+    private static final String NAMESPACE_LABEL_NAME = "namespace";
+    private static final String TOPIC_NAME_LABEL_NAME = "topic_name";
+    private static final String OPERATION_LABEL_NAME = "op";
+    private static final String STATUS_LABEL_NAME = "status";
+    private static final String PREFIX = "pulsar_txn_tb_snapshot_";
+
+    private static final Counter SNAPSHOT_SEGMENT_OP_TOTAL = Counter
+            .build(PREFIX + "segment_op_total",
+                    "Pulsar transaction buffer snapshot segment operation count.")
+            .labelNames(NAMESPACE_LABEL_NAME, TOPIC_NAME_LABEL_NAME, OPERATION_LABEL_NAME, STATUS_LABEL_NAME)
+            .register();
+
+    private static final Counter SNAPSHOT_INDEX_OP_TOTAL = Counter
+            .build(PREFIX + "index_op_total", "Pulsar transaction buffer snapshot index operation count.")
+            .labelNames(NAMESPACE_LABEL_NAME, TOPIC_NAME_LABEL_NAME, OPERATION_LABEL_NAME, STATUS_LABEL_NAME)
+            .register();
+
+    private static final Gauge SNAPSHOT_INDEX_TOTAL = Gauge
+            .build(PREFIX + "index_total",
+                    "Number of snapshot indexes maintained in the Pulsar transaction buffer.")
+            .labelNames("namespace", "topic")
+            .register();
+
+    private static final Histogram SNAPSHOT_INDEX_ENTRY_BYTES = Histogram
+            .build(PREFIX + "index_entry_bytes",
+                    "Size of the snapshot index entry maintained in the Pulsar transaction buffer.")
+            .labelNames("namespace", "topic")
+            .unit("bytes")
+            .register();
+
+    private final Counter.Child segmentOpAddSuccessChild;
+    private final Counter.Child segmentOpDelSuccessChild;
+    private final Counter.Child segmentOpReadSuccessChild;
+    private final Counter.Child indexOpAddSuccessChild;
+    private final Counter.Child indexOpDelSuccessChild;
+    private final Counter.Child indexOpReadSuccessChild;
+    private final Counter.Child segmentOpAddFailedChild;
+    private final Counter.Child segmentOpDelFailedChild;
+    private final Counter.Child segmentOpReadFailedChild;
+    private final Counter.Child indexOpAddFailedChild;
+    private final Counter.Child indexOpDelFailedChild;
+    private final Counter.Child indexOpReadFailedChild;
+    private final Gauge.Child snapshotIndexTotalChild;
+    private final Histogram.Child snapshotIndexEntryBytesChild;
+
+    private final String namespace;
+    private final String topicName;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    public TxnSnapshotSegmentStats(String namespace, String topicName) {
+        this.namespace = namespace;
+        this.topicName = topicName;
+
+        this.segmentOpAddSuccessChild = SNAPSHOT_SEGMENT_OP_TOTAL
+                .labels(namespace, topicName, "add", "success");
+        this.segmentOpDelSuccessChild = SNAPSHOT_SEGMENT_OP_TOTAL
+                .labels(namespace, topicName, "del", "success");
+        this.segmentOpReadSuccessChild = SNAPSHOT_SEGMENT_OP_TOTAL
+                .labels(namespace, topicName, "read", "success");
+        this.indexOpAddSuccessChild = SNAPSHOT_INDEX_OP_TOTAL
+                .labels(namespace, topicName, "add", "success");
+        this.indexOpDelSuccessChild = SNAPSHOT_INDEX_OP_TOTAL
+                .labels(namespace, topicName, "del", "success");
+        this.indexOpReadSuccessChild = SNAPSHOT_INDEX_OP_TOTAL
+                .labels(namespace, topicName, "read", "success");
+        this.segmentOpAddFailedChild = SNAPSHOT_SEGMENT_OP_TOTAL
+                .labels(namespace, topicName, "add", "fail");
+        this.segmentOpDelFailedChild = SNAPSHOT_SEGMENT_OP_TOTAL
+                .labels(namespace, topicName, "del", "fail");
+        this.segmentOpReadFailedChild = SNAPSHOT_SEGMENT_OP_TOTAL
+                .labels(namespace, topicName, "read", "fail");
+        this.indexOpAddFailedChild = SNAPSHOT_INDEX_OP_TOTAL
+                .labels(namespace, topicName, "add", "fail");
+        this.indexOpDelFailedChild = SNAPSHOT_INDEX_OP_TOTAL
+                .labels(namespace, topicName, "del", "fail");
+        this.indexOpReadFailedChild = SNAPSHOT_INDEX_OP_TOTAL
+                .labels(namespace, topicName, "read", "fail");
+        this.snapshotIndexTotalChild = SNAPSHOT_INDEX_TOTAL
+                .labels(namespace, topicName);
+        this.snapshotIndexEntryBytesChild = SNAPSHOT_INDEX_ENTRY_BYTES
+                .labels(namespace, topicName);
+    }
+
+    public void recordSegmentOpAddSuccess() {
+        this.segmentOpAddSuccessChild.inc();
+    }
+
+    public void recordSegmentOpDelSuccess() {
+        this.segmentOpDelSuccessChild.inc();
+    }
+
+    public void recordSegmentOpReadSuccess() {
+        this.segmentOpReadSuccessChild.inc();
+    }
+
+    public void recordIndexOpAddSuccess() {
+        this.indexOpAddSuccessChild.inc();
+    }
+
+    public void recordIndexOpDelSuccess() {
+        this.indexOpDelSuccessChild.inc();
+    }
+
+    public void recordIndexOpReadSuccess() {
+        this.indexOpReadSuccessChild.inc();
+    }
+
+    public void recordSegmentOpAddFail() {
+        this.segmentOpAddFailedChild.inc();
+    }
+
+    public void recordSegmentOpDelFail() {
+        this.segmentOpDelFailedChild.inc();
+    }
+
+    public void recordSegmentOpReadFail() {
+        this.segmentOpReadFailedChild.inc();
+    }
+
+    public void recordIndexOpAddFail() {
+        this.indexOpAddFailedChild.inc();
+    }
+
+    public void recordIndexOpDelFail() {
+        this.indexOpDelFailedChild.inc();
+    }
+
+    public void recordIndexOpReadFail() {
+        this.indexOpReadFailedChild.inc();
+    }
+
+    public void setSnapshotIndexTotal(double value) {
+        snapshotIndexTotalChild.set(value);
+    }
+
+    public void observeSnapshotIndexEntryBytes(double value) {
+        snapshotIndexEntryBytesChild.observe(value);
+    }
+
+    @Override
+    public void close() {
+        if (this.closed.compareAndSet(false, true)) {
+            SNAPSHOT_SEGMENT_OP_TOTAL.clear();
+            SNAPSHOT_INDEX_OP_TOTAL.clear();
+            SNAPSHOT_INDEX_TOTAL.remove(namespace, topicName);
+            SNAPSHOT_INDEX_ENTRY_BYTES.remove(namespace, topicName);
+        }
+    }
+}
+

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/stats/package-info.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/stats/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * The transaction buffer snapshot metadata.
+ */
+package org.apache.pulsar.broker.transaction.buffer.stats;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TxnSnapshotSegmentStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TxnSnapshotSegmentStatsTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction;
+
+
+import io.prometheus.client.CollectorRegistry;
+import org.apache.pulsar.broker.transaction.buffer.stats.TxnSnapshotSegmentStats;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.testng.AssertJUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+
+public class TxnSnapshotSegmentStatsTest {
+    private TxnSnapshotSegmentStats stats;
+    private final CollectorRegistry registry = new CollectorRegistry();
+    private final String namespace = "namespace";
+    private final String topicName = "topic_name";
+
+    @Before
+    public void setup() {
+        stats = new TxnSnapshotSegmentStats(namespace, topicName, registry);
+    }
+
+    @After
+    public void cleanup() {
+        stats.close();
+    }
+
+    @Test
+    public void testSegmentOperations() {
+        stats.recordSegmentOpAddSuccess();
+        stats.recordSegmentOpDelSuccess();
+        stats.recordSegmentOpReadSuccess();
+        stats.recordSegmentOpAddFail();
+        stats.recordSegmentOpDelFail();
+        stats.recordSegmentOpReadFail();
+
+        assertEquals(1.0, registry.getSampleValue("pulsar_txn_tb_snapshot_segment_op_total",
+                new String[]{ "namespace", "topic_name", "op", "status" },
+                new String[]{ namespace, topicName, "add", "success" }), 0.001);
+
+        assertEquals(1.0, registry.getSampleValue("pulsar_txn_tb_snapshot_segment_op_total",
+                new String[]{ "namespace", "topic_name", "op", "status" },
+                new String[]{ namespace, topicName, "del", "success" }), 0.001);
+
+        assertEquals(1.0, registry.getSampleValue("pulsar_txn_tb_snapshot_segment_op_total",
+                new String[]{ "namespace", "topic_name", "op", "status" },
+                new String[]{ namespace, topicName, "read", "success" }), 0.001);
+
+        assertEquals(1.0, registry.getSampleValue("pulsar_txn_tb_snapshot_segment_op_total",
+                new String[]{ "namespace", "topic_name", "op", "status" },
+                new String[]{ namespace, topicName, "add", "fail" }), 0.001);
+
+        assertEquals(1.0, registry.getSampleValue("pulsar_txn_tb_snapshot_segment_op_total",
+                new String[]{ "namespace", "topic_name", "op", "status" },
+                new String[]{ namespace, topicName, "del", "fail" }), 0.001);
+
+        assertEquals(1.0, registry.getSampleValue("pulsar_txn_tb_snapshot_segment_op_total",
+                new String[]{ "namespace", "topic_name", "op", "status" },
+                new String[]{ namespace, topicName, "read", "fail" }), 0.001);
+    }
+
+    @Test
+    public void testIndexOperations() {
+        stats.recordIndexOpAddSuccess();
+        stats.recordIndexOpDelSuccess();
+        stats.recordIndexOpReadSuccess();
+        stats.recordIndexOpAddFail();
+        stats.recordIndexOpDelFail();
+        stats.recordIndexOpReadFail();
+
+        assertEquals(1.0, registry.getSampleValue("pulsar_txn_tb_snapshot_index_op_total",
+                new String[]{ "namespace", "topic_name", "op", "status" },
+                new String[]{ namespace, topicName, "add", "success" }), 0.001);
+
+        assertEquals(1.0, registry.getSampleValue("pulsar_txn_tb_snapshot_index_op_total",
+                new String[]{ "namespace", "topic_name", "op", "status" },
+                new String[]{ namespace, topicName, "del", "success" }), 0.001);
+
+        assertEquals(1.0, registry.getSampleValue("pulsar_txn_tb_snapshot_index_op_total",
+                new String[]{ "namespace", "topic_name", "op", "status" },
+                new String[]{ namespace, topicName, "read", "success" }), 0.001);
+
+        assertEquals(1.0, registry.getSampleValue("pulsar_txn_tb_snapshot_index_op_total",
+                new String[]{ "namespace", "topic_name", "op", "status" },
+                new String[]{ namespace, topicName, "add", "fail" }), 0.001);
+
+        assertEquals(1.0, registry.getSampleValue("pulsar_txn_tb_snapshot_index_op_total",
+                new String[]{ "namespace", "topic_name", "op", "status" },
+                new String[]{ namespace, topicName, "del", "fail" }), 0.001);
+
+        assertEquals(1.0, registry.getSampleValue("pulsar_txn_tb_snapshot_index_op_total",
+                new String[]{ "namespace", "topic_name", "op", "status" },
+                new String[]{ namespace, topicName, "read", "fail" }), 0.001);
+    }
+
+    @Test
+    public void testSnapshotOperations() {
+        stats.setSnapshotSegmentTotal(5.0);
+
+        assertEquals(5.0, registry.getSampleValue("pulsar_txn_tb_snapshot_index_total",
+                new String[]{ "namespace", "topic" },
+                new String[]{ namespace, topicName }), 0.001);
+
+    }
+
+    @Test
+    public void testClose() {
+        // Verify metrics are registered
+        assertNotNull(registry.getSampleValue(
+                "pulsar_txn_tb_snapshot_segment_op_total",
+                new String[]{"namespace", "topic_name", "op", "status"},
+                new String[]{namespace, topicName, "add", "success"}));
+        assertNotNull(registry.getSampleValue(
+                "pulsar_txn_tb_snapshot_index_op_total",
+                new String[]{"namespace", "topic_name", "op", "status"},
+                new String[]{namespace, topicName, "add", "success"}));
+        assertNotNull(registry.getSampleValue(
+                "pulsar_txn_tb_snapshot_index_total",
+                new String[]{"namespace", "topic"},
+                new String[]{namespace, topicName}));
+        Double observedSum = registry.getSampleValue(
+                "pulsar_txn_tb_snapshot_index_entry_bytes_sum",
+                new String[]{"namespace", "topic"},
+                new String[]{namespace, topicName});
+
+        assertNotNull(observedSum);
+
+        // Call close
+        stats.close();
+
+        // Verify metrics are unregistered
+        AssertJUnit.assertNull(registry.getSampleValue(
+                "pulsar_txn_tb_snapshot_segment_op_total",
+                new String[]{"namespace", "topic_name", "op", "status"},
+                new String[]{namespace, topicName, "add", "success"}));
+        AssertJUnit.assertNull(registry.getSampleValue(
+                "pulsar_txn_tb_snapshot_index_op_total",
+                new String[]{"namespace", "topic_name", "op", "status"},
+                new String[]{namespace, topicName, "add", "success"}));
+        AssertJUnit.assertNull(registry.getSampleValue(
+                "pulsar_txn_tb_snapshot_index_total",
+                new String[]{"namespace", "topic"},
+                new String[]{namespace, topicName}));
+        AssertJUnit.assertNull(registry.getSampleValue(
+                "pulsar_txn_tb_snapshot_index_entry_bytes_sum",
+                new String[]{"namespace", "topic"},
+                new String[]{namespace, topicName}));
+    }
+
+}


### PR DESCRIPTION
Master https://github.com/apache/pulsar/issues/16913
### Motivation
Enhance monitoring capabilities for the transaction buffer snapshot segments by introducing new metrics. These metrics help users better understand the performance and behavior of the transaction buffer, enabling them to make informed decisions for tuning and troubleshooting purposes.

### Modification
Introduce new metrics related to transaction buffer snapshot segments, including counters for add, delete, and read operations, as well as gauges and histograms for snapshot indexes and index entry sizes. Additionally, update the `AbortTxnProcessor` to incorporate these new metrics and properly expose them through the Pulsar monitoring system.


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/liangyepianzhou/pulsar/pull/31