### PR TITLE
[fix][docs] Remove old template inlined

### DIFF
--- a/wiki/proposals/PIP.md
+++ b/wiki/proposals/PIP.md
@@ -115,5 +115,6 @@ Some examples:
 
 
 ## Template for a PIP design doc
-Located at https://github.com/apache/pulsar/blob/master/.github/ISSUE_TEMPLATE/pip.md
+
+Read [the template file](/.github/ISSUE_TEMPLATE/pip.md).
 

--- a/wiki/proposals/PIP.md
+++ b/wiki/proposals/PIP.md
@@ -115,39 +115,5 @@ Some examples:
 
 
 ## Template for a PIP design doc
+Located at https://github.com/apache/pulsar/blob/master/.github/ISSUE_TEMPLATE/pip.md
 
-```
-## Motivation
-
-Explain why this change is needed, what benefits it would bring to Apache Pulsar
-and what problem it's trying to solve.
-
-## Goal
-
-Define the scope of this proposal. Given the motivation stated above, what are
-the problems that this proposal is addressing and what other items will be
-considering out of scope, perhaps to be left to a different PIP.
-
-## API Changes
-
-Illustrate all the proposed changes to the API or wire protocol, with examples
-of all the newly added classes/methods, including Javadoc.
-
-## Implementation
-
-This should be a detailed description of all the changes that are
-expected to be made. It should be detailed enough that any developer that is
-familiar with Pulsar internals would be able to understand all the parts of the
-code changes for this proposal.
-
-This should also serve as documentation for any person that is trying to
-understand or debug the behavior of a certain feature.
-
-
-## Reject Alternatives
-
-If there are alternatives that were already considered by the authors or,
-after the discussion, by the community, and were rejected, please list them
-here along with the reason why they were rejected.
-
-```


### PR DESCRIPTION
We merged the new PIP template as a GitHub issue template, but forgot to remove the inline template.

### Motivation

The new PIP template was merged as GitHub Issue template, but forgot to remove inline template.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

