### PR TITLE
[fix][ci] Fix OWASP dependency check suppressions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@ flexible messaging model and an intuitive client API.</description>
     <errorprone-slf4j.version>0.1.4</errorprone-slf4j.version>
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
-    <dependency-check-maven.version>8.1.2</dependency-check-maven.version>
+    <dependency-check-maven.version>8.2.1</dependency-check-maven.version>
     <roaringbitmap.version>0.9.44</roaringbitmap.version>
     <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
     <oshi.version>6.4.0</oshi.version>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -229,72 +229,20 @@
         <cve>CVE-2021-42550</cve>
     </suppress>
 
-    <!-- jetcd matched against ETCD server CVEs-->
     <suppress>
-        <notes><![CDATA[
-       file name: jetcd-api-0.7.5.jar
-       ]]></notes>
-        <sha1>861af62ae22a71d30f401a80049397fe7ff44423</sha1>
-        <cve>CVE-2020-15113</cve>
-    </suppress>
-
-    <suppress>
-        <notes><![CDATA[
-       file name: jetcd-core-0.7.5.jar
-       ]]></notes>
-        <sha1>663f2ccc0ec7797954c333fa75feeb7d559948b0</sha1>
-        <cve>CVE-2020-15113</cve>
-    </suppress>
-
-    <suppress>
-        <notes><![CDATA[
-       file name: jetcd-common-0.7.5.jar
-       ]]></notes>
-        <sha1>abd0ffcd4e66046057c3bfb34affc0de870a038b</sha1>
-        <cve>CVE-2020-15113</cve>
-    </suppress>
-
-    <suppress>
-        <notes><![CDATA[
-       file name: jetcd-grpc-0.7.5.jar
-       ]]></notes>
-        <sha1>a2e99802fec5586daca0c4daae975fe601a057a8</sha1>
-        <cve>CVE-2017-8359</cve>
+        <notes>Ignore etdc CVEs in jetcd</notes>
+        <filePath regex="true">.*jetcd.*</filePath>
+        <cpe>cpe:/a:etcd:etcd</cpe>
     </suppress>
     <suppress>
-        <notes><![CDATA[
-       file name: jetcd-grpc-0.7.5.jar
-       ]]></notes>
-        <sha1>a2e99802fec5586daca0c4daae975fe601a057a8</sha1>
-        <cve>CVE-2020-15113</cve>
+        <notes>Ignore etdc CVEs in jetcd</notes>
+        <filePath regex="true">.*jetcd.*</filePath>
+        <cpe>cpe:/a:redhat:etcd</cpe>
     </suppress>
     <suppress>
-        <notes><![CDATA[
-       file name: jetcd-grpc-0.7.5.jar
-       ]]></notes>
-        <sha1>a2e99802fec5586daca0c4daae975fe601a057a8</sha1>
-        <cve>CVE-2020-7768</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-       file name: jetcd-grpc-0.7.5.jar
-       ]]></notes>
-        <sha1>a2e99802fec5586daca0c4daae975fe601a057a8</sha1>
-        <cve>CVE-2017-7861</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-       file name: jetcd-grpc-0.7.5.jar
-       ]]></notes>
-        <sha1>a2e99802fec5586daca0c4daae975fe601a057a8</sha1>
-        <cve>CVE-2017-9431</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-       file name: jetcd-grpc-0.7.5.jar
-       ]]></notes>
-        <sha1>a2e99802fec5586daca0c4daae975fe601a057a8</sha1>
-        <cve>CVE-2017-7860</cve>
+        <notes>Ignore grpc CVEs in jetcd</notes>
+        <filePath regex="true">.*jetcd-grpc.*</filePath>
+        <cpe>cpe:/a:grpc:grpc</cpe>
     </suppress>
 
     <!-- bouncycastle misdetections -->


### PR DESCRIPTION
### Motivation

OWASP dependency check fails because of false positives.

### Modifications

- jetcd shouldn't match etcd or grpc CVEs
   - add proper suppression rules that cover this
- keep OWASP Dependency Check version up-to-date
  - Upgrade to 8.2.1 version

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->