### PR TITLE
[fix][broker] Fix entry filter feature for the non-persistent topic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -26,7 +26,7 @@ import com.carrotsearch.hppc.ObjectObjectHashMap;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -199,7 +199,8 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             // entry internally retains data so, duplicateBuffer should be release here
             duplicateBuffer.release();
             if (subscription.getDispatcher() != null) {
-                subscription.getDispatcher().sendMessages(Collections.singletonList(entry));
+                // Dispatcher needs to call the set method to support entry filter feature.
+                subscription.getDispatcher().sendMessages(Arrays.asList(entry));
             } else {
                 // it happens when subscription is created but dispatcher is not created as consumer is not added
                 // yet

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/plugin/FilterEntryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/plugin/FilterEntryTest.java
@@ -51,6 +51,7 @@ import org.apache.pulsar.broker.service.AbstractTopic;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.broker.service.Dispatcher;
 import org.apache.pulsar.broker.service.EntryFilterSupport;
+import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.testcontext.PulsarTestContext;
@@ -286,10 +287,16 @@ public class FilterEntryTest extends BrokerTestBase {
 
     }
 
+    @DataProvider(name = "topicProvider")
+    public Object[][] topicProvider() {
+        return new Object[][]{
+                {"persistent://prop/ns-abc/topic" + UUID.randomUUID()},
+                {"non-persistent://prop/ns-abc/topic" + UUID.randomUUID()},
+        };
+    }
 
-    @Test
-    public void testFilteredMsgCount() throws Throwable {
-        String topic = "persistent://prop/ns-abc/topic" + UUID.randomUUID();
+    @Test(dataProvider = "topicProvider")
+    public void testFilteredMsgCount(String topic) throws Throwable {
         String subName = "sub";
 
         try (Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
@@ -298,7 +305,7 @@ public class FilterEntryTest extends BrokerTestBase {
                      .subscriptionName(subName).subscribe()) {
 
             // mock entry filters
-            PersistentSubscription subscription = (PersistentSubscription) pulsar.getBrokerService()
+            Subscription subscription = pulsar.getBrokerService()
                     .getTopicReference(topic).get().getSubscription(subName);
             Dispatcher dispatcher = subscription.getDispatcher();
             Field field = EntryFilterSupport.class.getDeclaredField("entryFilters");


### PR DESCRIPTION
### Motivation

The non-persistent topic can't support the entry filter feature, because the entry list of the non-persistent topic is a `SingletonList`, it doesn't support the `set` method. We'll encounter this exception when using the entry filter feature on a non-persistent topic.

```
2023-04-19T23:52:11,689 - INFO  - [pulsar-io-83-8:EntryFilterTest@40] - filterEntry for {}
2023-04-19T23:52:11,690 - INFO  - [pulsar-io-83-8:EntryFilterTest@54] - metadata {} key REJECT debug '-' outcome REJECT
2023-04-19T23:52:11,690 - WARN  - [pulsar-io-83-8:ServerCnx@406] - [/127.0.0.1:58969] Got exception java.lang.UnsupportedOperationException
	at java.base/java.util.AbstractList.set(AbstractList.java:136)
	at org.apache.pulsar.broker.service.AbstractBaseDispatcher.filterEntriesForConsumer(AbstractBaseDispatcher.java:153)
	at org.apache.pulsar.broker.service.AbstractBaseDispatcher.filterEntriesForConsumer(AbstractBaseDispatcher.java:100)
	at org.apache.pulsar.broker.service.nonpersistent.NonPersistentDispatcherSingleActiveConsumer.sendMessages(NonPersistentDispatcherSingleActiveConsumer.java:60)
	at org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic.lambda$publishMessage$2(NonPersistentTopic.java:204)
	at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:554)
	at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:277)
	at org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic.publishMessage(NonPersistentTopic.java:197)
	at org.apache.pulsar.broker.service.Producer.publishMessageToTopic(Producer.java:281)
	at org.apache.pulsar.broker.service.Producer.publishMessage(Producer.java:194)
	at org.apache.pulsar.broker.service.ServerCnx.handleSend(ServerCnx.java:1733)
	at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:222)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
```

AbstractBaseDispatcher.java
```
...

if (filterResult == EntryFilter.FilterResult.REJECT) {
    entriesToFiltered.add(entry.getPosition());
    entries.set(i, null);
    // FilterResult will be always `ACCEPTED` when there is No Filter
    // dont need to judge whether `hasFilter` is true or not.
    this.filterRejectedMsgs.add(entryMsgCnt);
    filteredEntryCount++;
    filteredMessageCount += entryMsgCnt;
    filteredBytesCount += metadataAndPayload.readableBytes();
    entry.release();
    continue;
} else if (filterResult == EntryFilter.FilterResult.RESCHEDULE) {
    entriesToRedeliver.add((PositionImpl) entry.getPosition());
    entries.set(i, null);
    // FilterResult will be always `ACCEPTED` when there is No Filter
    // dont need to judge whether `hasFilter` is true or not.
    this.filterRescheduledMsgs.add(entryMsgCnt);
    filteredEntryCount++;
    filteredMessageCount += entryMsgCnt;
    filteredBytesCount += metadataAndPayload.readableBytes();
    entry.release();
    continue;
}

...
```

### Modifications

Use method `Arrays.asList(entry)` instead of the method `Collections.singletonList(entry)`.

### Verifying this change

Adjust existing tests.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/gaoran10/pulsar/pull/27

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
