### PR TITLE
[fix] [broker] fix messages lost in scenario geo-replication if enabled duplication

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
@@ -58,6 +58,10 @@ public class GeoPersistentReplicator extends PersistentReplicator {
                 brokerService.pulsar().getConfiguration().isEnableReplicatedSubscriptions();
 
         try {
+            if (!isMessageContinuousAndRewindIfNot(entries)) {
+                return false;
+            }
+
             // This flag is set to true when we skip at least one local message,
             // in order to skip remaining local messages.
             boolean isLocalMessageSkippedOnce = false;
@@ -183,6 +187,7 @@ public class GeoPersistentReplicator extends PersistentReplicator {
                     msg.getMessageBuilder().clearTxnidLeastBits();
                     // Increment pending messages for messages produced locally
                     PENDING_MESSAGES_UPDATER.incrementAndGet(this);
+                    lastSent = entry.getPosition();
                     producer.sendAsync(msg, ProducerSendCallback.create(this, entry, msg));
                     atLeastOneMessageSentForReplication = true;
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ShadowReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ShadowReplicator.java
@@ -24,7 +24,6 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
-import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.client.impl.MessageIdImpl;


### PR DESCRIPTION
### Motivation

**Background of Deduplication:** Every message will have an attribute `sequence-id`, and Broker will mark the last `sequence-id` for each producer. If a producer sends a message with a smaller `sequence-id`, it will be rejected.

---

**Background of Geo-Replication:** The replicator works like this:  read messages from the source cluster; send messages to the target cluster; if there has something error, Replicator will rewind these messages; loop to the next reading.

**Background of ManagedCursor:** ManagedCursor marks the next position which will read from BK, and we call it `readPosition`, and update after a read is complete. For example: 
1. initialize `readPosition` with `0.`
2. read 10 messages
3. update `readPosition` to `10.`

--- 

<strong>(Highlight)</strong>Therefore, if messages are sent out of order, many messages will be discarded. for example: if send `1,2,3,5,4`, then the message `4` will be discarded by duplication check.

---

**There have two scenarios that make messages out of order**
- scenario-1
  - read messages from the original cluster
  - read messages from the original cluster
  - receive messages `[1,2,3]`(the callback of the first read)
  - send messages `[1,2,3]` to the remote cluster, but something is wrong. Replicator trigger `rewind` and try to send again.
  - receive messages `[4,5]`(the callback of the second read)
  - send messages `[4,5]` to remote cluster.
  - receive messages `[1,2,3]` after `rewind`.

- scenario-2

| time | `thread rewind` | `thread reading messages`|
| -- | --- | --- |
| 1 | receive messages `[3:0 ~ 4:0]` |  |
| 1 |  | async read start(`readPosition=4:0, markDeleted=3:0`) |
| 2 | rewind `readPosition` (` --> 3:0`)` | |
| 3 |  | read complete, set `readPosition`(` --> 5:0`) |
| 4 | receive messages `[4:0 ~ 5.0]` |  |
| 5 | the messages `3:0 ~ 4:0` will nolanger be received until next `rewind` |

### Modifications

Make the replicator processes messages only sequentially

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- https://github.com/poorbarcode/pulsar/pull/87