### PR TITLE
[improve][ci] Improve TestNG test execution to debug flaky test failures

### DIFF
--- a/buildtools/src/main/java/org/apache/pulsar/tests/FailFastNotifier.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/FailFastNotifier.java
@@ -124,8 +124,7 @@ public class FailFastNotifier
                         || iTestNGMethod.isAfterTestConfiguration())) {
                     throw new FailFastSkipException("Skipped after failure since testFailFast system property is set.");
                 }
-            }
-            if (FAIL_FAST_KILLSWITCH_FILE != null && FAIL_FAST_KILLSWITCH_FILE.exists()) {
+            } else if (FAIL_FAST_KILLSWITCH_FILE != null && FAIL_FAST_KILLSWITCH_FILE.exists()) {
                 throw new FailFastSkipException("Skipped after failure since kill switch file exists.");
             }
         }

--- a/buildtools/src/main/java/org/apache/pulsar/tests/PulsarTestListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/PulsarTestListener.java
@@ -44,20 +44,29 @@ public class PulsarTestListener implements ITestListener {
         if (!(result.getThrowable() instanceof SkipException)) {
             System.out.format("!!!!!!!!! FAILURE-- %s.%s(%s)-------\n", result.getTestClass(),
                     result.getMethod().getMethodName(), Arrays.toString(result.getParameters()));
-        }
-        if (result.getThrowable() != null) {
-            result.getThrowable().printStackTrace();
-            if (result.getThrowable() instanceof ThreadTimeoutException) {
-                System.out.println("====== THREAD DUMPS ======");
-                System.out.println(ThreadDumpUtil.buildThreadDiagnosticString());
+            if (result.getThrowable() != null) {
+                result.getThrowable().printStackTrace();
+                if (result.getThrowable() instanceof ThreadTimeoutException) {
+                    System.out.println("====== THREAD DUMPS ======");
+                    System.out.println(ThreadDumpUtil.buildThreadDiagnosticString());
+                }
             }
         }
     }
 
     @Override
     public void onTestSkipped(ITestResult result) {
-        System.out.format("~~~~~~~~~ SKIPPED -- %s.%s(%s)-------\n", result.getTestClass(),
-                result.getMethod().getMethodName(), Arrays.toString(result.getParameters()));
+        if (!(result.getThrowable() instanceof SkipException)) {
+            System.out.format("~~~~~~~~~ SKIPPED -- %s.%s(%s)-------\n", result.getTestClass(),
+                    result.getMethod().getMethodName(), Arrays.toString(result.getParameters()));
+            if (result.getThrowable() != null) {
+                result.getThrowable().printStackTrace();
+                if (result.getThrowable() instanceof ThreadTimeoutException) {
+                    System.out.println("====== THREAD DUMPS ======");
+                    System.out.println(ThreadDumpUtil.buildThreadDiagnosticString());
+                }
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
### Motivation

In order to investigate some flaky test failures such as #20386, it is necessary to add logging to find out what was the failure of the first attempt. In some cases, the exception in the test retry is not the root cause.

In the case of #20386, there's "Index 0 out of bounds for length 0" recorded in the skip message:
```
  <testcase name="testMsgDropStat" classname="org.apache.pulsar.client.api.NonPersistentTopicTest" time="0">
    <skipped message="Index 0 out of bounds for length 0"/>
```
However, the full exception isn't logged. 

### Modifications

- Log possible exceptions before retrying a test run
  - this will help debug issues when tests are retried
- Don't log anything when skipping is a result of fail fast mode (SkipException)
- Execute cleanup methods when using fail fast mode
 - the change in #19252 broke the logic that intends to run cleanup methods after the first failure

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->