### PR TITLE
[improve][sec] Suppress etcd CVE warnings

### DIFF
--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -232,6 +232,14 @@
     <!-- jetcd matched against ETCD server CVEs-->
     <suppress>
         <notes><![CDATA[
+       file name: jetcd-api-0.7.5.jar
+       ]]></notes>
+        <sha1>861af62ae22a71d30f401a80049397fe7ff44423</sha1>
+        <cve>CVE-2020-15113</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
        file name: jetcd-core-0.7.5.jar
        ]]></notes>
         <sha1>663f2ccc0ec7797954c333fa75feeb7d559948b0</sha1>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -229,6 +229,58 @@
         <cve>CVE-2021-42550</cve>
     </suppress>
 
+    <!-- jetcd matched against ETCD server CVEs-->
+    <suppress>
+        <notes><![CDATA[
+       file name: jetcd-core-0.7.5.jar
+       ]]></notes>
+        <sha1>663f2ccc0ec7797954c333fa75feeb7d559948b0</sha1>
+        <cve>CVE-2020-15113</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+       file name: jetcd-grpc-0.7.5.jar
+       ]]></notes>
+        <sha1>a2e99802fec5586daca0c4daae975fe601a057a8</sha1>
+        <cve>CVE-2017-8359</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: jetcd-grpc-0.7.5.jar
+       ]]></notes>
+        <sha1>a2e99802fec5586daca0c4daae975fe601a057a8</sha1>
+        <cve>CVE-2020-15113</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: jetcd-grpc-0.7.5.jar
+       ]]></notes>
+        <sha1>a2e99802fec5586daca0c4daae975fe601a057a8</sha1>
+        <cve>CVE-2020-7768</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: jetcd-grpc-0.7.5.jar
+       ]]></notes>
+        <sha1>a2e99802fec5586daca0c4daae975fe601a057a8</sha1>
+        <cve>CVE-2017-7861</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: jetcd-grpc-0.7.5.jar
+       ]]></notes>
+        <sha1>a2e99802fec5586daca0c4daae975fe601a057a8</sha1>
+        <cve>CVE-2017-9431</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+       file name: jetcd-grpc-0.7.5.jar
+       ]]></notes>
+        <sha1>a2e99802fec5586daca0c4daae975fe601a057a8</sha1>
+        <cve>CVE-2017-7860</cve>
+    </suppress>
+
     <!-- bouncycastle misdetections -->
     <suppress>
         <notes><![CDATA[

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -248,6 +248,14 @@
 
     <suppress>
         <notes><![CDATA[
+       file name: jetcd-common-0.7.5.jar
+       ]]></notes>
+        <sha1>abd0ffcd4e66046057c3bfb34affc0de870a038b</sha1>
+        <cve>CVE-2020-15113</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
        file name: jetcd-grpc-0.7.5.jar
        ]]></notes>
         <sha1>a2e99802fec5586daca0c4daae975fe601a057a8</sha1>


### PR DESCRIPTION
### Motivation

These CVEs were introduced by #20339. We upgraded to the latest version of jetcd, so I am suppressing the related CVEs.

OWASP is currently failing with:

> Error:  jetcd-core-0.7.5.jar: CVE-2020-15113(7.1)
Error:  jetcd-grpc-0.7.5.jar: CVE-2017-8359(9.8), CVE-2020-15113(7.1), CVE-2020-7768(9.8), CVE-2017-7861(9.8), CVE-2017-9431(9.8), CVE-2017-7860(9.8)

A subsequent run had the following failure:

>Error:  jetcd-api-0.7.5.jar: CVE-2020-15113(7.1)

And another error:

>Error:  jetcd-common-0.7.5.jar: CVE-2020-15113(7.1)

I retrieved the jar checksums from these two links:

* https://repo1.maven.org/maven2/io/etcd/jetcd-core/0.7.5/jetcd-core-0.7.5.jar.sha1
* https://repo1.maven.org/maven2/io/etcd/jetcd-grpc/0.7.5/jetcd-grpc-0.7.5.jar.sha1
* https://repo1.maven.org/maven2/io/etcd/jetcd-api/0.7.5/jetcd-api-0.7.5.jar.sha1
* https://repo1.maven.org/maven2/io/etcd/jetcd-common/0.7.5/jetcd-common-0.7.5.jar.sha1

### Modifications

* Update the `owasp-dependency-check-suppressions.xml` file.


### Documentation
- [x] `doc-not-needed`