### PR TITLE
[fix][build] Fix the pulsar-all image may use the wrong upstream image

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. >/dev/null 2>&1 && pwd )"
 cd $ROOT_DIR/docker
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -17,8 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
-ROOT_DIR=$(git rev-parse --show-toplevel)
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. >/dev/null 2>&1 && pwd )"
 cd $ROOT_DIR/docker
 
 mvn package -Pdocker,-main

--- a/docker/get-version.sh
+++ b/docker/get-version.sh
@@ -18,7 +18,7 @@
 # under the License.
 #
 
-ROOT_DIR=$(git rev-parse --show-toplevel)
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. >/dev/null 2>&1 && pwd )"
 
 pushd $ROOT_DIR > /dev/null
 

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -60,6 +60,20 @@
         <module>pulsar</module>
         <module>pulsar-all</module>
       </modules>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>pl.project13.maven</groupId>
+            <artifactId>git-commit-id-plugin</artifactId>
+            <configuration>
+              <skip>false</skip>
+              <injectAllReactorProjects>true</injectAllReactorProjects>
+              <runOnlyOnce>true</runOnlyOnce>
+              <skipPoms>false</skipPoms>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/docker/publish.sh
+++ b/docker/publish.sh
@@ -49,6 +49,9 @@ fi
 
 MVN_VERSION=`./get-version.sh`
 echo "Pulsar version: ${MVN_VERSION}"
+GIT_COMMIT_ID_ABBREV=$(git rev-parse --short=7 HEAD 2>/dev/null || echo no-git)
+GIT_BRANCH=$(git branch --show-current 2>/dev/null || echo no-git)
+IMAGE_TAG="${MVN_VERSION}-${GIT_COMMIT_ID_ABBREV}"
 
 if [[ -z ${DOCKER_REGISTRY} ]]; then
     docker_registry_org=${DOCKER_ORG}
@@ -62,15 +65,20 @@ set -x
 # Fail if any of the subsequent commands fail
 set -e
 
-docker tag apachepulsar/pulsar:latest ${docker_registry_org}/pulsar:latest
-docker tag apachepulsar/pulsar-all:latest ${docker_registry_org}/pulsar-all:latest
+if [[ "$GIT_BRANCH" == "master" ]]; then
+  docker tag apachepulsar/pulsar:${IMAGE_TAG} ${docker_registry_org}/pulsar:latest
+  docker tag apachepulsar/pulsar-all:${IMAGE_TAG} ${docker_registry_org}/pulsar-all:latest
+fi
 
-docker tag apachepulsar/pulsar:latest ${docker_registry_org}/pulsar:$MVN_VERSION
-docker tag apachepulsar/pulsar-all:latest ${docker_registry_org}/pulsar-all:$MVN_VERSION
+docker tag apachepulsar/pulsar:${IMAGE_TAG} ${docker_registry_org}/pulsar:$MVN_VERSION
+docker tag apachepulsar/pulsar-all:${IMAGE_TAG} ${docker_registry_org}/pulsar-all:$MVN_VERSION
 
 # Push all images and tags
-docker push ${docker_registry_org}/pulsar:latest
-docker push ${docker_registry_org}/pulsar-all:latest
+if [[ "$GIT_BRANCH" == "master" ]]; then
+  docker push ${docker_registry_org}/pulsar:latest
+  docker push ${docker_registry_org}/pulsar-all:latest
+fi
+
 docker push ${docker_registry_org}/pulsar:$MVN_VERSION
 docker push ${docker_registry_org}/pulsar-all:$MVN_VERSION
 

--- a/docker/publish.sh
+++ b/docker/publish.sh
@@ -18,7 +18,7 @@
 # under the License.
 #
 
-ROOT_DIR=$(git rev-parse --show-toplevel)
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. >/dev/null 2>&1 && pwd )"
 cd $ROOT_DIR/docker
 
 # We should only publish images that are made from official and approved releases

--- a/docker/pulsar-all/Dockerfile
+++ b/docker/pulsar-all/Dockerfile
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
+ARG PULSAR_IMAGE
 FROM busybox as pulsar-all
 
 ARG PULSAR_IO_DIR
@@ -26,6 +26,6 @@ ADD ${PULSAR_IO_DIR} /connectors
 ADD ${PULSAR_OFFLOADER_TARBALL} /
 RUN mv /apache-pulsar-offloaders-*/offloaders /offloaders
 
-FROM apachepulsar/pulsar:latest
+FROM $PULSAR_IMAGE
 COPY --from=pulsar-all /connectors /pulsar/connectors
 COPY --from=pulsar-all /offloaders /pulsar/offloaders

--- a/docker/pulsar-all/Dockerfile
+++ b/docker/pulsar-all/Dockerfile
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
 ARG PULSAR_IMAGE
 FROM busybox as pulsar-all
 

--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -143,12 +143,12 @@
                       <build>
                         <contextDir>${project.basedir}</contextDir>
                         <tags>
-                          <tag>latest</tag>
                           <tag>${project.version}</tag>
                         </tags>
                         <args>
                           <PULSAR_IO_DIR>target/apache-pulsar-io-connectors-${project.version}-bin</PULSAR_IO_DIR>
                           <PULSAR_OFFLOADER_TARBALL>target/pulsar-offloader-distribution-${project.version}-bin.tar.gz</PULSAR_OFFLOADER_TARBALL>
+                          <PULSAR_IMAGE>${docker.organization}/pulsar:${project.version}</PULSAR_IMAGE>
                         </args>
                         <buildx>
                           <platforms>

--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -143,6 +143,7 @@
                       <build>
                         <contextDir>${project.basedir}</contextDir>
                         <tags>
+                          <tag>latest</tag>
                           <tag>${project.version}-${git.commit.id.abbrev}</tag>
                         </tags>
                         <args>

--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -65,6 +65,10 @@
     </dependency>
   </dependencies>
 
+  <properties>
+    <git.commit.id.abbrev>no-git</git.commit.id.abbrev>
+  </properties>
+
   <profiles>
     <profile>
       <id>docker</id>

--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -126,29 +126,6 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>pl.project13.maven</groupId>
-            <artifactId>git-commit-id-plugin</artifactId>
-            <version>${git-commit-id-plugin.version}</version>
-            <executions>
-              <execution>
-                <id>git-info</id>
-                <goals>
-                  <goal>revision</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <useNativeGit>true</useNativeGit>
-              <prefix>git</prefix>
-              <failOnNoGitDirectory>true</failOnNoGitDirectory>
-              <skipPoms>false</skipPoms>
-              <gitDescribe>
-                <skip>false</skip>
-                <always>false</always>
-              </gitDescribe>
-            </configuration>
-          </plugin>
-          <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>docker-maven-plugin</artifactId>
             <executions>

--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -65,11 +65,18 @@
     </dependency>
   </dependencies>
 
-  <properties>
-    <git.commit.id.abbrev>no-git</git.commit.id.abbrev>
-  </properties>
-
   <profiles>
+    <profile>
+      <id>git-commit-id-no-git</id>
+      <activation>
+        <file>
+          <missing>${basedir}/../../.git/index</missing>
+        </file>
+      </activation>
+      <properties>
+        <git.commit.id.abbrev>no-git</git.commit.id.abbrev>
+      </properties>
+    </profile>
     <profile>
       <id>docker</id>
       <!-- include the docker image only when docker profile is active -->

--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -126,6 +126,29 @@
             </executions>
           </plugin>
           <plugin>
+            <groupId>pl.project13.maven</groupId>
+            <artifactId>git-commit-id-plugin</artifactId>
+            <version>${git-commit-id-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>git-info</id>
+                <goals>
+                  <goal>revision</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <useNativeGit>true</useNativeGit>
+              <prefix>git</prefix>
+              <failOnNoGitDirectory>true</failOnNoGitDirectory>
+              <skipPoms>false</skipPoms>
+              <gitDescribe>
+                <skip>false</skip>
+                <always>false</always>
+              </gitDescribe>
+            </configuration>
+          </plugin>
+          <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>docker-maven-plugin</artifactId>
             <executions>
@@ -143,12 +166,12 @@
                       <build>
                         <contextDir>${project.basedir}</contextDir>
                         <tags>
-                          <tag>${project.version}</tag>
+                          <tag>${project.version}-${git.commit.id.abbrev}</tag>
                         </tags>
                         <args>
                           <PULSAR_IO_DIR>target/apache-pulsar-io-connectors-${project.version}-bin</PULSAR_IO_DIR>
                           <PULSAR_OFFLOADER_TARBALL>target/pulsar-offloader-distribution-${project.version}-bin.tar.gz</PULSAR_OFFLOADER_TARBALL>
-                          <PULSAR_IMAGE>${docker.organization}/pulsar:${project.version}</PULSAR_IMAGE>
+                          <PULSAR_IMAGE>${docker.organization}/pulsar:${project.version}-${git.commit.id.abbrev}</PULSAR_IMAGE>
                         </args>
                         <buildx>
                           <platforms>

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -58,6 +58,13 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>pl.project13.maven</groupId>
+            <artifactId>git-commit-id-plugin</artifactId>
+            <configuration>
+              <skip>false</skip>
+            </configuration>
+          </plugin>
+          <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>docker-maven-plugin</artifactId>
             <executions>
@@ -81,6 +88,7 @@
                         </args>
                         <contextDir>${project.basedir}</contextDir>
                         <tags>
+                          <tag>latest</tag>
                           <tag>${project.version}-${git.commit.id.abbrev}</tag>
                         </tags>
                         <buildx>

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -50,21 +50,24 @@
   <properties>
     <UBUNTU_MIRROR>mirror://mirrors.ubuntu.com/mirrors.txt</UBUNTU_MIRROR>
     <UBUNTU_SECURITY_MIRROR>http://security.ubuntu.com/ubuntu/</UBUNTU_SECURITY_MIRROR>
-    <git.commit.id.abbrev>no-git</git.commit.id.abbrev>
   </properties>
 
   <profiles>
     <profile>
+      <id>git-commit-id-no-git</id>
+      <activation>
+        <file>
+          <missing>${basedir}/../../.git/index</missing>
+        </file>
+      </activation>
+      <properties>
+        <git.commit.id.abbrev>no-git</git.commit.id.abbrev>
+      </properties>
+    </profile>
+    <profile>
       <id>docker</id>
       <build>
         <plugins>
-          <plugin>
-            <groupId>pl.project13.maven</groupId>
-            <artifactId>git-commit-id-plugin</artifactId>
-            <configuration>
-              <skip>false</skip>
-            </configuration>
-          </plugin>
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>docker-maven-plugin</artifactId>

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -58,29 +58,6 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>pl.project13.maven</groupId>
-            <artifactId>git-commit-id-plugin</artifactId>
-            <version>${git-commit-id-plugin.version}</version>
-            <executions>
-              <execution>
-                <id>git-info</id>
-                <goals>
-                  <goal>revision</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <useNativeGit>true</useNativeGit>
-              <prefix>git</prefix>
-              <failOnNoGitDirectory>true</failOnNoGitDirectory>
-              <skipPoms>false</skipPoms>
-              <gitDescribe>
-                <skip>false</skip>
-                <always>false</always>
-              </gitDescribe>
-            </configuration>
-          </plugin>
-          <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>docker-maven-plugin</artifactId>
             <executions>

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -48,8 +48,9 @@
   </dependencies>
 
   <properties>
-      <UBUNTU_MIRROR>mirror://mirrors.ubuntu.com/mirrors.txt</UBUNTU_MIRROR>
-      <UBUNTU_SECURITY_MIRROR>http://security.ubuntu.com/ubuntu/</UBUNTU_SECURITY_MIRROR>
+    <UBUNTU_MIRROR>mirror://mirrors.ubuntu.com/mirrors.txt</UBUNTU_MIRROR>
+    <UBUNTU_SECURITY_MIRROR>http://security.ubuntu.com/ubuntu/</UBUNTU_SECURITY_MIRROR>
+    <git.commit.id.abbrev>no-git</git.commit.id.abbrev>
   </properties>
 
   <profiles>

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -58,6 +58,29 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>pl.project13.maven</groupId>
+            <artifactId>git-commit-id-plugin</artifactId>
+            <version>${git-commit-id-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>git-info</id>
+                <goals>
+                  <goal>revision</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <useNativeGit>true</useNativeGit>
+              <prefix>git</prefix>
+              <failOnNoGitDirectory>true</failOnNoGitDirectory>
+              <skipPoms>false</skipPoms>
+              <gitDescribe>
+                <skip>false</skip>
+                <always>false</always>
+              </gitDescribe>
+            </configuration>
+          </plugin>
+          <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>docker-maven-plugin</artifactId>
             <executions>
@@ -81,8 +104,7 @@
                         </args>
                         <contextDir>${project.basedir}</contextDir>
                         <tags>
-                          <tag>latest</tag>
-                          <tag>${project.version}</tag>
+                          <tag>${project.version}-${git.commit.id.abbrev}</tag>
                         </tags>
                         <buildx>
                           <platforms>

--- a/pom.xml
+++ b/pom.xml
@@ -1584,6 +1584,7 @@ flexible messaging model and an intuitive client API.</description>
           </execution>
         </executions>
         <configuration>
+          <skip>true</skip>
           <useNativeGit>true</useNativeGit>
           <prefix>git</prefix>
           <failOnNoGitDirectory>true</failOnNoGitDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -1572,6 +1572,30 @@ flexible messaging model and an intuitive client API.</description>
       </plugin>
 
       <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <version>${git-commit-id-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>git-info</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <useNativeGit>true</useNativeGit>
+          <prefix>git</prefix>
+          <failOnNoGitDirectory>true</failOnNoGitDirectory>
+          <skipPoms>false</skipPoms>
+          <gitDescribe>
+            <skip>false</skip>
+            <always>false</always>
+          </gitDescribe>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <version>${license-maven-plugin.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@ flexible messaging model and an intuitive client API.</description>
     <properties-maven-plugin.version>1.1.0</properties-maven-plugin.version>
     <nifi-nar-maven-plugin.version>1.5.0</nifi-nar-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-    <git-commit-id-plugin.version>4.0.2</git-commit-id-plugin.version>
+    <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
     <wagon-ssh-external.version>3.5.3</wagon-ssh-external.version>
     <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1587,7 +1587,7 @@ flexible messaging model and an intuitive client API.</description>
           <skip>true</skip>
           <useNativeGit>true</useNativeGit>
           <prefix>git</prefix>
-          <failOnNoGitDirectory>true</failOnNoGitDirectory>
+          <failOnNoGitDirectory>false</failOnNoGitDirectory>
           <skipPoms>false</skipPoms>
           <gitDescribe>
             <skip>false</skip>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -194,7 +194,7 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
-    
+
     <dependency>
       <groupId>com.google.protobuf</groupId>
 	  <artifactId>protobuf-java</artifactId>
@@ -296,6 +296,7 @@
           </execution>
         </executions>
         <configuration>
+          <skip>false</skip>
           <useNativeGit>true</useNativeGit>
           <prefix>git</prefix>
           <verbose>false</verbose>


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


Fixes #20420

### Motivation

When building the release candidate, the release mangers use their own account name to build and push the pulsar image. But currently the `pulsar-all` image always use `apachepulsar/pulsar` as the upstream image. And it may won't use the locally built image, which causes the issue.

### Modifications

* Specify the correct image name for `pulsar` image to build `pulsar-all`
* Remove the `latest` version from the build. The `latest` tag should only point to the latest major version. It's better to let the release manager specify the latest tag manually.
* Add github commit id to the image tag.

The image would like: apachepulsar/pulsar:3.1.0-SNAPSHOT-97a1a87


### Verifying this change

* Prepare the `pulsar` image: `docker tag apachepulsar/pulsar:3.0.0 snzkyang/pulsar:3.1.0-SNAPSHOT-97a1a87` 
* Run the build command of `pulsar-all` image:
```
mvn install \
        -DskipTests \
        -Pdocker \
        -Ddocker.platforms=linux/amd64 \
        -Ddocker.organization=snzkyang \
         -pl docker/pulsar-all
```
It will build successfully:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  09:29 min
[INFO] Finished at: 2023-05-30T11:29:28+08:00
[INFO] ------------------------------------------------------------------------
[INFO] 12 goals, 12 executed
```
* Verify
```
pulsar git:(iss-20420) ✗ docker run snzkyang/pulsar-all:3.1.0-SNAPSHOT-97a1a87 ls connectors
LICENSE
README
pulsar-io-aerospike-3.1.0-SNAPSHOT.nar
pulsar-io-alluxio-3.1.0-SNAPSHOT.nar
pulsar-io-batch-data-generator-3.1.0-SNAPSHOT.nar
pulsar-io-canal-3.1.0-SNAPSHOT.nar
pulsar-io-cassandra-3.1.0-SNAPSHOT.nar
pulsar-io-data-generator-3.1.0-SNAPSHOT.nar
pulsar-io-debezium-mongodb-3.1.0-SNAPSHOT.nar
...
```

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
