### PR TITLE
[improve][broker] Support revoking permission for AuthorizationProvider

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
@@ -186,6 +186,18 @@ public interface AuthorizationProvider extends Closeable {
             String authDataJson);
 
     /**
+     * Revoke authorization-action permission on a namespace to the given client.
+     * @param namespace
+     * @param role
+     * @return
+     */
+    default CompletableFuture<Void> revokePermissionAsync(NamespaceName namespace, String role) {
+        return FutureUtil.failedFuture(new IllegalStateException(
+                String.format("revokePermissionAsync on namespace %s is not supported by the Authorization",
+                        namespace)));
+    }
+
+    /**
      * Grant permission to roles that can access subscription-admin api.
      *
      * @param namespace
@@ -225,6 +237,20 @@ public interface AuthorizationProvider extends Closeable {
      */
     CompletableFuture<Void> grantPermissionAsync(TopicName topicName, Set<AuthAction> actions, String role,
             String authDataJson);
+
+
+    /**
+     * Revoke authorization-action permission on a topic to the given client.
+     * @param topicName
+     * @param role
+     * @return
+     */
+    default CompletableFuture<Void> revokePermissionAsync(TopicName topicName, String role) {
+        return FutureUtil.failedFuture(new IllegalStateException(
+                String.format("revokePermissionAsync on topicName %s is not supported by the Authorization",
+                        topicName)));
+    }
+
 
     /**
      * Check if a given <tt>role</tt> is allowed to execute a given <tt>operation</tt> on the tenant.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
@@ -251,7 +251,6 @@ public interface AuthorizationProvider extends Closeable {
                         topicName)));
     }
 
-
     /**
      * Check if a given <tt>role</tt> is allowed to execute a given <tt>operation</tt> on the tenant.
      *

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
@@ -189,7 +189,7 @@ public interface AuthorizationProvider extends Closeable {
      * Revoke authorization-action permission on a namespace to the given client.
      * @param namespace
      * @param role
-     * @return
+     * @return CompletableFuture<Void>
      */
     default CompletableFuture<Void> revokePermissionAsync(NamespaceName namespace, String role) {
         return FutureUtil.failedFuture(new IllegalStateException(
@@ -205,7 +205,7 @@ public interface AuthorizationProvider extends Closeable {
      * @param roles
      * @param authDataJson
      *            additional authdata in json format
-     * @return
+     * @return CompletableFuture<Void>
      */
     CompletableFuture<Void> grantSubscriptionPermissionAsync(NamespaceName namespace, String subscriptionName,
                                                              Set<String> roles, String authDataJson);
@@ -215,7 +215,7 @@ public interface AuthorizationProvider extends Closeable {
      * @param namespace
      * @param subscriptionName
      * @param role
-     * @return
+     * @return CompletableFuture<Void>
      */
     CompletableFuture<Void> revokeSubscriptionPermissionAsync(NamespaceName namespace, String subscriptionName,
             String role, String authDataJson);
@@ -243,7 +243,7 @@ public interface AuthorizationProvider extends Closeable {
      * Revoke authorization-action permission on a topic to the given client.
      * @param topicName
      * @param role
-     * @return
+     * @return CompletableFuture<Void>
      */
     default CompletableFuture<Void> revokePermissionAsync(TopicName topicName, String role) {
         return FutureUtil.failedFuture(new IllegalStateException(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -124,6 +124,17 @@ public class AuthorizationService {
     }
 
     /**
+     *
+     * Revoke authorization-action permission on a namespace to the given client.
+     *
+     * @param namespace
+     * @param role
+     */
+    public CompletableFuture<Void> revokePermissionAsync(NamespaceName namespace, String role) {
+        return provider.revokePermissionAsync(namespace, role);
+    }
+
+    /**
      * Grant permission to roles that can access subscription-admin api.
      *
      * @param namespace
@@ -157,16 +168,26 @@ public class AuthorizationService {
      * NOTE: used to complete with {@link IllegalArgumentException} when namespace not found or with
      * {@link IllegalStateException} when failed to grant permission.
      *
-     * @param topicname
+     * @param topicName
      * @param role
      * @param authDataJson
      *            additional authdata in json for targeted authorization provider
      * @completesWith null when the permissions are updated successfully.
      * @completesWith {@link MetadataStoreException} when the MetadataStore is not updated.
      */
-    public CompletableFuture<Void> grantPermissionAsync(TopicName topicname, Set<AuthAction> actions, String role,
+    public CompletableFuture<Void> grantPermissionAsync(TopicName topicName, Set<AuthAction> actions, String role,
                                                         String authDataJson) {
-        return provider.grantPermissionAsync(topicname, actions, role, authDataJson);
+        return provider.grantPermissionAsync(topicName, actions, role, authDataJson);
+    }
+
+    /**
+     * Revoke authorization-action permission on a topic to the given client.
+     *
+     * @param topicName
+     * @param role
+     */
+    public CompletableFuture<Void> revokePermissionAsync(TopicName topicName, String role) {
+        return provider.revokePermissionAsync(topicName, role);
     }
 
     /**
@@ -418,7 +439,7 @@ public class AuthorizationService {
     /**
      * Whether the authenticatedPrincipal and the originalPrincipal form a valid pair. This method assumes that
      * authenticatedPrincipal and originalPrincipal can be equal, as long as they are not a proxy role. This use
-     * case is relvant for the admin server because of the way the proxy handles authentication. The binary protocol
+     * case is relevant for the admin server because of the way the proxy handles authentication. The binary protocol
      * should not use this method.
      * @return true when roles are a valid combination and false when roles are an invalid combination
      */

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -261,8 +261,10 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
             return pulsarResources.getNamespaceResources()
                     .setPoliciesAsync(topicName.getNamespaceObject(), policies -> {
                         policies.auth_policies.getTopicAuthentication()
-                                .computeIfAbsent(topicName.toString(), __ -> new HashMap<>())
-                                .remove(role);
+                                .computeIfPresent(topicName.toString(), (k, v) -> {
+                                        v.remove(role);
+                                        return null;
+                                });
                         return policies;
                     }).whenComplete((__, ex) -> {
                         if (ex != null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -668,6 +668,54 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
     }
 
     @Test
+    public void testRevokePermission() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+        cleanup();
+        conf.setAuthorizationProvider(PulsarAuthorizationProvider.class.getName());
+        setup();
+
+        Authentication adminAuthentication = new ClientAuthentication("superUser");
+
+        @Cleanup
+        PulsarAdmin admin = spy(
+                PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString()).authentication(adminAuthentication).build());
+
+        Authentication authentication = new ClientAuthentication(clientRole);
+
+        replacePulsarClient(PulsarClient.builder()
+                .serviceUrl(pulsar.getBrokerServiceUrl())
+                .authentication(authentication));
+
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(brokerUrl.toString()).build());
+
+        admin.tenants().createTenant("public",
+                new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
+        admin.namespaces().createNamespace("public/default", Sets.newHashSet("test"));
+
+        AuthorizationService authorizationService = new AuthorizationService(conf, pulsar.getPulsarResources());
+        TopicName topicName = TopicName.get("persistent://public/default/t1");
+        NamespaceName namespaceName = NamespaceName.get("public/default");
+        String role = "test-role";
+        Set<AuthAction> actions = Sets.newHashSet(AuthAction.produce, AuthAction.consume);
+        Assert.assertFalse(authorizationService.canProduce(topicName, role, null));
+        Assert.assertFalse(authorizationService.canConsume(topicName, role, null, "sub1"));
+        authorizationService.grantPermissionAsync(topicName, actions, role, "auth-json").get();
+        Assert.assertTrue(authorizationService.canProduce(topicName, role, null));
+        Assert.assertTrue(authorizationService.canConsume(topicName, role, null, "sub1"));
+
+        authorizationService.revokePermissionAsync(topicName, role).get();
+        Assert.assertFalse(authorizationService.canProduce(topicName, role, null));
+        Assert.assertFalse(authorizationService.canConsume(topicName, role, null, "sub1"));
+
+        authorizationService.grantPermissionAsync(namespaceName, actions, role, null).get();
+        Assert.assertTrue(authorizationService.allowNamespaceOperationAsync(namespaceName, NamespaceOperation.GET_TOPIC, role, null).get());
+        authorizationService.revokePermissionAsync(namespaceName, role).get();
+        Assert.assertFalse(authorizationService.allowNamespaceOperationAsync(namespaceName, NamespaceOperation.GET_TOPIC, role, null).get());
+
+        log.info("-- Exiting {} test --", methodName);
+    }
+
+    @Test
     public void testAuthData() throws Exception {
         log.info("-- Starting {} test --", methodName);
         cleanup();
@@ -1050,6 +1098,8 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
             grantRoles.add(role);
             return CompletableFuture.completedFuture(null);
         }
+
+
     }
 
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -1098,8 +1098,6 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
             grantRoles.add(role);
             return CompletableFuture.completedFuture(null);
         }
-
-
     }
 
 }


### PR DESCRIPTION
### Motivation
Current AuthorizationProvider does not actually fully support the revocation of ACLs :
 - Revocation is only supported for subscription-specific ACLs on a namespace
-  When we revoke the permission on Pulsar admin REST API, the handler will always try to remove it from the namespace policies ([https://github.com/apache/pulsar/blob/242758d5770de46e506855ff881472cbc274cedb/pul[…]in/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java](https://github.com/apache/pulsar/blob/242758d5770de46e506855ff881472cbc274cedb/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java#L655)), instead of asking the AuthorizationProvider to do so.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


