### PR TITLE
[improve][fn] Optimize string concatenation in user metrics gen

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -603,12 +603,13 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
             String metricName = userMetricsLabelsEntry.getKey();
             String[] labels = userMetricsLabelsEntry.getValue();
             Summary.Child.Value summary = userMetricsSummary.labels(labels).get();
-            metricsMap.put(String.format("%s%s_sum", USER_METRIC_PREFIX, metricName), summary.sum);
-            metricsMap.put(String.format("%s%s_count", USER_METRIC_PREFIX, metricName), summary.count);
+            String prefix = USER_METRIC_PREFIX + metricName + "_";
+            metricsMap.put(prefix + "sum", summary.sum);
+            metricsMap.put(prefix + "count", summary.count);
             for (Map.Entry<Double, Double> entry : summary.quantiles.entrySet()) {
                 Double quantile = entry.getKey();
                 Double value = entry.getValue();
-                metricsMap.put(String.format("%s%s_%s", USER_METRIC_PREFIX, metricName, quantile), value);
+                metricsMap.put(prefix + quantile, value);
             }
         }
         return metricsMap;


### PR DESCRIPTION
### Motivation

Minor optimization for metrics generation in functions. String concatenation is faster than string format. This is valuable in the context of metrics where we can generate many strings in a tight loop.

### Modifications

* Replace `String.format` with string concatenation in several locations.
* Only create metrics prefix once.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [x] `doc-not-needed` 