### PR TITLE
[fix][test] Fix flaky PersistentSubscriptionTest

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -248,7 +248,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     private MetricsGenerator metricsGenerator;
 
     private TransactionMetadataStoreService transactionMetadataStoreService;
-    private TransactionBufferProvider transactionBufferProvider;
+    protected TransactionBufferProvider transactionBufferProvider;
     private TransactionBufferClient transactionBufferClient;
     private HashedWheelTimer transactionTimer;
 
@@ -270,7 +270,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
     private PulsarResources pulsarResources;
 
-    private TransactionPendingAckStoreProvider transactionPendingAckStoreProvider;
+    protected TransactionPendingAckStoreProvider transactionPendingAckStoreProvider;
     private final ExecutorProvider transactionExecutorProvider;
 
     public enum State {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/NonStartableTestPulsarService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/NonStartableTestPulsarService.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.testcontext;
 import static org.apache.pulsar.broker.BrokerTestUtil.spyWithClassAndConstructorArgs;
 import static org.mockito.Mockito.mock;
 import io.netty.channel.EventLoopGroup;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -39,6 +40,8 @@ import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.schema.DefaultSchemaRegistryService;
 import org.apache.pulsar.broker.service.schema.SchemaRegistryService;
 import org.apache.pulsar.broker.storage.ManagedLedgerStorage;
+import org.apache.pulsar.broker.transaction.buffer.TransactionBufferProvider;
+import org.apache.pulsar.broker.transaction.pendingack.TransactionPendingAckStoreProvider;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
@@ -88,6 +91,20 @@ class NonStartableTestPulsarService extends AbstractTestPulsarService {
             startNamespaceService();
         } catch (PulsarServerException e) {
             throw new RuntimeException(e);
+        }
+        if (config.isTransactionCoordinatorEnabled()) {
+            try {
+                transactionBufferProvider = TransactionBufferProvider
+                        .newProvider(config.getTransactionBufferProviderClassName());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            try {
+                transactionPendingAckStoreProvider = TransactionPendingAckStoreProvider
+                        .newProvider(config.getTransactionPendingAckStoreProviderClassName());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #19396

### Motivation

PersistentSubscriptionTest.setup is flaky because Mockito isn't thread safe. 

### Modifications

Replace the usage of Mockito for setting the TransactionBufferProvider and TransactionPendingAckStoreProvider
in the test.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->