### PR TITLE
[fix][broker] Initialize broker interceptors after broker is ready.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -787,6 +787,12 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 brokerService.setInterceptor(interceptor);
             }
             brokerService.start();
+            
+            // Initialize broker interceptors after broker is ready,
+            // so that the broker interceptors can access broker service properly.
+            if (interceptor != null) {
+                interceptor.initialize(this);
+            }
 
             // Load additional servlets
             this.brokerAdditionalServlets = AdditionalServlets.load(config);
@@ -875,12 +881,6 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             Map<String, Map<InetSocketAddress, ChannelInitializer<SocketChannel>>> protocolHandlerChannelInitializers =
                 this.protocolHandlers.newChannelInitializers();
             this.brokerService.startProtocolHandlers(protocolHandlerChannelInitializers);
-
-            // Initialize broker interceptors after broker is ready,
-            // so that the broker interceptors can access broker service properly.
-            if (interceptor != null) {
-                interceptor.initialize(this);
-            }
 
             acquireSLANamespace();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -785,7 +785,6 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             BrokerInterceptor interceptor = getBrokerInterceptor();
             if (interceptor != null) {
                 brokerService.setInterceptor(interceptor);
-                interceptor.initialize(this);
             }
             brokerService.start();
 
@@ -876,6 +875,12 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             Map<String, Map<InetSocketAddress, ChannelInitializer<SocketChannel>>> protocolHandlerChannelInitializers =
                 this.protocolHandlers.newChannelInitializers();
             this.brokerService.startProtocolHandlers(protocolHandlerChannelInitializers);
+
+            // Initialize broker interceptors after broker is ready,
+            // so that the broker interceptors can access broker service properly.
+            if (interceptor != null) {
+                interceptor.initialize(this);
+            }
 
             acquireSLANamespace();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/CounterBrokerInterceptor.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/CounterBrokerInterceptor.java
@@ -272,7 +272,8 @@ public class CounterBrokerInterceptor implements BrokerInterceptor {
 
     @Override
     public void initialize(PulsarService pulsarService) throws Exception {
-
+        // check pulsarService is ready.
+        pulsarService.getAdminClient().tenants().getTenants();
     }
 
     @Override


### PR DESCRIPTION
Initialize broker interceptors after broker is ready, so that the broker interceptors can access broker service properly.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
