### PR TITLE
[fix][client] Fix breaking changes for the deprecated methods of TopicMessageIdImpl

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
@@ -62,7 +62,7 @@ public class TopicMessageIdImpl implements MessageIdAdv, TopicMessageId {
 
     @Deprecated
     public MessageId getInnerMessageId() {
-        return new MessageIdImpl(getLedgerId(), getEntryId(), getPartitionIndex());
+        return msgId;
     }
 
     @Override

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TopicMessageIdImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TopicMessageIdImplTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.impl;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertSame;
 
 import org.testng.annotations.Test;
 
@@ -54,4 +55,12 @@ public class TopicMessageIdImplTest {
         assertNotEquals(topicMsgId1, topicMsgId2);
     }
 
+    @Test
+    public void testDeprecatedMethods() {
+        BatchMessageIdImpl msgId = new BatchMessageIdImpl(1, 2, 3, 4);
+        TopicMessageIdImpl topicMsgId = new TopicMessageIdImpl("topic-partition-0", "topic", msgId);
+        assertSame(topicMsgId.getInnerMessageId(), msgId);
+        assertEquals(topicMsgId.getTopicPartitionName(), topicMsgId.getOwnerTopic());
+        assertEquals(topicMsgId.getTopicName(), "topic");
+    }
 }


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/19414 introduces a breaking change for the deprecated `TopicMessageIdImpl#getInnerMessageId` method. It does not return the inner message id, instead, it creates a new `MessageIdImpl`.

### Modifications

Fix the `getInnerMessageId` method and add tests for these deprecated methods.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/BewareMyPower/pulsar/pull/28