### PR TITLE
[fix][test] Use delta when comparing doubles in checkLoadReportNicSpeed

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadReportNetworkLimitTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadReportNetworkLimitTest.java
@@ -60,12 +60,12 @@ public class LoadReportNetworkLimitTest extends MockedPulsarServiceBaseTest {
         LoadManagerReport report = admin.brokerStats().getLoadReport();
 
         if (SystemUtils.IS_OS_LINUX) {
-            assertEquals(report.getBandwidthIn().limit, usableNicCount * 5.4 * 1000 * 1000);
-            assertEquals(report.getBandwidthOut().limit, usableNicCount * 5.4 * 1000 * 1000);
+            assertEquals(report.getBandwidthIn().limit, usableNicCount * 5.4 * 1000 * 1000, 0.0001);
+            assertEquals(report.getBandwidthOut().limit, usableNicCount * 5.4 * 1000 * 1000, 0.0001);
         } else {
             // On non-Linux system we don't report the network usage
-            assertEquals(report.getBandwidthIn().limit, -1.0);
-            assertEquals(report.getBandwidthOut().limit, -1.0);
+            assertEquals(report.getBandwidthIn().limit, -1.0, 0.0001);
+            assertEquals(report.getBandwidthOut().limit, -1.0, 0.0001);
         }
     }
 


### PR DESCRIPTION
### Motivation

@dave2wave recently encountered this test failure:

```
20:46:55  [ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 1, Time elapsed: 15.301 s <<< FAILURE! - in org.apache.pulsar.broker.loadbalance.LoadReportNetworkLimitTest
20:46:55  [ERROR] checkLoadReportNicSpeed(org.apache.pulsar.broker.loadbalance.LoadReportNetworkLimitTest)  Time elapsed: 0.142 s  <<< FAILURE!
20:46:55  java.lang.AssertionError: expected [1.6200000000000004E7] but found [1.62E7]
20:46:55  	at org.testng.Assert.fail(Assert.java:99)
20:46:55  	at org.testng.Assert.failNotEquals(Assert.java:1037)
20:46:55  	at org.testng.Assert.assertEquals(Assert.java:701)
20:46:55  	at org.testng.Assert.assertEquals(Assert.java:712)
20:46:55  	at org.apache.pulsar.broker.loadbalance.LoadReportNetworkLimitTest.checkLoadReportNicSpeed(LoadReportNetworkLimitTest.java:63)
```

The test failed because we are not providing an acceptable delta for the equality check.

It looks like there are other tests where we have strict double or float comparisons. I am going to leave those for now to minimize the diff on this PR. I read through all of the open flaky test issues and none appear to be related to this class of flakiness.

### Modifications

* Add a delta to the assertions in the `checkLoadReportNicSpeed` test

### Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [x] `doc-not-needed` 