### PR TITLE
[improve][monitor] Add JVM start time metric

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/stats/JvmMetrics.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/stats/JvmMetrics.java
@@ -99,6 +99,9 @@ public class JvmMetrics {
 
         Runtime r = Runtime.getRuntime();
 
+        RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
+
+        m.put("jvm_start_time", runtimeMXBean.getStartTime());
         m.put("jvm_heap_used", r.totalMemory() - r.freeMemory());
         m.put("jvm_max_memory", r.maxMemory());
         m.put("jvm_total_memory", r.totalMemory());


### PR DESCRIPTION
### Motivation

Add `jvm_start_time` to help user get this metric even more accessible than though mbeans

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

