### PR TITLE
[improve][build] Revert "Upgrade jackson version to 2.15.0 for CVE-2022-1471 (#20177)"

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -246,17 +246,17 @@ The Apache Software License, Version 2.0
  * JCommander -- com.beust-jcommander-1.82.jar
  * High Performance Primitive Collections for Java -- com.carrotsearch-hppc-0.9.1.jar
  * Jackson
-     - com.fasterxml.jackson.core-jackson-annotations-2.15.0.jar
-     - com.fasterxml.jackson.core-jackson-core-2.15.0.jar
-     - com.fasterxml.jackson.core-jackson-databind-2.15.0.jar
-     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.15.0.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.15.0.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.15.0.jar
-     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.15.0.jar
-     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.15.0.jar
-     - com.fasterxml.jackson.datatype-jackson-datatype-jdk8-2.15.0.jar
-     - com.fasterxml.jackson.datatype-jackson-datatype-jsr310-2.15.0.jar
-     - com.fasterxml.jackson.module-jackson-module-parameter-names-2.15.0.jar
+     - com.fasterxml.jackson.core-jackson-annotations-2.14.2.jar
+     - com.fasterxml.jackson.core-jackson-core-2.14.2.jar
+     - com.fasterxml.jackson.core-jackson-databind-2.14.2.jar
+     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.14.2.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.14.2.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.14.2.jar
+     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.14.2.jar
+     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.14.2.jar
+     - com.fasterxml.jackson.datatype-jackson-datatype-jdk8-2.14.2.jar
+     - com.fasterxml.jackson.datatype-jackson-datatype-jsr310-2.14.2.jar
+     - com.fasterxml.jackson.module-jackson-module-parameter-names-2.14.2.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.9.1.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-2.0.1.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -311,17 +311,17 @@ This projects includes binary packages with the following licenses:
 The Apache Software License, Version 2.0
  * JCommander -- jcommander-1.82.jar
  * Jackson
-     - jackson-annotations-2.15.0.jar
-     - jackson-core-2.15.0.jar
-     - jackson-databind-2.15.0.jar
-     - jackson-dataformat-yaml-2.15.0.jar
-     - jackson-jaxrs-base-2.15.0.jar
-     - jackson-jaxrs-json-provider-2.15.0.jar
-     - jackson-module-jaxb-annotations-2.15.0.jar
-     - jackson-module-jsonSchema-2.15.0.jar
-     - jackson-datatype-jdk8-2.15.0.jar
-     - jackson-datatype-jsr310-2.15.0.jar
-     - jackson-module-parameter-names-2.15.0.jar
+     - jackson-annotations-2.14.2.jar
+     - jackson-core-2.14.2.jar
+     - jackson-databind-2.14.2.jar
+     - jackson-dataformat-yaml-2.14.2.jar
+     - jackson-jaxrs-base-2.14.2.jar
+     - jackson-jaxrs-json-provider-2.14.2.jar
+     - jackson-module-jaxb-annotations-2.14.2.jar
+     - jackson-module-jsonSchema-2.14.2.jar
+     - jackson-datatype-jdk8-2.14.2.jar
+     - jackson-datatype-jsr310-2.14.2.jar
+     - jackson-module-parameter-names-2.14.2.jar
  * Conscrypt -- conscrypt-openjdk-uber-2.5.2.jar
  * Gson
     - gson-2.8.9.jar

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@ flexible messaging model and an intuitive client API.</description>
     <bouncycastle.version>1.69</bouncycastle.version>
     <bouncycastle.bcpkix-fips.version>1.0.6</bouncycastle.bcpkix-fips.version>
     <bouncycastle.bc-fips.version>1.0.2.3</bouncycastle.bc-fips.version>
-    <jackson.version>2.15.0</jackson.version>
+    <jackson.version>2.14.2</jackson.version>
     <reflections.version>0.10.2</reflections.version>
     <swagger.version>1.6.2</swagger.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.common.util;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.databind.util.EnumResolver;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -55,6 +57,8 @@ public final class FieldParser {
 
     private static final Map<String, Method> CONVERTERS = new HashMap<>();
     private static final Map<Class<?>, Class<?>> WRAPPER_TYPES = new HashMap<>();
+
+    private static final AnnotationIntrospector ANNOTATION_INTROSPECTOR = new JacksonAnnotationIntrospector();
 
     static {
         // Preload converters and wrapperTypes.
@@ -96,8 +100,7 @@ public final class FieldParser {
 
         if (to.isEnum()) {
             // Converting string to enum
-            EnumResolver r = EnumResolver.constructUsingToString(
-                    ObjectMapperFactory.getMapper().getObjectMapper().getDeserializationConfig(), to);
+            EnumResolver r = EnumResolver.constructUsingToString((Class<Enum<?>>) to, ANNOTATION_INTROSPECTOR);
             T value = (T) r.findEnum((String) from);
             if (value == null) {
                 throw new RuntimeException("Invalid value '" + from + "' for enum " + to);

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -207,19 +207,19 @@ This projects includes binary packages with the following licenses:
 The Apache Software License, Version 2.0
 
   * Jackson
-    - jackson-annotations-2.15.0.jar
-    - jackson-core-2.15.0.jar
-    - jackson-databind-2.15.0.jar
-    - jackson-dataformat-smile-2.15.0.jar
-    - jackson-datatype-guava-2.15.0.jar
-    - jackson-datatype-jdk8-2.15.0.jar
-    - jackson-datatype-joda-2.15.0.jar
-    - jackson-datatype-jsr310-2.15.0.jar
-    - jackson-dataformat-yaml-2.15.0.jar
-    - jackson-jaxrs-base-2.15.0.jar
-    - jackson-jaxrs-json-provider-2.15.0.jar
-    - jackson-module-jaxb-annotations-2.15.0.jar
-    - jackson-module-jsonSchema-2.15.0.jar
+    - jackson-annotations-2.14.2.jar
+    - jackson-core-2.14.2.jar
+    - jackson-databind-2.14.2.jar
+    - jackson-dataformat-smile-2.14.2.jar
+    - jackson-datatype-guava-2.14.2.jar
+    - jackson-datatype-jdk8-2.14.2.jar
+    - jackson-datatype-joda-2.14.2.jar
+    - jackson-datatype-jsr310-2.14.2.jar
+    - jackson-dataformat-yaml-2.14.2.jar
+    - jackson-jaxrs-base-2.14.2.jar
+    - jackson-jaxrs-json-provider-2.14.2.jar
+    - jackson-module-jaxb-annotations-2.14.2.jar
+    - jackson-module-jsonSchema-2.14.2.jar
  * Guava
     - guava-31.0.1-jre.jar
     - listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
@@ -456,7 +456,7 @@ The Apache Software License, Version 2.0
   * Snappy
     - snappy-java-1.1.8.4.jar
   * Jackson
-    - jackson-module-parameter-names-2.15.0.jar
+    - jackson-module-parameter-names-2.14.2.jar
   * Java Assist
     - javassist-3.25.0-GA.jar
   * Java Native Access


### PR DESCRIPTION
This reverts commit fd60e9e8380af1c7680999cbb5bff8160ba3571a.

### Motivation

There's a regression of Jackson. 
https://github.com/FasterXML/jackson-databind/issues/3874

### Modifications

- Revert upgrading operation
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

