### PR TITLE
[improve][client] Document Java Client's Seek logic thread-safety improved in #20242

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -465,6 +465,9 @@ public interface Consumer<T> extends Closeable, MessageAcknowledger {
 
     /**
      * Reset the subscription associated with this consumer to a specific message id.
+     * <p>
+     * If there is already a seek operation in progress, the method will log a warning and 
+     * return a future completed exceptionally.
      *
      * <p>The message id can either be a specific message or represent the first or last messages in the topic.
      * <ul>
@@ -483,6 +486,9 @@ public interface Consumer<T> extends Closeable, MessageAcknowledger {
 
     /**
      * Reset the subscription associated with this consumer to a specific message publish time.
+     * <p>
+     * If there is already a seek operation in progress, the method will log a warning and 
+     * return a future completed exceptionally.
      *
      * @param timestamp
      *            the message publish time where to reposition the subscription
@@ -492,6 +498,10 @@ public interface Consumer<T> extends Closeable, MessageAcknowledger {
 
     /**
      * Reset the subscription associated with this consumer to a specific message ID or message publish time.
+     * <p>
+     * If there is already a seek operation in progress, the method will log a warning and 
+     * return a future completed exceptionally.
+     * 
      * <p>
      * The Function input is topic+partition. It returns only timestamp or MessageId.
      * <p>

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -466,7 +466,7 @@ public interface Consumer<T> extends Closeable, MessageAcknowledger {
     /**
      * Reset the subscription associated with this consumer to a specific message id.
      * <p>
-     * If there is already a seek operation in progress, the method will log a warning and 
+     * If there is already a seek operation in progress, the method will log a warning and
      * return a future completed exceptionally.
      *
      * <p>The message id can either be a specific message or represent the first or last messages in the topic.
@@ -487,7 +487,7 @@ public interface Consumer<T> extends Closeable, MessageAcknowledger {
     /**
      * Reset the subscription associated with this consumer to a specific message publish time.
      * <p>
-     * If there is already a seek operation in progress, the method will log a warning and 
+     * If there is already a seek operation in progress, the method will log a warning and
      * return a future completed exceptionally.
      *
      * @param timestamp
@@ -499,9 +499,9 @@ public interface Consumer<T> extends Closeable, MessageAcknowledger {
     /**
      * Reset the subscription associated with this consumer to a specific message ID or message publish time.
      * <p>
-     * If there is already a seek operation in progress, the method will log a warning and 
+     * If there is already a seek operation in progress, the method will log a warning and
      * return a future completed exceptionally.
-     * 
+     *
      * <p>
      * The Function input is topic+partition. It returns only timestamp or MessageId.
      * <p>
@@ -534,7 +534,7 @@ public interface Consumer<T> extends Closeable, MessageAcknowledger {
     /**
      * The asynchronous version of {@link Consumer#seek(MessageId)}.
      * <p>
-     * If there is already a seek operation in progress, the method will log a warning and 
+     * If there is already a seek operation in progress, the method will log a warning and
      * return a future completed exceptionally.
      */
     CompletableFuture<Void> seekAsync(MessageId messageId);

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -523,11 +523,15 @@ public interface Consumer<T> extends Closeable, MessageAcknowledger {
 
     /**
      * The asynchronous version of {@link Consumer#seek(MessageId)}.
+     * <p>
+     * If there is already a seek operation in progress, the method will log a warning and return a canceled future.
      */
     CompletableFuture<Void> seekAsync(MessageId messageId);
 
     /**
      * Reset the subscription associated with this consumer to a specific message publish time.
+     * <p>
+     * If there is already a seek operation in progress, the method will log a warning and return a canceled future.
      *
      * @param timestamp
      *            the message publish time where to reposition the subscription

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -524,14 +524,16 @@ public interface Consumer<T> extends Closeable, MessageAcknowledger {
     /**
      * The asynchronous version of {@link Consumer#seek(MessageId)}.
      * <p>
-     * If there is already a seek operation in progress, the method will log a warning and return a canceled future.
+     * If there is already a seek operation in progress, the method will log a warning and 
+     * return a future completed exceptionally.
      */
     CompletableFuture<Void> seekAsync(MessageId messageId);
 
     /**
      * Reset the subscription associated with this consumer to a specific message publish time.
      * <p>
-     * If there is already a seek operation in progress, the method will log a warning and return a canceled future.
+     * If there is already a seek operation in progress, the method will log a warning and
+     * return a future completed exceptionally.
      *
      * @param timestamp
      *            the message publish time where to reposition the subscription


### PR DESCRIPTION
Master Issue: #19671 

### Motivation

Improves JavaDoc describing changes made by PR #20242 as suggested by in [review](https://github.com/apache/pulsar/pull/20242#pullrequestreview-1417853594)

**EDIT:** modified JavaDoc to also cover https://github.com/apache/pulsar/pull/20321 accordingly

### Modifications

Add JavaDoc regarding thready-safety to the methods in scope of #20242

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework only adds JavaDoc

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/JooHyukKim/pulsar/pull/2