### PR TITLE
[fix][build] Configure git-commit-id-plugin to skip git describe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1588,10 +1588,10 @@ flexible messaging model and an intuitive client API.</description>
           <useNativeGit>true</useNativeGit>
           <prefix>git</prefix>
           <failOnNoGitDirectory>false</failOnNoGitDirectory>
+          <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
           <skipPoms>false</skipPoms>
           <gitDescribe>
-            <skip>false</skip>
-            <always>false</always>
+            <skip>true</skip>
           </gitDescribe>
         </configuration>
       </plugin>


### PR DESCRIPTION
### Motivation

Follow up on #20435 changes to fix build that could fail with git describe error "fatal: No names found, cannot describe anything."

Full error message:
```
19:01:27  [ERROR] Failed to execute goal pl.project13.maven:git-commit-id-plugin:4.9.10:revision (git-info) on project 
docker-images: Could not complete Mojo execution... pl.project13.core.NativeGitProvider$NativeCommandException: 
Git command exited with invalid status [128]: directory: `/home/ubuntu/workspace/Apache_Pulsar__Deploy_branch-3.0/docker`, 
command: `git describe --dirty=-dirty --match=* --abbrev=7`, stdout: ``,
stderr: `fatal: No names found, cannot describe anything.` -> [Help 1]
```

### Modifications

- Configure git-commit-id-plugin to skip "git describe"
- Ignore errors when git-commit-id-plugin fails too run the git command
  - similar config has been used in pulsar-common/pom.xml

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->