### PR TITLE
[improve][broker] Change limitStatsLogging config default value to true

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1078,8 +1078,8 @@ bookkeeperExplicitLacIntervalInMills=0
 # bookkeeperClientExposeStatsToPrometheus=false
 
 # If bookkeeperClientExposeStatsToPrometheus is set to true, we can set bookkeeperClientLimitStatsLogging=true
-# to limit per_channel_bookie_client metrics. default is false
-# bookkeeperClientLimitStatsLogging=false
+# to limit per_channel_bookie_client metrics. default is true
+# bookkeeperClientLimitStatsLogging=true
 
 ### --- Managed Ledger --- ###
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -697,8 +697,8 @@ bookkeeperUseV2WireProtocol=true
 # bookkeeperClientExposeStatsToPrometheus=false
 
 # If bookkeeperClientExposeStatsToPrometheus is set to true, we can set bookkeeperClientLimitStatsLogging=true
-# to limit per_channel_bookie_client metrics. default is false
-# bookkeeperClientLimitStatsLogging=false
+# to limit per_channel_bookie_client metrics. default is true
+# bookkeeperClientLimitStatsLogging=true
 
 ### --- Managed Ledger --- ###
 

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -745,8 +745,8 @@ bookkeeperExplicitLacIntervalInMills=0
 # bookkeeperClientExposeStatsToPrometheus=false
 
 # If bookkeeperClientExposeStatsToPrometheus is set to true, we can set bookkeeperClientLimitStatsLogging=true
-# to limit per_channel_bookie_client metrics. default is false
-# bookkeeperClientLimitStatsLogging=false
+# to limit per_channel_bookie_client metrics. default is true
+# bookkeeperClientLimitStatsLogging=true
 
 ### --- Managed Ledger --- ###
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1820,7 +1820,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             category = CATEGORY_STORAGE_BK,
             doc = "whether limit per_channel_bookie_client metrics of bookkeeper client stats"
     )
-    private boolean bookkeeperClientLimitStatsLogging = false;
+    private boolean bookkeeperClientLimitStatsLogging = true;
 
     @FieldContext(
             category = CATEGORY_STORAGE_BK,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/BookKeeperClientFactoryImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/BookKeeperClientFactoryImplTest.java
@@ -303,22 +303,22 @@ public class BookKeeperClientFactoryImplTest {
     public void testBookKeeperLimitStatsLoggingConfiguration() throws Exception {
         BookKeeperClientFactoryImpl factory = new BookKeeperClientFactoryImpl();
         ServiceConfiguration conf = new ServiceConfiguration();
-        assertFalse(
-                factory.createBkClientConfiguration(mock(MetadataStoreExtended.class), conf).getLimitStatsLogging());
+        assertTrue(factory.createBkClientConfiguration(mock(MetadataStoreExtended.class), conf)
+                .getLimitStatsLogging());
         EventLoopGroup eventLoopGroup = mock(EventLoopGroup.class);
         BookKeeper.Builder builder = factory.getBookKeeperBuilder(conf, eventLoopGroup, mock(StatsLogger.class),
                 factory.createBkClientConfiguration(mock(MetadataStoreExtended.class), conf));
         ClientConfiguration clientConfiguration =
                 (ClientConfiguration) FieldUtils.readField(builder, "conf", true);
-        assertFalse(clientConfiguration.getLimitStatsLogging());
+        assertTrue(clientConfiguration.getLimitStatsLogging());
 
-        conf.setBookkeeperClientLimitStatsLogging(true);
-        assertTrue(factory.createBkClientConfiguration(mock(MetadataStoreExtended.class), conf)
-                .getLimitStatsLogging());
+        conf.setBookkeeperClientLimitStatsLogging(false);
+        assertFalse(
+                factory.createBkClientConfiguration(mock(MetadataStoreExtended.class), conf).getLimitStatsLogging());
         builder = factory.getBookKeeperBuilder(conf, eventLoopGroup, mock(StatsLogger.class),
                 factory.createBkClientConfiguration(mock(MetadataStoreExtended.class), conf));
         clientConfiguration =
                 (ClientConfiguration) FieldUtils.readField(builder, "conf", true);
-        assertTrue(clientConfiguration.getLimitStatsLogging());
+        assertFalse(clientConfiguration.getLimitStatsLogging());
     }
 }


### PR DESCRIPTION
### Motivation

Since https://github.com/apache/bookkeeper/pull/3719 has set limitStatsLogging config default true in bookie, it is better to also set it default true in broker config.

### Verifying this change

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [x] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/TakaHiR07/pulsar/pull/8


