### PR TITLE
[fix] [broker] Fix incorrect recent joined position of consumers in Key_Shared mode

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -164,7 +164,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
                 // There is a pending read from previous run. We must wait for it to complete and then rewind
                 shouldRewindBeforeReadingOrReplaying = true;
             } else {
-                cursor.rewind();
+                rewindCursor();
                 shouldRewindBeforeReadingOrReplaying = false;
             }
             redeliveryMessages.clear();
@@ -189,6 +189,10 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         consumerSet.add(consumer);
 
         return CompletableFuture.completedFuture(null);
+    }
+
+    protected synchronized void rewindCursor() {
+        cursor.rewind();
     }
 
     @Override
@@ -563,7 +567,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         if (shouldRewindBeforeReadingOrReplaying && readType == ReadType.Normal) {
             // All consumers got disconnected before the completion of the read operation
             entries.forEach(Entry::release);
-            cursor.rewind();
+            rewindCursor();
             shouldRewindBeforeReadingOrReplaying = false;
             readMoreEntries();
             return;
@@ -679,7 +683,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
                 // Do nothing, cursor will be rewind at reconnection
                 log.info("[{}] rewind because no available consumer found from total {}", name, consumerList.size());
                 entries.subList(start, entries.size()).forEach(Entry::release);
-                cursor.rewind();
+                rewindCursor();
                 return false;
             }
 
@@ -846,7 +850,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
 
         if (shouldRewindBeforeReadingOrReplaying) {
             shouldRewindBeforeReadingOrReplaying = false;
-            cursor.rewind();
+            rewindCursor();
         }
 
         if (readType == ReadType.Normal) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -97,6 +97,12 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
         }
     }
 
+    @Override
+    protected synchronized void rewindCursor(){
+        super.rewindCursor();
+        recentlyJoinedConsumers.clear();
+    }
+
     @VisibleForTesting
     public StickyKeyConsumerSelector getSelector() {
         return selector;


### PR DESCRIPTION
### Motivation

<strong>Background-1</strong>: After all consumers are removed, the Dispatcher will call `cursor.rewind` and reset all attributes in memory, making the Dispatcher like a new Dispatcher.

<strong>Background-2</strong>: there have a variable `recentlyJoinedConsumers` records the read position of the cursor when a new consumer registers.

If there has an in-flight reading, Dispatcher does not call `cursor.rewind` immediately but waits for the in-flight reading complete, it makes the `recentJoinedPosition` of new consumers in the wrong position.

### Modifications

After `rewind`, clear `recentJoinedPosition`  

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository:
- x
