### PR TITLE
[improve][broker] PIP-275:Introduce topicOrderedExecutorThreadNum to deprecate numWorkerThreadsForNonPersistentTopic

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -474,8 +474,8 @@ maxConcurrentTopicLoadRequest=5000
 # Max concurrent non-persistent message can be processed per connection
 maxConcurrentNonPersistentMessagePerConnection=1000
 
-# Number of worker threads to serve non-persistent topic
-numWorkerThreadsForNonPersistentTopic=
+# Number of worker threads to serve topic ordered executor
+topicOrderedExecutorThreadNum=
 
 # Enable broker to load persistent topics
 enablePersistentTopics=true
@@ -1816,3 +1816,7 @@ persistentUnackedRangesWithMultipleEntriesEnabled=false
 
 # Deprecated - Use managedLedgerCacheEvictionIntervalMs instead
 managedLedgerCacheEvictionFrequency=0
+
+# Number of worker threads to serve non-persistent topic
+# Deprecated - use topicOrderedExecutorThreadNum instead.
+numWorkerThreadsForNonPersistentTopic=

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -281,8 +281,8 @@ maxConcurrentTopicLoadRequest=5000
 # Max concurrent non-persistent message can be processed per connection
 maxConcurrentNonPersistentMessagePerConnection=1000
 
-# Number of worker threads to serve non-persistent topic
-numWorkerThreadsForNonPersistentTopic=8
+# Number of worker threads to serve topic ordered executor
+topicOrderedExecutorThreadNum=8
 
 # Enable broker to load persistent topics
 enablePersistentTopics=true
@@ -1200,6 +1200,10 @@ functionsWorkerEnablePackageManagement=false
 ### --- Deprecated settings --- ###
 
 # These settings are left here for compatibility
+
+# Number of worker threads to serve non-persistent topic
+# Deprecated - use topicOrderedExecutorThreadNum instead.
+numWorkerThreadsForNonPersistentTopic=8
 
 # Zookeeper session timeout in milliseconds
 # Deprecated: use metadataStoreSessionTimeoutMillis

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -332,8 +332,8 @@ maxConcurrentTopicLoadRequest=5000
 # Max concurrent non-persistent message can be processed per connection
 maxConcurrentNonPersistentMessagePerConnection=1000
 
-# Number of worker threads to serve non-persistent topic
-numWorkerThreadsForNonPersistentTopic=8
+# Number of worker threads to serve topic ordered executor
+topicOrderedExecutorThreadNum=8
 
 # Enable broker to load persistent topics
 enablePersistentTopics=true
@@ -1126,6 +1126,10 @@ fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
 fileSystemURI=
 
 ### --- Deprecated config variables --- ###
+
+# Number of worker threads to serve non-persistent topic
+# Deprecated - use topicOrderedExecutorThreadNum instead.
+numWorkerThreadsForNonPersistentTopic=8
 
 # Deprecated. Use configurationStoreServers
 globalZookeeperServers={{ zookeeper_servers }}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1199,8 +1199,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int numWorkerThreadsForNonPersistentTopic = -1;
     @FieldContext(
             category = CATEGORY_SERVER,
-            doc = "Number of worker threads to serve persistent topic")
-    private int numWorkerThreadsForPersistentTopic = Runtime.getRuntime().availableProcessors();
+            doc = "Number of worker threads to serve topic ordered executor")
+    private int numWorkersTopicOrderedExecutor = Runtime.getRuntime().availableProcessors();
 
     @FieldContext(
         category = CATEGORY_SERVER,
@@ -3482,8 +3482,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
                 : Math.min(MAX_ML_CACHE_EVICTION_INTERVAL_MS, managedLedgerCacheEvictionIntervalMs);
     }
 
-    public int getNumWorkerThreadsForPersistentTopic() {
+    public int getNumWorkersTopicOrderedExecutor() {
         return numWorkerThreadsForNonPersistentTopic > 0
-                ? numWorkerThreadsForNonPersistentTopic : numWorkerThreadsForPersistentTopic;
+                ? numWorkerThreadsForNonPersistentTopic : numWorkersTopicOrderedExecutor;
     }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1190,10 +1190,17 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_SERVER,
         doc = "Max concurrent non-persistent message can be processed per connection")
     private int maxConcurrentNonPersistentMessagePerConnection = 1000;
+    @Deprecated
     @FieldContext(
         category = CATEGORY_SERVER,
-        doc = "Number of worker threads to serve non-persistent topic")
-    private int numWorkerThreadsForNonPersistentTopic = Runtime.getRuntime().availableProcessors();
+        deprecated = true,
+        doc = "Number of worker threads to serve non-persistent topic.\n"
+                + "@deprecated - use numWorkerThreadsForPersistentTopic instead.")
+    private int numWorkerThreadsForNonPersistentTopic = -1;
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Number of worker threads to serve persistent topic")
+    private int numWorkerThreadsForPersistentTopic = Runtime.getRuntime().availableProcessors();
 
     @FieldContext(
         category = CATEGORY_SERVER,
@@ -3473,5 +3480,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
                         Math.min(managedLedgerCacheEvictionFrequency, MAX_ML_CACHE_EVICTION_FREQUENCY),
                                    MIN_ML_CACHE_EVICTION_FREQUENCY))
                 : Math.min(MAX_ML_CACHE_EVICTION_INTERVAL_MS, managedLedgerCacheEvictionIntervalMs);
+    }
+
+    public int getNumWorkerThreadsForPersistentTopic() {
+        return numWorkerThreadsForNonPersistentTopic > 0
+                ? numWorkerThreadsForNonPersistentTopic : numWorkerThreadsForPersistentTopic;
     }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1190,6 +1190,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_SERVER,
         doc = "Max concurrent non-persistent message can be processed per connection")
     private int maxConcurrentNonPersistentMessagePerConnection = 1000;
+
     @Deprecated
     @FieldContext(
         category = CATEGORY_SERVER,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1200,7 +1200,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
             category = CATEGORY_SERVER,
             doc = "Number of worker threads to serve topic ordered executor")
-    private int numWorkersTopicOrderedExecutor = Runtime.getRuntime().availableProcessors();
+    private int topicOrderedExecutorThreadNum = Runtime.getRuntime().availableProcessors();
 
     @FieldContext(
         category = CATEGORY_SERVER,
@@ -3482,8 +3482,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
                 : Math.min(MAX_ML_CACHE_EVICTION_INTERVAL_MS, managedLedgerCacheEvictionIntervalMs);
     }
 
-    public int getNumWorkersTopicOrderedExecutor() {
+    public int getTopicOrderedExecutorThreadNum() {
         return numWorkerThreadsForNonPersistentTopic > 0
-                ? numWorkerThreadsForNonPersistentTopic : numWorkersTopicOrderedExecutor;
+                ? numWorkerThreadsForNonPersistentTopic : topicOrderedExecutorThreadNum;
     }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1195,7 +1195,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_SERVER,
         deprecated = true,
         doc = "Number of worker threads to serve non-persistent topic.\n"
-                + "@deprecated - use numWorkerThreadsForPersistentTopic instead.")
+                + "@deprecated - use topicOrderedExecutorThreadNum instead.")
     private int numWorkerThreadsForNonPersistentTopic = -1;
     @FieldContext(
             category = CATEGORY_SERVER,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -316,7 +316,7 @@ public class BrokerService implements Closeable {
                         PersistentOfflineTopicStats>newBuilder().build();
 
         this.topicOrderedExecutor = OrderedExecutor.newBuilder()
-                .numThreads(pulsar.getConfiguration().getNumWorkerThreadsForPersistentTopic())
+                .numThreads(pulsar.getConfiguration().getNumWorkersTopicOrderedExecutor())
                 .name("broker-topic-workers").build();
         final DefaultThreadFactory acceptorThreadFactory =
                 new ExecutorProvider.ExtendedThreadFactory("pulsar-acceptor");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -316,7 +316,7 @@ public class BrokerService implements Closeable {
                         PersistentOfflineTopicStats>newBuilder().build();
 
         this.topicOrderedExecutor = OrderedExecutor.newBuilder()
-                .numThreads(pulsar.getConfiguration().getNumWorkerThreadsForNonPersistentTopic())
+                .numThreads(pulsar.getConfiguration().getNumWorkerThreadsForPersistentTopic())
                 .name("broker-topic-workers").build();
         final DefaultThreadFactory acceptorThreadFactory =
                 new ExecutorProvider.ExtendedThreadFactory("pulsar-acceptor");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -316,7 +316,7 @@ public class BrokerService implements Closeable {
                         PersistentOfflineTopicStats>newBuilder().build();
 
         this.topicOrderedExecutor = OrderedExecutor.newBuilder()
-                .numThreads(pulsar.getConfiguration().getNumWorkersTopicOrderedExecutor())
+                .numThreads(pulsar.getConfiguration().getTopicOrderedExecutorThreadNum())
                 .name("broker-topic-workers").build();
         final DefaultThreadFactory acceptorThreadFactory =
                 new ExecutorProvider.ExtendedThreadFactory("pulsar-acceptor");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/EmbeddedPulsarCluster.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/EmbeddedPulsarCluster.java
@@ -112,7 +112,7 @@ public class EmbeddedPulsarCluster implements AutoCloseable {
         conf.setWebServicePort(Optional.of(0));
         conf.setNumExecutorThreadPoolSize(1);
         conf.setNumCacheExecutorThreadPoolSize(1);
-        conf.setNumWorkerThreadsForNonPersistentTopic(1);
+        conf.setTopicOrderedExecutorThreadNum(1);
         conf.setNumIOThreads(1);
         conf.setNumOrderedExecutorThreads(1);
         conf.setBookkeeperClientNumWorkerThreads(1);


### PR DESCRIPTION
PIP: https://github.com/apache/pulsar/pull/20507

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

See https://github.com/apache/pulsar/pull/20507

### Modifications

Introduce `topicOrderedExecutorThreadNum ` to deprecate `numWorkerThreadsForNonPersistentTopic`


### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/AnonHxy/pulsar/pull/41
