### PR TITLE
[fix][broker] Fix recentlyJoinedConsumers to address the out-of-order issue

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImplRecyclable.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionImplRecyclable.java
@@ -38,6 +38,14 @@ public class PositionImplRecyclable extends PositionImpl implements Position {
         this.recyclerHandle = recyclerHandle;
     }
 
+    public void setLedgerId(final long ledgerId) {
+        this.ledgerId = ledgerId;
+    }
+
+    public void setEntryId(final long entryId) {
+        this.entryId = entryId;
+    }
+
     public static PositionImplRecyclable create() {
         return RECYCLER.get();
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -134,7 +134,7 @@ public class Consumer {
 
     private static final double avgPercent = 0.9;
     private boolean preciseDispatcherFlowControl;
-    private PositionImpl readPositionWhenJoining;
+    private String lastSentPositionsWhenJoiningString;
     private final String clientAddress; // IP address only, no port number included
     private final MessageId startMessageId;
     private final boolean isAcknowledgmentAtBatchIndexLevelEnabled;
@@ -867,8 +867,8 @@ public class Consumer {
         stats.unackedMessages = unackedMessages;
         stats.blockedConsumerOnUnackedMsgs = blockedConsumerOnUnackedMsgs;
         stats.avgMessagesPerEntry = getAvgMessagesPerEntry();
-        if (readPositionWhenJoining != null) {
-            stats.readPositionWhenJoining = readPositionWhenJoining.toString();
+        if (lastSentPositionsWhenJoiningString != null) {
+            stats.lastSentPositionsWhenJoining = lastSentPositionsWhenJoiningString;
         }
         return stats;
     }
@@ -1088,8 +1088,8 @@ public class Consumer {
         return preciseDispatcherFlowControl;
     }
 
-    public void setReadPositionWhenJoining(PositionImpl readPositionWhenJoining) {
-        this.readPositionWhenJoining = readPositionWhenJoining;
+    public void setLastSentPositionsWhenJoiningString(String lastSentPositionsWhenJoiningString) {
+        this.lastSentPositionsWhenJoiningString = lastSentPositionsWhenJoiningString;
     }
 
     public int getMaxUnackedMessages() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -1188,7 +1188,11 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
     }
 
     protected int getStickyKeyHash(Entry entry) {
-        return StickyKeyConsumerSelector.makeStickyKeyHash(peekStickyKey(entry.getDataBuffer()));
+        return getStickyKeyHash(peekStickyKey(entry.getDataBuffer()));
+    }
+
+    protected int getStickyKeyHash(byte[] stickyKey) {
+        return StickyKeyConsumerSelector.makeStickyKeyHash(stickyKey);
     }
 
     private static final Logger log = LoggerFactory.getLogger(PersistentDispatcherMultipleConsumers.class);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1186,11 +1186,19 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
             subStats.allowOutOfOrderDelivery = keySharedDispatcher.isAllowOutOfOrderDelivery();
             subStats.keySharedMode = keySharedDispatcher.getKeySharedMode().toString();
 
-            LinkedHashMap<Consumer, PositionImpl> recentlyJoinedConsumers = keySharedDispatcher
+            LinkedHashMap<Consumer, PersistentStickyKeyDispatcherMultipleConsumers.LastSentPositions>
+                    recentlyJoinedConsumers = keySharedDispatcher
                     .getRecentlyJoinedConsumers();
             if (recentlyJoinedConsumers != null && recentlyJoinedConsumers.size() > 0) {
                 recentlyJoinedConsumers.forEach((k, v) -> {
-                    subStats.consumersAfterMarkDeletePosition.put(k.consumerName(), v.toString());
+                    // Dispatchers allows same name consumers
+                    final StringBuilder stringBuilder = new StringBuilder();
+                    stringBuilder.append("consumerName=").append(k.consumerName())
+                            .append(", consumerId=").append(k.consumerId());
+                    if (k.cnx() != null) {
+                        stringBuilder.append(", address=").append(k.cnx().clientAddress());
+                    }
+                    subStats.recentlyJoinedConsumers.put(stringBuilder.toString(), v.toPositionSetString());
                 });
             }
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -154,7 +154,9 @@ public class LoadBalancerTest {
         executor.shutdownNow();
 
         for (int i = 0; i < BROKER_COUNT; i++) {
-            pulsarAdmins[i].close();
+            if (pulsarAdmins[i] != null) {
+                pulsarAdmins[i].close();
+            }
             if (pulsarServices[i] != null) {
                 pulsarServices[i].close();
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/SubscriptionStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/SubscriptionStatsTest.java
@@ -116,7 +116,7 @@ public class SubscriptionStatsTest extends ProducerConsumerBase {
         TopicStats stats = admin.topics().getStats(topicName);
         Assert.assertEquals(stats.getSubscriptions().size(), 1);
         Assert.assertEquals(stats.getSubscriptions().entrySet().iterator().next().getValue()
-                .getConsumersAfterMarkDeletePosition().size(), 1);
+                .getRecentlyJoinedConsumers().size(), 1);
 
         consumer1.close();
         consumer2.close();

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ConsumerStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ConsumerStats.java
@@ -69,8 +69,8 @@ public interface ConsumerStats {
     /** Flag to verify if consumer is blocked due to reaching threshold of unacked messages. */
     boolean isBlockedConsumerOnUnackedMsgs();
 
-    /** The read position of the cursor when the consumer joining. */
-    String getReadPositionWhenJoining();
+    /** Last sent positions per sticky key of the cursor when the consumer joining. */
+    String getLastSentPositionsWhenJoining();
 
     /** Address of this consumer. */
     String getAddress();

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
@@ -115,8 +115,8 @@ public interface SubscriptionStats {
     /** Whether the Key_Shared subscription mode is AUTO_SPLIT or STICKY. */
     String getKeySharedMode();
 
-    /** This is for Key_Shared subscription to get the recentJoinedConsumers in the Key_Shared subscription. */
-    Map<String, String> getConsumersAfterMarkDeletePosition();
+    /** This is for Key_Shared subscription to get the recentlyJoinedConsumers in the Key_Shared subscription. */
+    Map<String, String> getRecentlyJoinedConsumers();
 
     /** SubscriptionProperties (key/value strings) associated with this subscribe. */
     Map<String, String> getSubscriptionProperties();

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
@@ -75,8 +75,8 @@ public class ConsumerStatsImpl implements ConsumerStats {
     /** Flag to verify if consumer is blocked due to reaching threshold of unacked messages. */
     public boolean blockedConsumerOnUnackedMsgs;
 
-    /** The read position of the cursor when the consumer joining. */
-    public String readPositionWhenJoining;
+    /** Last sent positions per sticky key of the cursor when the consumer joining. */
+    public String lastSentPositionsWhenJoining;
 
     /** Address of this consumer. */
     @JsonIgnore
@@ -129,7 +129,7 @@ public class ConsumerStatsImpl implements ConsumerStats {
         this.availablePermits += stats.availablePermits;
         this.unackedMessages += stats.unackedMessages;
         this.blockedConsumerOnUnackedMsgs = stats.blockedConsumerOnUnackedMsgs;
-        this.readPositionWhenJoining = stats.readPositionWhenJoining;
+        this.lastSentPositionsWhenJoining = stats.lastSentPositionsWhenJoining;
         return this;
     }
 
@@ -177,8 +177,8 @@ public class ConsumerStatsImpl implements ConsumerStats {
         this.stringBuffer.append(clientVersion);
     }
 
-    public String getReadPositionWhenJoining() {
-        return readPositionWhenJoining;
+    public String getLastSentPositionsWhenJoining() {
+        return lastSentPositionsWhenJoining;
     }
 
     public String getLastAckedTime() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
@@ -122,8 +122,8 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
     /** Whether the Key_Shared subscription mode is AUTO_SPLIT or STICKY. */
     public String keySharedMode;
 
-    /** This is for Key_Shared subscription to get the recentJoinedConsumers in the Key_Shared subscription. */
-    public Map<String, String> consumersAfterMarkDeletePosition;
+    /** This is for Key_Shared subscription to get the recentlyJoinedConsumers in the Key_Shared subscription. */
+    public Map<String, String> recentlyJoinedConsumers;
 
     /** The number of non-contiguous deleted messages ranges. */
     public int nonContiguousDeletedMessagesRanges;
@@ -149,7 +149,7 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
 
     public SubscriptionStatsImpl() {
         this.consumers = new ArrayList<>();
-        this.consumersAfterMarkDeletePosition = new LinkedHashMap<>();
+        this.recentlyJoinedConsumers = new LinkedHashMap<>();
         this.subscriptionProperties = new HashMap<>();
         this.bucketDelayedIndexStats = new HashMap<>();
     }
@@ -171,7 +171,7 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
         lastExpireTimestamp = 0L;
         lastMarkDeleteAdvancedTimestamp = 0L;
         consumers.clear();
-        consumersAfterMarkDeletePosition.clear();
+        recentlyJoinedConsumers.clear();
         nonContiguousDeletedMessagesRanges = 0;
         nonContiguousDeletedMessagesRangesSerializedSize = 0;
         delayedMessageIndexSizeInBytes = 0;
@@ -214,7 +214,7 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
             }
         }
         this.allowOutOfOrderDelivery |= stats.allowOutOfOrderDelivery;
-        this.consumersAfterMarkDeletePosition.putAll(stats.consumersAfterMarkDeletePosition);
+        this.recentlyJoinedConsumers.putAll(stats.recentlyJoinedConsumers);
         this.nonContiguousDeletedMessagesRanges += stats.nonContiguousDeletedMessagesRanges;
         this.nonContiguousDeletedMessagesRangesSerializedSize += stats.nonContiguousDeletedMessagesRangesSerializedSize;
         this.delayedMessageIndexSizeInBytes += stats.delayedMessageIndexSizeInBytes;


### PR DESCRIPTION
<!--
### Contribution Checklist

  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*.
  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message
  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

The Key_Shared subscription type has the following issues.

1. Key_Shared subscription has out-of-order cases because of the race condition of [the recently joined consumers feature](https://github.com/apache/pulsar/blob/35e9897742b7db4bd29349940075a819b2ad6999/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java#L400-L408).
   Consider the following flow.

   1. Assume that the current read position is `1:6` and the recently joined consumers is empty.
   2. Called [OpReadEntry#internalReadEntriesComplete](https://github.com/apache/pulsar/blob/35e9897742b7db4bd29349940075a819b2ad6999/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java#L92-L95) from thread-1.
      Then, the current read position is updated to `1:11` (Messages from `1:6` to `1:10` have yet to be dispatched to consumers).
   3. Called [PersistentStickyKeyDispatcherMultipleConsumers#addConsumer](https://github.com/apache/pulsar/blob/35e9897742b7db4bd29349940075a819b2ad6999/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java#L130-L131) from thread-2.
      Then, the new consumer is stored to recently joined consumers with read position `1:11`.
   4. Called [PersistentDispatcherMultipleConsumers#trySendMessagesToConsumers](https://github.com/apache/pulsar/blob/35e9897742b7db4bd29349940075a819b2ad6999/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java#L174) from thread-5.
      Then, messages from `1:6` to `1:10` are dispatched to consumers. From the recently joined consumers feature, the new consumer can receive messages from `1:6` to `1:10`. **However, it is not expected.**
      For example, if existing consumers have some unacked messages and disconnect, it causes out of order in some cases.

2. Key_Shared subscription has a redundant process.
   [The stuckConsumers feature](https://github.com/apache/pulsar/blob/35e9897742b7db4bd29349940075a819b2ad6999/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java#L369-L375) was introduced from https://github.com/apache/pulsar/pull/7553 .
   However, it can't fix the issue entirely because it doesn't consider the range changes.
   After this commit, https://github.com/apache/pulsar/pull/10762 was introduced. It fixes the issue.

### Modifications

1. Store last sent position instead of read position to recently joined consumers.
   Updating read position, then dispatching messages, and adding new consumer are not exclusive.
   I used the last send position to get a position without any new exclusion features.

2. Keep the last sent position per key.
   When I introduced the last sent position, I noticed a new concern. Consider the following flow.

   1. Assume that the [entries](https://github.com/apache/pulsar/blob/35e9897742b7db4bd29349940075a819b2ad6999/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java#L174) has the following messages,
      - `msg-1`, key: `key-a`, position: `1:1`
      - `msg-2`, key: `key-a`, position: `1:2`
      - `msg-3`, key: `key-a`, position: `1:3`
      - `msg-4`, key: `key-b`, position: `1:4`
      - `msg-5`, key: `key-b`, position: `1:5`
      - `msg-6`, key: `key-b`, position: `1:6`
      the dispatcher has two consumers (`c1` `messagesForC` is 1, `c2` `messageForC` is 1000), and the selector will return `c1` if `key-a` and `c2` if `key-b`.
   2. Send `msg-1` to `c1` and `msg-4` - `msg-6` to `c2`.
      - So, the current last sent position is `1:6`.
      - `c1` never acknowledge `msg-1`.
   3. Add new consumer `c3`, and the selector will return `c3` if `key-a`.
   4. Send `msg-2` - `msg-3` to `c3` because `1:2` and `1:3` are less than the last sent position, `1:6`.
   5. Disconnect `c1`.
   6. Send `msg-1` to `c3`.
      Now, `c3` receives messages without expected order about `key-a`.

   To avoid this issue, I introduce the last sent positions feature.

3. Remove redundant features due to the addition of the last sent positions feature.

   1. Remove this condition because the last sent positions feature restricts part of messages.
      New consumers can receive any new messages with the message key that is not in the last sent position.
      https://github.com/apache/pulsar/blob/35e9897742b7db4bd29349940075a819b2ad6999/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java#L323-L336

   2. Remove this behavior because the last sent positions has positions per key.
      If some key is stuck at a certain point in time, from that point, new consumers store the same information about the key to the `recentlyJoinedConsumers`.
      https://github.com/apache/pulsar/blob/35e9897742b7db4bd29349940075a819b2ad6999/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java#L365-L399

   3. Remove this behavior because this calculation is moved to LastSentPositions#compareToLastSentPosition.
      https://github.com/apache/pulsar/blob/35e9897742b7db4bd29349940075a819b2ad6999/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java#L400-L408

4. Remove the stuckConsumers feature.
5. Reconstruct some consumer stats fields related to Key_Shared.
   **This is a breaking change.** However, if this PR is merged, the existing field which is removed in this PR is no longer needed.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
- Added unit test to ensure the behavior of last sent positions feature works properly

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/equanz/pulsar/pull/1

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.
apache/pulsar pull requests should be first tested in your own fork since the
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in
a forked repository.
The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
