### PR TITLE
[fix][build] Fix publish image script

### DIFF
--- a/docker/publish.sh
+++ b/docker/publish.sh
@@ -62,11 +62,11 @@ set -x
 # Fail if any of the subsequent commands fail
 set -e
 
-docker tag pulsar:latest ${docker_registry_org}/pulsar:latest
-docker tag pulsar-all:latest ${docker_registry_org}/pulsar-all:latest
+docker tag apachepulsar/pulsar:latest ${docker_registry_org}/pulsar:latest
+docker tag apachepulsar/pulsar-all:latest ${docker_registry_org}/pulsar-all:latest
 
-docker tag pulsar:latest ${docker_registry_org}/pulsar:$MVN_VERSION
-docker tag pulsar-all:latest ${docker_registry_org}/pulsar-all:$MVN_VERSION
+docker tag apachepulsar/pulsar:latest ${docker_registry_org}/pulsar:$MVN_VERSION
+docker tag apachepulsar/pulsar-all:latest ${docker_registry_org}/pulsar-all:$MVN_VERSION
 
 # Push all images and tags
 docker push ${docker_registry_org}/pulsar:latest


### PR DESCRIPTION
### Motivation

In the old version, the pulsar can build the multiple images:
- `pulsar:latest`
- `pulsar:VERSION`
- `pulsar-all:latest`
- `pulsar-all:VERSION`
- `apachepulsar/pulsar:latest`
- `apachepulsar/pulsar:VERSION`
- `apachepulsar/pulsar-all:latest`
- `apachepulsar/pulsar-all:VERSION`

After https://github.com/apache/pulsar/pull/19432 is merged, we only have the following images:
- `apachepulsar/pulsar:latest`
- `apachepulsar/pulsar:VERSION`
- `apachepulsar/pulsar-all:latest`
- `apachepulsar/pulsar-all:VERSION`


The `pulsar:latest` and `pulsar-all:latest` images are used in the `docker/publish.sh` script, #19432 breaks the publish script.

### Modifications

- Use `apachepulsar/pulsar:latest` instead of `pulsar:latest`
- Use `apachepulsar/pulsar-all:latest` instead of `pulsar-all:latest`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->