### PR TITLE
[branch-2.10][fix][build] Upgrade swagger version to fix CVE-2022-1471

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -334,9 +334,9 @@ The Apache Software License, Version 2.0
  * J2ObjC Annotations -- com.google.j2objc-j2objc-annotations-1.3.jar
  * Netty Reactive Streams -- com.typesafe.netty-netty-reactive-streams-2.0.6.jar
  * Swagger
-    - io.swagger-swagger-annotations-1.6.2.jar
-    - io.swagger-swagger-core-1.6.2.jar
-    - io.swagger-swagger-models-1.6.2.jar
+    - io.swagger-swagger-annotations-1.6.10.jar
+    - io.swagger-swagger-core-1.6.10.jar
+    - io.swagger-swagger-models-1.6.10.jar
  * DataSketches
     - com.yahoo.datasketches-memory-0.8.3.jar
     - com.yahoo.datasketches-sketches-core-0.8.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@ flexible messaging model and an intuitive client API.</description>
     <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
     <jackson.version>2.14.2</jackson.version>
     <reflections.version>0.9.11</reflections.version>
-    <swagger.version>1.6.2</swagger.version>
+    <swagger.version>1.6.10</swagger.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
     <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
     <typetools.version>0.5.0</typetools.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -475,7 +475,7 @@ The Apache Software License, Version 2.0
   * Apache Yetus Audience Annotations
     - audience-annotations-0.5.0.jar
   * Swagger
-    - swagger-annotations-1.6.2.jar
+    - swagger-annotations-1.6.10.jar
   * Perfmark
     - perfmark-api-0.19.0.jar
   * Annotations


### PR DESCRIPTION
### Motivation
 Upgrade swagger version to fix CVE-2022-1471

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


