### PR TITLE
[fix] Increase timeout on ManagedLedgerCompressionTest flaky test

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ManagedLedgerCompressionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ManagedLedgerCompressionTest.java
@@ -50,7 +50,7 @@ public class ManagedLedgerCompressionTest extends BrokerTestBase {
         super.internalCleanup();
     }
 
-    @Test(timeOut = 1000 * 30)
+    @Test(timeOut = 1000 * 60)
     public void testRestartBrokerEnableManagedLedgerInfoCompression() throws Exception {
         String topic = newTopicName();
         @Cleanup


### PR DESCRIPTION
Fixes #16497

### Motivation

In reviewing the errors associated with `ManagedLedgerCompressionTest#testRestartBrokerEnableManagedLedgerInfoCompression`, it seems like the problem is the number of broker restarts that occur. When I run this test on my laptop, it takes 20 seconds. I profiled it, and the most expensive part is starting up the broker's WebService, which is unfortunate because it is not tested here.

I propose as a temporary "fix" that we increase the timeout on this test to 60 seconds. The failure reports are all related to timeouts, and there is nothing fancy about this test that makes me think the test itself should be flaky.

### Modifications

* Increase test timeout from 30 to 60 seconds

### Documentation

- [x] `doc-not-needed`