### PR TITLE
[improve][build] Improve the publishing of docker image

### DIFF
--- a/docker/publish.sh
+++ b/docker/publish.sh
@@ -62,16 +62,24 @@ set -x
 # Fail if any of the subsequent commands fail
 set -e
 
-docker tag apachepulsar/pulsar:latest ${docker_registry_org}/pulsar:latest
-docker tag apachepulsar/pulsar-all:latest ${docker_registry_org}/pulsar-all:latest
-
-docker tag apachepulsar/pulsar:latest ${docker_registry_org}/pulsar:$MVN_VERSION
-docker tag apachepulsar/pulsar-all:latest ${docker_registry_org}/pulsar-all:$MVN_VERSION
+docker tag apachepulsar/pulsar:$MVN_VERSION ${docker_registry_org}/pulsar:$MVN_VERSION
+docker tag apachepulsar/pulsar-all:$MVN_VERSION ${docker_registry_org}/pulsar-all:$MVN_VERSION
 
 # Push all images and tags
-docker push ${docker_registry_org}/pulsar:latest
-docker push ${docker_registry_org}/pulsar-all:latest
 docker push ${docker_registry_org}/pulsar:$MVN_VERSION
 docker push ${docker_registry_org}/pulsar-all:$MVN_VERSION
+
+read -r -p "Do you want to publish the latest images? Default to 'n'.
+NOTICE: Enter 'y' if the Pulsar is the latest version, otherwise enter 'n'.
+(y/n)" yn
+
+case $yn in
+  y )
+    docker tag apachepulsar/pulsar:$MVN_VERSION ${docker_registry_org}/pulsar:latest
+    docker tag apachepulsar/pulsar-all:$MVN_VERSION ${docker_registry_org}/pulsar-all:latest
+    docker push ${docker_registry_org}/pulsar:latest
+    docker push ${docker_registry_org}/pulsar-all:latest
+    ;;
+esac
 
 echo "Finished pushing images to ${docker_registry_org}"

--- a/docker/pulsar-all/Dockerfile
+++ b/docker/pulsar-all/Dockerfile
@@ -21,11 +21,12 @@ FROM busybox as pulsar-all
 
 ARG PULSAR_IO_DIR
 ARG PULSAR_OFFLOADER_TARBALL
+ARG PULSAR_IMAGE
 
 ADD ${PULSAR_IO_DIR} /connectors
 ADD ${PULSAR_OFFLOADER_TARBALL} /
 RUN mv /apache-pulsar-offloaders-*/offloaders /offloaders
 
-FROM apachepulsar/pulsar:latest
+FROM ${PULSAR_IMAGE}
 COPY --from=pulsar-all /connectors /pulsar/connectors
 COPY --from=pulsar-all /offloaders /pulsar/offloaders

--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -149,6 +149,7 @@
                         <args>
                           <PULSAR_IO_DIR>target/apache-pulsar-io-connectors-${project.version}-bin</PULSAR_IO_DIR>
                           <PULSAR_OFFLOADER_TARBALL>target/pulsar-offloader-distribution-${project.version}-bin.tar.gz</PULSAR_OFFLOADER_TARBALL>
+                          <PULSAR_IMAGE>${docker.organization}/pulsar:${project.version}</PULSAR_IMAGE>
                         </args>
                         <buildx>
                           <platforms>


### PR DESCRIPTION
### Motivation

1. Right now the `docker/publish.sh` script always publishes the latest image, this causes the pulsar version issue: https://github.com/apache/pulsar/issues/19544
2. When using the custom docker.organization, the `pulsar-all/Dockerfile` always uses the `apachepulsar/pulsar:latest` as the base image, so cause https://github.com/apache/pulsar/issues/20420

### Modifications

- Add a prompt to confirm the publishing of the latest images in the `docker/publish.sh` script.
- Pass the `PULSAR_IMAGE` to the `docker/pulsar-all/Dockerfile` to avoid using incorrect image.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->