### PR TITLE
[fix] [broker] [branch-2.10] Upgrade rocksDB version to 6.16.4 to keep sync with BookKeeper 4.14.7

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -450,7 +450,7 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.51.v20230217.jar
     - org.eclipse.jetty-jetty-alpn-server-9.4.51.v20230217.jar
  * SnakeYaml -- org.yaml-snakeyaml-2.0.jar
- * RocksDB - org.rocksdb-rocksdbjni-6.10.2.jar
+ * RocksDB - org.rocksdb-rocksdbjni-6.16.4.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar
  * Apache Thrift - org.apache.thrift-libthrift-0.14.2.jar
  * OkHttp3

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ flexible messaging model and an intuitive client API.</description>
     <athenz.version>1.10.50</athenz.version>
     <prometheus.version>0.5.0</prometheus.version>
     <vertx.version>3.9.8</vertx.version>
-    <rocksdb.version>6.10.2</rocksdb.version>
+    <rocksdb.version>6.16.4</rocksdb.version>
     <slf4j.version>1.7.32</slf4j.version>
     <commons.collections.version>3.2.2</commons.collections.version>
     <log4j2.version>2.18.0</log4j2.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -411,7 +411,7 @@ The Apache Software License, Version 2.0
     - presto-spi-332.jar
     - presto-record-decoder-332.jar
   * RocksDB JNI
-    - rocksdbjni-6.10.2.jar
+    - rocksdbjni-6.16.4.jar
   * SnakeYAML
     - snakeyaml-2.0.jar
   * Bean Validation API


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Master Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/wiki/proposals/PIP.md -->

### Motivation
Pulsar 2.10 uses BookKeeper 4.14.7, and BookKeeper 4.14.7 uses RocksDB 6.16.4. 
However, Pulsar also introduced RocksDB dependency and uses 6.10.2. When packaging all the dependencies into the Pulsar release package, the RocksDB 6.10.2 in Pulsar will override the RocksDB 6.16.4 in BookKeeper. The Pulsar release package will only contain RocksDB 6.10.2 in the end.

We encountered a RocksDB 6.10.2 memory leak issue when upgrading from Pulsar 2.9.x to 2.10.x, but still have not found any related issues in RocksDB. Pulsar 2.9.x uses RocksDB 6.16.4. One related issue is https://github.com/apache/bookkeeper/issues/3507

The reason why we revert https://github.com/apache/pulsar/pull/20287 is that we found the bookie throws method not found exception when upgrading RocksDb to 6.29.4.1 https://github.com/apache/pulsar/pull/20243#issuecomment-1540505700

The root cause of the exception is
-  RocksDB ABI broken : https://github.com/facebook/rocksdb/commit/1001bc01c9ea06785c2d5261ca9fe7ac0eac0625#r69967694 This commit was included in RocksDB [6.17.3](https://github.com/facebook/rocksdb/releases/tag/v6.17.3). Code compiled with RocksDB <6.17.3 isn't compatible with a newer RocksDB version at runtime. https://github.com/apache/pulsar/pull/14962#issuecomment-1084192562 
- The BookKeeper 4.14.7 complies RocksDB 6.16.4 and uses RocksDB 6.29.4.1 at runtime

So we should upgrade the RocksDB version in Pulsar with the following steps.
- Upgrade the RocksDB version to 6.16.4 to keep sync with BookKeeper 4.14.7 first to fix the RocksDB memory leak issue.
- Upgrade BookKeeper branch-4.14 RocksDB version to 6.29.4.1 and trigger a new release 4.14.8
- Upgrade Pulsar branch-2.10's BookKeeper dependency to 4.14.8
- Upgrade Pulsar's RocksDB version to 6.29.4.1

The reason why we should upgrade Pulsar's RocksDB version to 6.29.4.1 is https://github.com/apache/bookkeeper/issues/3734#issuecomment-1407626941. Pulsar 3.0 uses BookKeeper 4.16.0 which uses RocksDB 7.9.2, and we should make sure Pulsar can roll back from 3.0 to 2.10.x

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
