### PR TITLE
[fix][test] Fix test `testThreadSwitchOfZkMetadataStore`

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -432,7 +432,7 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
     @Test(dataProvider = "conditionOfSwitchThread")
     public void testThreadSwitchOfZkMetadataStore(boolean hasSynchronizer, boolean enabledBatch) throws Exception {
         final String prefix = newKey();
-        final String metadataStoreNamePrefix = "metadata-store-";
+        final String metadataStoreNamePrefix = "metadata-store";
         MetadataStoreConfig.MetadataStoreConfigBuilder builder =
                 MetadataStoreConfig.builder();
         builder.batchingEnabled(enabledBatch);

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -432,10 +432,9 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
     @Test(dataProvider = "conditionOfSwitchThread")
     public void testThreadSwitchOfZkMetadataStore(boolean hasSynchronizer, boolean enabledBatch) throws Exception {
         final String prefix = newKey();
-        final String metadataStoreName = UUID.randomUUID().toString().replaceAll("-", "");
+        final String metadataStoreNamePrefix = "metadata-store-";
         MetadataStoreConfig.MetadataStoreConfigBuilder builder =
-                MetadataStoreConfig.builder().metadataStoreName(metadataStoreName);
-        builder.fsyncEnable(false);
+                MetadataStoreConfig.builder();
         builder.batchingEnabled(enabledBatch);
         if (!hasSynchronizer) {
             builder.synchronizer(null);
@@ -447,8 +446,8 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
         final Runnable verify = () -> {
             String currentThreadName = Thread.currentThread().getName();
             String errorMessage = String.format("Expect to switch to thread %s, but currently it is thread %s",
-                    metadataStoreName, currentThreadName);
-            assertTrue(Thread.currentThread().getName().startsWith(metadataStoreName), errorMessage);
+                    metadataStoreNamePrefix, currentThreadName);
+            assertTrue(Thread.currentThread().getName().startsWith(metadataStoreNamePrefix), errorMessage);
         };
 
         // put with node which has parent(but the parent node is not exists).

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;


### PR DESCRIPTION
### Motivation

After the PR #20303 was cherry-picked inti `branch-2.11`, the test `testThreadSwitchOfZkMetadataStore` was failed.

The root cause: the attribute `metadataStoreName` is a new attribute provided by the PR https://github.com/apache/pulsar/pull/17041, at it released at `3.0.0`, so it is not included in `branch-2.11`, so the name of thread-pool of Metadata store is a fixed value `metadata-store`

```java
protected AbstractMetadataStore() {
    this.executor = Executors
            .newSingleThreadScheduledExecutor(new DefaultThreadFactory("metadata-store"));
    registerListener(this);
    ...
}

```

### Modifications

Instead of a special value, verify the name of the thread pool by the fixed value `metadata-store`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x