### PR TITLE
[fix] [meta]Switch to the metadata store thread after zk operation

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -530,7 +531,19 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
         try {
             executor.execute(task);
         } catch (Throwable t) {
-            executor.execute(() -> future.completeExceptionally(t));
+            future.completeExceptionally(t);
+        }
+    }
+
+    /**
+     * Run the task in the executor thread and fail the future if the executor is shutting down.
+     */
+    @VisibleForTesting
+    public void execute(Runnable task, Supplier<List<CompletableFuture<?>>> futures) {
+        try {
+            executor.execute(task);
+        } catch (final Throwable t) {
+            futures.get().forEach(f -> f.completeExceptionally(t));
         }
     }
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -530,7 +530,7 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
         try {
             executor.execute(task);
         } catch (Throwable t) {
-            future.completeExceptionally(t);
+            executor.execute(() -> future.completeExceptionally(t));
         }
     }
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -207,25 +207,26 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
                 for (int i = 0; i < ops.size(); i++) {
                     OpResult opr = results.get(i);
                     MetadataOp op = ops.get(i);
+                    execute(() -> {
+                        switch (op.getType()) {
+                            case PUT:
+                                handlePutResult(op.asPut(), opr);
+                                break;
+                            case DELETE:
+                                handleDeleteResult(op.asDelete(), opr);
+                                break;
+                            case GET:
+                                handleGetResult(op.asGet(), opr);
+                                break;
+                            case GET_CHILDREN:
+                                handleGetChildrenResult(op.asGetChildren(), opr);
+                                break;
 
-                    switch (op.getType()) {
-                        case PUT:
-                            handlePutResult(op.asPut(), opr);
-                            break;
-                        case DELETE:
-                            handleDeleteResult(op.asDelete(), opr);
-                            break;
-                        case GET:
-                            handleGetResult(op.asGet(), opr);
-                            break;
-                        case GET_CHILDREN:
-                            handleGetChildrenResult(op.asGetChildren(), opr);
-                            break;
-
-                        default:
-                            op.getFuture().completeExceptionally(new MetadataStoreException(
-                                    "Operation type not supported in multi: " + op.getType()));
-                    }
+                            default:
+                                op.getFuture().completeExceptionally(new MetadataStoreException(
+                                        "Operation type not supported in multi: " + op.getType()));
+                        }
+                    }, op.getFuture());
                 }
             }, null);
         } catch (Throwable t) {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -204,30 +204,29 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
                 }
 
                 // Trigger all the futures in the batch
-                for (int i = 0; i < ops.size(); i++) {
-                    OpResult opr = results.get(i);
-                    MetadataOp op = ops.get(i);
-                    execute(() -> {
-                        switch (op.getType()) {
-                            case PUT:
-                                handlePutResult(op.asPut(), opr);
-                                break;
-                            case DELETE:
-                                handleDeleteResult(op.asDelete(), opr);
-                                break;
-                            case GET:
-                                handleGetResult(op.asGet(), opr);
-                                break;
-                            case GET_CHILDREN:
-                                handleGetChildrenResult(op.asGetChildren(), opr);
-                                break;
-
-                            default:
-                                op.getFuture().completeExceptionally(new MetadataStoreException(
-                                        "Operation type not supported in multi: " + op.getType()));
+                execute(() -> {
+                    for (int i = 0; i < ops.size(); i++) {
+                        OpResult opr = results.get(i);
+                        MetadataOp op = ops.get(i);
+                            switch (op.getType()) {
+                                case PUT:
+                                    handlePutResult(op.asPut(), opr);
+                                    break;
+                                case DELETE:
+                                    handleDeleteResult(op.asDelete(), opr);
+                                    break;
+                                case GET:
+                                    handleGetResult(op.asGet(), opr);
+                                    break;
+                                case GET_CHILDREN:
+                                    handleGetChildrenResult(op.asGetChildren(), opr);
+                                    break;
+                                default:
+                                    op.getFuture().completeExceptionally(new MetadataStoreException(
+                                            "Operation type not supported in multi: " + op.getType()));
+                            }
                         }
-                    }, op.getFuture());
-                }
+                }, () -> ops.stream().map(MetadataOp::getFuture).collect(Collectors.toList()));
             }, null);
         } catch (Throwable t) {
             ops.forEach(o -> o.getFuture().completeExceptionally(new MetadataStoreException(t)));

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -50,8 +51,10 @@ import org.apache.pulsar.metadata.api.MetadataStoreFactory;
 import org.apache.pulsar.metadata.api.Notification;
 import org.apache.pulsar.metadata.api.NotificationType;
 import org.apache.pulsar.metadata.api.Stat;
+import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.assertj.core.util.Lists;
 import org.awaitility.Awaitility;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Slf4j
@@ -423,6 +426,75 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
 
         zks.checkContainers();
         assertFalse(store.exists(prefix).join());
+    }
+
+    @DataProvider(name = "conditionOfSwitchThread")
+    public Object[][] conditionOfSwitchThread(){
+        return new Object[][]{
+            {false, false},
+            {false, true},
+            {true, false},
+            {true, true}
+        };
+    }
+
+    @Test(dataProvider = "conditionOfSwitchThread")
+    public void testThreadSwitchOfZkMetadataStore(boolean hasSynchronizer, boolean enabledBatch) throws Exception {
+        final String prefix = newKey();
+        final String metadataStoreName = UUID.randomUUID().toString().replaceAll("-", "");
+        MetadataStoreConfig.MetadataStoreConfigBuilder builder =
+                MetadataStoreConfig.builder().metadataStoreName(metadataStoreName);
+        builder.fsyncEnable(false);
+        builder.batchingEnabled(enabledBatch);
+        if (!hasSynchronizer) {
+            builder.synchronizer(null);
+        }
+        MetadataStoreConfig config = builder.build();
+        @Cleanup
+        ZKMetadataStore store = (ZKMetadataStore) MetadataStoreFactory.create(zks.getConnectionString(), config);
+
+        final Runnable verify = () -> {
+            String currentThreadName = Thread.currentThread().getName();
+            String errorMessage = String.format("Expect to switch to thread %s, but currently it is thread %s",
+                    metadataStoreName, currentThreadName);
+            if (!Thread.currentThread().getName().startsWith(metadataStoreName)){
+                throw new RuntimeException(errorMessage);
+            }
+        };
+
+        // put with node which has parent(but the parent node is not exists).
+        store.put(prefix + "/a1/b1/c1", "value".getBytes(), Optional.of(-1L)).thenApply((ignore) -> {
+            verify.run();
+            return null;
+        }).join();
+        // put.
+        store.put(prefix + "/b1", "value".getBytes(), Optional.of(-1L)).thenApply((ignore) -> {
+            verify.run();
+            return null;
+        }).join();
+        // get.
+        store.get(prefix + "/b1").thenApply((ignore) -> {
+            verify.run();
+            return null;
+        }).join();
+        // get the node which is not exists.
+        store.get(prefix + "/non").thenApply((ignore) -> {
+            verify.run();
+            return null;
+        }).join();
+        // delete.
+        store.delete(prefix + "/b1", Optional.empty()).thenApply((ignore) -> {
+            verify.run();
+            return null;
+        }).join();
+        // delete the node which is not exists.
+        store.delete(prefix + "/non", Optional.empty()).thenApply((ignore) -> {
+            verify.run();
+            return null;
+        }).exceptionally(ex -> {
+            verify.run();
+            return null;
+        }).join();
     }
 
     @Test(dataProvider = "impl")

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -457,9 +457,7 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
             String currentThreadName = Thread.currentThread().getName();
             String errorMessage = String.format("Expect to switch to thread %s, but currently it is thread %s",
                     metadataStoreName, currentThreadName);
-            if (!Thread.currentThread().getName().startsWith(metadataStoreName)){
-                throw new RuntimeException(errorMessage);
-            }
+            assertTrue(Thread.currentThread().getName().startsWith(metadataStoreName), errorMessage);
         };
 
         // put with node which has parent(but the parent node is not exists).


### PR DESCRIPTION
### Motivation

#5358 makes the thread switch to the metadata store thread after the ZK operation.
#13043 Add the feature `batch operation` for `ZKMetadataStore`, but after the batch operation is done, the thread is not switched back.

Now, if we call `put /a`, it will use the `event thread` of the ZK client after the operation; but if we call `put /a/b/c`(the node `/a` is not exists), it will use the `metadata store thread`  after the operation.

### Modifications

- Switch to the metadata store thread after the batch operation.
- If there has any exception, error handling also uses the metadata store thread

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
- x
