### PR TITLE
[fix][broker] Remove useless field in the DelayedMessageIndexBucketSegment.proto

### DIFF
--- a/pulsar-broker/src/main/proto/DelayedMessageIndexBucketSegment.proto
+++ b/pulsar-broker/src/main/proto/DelayedMessageIndexBucketSegment.proto
@@ -31,5 +31,4 @@ message DelayedIndex {
 
 message SnapshotSegment {
     repeated DelayedIndex indexes = 1;
-    map<uint64, bytes> delayed_index_bit_map = 2;
 }


### PR DESCRIPTION
### Motivation & Modifications

<img width="851" alt="image" src="https://user-images.githubusercontent.com/26179648/233825959-04e3805d-6183-4690-806e-edaf3e46acbd.png">

Remove the useless (not supported)field in the DelayedMessageIndexBucketSegment.proto, It was introduced by PR #20158

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
