### PR TITLE
[fix][doc] change the method of generating reference docs titles.

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdGenerateDocument.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdGenerateDocument.java
@@ -108,7 +108,7 @@ public class CmdGenerateDocument extends CmdBase {
             sb.append("\n\n");
             CmdBase cmdObj = (CmdBase) obj.getObjects().get(0);
             cmdObj.jcommander.getCommands().forEach((subK, subV) -> {
-                sb.append("\n\n## <em>").append(subK).append("</em>\n\n");
+                sb.append("\n\n## ").append(subK).append("\n\n");
                 sb.append(cmdObj.getUsageFormatter().getCommandDescription(subK)).append("\n\n");
                 sb.append("**Command:**\n\n");
                 sb.append("```shell\n$ pulsar-admin ").append(module).append(" ")

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/CmdGenerateDocs.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/CmdGenerateDocs.java
@@ -118,7 +118,7 @@ public class CmdGenerateDocs {
             sb.append(" subcommand").append("\n```").append("\n\n");
             cmdObj.getCommands().forEach((subK, subV) -> {
                 if (!subK.equals(name)) {
-                    sb.append("\n\n## <em>").append(subK).append("</em>\n\n");
+                    sb.append("\n\n## ").append(subK).append("\n\n");
                     String subDesc = cmdObj.getUsageFormatter().getCommandDescription(subK);
                     if (null != subDesc && !subDesc.isEmpty()) {
                         sb.append(subDesc).append("\n");


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar-site/pull/603
To make the navigation bar work better, I changed the method of generating reference docs titles.

### Modifications

just modified the logic of reference docs generation. Other words: ### <em>title</em> ---> ### title

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following 

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

Hi @tisonkun PTAL.
and I didn't find the generating method for `bookkeeper`, `pulsar-daemon` and `pulsar-shell`, are they also automatically generated?