### PR TITLE
[pip][design] PIP-275: Introduce topicOrderedExecutorThreadNum to deprecate numWorkerThreadsForNonPersistentTopic in configuration

### DIFF
--- a/pip/pip-275.md
+++ b/pip/pip-275.md
@@ -1,59 +1,44 @@
-<!--
-RULES
-* Never place a link to an external site like Google Doc. The proposal should be in this issue entirely.
-* Use a spelling and grammar checker tools if available for you (there are plenty of free ones).
-
-PROPOSAL HEALTH CHECK
-I can read the design document and understand the problem statement and what you plan to change *without* resorting to a couple of hours of code reading just to start having a high level understanding of the change.
-
-THIS COMMENTS
-Please remove them when done.
--->
-
 # Background knowledge
-
-<!--
-Describes all the knowledge you need to know in order to understand all the other sections in this PIP
-
-* Give a high level explanation on all concepts you will be using throughout this document. For example, if you want to talk about Persistent Subscriptions, explain briefly (1 paragraph) what this is. If you're going to talk about Transaction Buffer, explain briefly what this is. 
-  If you're going to change something specific, then go into more detail about it and how it works. 
-* Provide links where possible if a person wants to dig deeper into the background information. 
-
-DON'T
-* Do not include links *instead* explanation. Do provide links for further explanation.
-
-EXAMPLES
-* See [PIP-248](https://github.com/apache/pulsar/issues/19601), Background section to get an understanding on how you add the background knowledge needed.
-  (They also included the motivation there, but ignore it as we place that in Motivation section explicitly).
--->
+As we can see from the doc[0] that `numWorkerThreadsForNonPersistentTopic` is a configuration to specify the number of worker threads to serve non-persistent topic.
+Actually, `numWorkerThreadsForNonPersistentTopic` will specify the thread number of `BrokerService#topicOrderedExecutor`. Initially it was meant only for non-persistent topics,
+but now it is used for anything that needs to be done under strict order for a topic, like processing Subscriptions even for a persistent topic:
+* There is only one place invoke `topicOrderedExecutor` for non-persistent topics.[1]
+* Other places will invoke `topicOrderedExecutor` for persistent-topic or persistent-dispatcher. [2][3][4][5]
 
 # Motivation
-
-Introduce `numWorkerThreadsForPersistentTopic` to deprecate `numWorkerThreadsForNonPersistentTopic`.
-
-As we see from the following, the `numWorkerThreadsForNonPersistentTopic` is used to specify for PersistentTopic, not NonPersistentTopic. So I propose change the config item from `numWorkerThreadsForNonPersistentTopic` to `numWorkerThreadsForPersistentTopic`:
-
-<img width="1128" alt="image" src="https://github.com/apache/pulsar/assets/10233437/5c6ed147-e8c1-4c08-b3cf-6886e9b99c8f">
-
--->
+Introduce `numWorkersTopicOrderedExecutor` to deprecate `numWorkerThreadsForNonPersistentTopic`. Because`numWorkersTopicOrderedExecutor` is a more accurate name 
 
 ### Configuration
-
-Introduce `numWorkerThreadsForPersistentTopic` to deprecate `numWorkerThreadsForNonPersistentTopic`
-
-# Backward & Forward Compatibility
-* Change `numWorkerThreadsForNonPersistentTopic` default values as `-1`
-* Introduce new config `numWorkerThreadsForPersistentTopic` with default value `Runtime.getRuntime().availableProcessors()`
-* All places invoke `getNumWorkerThreadsForNonPersistentTopic()` will be repleace by `getNumWorkerThreadsForPersistentTopic()`
-* So if user doesn't set the `numWorkerThreadsForNonPersistentTopic`, the value of worker threads will keep `Runtime.getRuntime().availableProcessors()`
-* If user set the `numWorkerThreadsForNonPersistentTopic` before, the value will keep what user set before.
+* Introduce `numWorkersTopicOrderedExecutor`:
+```
+private int numWorkersTopicOrderedExecutor = Runtime.getRuntime().availableProcessors();
+```
+* deprecate `numWorkerThreadsForNonPersistentTopic` and change it's default value to `-1`:
 ```
 private int numWorkerThreadsForNonPersistentTopic = -1;
-private int numWorkerThreadsForPersistentTopic = Runtime.getRuntime().availableProcessors();
-
-public int getNumWorkerThreadsForPersistentTopic() {
-        return numWorkerThreadsForNonPersistentTopic > 0
-                ? numWorkerThreadsForNonPersistentTopic : numWorkerThreadsForPersistentTopic;
-    }
 ```
 
+# Backward & Forward Compatibility
+
+* Add method `ServiceConfiguration#getNumWorkersTopicOrderedExecutor()`:
+```
+public int getNumWorkersTopicOrderedExecutor() {
+        return numWorkerThreadsForNonPersistentTopic > 0
+                ? numWorkerThreadsForNonPersistentTopic : numWorkersTopicOrderedExecutor;
+    }
+```
+* if user doesn't set the `numWorkerThreadsForNonPersistentTopic`, the value of worker threads will keep `Runtime.getRuntime().availableProcessors()`
+* If user has set the `numWorkerThreadsForNonPersistentTopic`, the value will keep what user set before.
+
+
+# Links
+* [0] https://github.com/apache/pulsar/blob/ac46e2e4fc48dff74233623afa3635ef5285e34d/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java#LL1194C16-L1194C72
+* [1] https://github.com/apache/pulsar/blob/50b9a93e42e412d9f17b1637287d1a4c7c7ab148/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java#L1705-L1709
+* [2] https://github.com/apache/pulsar/blob/50b9a93e42e412d9f17b1637287d1a4c7c7ab148/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java#L134-L142
+* [3] https://github.com/apache/pulsar/blob/50b9a93e42e412d9f17b1637287d1a4c7c7ab148/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java#L279-L281
+* [4] https://github.com/apache/pulsar/blob/50b9a93e42e412d9f17b1637287d1a4c7c7ab148/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java#L77-L83
+* [5] https://github.com/apache/pulsar/blob/50b9a93e42e412d9f17b1637287d1a4c7c7ab148/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java#L392-L396
+
+
+* Mailing List discussion thread: https://lists.apache.org/thread/hx8v824v5wdoz3kn44s4t9pzgfnqkt1o
+* Mailing List voting thread:

--- a/pip/pip-275.md
+++ b/pip/pip-275.md
@@ -45,4 +45,4 @@ Because we have overwritten method `getTopicOrderedExecutorThreadNum()` from lom
 
 # Links
 * Mailing List discussion thread: https://lists.apache.org/thread/hx8v824v5wdoz3kn44s4t9pzgfnqkt1o
-* Mailing List voting thread:
+* Mailing List voting thread: https://lists.apache.org/thread/ywk6z440qt0vs32210799m508gbxfshm

--- a/pip/pip-275.md
+++ b/pip/pip-275.md
@@ -1,44 +1,48 @@
 # Background knowledge
-As we can see from the doc[0] that `numWorkerThreadsForNonPersistentTopic` is a configuration to specify the number of worker threads to serve non-persistent topic.
+As we can see from the [doc](https://github.com/apache/pulsar/blob/ac46e2e4fc48dff74233623afa3635ef5285e34d/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java#LL1194C16-L1194C72) that `numWorkerThreadsForNonPersistentTopic` is a configuration to specify the number of worker threads to serve non-persistent topic.
 Actually, `numWorkerThreadsForNonPersistentTopic` will specify the thread number of `BrokerService#topicOrderedExecutor`. Initially it was meant only for non-persistent topics,
 but now it is used for anything that needs to be done under strict order for a topic, like processing Subscriptions even for a persistent topic:
-* There is only one place invoke `topicOrderedExecutor` for non-persistent topics.[1]
-* Other places will invoke `topicOrderedExecutor` for persistent-topic or persistent-dispatcher. [2][3][4][5]
+* There is only one place invoke `topicOrderedExecutor` for non-persistent topics.[[1]](https://github.com/apache/pulsar/blob/50b9a93e42e412d9f17b1637287d1a4c7c7ab148/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java#L1706)
+* Other places will invoke `topicOrderedExecutor` for persistent-topic or persistent-dispatcher. [[2]](https://github.com/apache/pulsar/blob/50b9a93e42e412d9f17b1637287d1a4c7c7ab148/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java#L141) [[3]](https://github.com/apache/pulsar/blob/50b9a93e42e412d9f17b1637287d1a4c7c7ab148/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java#L279) [[4]](https://github.com/apache/pulsar/blob/50b9a93e42e412d9f17b1637287d1a4c7c7ab148/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java#L82) [[5]](https://github.com/apache/pulsar/blob/50b9a93e42e412d9f17b1637287d1a4c7c7ab148/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java#L395)
 
 # Motivation
-Introduce `numWorkersTopicOrderedExecutor` to deprecate `numWorkerThreadsForNonPersistentTopic`. Because`numWorkersTopicOrderedExecutor` is a more accurate name 
+
+Making this config has a better name and increase the ability of users to understand what they are configuring.
+
+# High Level Design
+
+Introduce `topicOrderedExecutorThreadNum` to deprecate `numWorkerThreadsForNonPersistentTopic`.
+
+# Detailed Design
+
+## Design & Implementation Details
 
 ### Configuration
-* Introduce `numWorkersTopicOrderedExecutor`:
+
+* Introduce `topicOrderedExecutorThreadNum` with default value `Runtime.getRuntime().availableProcessors()`:
 ```
-private int numWorkersTopicOrderedExecutor = Runtime.getRuntime().availableProcessors();
+private int topicOrderedExecutorThreadNum = Runtime.getRuntime().availableProcessors();
 ```
-* deprecate `numWorkerThreadsForNonPersistentTopic` and change it's default value to `-1`:
+* deprecate `numWorkerThreadsForNonPersistentTopic` and change it's default value from `Runtime.getRuntime().availableProcessors()` to `-1`:
 ```
 private int numWorkerThreadsForNonPersistentTopic = -1;
 ```
-
-# Backward & Forward Compatibility
-
-* Add method `ServiceConfiguration#getNumWorkersTopicOrderedExecutor()`:
+* Overwrite method `ServiceConfiguration#getTopicOrderedExecutorThreadNum()` from lombok.
 ```
-public int getNumWorkersTopicOrderedExecutor() {
+public int getTopicOrderedExecutorThreadNum() {
         return numWorkerThreadsForNonPersistentTopic > 0
-                ? numWorkerThreadsForNonPersistentTopic : numWorkersTopicOrderedExecutor;
+                ? numWorkerThreadsForNonPersistentTopic : topicOrderedExecutorThreadNum;
     }
 ```
+
+*  And all places calling `ServiceConfiguration#getNumWorkerThreadsForNonPersistentTopic()` will call `ServiceConfiguration#getTopicOrderedExecutorThreadNum()` instead.
+
+# Backward & Forward Compatibility
+Because we have overwritten method `getTopicOrderedExecutorThreadNum()` from lombok, so:
 * if user doesn't set the `numWorkerThreadsForNonPersistentTopic`, the value of worker threads will keep `Runtime.getRuntime().availableProcessors()`
 * If user has set the `numWorkerThreadsForNonPersistentTopic`, the value will keep what user set before.
 
 
 # Links
-* [0] https://github.com/apache/pulsar/blob/ac46e2e4fc48dff74233623afa3635ef5285e34d/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java#LL1194C16-L1194C72
-* [1] https://github.com/apache/pulsar/blob/50b9a93e42e412d9f17b1637287d1a4c7c7ab148/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java#L1705-L1709
-* [2] https://github.com/apache/pulsar/blob/50b9a93e42e412d9f17b1637287d1a4c7c7ab148/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java#L134-L142
-* [3] https://github.com/apache/pulsar/blob/50b9a93e42e412d9f17b1637287d1a4c7c7ab148/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java#L279-L281
-* [4] https://github.com/apache/pulsar/blob/50b9a93e42e412d9f17b1637287d1a4c7c7ab148/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java#L77-L83
-* [5] https://github.com/apache/pulsar/blob/50b9a93e42e412d9f17b1637287d1a4c7c7ab148/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java#L392-L396
-
-
 * Mailing List discussion thread: https://lists.apache.org/thread/hx8v824v5wdoz3kn44s4t9pzgfnqkt1o
 * Mailing List voting thread:

--- a/pip/pip-275.md
+++ b/pip/pip-275.md
@@ -1,0 +1,59 @@
+<!--
+RULES
+* Never place a link to an external site like Google Doc. The proposal should be in this issue entirely.
+* Use a spelling and grammar checker tools if available for you (there are plenty of free ones).
+
+PROPOSAL HEALTH CHECK
+I can read the design document and understand the problem statement and what you plan to change *without* resorting to a couple of hours of code reading just to start having a high level understanding of the change.
+
+THIS COMMENTS
+Please remove them when done.
+-->
+
+# Background knowledge
+
+<!--
+Describes all the knowledge you need to know in order to understand all the other sections in this PIP
+
+* Give a high level explanation on all concepts you will be using throughout this document. For example, if you want to talk about Persistent Subscriptions, explain briefly (1 paragraph) what this is. If you're going to talk about Transaction Buffer, explain briefly what this is. 
+  If you're going to change something specific, then go into more detail about it and how it works. 
+* Provide links where possible if a person wants to dig deeper into the background information. 
+
+DON'T
+* Do not include links *instead* explanation. Do provide links for further explanation.
+
+EXAMPLES
+* See [PIP-248](https://github.com/apache/pulsar/issues/19601), Background section to get an understanding on how you add the background knowledge needed.
+  (They also included the motivation there, but ignore it as we place that in Motivation section explicitly).
+-->
+
+# Motivation
+
+Introduce `numWorkerThreadsForPersistentTopic` to deprecate `numWorkerThreadsForNonPersistentTopic`.
+
+As we see from the following, the `numWorkerThreadsForNonPersistentTopic` is used to specify for PersistentTopic, not NonPersistentTopic. So I propose change the config item from `numWorkerThreadsForNonPersistentTopic` to `numWorkerThreadsForPersistentTopic`:
+
+<img width="1128" alt="image" src="https://github.com/apache/pulsar/assets/10233437/5c6ed147-e8c1-4c08-b3cf-6886e9b99c8f">
+
+-->
+
+### Configuration
+
+Introduce `numWorkerThreadsForPersistentTopic` to deprecate `numWorkerThreadsForNonPersistentTopic`
+
+# Backward & Forward Compatibility
+* Change `numWorkerThreadsForNonPersistentTopic` default values as `-1`
+* Introduce new config `numWorkerThreadsForPersistentTopic` with default value `Runtime.getRuntime().availableProcessors()`
+* All places invoke `getNumWorkerThreadsForNonPersistentTopic()` will be repleace by `getNumWorkerThreadsForPersistentTopic()`
+* So if user doesn't set the `numWorkerThreadsForNonPersistentTopic`, the value of worker threads will keep `Runtime.getRuntime().availableProcessors()`
+* If user set the `numWorkerThreadsForNonPersistentTopic` before, the value will keep what user set before.
+```
+private int numWorkerThreadsForNonPersistentTopic = -1;
+private int numWorkerThreadsForPersistentTopic = Runtime.getRuntime().availableProcessors();
+
+public int getNumWorkerThreadsForPersistentTopic() {
+        return numWorkerThreadsForNonPersistentTopic > 0
+                ? numWorkerThreadsForNonPersistentTopic : numWorkerThreadsForPersistentTopic;
+    }
+```
+


### PR DESCRIPTION
### Motivation

This is a pip to Introduce `topicOrderedExecutorThreadNum` to deprecate `numWorkerThreadsForNonPersistentTopic`


### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
