### PR TITLE
[fix][sec] Upgrade Guava to 32.0.0 to address CVE-2023-2976

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -49,7 +49,7 @@
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
     <netty.version>4.1.93.Final</netty.version>
     <guice.version>4.2.3</guice.version>
-    <guava.version>31.0.1-jre</guava.version>
+    <guava.version>32.0.0-jre</guava.version>
     <ant.version>1.10.12</ant.version>
     <snakeyaml.version>2.0</snakeyaml.version>
     <mockito.version>3.12.4</mockito.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -265,7 +265,7 @@ The Apache Software License, Version 2.0
     - com.google.code.gson-gson-2.8.9.jar
     - io.gsonfire-gson-fire-1.8.5.jar
  * Guava
-    - com.google.guava-guava-31.0.1-jre.jar
+    - com.google.guava-guava-32.0.0-jre.jar
     - com.google.guava-failureaccess-1.0.1.jar
     - com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
  * J2ObjC Annotations -- com.google.j2objc-j2objc-annotations-1.3.jar
@@ -518,7 +518,7 @@ MIT License
     - org.slf4j-slf4j-api-1.7.32.jar
     - org.slf4j-jcl-over-slf4j-1.7.32.jar
  * The Checker Framework
-    - org.checkerframework-checker-qual-3.12.0.jar
+    - org.checkerframework-checker-qual-3.33.0.jar
  * oshi
     - com.github.oshi-oshi-core-java11-6.4.0.jar
  * Auth0, Inc.

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -326,7 +326,7 @@ The Apache Software License, Version 2.0
  * Gson
     - gson-2.8.9.jar
  * Guava
-    - guava-31.0.1-jre.jar
+    - guava-32.0.0-jre.jar
     - failureaccess-1.0.1.jar
     - listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
  * J2ObjC Annotations -- j2objc-annotations-1.3.jar
@@ -422,7 +422,7 @@ MIT License
  * SLF4J -- ../licenses/LICENSE-SLF4J.txt
     - slf4j-api-1.7.32.jar
  * The Checker Framework
-    - checker-qual-3.12.0.jar
+    - checker-qual-3.33.0.jar
 
 Protocol Buffers License
  * Protocol Buffers

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@ flexible messaging model and an intuitive client API.</description>
     <hadoop2.version>2.10.2</hadoop2.version>
     <hadoop3.version>3.3.5</hadoop3.version>
     <hbase.version>2.4.16</hbase.version>
-    <guava.version>31.0.1-jre</guava.version>
+    <guava.version>32.0.0-jre</guava.version>
     <jcip.version>1.0</jcip.version>
     <prometheus-jmx.version>0.16.1</prometheus-jmx.version>
     <confluent.version>6.2.8</confluent.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -221,7 +221,7 @@ The Apache Software License, Version 2.0
     - jackson-module-jaxb-annotations-2.14.2.jar
     - jackson-module-jsonSchema-2.14.2.jar
  * Guava
-    - guava-31.0.1-jre.jar
+    - guava-32.0.0-jre.jar
     - listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
     - failureaccess-1.0.1.jar
  * Google Guice
@@ -521,7 +521,7 @@ MIT License
  * JCL 1.2 Implemented Over SLF4J
    - jcl-over-slf4j-1.7.32.jar
  * Checker Qual
-   - checker-qual-3.12.0.jar
+   - checker-qual-3.33.0.jar
  * ScribeJava
    - scribejava-apis-6.9.0.jar
    - scribejava-core-6.9.0.jar

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -37,7 +37,7 @@
     <objenesis.version>2.6</objenesis.version>
     <objectsize.version>0.0.12</objectsize.version>
     <maven.version>3.0.5</maven.version>
-    <guava.version>31.0.1-jre</guava.version>
+    <guava.version>32.0.0-jre</guava.version>
     <asynchttpclient.version>2.12.1</asynchttpclient.version>
     <errorprone.version>2.5.1</errorprone.version>
     <javax.servlet-api>4.0.1</javax.servlet-api>


### PR DESCRIPTION
### Motivation & Modifications

Upgrade Guava to 32.0.0 to address CVE-2023-2976

More details in Guava 32.0.0 release notes: https://github.com/google/guava/releases/tag/v32.0.0

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->