### PR TITLE
[feat][broker] introduce precise broker publish rate limiting

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -912,6 +912,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private boolean preciseTopicPublishRateLimiterEnable = false;
     @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Enable precise rate limit for broker publish"
+    )
+    private boolean preciseBrokerPublishRateLimiterEnable = false;
+    @FieldContext(
         category = CATEGORY_SERVER,
         dynamic = true,
         doc = "Tick time to schedule task that checks broker publish rate limiting across all topics  "

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -1116,6 +1116,12 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
         return  getBrokerPublishRateLimiter().isPublishRateExceeded();
     }
 
+    public boolean isBrokerPublishRateExceeded(int numberMessages, int bytes) {
+        // whether broker publish rate exceed
+        return preciseTopicPublishRateLimitingEnable
+                && !getBrokerPublishRateLimiter().tryAcquire(numberMessages, bytes);
+    }
+
     public PublishRateLimiter getTopicPublishRateLimiter() {
         return topicPublishRateLimiter;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2760,7 +2760,15 @@ public class BrokerService implements Closeable {
         if (brokerPublishRateLimiter == null
             || brokerPublishRateLimiter == PublishRateLimiter.DISABLED_RATE_LIMITER) {
             // create new rateLimiter if rate-limiter is disabled
-            brokerPublishRateLimiter = new PublishRateLimiterImpl(publishRate);
+            if (preciseTopicPublishRateLimitingEnable) {
+                brokerPublishRateLimiter = new PrecisPublishLimiter(publishRate, () -> {
+                    forEachTopic(topic -> {
+                        topic.enableCnxAutoRead();
+                    });
+                }, pulsar().getExecutor());
+            } else {
+                brokerPublishRateLimiter = new PublishRateLimiterImpl(publishRate);
+            }
         } else {
             brokerPublishRateLimiter.update(publishRate);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -3047,7 +3047,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 producer.getTopic().disableCnxAutoRead();
                 return;
             }
-            isPublishRateExceeded = producer.getTopic().isBrokerPublishRateExceeded();
+            isPublishRateExceeded = producer.getTopic().isBrokerPublishRateExceeded(numMessages, msgSize);
         } else {
             if (producer.getTopic().isResourceGroupRateLimitingEnabled()) {
                 final boolean resourceGroupPublishRateExceeded =

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -224,6 +224,8 @@ public interface Topic {
 
     void resetBrokerPublishCountAndEnableReadIfRequired(boolean doneReset);
 
+    void enableProducerReadForPublishRateLimiting();
+
     boolean isPublishRateExceeded();
 
     boolean isTopicPublishRateExceeded(int msgSize, int numMessages);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -234,6 +234,8 @@ public interface Topic {
 
     boolean isBrokerPublishRateExceeded();
 
+    boolean isBrokerPublishRateExceeded(int msgSize, int numMessages);
+
     boolean isReplicationBacklogExist();
 
     void disableCnxAutoRead();


### PR DESCRIPTION
### Motivation
The publish rate limit for each broker is ineffective, and the reason for this problem is the same as https://github.com/apache/pulsar/pull/7078;

### Modifications
When preciseTopicPublishRateLimiterEnable=true, use PrecisPublishLimiter as the publish rate limit for each broker.

**A comparative test：**
test steps：
1.Start prducer perf, the qps of broker is 10w/s:
<img width="1709" alt="image" src="https://github.com/apache/pulsar/assets/19296967/afdb2f28-9af7-4353-b1cf-d7c26afb8a9d">
2.Enable broker speed limit：
`sh bin/pulsar-admin brokers  update-dynamic-config  --config  brokerPublisherThrottlingMaxMessageRate  --value  50000`

3.The speed limit effect is as follows:  **Broker write rate limit does not take effect**
<img width="1716" alt="image" src="https://github.com/apache/pulsar/assets/19296967/2349ba89-3e1a-4a9d-b04b-4feab0dc05d6">

4.Use the improved precision speed limit feature：**It can be seen that the speed limit effect is as expected**
<img width="1647" alt="image" src="https://github.com/apache/pulsar/assets/19296967/28fd382d-348d-49cf-9d9f-c2b949760652">




### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lordcheng10/pulsar/pull/49
