### PR TITLE
[feat] [broker] Add broker health check status into prometheus metrics 

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1689,6 +1689,8 @@ exposePublisherStats=true
 statsUpdateFrequencyInSecs=60
 statsUpdateInitialDelayInSecs=60
 
+healthCheckMetricsUpdateTimeInSeconds=-1
+
 # Enable expose the precise backlog stats.
 # Set false to use published counter and consumed counter to calculate, this would be more efficient but may be inaccurate.
 # Default is false.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -3281,6 +3281,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private int statsUpdateInitialDelayInSecs = 60;
     @FieldContext(
+            category = CATEGORY_METRICS,
+            minValue = -1,
+            doc = "HealthCheck update frequency in seconds. Disable health check with value -1 (Default value -1)"
+    )
+    private int healthCheckMetricsUpdateTimeInSeconds = -1;
+    @FieldContext(
         category = CATEGORY_METRICS,
         doc = "If true, aggregate publisher stats of PartitionedTopicStats by producerName"
     )

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -51,6 +51,7 @@ import javax.ws.rs.core.Response.Status;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.PulsarService.State;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.admin.AdminResource;
@@ -422,26 +423,35 @@ public class BrokersBase extends AdminResource {
     }
 
     private CompletableFuture<Void> internalRunHealthCheck(TopicVersion topicVersion) {
-        String brokerId = pulsar().getBrokerId();
+        return internalRunHealthCheck(topicVersion, pulsar(), clientAppId());
+    }
+
+
+    public static CompletableFuture<Void> internalRunHealthCheck(TopicVersion topicVersion, PulsarService pulsar,
+                                                                 String clientAppId) {
+        NamespaceName namespaceName = (topicVersion == TopicVersion.V2)
+                ? NamespaceService.getHeartbeatNamespaceV2(pulsar.getAdvertisedAddress(), pulsar.getConfiguration())
+                : NamespaceService.getHeartbeatNamespace(pulsar.getAdvertisedAddress(), pulsar.getConfiguration());
+        String brokerId = pulsar.getBrokerId();
         final String topicName =
-                getHeartbeatTopicName(brokerId, pulsar().getConfiguration(), (topicVersion == TopicVersion.V2));
-        LOG.info("[{}] Running healthCheck with topic={}", clientAppId(), topicName);
+                getHeartbeatTopicName(brokerId, pulsar.getConfiguration(), (topicVersion == TopicVersion.V2));
+        LOG.info("[{}] Running healthCheck with topic={}", clientAppId, topicName);
         final String messageStr = UUID.randomUUID().toString();
         final String subscriptionName = "healthCheck-" + messageStr;
         // create non-partitioned topic manually and close the previous reader if present.
-        return pulsar().getBrokerService().getTopic(topicName, true)
+        return pulsar.getBrokerService().getTopic(topicName, true)
             .thenCompose(topicOptional -> {
                 if (!topicOptional.isPresent()) {
                     LOG.error("[{}] Fail to run health check while get topic {}. because get null value.",
-                            clientAppId(), topicName);
+                            clientAppId, topicName);
                     throw new RestException(Status.NOT_FOUND,
                             String.format("Topic [%s] not found after create.", topicName));
                 }
                 PulsarClient client;
                 try {
-                    client = pulsar().getClient();
+                    client = pulsar.getClient();
                 } catch (PulsarServerException e) {
-                    LOG.error("[{}] Fail to run health check while get client.", clientAppId());
+                    LOG.error("[{}] Fail to run health check while get client.", clientAppId);
                     throw new RestException(e);
                 }
                 CompletableFuture<Void> resultFuture = new CompletableFuture<>();
@@ -451,17 +461,18 @@ public class BrokersBase extends AdminResource {
                                 .startMessageId(MessageId.latest)
                                 .createAsync().exceptionally(createException -> {
                                     producer.closeAsync().exceptionally(ex -> {
-                                        LOG.error("[{}] Close producer fail while heath check.", clientAppId());
+                                        LOG.error("[{}] Close producer fail while heath check.", clientAppId);
                                         return null;
                                     });
                                     throw FutureUtil.wrapToCompletionException(createException);
                                 }).thenCompose(reader -> producer.sendAsync(messageStr)
                                         .thenCompose(__ -> FutureUtil.addTimeoutHandling(
                                                 healthCheckRecursiveReadNext(reader, messageStr),
-                                                HEALTH_CHECK_READ_TIMEOUT, pulsar().getBrokerService().executor(),
+                                                HEALTH_CHECK_READ_TIMEOUT, pulsar.getBrokerService().executor(),
                                                 () -> HEALTH_CHECK_TIMEOUT_EXCEPTION))
                                         .whenComplete((__, ex) -> {
-                                            closeAndReCheck(producer, reader, topicOptional.get(), subscriptionName)
+                                            closeAndReCheck(producer, reader, topicOptional.get(), subscriptionName,
+                                                    clientAppId)
                                                     .whenComplete((unused, innerEx) -> {
                                                         if (ex != null) {
                                                             resultFuture.completeExceptionally(ex);
@@ -479,6 +490,11 @@ public class BrokersBase extends AdminResource {
             });
     }
 
+    private CompletableFuture<Void> closeAndReCheck(Producer<String> producer, Reader<String> reader,
+                                                           Topic topic, String subscriptionName) {
+        return closeAndReCheck(producer, reader, topic, subscriptionName, clientAppId());
+    }
+
     /**
      * Close producer and reader and then to re-check if this operation is success.
      *
@@ -491,8 +507,8 @@ public class BrokersBase extends AdminResource {
      * @param topic  Topic
      * @param subscriptionName  Subscription name
      */
-    private CompletableFuture<Void> closeAndReCheck(Producer<String> producer, Reader<String> reader,
-                                                    Topic topic, String subscriptionName) {
+    private static CompletableFuture<Void> closeAndReCheck(Producer<String> producer, Reader<String> reader,
+                                                    Topic topic, String subscriptionName, String clientAppId) {
         // no matter exception or success, we still need to
         // close producer/reader
         CompletableFuture<Void> producerFuture = producer.closeAsync();
@@ -503,7 +519,7 @@ public class BrokersBase extends AdminResource {
         return FutureUtil.waitForAll(Collections.unmodifiableList(futures))
                 .exceptionally(closeException -> {
                     if (readerFuture.isCompletedExceptionally()) {
-                        LOG.error("[{}] Close reader fail while heath check.", clientAppId());
+                        LOG.error("[{}] Close reader fail while heath check.", clientAppId);
                         Subscription subscription =
                                 topic.getSubscription(subscriptionName);
                         // re-check subscription after reader close
@@ -511,24 +527,24 @@ public class BrokersBase extends AdminResource {
                             LOG.warn("[{}] Force delete subscription {} "
                                             + "when it still exists after the"
                                             + " reader is closed.",
-                                    clientAppId(), subscription);
+                                    clientAppId, subscription);
                             subscription.deleteForcefully()
                                     .exceptionally(ex -> {
                                         LOG.error("[{}] Force delete subscription fail"
                                                         + " while health check",
-                                                clientAppId(), ex);
+                                                clientAppId, ex);
                                         return null;
                                     });
                         }
                     } else {
                         // producer future fail.
-                        LOG.error("[{}] Close producer fail while heath check.", clientAppId());
+                        LOG.error("[{}] Close producer fail while heath check.", clientAppId);
                     }
                     return null;
                 });
     }
 
-    private CompletableFuture<Void> healthCheckRecursiveReadNext(Reader<String> reader, String content) {
+    private static CompletableFuture<Void> healthCheckRecursiveReadNext(Reader<String> reader, String content) {
         return reader.readNextAsync()
                 .thenCompose(msg -> {
                     if (!Objects.equals(content, msg.getValue())) {


### PR DESCRIPTION
### Motivation

Issue: https://github.com/apache/pulsar/issues/20146
To add broker health check into prometheus metric.

### Modifications

Schedule a job at 1 minute time interval which calls healthCheck API on broker and updates the pulsar stats based on the broker health.

### Verifying this change

Unit test cases were added to verify this change.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-complete` <!-- Docs have been already added -->

