### PR TITLE
[cleanup][test] CSContainer needs not to inherit from ZKContainer

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/auth/token/PulsarTokenAuthenticationBaseSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/auth/token/PulsarTokenAuthenticationBaseSuite.java
@@ -68,7 +68,7 @@ public abstract class PulsarTokenAuthenticationBaseSuite extends PulsarClusterTe
     protected static final String PROXY_ROLE = "proxy";
     protected static final String REGULAR_USER_ROLE = "client";
 
-    protected ZKContainer<?> cmdContainer;
+    protected ZKContainer cmdContainer;
 
     @BeforeClass(alwaysRun = true)
     @Override
@@ -76,7 +76,7 @@ public abstract class PulsarTokenAuthenticationBaseSuite extends PulsarClusterTe
         incrementSetupNumber();
         // Before starting the cluster, generate the secret key and the token
         // Use Zk container to have 1 container available before starting the cluster
-        this.cmdContainer = new ZKContainer<>("cli-setup");
+        this.cmdContainer = new ZKContainer("cli-setup");
         cmdContainer
                 .withNetwork(Network.newNetwork())
                 .withNetworkAliases(ZKContainer.NAME)

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/ClientToolTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/ClientToolTest.java
@@ -59,7 +59,7 @@ public class ClientToolTest extends TopicMessagingBase {
     private void testProduceConsume(String serviceUrl, String topicName) throws Exception {
         List<String> data = randomStrings();
         // Using the ZK container as it is separate from brokers, so its environment resembles real world usage more
-        ZKContainer<?> clientToolContainer = pulsarCluster.getZooKeeper();
+        ZKContainer clientToolContainer = pulsarCluster.getZooKeeper();
         produce(clientToolContainer, serviceUrl, topicName, data);
         List<String> consumed = consume(clientToolContainer, serviceUrl, topicName);
         assertEquals(consumed, data);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/PerfToolTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/PerfToolTest.java
@@ -38,7 +38,7 @@ public class PerfToolTest extends TopicMessagingBase {
         String serviceUrl = "pulsar://" + pulsarCluster.getProxy().getContainerName() + ":" + PulsarContainer.BROKER_PORT;
         final String topicName = getNonPartitionedTopic("testProduce", true);
         // Using the ZK container as it is separate from brokers, so its environment resembles real world usage more
-        ZKContainer<?> clientToolContainer = pulsarCluster.getZooKeeper();
+        ZKContainer clientToolContainer = pulsarCluster.getZooKeeper();
         ContainerExecResult produceResult = produceWithPerfTool(clientToolContainer, serviceUrl, topicName, MESSAGE_COUNT);
         checkOutputForLogs(produceResult,"PerformanceProducer - Aggregated throughput stats",
                 "PerformanceProducer - Aggregated latency stats");
@@ -49,7 +49,7 @@ public class PerfToolTest extends TopicMessagingBase {
         String serviceUrl = "pulsar://" + pulsarCluster.getProxy().getContainerName() + ":" + PulsarContainer.BROKER_PORT;
         final String topicName = getNonPartitionedTopic("testConsume", true);
         // Using the ZK container as it is separate from brokers, so its environment resembles real world usage more
-        ZKContainer<?> clientToolContainer = pulsarCluster.getZooKeeper();
+        ZKContainer clientToolContainer = pulsarCluster.getZooKeeper();
         ContainerExecResult consumeResult = consumeWithPerfTool(clientToolContainer, serviceUrl, topicName);
         checkOutputForLogs(consumeResult,"PerformanceConsumer - Aggregated throughput stats",
                 "PerformanceConsumer - Aggregated latency stats");
@@ -60,7 +60,7 @@ public class PerfToolTest extends TopicMessagingBase {
         String serviceUrl = "pulsar://" + pulsarCluster.getProxy().getContainerName() + ":" + PulsarContainer.BROKER_PORT;
         final String topicName = getNonPartitionedTopic("testRead", true);
         // Using the ZK container as it is separate from brokers, so its environment resembles real world usage more
-        ZKContainer<?> clientToolContainer = pulsarCluster.getZooKeeper();
+        ZKContainer clientToolContainer = pulsarCluster.getZooKeeper();
         ContainerExecResult readResult = readWithPerfTool(clientToolContainer, serviceUrl, topicName);
         checkOutputForLogs(readResult,"PerformanceReader - Aggregated throughput stats ",
                 "PerformanceReader - Aggregated latency stats");

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/CSContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/CSContainer.java
@@ -21,7 +21,7 @@ package org.apache.pulsar.tests.integration.containers;
 /**
  * A pulsar container that runs configuration store.
  */
-public class CSContainer extends ZKContainer<CSContainer> {
+public class CSContainer extends PulsarContainer<CSContainer> {
 
     public static final String NAME = "configuration-store";
 
@@ -33,5 +33,10 @@ public class CSContainer extends ZKContainer<CSContainer> {
             "bin/run-global-zk.sh",
             CS_PORT,
             INVALID_PORT);
+    }
+
+    @Override
+    protected boolean isCodeCoverageEnabled() {
+        return false;
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ZKContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ZKContainer.java
@@ -18,16 +18,12 @@
  */
 package org.apache.pulsar.tests.integration.containers;
 
-import org.apache.pulsar.tests.integration.utils.DockerUtils;
-
 /**
  * A pulsar container that runs zookeeper.
  */
-public class ZKContainer<SelfT extends PulsarContainer<SelfT>> extends PulsarContainer<SelfT> {
+public class ZKContainer extends PulsarContainer<ZKContainer> {
 
     public static final String NAME = "zookeeper";
-
-    private volatile boolean dumpZkDataBeforeStop = false;
 
     public ZKContainer(String clusterName) {
         super(
@@ -37,37 +33,6 @@ public class ZKContainer<SelfT extends PulsarContainer<SelfT>> extends PulsarCon
             "bin/run-local-zk.sh",
             ZK_PORT,
             INVALID_PORT);
-    }
-
-    public ZKContainer(String clusterName,
-                       String hostname,
-                       String serviceName,
-                       String serviceEntryPoint,
-                       int servicePort,
-                       int httpPort) {
-        super(
-            clusterName,
-            hostname,
-            serviceName,
-            serviceEntryPoint,
-            servicePort,
-            httpPort);
-    }
-
-    public void enableDumpZkDataBeforeStop(boolean enabled) {
-        this.dumpZkDataBeforeStop = enabled;
-    }
-
-    @Override
-    protected void beforeStop() {
-        super.beforeStop();
-        if (null != getContainerId() && dumpZkDataBeforeStop) {
-            DockerUtils.dumpContainerDirToTargetCompressed(
-                getDockerClient(),
-                getContainerId(),
-                "/pulsar/data/zookeeper"
-            );
-        }
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
@@ -85,7 +85,7 @@ public class PulsarCluster {
     @Getter
     private final String clusterName;
     private final Network network;
-    private final ZKContainer<?> zkContainer;
+    private final ZKContainer zkContainer;
     private final CSContainer csContainer;
     private final boolean sharedCsContainer;
     private final Map<String, BKContainer> bookieContainers;


### PR DESCRIPTION
Code cleanup so that we read code more smoothly ..

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
