### PR TITLE
[fix][broker] Fix race condition in ManagedCursorImpl related to skipping messages

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -837,16 +837,17 @@ public class ManagedCursorImpl implements ManagedCursor {
             return;
         }
 
-        PositionImpl startPosition = ledger.getNextValidPosition(markDeletePosition);
+        PositionImpl currentMarkDeletePosition = markDeletePosition;
+        PositionImpl startPosition = ledger.getNextValidPosition(currentMarkDeletePosition);
         PositionImpl endPosition = ledger.getLastPosition();
         if (startPosition.compareTo(endPosition) <= 0) {
             long numOfEntries = getNumberOfEntries(Range.closed(startPosition, endPosition));
             if (numOfEntries >= n) {
                 long deletedMessages = 0;
                 if (deletedEntries == IndividualDeletedEntries.Exclude) {
-                    deletedMessages = getNumIndividualDeletedEntriesToSkip(n);
+                    deletedMessages = getNumIndividualDeletedEntriesToSkip(n, currentMarkDeletePosition);
                 }
-                PositionImpl positionAfterN = ledger.getPositionAfterN(markDeletePosition, n + deletedMessages,
+                PositionImpl positionAfterN = ledger.getPositionAfterN(currentMarkDeletePosition, n + deletedMessages,
                         PositionBound.startExcluded);
                 ledger.asyncReadEntry(positionAfterN, callback, ctx);
             } else {
@@ -1711,11 +1712,12 @@ public class ManagedCursorImpl implements ManagedCursor {
             final SkipEntriesCallback callback, Object ctx) {
         log.info("[{}] Skipping {} entries on cursor {}", ledger.getName(), numEntriesToSkip, name);
         long numDeletedMessages = 0;
+        PositionImpl currentMarkDeletePosition = markDeletePosition;
         if (deletedEntries == IndividualDeletedEntries.Exclude) {
-            numDeletedMessages = getNumIndividualDeletedEntriesToSkip(numEntriesToSkip);
+            numDeletedMessages = getNumIndividualDeletedEntriesToSkip(numEntriesToSkip, currentMarkDeletePosition);
         }
 
-        asyncMarkDelete(ledger.getPositionAfterN(markDeletePosition, numEntriesToSkip + numDeletedMessages,
+        asyncMarkDelete(ledger.getPositionAfterN(currentMarkDeletePosition, numEntriesToSkip + numDeletedMessages,
                 PositionBound.startExcluded), new MarkDeleteCallback() {
                     @Override
                     public void markDeleteComplete(Object ctx) {
@@ -1752,10 +1754,11 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
     }
 
-    long getNumIndividualDeletedEntriesToSkip(long numEntries) {
+    long getNumIndividualDeletedEntriesToSkip(long numEntries, PositionImpl currentMarkDeletePosition) {
         lock.readLock().lock();
         try {
-            InvidualDeletedMessagesHandlingState state = new InvidualDeletedMessagesHandlingState(markDeletePosition);
+            InvidualDeletedMessagesHandlingState state =
+                    new InvidualDeletedMessagesHandlingState(currentMarkDeletePosition);
             individualDeletedMessages.forEach((r) -> {
                 try {
                     state.endPosition = r.lowerEndpoint();
@@ -1772,7 +1775,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                     } else {
                         if (log.isDebugEnabled()) {
                             log.debug("[{}] deletePosition {} moved ahead without clearing deleteMsgs {} for cursor {}",
-                                    ledger.getName(), markDeletePosition, r.lowerEndpoint(), name);
+                                    ledger.getName(), currentMarkDeletePosition, r.lowerEndpoint(), name);
                         }
                     }
                     return true;


### PR DESCRIPTION
### Motivation

- markDeletePosition might get updated during skipping and this would result in a race condition which could potentially lead to unintended skipping of messages

### Modifications

- store current markDeletePosition to a variable to ensure consistency in the `asyncGetNthEntry` and `asyncSkipEntries` methods of `ManagedCursorImpl`. 
  - pass the stored reference to `getNumIndividualDeletedEntriesToSkip` method to ensure that different position calculations are consistently using the same `markDeletePosition`. 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->