### PR TITLE
[improve][broker] Replace String.intern() with Guava Interner

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
@@ -34,6 +34,7 @@ import org.apache.pulsar.client.impl.ProducerImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.common.util.StringInterner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,9 +74,9 @@ public abstract class AbstractReplicator {
         this.brokerService = brokerService;
         this.localTopicName = localTopicName;
         this.replicatorPrefix = replicatorPrefix;
-        this.localCluster = localCluster.intern();
+        this.localCluster = StringInterner.intern(localCluster);
         this.remoteTopicName = remoteTopicName;
-        this.remoteCluster = remoteCluster.intern();
+        this.remoteCluster = StringInterner.intern(remoteCluster);
         this.replicationClient = replicationClient;
         this.client = (PulsarClientImpl) brokerService.pulsar().getClient();
         this.producer = null;
@@ -228,7 +229,7 @@ public abstract class AbstractReplicator {
     }
 
     public static String getReplicatorName(String replicatorPrefix, String cluster) {
-        return (replicatorPrefix + "." + cluster).intern();
+        return StringInterner.intern(replicatorPrefix + "." + cluster);
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.unsafeGetPartitionedTopicMetadataAsync;
 import static org.apache.pulsar.broker.lookup.TopicLookupBase.lookupTopicAsync;
 import static org.apache.pulsar.broker.service.persistent.PersistentTopic.getMigratedClusterUrl;
@@ -716,7 +717,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             log.debug("[{}] connect state change to : [{}]", remoteAddress, State.Connected.name());
         }
         setRemoteEndpointProtocolVersion(clientProtoVersion);
-        this.clientVersion = StringInterner.intern(clientVersion);
+        if (isNotBlank(clientVersion)) {
+            this.clientVersion = StringInterner.intern(clientVersion);
+        }
         if (!service.isAuthenticationEnabled()) {
             log.info("[{}] connected with clientVersion={}, clientProtocolVersion={}, proxyVersion={}", remoteAddress,
                     clientVersion, clientProtoVersion, proxyVersion);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.unsafeGetPartitionedTopicMetadataAsync;
 import static org.apache.pulsar.broker.lookup.TopicLookupBase.lookupTopicAsync;
 import static org.apache.pulsar.broker.service.persistent.PersistentTopic.getMigratedClusterUrl;
@@ -164,6 +163,7 @@ import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.common.topics.TopicList;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.common.util.StringInterner;
 import org.apache.pulsar.common.util.collections.ConcurrentLongHashMap;
 import org.apache.pulsar.common.util.netty.NettyChannelUtil;
 import org.apache.pulsar.common.util.netty.NettyFutureUtil;
@@ -716,9 +716,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             log.debug("[{}] connect state change to : [{}]", remoteAddress, State.Connected.name());
         }
         setRemoteEndpointProtocolVersion(clientProtoVersion);
-        if (isNotBlank(clientVersion)) {
-            this.clientVersion = clientVersion.intern();
-        }
+        this.clientVersion = StringInterner.intern(clientVersion);
         if (!service.isAuthenticationEnabled()) {
             log.info("[{}] connected with clientVersion={}, clientProtocolVersion={}, proxyVersion={}", remoteAddress,
                     clientVersion, clientProtoVersion, proxyVersion);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/StringInterner.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/StringInterner.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util;
+
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
+
+/**
+ * Deduplicates String instances by interning them using Guava's Interner
+ * which is more efficient than String.intern().
+ */
+public class StringInterner {
+    private static final StringInterner INSTANCE = new StringInterner();
+    private final Interner<String> interner;
+
+    public static String intern(String sample) {
+        return INSTANCE.doIntern(sample);
+    }
+
+    private StringInterner() {
+        this.interner = Interners.newWeakInterner();
+    }
+
+    String doIntern(String sample) {
+        if (sample == null) {
+            return null;
+        }
+        return interner.intern(sample);
+    }
+}


### PR DESCRIPTION
### Motivation

It is not recommended to use `String.intern()` at all. Guava contains a better replacement in it's Interner class.
One of the problems with `String.intern()` is that it could expose the server to a certain type of Denial of Service (DoS) attack. Any String instance that is interned with String.intern(), will remain in memory until the JVM is restarted. An attacker can use this to cause a denial of service. With Guava's weak reference based interner `Interners.newWeakInterner()`, there is no such problem.
`String.intern()` might cause memory leaks outside of DoS attacks since the instances will never be collected by GC.
That's one of the reasons why Guava's weak reference based solution is more robust.

Gradle build tool has been using Guava's interner for years (since it was introduced in 2015 with https://github.com/gradle/gradle/commit/799e03e6) and it has been a successful solution in reducing String instance duplication without the problems that `String.intern()` has.

### Modifications

Replace `String.intern()` with the singleton instance that uses Guava Interner

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->