### PR TITLE
[fix][broker] Return isPartitionedTopicBeingDeletedAsync=true when a partitioned topic metadata is empty

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -329,7 +329,8 @@ public class NamespaceResources extends BaseResources<Policies> {
             }
             return getPartitionedTopicMetadataAsync(tn, true)
                     .thenApply(mdOpt -> mdOpt.map(partitionedTopicMetadata -> partitionedTopicMetadata.deleted)
-                            .orElse(false));
+                            // if mdOpt.isEmpty, assuming the partition topic has been deleted.
+                            .orElse(true));
         }
 
         public CompletableFuture<Void> runWithMarkDeleteAsync(TopicName topic,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMultiBrokersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMultiBrokersTest.java
@@ -181,8 +181,6 @@ public class AdminApiMultiBrokersTest extends MultiBrokerBaseTest {
         admin.topics().deletePartitionedTopic(topic, true);
 
         log.info("closing producer and consumer");
-        producer.close();
-        consumer.close();
 
         // topic autocreate might sneak in after the delete / before close
         // but the topic metadata should be consistent to go through deletion again
@@ -208,5 +206,7 @@ public class AdminApiMultiBrokersTest extends MultiBrokerBaseTest {
             log.info("trying to create the topic again");
             ((TopicsImpl) admin.topics()).createPartitionedTopicAsync(topic, numPartitions, true, null).get();
         }
+        producer.close();
+        consumer.close();
     }
 }


### PR DESCRIPTION

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->



<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

Found a partition metadata inconsistency issue due to the racing condition between forceful deletion of partitioned topics and topic partition auto-creation from consumers' re-connection.

Upon delete-partitioned-topic command with force=true for partitioned topics, existing subscriptions reconnect, which recreates topic partitions. Meanwhile, the partitioned topic(the root topic) is removed from the metadata store.


Issue reproduction step:

1. run broker
`bin/pulsar standalone`
2. run consumer
```
bin/pulsar-admin tenants create my-tenant
bin/pulsar-admin namespaces create my-tenant/my-namespace --bundles 5
bin/pulsar-admin topics create-partitioned-topic persistent://my-tenant/my-namespace/my-topic -p 2
bin/pulsar-client consume -s sub-read persistent://my-tenant/my-namespace/my-topic -p Earliest -n 0
```
3. delete the partitioned topic
`bin/pulsar-admin topics delete-partitioned-topic persistent://my-tenant/my-namespace/my-topic --force`
4. check topics
```
curl -X GET http://localhost:8080/admin/v2/persistent/my-tenant/my-namespace
["persistent://my-tenant/my-namespace/my-topic-partition-0","persistent://my-tenant/my-namespace/my-topic-partition-1"]%
curl -X GET http://localhost:8080/admin/v2/persistent/my-tenant/my-namespace/partitioned
[]%
```
5. check the topic creation fails
```
bin/pulsar-admin topics create-partitioned-topic persistent://my-tenant/my-namespace/my-topic -p 2
2023-06-09T17:55:01,664-0700 [AsyncHttpClient-7-1] WARN  org.apache.pulsar.client.admin.internal.BaseResource - [http://localhost:8080/admin/v2/persistent/my-tenant/my-namespace/my-topic/partitions?createLocalTopicOnly=false] Failed to perform http put request: javax.ws.rs.ClientErrorException: HTTP 409 This topic already exists
This topic already exists

Reason: This topic already exists
```

### Modifications

- return isPartitionedTopicBeingDeletedAsync true when a partitioned topic metadata is empty.

### Verifying this change

- [x] Make sure that the change passes the CI checks.



This change is already covered by existing tests, such as *(please describe tests)*.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: not provided as this is a trivial fix

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
