### PR TITLE
[pip][design] PIP-274: Support pluggable topic compactor

### DIFF
--- a/pip/pip-274.md
+++ b/pip/pip-274.md
@@ -6,9 +6,12 @@ More topic compaction details can be found in [Pulsar Topic Compaction](https://
 # Motivation
 
 Currently, the implementation of Pulsar Topic Compaction is fixed and does not support custom strategy, which limits users from using more Compactor policies in their applications.
-For example, in Kop, we need to parse the Kafka format, but the current implementation of Pulsar topic Compaction does not support this feature.
+
+
+For example, we need to parse the Kafka format then compact message in Kop, but the current implementation of Pulsar topic compaction does not support this feature.
 Another the topic compaction logic implemented in `TwoPhaseCompactor` only compacts messages to the last one, but sometimes we need to keep the first valid message e.g [`StrategicTwoPhaseCompactor`](https://github.com/coderzc/pulsar/blob/0e9935c493060b13b322a84c5418146423992369/pulsar-broker/src/main/java/org/apache/pulsar/compaction/StrategicTwoPhaseCompactor.java).
-So we need to make the compactor pluggable to support more compaction strategy.
+
+So we need to make the topic compactor pluggable to support more compaction strategy.
 
 # Goals
 
@@ -42,7 +45,7 @@ DON'T
 * Avoid code snippets, unless it's essential to explain your intent.
 -->
 
-Make the compactor pluggable, users can customize the compactor implementation according to their own special scenarios.
+Make the topic compactor pluggable, users can customize the compactor implementation according to their own special scenarios.
 
 
 # Detailed Design
@@ -119,5 +122,5 @@ If there are alternatives that were already considered by the authors or, after 
 <!--
 Updated afterwards
 -->
-* Mailing List discussion thread:
+* Mailing List discussion thread: https://lists.apache.org/thread/svyodx3q1nrdd6fyrsfv3xmo0lgn6j2j
 * Mailing List voting thread:

--- a/pip/pip-274.md
+++ b/pip/pip-274.md
@@ -1,0 +1,123 @@
+# Background knowledge
+
+Apache Pulsar is a distributed messaging system that supports multiple messaging protocols and storage methods. Among them, Pulsar Topic Compaction is a mechanism to clean up duplicate messages in topics to reduce storage space and improve system efficiency.
+More topic compaction details can be found in [Pulsar Topic Compaction](https://pulsar.apache.org/docs/en/concepts-topic-compaction/).
+
+# Motivation
+
+Currently, the implementation of Pulsar Topic Compaction is fixed and does not support custom strategy, which limits users from using more Compactor policies in their applications.
+For example, in Kop, we need to parse the Kafka format, but the current implementation of Pulsar topic Compaction does not support this feature.
+Another the topic compaction logic implemented in `TwoPhaseCompactor` only compacts messages to the last one, but sometimes we need to keep the first valid message e.g [`StrategicTwoPhaseCompactor`](https://github.com/coderzc/pulsar/blob/0e9935c493060b13b322a84c5418146423992369/pulsar-broker/src/main/java/org/apache/pulsar/compaction/StrategicTwoPhaseCompactor.java).
+So we need to make the compactor pluggable to support more compaction strategy.
+
+# Goals
+
+## In Scope
+
+<!--
+What this PIP intend to achieve once It's integrated into Pulsar.
+Why does it benefit Pulsar.
+-->
+
+Make the compactor pluggable.
+
+## Out of Scope
+
+<!--
+Describe what you have decided to keep out of scope, perhaps left for a different PIP/s.
+-->
+
+
+# High Level Design
+
+<!--
+Describe the design of your solution in *high level*.
+Describe the solution end to end, from a birds-eye view.
+Don't go into implementation details in this section.
+
+I should be able to finish reading from beginning of the PIP to here (including) and understand the feature and 
+how you intend to solve it, end to end.
+
+DON'T
+* Avoid code snippets, unless it's essential to explain your intent.
+-->
+
+Make the compactor pluggable, users can customize the compactor implementation according to their own special scenarios.
+
+
+# Detailed Design
+
+## Design & Implementation Details
+
+<!--
+This is the section where you dive into the details. It can be:
+* Concrete class names and their roles and responsibility, including methods.
+* Code snippets of existing code.
+* Interface names and its methods.
+* ...
+-->
+* Define a standard Compactor interface that specifies the methods and properties that the Compactor implementation needs to implement. This interface should include methods for Compactor initialization, Compactor execution, and getting Compactor stats.
+```java
+public interface Compactor {
+
+    void initialize(ServiceConfiguration conf,
+                    PulsarClient pulsar,
+                    BookKeeper bk,
+                    ScheduledExecutorService scheduler);
+
+    CompletableFuture<Long> compact(String topic);
+
+    CompactorMXBean getStats();
+}
+```
+
+* Rename `org.apache.pulsar.compaction.Compactor` to `org.apache.pulsar.compaction.AbstractCompactor` and make it implement `Compactor` interface.
+
+* Load custom compactor based on configuration in `org.apache.pulsar.broker.PulsarService.newCompactor` and `CompactorTool`.
+
+## Public-facing Changes
+
+<!--
+Describe the additions you plan to make for each public facing component. 
+Remove the sections you are not changing.
+Clearly mark any changes which are BREAKING backward compatability.
+-->
+
+
+### Configuration
+
+broker.conf
+```
+compactorClassName=org.apache.pulsar.compaction.TwoPhaseCompactor
+```
+
+# Backward & Forward Compatability
+
+## Revert
+
+<!--
+Describe a cookbook detailing the steps required to revert pulsar to previous version *without* this feature.
+-->
+
+
+## Upgrade
+
+<!--
+Specify the list of instructions, if there are such, needed to perform before/after upgrading to Pulsar version containing this feature.
+-->
+
+# Alternatives
+
+<!--
+If there are alternatives that were already considered by the authors or, after the discussion, by the community, and were rejected, please list them here along with the reason why they were rejected.
+-->
+
+# General Notes
+
+# Links
+
+<!--
+Updated afterwards
+-->
+* Mailing List discussion thread:
+* Mailing List voting thread:


### PR DESCRIPTION
Motivation

This is a PIP to enable support pluggable compactor. The PR contents have the motivation.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
