### PR TITLE
[improve][ci] Split Pulsar IO unit test job to multiple jobs

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -198,6 +198,8 @@ jobs:
           - name: Pulsar IO
             group: PULSAR_IO
             timeout: 75
+          - name: Pulsar IO - Elastic Search
+            group: PULSAR_IO_ELASTIC
           - name: Pulsar Client
             group: CLIENT
 

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -200,6 +200,8 @@ jobs:
             timeout: 75
           - name: Pulsar IO - Elastic Search
             group: PULSAR_IO_ELASTIC
+          - name: Pulsar IO - Kafka Connect Adaptor
+            group: PULSAR_IO_KAFKA_CONNECT
           - name: Pulsar Client
             group: CLIENT
 

--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -188,6 +188,12 @@ function test_group_pulsar_io() {
     echo "::endgroup::"
 }
 
+function test_group_pulsar_io_elastic() {
+    echo "::group::Running elastic-search tests"
+    mvn_test --install -Ppulsar-io-elastic-tests,-main
+    echo "::endgroup::"
+}
+
 function list_test_groups() {
   declare -F | awk '{print $NF}' | sort | grep -E '^test_group_' | sed 's/^test_group_//g' | tr '[:lower:]' '[:upper:]'
 }

--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -194,6 +194,12 @@ function test_group_pulsar_io_elastic() {
     echo "::endgroup::"
 }
 
+function test_group_pulsar_io_kafka_connect() {
+    echo "::group::Running Pulsar IO Kafka connect adaptor tests"
+    mvn_test --install -Ppulsar-io-kafka-connect-tests,-main
+    echo "::endgroup::"
+}
+
 function list_test_groups() {
   declare -F | awk '{print $NF}' | sort | grep -E '^test_group_' | sed 's/^test_group_//g' | tr '[:lower:]' '[:upper:]'
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2446,6 +2446,13 @@ flexible messaging model and an intuitive client API.</description>
     </profile>
 
     <profile>
+      <id>pulsar-io-kafka-connect-tests</id>
+      <modules>
+        <module>pulsar-io</module>
+      </modules>
+    </profile>
+
+    <profile>
       <id>pulsar-sql-tests</id>
       <modules>
         <module>pulsar-sql</module>

--- a/pom.xml
+++ b/pom.xml
@@ -2439,6 +2439,13 @@ flexible messaging model and an intuitive client API.</description>
     </profile>
 
     <profile>
+      <id>pulsar-io-elastic-tests</id>
+      <modules>
+        <module>pulsar-io</module>
+      </modules>
+    </profile>
+
+    <profile>
       <id>pulsar-sql-tests</id>
       <modules>
         <module>pulsar-sql</module>

--- a/pulsar-io/pom.xml
+++ b/pulsar-io/pom.xml
@@ -91,15 +91,11 @@
         <module>cassandra</module>
         <module>aerospike</module>
         <module>http</module>
-        <module>kafka</module>
         <module>rabbitmq</module>
         <module>kinesis</module>
         <module>hdfs3</module>
         <module>jdbc</module>
         <module>data-generator</module>
-        <module>kafka-connect-adaptor</module>
-        <module>kafka-connect-adaptor-nar</module>
-        <module>debezium</module>
         <module>hdfs2</module>
         <module>canal</module>
         <module>file</module>
@@ -122,6 +118,18 @@
         <module>core</module>
         <module>common</module>
         <module>elastic-search</module>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>pulsar-io-kafka-connect-tests</id>
+      <modules>
+        <module>core</module>
+        <module>common</module>
+        <module>kafka</module>
+        <module>kafka-connect-adaptor</module>
+        <module>kafka-connect-adaptor-nar</module>
+        <module>debezium</module>
       </modules>
     </profile>
 

--- a/pulsar-io/pom.xml
+++ b/pulsar-io/pom.xml
@@ -97,7 +97,6 @@
         <module>hdfs3</module>
         <module>jdbc</module>
         <module>data-generator</module>
-        <module>elastic-search</module>
         <module>kafka-connect-adaptor</module>
         <module>kafka-connect-adaptor-nar</module>
         <module>debezium</module>
@@ -114,6 +113,15 @@
         <module>dynamodb</module>
         <module>nsq</module>
         <module>alluxio</module>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>pulsar-io-elastic-tests</id>
+      <modules>
+        <module>core</module>
+        <module>common</module>
+        <module>elastic-search</module>
       </modules>
     </profile>
 

--- a/pulsar-io/pom.xml
+++ b/pulsar-io/pom.xml
@@ -85,7 +85,6 @@
         <module>batch-discovery-triggerers</module>
         <module>batch-data-generator</module>
         <module>common</module>
-        <module>docs</module>
         <module>aws</module>
         <module>twitter</module>
         <module>cassandra</module>


### PR DESCRIPTION
### Motivation

- the tests in Pulsar IO are extremely slow and could cause the current 75 minute limit to exceed.
- elastic-search tests are the slowest Pulsar IO tests
  - Elasticsearch tests took over 12 minutes here: https://ge.apache.org/s/ge3kvi7torsxq/performance/execution#goal-mlju2z5u77bvw 
  - Also seen here: https://ge.apache.org/s/ge3kvi7torsxq/tests/overview 
- Kafka Connect Adaptor & Debezium tests are another set of slow tests

### Modifications

- add new maven profile pulsar-io-elastic-tests that can be used to target Elasticsearch tests
- run Elasticsearch tests in a separate build job
- add new maven profile pulsar-io-kafka-connect-tests that can be used to target Kafka Connect related tests
- run Kafka Connect adaptor tests in a separate build job

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->