### PR TITLE
[fix][test] Fix flaky test `ConcurrentBitmapSortedLongPairSetTest`

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/utils/ConcurrentBitmapSortedLongPairSetTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/utils/ConcurrentBitmapSortedLongPairSetTest.java
@@ -188,15 +188,12 @@ public class ConcurrentBitmapSortedLongPairSetTest {
         List<Future<?>> futures = new ArrayList<>();
         for (int i = 0; i < nThreads; i++) {
             final int threadIdx = i;
-
             futures.add(executor.submit(() -> {
-                Random random = new Random();
 
+                int start = N * (threadIdx + 1);
                 for (int j = 0; j < N; j++) {
-                    int key = random.nextInt();
+                    int key = start + j;
                     // Ensure keys are unique
-                    key -= key % (threadIdx + 1);
-                    key = Math.abs(key);
                     set.add(key, key);
                 }
             }));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/utils/ConcurrentBitmapSortedLongPairSetTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/utils/ConcurrentBitmapSortedLongPairSetTest.java
@@ -26,7 +26,6 @@ import org.apache.pulsar.common.util.collections.ConcurrentLongPairSet;
 import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/actions/runs/4751705649/jobs/8462387478?pr=20122

```
Error:  Tests run: 7, Failures: 1, Errors: 0, Skipped: 6, Time elapsed: 0.176 s <<< FAILURE! - in org.apache.pulsar.utils.ConcurrentBitmapSortedLongPairSetTest
  Error:  concurrentInsertions(org.apache.pulsar.utils.ConcurrentBitmapSortedLongPairSetTest)  Time elapsed: 0.038 s  <<< FAILURE!
  java.lang.AssertionError: expected [8000] but found [7999]
  	at org.testng.Assert.fail(Assert.java:110)
  	at org.testng.Assert.failNotEquals(Assert.java:1413)
  	at org.testng.Assert.assertEqualsImpl(Assert.java:149)
  	at org.testng.Assert.assertEquals(Assert.java:131)
  	at org.testng.Assert.assertEquals(Assert.java:1240)
  	at org.testng.Assert.assertEquals(Assert.java:1274)
  	at org.apache.pulsar.utils.ConcurrentBitmapSortedLongPairSetTest.concurrentInsertions(ConcurrentBitmapSortedLongPairSetTest.java:209)
  	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
  	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
  	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:139)
  	at org.testng.internal.invokers.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:47)
  	at org.testng.internal.invokers.InvokeMethodRunnable.call(InvokeMethodRunnable.java:76)
  	at org.testng.internal.invokers.InvokeMethodRunnable.call(InvokeMethodRunnable.java:11)
  	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
  	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
  	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
  	at java.base/java.lang.Thread.run(Thread.java:833)
```

The `key` is duplicated in the test and cause it failed. Make the `key` unique.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


