### PR TITLE
[fix][test] Replace calls to Auth0 with calls to wiremock

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockOIDCIdentityProvider.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockOIDCIdentityProvider.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.auth;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.Response;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.impl.DefaultJwtBuilder;
+import io.jsonwebtoken.security.Keys;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Base64;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Mock OIDC (and therefore OAuth2) server for testing. Note that the client_id is mapped to the token's subject claim.
+ */
+public class MockOIDCIdentityProvider {
+    private final WireMockServer server;
+    private final PublicKey publicKey;
+    private final String audience;
+    public MockOIDCIdentityProvider(String clientSecret, String audience, long tokenTTLMillis) {
+        this.audience = audience;
+        KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.RS256);
+        publicKey = keyPair.getPublic();
+        server = new WireMockServer(wireMockConfig().port(0)
+                .extensions(new OAuth2Transformer(keyPair, tokenTTLMillis)));
+        server.start();
+
+        // Set up a correct openid-configuration that points to the next stub
+        server.stubFor(
+                get(urlEqualTo("/.well-known/openid-configuration"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("""
+                                        {
+                                          "issuer": "%s",
+                                          "token_endpoint": "%s/oauth/token"
+                                        }
+                                        """.replace("%s", server.baseUrl()))));
+
+        // Only respond when the client sends the expected request body
+        server.stubFor(post(urlEqualTo("/oauth/token"))
+                .withRequestBody(matching(".*grant_type=client_credentials.*"))
+                .withRequestBody(matching(".*audience=" + URLEncoder.encode(audience, StandardCharsets.UTF_8) + ".*"))
+                .withRequestBody(matching(".*client_id=.*"))
+                .withRequestBody(matching(".*client_secret=" + clientSecret + "(&.*|$)"))
+                .willReturn(aResponse().withTransformers("o-auth-token-transformer").withStatus(200)));
+    }
+
+    public void stop() {
+        server.stop();
+    }
+
+    public String getBase64EncodedPublicKey() {
+        return Base64.getEncoder().encodeToString(publicKey.getEncoded());
+    }
+
+    public String getIssuer() {
+        return server.baseUrl();
+    }
+
+    class OAuth2Transformer extends ResponseTransformer {
+
+        private final PrivateKey privateKey;
+        private final long tokenTTL;
+
+        private final Pattern clientIdToRolePattern = Pattern.compile("client_id=([A-Za-z0-9-]*)(&|$)");
+
+        OAuth2Transformer(KeyPair key, long tokenTTLMillis) {
+            this.privateKey = key.getPrivate();
+            this.tokenTTL = tokenTTLMillis;
+        }
+
+        @Override
+        public Response transform(Request request, Response response, FileSource files, Parameters parameters) {
+            Matcher m = clientIdToRolePattern.matcher(request.getBodyAsString());
+            if (m.find()) {
+                String role = m.group(1);
+                return Response.Builder.like(response).but().body("""
+                        {
+                          "access_token": "%s",
+                          "expires_in": %d,
+                          "token_type":"Bearer"
+                        }
+                        """.formatted(generateToken(role),
+                        TimeUnit.MILLISECONDS.toSeconds(tokenTTL))).build();
+            } else {
+                return Response.Builder.like(response).but().body("Invalid request").status(400).build();
+            }
+        }
+
+        @Override
+        public String getName() {
+            return "o-auth-token-transformer";
+        }
+
+        @Override
+        public boolean applyGlobally() {
+            return false;
+        }
+
+        private String generateToken(String role) {
+            long now = System.currentTimeMillis();
+            DefaultJwtBuilder defaultJwtBuilder = new DefaultJwtBuilder();
+            defaultJwtBuilder.setHeaderParam("typ", "JWT");
+            defaultJwtBuilder.setHeaderParam("alg", "RS256");
+            defaultJwtBuilder.setIssuer(server.baseUrl());
+            defaultJwtBuilder.setSubject(role);
+            defaultJwtBuilder.setAudience(audience);
+            defaultJwtBuilder.setIssuedAt(new Date(now));
+            defaultJwtBuilder.setNotBefore(new Date(now));
+            defaultJwtBuilder.setExpiration(new Date(now + tokenTTL));
+            defaultJwtBuilder.signWith(privateKey);
+            return defaultJwtBuilder.compact();
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenOauth2AuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenOauth2AuthenticatedProducerConsumerTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pulsar.client.api;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenOauth2AuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenOauth2AuthenticatedProducerConsumerTest.java
@@ -18,38 +18,22 @@
  */
 package org.apache.pulsar.client.api;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.common.FileSource;
-import com.github.tomakehurst.wiremock.extension.Parameters;
-import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
-import com.github.tomakehurst.wiremock.http.Request;
-import com.github.tomakehurst.wiremock.http.Response;
 import com.google.common.collect.Sets;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.impl.DefaultJwtBuilder;
-import io.jsonwebtoken.security.Keys;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.KeyPair;
-import java.security.PrivateKey;
 import java.time.Duration;
-import java.util.Base64;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.broker.auth.MockOIDCIdentityProvider;
 import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.impl.ProducerImpl;
@@ -74,54 +58,25 @@ import org.testng.annotations.Test;
 public class TokenOauth2AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(TokenOauth2AuthenticatedProducerConsumerTest.class);
 
-    private WireMockServer server;
-
-    private final String ADMIN_ROLE = "Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x@clients";
+    private MockOIDCIdentityProvider server;
 
     // Credentials File, which contains "client_id" and "client_secret"
     private final String CREDENTIALS_FILE = "./src/test/resources/authentication/token/credentials_file.json";
-    private final String AUDIENCE = "https://dev-kt-aa9ne.us.auth0.com/api/v2/";
+    private final String audience = "my-pulsar-cluster";
 
     @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
-        // Create the token key pair
-        KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.RS256);
-
-        // Start mocked OAuth2 server
-        server = new WireMockServer(wireMockConfig().port(0).extensions(new OAuth2Transformer(keyPair, 3000)));
-        server.start();
-
-        // Set up a correct openid-configuration that points to the next stub
-        server.stubFor(
-                get(urlEqualTo("/.well-known/openid-configuration"))
-                        .willReturn(aResponse()
-                                .withHeader("Content-Type", "application/json")
-                                .withBody("""
-                                        {
-                                          "issuer": "%s",
-                                          "token_endpoint": "%s/oauth/token"
-                                        }
-                                        """.replace("%s", server.baseUrl()))));
-
-        // Only respond when the client sends the expected request body
-        server.stubFor(
-                post(urlEqualTo("/oauth/token"))
-                        .withRequestBody(
-                                equalTo("audience=https%3A%2F%2Fdev-kt-aa9ne.us.auth0.com%2Fapi%2Fv2%2F&"
-                                        + "client_id=Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x&"
-                                        + "client_secret=rT7ps7WY8uhdVuBTKWZkttwLdQotmdEliaM5rLfmgNibvqziZ-g07ZH52N"
-                                        + "_poGAb&grant_type=client_credentials"))
-                        .willReturn(aResponse()
-                                .withTransformers("o-auth-token-transformer")
-                                .withStatus(200)));
+        String clientSecret = "super-secret-client-secret";
+        server = new MockOIDCIdentityProvider(clientSecret, audience, 3000);
 
         conf.setAuthenticationEnabled(true);
         conf.setAuthorizationEnabled(true);
         conf.setAuthenticationRefreshCheckSeconds(1);
 
         Set<String> superUserRoles = new HashSet<>();
-        superUserRoles.add(ADMIN_ROLE);
+        // Matches the role in th credentials file
+        superUserRoles.add("my-admin-role");
         conf.setSuperUserRoles(superUserRoles);
 
         Set<String> providers = new HashSet<>();
@@ -131,16 +86,15 @@ public class TokenOauth2AuthenticatedProducerConsumerTest extends ProducerConsum
         conf.setBrokerClientAuthenticationPlugin(AuthenticationOAuth2.class.getName());
         conf.setBrokerClientAuthenticationParameters("{\n"
                 + "  \"privateKey\": \"" + CREDENTIALS_FILE + "\",\n"
-                + "  \"issuerUrl\": \"" + server.baseUrl() + "\",\n"
-                + "  \"audience\": \"" + AUDIENCE + "\",\n"
+                + "  \"issuerUrl\": \"" + server.getIssuer() + "\",\n"
+                + "  \"audience\": \"" + audience + "\",\n"
                 + "}\n");
 
         conf.setClusterName("test");
 
         // Set provider domain name
         Properties properties = new Properties();
-        properties.setProperty("tokenPublicKey", "data:;base64,"
-                + Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
+        properties.setProperty("tokenPublicKey", "data:;base64," + server.getBase64EncodedPublicKey());
 
         conf.setProperties(properties);
         super.init();
@@ -153,9 +107,9 @@ public class TokenOauth2AuthenticatedProducerConsumerTest extends ProducerConsum
 
         // AuthenticationOAuth2
         Authentication authentication = AuthenticationFactoryOAuth2.clientCredentials(
-                new URL(server.baseUrl()),
+                new URL(server.getIssuer()),
                 path.toUri().toURL(),  // key file path
-                AUDIENCE
+                audience
         );
 
         admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString())
@@ -291,53 +245,5 @@ public class TokenOauth2AuthenticatedProducerConsumerTest extends ProducerConsum
         // Acknowledge the consumption of all messages at once
         consumer.acknowledgeCumulative(msg);
         consumer.close();
-    }
-
-    class OAuth2Transformer extends ResponseTransformer {
-
-        private final PrivateKey privateKey;
-        private final long tokenTTL;
-
-        OAuth2Transformer(KeyPair key, long tokenTTLMillis) {
-            this.privateKey = key.getPrivate();
-            this.tokenTTL = tokenTTLMillis;
-        }
-
-        @Override
-        public Response transform(Request request, Response response, FileSource files, Parameters parameters) {
-            return Response.Builder.like(response).but().body("""
-                                                              {
-                                                                "access_token": "%s",
-                                                                "expires_in": %d,
-                                                                "token_type":"Bearer"
-                                                              }
-                                                              """.formatted(generateToken(),
-                    TimeUnit.MILLISECONDS.toSeconds(tokenTTL))).build();
-        }
-
-        @Override
-        public String getName() {
-            return "o-auth-token-transformer";
-        }
-
-        @Override
-        public boolean applyGlobally() {
-            return false;
-        }
-
-        private String generateToken() {
-            long now = System.currentTimeMillis();
-            DefaultJwtBuilder defaultJwtBuilder = new DefaultJwtBuilder();
-            defaultJwtBuilder.setHeaderParam("typ", "JWT");
-            defaultJwtBuilder.setHeaderParam("alg", "RS256");
-            defaultJwtBuilder.setIssuer(server.baseUrl());
-            defaultJwtBuilder.setSubject(ADMIN_ROLE);
-            defaultJwtBuilder.setAudience(AUDIENCE);
-            defaultJwtBuilder.setIssuedAt(new Date(now));
-            defaultJwtBuilder.setNotBefore(new Date(now));
-            defaultJwtBuilder.setExpiration(new Date(now + tokenTTL));
-            defaultJwtBuilder.signWith(privateKey);
-            return defaultJwtBuilder.compact();
-        }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenOauth2AuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenOauth2AuthenticatedProducerConsumerTest.java
@@ -42,7 +42,9 @@ import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -62,12 +64,15 @@ public class TokenOauth2AuthenticatedProducerConsumerTest extends ProducerConsum
     private final String CREDENTIALS_FILE = "./src/test/resources/authentication/token/credentials_file.json";
     private final String audience = "my-pulsar-cluster";
 
+    @BeforeClass(alwaysRun = true)
+    protected void setupClass() {
+        String clientSecret = "super-secret-client-secret";
+        server = new MockOIDCIdentityProvider(clientSecret, audience, 3000);
+    }
+
     @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
-        String clientSecret = "super-secret-client-secret";
-        server = new MockOIDCIdentityProvider(clientSecret, audience, 3000);
-
         conf.setAuthenticationEnabled(true);
         conf.setAuthorizationEnabled(true);
         conf.setAuthenticationRefreshCheckSeconds(1);
@@ -123,6 +128,10 @@ public class TokenOauth2AuthenticatedProducerConsumerTest extends ProducerConsum
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    protected void cleanupAfterClass() {
         server.stop();
     }
 

--- a/pulsar-broker/src/test/resources/authentication/token/credentials_file.json
+++ b/pulsar-broker/src/test/resources/authentication/token/credentials_file.json
@@ -1,4 +1,4 @@
 {
-  "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",
-  "client_secret":"rT7ps7WY8uhdVuBTKWZkttwLdQotmdEliaM5rLfmgNibvqziZ-g07ZH52N_poGAb"
+  "client_id":"my-admin-role",
+  "client_secret":"super-secret-client-secret"
 }

--- a/pulsar-proxy/pom.xml
+++ b/pulsar-proxy/pom.xml
@@ -185,6 +185,12 @@
       <artifactId>testcontainers</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-jre8</artifactId>
+      <version>${wiremock.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsTestWithAuth.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsTestWithAuth.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.util.Optional;
 
+import org.apache.pulsar.broker.auth.MockOIDCIdentityProvider;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
@@ -38,17 +39,22 @@ public class ProxyTlsTestWithAuth extends MockedPulsarServiceBaseTest {
     private ProxyService proxyService;
     private ProxyConfiguration proxyConfig = new ProxyConfiguration();
 
+    private MockOIDCIdentityProvider server;
+
     @Override
     @BeforeClass
     protected void setup() throws Exception {
         internalSetup();
+        String clientSecret = "super-secret-client-secret";
+        server = new MockOIDCIdentityProvider(clientSecret, "an-audience", 3000);
+
 
         File tempFile = File.createTempFile("oauth2", ".tmp");
         tempFile.deleteOnExit();
         FileWriter writer = new FileWriter(tempFile);
         writer.write("{\n" +
-            "  \"client_id\":\"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x\",\n" +
-            "  \"client_secret\":\"rT7ps7WY8uhdVuBTKWZkttwLdQotmdEliaM5rLfmgNibvqziZ-g07ZH52N_poGAb\"\n" +
+            "  \"client_id\":\"my-user\",\n" +
+            "  \"client_secret\":\"" + clientSecret + "\"\n" +
             "}");
         writer.flush();
         writer.close();
@@ -65,8 +71,8 @@ public class ProxyTlsTestWithAuth extends MockedPulsarServiceBaseTest {
         proxyConfig.setConfigurationMetadataStoreUrl(GLOBAL_DUMMY_VALUE);
         proxyConfig.setBrokerClientAuthenticationPlugin("org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2");
         proxyConfig.setBrokerClientAuthenticationParameters("{\"grant_type\":\"client_credentials\"," +
-            " \"issuerUrl\":\"https://dev-kt-aa9ne.us.auth0.com\"," +
-            " \"audience\": \"https://dev-kt-aa9ne.us.auth0.com/api/v2/\"," +
+            " \"issuerUrl\":\"" + server.getIssuer() + "\"," +
+            " \"audience\": \"an-audience\"," +
             " \"privateKey\":\"file://" + tempFile.getAbsolutePath() + "\"}");
 
         proxyService = Mockito.spy(new ProxyService(proxyConfig, new AuthenticationService(

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsTestWithAuth.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsTestWithAuth.java
@@ -48,7 +48,6 @@ public class ProxyTlsTestWithAuth extends MockedPulsarServiceBaseTest {
         String clientSecret = "super-secret-client-secret";
         server = new MockOIDCIdentityProvider(clientSecret, "an-audience", 3000);
 
-
         File tempFile = File.createTempFile("oauth2", ".tmp");
         tempFile.deleteOnExit();
         FileWriter writer = new FileWriter(tempFile);
@@ -87,8 +86,8 @@ public class ProxyTlsTestWithAuth extends MockedPulsarServiceBaseTest {
     @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
         internalCleanup();
-
         proxyService.close();
+        server.stop();
     }
 
     @Test

--- a/pulsar-testclient/pom.xml
+++ b/pulsar-testclient/pom.xml
@@ -112,6 +112,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
+			<version>${wiremock.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 
 	</dependencies>
 

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/Oauth2PerformanceTransactionTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/Oauth2PerformanceTransactionTest.java
@@ -43,7 +43,6 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
-import org.apache.pulsar.client.api.TokenOauth2AuthenticatedProducerConsumerTest;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
@@ -62,7 +61,7 @@ public class Oauth2PerformanceTransactionTest extends ProducerConsumerBase {
     private final String testNamespace = "perf";
     private final String myNamespace = testTenant + "/" + testNamespace;
     private final String testTopic = "persistent://" + myNamespace + "/test-";
-    private static final Logger log = LoggerFactory.getLogger(TokenOauth2AuthenticatedProducerConsumerTest.class);
+    private static final Logger log = LoggerFactory.getLogger(Oauth2PerformanceTransactionTest.class);
 
     // Credentials File, which contains "client_id" and "client_secret"
     private final String CREDENTIALS_FILE = "./src/test/resources/authentication/token/credentials_file.json";

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/Oauth2PerformanceTransactionTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/Oauth2PerformanceTransactionTest.java
@@ -120,6 +120,7 @@ public class Oauth2PerformanceTransactionTest extends ProducerConsumerBase {
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
+        server.stop();
     }
 
     // setup both admin and pulsar client

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/Oauth2PerformanceTransactionTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/Oauth2PerformanceTransactionTest.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.broker.auth.MockOIDCIdentityProvider;
 import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.Consumer;
@@ -63,30 +64,23 @@ public class Oauth2PerformanceTransactionTest extends ProducerConsumerBase {
     private final String testTopic = "persistent://" + myNamespace + "/test-";
     private static final Logger log = LoggerFactory.getLogger(TokenOauth2AuthenticatedProducerConsumerTest.class);
 
-    // public key in oauth2 server to verify the client passed in token. get from https://jwt.io/
-    private final String TOKEN_TEST_PUBLIC_KEY = "data:;base64,MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2tZd/"
-            + "4gJda3U2Pc3tpgRAN7JPGWx/Gn17v/0IiZlNNRbP/Mmf0Vc6G1qsnaRaWNWOR+t6/a6ekFHJMikQ1N2X6yfz4UjMc8/G2FDPRm"
-            + "WjA+GURzARjVhxc/BBEYGoD0Kwvbq/u9CZm2QjlKrYaLfg3AeB09j0btNrDJ8rBsNzU6AuzChRvXj9IdcE/A/4N/UQ+S9cJ4UXP6"
-            + "NJbToLwajQ5km+CnxdGE6nfB7LWHvOFHjn9C2Rb9e37CFlmeKmIVFkagFM0gbmGOb6bnGI8Bp/VNGV0APef4YaBvBTqwoZ1Z4aDH"
-            + "y5eRxXfAMdtBkBupmBXqL6bpd15XRYUbu/7ck9QIDAQAB";
-
-    private final String ADMIN_ROLE = "Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x@clients";
-
     // Credentials File, which contains "client_id" and "client_secret"
     private final String CREDENTIALS_FILE = "./src/test/resources/authentication/token/credentials_file.json";
 
     private final String authenticationPlugin = "org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2";
 
+    private MockOIDCIdentityProvider server;
     private String authenticationParameters;
 
     @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
+        server = new MockOIDCIdentityProvider("a-client-secret", "my-test-audience", 30000);
         Path path = Paths.get(CREDENTIALS_FILE).toAbsolutePath();
         HashMap<String, Object> params = new HashMap<>();
-        params.put("issuerUrl", new URL("https://dev-kt-aa9ne.us.auth0.com"));
+        params.put("issuerUrl", server.getIssuer());
         params.put("privateKey", path.toUri().toURL());
-        params.put("audience", "https://dev-kt-aa9ne.us.auth0.com/api/v2/");
+        params.put("audience", "my-test-audience");
         ObjectMapper jsonMapper = ObjectMapperFactory.create();
         authenticationParameters = jsonMapper.writeValueAsString(params);
 
@@ -96,7 +90,7 @@ public class Oauth2PerformanceTransactionTest extends ProducerConsumerBase {
         conf.setAuthenticationRefreshCheckSeconds(5);
 
         Set<String> superUserRoles = new HashSet<>();
-        superUserRoles.add(ADMIN_ROLE);
+        superUserRoles.add("superuser");
         conf.setSuperUserRoles(superUserRoles);
 
         Set<String> providers = new HashSet<>();
@@ -107,7 +101,7 @@ public class Oauth2PerformanceTransactionTest extends ProducerConsumerBase {
 
         // Set provider domain name
         Properties properties = new Properties();
-        properties.setProperty("tokenPublicKey", TOKEN_TEST_PUBLIC_KEY);
+        properties.setProperty("tokenPublicKey", server.getBase64EncodedPublicKey());
 
         conf.setProperties(properties);
 

--- a/pulsar-testclient/src/test/resources/authentication/token/credentials_file.json
+++ b/pulsar-testclient/src/test/resources/authentication/token/credentials_file.json
@@ -1,5 +1,5 @@
 {
   "type": "client_credentials",
-  "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",
-  "client_secret":"rT7ps7WY8uhdVuBTKWZkttwLdQotmdEliaM5rLfmgNibvqziZ-g07ZH52N_poGAb"
+  "client_id":"superuser",
+  "client_secret":"a-client-secret"
 }


### PR DESCRIPTION
Fixes #20473 

### Motivation

Our tests should be independent of external services like Auth0. We can use `WireMock` to create a server that responds to all OAuth2 requests. This PR removes calls to Auth0.com and replaces them with calls to a wiremock server.

### Modifications

* Add a generic class to create an OIDC/OAuth2 wiremock server that can be used to get tokens.

### Verifying this change

Tests are modified and still pass.

### Documentation

- [x] `doc-not-needed`
