### PR TITLE
[improve][broker] Reuse netty timer and eventloop for broker side `PulsarAdminImpl`

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1650,6 +1650,11 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 // zk-operation timeout
                 builder.readTimeout(conf.getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
 
+                // reuse eventLoop
+                builder.setEventLoopGroup(this.getIoEventLoopGroup());
+                // reuse nettyTimer
+                builder.setNettyTimer(this.getBrokerClientSharedTimer());
+
                 this.adminClient = builder.build();
                 LOG.info("created admin with url {} ", adminApiUrl);
             } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1485,6 +1485,11 @@ public class BrokerService implements Closeable {
                 // zk-operation timeout
                 builder.readTimeout(conf.getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
 
+                // reuse eventLoop
+                builder.setEventLoopGroup(pulsar.getIoEventLoopGroup());
+                // reuse nettyTimer
+                builder.setNettyTimer(pulsar.getBrokerClientSharedTimer());
+
                 PulsarAdmin adminClient = builder.build();
                 log.info("created admin with url {} ", adminApiUrl);
                 return adminClient;

--- a/pulsar-client-admin-api/pom.xml
+++ b/pulsar-client-admin-api/pom.xml
@@ -43,6 +43,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+        </dependency>
         
     </dependencies>
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.client.admin;
 
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.Timer;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -326,5 +328,22 @@ public interface PulsarAdminBuilder {
      * @return
      */
     PulsarAdminBuilder setContextClassLoader(ClassLoader clientBuilderClassLoader);
+
+
+    /**
+     * This override the pulsar admin client
+     * netty EventLoopGroup when admin is created on the broker side.
+     * @param eventLoopGroup
+     * @return this
+     */
+    PulsarAdminBuilder setEventLoopGroup(EventLoopGroup eventLoopGroup);
+
+    /**
+     * This override the pulsar admin client
+     * netty Timer when admin is created on the broker side.
+     * @param nettyTimer
+     * @return this
+     */
+    PulsarAdminBuilder setNettyTimer(Timer nettyTimer);
 
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.client.admin.internal;
 
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.Timer;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -225,6 +227,18 @@ public class PulsarAdminBuilderImpl implements PulsarAdminBuilder {
     @Override
     public PulsarAdminBuilder setContextClassLoader(ClassLoader clientBuilderClassLoader) {
         this.clientBuilderClassLoader = clientBuilderClassLoader;
+        return this;
+    }
+
+    @Override
+    public PulsarAdminBuilder setEventLoopGroup(EventLoopGroup eventLoopGroup) {
+        this.conf.setEventLoopGroup(eventLoopGroup);
+        return this;
+    }
+
+    @Override
+    public PulsarAdminBuilder setNettyTimer(Timer nettyTimer) {
+        this.conf.setNettyTimer(nettyTimer);
         return this;
     }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
@@ -115,6 +115,16 @@ public class AsyncHttpConnector implements Connector {
             }
         });
 
+        // reuse eventLoopGroup if provided.
+        if (conf.getEventLoopGroup() != null) {
+            confBuilder.setEventLoopGroup(conf.getEventLoopGroup());
+        }
+
+        // reuse nettyTimer if provided.
+        if (conf.getNettyTimer() != null) {
+            confBuilder.setNettyTimer(conf.getNettyTimer());
+        }
+
         serviceNameResolver = new PulsarServiceNameResolver();
         if (conf != null && StringUtils.isNotBlank(conf.getServiceUrl())) {
             serviceNameResolver.updateServiceUrl(conf.getServiceUrl());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.client.impl.conf;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.Timer;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.Serializable;
 import java.net.InetSocketAddress;
@@ -384,6 +386,12 @@ public class ClientConfigurationData implements Serializable, Cloneable {
             value = "The extra description of the client version. The length cannot exceed 64."
     )
     private String description;
+
+    @JsonIgnore
+    private EventLoopGroup eventLoopGroup;
+
+    @JsonIgnore
+    private Timer nettyTimer;
 
     /**
      * Gets the authentication settings for the client.


### PR DESCRIPTION
### Motivation

Current when PulsarAdmin is create on the broker side. the internal async http client will create its own netty eventloop and netty timer. maybe we can just reuse the broker side resources like PulsarClient.


### Modifications
1.  add configuration in PulsarAdminBuilder to support set eventloop and timer. 
2. save those object in `ClientConfigurationData` just to pass those object to the `AsyncHttpClientConnector` for easy parameter pass.
3. set those object when create `AsyncHttpClient`

### Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
