### PR TITLE
[improve][misc] Return failed future in async method instead of throw exception directly

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -3107,10 +3107,14 @@ public class BrokerService implements Closeable {
                                                                                         Optional<Policies> policies) {
         final int defaultNumPartitions = pulsar.getBrokerService().getDefaultNumPartitions(topicName, policies);
         final int maxPartitions = pulsar().getConfig().getMaxNumPartitionsPerPartitionedTopic();
-        checkArgument(defaultNumPartitions > 0,
-                "Default number of partitions should be more than 0");
-        checkArgument(maxPartitions <= 0 || defaultNumPartitions <= maxPartitions,
-                "Number of partitions should be less than or equal to " + maxPartitions);
+        if (defaultNumPartitions <= 0) {
+            return FutureUtil.failedFuture(
+                    new IllegalArgumentException("Default number of partitions should be more than 0"));
+        }
+        if (maxPartitions > 0 && defaultNumPartitions > maxPartitions) {
+            return FutureUtil.failedFuture(new IllegalArgumentException(
+                    "Number of partitions should be less than or equal to " + maxPartitions));
+        }
 
         PartitionedTopicMetadata configMetadata = new PartitionedTopicMetadata(defaultNumPartitions);
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -59,6 +59,7 @@ import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.policies.data.SubscriptionAuthMode;
 import org.apache.pulsar.common.policies.data.TopicHashPositions;
 import org.apache.pulsar.common.util.Codec;
+import org.apache.pulsar.common.util.FutureUtil;
 
 public class NamespacesImpl extends BaseResource implements Namespaces {
 
@@ -182,7 +183,10 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     @Override
     public CompletableFuture<Void> createNamespaceAsync(String namespace, Policies policies) {
         NamespaceName ns = NamespaceName.get(namespace);
-        checkArgument(ns.isV2(), "Create namespace with policies is only supported on newer namespaces");
+        if (!ns.isV2()) {
+            return FutureUtil.failedFuture(new IllegalArgumentException(
+                    "Create namespace with policies is only supported on newer namespaces"));
+        }
         WebTarget path = namespacePath(ns);
         // For V2 API we pass full Policy class instance
         return asyncPutRequest(path, Entity.entity(policies, MediaType.APPLICATION_JSON));

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NonPersistentTopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NonPersistentTopicsImpl.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.NonPersistentTopicStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
+import org.apache.pulsar.common.util.FutureUtil;
 
 public class NonPersistentTopicsImpl extends BaseResource implements NonPersistentTopics {
 
@@ -51,7 +52,9 @@ public class NonPersistentTopicsImpl extends BaseResource implements NonPersiste
 
     @Override
     public CompletableFuture<Void> createPartitionedTopicAsync(String topic, int numPartitions) {
-        checkArgument(numPartitions > 0, "Number of partitions should be more than 0");
+        if (numPartitions <= 0) {
+            return FutureUtil.failedFuture(new IllegalArgumentException("Number of partitions should be more than 0"));
+        }
         TopicName topicName = validateTopic(topic);
         WebTarget path = topicPath(topicName, "partitions");
         return asyncPutRequest(path, Entity.entity(numPartitions, MediaType.APPLICATION_JSON));

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -92,6 +92,7 @@ import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.stats.AnalyzeSubscriptionBacklogResult;
 import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.DateFormatter;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -329,7 +330,9 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     public CompletableFuture<Void> createPartitionedTopicAsync(
             String topic, int numPartitions, boolean createLocalTopicOnly, Map<String, String> properties) {
-        checkArgument(numPartitions > 0, "Number of partitions should be more than 0");
+        if (numPartitions <= 0) {
+            return FutureUtil.failedFuture(new IllegalArgumentException("Number of partitions must be more than 0"));
+        }
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "partitions")
                 .queryParam("createLocalTopicOnly", Boolean.toString(createLocalTopicOnly));
@@ -382,7 +385,9 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public CompletableFuture<Void> updatePartitionedTopicAsync(String topic, int numPartitions,
             boolean updateLocalTopicOnly, boolean force) {
-        checkArgument(numPartitions > 0, "Number of partitions must be more than 0");
+        if (numPartitions <= 0) {
+            return FutureUtil.failedFuture(new IllegalArgumentException("Number of partitions must be more than 0"));
+        }
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "partitions");
         path = path.queryParam("updateLocalTopicOnly", Boolean.toString(updateLocalTopicOnly)).queryParam("force",
@@ -878,7 +883,9 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages) {
-        checkArgument(numMessages > 0);
+        if (numMessages <= 0) {
+            return FutureUtil.failedFuture(new IllegalArgumentException("numMessages must be positive"));
+        }
         CompletableFuture<List<Message<byte[]>>> future = new CompletableFuture<List<Message<byte[]>>>();
         peekMessagesAsync(topic, subName, numMessages, new ArrayList<>(), future, 1);
         return future;
@@ -2742,8 +2749,12 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public CompletableFuture<Void> createShadowTopicAsync(String shadowTopic, String sourceTopic,
                                                           Map<String, String> properties) {
-        checkArgument(TopicName.get(shadowTopic).isPersistent(), "Shadow topic must be persistent");
-        checkArgument(TopicName.get(sourceTopic).isPersistent(), "Source topic must be persistent");
+        if (!TopicName.get(shadowTopic).isPersistent()) {
+            return FutureUtil.failedFuture(new IllegalArgumentException("Shadow topic must be persistent"));
+        }
+        if (!TopicName.get(sourceTopic).isPersistent()) {
+            return FutureUtil.failedFuture(new IllegalArgumentException("Source topic must be persistent"));
+        }
         return getPartitionedTopicMetadataAsync(sourceTopic).thenCompose(sourceTopicMeta -> {
             HashMap<String, String> shadowProperties = new HashMap<>();
             if (properties != null) {

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TransactionsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TransactionsImpl.java
@@ -41,6 +41,7 @@ import org.apache.pulsar.common.policies.data.TransactionMetadata;
 import org.apache.pulsar.common.policies.data.TransactionPendingAckInternalStats;
 import org.apache.pulsar.common.policies.data.TransactionPendingAckStats;
 import org.apache.pulsar.common.stats.PositionInPendingAckStats;
+import org.apache.pulsar.common.util.FutureUtil;
 
 public class TransactionsImpl extends BaseResource implements Transactions {
     private final WebTarget adminV3Transactions;
@@ -234,7 +235,10 @@ public class TransactionsImpl extends BaseResource implements Transactions {
 
     @Override
     public CompletableFuture<Void> scaleTransactionCoordinatorsAsync(int replicas) {
-        checkArgument(replicas > 0, "Number of transaction coordinators must be more than 0");
+        if (replicas <= 0) {
+            return FutureUtil.failedFuture(
+                    new IllegalArgumentException("Number of transaction coordinators must be more than 0"));
+        }
         WebTarget path = adminV3Transactions.path("transactionCoordinator");
         path = path.path("replicas");
         return asyncPostRequest(path, Entity.entity(replicas, MediaType.APPLICATION_JSON));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -620,12 +620,16 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
                                                     Transaction txn) {
         TransactionImpl txnImpl = null;
         if (null != txn) {
-            checkArgument(txn instanceof TransactionImpl);
-            txnImpl = (TransactionImpl) txn;
-            CompletableFuture<Void> completableFuture = new CompletableFuture<>();
-           if (!txnImpl.checkIfOpen(completableFuture)) {
-               return completableFuture;
-           }
+            if (txn instanceof TransactionImpl) {
+                txnImpl = (TransactionImpl) txn;
+                CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+                if (!txnImpl.checkIfOpen(completableFuture)) {
+                    return completableFuture;
+                }
+            } else {
+                return FutureUtil.failedFuture(
+                        new IllegalArgumentException("The txn must be an instance of TransactionImpl"));
+            }
         }
         return doAcknowledgeWithTxn(messageId, AckType.Individual, Collections.emptyMap(), txnImpl);
     }
@@ -644,8 +648,12 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
 
         TransactionImpl txnImpl = null;
         if (null != txn) {
-            checkArgument(txn instanceof TransactionImpl);
-            txnImpl = (TransactionImpl) txn;
+            if (txn instanceof TransactionImpl) {
+                txnImpl = (TransactionImpl) txn;
+            } else {
+                return FutureUtil.failedFuture(
+                        new IllegalArgumentException("The txn must be an instance of TransactionImpl"));
+            }
         }
         return doAcknowledgeWithTxn(messageId, AckType.Cumulative, Collections.emptyMap(), txnImpl);
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -430,10 +430,14 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 cancellationHandler.setCancelAction(() -> pendingReceives.remove(result));
             } else {
                 decreaseIncomingMessageSize(message);
-                checkState(message instanceof TopicMessageImpl);
-                unAckedMessageTracker.add(message.getMessageId(), message.getRedeliveryCount());
-                resumeReceivingFromPausedConsumersIfNeeded();
-                result.complete(message);
+                if (message instanceof TopicMessageImpl) {
+                    unAckedMessageTracker.add(message.getMessageId(), message.getRedeliveryCount());
+                    resumeReceivingFromPausedConsumersIfNeeded();
+                    result.complete(message);
+                } else {
+                    result.completeExceptionally(new IllegalStateException(
+                            "Received message is not a TopicMessageImpl: " + message.getClass().getName()));
+                }
             }
         });
         return result;
@@ -1171,7 +1175,10 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
     // un-subscribe a given topic
     public CompletableFuture<Void> unsubscribeAsync(String topicName) {
-        checkArgument(TopicName.isValid(topicName), "Invalid topic name:" + topicName);
+        if (!TopicName.isValid(topicName)) {
+            return FutureUtil.failedFuture(
+                new PulsarClientException.InvalidTopicNameException("Invalid topic name:" + topicName));
+        }
 
         if (getState() == State.Closing || getState() == State.Closed) {
             return FutureUtil.failedFuture(
@@ -1225,7 +1232,10 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
     // Remove a consumer for a topic
     public CompletableFuture<Void> removeConsumerAsync(String topicName) {
-        checkArgument(TopicName.isValid(topicName), "Invalid topic name:" + topicName);
+        if (!TopicName.isValid(topicName)) {
+            return FutureUtil.failedFuture(
+                    new PulsarClientException.InvalidTopicNameException("Invalid topic name:" + topicName));
+        }
 
         if (getState() == State.Closing || getState() == State.Closed) {
             return FutureUtil.failedFuture(

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -229,8 +229,11 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
             return completableFuture;
         }
         int partition = routerPolicy.choosePartition(message, topicMetadata);
-        checkArgument(partition >= 0 && partition < topicMetadata.numPartitions(),
-                "Illegal partition index chosen by the message routing policy: " + partition);
+        if (partition < 0 || partition >= topicMetadata.numPartitions()) {
+            completableFuture.completeExceptionally(new IllegalArgumentException(
+                    "Illegal partition index chosen by the message routing policy: " + partition));
+            return completableFuture;
+        }
 
         if (conf.isLazyStartPartitionedProducers() && !producers.containsKey(partition)) {
             final ProducerImpl<T> newProducer = createProducer(partition, Optional.ofNullable(overrideProducerName));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -93,8 +93,10 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     @Override
     public CompletableFuture<Producer<T>> createAsync() {
         // config validation
-        checkArgument(!(conf.isBatchingEnabled() && conf.isChunkingEnabled()),
-                "Batching and chunking of messages can't be enabled together");
+        if (conf.isBatchingEnabled() && conf.isChunkingEnabled()) {
+            return FutureUtil.failedFuture(
+                    new IllegalArgumentException("Batching and chunking of messages can't be enabled together"));
+        }
         if (conf.getTopicName() == null) {
             return FutureUtil
                     .failedFuture(new IllegalArgumentException("Topic name must be set on the producer builder"));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -428,7 +428,11 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     }
 
     public void sendAsync(Message<?> message, SendCallback callback) {
-        checkArgument(message instanceof MessageImpl);
+        if (!(message instanceof MessageImpl)) {
+            callback.sendComplete(
+                    new IllegalArgumentException("Invalid message type: " + message.getClass().getName()));
+            return;
+        }
 
         if (!isValidProducerState(callback, message.getSequenceId())) {
             return;


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

Throws an exception from a async method generally a bad practice, for example in `ProducerBuilderImpl#createAsync`, `checkArgument` may throws a runtime exception directly:
https://github.com/apache/pulsar/blob/50b9a93e42e412d9f17b1637287d1a4c7c7ab148/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java#L94-L97

If user call it in a async context, it may cause some unexpected behavior, here is a case:
```java
CompletableFuture<xxx> future = new CompletableFuture<>();
xxx.whenComplete((v, ex) -> {
    xxx.createAsync().whenComplete((v, ex) -> {
        if (ex != null) {
            future.completeExceptionally(ex);
        } else {
            future.complete(v);
        }
    });
})
```
If `createAsync()` throws an exception from inside, the `future` will never get completed. This kind of problem is very hard to troubleshooting cause it could haven’t any log.

So I wrote a PMD rule to examine the entire Pulsar codebase (current master branch), aiming to identify similar kinds of problems. Here it is:
```
//MethodDeclaration[matches(@Name, "Async$")]
  [.//PrimaryPrefix/Name[matches(@Image, "(requireNonNull|checkNotNull|checkState|checkArgument)$")]]
```
Note: this rule may not be able to scan all similar code issues.

### Modifications

Return a failed future instead of throw exception directly, for the given case above, it's will be change to:
```java
public CompletableFuture<Producer<T>> createAsync() {
    // config validation
    if (conf.isBatchingEnabled() && conf.isChunkingEnabled()) {
        return FutureUtil.failedFuture(
                new IllegalArgumentException("Batching and chunking of messages can't be enabled together"));
    }
```

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
