### PR TITLE
[fix][monitor] topic with double quote breaks the prometheus format

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricStreams.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricStreams.java
@@ -41,7 +41,11 @@ public class PrometheusMetricStreams {
         SimpleTextOutputStream stream = initGaugeType(metricName);
         stream.write(metricName).write('{');
         for (int i = 0; i < labelsAndValuesArray.length; i += 2) {
-            stream.write(labelsAndValuesArray[i]).write("=\"").write(labelsAndValuesArray[i + 1]).write('\"');
+            String labelValue = labelsAndValuesArray[i + 1];
+            if (labelValue != null) {
+                labelValue = labelValue.replace("\"", "\\\"");
+            }
+            stream.write(labelsAndValuesArray[i]).write("=\"").write(labelValue).write('\"');
             if (i + 2 != labelsAndValuesArray.length) {
                 stream.write(',');
             }


### PR DESCRIPTION
### Motivation

If you create a topic with the double quote in the name (e.g. `public/default/"mytopic`) then there are some metrics that are generated in a broken format. 

```
pulsar_subscriptions_count{cluster="mycluster",namespace="namespace1",topic="persistent://public/default/"mytopic"} 0.0
```

This leads to errors in the grafana dashboards. 

### Modifications

* Escape all label values when generating the metrics

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->