### PR TITLE
[improve][admin] Pretty print bookies racks-placement command output

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
@@ -214,8 +214,16 @@ public abstract class CliCommand {
             if (item instanceof String) {
                 System.out.println(item);
             } else {
-                System.out.println(writer.writeValueAsString(item));
+                prettyPrint(item);
             }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    <T> void prettyPrint(T item) {
+        try {
+            System.out.println(writer.writeValueAsString(item));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBookies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBookies.java
@@ -35,7 +35,7 @@ public class CmdBookies extends CmdBase {
 
         @Override
         void run() throws Exception {
-            print(getAdmin().bookies().getBookiesRackInfo());
+            prettyPrint(getAdmin().bookies().getBookiesRackInfo());
         }
     }
 


### PR DESCRIPTION
### Motivation

Pretty print the output from "bin/pulsar-admin bookies racks-placement" command so that it is in a more readable format 

### Modifications

Use Gson package to pretty print the output of the above command

### Verifying this change

This change is already covered by existing tests, such as bookies() testcase in PulsarAdminToolTest.java

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
