### PR TITLE
[improve][build] Upgrade Testcontainers to 1.18.3 & docker-java to 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,11 +251,11 @@ flexible messaging model and an intuitive client API.</description>
     <netty-reactive-streams.version>2.0.6</netty-reactive-streams.version>
 
     <!-- test dependencies -->
-    <testcontainers.version>1.17.6</testcontainers.version>
+    <testcontainers.version>1.18.3</testcontainers.version>
     <hamcrest.version>2.2</hamcrest.version>
 
     <!-- Set docker-java.version to the version of docker-java used in Testcontainers -->
-    <docker-java.version>3.2.13</docker-java.version>
+    <docker-java.version>3.3.0</docker-java.version>
     <kerby.version>1.1.1</kerby.version>
     <testng.version>7.7.1</testng.version>
     <mockito.version>3.12.4</mockito.version>


### PR DESCRIPTION
### Motivation

- keep the dependency up-to-date

### Modifications

Upgrade Testcontainers to 1.18.3 and docker-java to 3.3.0 .
docker-java version has to be kept in sync with Testcontainers version.

The correct version can be found in the testcontainers pom. For example for 1.18.3, one can find the docker-java version here: https://repo1.maven.org/maven2/org/testcontainers/testcontainers/1.18.3/testcontainers-1.18.3.pom

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->