### PR TITLE
[feat][meta] Upgrade to jetcd to 0.7.5

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -433,7 +433,6 @@ The Apache Software License, Version 2.0
     - io.grpc-grpc-services-1.45.1.jar
     - io.grpc-grpc-xds-1.45.1.jar
     - io.grpc-grpc-rls-1.45.1.jar
-    - com.google.auto.service-auto-service-annotations-1.0.jar
   * Perfmark
     - io.perfmark-perfmark-api-0.19.0.jar
   * OpenCensus
@@ -475,6 +474,7 @@ The Apache Software License, Version 2.0
     - io.vertx-vertx-core-4.3.8.jar
     - io.vertx-vertx-web-4.3.8.jar
     - io.vertx-vertx-web-common-4.3.8.jar
+    - io.vertx-vertx-grpc-4.3.5.jar
   * Apache ZooKeeper
     - org.apache.zookeeper-zookeeper-3.8.1.jar
     - org.apache.zookeeper-zookeeper-jute-3.8.1.jar
@@ -487,8 +487,10 @@ The Apache Software License, Version 2.0
     - com.google.auto.value-auto-value-annotations-1.9.jar
     - com.google.re2j-re2j-1.5.jar
   * Jetcd
-    - io.etcd-jetcd-common-0.5.11.jar
-    - io.etcd-jetcd-core-0.5.11.jar
+    - io.etcd-jetcd-api-0.7.5.jar
+    - io.etcd-jetcd-common-0.7.5.jar
+    - io.etcd-jetcd-core-0.7.5.jar
+    - io.etcd-jetcd-grpc-0.7.5.jar
   * IPAddress
     - com.github.seancfoley-ipaddress-5.3.3.jar
   * RxJava

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@ flexible messaging model and an intuitive client API.</description>
     <spring.version>5.3.27</spring.version>
     <apache-http-client.version>4.5.13</apache-http-client.version>
     <apache-httpcomponents.version>4.4.15</apache-httpcomponents.version>
-    <jetcd.version>0.5.11</jetcd.version>
+    <jetcd.version>0.7.5</jetcd.version>
     <snakeyaml.version>2.0</snakeyaml.version>
     <ant.version>1.10.12</ant.version>
     <seancfoley.ipaddress.version>5.3.3</seancfoley.ipaddress.version>

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -21,7 +21,7 @@ package org.apache.pulsar.metadata;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import io.etcd.jetcd.launcher.EtcdCluster;
-import io.etcd.jetcd.launcher.EtcdClusterFactory;
+import io.etcd.jetcd.test.EtcdClusterExtension;
 import java.io.File;
 import java.net.URI;
 import java.util.UUID;
@@ -84,10 +84,11 @@ public abstract class BaseMetadataStoreTest extends TestRetrySupport {
 
     private synchronized String getEtcdClusterConnectString() {
         if (etcdCluster == null) {
-            etcdCluster = EtcdClusterFactory.buildCluster("test", 1, false);
+            etcdCluster = EtcdClusterExtension.builder().withClusterName("test").withNodes(1).withSsl(false).build()
+                    .cluster();
             etcdCluster.start();
         }
-        return etcdCluster.getClientEndpoints().stream().map(URI::toString).collect(Collectors.joining(","));
+        return etcdCluster.clientEndpoints().stream().map(URI::toString).collect(Collectors.joining(","));
     }
 
     public static Supplier<String> stringSupplier(Supplier<String> supplier) {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/coordination/impl/LeaderElectionImplTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/coordination/impl/LeaderElectionImplTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 
 public class LeaderElectionImplTest extends BaseMetadataStoreTest {
 
-    @Test(dataProvider = "impl", timeOut = 10000)
+    @Test(dataProvider = "impl", timeOut = 20000)
     public void validateDeadLock(String provider, Supplier<String> urlSupplier)
             throws Exception {
         if (provider.equals("Memory") || provider.equals("RocksDB")) {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/EtcdMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/EtcdMetadataStoreTest.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.io.Resources;
 import io.etcd.jetcd.launcher.EtcdCluster;
-import io.etcd.jetcd.launcher.EtcdClusterFactory;
 
+import io.etcd.jetcd.test.EtcdClusterExtension;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -44,7 +44,8 @@ public class EtcdMetadataStoreTest {
     @Test
     public void testCluster() throws Exception {
         @Cleanup
-        EtcdCluster etcdCluster = EtcdClusterFactory.buildCluster("test-cluster", 3, false);
+        EtcdCluster etcdCluster = EtcdClusterExtension.builder().withClusterName("test-cluster").withNodes(3)
+                .withSsl(false).build().cluster();
         etcdCluster.start();
 
         EtcdConfig etcdConfig = EtcdConfig.builder().useTls(false)
@@ -56,7 +57,7 @@ public class EtcdMetadataStoreTest {
         new ObjectMapper(new YAMLFactory()).writeValue(etcdConfigPath.toFile(), etcdConfig);
 
         String metadataURL =
-                "etcd:" + etcdCluster.getClientEndpoints().stream().map(URI::toString).collect(Collectors.joining(","));
+                "etcd:" + etcdCluster.clientEndpoints().stream().map(URI::toString).collect(Collectors.joining(","));
 
         @Cleanup
         MetadataStore store = MetadataStoreFactory.create(metadataURL,
@@ -71,7 +72,8 @@ public class EtcdMetadataStoreTest {
     @Test
     public void testClusterWithTls() throws Exception {
         @Cleanup
-        EtcdCluster etcdCluster = EtcdClusterFactory.buildCluster("test-cluster", 3, true);
+        EtcdCluster etcdCluster = EtcdClusterExtension.builder().withClusterName("test-cluster").withNodes(3)
+                .withSsl(true).build().cluster();
         etcdCluster.start();
 
         EtcdConfig etcdConfig = EtcdConfig.builder().useTls(true)
@@ -86,7 +88,7 @@ public class EtcdMetadataStoreTest {
         new ObjectMapper(new YAMLFactory()).writeValue(etcdConfigPath.toFile(), etcdConfig);
 
         String metadataURL =
-                "etcd:" + etcdCluster.getClientEndpoints().stream().map(URI::toString).collect(Collectors.joining(","));
+                "etcd:" + etcdCluster.clientEndpoints().stream().map(URI::toString).collect(Collectors.joining(","));
 
         @Cleanup
         MetadataStore store = MetadataStoreFactory.create(metadataURL,
@@ -101,7 +103,8 @@ public class EtcdMetadataStoreTest {
     @Test
     public void testTlsInstance() throws Exception {
         @Cleanup
-        EtcdCluster etcdCluster = EtcdClusterFactory.buildCluster("test-tls", 1, true);
+        EtcdCluster etcdCluster = EtcdClusterExtension.builder().withClusterName("test-tls").withNodes(1)
+                .withSsl(true).build().cluster();
         etcdCluster.start();
 
         EtcdConfig etcdConfig = EtcdConfig.builder().useTls(true)
@@ -115,7 +118,7 @@ public class EtcdMetadataStoreTest {
         new ObjectMapper(new YAMLFactory()).writeValue(etcdConfigPath.toFile(), etcdConfig);
 
         String metadataURL =
-                "etcd:" + etcdCluster.getClientEndpoints().stream().map(URI::toString).collect(Collectors.joining(","));
+                "etcd:" + etcdCluster.clientEndpoints().stream().map(URI::toString).collect(Collectors.joining(","));
 
         @Cleanup
         MetadataStore store = MetadataStoreFactory.create(metadataURL,

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -272,9 +272,13 @@ The Apache Software License, Version 2.0
     - grpc-protobuf-lite-1.45.1.jar
     - grpc-stub-1.45.1.jar
   * JEtcd
-    - jetcd-common-0.5.11.jar
-    - jetcd-core-0.5.11.jar
-
+    - jetcd-api-0.7.5.jar
+    - jetcd-common-0.7.5.jar
+    - jetcd-core-0.7.5.jar
+    - jetcd-grpc-0.7.5.jar
+  * Vertx
+    - vertx-core-4.3.8.jar
+    - vertx-grpc-4.3.5.jar
  * Joda Time
     - joda-time-2.10.10.jar
     - failsafe-2.4.4.jar
@@ -476,8 +480,6 @@ The Apache Software License, Version 2.0
     - swagger-annotations-1.6.2.jar
   * Perfmark
     - perfmark-api-0.19.0.jar
-  * Annotations
-    - auto-service-annotations-1.0.jar
   * RabbitMQ Java Client
     - amqp-client-5.5.3.jar
   * Stream Lib
@@ -520,9 +522,6 @@ MIT License
    - jcl-over-slf4j-1.7.32.jar
  * Checker Qual
    - checker-qual-3.12.0.jar
- * Annotations
-   - animal-sniffer-annotations-1.19.jar
-   - annotations-4.1.1.4.jar
  * ScribeJava
    - scribejava-apis-6.9.0.jar
    - scribejava-core-6.9.0.jar

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -229,51 +229,6 @@
         <cve>CVE-2021-42550</cve>
     </suppress>
 
-    <!-- jetcd matched against ETCD server CVEs-->
-    <suppress>
-        <notes><![CDATA[
-       file name: jetcd-core-0.5.11.jar
-       ]]></notes>
-        <sha1>c85851ca3ea8128d480d3f75c568a37e64e8a77b</sha1>
-        <cve>CVE-2020-15106</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-       file name: jetcd-core-0.5.11.jar
-       ]]></notes>
-        <sha1>c85851ca3ea8128d480d3f75c568a37e64e8a77b</sha1>
-        <cve>CVE-2020-15112</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-       file name: jetcd-core-0.5.11.jar
-       ]]></notes>
-        <sha1>c85851ca3ea8128d480d3f75c568a37e64e8a77b</sha1>
-        <cve>CVE-2020-15113</cve>
-    </suppress>
-
-    <suppress>
-        <notes><![CDATA[
-       file name: jetcd-common-0.5.11.jar
-       ]]></notes>
-        <sha1>6dac6efe035a2be9ba299fbf31be5f903401869f</sha1>
-        <cve>CVE-2020-15106</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-       file name: jetcd-common-0.5.11.jar
-       ]]></notes>
-        <sha1>6dac6efe035a2be9ba299fbf31be5f903401869f</sha1>
-        <cve>CVE-2020-15112</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-       file name: jetcd-common-0.5.11.jar
-       ]]></notes>
-        <sha1>6dac6efe035a2be9ba299fbf31be5f903401869f</sha1>
-        <cve>CVE-2020-15113</cve>
-    </suppress>
-
     <!-- bouncycastle misdetections -->
     <suppress>
         <notes><![CDATA[


### PR DESCRIPTION
Fixes #20308

### Motivation

As described in #20308, we have test flakiness because of an issue in the etcd dependency. This PR upgrades etcd to fix the test.

I am not familiar with this integration. If there is any reason we should avoid this upgrade, please comment as much.

### Modifications

* Upgrade etcd dependency from 0.5.11 to 0.7.5
* Update license files
* Increase test timeout since it was failing during docker pull on my local machine
* Replace code with the new methods/classes

### Verifying this change

Tests passing should be sufficient.

### Documentation

- [x] `doc-not-needed`

### Matching PR in forked repository

PR in forked repository: https://github.com/michaeljmarshall/pulsar/pull/49