### PR TITLE
[improve][ci] Improve maven dependency caching and downloading in CI

### DIFF
--- a/.github/workflows/ci-maven-cache-update.yaml
+++ b/.github/workflows/ci-maven-cache-update.yaml
@@ -40,13 +40,14 @@ on:
   # trigger on a schedule so that the cache will be rebuilt if it happens to expire
   schedule:
     - cron: '30 */12 * * *'
+  workflow_dispatch:
 
 env:
   MAVEN_OPTS: -Xss1500k -Daether.connector.http.reuseConnections=false -Daether.connector.requestTimeout=60000 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.http.serviceUnavailableRetryStrategy.class=standard -Dmaven.wagon.rto=60000
 
 jobs:
   update-maven-dependencies-cache:
-    name: Update Maven dependency cache for ${{ matrix.name }}
+    name: ${{ matrix.name }} - Update Maven dependency cache
     env:
       JOB_NAME: Update Maven dependency cache for ${{ matrix.name }}
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
@@ -60,11 +61,17 @@ jobs:
           - name: all modules
             runs-on: ubuntu-20.04
             cache_name: 'm2-dependencies-all'
-            mvn_arguments: ''
+            mvn_arguments: '-Pmain -DintegrationTests'
+
+          - name: all modules for docker build
+            runs-on: ubuntu-20.04
+            cache_name: 'm2-dependencies-docker-all'
+            mvn_arguments: '-Pmain -DintegrationTests -DnarPluginPhase=package'
 
           - name: all modules - macos
             runs-on: macos-11
             cache_name: 'm2-dependencies-all'
+            mvn_arguments: '-Pmain'
 
           - name: core-modules
             runs-on: ubuntu-20.04
@@ -79,7 +86,7 @@ jobs:
         uses: ./.github/actions/tune-runner-vm
 
       - name: Detect changed files
-        if: ${{ github.event_name != 'schedule' }}
+        if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
@@ -89,7 +96,7 @@ jobs:
               - '**/pom.xml'
 
       - name: Cache local Maven repository
-        if: ${{ github.event_name == 'schedule' || steps.changes.outputs.poms == 'true' }}
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || steps.changes.outputs.poms == 'true' }}
         id: cache
         uses: actions/cache@v3
         timeout-minutes: 5
@@ -104,13 +111,16 @@ jobs:
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
-        if: ${{ (github.event_name == 'schedule' || steps.changes.outputs.poms == 'true') && steps.cache.outputs.cache-hit != 'true' }}
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || steps.changes.outputs.poms == 'true') && steps.cache.outputs.cache-hit != 'true' }}
         with:
           distribution: 'temurin'
           java-version: 17
 
       - name: Download dependencies
-        if: ${{ (github.event_name == 'schedule' || steps.changes.outputs.poms == 'true') && steps.cache.outputs.cache-hit != 'true' }}
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || steps.changes.outputs.poms == 'true') && steps.cache.outputs.cache-hit != 'true' }}
         run: |
+          # disable CVE-2021-26291 mitigation since it causes the build to be very slow when NAR files are built
+          $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh mvn_unblock_http_repositories
           # download dependencies, ignore errors
-          mvn -B -fn -ntp ${{ matrix.mvn_arguments }} dependency:go-offline
+          mvn -B -fn -ntp ${{ matrix.mvn_arguments }} -Pskip-all,skipDocker install || true
+          mvn -B -fn -ntp ${{ matrix.mvn_arguments }} dependency:go-offline || true

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -750,8 +750,11 @@ jobs:
           path: |
             ~/.m2/repository/*/*/*
             !~/.m2/repository/org/apache/pulsar
-          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-m2-dependencies-docker-all-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
+            ${{ runner.os }}-m2-dependencies-docker-all-
+            ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-all-
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
@@ -776,6 +779,8 @@ jobs:
 
       - name: Build latest-version-image docker image
         run: |
+          # disable CVE-2021-26291 mitigation since it causes the build to be very slow when NAR files are built
+          $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh mvn_unblock_http_repositories          
           # build docker image
           # include building of Pulsar SQL, Connectors, Offloaders and server distros
           mvn -B -am -pl pulsar-sql/presto-distribution,distribution/io,distribution/offloaders,distribution/server,distribution/shell,tests/docker-images/latest-version-image install \

--- a/build/run_integration_group.sh
+++ b/build/run_integration_group.sh
@@ -40,12 +40,18 @@ mvn_list_modules() {
   )
 }
 
+function mvn_unblock_http_repositories() {
+  # disable CVE-2021-26291 mitigation since it causes the build to be very slow when NAR files are built
+  $SCRIPT_DIR/pulsar_ci_tool.sh mvn_unblock_http_repositories
+}
+
 # runs integration tests
 # 1. cds to "tests" directory and lists the active modules to be used as value
 #    for "-pl" parameter of later mvn commands
 # 2. runs "mvn -pl [active_modules] -am install [given_params]" to build and install required dependencies
 # 3. finally runs tests with "mvn -pl [active_modules] test [given_params]"
 mvn_run_integration_test() {
+  mvn_unblock_http_repositories
   set +x
   # skip test run if next parameter is "--build-only"
   local build_only=0

--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -26,8 +26,14 @@ set -o errexit
 
 MVN_TEST_OPTIONS='mvn -B -ntp -DskipSourceReleaseAssembly=true -DskipBuildDistribution=true -Dspotbugs.skip=true -Dlicense.skip=true -Dcheckstyle.skip=true -Drat.skip=true'
 
+function mvn_unblock_http_repositories() {
+  # disable CVE-2021-26291 mitigation since it causes the build to be very slow when NAR files are built
+  $SCRIPT_DIR/pulsar_ci_tool.sh mvn_unblock_http_repositories
+}
+
 function mvn_test() {
   (
+    mvn_unblock_http_repositories
     local clean_arg=""
     if [[ "$1" == "--clean" ]]; then
         clean_arg="clean"


### PR DESCRIPTION
### Motivation

Downloading Maven dependencies is very slow when building the pulsar-all docker image in CI that is needed for running system tests. There are seem to be a lot of maven dependency cache misses which slow down CI builds.

### Modifications

- `dependency:go-offline` used to build caches isn't caching all dependencies and pom files
  - use `-Pskip-all,skipDocker install` as the first step to trigger downloads and to improve cache coverage without requiring to build everything
- add a new cache `m2-dependencies-docker-all` that is used for building the pulsar-all docker image
  - addresses downloading the dependencies required for building all NAR files for Pulsar IO connectors
- add dependencies for integration tests in the m2-dependencies-all cache
- unblock downloads from http repositories
  - blocking http repository downloads makes NAR file creation extra slow
  - disables CVE-2021-26291 mitigation in Maven 3.8.1
    - https://maven.apache.org/docs/3.8.1/release-notes.html#cve-2021-26291

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

See https://github.com/lhotari/pulsar/actions/runs/5079566424 experiment