### PR TITLE
[fix][fn] Support customizing TLS config for function download command

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -885,6 +885,18 @@ public class KubernetesRuntime implements Runtime {
                         "--auth-params",
                         authConfig.getClientAuthenticationParameters()));
             }
+            cmd.addAll(Arrays.asList(
+                    "--use-tls",
+                    Boolean.toString(authConfig.isUseTls()),
+                    "--tls-allow-insecure",
+                    Boolean.toString(authConfig.isTlsAllowInsecureConnection()),
+                    "--tls-enable-hostname-verification",
+                    Boolean.toString(authConfig.isTlsHostnameVerificationEnable())));
+            if (isNotBlank(authConfig.getTlsTrustCertsFilePath())) {
+                cmd.addAll(Arrays.asList(
+                        "--tls-trust-cert-path",
+                        authConfig.getTlsTrustCertsFilePath()));
+            }
         }
 
         cmd.addAll(Arrays.asList(

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -886,8 +886,6 @@ public class KubernetesRuntime implements Runtime {
                         authConfig.getClientAuthenticationParameters()));
             }
             cmd.addAll(Arrays.asList(
-                    "--use-tls",
-                    Boolean.toString(authConfig.isUseTls()),
                     "--tls-allow-insecure",
                     Boolean.toString(authConfig.isTlsAllowInsecureConnection()),
                     "--tls-enable-hostname-verification",

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
@@ -852,7 +852,7 @@ public class KubernetesRuntimeTest {
         V1StatefulSet spec = container.createStatefulSet();
         String expectedDownloadCommand = "pulsar-admin --admin-url " + pulsarAdminUrl
                 + " --auth-plugin com.MyAuth --auth-params {\"authParam1\": \"authParamValue1\"}"
-                + " --use-tls false --tls-allow-insecure false --tls-enable-hostname-verification false"
+                + " --tls-allow-insecure false --tls-enable-hostname-verification false"
                 + " functions download "
                 + "--tenant " + TEST_TENANT
                 + " --namespace " + TEST_NAMESPACE
@@ -879,7 +879,7 @@ public class KubernetesRuntimeTest {
         V1StatefulSet spec = container.createStatefulSet();
         String expectedDownloadCommand = "pulsar-admin --admin-url " + pulsarAdminUrl
                 + " --auth-plugin com.MyAuth --auth-params {\"authParam1\": \"authParamValue1\"}"
-                + " --use-tls false --tls-allow-insecure false --tls-enable-hostname-verification false"
+                + " --tls-allow-insecure false --tls-enable-hostname-verification false"
                 + " functions download "
                 + "--tenant " + TEST_TENANT
                 + " --namespace " + TEST_NAMESPACE
@@ -900,7 +900,7 @@ public class KubernetesRuntimeTest {
                 }, AuthenticationConfig.builder()
                         .clientAuthenticationPlugin("com.MyAuth")
                         .clientAuthenticationParameters("{\"authParam1\": \"authParamValue1\"}")
-                        .useTls(true)
+                        .useTls(true) // set to verify it is ignored because pulsar admin does not consider this setting
                         .tlsHostnameVerificationEnable(true)
                         .tlsTrustCertsFilePath("/my/ca.pem")
                         .build());
@@ -909,7 +909,7 @@ public class KubernetesRuntimeTest {
         V1StatefulSet spec = container.createStatefulSet();
         String expectedDownloadCommand = "pulsar-admin --admin-url " + pulsarAdminUrl
                 + " --auth-plugin com.MyAuth --auth-params {\"authParam1\": \"authParamValue1\"}"
-                + " --use-tls true --tls-allow-insecure false --tls-enable-hostname-verification true"
+                + " --tls-allow-insecure false --tls-enable-hostname-verification true"
                 + " --tls-trust-cert-path /my/ca.pem"
                 + " functions download "
                 + "--tenant " + TEST_TENANT

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
@@ -852,6 +852,7 @@ public class KubernetesRuntimeTest {
         V1StatefulSet spec = container.createStatefulSet();
         String expectedDownloadCommand = "pulsar-admin --admin-url " + pulsarAdminUrl
                 + " --auth-plugin com.MyAuth --auth-params {\"authParam1\": \"authParamValue1\"}"
+                + " --use-tls false --tls-allow-insecure false --tls-enable-hostname-verification false"
                 + " functions download "
                 + "--tenant " + TEST_TENANT
                 + " --namespace " + TEST_NAMESPACE
@@ -878,6 +879,38 @@ public class KubernetesRuntimeTest {
         V1StatefulSet spec = container.createStatefulSet();
         String expectedDownloadCommand = "pulsar-admin --admin-url " + pulsarAdminUrl
                 + " --auth-plugin com.MyAuth --auth-params {\"authParam1\": \"authParamValue1\"}"
+                + " --use-tls false --tls-allow-insecure false --tls-enable-hostname-verification false"
+                + " functions download "
+                + "--tenant " + TEST_TENANT
+                + " --namespace " + TEST_NAMESPACE
+                + " --name " + TEST_NAME
+                + " --destination-file " + pulsarRootDir + "/" + userJarFile;
+        String containerCommand = spec.getSpec().getTemplate().getSpec().getContainers().get(0).getCommand().get(2);
+        assertTrue(containerCommand.contains(expectedDownloadCommand), "Found:" + containerCommand);
+    }
+
+    @Test
+    public void testCustomKubernetesDownloadCommandsWithAuthAndCustomTLSWithoutAuthSpec() throws Exception {
+        InstanceConfig config = createJavaInstanceConfig(FunctionDetails.Runtime.JAVA, false);
+        config.setFunctionDetails(createFunctionDetails(FunctionDetails.Runtime.JAVA, false));
+
+        factory = createKubernetesRuntimeFactory(null,
+                10, 1.0, 1.0, Optional.empty(), null, wconfig -> {
+                    wconfig.setAuthenticationEnabled(true);
+                }, AuthenticationConfig.builder()
+                        .clientAuthenticationPlugin("com.MyAuth")
+                        .clientAuthenticationParameters("{\"authParam1\": \"authParamValue1\"}")
+                        .useTls(true)
+                        .tlsHostnameVerificationEnable(true)
+                        .tlsTrustCertsFilePath("/my/ca.pem")
+                        .build());
+
+        KubernetesRuntime container = factory.createContainer(config, userJarFile, userJarFile, null, null, 30l);
+        V1StatefulSet spec = container.createStatefulSet();
+        String expectedDownloadCommand = "pulsar-admin --admin-url " + pulsarAdminUrl
+                + " --auth-plugin com.MyAuth --auth-params {\"authParam1\": \"authParamValue1\"}"
+                + " --use-tls true --tls-allow-insecure false --tls-enable-hostname-verification true"
+                + " --tls-trust-cert-path /my/ca.pem"
                 + " functions download "
                 + "--tenant " + TEST_TENANT
                 + " --namespace " + TEST_NAMESPACE


### PR DESCRIPTION
### Motivation

We support configuring custom TLS trusted certs when running functions, but not when downloading them. This PR fixes that by mapping the configuration in the same way we do with functions:

https://github.com/apache/pulsar/blob/f04252b84a8b594ea371645e367c491aa8e2dd80/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java#L425-L434

### Modifications

* Configure using TLS, allowing insecure TLS, hostname verification, and the custom trusted cert path

### Verifying this change

I added a new test.

### Documentation

- [x] `doc-not-needed`
