### PR TITLE
[fix][test] Disable invalid test BrokerServiceTest#testBrokerStatsTopicLoadFailed

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -1517,7 +1517,8 @@ public class BrokerServiceTest extends BrokerTestBase {
     }
 
 
-    @Test
+    // this test is disabled since it is flaky
+    @Test(enabled = false)
     public void testBrokerStatsTopicLoadFailed() throws Exception {
         admin.namespaces().createNamespace("prop/ns-test");
 


### PR DESCRIPTION
Fixes #20492

### Motivation

The test BrokerServiceTest#testBrokerStatsTopicLoadFailed introduced in #19236 is invalid. 
* It modifies the current shared state and that causes other tests to fail. 
* The test uses Awaitility with a 2 minute timeout. That is too long for unit tests.

### Modifications

- disable the test until it is fixed

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->