### PR TITLE
[fix][admin] Fix examine messages if total message is zero

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3043,10 +3043,9 @@ public class PersistentTopicsBase extends AdminResource {
                                 "Examine messages on a non-persistent topic is not allowed");
                     }
                     try {
-                        CompletableFuture<Entry> future = new CompletableFuture<>();
                         PersistentTopic persistentTopic = (PersistentTopic) topic;
                         long totalMessage = persistentTopic.getNumberOfEntries();
-                        if(totalMessage == 0) {
+                        if(totalMessage <= 0) {
                             throw new RestException(Status.INTERNAL_SERVER_ERROR,
                                     "Could not examine messages due to the total message is zero");
                         }
@@ -3054,7 +3053,7 @@ public class PersistentTopicsBase extends AdminResource {
 
                         long messageToSkip = initialPositionLocal.equals("earliest") ? messagePositionLocal :
                                 totalMessage - messagePositionLocal + 1;
-
+                        CompletableFuture<Entry> future = new CompletableFuture<>();
                         PositionImpl readPosition = persistentTopic.getPositionAfterN(startPosition, messageToSkip);
                         persistentTopic.asyncReadEntry(readPosition, new AsyncCallbacks.ReadEntryCallback() {
                             @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3045,8 +3045,8 @@ public class PersistentTopicsBase extends AdminResource {
                     try {
                         PersistentTopic persistentTopic = (PersistentTopic) topic;
                         long totalMessage = persistentTopic.getNumberOfEntries();
-                        if(totalMessage <= 0) {
-                            throw new RestException(Status.INTERNAL_SERVER_ERROR,
+                        if (totalMessage <= 0) {
+                            throw new RestException(Status.PRECONDITION_FAILED,
                                     "Could not examine messages due to the total message is zero");
                         }
                         PositionImpl startPosition = persistentTopic.getFirstPosition();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3043,13 +3043,18 @@ public class PersistentTopicsBase extends AdminResource {
                                 "Examine messages on a non-persistent topic is not allowed");
                     }
                     try {
+                        CompletableFuture<Entry> future = new CompletableFuture<>();
                         PersistentTopic persistentTopic = (PersistentTopic) topic;
                         long totalMessage = persistentTopic.getNumberOfEntries();
+                        if(totalMessage == 0) {
+                            throw new RestException(Status.INTERNAL_SERVER_ERROR,
+                                    "Could not examine messages due to the total message is zero");
+                        }
                         PositionImpl startPosition = persistentTopic.getFirstPosition();
 
                         long messageToSkip = initialPositionLocal.equals("earliest") ? messagePositionLocal :
                                 totalMessage - messagePositionLocal + 1;
-                        CompletableFuture<Entry> future = new CompletableFuture<>();
+
                         PositionImpl readPosition = persistentTopic.getPositionAfterN(startPosition, messageToSkip);
                         persistentTopic.asyncReadEntry(readPosition, new AsyncCallbacks.ReadEntryCallback() {
                             @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -1150,6 +1150,14 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
                             + "topic partition");
         }
 
+        try {
+            admin.topics().examineMessage(topicName + "-partition-0", "earliest", 1);
+            Assert.fail();
+        } catch (PulsarAdminException e) {
+            Assert.assertEquals(e.getMessage(),
+                    "Could not examine messages due to the total message is zero");
+        }
+
         producer.send("message1");
         Assert.assertEquals(
                 new String(admin.topics().examineMessage(topicName + "-partition-0", "earliest", 1).getData()),


### PR DESCRIPTION
### Motivation

If the total messages is zero, we should throw exception fast, insteading  throwing exception when reading from the ledger.
### Modifications

If the total messages is zero, throw exception

### Verifying this change

- [x] Make sure that the change passes the CI checks.
- org.apache.pulsar.broker.admin.PersistentTopicsTest#testExamineMessage will cover this test

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/AnonHxy/pulsar/pull/36
