### PR TITLE
[improve][build] Upgrade dependencies to reduce CVE

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -334,9 +334,9 @@ The Apache Software License, Version 2.0
  * J2ObjC Annotations -- com.google.j2objc-j2objc-annotations-1.3.jar
  * Netty Reactive Streams -- com.typesafe.netty-netty-reactive-streams-2.0.6.jar
  * Swagger
-    - io.swagger-swagger-annotations-1.6.2.jar
-    - io.swagger-swagger-core-1.6.2.jar
-    - io.swagger-swagger-models-1.6.2.jar
+    - io.swagger-swagger-annotations-1.6.10.jar
+    - io.swagger-swagger-core-1.6.10.jar
+    - io.swagger-swagger-models-1.6.10.jar
  * DataSketches
     - com.yahoo.datasketches-memory-0.8.3.jar
     - com.yahoo.datasketches-sketches-core-0.8.3.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -435,25 +435,25 @@ The Apache Software License, Version 2.0
     - org.asynchttpclient-async-http-client-2.12.1.jar
     - org.asynchttpclient-async-http-client-netty-utils-2.12.1.jar
  * Jetty
-    - org.eclipse.jetty-jetty-client-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-continuation-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-http-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-io-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-proxy-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-security-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-server-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-servlet-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-servlets-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-util-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-util-ajax-9.4.48.v20220622.jar
-    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.48.v20220622.jar
-    - org.eclipse.jetty.websocket-websocket-api-9.4.48.v20220622.jar
-    - org.eclipse.jetty.websocket-websocket-client-9.4.48.v20220622.jar
-    - org.eclipse.jetty.websocket-websocket-common-9.4.48.v20220622.jar
-    - org.eclipse.jetty.websocket-websocket-server-9.4.48.v20220622.jar
-    - org.eclipse.jetty.websocket-websocket-servlet-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-alpn-server-9.4.48.v20220622.jar
+    - org.eclipse.jetty-jetty-client-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-continuation-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-http-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-io-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-proxy-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-security-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-server-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-servlet-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-servlets-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-util-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-util-ajax-9.4.51.v20230217.jar
+    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.51.v20230217.jar
+    - org.eclipse.jetty.websocket-websocket-api-9.4.51.v20230217.jar
+    - org.eclipse.jetty.websocket-websocket-client-9.4.51.v20230217.jar
+    - org.eclipse.jetty.websocket-websocket-common-9.4.51.v20230217.jar
+    - org.eclipse.jetty.websocket-websocket-server-9.4.51.v20230217.jar
+    - org.eclipse.jetty.websocket-websocket-servlet-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-alpn-server-9.4.51.v20230217.jar
  * SnakeYaml -- org.yaml-snakeyaml-2.0.jar
  * RocksDB - org.rocksdb-rocksdbjni-6.29.4.1.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -329,9 +329,9 @@ The Apache Software License, Version 2.0
  * J2ObjC Annotations -- j2objc-annotations-1.3.jar
  * Netty Reactive Streams -- netty-reactive-streams-2.0.6.jar
  * Swagger
-    - swagger-annotations-1.6.2.jar
-    - swagger-core-1.6.2.jar
-    - swagger-models-1.6.2.jar
+    - swagger-annotations-1.6.10.jar
+    - swagger-core-1.6.10.jar
+    - swagger-models-1.6.10.jar
  * DataSketches
     - memory-0.8.3.jar
     - sketches-core-0.8.3.jar
@@ -390,14 +390,14 @@ The Apache Software License, Version 2.0
     - async-http-client-2.12.1.jar
     - async-http-client-netty-utils-2.12.1.jar
  * Jetty
-    - jetty-client-9.4.48.v20220622.jar
-    - jetty-http-9.4.48.v20220622.jar
-    - jetty-io-9.4.48.v20220622.jar
-    - jetty-util-9.4.48.v20220622.jar
-    - javax-websocket-client-impl-9.4.48.v20220622.jar
-    - websocket-api-9.4.48.v20220622.jar
-    - websocket-client-9.4.48.v20220622.jar
-    - websocket-common-9.4.48.v20220622.jar
+    - jetty-client-9.4.51.v20230217.jar
+    - jetty-http-9.4.51.v20230217.jar
+    - jetty-io-9.4.51.v20230217.jar
+    - jetty-util-9.4.51.v20230217.jar
+    - javax-websocket-client-impl-9.4.51.v20230217.jar
+    - websocket-api-9.4.51.v20230217.jar
+    - websocket-client-9.4.51.v20230217.jar
+    - websocket-common-9.4.51.v20230217.jar
  * SnakeYaml -- snakeyaml-2.0.jar
  * Google Error Prone Annotations - error_prone_annotations-2.5.1.jar
  * Javassist -- javassist-3.25.0-GA.jar

--- a/pom.xml
+++ b/pom.xml
@@ -123,8 +123,9 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.8.4</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
-    <netty.version>4.1.86.Final</netty.version>
-    <jetty.version>9.4.48.v20220622</jetty.version>
+    <netty.version>4.1.87.Final</netty.version>
+    <netty-iouring.version>0.0.17.Final</netty-iouring.version>
+    <jetty.version>9.4.51.v20230217</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.34</jersey.version>
     <athenz.version>1.10.50</athenz.version>

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@ flexible messaging model and an intuitive client API.</description>
     <kotlin-stdlib.version>1.8.20</kotlin-stdlib.version>
     <nsq-client.version>1.0</nsq-client.version>
     <cron-utils.version>9.1.6</cron-utils.version>
-    <spring.version>5.3.20</spring.version>
+    <spring.version>5.3.27</spring.version>
     <apache-http-client.version>4.5.13</apache-http-client.version>
     <apache-httpcomponents.version>4.4.15</apache-httpcomponents.version>
     <jetcd.version>0.5.11</jetcd.version>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@ flexible messaging model and an intuitive client API.</description>
     <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
     <jackson.version>2.14.2</jackson.version>
     <reflections.version>0.9.11</reflections.version>
-    <swagger.version>1.6.2</swagger.version>
+    <swagger.version>1.6.10</swagger.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
     <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
     <typetools.version>0.5.0</typetools.version>

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,7 @@ flexible messaging model and an intuitive client API.</description>
     <commons-lang3.version>3.11</commons-lang3.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-io.version>2.8.0</commons-io.version>
+    <commons-net.version>3.9.0</commons-net.version>
     <commons-codec.version>1.15</commons-codec.version>
     <javax.ws.rs-api.version>2.1</javax.ws.rs-api.version>
     <hdrHistogram.version>2.1.9</hdrHistogram.version>
@@ -670,6 +671,11 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>commons-configuration</groupId>
         <artifactId>commons-configuration</artifactId>
         <version>${commons-configuration.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-net</groupId>
+        <artifactId>commons-net</artifactId>
+        <version>${commons-net.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -123,8 +123,7 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.8.4</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
-    <netty.version>4.1.87.Final</netty.version>
-    <netty-iouring.version>0.0.17.Final</netty-iouring.version>
+    <netty.version>4.1.86.Final</netty.version>
     <jetty.version>9.4.51.v20230217</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.34</jersey.version>

--- a/pulsar-io/flume/pom.xml
+++ b/pulsar-io/flume/pom.xml
@@ -90,6 +90,10 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty</artifactId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>commons-collections</artifactId>
+                    <groupId>commons-collections</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pulsar-io/hdfs2/pom.xml
+++ b/pulsar-io/hdfs2/pom.xml
@@ -53,7 +53,7 @@
   	<dependency>
   		<groupId>org.apache.hadoop</groupId>
   		<artifactId>hadoop-client</artifactId>
-  		<version>3.2.3</version>
+  		<version>2.8.5</version>
         <exclusions>
             <exclusion>
                 <groupId>log4j</groupId>

--- a/pulsar-io/hdfs2/pom.xml
+++ b/pulsar-io/hdfs2/pom.xml
@@ -53,7 +53,7 @@
   	<dependency>
   		<groupId>org.apache.hadoop</groupId>
   		<artifactId>hadoop-client</artifactId>
-  		<version>2.8.5</version>
+  		<version>3.2.3</version>
         <exclusions>
             <exclusion>
                 <groupId>log4j</groupId>

--- a/pulsar-io/hdfs2/pom.xml
+++ b/pulsar-io/hdfs2/pom.xml
@@ -50,10 +50,15 @@
       <artifactId>commons-collections4</artifactId>
     </dependency>
 
+    <dependency>
+       <groupId>org.apache.commons</groupId>
+       <artifactId>commons-lang3</artifactId>
+    </dependency>
+
   	<dependency>
   		<groupId>org.apache.hadoop</groupId>
   		<artifactId>hadoop-client</artifactId>
-  		<version>2.8.5</version>
+  		<version>3.2.3</version>
         <exclusions>
             <exclusion>
                 <groupId>log4j</groupId>

--- a/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/AbstractHdfsConfig.java
+++ b/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/AbstractHdfsConfig.java
@@ -21,7 +21,7 @@ package org.apache.pulsar.io.hdfs2;
 import java.io.Serializable;
 import lombok.Data;
 import lombok.experimental.Accessors;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Configuration object for all HDFS components.

--- a/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/AbstractHdfsConnector.java
+++ b/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/AbstractHdfsConnector.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.net.SocketFactory;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;

--- a/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/sink/HdfsAbstractSink.java
+++ b/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/sink/HdfsAbstractSink.java
@@ -26,7 +26,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;

--- a/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/sink/HdfsSinkConfig.java
+++ b/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/sink/HdfsSinkConfig.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.io.hdfs2.AbstractHdfsConfig;
 
 /**

--- a/pulsar-io/hdfs3/pom.xml
+++ b/pulsar-io/hdfs3/pom.xml
@@ -53,6 +53,10 @@
       <groupId>commons-net</groupId>
       <artifactId>commons-net</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
     
   	<dependency>
   		<groupId>org.apache.hadoop</groupId>

--- a/pulsar-io/hdfs3/pom.xml
+++ b/pulsar-io/hdfs3/pom.xml
@@ -49,11 +49,15 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-net</groupId>
+      <artifactId>commons-net</artifactId>
+    </dependency>
     
   	<dependency>
   		<groupId>org.apache.hadoop</groupId>
   		<artifactId>hadoop-client</artifactId>
-  		<version>3.1.1</version>
+  		<version>3.2.3</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -66,6 +70,10 @@
           <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
           </exclusion>
         </exclusions>
   	</dependency>

--- a/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/AbstractHdfsConfig.java
+++ b/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/AbstractHdfsConfig.java
@@ -21,7 +21,7 @@ package org.apache.pulsar.io.hdfs3;
 import java.io.Serializable;
 import lombok.Data;
 import lombok.experimental.Accessors;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Configuration object for all HDFS components.

--- a/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/AbstractHdfsConnector.java
+++ b/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/AbstractHdfsConnector.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.net.SocketFactory;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;

--- a/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/sink/HdfsAbstractSink.java
+++ b/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/sink/HdfsAbstractSink.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FSDataOutputStreamBuilder;
 import org.apache.hadoop.fs.FileSystem;

--- a/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/sink/HdfsSinkConfig.java
+++ b/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/sink/HdfsSinkConfig.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.io.hdfs3.AbstractHdfsConfig;
 
 /**

--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -92,6 +92,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>${commons-text.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.github.wnameless.json</groupId>
       <artifactId>json-flattener</artifactId>
       <version>${json-flattener.version}</version>

--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -95,6 +95,12 @@
       <groupId>com.github.wnameless.json</groupId>
       <artifactId>json-flattener</artifactId>
       <version>${json-flattener.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-text</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -484,7 +484,7 @@ The Apache Software License, Version 2.0
   * Apache Yetus Audience Annotations
     - audience-annotations-0.12.0.jar
   * Swagger
-    - swagger-annotations-1.6.2.jar
+    - swagger-annotations-1.6.10.jar
   * Perfmark
     - perfmark-api-0.19.0.jar
   * Annotations

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -273,23 +273,23 @@ The Apache Software License, Version 2.0
  * Joda Time
     - joda-time-2.10.5.jar
     - failsafe-2.4.4.jar
- * Jetty
-    - http2-client-9.4.48.v20220622.jar
-    - http2-common-9.4.48.v20220622.jar
-    - http2-hpack-9.4.48.v20220622.jar
-    - http2-http-client-transport-9.4.48.v20220622.jar
-    - jetty-alpn-client-9.4.48.v20220622.jar
-    - http2-server-9.4.48.v20220622.jar
-    - jetty-alpn-java-client-9.4.48.v20220622.jar
-    - jetty-client-9.4.48.v20220622.jar
-    - jetty-http-9.4.48.v20220622.jar
-    - jetty-io-9.4.48.v20220622.jar
-    - jetty-jmx-9.4.48.v20220622.jar
-    - jetty-security-9.4.48.v20220622.jar
-    - jetty-server-9.4.48.v20220622.jar
-    - jetty-servlet-9.4.48.v20220622.jar
-    - jetty-util-9.4.48.v20220622.jar
-    - jetty-util-ajax-9.4.48.v20220622.jar
+  * Jetty
+    - http2-client-9.4.51.v20230217.jar
+    - http2-common-9.4.51.v20230217.jar
+    - http2-hpack-9.4.51.v20230217.jar
+    - http2-http-client-transport-9.4.51.v20230217.jar
+    - jetty-alpn-client-9.4.51.v20230217.jar
+    - http2-server-9.4.51.v20230217.jar
+    - jetty-alpn-java-client-9.4.51.v20230217.jar
+    - jetty-client-9.4.51.v20230217.jar
+    - jetty-http-9.4.51.v20230217.jar
+    - jetty-io-9.4.51.v20230217.jar
+    - jetty-jmx-9.4.51.v20230217.jar
+    - jetty-security-9.4.51.v20230217.jar
+    - jetty-server-9.4.51.v20230217.jar
+    - jetty-servlet-9.4.51.v20230217.jar
+    - jetty-util-9.4.51.v20230217.jar
+    - jetty-util-ajax-9.4.51.v20230217.jar
   * Apache BVal
     - bval-jsr-2.0.0.jar
   * Bytecode

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -104,6 +104,12 @@
       <groupId>io.prestosql</groupId>
       <artifactId>presto-cli</artifactId>
       <version>${presto.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>logback-core</artifactId>
+          <groupId>ch.qos.logback</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -41,6 +41,12 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>logback-core</artifactId>
+                    <groupId>ch.qos.logback</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -64,35 +64,6 @@
         <cve>CVE-2022-23712</cve>
     </suppress>
 
-    <!-- see https://github.com/apache/pulsar/pull/14629 -->
-    <suppress>
-        <notes><![CDATA[
-   file name: kotlin-stdlib-common-1.4.32.jar
-   ]]></notes>
-        <sha1>ef50bfa2c0491a11dcc35d9822edbfd6170e1ea2</sha1>
-        <cpe>cpe:/a:jetbrains:kotlin</cpe>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: kotlin-stdlib-jdk7-1.4.32.jar
-   ]]></notes>
-        <sha1>3546900a3ebff0c43f31190baf87a9220e37b7ea</sha1>
-        <cve>CVE-2022-24329</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: kotlin-stdlib-jdk8-1.4.32.jar
-   ]]></notes>
-        <sha1>3302f9ec8a5c1ed220781dbd37770072549bd333</sha1>
-        <cve>CVE-2022-24329</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: kotlin-stdlib-1.4.32.jar
-   ]]></notes>
-        <sha1>461367948840adbb0839c51d91ed74ef4a9ccb52</sha1>
-        <cve>CVE-2022-24329</cve>
-    </suppress>
 
     <!-- see https://github.com/alibaba/canal/issues/4010 -->
     <suppress>


### PR DESCRIPTION
Don't merge
Cherry-pick #20162, #20172 
### Motivation

Upgrade the jetty server version to avoid [CVE-2023-26048](https://access.redhat.com/security/cve/CVE-2023-26048)
Upgrade kotlin version to avoid [CVE-2022-24329](https://access.redhat.com/security/cve/CVE-2022-24329)
Upgrade swagger version to fix [CVE-2022-1471]((https://access.redhat.com/security/cve/CVE-2022-24329))

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->