### PR TITLE
[feat] Add hostname verification config to ClusterData

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1295,6 +1295,10 @@ public class BrokerService implements Closeable {
                 }
                 String serviceUrlTls = isNotBlank(data.getBrokerServiceUrlTls()) ? data.getBrokerServiceUrlTls()
                         : data.getServiceUrlTls();
+                // In the event that the zookeeper data has not been updated, allow local broker config to
+                // override the cluster config.
+                final boolean hostnameVerificationEnabled = data.isTlsHostnameVerificationEnabled()
+                        || pulsar.getConfiguration().isTlsHostnameVerificationEnabled();
                 if (data.isBrokerClientTlsEnabled()) {
                     configTlsSettings(clientBuilder, serviceUrlTls,
                             data.isBrokerClientTlsEnabledWithKeyStore(),
@@ -1308,7 +1312,7 @@ public class BrokerService implements Closeable {
                             data.getBrokerClientTrustCertsFilePath(),
                             data.getBrokerClientKeyFilePath(),
                             data.getBrokerClientCertificateFilePath(),
-                            pulsar.getConfiguration().isTlsHostnameVerificationEnabled()
+                            hostnameVerificationEnabled
                     );
                 } else if (pulsar.getConfiguration().isBrokerClientTlsEnabled()) {
                     configTlsSettings(clientBuilder, serviceUrlTls,
@@ -1323,7 +1327,7 @@ public class BrokerService implements Closeable {
                             pulsar.getConfiguration().getBrokerClientTrustCertsFilePath(),
                             pulsar.getConfiguration().getBrokerClientKeyFilePath(),
                             pulsar.getConfiguration().getBrokerClientCertificateFilePath(),
-                            pulsar.getConfiguration().isTlsHostnameVerificationEnabled()
+                            hostnameVerificationEnabled
                     );
                 } else {
                     clientBuilder.serviceUrl(
@@ -1432,6 +1436,10 @@ public class BrokerService implements Closeable {
                 }
                 String adminApiUrl = isTlsEnabled ? data.getServiceUrlTls() : data.getServiceUrl();
                 builder.serviceHttpUrl(adminApiUrl);
+                // In the event that the zookeeper data has not been updated, allow local broker config to
+                // override the cluster config.
+                final boolean hostnameVerificationEnabled = data.isTlsHostnameVerificationEnabled()
+                        || pulsar.getConfiguration().isTlsHostnameVerificationEnabled();
                 if (data.isBrokerClientTlsEnabled()) {
                     configAdminTlsSettings(builder,
                             data.isBrokerClientTlsEnabledWithKeyStore(),
@@ -1445,7 +1453,7 @@ public class BrokerService implements Closeable {
                             data.getBrokerClientTrustCertsFilePath(),
                             data.getBrokerClientKeyFilePath(),
                             data.getBrokerClientCertificateFilePath(),
-                            pulsar.getConfiguration().isTlsHostnameVerificationEnabled()
+                            hostnameVerificationEnabled
                     );
                 } else if (conf.isBrokerClientTlsEnabled()) {
                     configAdminTlsSettings(builder,
@@ -1460,7 +1468,7 @@ public class BrokerService implements Closeable {
                             conf.getBrokerClientTrustCertsFilePath(),
                             conf.getBrokerClientKeyFilePath(),
                             conf.getBrokerClientCertificateFilePath(),
-                            pulsar.getConfiguration().isTlsHostnameVerificationEnabled()
+                            hostnameVerificationEnabled
                     );
                 }
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
@@ -48,6 +48,8 @@ public interface ClusterData {
 
     boolean isTlsAllowInsecureConnection();
 
+    boolean isTlsHostnameVerificationEnabled();
+
     boolean isBrokerClientTlsEnabledWithKeyStore();
 
     String getBrokerClientTlsTrustStoreType();
@@ -96,6 +98,8 @@ public interface ClusterData {
         Builder brokerClientTlsEnabled(boolean enabled);
 
         Builder tlsAllowInsecureConnection(boolean enabled);
+
+        Builder tlsHostnameVerificationEnabled(boolean enabled);
 
         Builder brokerClientTlsEnabledWithKeyStore(boolean enabled);
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
@@ -320,6 +320,10 @@ public class CmdClusters extends CmdBase {
         @Parameter(names = "--tls-allow-insecure", description = "Allow insecure tls connection", required = false)
         protected Boolean tlsAllowInsecureConnection;
 
+        @Parameter(names = "--hostname-verification-enabled", description = "Enable hostname verification",
+                required = false)
+        protected Boolean tlsHostnameVerificationEnabled;
+
         @Parameter(names = "--tls-enable-keystore",
                 description = "Whether use KeyStore type to authenticate", required = false)
         protected Boolean brokerClientTlsEnabledWithKeyStore;
@@ -410,6 +414,9 @@ public class CmdClusters extends CmdBase {
             }
             if (tlsAllowInsecureConnection != null) {
                 builder.tlsAllowInsecureConnection(tlsAllowInsecureConnection);
+            }
+            if (tlsHostnameVerificationEnabled != null) {
+                builder.tlsHostnameVerificationEnabled(tlsHostnameVerificationEnabled);
             }
             if (brokerClientTlsEnabledWithKeyStore != null) {
                 builder.brokerClientTlsEnabledWithKeyStore(brokerClientTlsEnabledWithKeyStore);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -82,8 +82,8 @@ public class PulsarAdminTool {
         @Parameter(names = { "--tls-trust-cert-path" }, description = "Allow TLS trust cert file path")
         String tlsTrustCertsFilePath;
 
-        @Parameter(names = { "--tls-enable-hostname-verification" },
-                description = "Enable TLS common name verification")
+        @Parameter(names = { "--tls-enable-hostname-verification", "--hostname-verification-enabled" },
+                description = "Enable TLS hostname verification")
         Boolean tlsEnableHostnameVerification;
 
         @Parameter(names = {"--tls-provider"}, description = "Set up TLS provider. "

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
@@ -110,6 +110,11 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
     )
     private boolean tlsAllowInsecureConnection;
     @ApiModelProperty(
+            name = "tlsHostnameVerificationEnabled",
+            value = "Enable TLS hostname verification"
+    )
+    private boolean tlsHostnameVerificationEnabled = false;
+    @ApiModelProperty(
         name = "brokerClientTlsEnabledWithKeyStore",
         value = "Whether internal client use KeyStore type to authenticate with other Pulsar brokers"
     )
@@ -203,6 +208,7 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
                 .peerClusterNames(peerClusterNames)
                 .brokerClientTlsEnabled(brokerClientTlsEnabled)
                 .tlsAllowInsecureConnection(tlsAllowInsecureConnection)
+                .tlsHostnameVerificationEnabled(tlsHostnameVerificationEnabled)
                 .brokerClientTlsEnabledWithKeyStore(brokerClientTlsEnabledWithKeyStore)
                 .brokerClientTlsTrustStoreType(brokerClientTlsTrustStoreType)
                 .brokerClientTlsTrustStore(brokerClientTlsTrustStore)
@@ -231,6 +237,7 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
         private LinkedHashSet<String> peerClusterNames;
         private boolean brokerClientTlsEnabled = false;
         private boolean tlsAllowInsecureConnection = false;
+        private boolean tlsHostnameVerificationEnabled = false;
         private boolean brokerClientTlsEnabledWithKeyStore = false;
         private String brokerClientTlsTrustStoreType = "JKS";
         private String brokerClientTlsTrustStore;
@@ -300,6 +307,11 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
 
         public ClusterDataImplBuilder tlsAllowInsecureConnection(boolean tlsAllowInsecureConnection) {
             this.tlsAllowInsecureConnection = tlsAllowInsecureConnection;
+            return this;
+        }
+
+        public ClusterDataImplBuilder tlsHostnameVerificationEnabled(boolean tlsHostnameVerificationEnabled) {
+            this.tlsHostnameVerificationEnabled = tlsHostnameVerificationEnabled;
             return this;
         }
 
@@ -387,6 +399,7 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
                     peerClusterNames,
                     brokerClientTlsEnabled,
                     tlsAllowInsecureConnection,
+                    tlsHostnameVerificationEnabled,
                     brokerClientTlsEnabledWithKeyStore,
                     brokerClientTlsTrustStoreType,
                     brokerClientTlsTrustStore,

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataImplTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataImplTest.java
@@ -42,6 +42,7 @@ public class ClusterDataImplTest {
                 .peerClusterNames(new LinkedHashSet<>())
                 .brokerClientTlsEnabled(true)
                 .tlsAllowInsecureConnection(false)
+                .tlsHostnameVerificationEnabled(true)
                 .brokerClientTlsEnabledWithKeyStore(true)
                 .brokerClientTlsTrustStoreType("JKS")
                 .brokerClientTlsTrustStore("/my/trust/store")

--- a/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
+++ b/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
@@ -179,8 +179,8 @@ public class LocalRunner implements AutoCloseable {
     @Parameter(names = "--tlsAllowInsecureConnection", description = "Allow insecure tls connection\n",
             hidden = true, arity = 1)
     protected boolean tlsAllowInsecureConnection;
-    @Parameter(names = "--tlsHostNameVerificationEnabled", description = "Enable hostname verification", hidden = true
-            , arity = 1)
+    @Parameter(names = {"--tlsHostNameVerificationEnabled", "--tlsHostnameVerificationEnabled"},
+            description = "Enable hostname verification", hidden = true, arity = 1)
     protected boolean tlsHostNameVerificationEnabled;
     @Parameter(names = "--tlsTrustCertFilePath", description = "tls trust cert file path", hidden = true)
     protected String tlsTrustCertFilePath;


### PR DESCRIPTION
PIP: This will be part of an upcoming PIP. Leaving it as a draft for now.

### Motivation

It would be helpful to explicitly configure the pulsar client's hostname verification configuration for each remote cluster in the cluster configuration data.

### Modifications

* TBD

### Verifying this change

This is a trivial change from a configuration perspective. I expect many tests will fail though, so those will also verify the changes.

### Does this pull request potentially affect one of the following parts:

- [x] The default values of configurations

### Documentation

- [x] `doc-required` 

### Matching PR in forked repository

PR in forked repository: https://github.com/michaeljmarshall/pulsar/pull/45