### PR TITLE
[fix][broker] Fix NPE cause by topic publish rate limiter.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -115,7 +115,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
 
     protected volatile Boolean isAllowAutoUpdateSchema;
 
-    protected volatile PublishRateLimiter topicPublishRateLimiter;
+    protected volatile PublishRateLimiter topicPublishRateLimiter = PublishRateLimiter.DISABLED_RATE_LIMITER;
     private final Object topicPublishRateLimiterLock = new Object();
 
     protected volatile ResourceGroupPublishLimiter resourceGroupPublishLimiter;


### PR DESCRIPTION
Fixes #20301

### Motivation

`topicPublishRateLimiter` in `org.apache.pulsar.broker.service.AbstractTopic` can only be set in `updatePublishDispatcher`. So the `topicPublishRateLimiter` in topic can shortly be `null` just when the topic object is created and before `initialize`. At this time, if the broker service starts to do `checkTopicPublishThrottlingRate` (`org.apache.pulsar.broker.service.BrokerService#setupTopicPublishRateLimiterMonitor`), which will cause NPE.

Error log sample:
```
2023-05-11T14:18:10,426+0800 [pulsar-topic-publish-rate-limiter-monitor-39-1] ERROR org.apache.bookkeeper.common.util.SafeRunnable - Unexpected throwable caught
java.lang.NullPointerException: null
        at org.apache.pulsar.broker.service.AbstractTopic.checkTopicPublishThrottlingRate(AbstractTopic.java:843) ~[org.apache.pulsar-pulsar-broker-2.10.4.jar:2.10.4]
        at java.util.Optional.ifPresent(Optional.java:183) ~[?:?]
        at org.apache.pulsar.broker.service.BrokerService.lambda$forEachTopic$80(BrokerService.java:1874) ~[org.apache.pulsar-pulsar-broker-2.10.4.jar:2.10.4]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:544) ~[org.apache.pulsar-pulsar-common-2.10.4.jar:2.10.4]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:272) ~[org.apache.pulsar-pulsar-common-2.10.4.jar:2.10.4]
        at org.apache.pulsar.broker.service.BrokerService.forEachTopic(BrokerService.java:1872) ~[org.apache.pulsar-pulsar-broker-2.10.4.jar:2.10.4]
        at org.apache.pulsar.broker.service.BrokerService.checkTopicPublishThrottlingRate(BrokerService.java:1849) ~[org.apache.pulsar-pulsar-broker-2.10.4.jar:2.10.4]
        at org.apache.pulsar.broker.service.BrokerService.lambda$setupTopicPublishRateLimiterMonitor$7(BrokerService.java:620) ~[org.apache.pulsar-pulsar-broker-2.10.4.jar:2.10.4]
        at org.apache.bookkeeper.mledger.util.SafeRun$1.safeRun(SafeRun.java:32) ~[org.apache.pulsar-managed-ledger-2.10.4.jar:2.10.4]
        at org.apache.bookkeeper.common.util.SafeRunnable.run(SafeRunnable.java:36) ~[org.apache.bookkeeper-bookkeeper-common-4.14.7.gemini.0.jar:4.14.7.gemini.0]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.87.Final.jar:4.1.87.Final]
        at java.lang.Thread.run(Thread.java:829) ~[?:?]
```

### Modifications

Set the default value `PublishRateLimiter.DISABLED_RATE_LIMITER` to `topicPublishRateLimiter` in `AbstractTopic`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is hard to be covered by tests.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dragonls/pulsar/pull/9
