### PR TITLE
[improve][broker] Supplement schema ledger if schema ledger is lost

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -697,6 +697,31 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
                 .checkConsumerCompatibility(id, schema, getSchemaCompatibilityStrategy());
     }
 
+    protected CompletableFuture<Void> tryCompleteTheLostSchema(SchemaVersion schemaVersion, SchemaData schema) {
+        String id = getSchemaId();
+        return brokerService.pulsar()
+                .getSchemaRegistryService()
+                .tryCompleteTheLostSchema(id, schemaVersion, schema);
+    }
+
+    @Override
+    public CompletableFuture<Long> findSchemaVersion(SchemaData schema) {
+        String id = getSchemaId();
+        return brokerService.pulsar()
+                .getSchemaRegistryService()
+                .findSchemaVersion(id, schema);
+    }
+
+    protected CompletableFuture<SchemaVersion> getLatestSchemaVersion() {
+        return brokerService.pulsar()
+                .getSchemaRegistryService()
+                .getLatestSchemaVersion(getSchemaId())
+                .thenApply(schemaVersion -> {
+                    log.warn("~~~~~~~~~~~~~~~~~~~~~~" + schemaVersion);
+                    return schemaVersion;
+                });
+    }
+
     @Override
     public CompletableFuture<Optional<Long>> addProducer(Producer producer,
                                                          CompletableFuture<Void> producerQueuedFuture) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -60,7 +60,7 @@ import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
 import org.apache.pulsar.common.policies.data.TopicOperation;
 import org.apache.pulsar.common.policies.data.stats.ConsumerStatsImpl;
 import org.apache.pulsar.common.protocol.Commands;
-import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.common.protocol.schema.SchemaData;
 import org.apache.pulsar.common.stats.Rate;
 import org.apache.pulsar.common.util.DateFormatter;
 import org.apache.pulsar.common.util.FutureUtil;
@@ -146,7 +146,11 @@ public class Consumer {
     private long negtiveUnackedMsgsTimestamp;
 
     @Getter
-    private final SchemaType schemaType;
+    private final SchemaData schemaData;
+    @Getter
+    @Setter
+    private final long schemaVersion;
+
 
     public Consumer(Subscription subscription, SubType subType, String topicName, long consumerId,
                     int priorityLevel, String consumerName,
@@ -154,7 +158,7 @@ public class Consumer {
                     Map<String, String> metadata, boolean readCompacted,
                     KeySharedMeta keySharedMeta, MessageId startMessageId, long consumerEpoch) {
         this(subscription, subType, topicName, consumerId, priorityLevel, consumerName, isDurable, cnx, appId,
-                metadata, readCompacted, keySharedMeta, startMessageId, consumerEpoch, null);
+                metadata, readCompacted, keySharedMeta, startMessageId, consumerEpoch, null, -1L);
     }
 
     public Consumer(Subscription subscription, SubType subType, String topicName, long consumerId,
@@ -162,7 +166,7 @@ public class Consumer {
                     boolean isDurable, TransportCnx cnx, String appId,
                     Map<String, String> metadata, boolean readCompacted,
                     KeySharedMeta keySharedMeta, MessageId startMessageId,
-                    long consumerEpoch, SchemaType schemaType) {
+                    long consumerEpoch, SchemaData schemaData, long schemaVersion) {
         this.subscription = subscription;
         this.subType = subType;
         this.topicName = topicName;
@@ -220,7 +224,8 @@ public class Consumer {
         this.isAcknowledgmentAtBatchIndexLevelEnabled = subscription.getTopic().getBrokerService()
                 .getPulsar().getConfiguration().isAcknowledgmentAtBatchIndexLevelEnabled();
 
-        this.schemaType = schemaType;
+        this.schemaData = schemaData;
+        this.schemaVersion = schemaVersion;
     }
 
     @VisibleForTesting
@@ -248,7 +253,8 @@ public class Consumer {
         this.clientAddress = null;
         this.startMessageId = null;
         this.isAcknowledgmentAtBatchIndexLevelEnabled = false;
-        this.schemaType = null;
+        this.schemaData = null;
+        this.schemaVersion = -1L;
         MESSAGE_PERMITS_UPDATER.set(this, availablePermits);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -55,6 +55,7 @@ import org.apache.pulsar.common.policies.data.TopicOperation;
 import org.apache.pulsar.common.policies.data.stats.NonPersistentPublisherStatsImpl;
 import org.apache.pulsar.common.policies.data.stats.PublisherStatsImpl;
 import org.apache.pulsar.common.protocol.Commands;
+import org.apache.pulsar.common.protocol.schema.SchemaData;
 import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.stats.Rate;
 import org.apache.pulsar.common.util.DateFormatter;
@@ -98,15 +99,26 @@ public class Producer {
     private final Map<String, String> metadata;
 
     private final SchemaVersion schemaVersion;
+    private final SchemaData schemaData;
     private final String clientAddress; // IP address only, no port number included
     private final AtomicBoolean isDisconnecting = new AtomicBoolean(false);
+
+    public Producer(Topic topic, TransportCnx cnx, long producerId, String producerName, String appId,
+                    boolean isEncrypted, Map<String, String> metadata, SchemaVersion schemaVersion, long epoch,
+                    boolean userProvidedProducerName,
+                    ProducerAccessMode accessMode,
+                    Optional<Long> topicEpoch,
+                    boolean supportsPartialProducer) {
+        this(topic, cnx, producerId, producerName, appId, isEncrypted, metadata, schemaVersion, epoch,
+                userProvidedProducerName, accessMode, topicEpoch, supportsPartialProducer, null);
+    }
 
     public Producer(Topic topic, TransportCnx cnx, long producerId, String producerName, String appId,
             boolean isEncrypted, Map<String, String> metadata, SchemaVersion schemaVersion, long epoch,
             boolean userProvidedProducerName,
             ProducerAccessMode accessMode,
             Optional<Long> topicEpoch,
-            boolean supportsPartialProducer) {
+            boolean supportsPartialProducer, SchemaData schemaData) {
         final ServiceConfiguration serviceConf =  cnx.getBrokerService().pulsar().getConfiguration();
 
         this.topic = topic;
@@ -155,6 +167,7 @@ public class Producer {
 
         this.isEncrypted = isEncrypted;
         this.schemaVersion = schemaVersion;
+        this.schemaData = schemaData;
         this.accessMode = accessMode;
         this.topicEpoch = topicEpoch;
 
@@ -825,6 +838,10 @@ public class Producer {
 
     public SchemaVersion getSchemaVersion() {
         return schemaVersion;
+    }
+
+    public SchemaData getSchemaData() {
+        return schemaData;
     }
 
     public ProducerAccessMode getAccessMode() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SubscriptionOption.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SubscriptionOption.java
@@ -29,7 +29,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.api.proto.KeySharedMeta;
 import org.apache.pulsar.common.api.proto.KeyValue;
-import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.common.protocol.schema.SchemaData;
 
 @Getter
 @Builder
@@ -50,7 +50,8 @@ public class SubscriptionOption {
     private KeySharedMeta keySharedMeta;
     private Optional<Map<String, String>> subscriptionProperties;
     private long consumerEpoch;
-    private SchemaType schemaType;
+    private SchemaData schemaData;
+    private long schemaVersion;
 
     public static Optional<Map<String, String>> getPropertiesMap(List<KeyValue> list) {
         if (list == null) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -307,7 +307,9 @@ public interface Topic {
      * add the passed schema to the topic. Otherwise, check that the passed schema is compatible
      * with what the topic already has.
      */
-    CompletableFuture<Void> addSchemaIfIdleOrCheckCompatible(SchemaData schema);
+    CompletableFuture<Long> addSchemaIfIdleOrCheckCompatible(SchemaData schema);
+
+    CompletableFuture<Long> findSchemaVersion(SchemaData schema);
 
     CompletableFuture<Void> deleteForcefully();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/DefaultSchemaRegistryService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/DefaultSchemaRegistryService.java
@@ -71,6 +71,17 @@ public class DefaultSchemaRegistryService implements SchemaRegistryService {
     }
 
     @Override
+    public CompletableFuture<Void> tryCompleteTheLostSchema(String schemaId, SchemaVersion schemaVersion,
+                                                            SchemaData schema) {
+        return completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<SchemaVersion> getLatestSchemaVersion(String schemaId) {
+        return completedFuture(null);
+    }
+
+    @Override
     public CompletableFuture<SchemaVersion> deleteSchema(String schemaId, String user, boolean force) {
         return completedFuture(null);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistry.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistry.java
@@ -59,6 +59,10 @@ public interface SchemaRegistry extends AutoCloseable {
     CompletableFuture<SchemaVersion> getSchemaVersionBySchemaData(List<SchemaAndMetadata> schemaAndMetadataList,
                                                                   SchemaData schemaData);
 
+    CompletableFuture<Void> tryCompleteTheLostSchema(String schemaId, SchemaVersion schemaVersion, SchemaData schema);
+
+    CompletableFuture<SchemaVersion> getLatestSchemaVersion(String schemaId);
+
     SchemaVersion versionFromBytes(byte[] version);
 
     class SchemaAndMetadata {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/SchemaServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/SchemaServiceTest.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 import com.google.common.collect.Multimap;
 import com.google.common.hash.HashFunction;
@@ -32,6 +33,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -40,11 +42,23 @@ import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Cleanup;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.service.schema.SchemaRegistry.SchemaAndMetadata;
 import org.apache.pulsar.broker.stats.PrometheusMetricsTest;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.protocol.schema.SchemaData;
@@ -54,6 +68,7 @@ import org.apache.pulsar.common.schema.SchemaType;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker")
@@ -82,13 +97,15 @@ public class SchemaServiceTest extends MockedPulsarServiceBaseTest {
     private static final SchemaData schemaData3 = getSchemaData(schemaJson3);
 
     private SchemaRegistryServiceImpl schemaRegistryService;
+    private BookkeeperSchemaStorage storage;
 
     @BeforeMethod
     @Override
     protected void setup() throws Exception {
         conf.setSchemaRegistryStorageClassName("org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorageFactory");
         super.internalSetup();
-        BookkeeperSchemaStorage storage = new BookkeeperSchemaStorage(pulsar);
+        super.setupDefaultTenantAndNamespace();
+        storage = new BookkeeperSchemaStorage(pulsar);
         storage.start();
         Map<SchemaType, SchemaCompatibilityCheck> checkMap = new HashMap<>();
         checkMap.put(SchemaType.AVRO, new AvroSchemaCompatibilityCheck());
@@ -324,6 +341,148 @@ public class SchemaServiceTest extends MockedPulsarServiceBaseTest {
             Assert.assertEquals(e.getClass(), PulsarServerException.class);
             Assert.assertTrue(e.getMessage().contains("User class must be in class path"));
         }
+    }
+
+    @Test(dataProvider = "lostSchemaLedgerIndexes", timeOut = 30000)
+    public void testSchemaLedgerLost(List<Integer> lostSchemaLedgerIndexes) throws Exception {
+        final String namespace = "public/default";
+        final String topic = namespace + "/testSchemaLedgerLost";
+        final Schema<V1Data> schemaV1 = Schema.AVRO(V1Data.class);
+        final Schema<V2Data> schemaV2 = Schema.AVRO(V2Data.class);
+        admin.namespaces().setSchemaCompatibilityStrategy(namespace, SchemaCompatibilityStrategy.BACKWARD);
+        admin.topics().createNonPartitionedTopic(topic);
+        admin.topics().setSchemaValidationEnforced(topic, true);
+
+        Producer<V1Data> producer1 = pulsarClient.newProducer(schemaV1)
+                .topic(topic)
+                .producerName("producer1")
+                .create();
+        Producer<V2Data> producer2 = pulsarClient.newProducer(schemaV2)
+                .topic(topic)
+                .producerName("producer2")
+                .create();
+        Consumer<V1Data> consumer1 = pulsarClient.newConsumer(schemaV1)
+                .topic(topic)
+                .subscriptionType(SubscriptionType.Shared)
+                .subscriptionName("sub0")
+                .consumerName("consumer1")
+                .subscribe();
+        // @Cleanup
+        // Consumer<V2Data> consumer2 = pulsarClient.newConsumer(schemaV2)
+        //         .topic(topic)
+        //         .subscriptionType(SubscriptionType.Shared)
+        //         .subscriptionName("sub0")
+        //         .consumerName("consumerAfterLostLedger2")
+        //         .subscribe();
+
+        SchemaAndMetadata schemaAndMetadata0 = schemaRegistryService.getSchema(TopicName.get(topic)
+                .getSchemaName(), new LongSchemaVersion(0)).get();
+        SchemaAndMetadata schemaAndMetadata1 = schemaRegistryService.getSchema(TopicName.get(topic)
+                .getSchemaName(), new LongSchemaVersion(1)).get();
+
+        // delete ledger
+        String key = TopicName.get(topic).getSchemaName();
+        List<Long> schemaLedgerList = storage.getSchemaLedgerList(key);
+        Assert.assertEquals(schemaLedgerList.size(), 2);
+        for (int i = 0; i < schemaLedgerList.size(); i++){
+            if (lostSchemaLedgerIndexes.contains(i)){
+                storage.getBookKeeper().deleteLedger(schemaLedgerList.get(i));
+            }
+        }
+
+        // Without introducing this pr, connected producers or consumers are not affected if the schema ledger is lost
+        final int numMessages = 5;
+        for (int i = 0; i < numMessages; i++) {
+            producer1.send(new V1Data(i));
+            producer2.send(new V2Data(i, i + 1));
+        }
+        for (int i = 0; i < numMessages; i++) {
+            Message<V1Data> msg = consumer1.receive(3, TimeUnit.SECONDS);
+            consumer1.acknowledge(msg);
+        }
+
+        // try to fix the lost schema ledger
+        if (lostSchemaLedgerIndexes.contains(0) && lostSchemaLedgerIndexes.contains(1)) {
+            schemaRegistryService.tryCompleteTheLostSchema(TopicName.get(topic)
+                            .getSchemaName(), new LongSchemaVersion(0)
+                    , schemaAndMetadata0.schema);
+            // TODO: BadVersion for /schemas/public/default/testSchemaLedgerLost. Need to fix.
+            //  When lostSchemaLedgerIndexes contains 0 and 1.
+            schemaRegistryService.tryCompleteTheLostSchema(TopicName.get(topic)
+                            .getSchemaName(), new LongSchemaVersion(1)
+                    , schemaAndMetadata1.schema);
+        } else if (lostSchemaLedgerIndexes.contains(0) && !lostSchemaLedgerIndexes.contains(1)) {
+            schemaRegistryService.tryCompleteTheLostSchema(TopicName.get(topic)
+                            .getSchemaName(), new LongSchemaVersion(0)
+                    , schemaAndMetadata0.schema);
+        } else if (!lostSchemaLedgerIndexes.contains(0) && lostSchemaLedgerIndexes.contains(1)) {
+            schemaRegistryService.tryCompleteTheLostSchema(TopicName.get(topic)
+                            .getSchemaName(), new LongSchemaVersion(1)
+                    , schemaAndMetadata1.schema);
+        }
+
+        @Cleanup
+        Producer<V1Data> producerAfterLostLedger1 = pulsarClient.newProducer(schemaV1)
+                .topic(topic)
+                .producerName("producerAfterLostLedger1")
+                .create();
+        assertNotNull(producerAfterLostLedger1.send(new V1Data(10)));
+        @Cleanup
+        Producer<V2Data> producerAfterLostLedger2 = pulsarClient.newProducer(schemaV2)
+                .topic(topic)
+                .producerName("producerAfterLostLedger2")
+                .create();
+        assertNotNull(producerAfterLostLedger2.send(new V2Data(10, 10)));
+
+        @Cleanup
+        Consumer<V1Data> consumerAfterLostLedger1 = pulsarClient.newConsumer(schemaV1)
+                .topic(topic)
+                .subscriptionType(SubscriptionType.Shared)
+                .subscriptionName("sub1")
+                .consumerName("consumerAfterLostLedger1")
+                .subscribe();
+        producer1.send(new V1Data(11));
+        assertNotNull(consumerAfterLostLedger1.receive(3, TimeUnit.SECONDS));
+
+        @Cleanup
+        Consumer<V2Data> consumerAfterLostLedger2 = pulsarClient.newConsumer(schemaV2)
+                .topic(topic)
+                .subscriptionType(SubscriptionType.Shared)
+                .subscriptionName("sub0")
+                .consumerName("consumerAfterLostLedger2")
+                .subscribe();
+        producer2.send(new V2Data(11, 11));
+        assertNotNull(consumerAfterLostLedger2.receive(3, TimeUnit.SECONDS));
+
+        producer1.close();
+        producer2.close();
+        consumer1.close();
+    }
+
+    @DataProvider(name = "lostSchemaLedgerIndexes")
+    public Object[][] lostSchemaLedgerIndexes(){
+        return new Object[][]{
+                // {Arrays.asList(0,1)},
+                {Arrays.asList(0)},
+                {Arrays.asList(1)}
+        };
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    static class V1Data {
+        int i;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    static class V2Data {
+        int i;
+        Integer j;
     }
 
     private void putSchema(String schemaId, SchemaData schema, SchemaVersion expectedVersion) throws Exception {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaStorage.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/schema/SchemaStorage.java
@@ -54,6 +54,10 @@ public interface SchemaStorage {
 
     SchemaVersion versionFromBytes(byte[] version);
 
+    CompletableFuture<SchemaVersion> getLatestSchemaVersion(String key);
+
+    CompletableFuture<Long> tryCompleteTheLostSchemaLedger(String schemaId, SchemaVersion version, SchemaData schema);
+
     void start() throws Exception;
 
     void close() throws Exception;


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #20414

<!-- or this PR is one task of an issue -->

Master Issue: #https://github.com/apache/pulsar/issues/20414

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/wiki/proposals/PIP.md -->

### Motivation

https://github.com/apache/pulsar/issues/17221 describes an environment when multiple bookie copies are corrupted, or a Ledger has been deleted. The loss of schema ledger results in new producers and consumers not even being created and working properly.

So we need a solution that does not just skip the schema with the missing ledger, but actually supplements the broken schema ledger.

### Modifications

<!-- Describe the modifications you've done. -->
Add a new method `tryCompleteTheLostSchema()` in `SchemaStorage` and `SchemaRegistry`
```java
CompletableFuture<Long> tryCompleteTheLostSchemaLedger(String key, SchemaVersion version, SchemaData schema);
```
1. get schemalocator from metastore
2. Create a new ledger. And write `SchemaStorageFormat.SchemaEntry` built with `schemaData` and `schemaVersion`.
3. update schemalocator to metastore(new ledger id)


### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
