### PR TITLE
[fix][fn] TLS args admin download command use zero arity

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -885,11 +885,12 @@ public class KubernetesRuntime implements Runtime {
                         "--auth-params",
                         authConfig.getClientAuthenticationParameters()));
             }
-            cmd.addAll(Arrays.asList(
-                    "--tls-allow-insecure",
-                    Boolean.toString(authConfig.isTlsAllowInsecureConnection()),
-                    "--tls-enable-hostname-verification",
-                    Boolean.toString(authConfig.isTlsHostnameVerificationEnable())));
+            if (authConfig.isTlsAllowInsecureConnection()) {
+                cmd.add("--tls-allow-insecure");
+            }
+            if (authConfig.isTlsHostnameVerificationEnable()) {
+                cmd.add("--tls-enable-hostname-verification");
+            }
             if (isNotBlank(authConfig.getTlsTrustCertsFilePath())) {
                 cmd.addAll(Arrays.asList(
                         "--tls-trust-cert-path",

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
@@ -852,7 +852,6 @@ public class KubernetesRuntimeTest {
         V1StatefulSet spec = container.createStatefulSet();
         String expectedDownloadCommand = "pulsar-admin --admin-url " + pulsarAdminUrl
                 + " --auth-plugin com.MyAuth --auth-params {\"authParam1\": \"authParamValue1\"}"
-                + " --tls-allow-insecure false --tls-enable-hostname-verification false"
                 + " functions download "
                 + "--tenant " + TEST_TENANT
                 + " --namespace " + TEST_NAMESPACE
@@ -879,7 +878,6 @@ public class KubernetesRuntimeTest {
         V1StatefulSet spec = container.createStatefulSet();
         String expectedDownloadCommand = "pulsar-admin --admin-url " + pulsarAdminUrl
                 + " --auth-plugin com.MyAuth --auth-params {\"authParam1\": \"authParamValue1\"}"
-                + " --tls-allow-insecure false --tls-enable-hostname-verification false"
                 + " functions download "
                 + "--tenant " + TEST_TENANT
                 + " --namespace " + TEST_NAMESPACE
@@ -909,7 +907,7 @@ public class KubernetesRuntimeTest {
         V1StatefulSet spec = container.createStatefulSet();
         String expectedDownloadCommand = "pulsar-admin --admin-url " + pulsarAdminUrl
                 + " --auth-plugin com.MyAuth --auth-params {\"authParam1\": \"authParamValue1\"}"
-                + " --tls-allow-insecure false --tls-enable-hostname-verification true"
+                + " --tls-enable-hostname-verification"
                 + " --tls-trust-cert-path /my/ca.pem"
                 + " functions download "
                 + "--tenant " + TEST_TENANT


### PR DESCRIPTION
### Motivation

#20482 broke the function download command with this error:

```
Expected a command, got false
Usage: pulsar-admin [options] [command] [command options]
  Options:
    --admin-url
      Admin Service URL to which to connect.
      Default: http://localhost:8080/
```

The problem is that the TLS args for hostname verification and for insecure TLS are zero arity, and therefore, we should not add the `false` or the `true` arguments.

### Modifications

* Correct the changes made to the TLS args passed to the `pulsar-admin` CLI tool

### Documentation

- [x] `doc-not-needed`