### PR TITLE
[improve][build] Upgrade dependencies to reduce CVE

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -334,9 +334,9 @@ The Apache Software License, Version 2.0
  * J2ObjC Annotations -- com.google.j2objc-j2objc-annotations-1.3.jar
  * Netty Reactive Streams -- com.typesafe.netty-netty-reactive-streams-2.0.6.jar
  * Swagger
-    - io.swagger-swagger-annotations-1.6.2.jar
-    - io.swagger-swagger-core-1.6.2.jar
-    - io.swagger-swagger-models-1.6.2.jar
+    - io.swagger-swagger-annotations-1.6.10.jar
+    - io.swagger-swagger-core-1.6.10.jar
+    - io.swagger-swagger-models-1.6.10.jar
  * DataSketches
     - com.yahoo.datasketches-memory-0.8.3.jar
     - com.yahoo.datasketches-sketches-core-0.8.3.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -449,7 +449,7 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty.websocket-websocket-servlet-9.4.51.v20230217.jar
     - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.51.v20230217.jar
     - org.eclipse.jetty-jetty-alpn-server-9.4.51.v20230217.jar
- * SnakeYaml -- org.yaml-snakeyaml-1.32.jar
+ * SnakeYaml -- org.yaml-snakeyaml-2.0.jar
  * RocksDB - org.rocksdb-rocksdbjni-6.16.4.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar
  * Apache Thrift - org.apache.thrift-libthrift-0.14.2.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -430,25 +430,25 @@ The Apache Software License, Version 2.0
     - org.asynchttpclient-async-http-client-2.12.1.jar
     - org.asynchttpclient-async-http-client-netty-utils-2.12.1.jar
  * Jetty
-    - org.eclipse.jetty-jetty-client-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-continuation-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-http-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-io-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-proxy-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-security-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-server-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-servlet-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-servlets-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-util-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-util-ajax-9.4.48.v20220622.jar
-    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.48.v20220622.jar
-    - org.eclipse.jetty.websocket-websocket-api-9.4.48.v20220622.jar
-    - org.eclipse.jetty.websocket-websocket-client-9.4.48.v20220622.jar
-    - org.eclipse.jetty.websocket-websocket-common-9.4.48.v20220622.jar
-    - org.eclipse.jetty.websocket-websocket-server-9.4.48.v20220622.jar
-    - org.eclipse.jetty.websocket-websocket-servlet-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.48.v20220622.jar
-    - org.eclipse.jetty-jetty-alpn-server-9.4.48.v20220622.jar
+    - org.eclipse.jetty-jetty-client-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-continuation-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-http-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-io-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-proxy-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-security-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-server-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-servlet-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-servlets-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-util-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-util-ajax-9.4.51.v20230217.jar
+    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.51.v20230217.jar
+    - org.eclipse.jetty.websocket-websocket-api-9.4.51.v20230217.jar
+    - org.eclipse.jetty.websocket-websocket-client-9.4.51.v20230217.jar
+    - org.eclipse.jetty.websocket-websocket-common-9.4.51.v20230217.jar
+    - org.eclipse.jetty.websocket-websocket-server-9.4.51.v20230217.jar
+    - org.eclipse.jetty.websocket-websocket-servlet-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-alpn-server-9.4.51.v20230217.jar
  * SnakeYaml -- org.yaml-snakeyaml-1.32.jar
  * RocksDB - org.rocksdb-rocksdbjni-6.16.4.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar
@@ -459,10 +459,10 @@ The Apache Software License, Version 2.0
  * Okio - com.squareup.okio-okio-2.8.0.jar
  * Javassist -- org.javassist-javassist-3.25.0-GA.jar
  * Kotlin Standard Lib
-     - org.jetbrains.kotlin-kotlin-stdlib-1.4.32.jar
-     - org.jetbrains.kotlin-kotlin-stdlib-common-1.4.32.jar
-     - org.jetbrains.kotlin-kotlin-stdlib-jdk7-1.4.32.jar
-     - org.jetbrains.kotlin-kotlin-stdlib-jdk8-1.4.32.jar
+     - org.jetbrains.kotlin-kotlin-stdlib-1.6.0.jar
+     - org.jetbrains.kotlin-kotlin-stdlib-common-1.6.0.jar
+     - org.jetbrains.kotlin-kotlin-stdlib-jdk7-1.6.0.jar
+     - org.jetbrains.kotlin-kotlin-stdlib-jdk8-1.6.0.jar
      - org.jetbrains-annotations-13.0.jar
  * gRPC
     - io.grpc-grpc-all-1.45.1.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -312,14 +312,14 @@ The Apache Software License, Version 2.0
  * JCommander -- com.beust-jcommander-1.78.jar
  * High Performance Primitive Collections for Java -- com.carrotsearch-hppc-0.7.3.jar
  * Jackson
-     - com.fasterxml.jackson.core-jackson-annotations-2.13.4.jar
-     - com.fasterxml.jackson.core-jackson-core-2.13.4.jar
-     - com.fasterxml.jackson.core-jackson-databind-2.13.4.2.jar
-     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.13.4.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.13.4.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.13.4.jar
-     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.13.4.jar
-     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.13.4.jar
+     - com.fasterxml.jackson.core-jackson-annotations-2.14.2.jar
+     - com.fasterxml.jackson.core-jackson-core-2.14.2.jar
+     - com.fasterxml.jackson.core-jackson-databind-2.14.2.jar
+     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.14.2.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.14.2.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.14.2.jar
+     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.14.2.jar
+     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.14.2.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.9.1.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-2.0.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@ flexible messaging model and an intuitive client API.</description>
     <log4j2.version>2.18.0</log4j2.version>
     <bouncycastle.version>1.69</bouncycastle.version>
     <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
-    <jackson.version>2.13.4.20221013</jackson.version>
+    <jackson.version>2.14.2</jackson.version>
     <reflections.version>0.9.11</reflections.version>
     <swagger.version>1.6.10</swagger.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@ flexible messaging model and an intuitive client API.</description>
     <curator.version>5.1.0</curator.version>
     <netty.version>4.1.87.Final</netty.version>
     <netty-tc-native.version>2.0.56.Final</netty-tc-native.version>
-    <jetty.version>9.4.48.v20220622</jetty.version>
+    <jetty.version>9.4.51.v20230217</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.34</jersey.version>
     <athenz.version>1.10.9</athenz.version>
@@ -201,7 +201,7 @@ flexible messaging model and an intuitive client API.</description>
     <!-- use okio version that matches the okhttp3 version -->
     <okio.version>2.8.0</okio.version>
     <!-- override kotlin-stdlib used by okio in order to address CVE-2020-29582 -->
-    <kotlin-stdlib.version>1.4.32</kotlin-stdlib.version>
+    <kotlin-stdlib.version>1.6.0</kotlin-stdlib.version>
     <nsq-client.version>1.0</nsq-client.version>
     <cron-utils.version>9.1.6</cron-utils.version>
     <spring-context.version>5.3.19</spring-context.version>

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@ flexible messaging model and an intuitive client API.</description>
     <kotlin-stdlib.version>1.6.0</kotlin-stdlib.version>
     <nsq-client.version>1.0</nsq-client.version>
     <cron-utils.version>9.1.6</cron-utils.version>
-    <spring-context.version>5.3.20</spring-context.version>
+    <spring-context.version>5.3.27</spring-context.version>
     <apache-http-client.version>4.5.13</apache-http-client.version>
     <seancfoley.ipaddress.version>5.3.3</seancfoley.ipaddress.version>
     <netty-reactive-streams.version>2.0.6</netty-reactive-streams.version>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@ flexible messaging model and an intuitive client API.</description>
 
     <!-- apache commons -->
     <commons-compress.version>1.21</commons-compress.version>
-    <snakeyaml.version>1.32</snakeyaml.version>
+    <snakeyaml.version>2.0</snakeyaml.version>
     <bookkeeper.version>4.14.7</bookkeeper.version>
     <zookeeper.version>3.6.3</zookeeper.version>
     <commons-cli.version>1.5.0</commons-cli.version>
@@ -179,6 +179,7 @@ flexible messaging model and an intuitive client API.</description>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-io.version>2.8.0</commons-io.version>
     <commons-codec.version>1.15</commons-codec.version>
+    <commons-net.version>3.9.0</commons-net.version>
     <javax.ws.rs-api.version>2.1</javax.ws.rs-api.version>
     <hdrHistogram.version>2.1.9</hdrHistogram.version>
     <javax.servlet-api>3.1.0</javax.servlet-api>
@@ -226,7 +227,7 @@ flexible messaging model and an intuitive client API.</description>
     <skyscreamer.version>1.5.0</skyscreamer.version>
     <objenesis.version>3.1</objenesis.version>
     <awaitility.version>4.0.3</awaitility.version>
-    <jettison.version>1.5.3</jettison.version>
+    <jettison.version>1.5.4</jettison.version>
     <woodstox.version>5.4.0</woodstox.version>
 
     <!-- Plugin dependencies -->
@@ -660,6 +661,12 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons-lang3.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>commons-net</groupId>
+        <artifactId>commons-net</artifactId>
+        <version>${commons-net.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@ flexible messaging model and an intuitive client API.</description>
     <kotlin-stdlib.version>1.6.0</kotlin-stdlib.version>
     <nsq-client.version>1.0</nsq-client.version>
     <cron-utils.version>9.1.6</cron-utils.version>
-    <spring-context.version>5.3.19</spring-context.version>
+    <spring-context.version>5.3.20</spring-context.version>
     <apache-http-client.version>4.5.13</apache-http-client.version>
     <seancfoley.ipaddress.version>5.3.3</seancfoley.ipaddress.version>
     <netty-reactive-streams.version>2.0.6</netty-reactive-streams.version>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@ flexible messaging model and an intuitive client API.</description>
     <bouncycastlefips.version>1.0.2</bouncycastlefips.version>
     <jackson.version>2.13.4.20221013</jackson.version>
     <reflections.version>0.9.11</reflections.version>
-    <swagger.version>1.6.2</swagger.version>
+    <swagger.version>1.6.10</swagger.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
     <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
     <typetools.version>0.5.0</typetools.version>

--- a/pulsar-io/canal/pom.xml
+++ b/pulsar-io/canal/pom.xml
@@ -63,14 +63,45 @@
             <version>${spring-context.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+            <version>${spring-context.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.9</version>
         </dependency>
         <dependency>
             <groupId>com.alibaba.otter</groupId>
             <artifactId>canal.client</artifactId>
             <version>1.1.4</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>spring-aop</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-beans</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-jdbc</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-orm</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-tx</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-expression</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/pulsar-io/canal/pom.xml
+++ b/pulsar-io/canal/pom.xml
@@ -55,7 +55,17 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.73</version>
+            <version>1.2.83</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>${spring-context.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.alibaba.otter</groupId>

--- a/pulsar-io/flume/pom.xml
+++ b/pulsar-io/flume/pom.xml
@@ -72,6 +72,12 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro-ipc</artifactId>
             <version>1.8.1</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>netty</artifactId>
+                    <groupId>io.netty</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
@@ -106,7 +112,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>30.0-jre</version>
         </dependency>
     </dependencies>
 

--- a/pulsar-io/hdfs2/pom.xml
+++ b/pulsar-io/hdfs2/pom.xml
@@ -48,7 +48,7 @@
   	<dependency>
   		<groupId>org.apache.hadoop</groupId>
   		<artifactId>hadoop-client</artifactId>
-  		<version>2.8.5</version>
+  		<version>3.2.3</version>
         <exclusions>
             <exclusion>
                 <groupId>log4j</groupId>

--- a/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/AbstractHdfsConfig.java
+++ b/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/AbstractHdfsConfig.java
@@ -23,7 +23,7 @@ import java.io.Serializable;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Configuration object for all HDFS components.

--- a/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/AbstractHdfsConnector.java
+++ b/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/AbstractHdfsConnector.java
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.SocketFactory;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;

--- a/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/sink/HdfsAbstractSink.java
+++ b/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/sink/HdfsAbstractSink.java
@@ -27,7 +27,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;

--- a/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/sink/HdfsSinkConfig.java
+++ b/pulsar-io/hdfs2/src/main/java/org/apache/pulsar/io/hdfs2/sink/HdfsSinkConfig.java
@@ -32,7 +32,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.io.hdfs2.AbstractHdfsConfig;
 
 /**

--- a/pulsar-io/hdfs3/pom.xml
+++ b/pulsar-io/hdfs3/pom.xml
@@ -48,7 +48,7 @@
   	<dependency>
   		<groupId>org.apache.hadoop</groupId>
   		<artifactId>hadoop-client</artifactId>
-  		<version>3.1.1</version>
+  		<version>3.2.3</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>

--- a/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/AbstractHdfsConfig.java
+++ b/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/AbstractHdfsConfig.java
@@ -23,7 +23,7 @@ import java.io.Serializable;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Configuration object for all HDFS components.

--- a/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/AbstractHdfsConnector.java
+++ b/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/AbstractHdfsConnector.java
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.SocketFactory;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;

--- a/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/sink/HdfsAbstractSink.java
+++ b/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/sink/HdfsAbstractSink.java
@@ -24,7 +24,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FSDataOutputStreamBuilder;
 import org.apache.hadoop.fs.FileSystem;

--- a/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/sink/HdfsSinkConfig.java
+++ b/pulsar-io/hdfs3/src/main/java/org/apache/pulsar/io/hdfs3/sink/HdfsSinkConfig.java
@@ -30,7 +30,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.io.hdfs3.AbstractHdfsConfig;
 
 /**

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -207,19 +207,19 @@ This projects includes binary packages with the following licenses:
 The Apache Software License, Version 2.0
 
   * Jackson
-    - jackson-annotations-2.13.4.jar
-    - jackson-core-2.13.4.jar
-    - jackson-databind-2.13.4.2.jar
-    - jackson-dataformat-smile-2.13.4.jar
-    - jackson-datatype-guava-2.13.4.jar
-    - jackson-datatype-jdk8-2.13.4.jar
-    - jackson-datatype-joda-2.13.4.jar
-    - jackson-datatype-jsr310-2.13.4.jar
-    - jackson-dataformat-yaml-2.13.4.jar
-    - jackson-jaxrs-base-2.13.4.jar
-    - jackson-jaxrs-json-provider-2.13.4.jar
-    - jackson-module-jaxb-annotations-2.13.4.jar
-    - jackson-module-jsonSchema-2.13.4.jar
+    - jackson-annotations-2.14.2.jar
+    - jackson-core-2.14.2.jar
+    - jackson-databind-2.14.2.jar
+    - jackson-dataformat-smile-2.14.2.jar
+    - jackson-datatype-guava-2.14.2.jar
+    - jackson-datatype-jdk8-2.14.2.jar
+    - jackson-datatype-joda-2.14.2.jar
+    - jackson-datatype-jsr310-2.14.2.jar
+    - jackson-dataformat-yaml-2.14.2.jar
+    - jackson-jaxrs-base-2.14.2.jar
+    - jackson-jaxrs-json-provider-2.14.2.jar
+    - jackson-module-jaxb-annotations-2.14.2.jar
+    - jackson-module-jsonSchema-2.14.2.jar
  * Guava
     - guava-30.1-jre.jar
     - listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
@@ -444,7 +444,7 @@ The Apache Software License, Version 2.0
   * Snappy
     - snappy-java-1.1.7.jar
   * Jackson
-    - jackson-module-parameter-names-2.13.4.jar
+    - jackson-module-parameter-names-2.14.2.jar
   * Java Assist
     - javassist-3.25.0-GA.jar
   * Java Native Access

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -259,22 +259,22 @@ The Apache Software License, Version 2.0
  * Joda Time
     - joda-time-2.10.5.jar
   * Jetty
-    - http2-client-9.4.48.v20220622.jar
-    - http2-common-9.4.48.v20220622.jar
-    - http2-hpack-9.4.48.v20220622.jar
-    - http2-http-client-transport-9.4.48.v20220622.jar
-    - jetty-alpn-client-9.4.48.v20220622.jar
-    - http2-server-9.4.48.v20220622.jar
-    - jetty-alpn-java-client-9.4.48.v20220622.jar
-    - jetty-client-9.4.48.v20220622.jar
-    - jetty-http-9.4.48.v20220622.jar
-    - jetty-io-9.4.48.v20220622.jar
-    - jetty-jmx-9.4.48.v20220622.jar
-    - jetty-security-9.4.48.v20220622.jar
-    - jetty-server-9.4.48.v20220622.jar
-    - jetty-servlet-9.4.48.v20220622.jar
-    - jetty-util-9.4.48.v20220622.jar
-    - jetty-util-ajax-9.4.48.v20220622.jar
+    - http2-client-9.4.51.v20230217.jar
+    - http2-common-9.4.51.v20230217.jar
+    - http2-hpack-9.4.51.v20230217.jar
+    - http2-http-client-transport-9.4.51.v20230217.jar
+    - jetty-alpn-client-9.4.51.v20230217.jar
+    - http2-server-9.4.51.v20230217.jar
+    - jetty-alpn-java-client-9.4.51.v20230217.jar
+    - jetty-client-9.4.51.v20230217.jar
+    - jetty-http-9.4.51.v20230217.jar
+    - jetty-io-9.4.51.v20230217.jar
+    - jetty-jmx-9.4.51.v20230217.jar
+    - jetty-security-9.4.51.v20230217.jar
+    - jetty-server-9.4.51.v20230217.jar
+    - jetty-servlet-9.4.51.v20230217.jar
+    - jetty-util-9.4.51.v20230217.jar
+    - jetty-util-ajax-9.4.51.v20230217.jar
   * Apache BVal
     - bval-jsr-2.0.0.jar
   * Bytecode

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -460,7 +460,7 @@ The Apache Software License, Version 2.0
   * Apache Yetus Audience Annotations
     - audience-annotations-0.5.0.jar
   * Swagger
-    - swagger-annotations-1.6.2.jar
+    - swagger-annotations-1.6.10.jar
 
 Protocol Buffers License
  * Protocol Buffers

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -398,7 +398,7 @@ The Apache Software License, Version 2.0
   * RocksDB JNI
     - rocksdbjni-6.16.4.jar
   * SnakeYAML
-    - snakeyaml-1.32.jar
+    - snakeyaml-2.0.jar
   * Bean Validation API
     - validation-api-2.0.1.Final.jar
   * Objectsize

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -134,6 +134,10 @@
                     <artifactId>http2-server</artifactId>
                     <groupId>org.eclipse.jetty.http2</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>http-server</artifactId>
+                    <groupId>io.airlift</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -126,6 +126,14 @@
                     <artifactId>jetty-security</artifactId>
                     <groupId>org.eclipse.jetty</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>async-http-client</artifactId>
+                    <groupId>com.ning</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>http2-server</artifactId>
+                    <groupId>org.eclipse.jetty.http2</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/pulsar-sql/presto-pulsar/pom.xml
+++ b/pulsar-sql/presto-pulsar/pom.xml
@@ -117,6 +117,16 @@
             <artifactId>presto-main</artifactId>
             <version>${presto.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>jetty-client</artifactId>
+                    <groupId>org.eclipse.jetty</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jetty-security</artifactId>
+                    <groupId>org.eclipse.jetty</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/tiered-storage/file-system/pom.xml
+++ b/tiered-storage/file-system/pom.xml
@@ -37,6 +37,11 @@
             <artifactId>managed-ledger</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs-client</artifactId>
@@ -54,6 +59,10 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-net</groupId>
+                    <artifactId>commons-net</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Cherry-pick #20162, #20172 
### Motivation

Upgrade the jetty server version to avoid [CVE-2023-26048](https://access.redhat.com/security/cve/CVE-2023-26048)
Upgrade kotlin version to avoid [CVE-2022-24329](https://access.redhat.com/security/cve/CVE-2022-24329)
Upgrade swagger version to fix [CVE-2022-1471]((https://access.redhat.com/security/cve/CVE-2022-24329))


![image](https://user-images.githubusercontent.com/6297296/236661371-afab7396-1c1e-4d8e-8d90-66a8b930a77c.png)

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->