### PR TITLE
[improve][broker] Add metric prefix for `topic_load_times`

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
@@ -33,6 +33,7 @@ public class BrokerOperabilityMetrics {
     private static final Counter TOPIC_LOAD_FAILED = Counter.build("topic_load_failed", "-").register();
     private final List<Metrics> metricsList;
     private final String localCluster;
+    private final DimensionStats oldTopicLoadStats;
     private final DimensionStats topicLoadStats;
     private final String brokerName;
     private final LongAdder connectionTotalCreatedCount;
@@ -44,7 +45,8 @@ public class BrokerOperabilityMetrics {
     public BrokerOperabilityMetrics(String localCluster, String brokerName) {
         this.metricsList = new ArrayList<>();
         this.localCluster = localCluster;
-        this.topicLoadStats = new DimensionStats("topic_load_times", 60);
+        this.oldTopicLoadStats = new DimensionStats("topic_load_times", 60);
+        this.topicLoadStats = new DimensionStats("brk_topic_load_times", 60);
         this.brokerName = brokerName;
         this.connectionTotalCreatedCount = new LongAdder();
         this.connectionCreateSuccessCount = new LongAdder();
@@ -59,6 +61,7 @@ public class BrokerOperabilityMetrics {
     }
 
     private void generate() {
+        metricsList.add(getOldTopicLoadMetrics());
         metricsList.add(getTopicLoadMetrics());
         metricsList.add(getConnectionMetrics());
     }
@@ -85,6 +88,10 @@ public class BrokerOperabilityMetrics {
         return dimensionMap;
     }
 
+    Metrics getOldTopicLoadMetrics() {
+        return getDimensionMetrics("topic_load_times", "topic_load", oldTopicLoadStats);
+    }
+
     Metrics getTopicLoadMetrics() {
         Metrics metrics = getDimensionMetrics("pulsar_topic_load_times", "topic_load", topicLoadStats);
         metrics.put("brk_topic_load_failed_count", TOPIC_LOAD_FAILED.get());
@@ -109,10 +116,12 @@ public class BrokerOperabilityMetrics {
 
     public void reset() {
         metricsList.clear();
+        oldTopicLoadStats.reset();
         topicLoadStats.reset();
     }
 
     public void recordTopicLoadTimeValue(long topicLoadLatencyMs) {
+        oldTopicLoadStats.recordDimensionTimeValue(topicLoadLatencyMs, TimeUnit.MILLISECONDS);
         topicLoadStats.recordDimensionTimeValue(topicLoadLatencyMs, TimeUnit.MILLISECONDS);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
@@ -89,7 +89,8 @@ public class BrokerOperabilityMetrics {
     }
 
     Metrics getOldTopicLoadMetrics() {
-        return getDimensionMetrics("topic_load_times", "topic_load", oldTopicLoadStats);
+        Metrics metrics = getDimensionMetrics("topic_load_times", "topic_load", oldTopicLoadStats);
+        return metrics;
     }
 
     Metrics getTopicLoadMetrics() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
@@ -86,7 +86,7 @@ public class BrokerOperabilityMetrics {
     }
 
     Metrics getTopicLoadMetrics() {
-        Metrics metrics = getDimensionMetrics("topic_load_times", "topic_load", topicLoadStats);
+        Metrics metrics = getDimensionMetrics("pulsar_topic_load_times", "topic_load", topicLoadStats);
         metrics.put("brk_topic_load_failed_count", TOPIC_LOAD_FAILED.get());
         return metrics;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
@@ -46,7 +46,7 @@ public class BrokerOperabilityMetrics {
         this.metricsList = new ArrayList<>();
         this.localCluster = localCluster;
         this.oldTopicLoadStats = new DimensionStats("topic_load_times", 60);
-        this.topicLoadStats = new DimensionStats("brk_topic_load_times", 60);
+        this.topicLoadStats = new DimensionStats("pulsar_topic_load_times", 60);
         this.brokerName = brokerName;
         this.connectionTotalCreatedCount = new LongAdder();
         this.connectionCreateSuccessCount = new LongAdder();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/DimensionStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/DimensionStats.java
@@ -64,7 +64,7 @@ public class DimensionStats {
                 defaultRegistry.register(summary);
             } catch (IllegalArgumentException ie) {
                 // it only happens in test-cases when try to register summary multiple times in registry
-                log.warn("{} is already registred {}", name, ie.getMessage());
+                log.warn("{} is already registered {}", name, ie.getMessage());
             }
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -246,6 +246,14 @@ public class PrometheusMetricsTest extends BrokerTestBase {
                 assertEquals(item.value, 3.0);
             }
         });
+        Collection<Metric> topicLoadTimesMetrics = metrics.get("topic_load_times");
+        Collection<Metric> topicLoadTimesCountMetrics = metrics.get("topic_load_times_count");
+        assertEquals(topicLoadTimesMetrics.size(), 6);
+        assertEquals(topicLoadTimesCountMetrics.size(), 1);
+        Collection<Metric> pulsarTopicLoadTimesMetrics = metrics.get("pulsar_topic_load_times");
+        Collection<Metric> pulsarTopicLoadTimesCountMetrics = metrics.get("pulsar_topic_load_times_count");
+        assertEquals(pulsarTopicLoadTimesMetrics.size(), 6);
+        assertEquals(pulsarTopicLoadTimesCountMetrics.size(), 1);
     }
 
     @Test


### PR DESCRIPTION
Fix [PIP-273](#20476)

### Motivation
`topic_load_times` was added by #507,  it's too earlier. And then we added the `pulsar` prefix for all the metrics, but leaves it. So in order to keep the same prefix, we'd better update it.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

