### PR TITLE
[improve][broker] Emit the namespace bundle listener event on extensible load manager

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1202,13 +1202,13 @@ public class NamespaceService implements AutoCloseable {
         return future.thenRun(() -> bundleFactory.invalidateBundleCache(nsBundle.getNamespaceObject()));
     }
 
-    protected void onNamespaceBundleOwned(NamespaceBundle bundle) {
+    public void onNamespaceBundleOwned(NamespaceBundle bundle) {
         for (NamespaceBundleOwnershipListener bundleOwnedListener : bundleOwnershipListeners) {
             notifyNamespaceBundleOwnershipListener(bundle, bundleOwnedListener);
         }
     }
 
-    protected void onNamespaceBundleUnload(NamespaceBundle bundle) {
+    public void onNamespaceBundleUnload(NamespaceBundle bundle) {
         for (NamespaceBundleOwnershipListener bundleOwnedListener : bundleOwnershipListeners) {
             try {
                 if (bundleOwnedListener.test(bundle)) {
@@ -1220,7 +1220,7 @@ public class NamespaceService implements AutoCloseable {
         }
     }
 
-    protected void onNamespaceBundleSplit(NamespaceBundle bundle) {
+    public void onNamespaceBundleSplit(NamespaceBundle bundle) {
         for (NamespaceBundleSplitListener bundleSplitListener : bundleSplitListeners) {
             try {
                 if (bundleSplitListener.test(bundle)) {


### PR DESCRIPTION
PIP: https://github.com/apache/pulsar/issues/16691

### Motivation

Some pulsar plugins like [KoP](https://github.com/streamnative/kop) require using the namespace bundle listener to be aware of the bundle load or unload event. In KoP it will use to immigrate or emigrate the group/txn coordinator data.

But in the extensible load manager, we do not trigger the event.

### Modifications

* Trigger the unload/load/split event when using the extensible load manager.
* Add unit test to verify this feature.

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->