### PR TITLE
[improve][broker] Support get/remove permissions for AuthorizationProvider

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
@@ -444,7 +444,7 @@ public interface AuthorizationProvider extends Closeable {
     /**
      * Get authorization-action permissions on a topic to the given client.
      * @param topicName
-     * @return CompletableFuture<Void>
+     * @return CompletableFuture<Map<String, Set<AuthAction>>>
      */
     default CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(TopicName topicName) {
         return FutureUtil.failedFuture(new IllegalStateException(
@@ -452,6 +452,11 @@ public interface AuthorizationProvider extends Closeable {
                         topicName)));
     }
 
+    /**
+     * Get authorization-action permissions on a topic to the given client.
+     * @param namespaceName
+     * @return CompletableFuture<Map<String, Set<String>>>
+     */
     default CompletableFuture<Map<String, Set<String>>> getSubscriptionPermissionsAsync(NamespaceName namespaceName) {
         return FutureUtil.failedFuture(new IllegalStateException(
                 String.format("getSubscriptionPermissionsAsync on namespace %s is not supported by the Authorization",
@@ -461,7 +466,7 @@ public interface AuthorizationProvider extends Closeable {
     /**
      * Get authorization-action permissions on a namespace to the given client.
      * @param namespaceName
-     * @return CompletableFuture<Void>
+     * @return CompletableFuture<Map<String, Set<AuthAction>>>
      */
     default CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(NamespaceName namespaceName) {
         return FutureUtil.failedFuture(new IllegalStateException(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
@@ -428,4 +428,48 @@ public interface AuthorizationProvider extends Closeable {
             throw new RestException(e.getCause());
         }
     }
+
+    /**
+     * Remove authorization-action permissions on a topic to the given client.
+     * @param topicName
+     * @return CompletableFuture<Void>
+     */
+    default CompletableFuture<Void> removePermissionsAsync(TopicName topicName) {
+        return FutureUtil.failedFuture(new IllegalStateException(
+                String.format("removePermissionsAsync on topicName %s is not supported by the Authorization",
+                        topicName)));
+    }
+
+    /**
+     * Remove authorization-action permissions on a namespace to the given client.
+     * @param namespaceName
+     * @return CompletableFuture<Void>
+     */
+    default CompletableFuture<Void> removePermissionsAsync(NamespaceName namespaceName) {
+        return FutureUtil.failedFuture(new IllegalStateException(
+                String.format("removePermissionsAsync on namespaceName %s is not supported by the Authorization",
+                        namespaceName)));
+    }
+
+    /**
+     * Get authorization-action permissions on a topic to the given client.
+     * @param topicName
+     * @return CompletableFuture<Void>
+     */
+    default CompletableFuture<Void> getPermissionsAsync(TopicName topicName) {
+        return FutureUtil.failedFuture(new IllegalStateException(
+                String.format("getPermissionsAsync on topicName %s is not supported by the Authorization",
+                        topicName)));
+    }
+
+    /**
+     * Get authorization-action permissions on a namespace to the given client.
+     * @param namespaceName
+     * @return CompletableFuture<Void>
+     */
+    default CompletableFuture<Void> getPermissionsAsync(NamespaceName namespaceName) {
+        return FutureUtil.failedFuture(new IllegalStateException(
+                String.format("getPermissionsAsync on namespaceName %s is not supported by the Authorization",
+                        namespaceName)));
+    }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
@@ -431,7 +431,7 @@ public interface AuthorizationProvider extends Closeable {
     }
 
     /**
-     * Remove authorization-action permissions on a topic to the given client.
+     * Remove authorization-action permissions on a topic.
      * @param topicName
      * @return CompletableFuture<Void>
      */
@@ -442,7 +442,7 @@ public interface AuthorizationProvider extends Closeable {
     }
 
     /**
-     * Get authorization-action permissions on a topic to the given client.
+     * Get authorization-action permissions on a topic.
      * @param topicName
      * @return CompletableFuture<Map<String, Set<AuthAction>>>
      */
@@ -453,7 +453,7 @@ public interface AuthorizationProvider extends Closeable {
     }
 
     /**
-     * Get authorization-action permissions on a topic to the given client.
+     * Get authorization-action permissions on a topic.
      * @param namespaceName
      * @return CompletableFuture<Map<String, Set<String>>>
      */
@@ -464,7 +464,7 @@ public interface AuthorizationProvider extends Closeable {
     }
 
     /**
-     * Get authorization-action permissions on a namespace to the given client.
+     * Get authorization-action permissions on a namespace.
      * @param namespaceName
      * @return CompletableFuture<Map<String, Set<AuthAction>>>
      */

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.authorization;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -441,25 +442,20 @@ public interface AuthorizationProvider extends Closeable {
     }
 
     /**
-     * Remove authorization-action permissions on a namespace to the given client.
-     * @param namespaceName
-     * @return CompletableFuture<Void>
-     */
-    default CompletableFuture<Void> removePermissionsAsync(NamespaceName namespaceName) {
-        return FutureUtil.failedFuture(new IllegalStateException(
-                String.format("removePermissionsAsync on namespaceName %s is not supported by the Authorization",
-                        namespaceName)));
-    }
-
-    /**
      * Get authorization-action permissions on a topic to the given client.
      * @param topicName
      * @return CompletableFuture<Void>
      */
-    default CompletableFuture<Void> getPermissionsAsync(TopicName topicName) {
+    default CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(TopicName topicName) {
         return FutureUtil.failedFuture(new IllegalStateException(
                 String.format("getPermissionsAsync on topicName %s is not supported by the Authorization",
                         topicName)));
+    }
+
+    default CompletableFuture<Map<String, Set<String>>> getSubscriptionPermissionsAsync(NamespaceName namespaceName) {
+        return FutureUtil.failedFuture(new IllegalStateException(
+                String.format("getSubscriptionPermissionsAsync on namespace %s is not supported by the Authorization",
+                        namespaceName)));
     }
 
     /**
@@ -467,7 +463,7 @@ public interface AuthorizationProvider extends Closeable {
      * @param namespaceName
      * @return CompletableFuture<Void>
      */
-    default CompletableFuture<Void> getPermissionsAsync(NamespaceName namespaceName) {
+    default CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(NamespaceName namespaceName) {
         return FutureUtil.failedFuture(new IllegalStateException(
                 String.format("getPermissionsAsync on namespaceName %s is not supported by the Authorization",
                         namespaceName)));

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.authorization;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import java.net.SocketAddress;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -814,5 +815,21 @@ public class AuthorizationService {
         } catch (ExecutionException e) {
             throw new RestException(e.getCause());
         }
+    }
+
+    public CompletableFuture<Void> removePermissionsAsync(TopicName topicName) {
+        return provider.removePermissionsAsync(topicName);
+    }
+
+    public CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(TopicName topicName) {
+        return provider.getPermissionsAsync(topicName);
+    }
+
+    public CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(NamespaceName namespaceName) {
+        return provider.getPermissionsAsync(namespaceName);
+    }
+
+    public CompletableFuture<Map<String, Set<String>>> getSubscriptionPermissionsAsync(NamespaceName namespaceName) {
+        return provider.getSubscriptionPermissionsAsync(namespaceName);
     }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.authorization;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,8 +28,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.core.Response;
-
-import com.google.common.collect.Sets;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -46,7 +46,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.AsyncResponse;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -112,7 +112,6 @@ import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.AuthAction;
-import org.apache.pulsar.common.policies.data.AuthPolicies;
 import org.apache.pulsar.common.policies.data.AutoSubscriptionCreationOverride;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.DelayedDeliveryPolicies;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -293,8 +293,8 @@ public class Namespaces extends NamespacesBase {
                                @PathParam("namespace") String namespace) {
         validateNamespaceName(property, cluster, namespace);
         validateNamespaceOperationAsync(NamespaceName.get(property, namespace), NamespaceOperation.GET_PERMISSION)
-                .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
-                .thenAccept(policies -> response.resume(policies.auth_policies.getNamespaceAuthentication()))
+                .thenCompose(__ -> getAuthorizationService().getPermissionsAsync(namespaceName))
+                .thenAccept(permissions -> response.resume(permissions))
                 .exceptionally(ex -> {
                     log.error("Failed to get permissions for namespace {}", namespaceName, ex);
                     resumeAsyncResponseExceptionally(response, ex);
@@ -314,8 +314,8 @@ public class Namespaces extends NamespacesBase {
                                             @PathParam("namespace") String namespace) {
         validateNamespaceName(property, cluster, namespace);
         validateNamespaceOperationAsync(NamespaceName.get(property, namespace), NamespaceOperation.GET_PERMISSION)
-                .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
-                .thenAccept(policies -> response.resume(policies.auth_policies.getSubscriptionAuthentication()))
+                .thenCompose(__ -> getAuthorizationService().getSubscriptionPermissionsAsync(namespaceName))
+                .thenAccept(permissions -> response.resume(permissions))
                 .exceptionally(ex -> {
                     log.error("[{}] Failed to get permissions on subscription for namespace {}: {} ",
                             clientAppId(), namespaceName,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -240,7 +240,8 @@ public class Namespaces extends NamespacesBase {
                                                        @PathParam("namespace") String namespace) {
         validateNamespaceName(tenant, namespace);
         validateNamespaceOperationAsync(NamespaceName.get(tenant, namespace), NamespaceOperation.GET_PERMISSION)
-                .thenAccept(policies -> response.resume(getAuthorizationService().getPermissionsAsync(namespaceName)))
+                .thenCompose(__ -> getAuthorizationService().getPermissionsAsync(namespaceName))
+                .thenAccept(permissions -> response.resume(permissions))
                 .exceptionally(ex -> {
                     log.error("Failed to get permissions for namespace {}", namespaceName, ex);
                     resumeAsyncResponseExceptionally(response, ex);
@@ -259,8 +260,8 @@ public class Namespaces extends NamespacesBase {
                                             @PathParam("namespace") String namespace) {
         validateNamespaceName(tenant, namespace);
         validateNamespaceOperationAsync(NamespaceName.get(tenant, namespace), NamespaceOperation.GET_PERMISSION)
-                .thenAccept(policies -> response.resume(getAuthorizationService()
-                        .getSubscriptionPermissionsAsync(namespaceName)))
+                .thenCompose(__ -> getAuthorizationService().getSubscriptionPermissionsAsync(namespaceName))
+                .thenAccept(permissions -> response.resume(permissions))
                 .exceptionally(ex -> {
                     log.error("[{}] Failed to get permissions on subscription for namespace {}: {} ", clientAppId(),
                             namespaceName, ex.getCause().getMessage(), ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -240,8 +240,7 @@ public class Namespaces extends NamespacesBase {
                                                        @PathParam("namespace") String namespace) {
         validateNamespaceName(tenant, namespace);
         validateNamespaceOperationAsync(NamespaceName.get(tenant, namespace), NamespaceOperation.GET_PERMISSION)
-                .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
-                .thenAccept(policies -> response.resume(policies.auth_policies.getNamespaceAuthentication()))
+                .thenAccept(policies -> response.resume(getAuthorizationService().getPermissionsAsync(namespaceName)))
                 .exceptionally(ex -> {
                     log.error("Failed to get permissions for namespace {}", namespaceName, ex);
                     resumeAsyncResponseExceptionally(response, ex);
@@ -260,8 +259,8 @@ public class Namespaces extends NamespacesBase {
                                             @PathParam("namespace") String namespace) {
         validateNamespaceName(tenant, namespace);
         validateNamespaceOperationAsync(NamespaceName.get(tenant, namespace), NamespaceOperation.GET_PERMISSION)
-                .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
-                .thenAccept(policies -> response.resume(policies.auth_policies.getSubscriptionAuthentication()))
+                .thenAccept(policies -> response.resume(getAuthorizationService()
+                        .getSubscriptionPermissionsAsync(namespaceName)))
                 .exceptionally(ex -> {
                     log.error("[{}] Failed to get permissions on subscription for namespace {}: {} ", clientAppId(),
                             namespaceName, ex.getCause().getMessage(), ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1197,11 +1197,8 @@ public class BrokerService implements Closeable {
                 future.complete(null);
                 return;
             }
-            pulsar.getPulsarResources().getNamespaceResources()
-                    .setPoliciesAsync(TopicName.get(topic).getNamespaceObject(), p -> {
-                        p.auth_policies.getTopicAuthentication().remove(topic);
-                        return p;
-                    }).thenAccept(v -> {
+            authorizationService.removePermissionsAsync(TopicName.get(topic))
+                    .thenAccept(v -> {
                         log.info("Successfully delete authentication policies for topic {}", topic);
                         future.complete(null);
                     }).exceptionally(ex1 -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1185,18 +1185,8 @@ public class BrokerService implements Closeable {
             future.completeExceptionally(new MetadataStoreException("The number of retries has exhausted"));
             return;
         }
-        NamespaceName namespaceName = TopicName.get(topic).getNamespaceObject();
         // Check whether there are auth policies for the topic
-        pulsar.getPulsarResources().getNamespaceResources().getPoliciesAsync(namespaceName).thenAccept(optPolicies -> {
-            if (!optPolicies.isPresent()) {
-                // if there is no auth policy for the topic, just complete and return
-                if (log.isDebugEnabled()) {
-                    log.debug("Authentication policies not found for topic {}", topic);
-                }
-                future.complete(null);
-                return;
-            }
-            authorizationService.removePermissionsAsync(TopicName.get(topic))
+        authorizationService.removePermissionsAsync(TopicName.get(topic))
                     .thenAccept(v -> {
                         log.info("Successfully delete authentication policies for topic {}", topic);
                         future.complete(null);
@@ -1213,11 +1203,6 @@ public class BrokerService implements Closeable {
                         }
                         return null;
                     });
-        }).exceptionally(ex -> {
-            log.error("Failed to get policies for topic {}", topic, ex);
-            future.completeExceptionally(ex);
-            return null;
-        });
     }
 
     private CompletableFuture<Optional<Topic>> createNonPersistentTopic(String topic) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1188,8 +1188,7 @@ public class BrokerService implements Closeable {
         NamespaceName namespaceName = TopicName.get(topic).getNamespaceObject();
         // Check whether there are auth policies for the topic
         pulsar.getPulsarResources().getNamespaceResources().getPoliciesAsync(namespaceName).thenAccept(optPolicies -> {
-            if (!optPolicies.isPresent() || !optPolicies.get().auth_policies.getTopicAuthentication()
-                    .containsKey(topic)) {
+            if (!optPolicies.isPresent()) {
                 // if there is no auth policy for the topic, just complete and return
                 if (log.isDebugEnabled()) {
                     log.debug("Authentication policies not found for topic {}", topic);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferCloseTest.java
@@ -61,7 +61,7 @@ public class TransactionBufferCloseTest extends TransactionTestBase {
         };
     }
 
-    @Test(timeOut = 10_000, dataProvider = "isPartition")
+    @Test(dataProvider = "isPartition")
     public void deleteTopicCloseTransactionBufferTest(boolean isPartition) throws Exception {
         int partitionCount = isPartition ? 30 : 1;
         List<TopicName> topicNames = createAndLoadTopics(isPartition, partitionCount);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferCloseTest.java
@@ -61,7 +61,7 @@ public class TransactionBufferCloseTest extends TransactionTestBase {
         };
     }
 
-    @Test(dataProvider = "isPartition")
+    @Test(timeOut = 10_000, dataProvider = "isPartition")
     public void deleteTopicCloseTransactionBufferTest(boolean isPartition) throws Exception {
         int partitionCount = isPartition ? 30 : 1;
         List<TopicName> topicNames = createAndLoadTopics(isPartition, partitionCount);

--- a/pulsar-websocket/src/main/resources/findbugsExclude.xml
+++ b/pulsar-websocket/src/main/resources/findbugsExclude.xml
@@ -199,4 +199,9 @@
     <Method name="&lt;init&gt;"/>
     <Bug pattern="EI_EXPOSE_REP2"/>
   </Match>
+  <Match>
+    <Class name="org.apache.pulsar.websocket.WebSocketService"/>
+    <Method name="getAuthorizationService"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
### Motivation

This is a follow-up improvement for AuthorizationProvider.  As discussed in the [#20478-comment](https://github.com/apache/pulsar/pull/20478#issuecomment-1575333713), we need more methods to avoid admin handling permissions directly.

### Modification
1. Add `removePermissionsAsync`: when deleting partitioned topics, we need to delete the authentication data.
2. Add `getPermissionsAsync`: we have topic level API to get all the permissions. so we need this.
3. Add `getSubscriptionPermissionsAsync`: we have topic level API to get all subscription permissions.
4. Add `getPermissionsAsync`: we have namespace level API to get all the permissions.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

