### PR TITLE
[optimize][txn] Implement lazy loading for transaction buffer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -146,14 +146,6 @@ public interface Topic {
     void removeProducer(Producer producer);
 
     /**
-     * Wait TransactionBuffer Recovers completely.
-     * Take snapshot after TB Recovers completely.
-     * @param isTxnEnabled
-     * @return a future which has completely if isTxn = false. Or a future return by takeSnapshot.
-     */
-    CompletableFuture<Void> checkIfTransactionBufferRecoverCompletely(boolean isTxnEnabled);
-
-    /**
      * record add-latency.
      */
     void recordAddLatency(long latency, TimeUnit unit);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -250,11 +250,6 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
     }
 
     @Override
-    public CompletableFuture<Void> checkIfTransactionBufferRecoverCompletely(boolean isTxnEnabled) {
-        return  CompletableFuture.completedFuture(null);
-    }
-
-    @Override
     public CompletableFuture<Consumer> subscribe(SubscriptionOption option) {
         return internalSubscribe(option.getCnx(), option.getSubscriptionName(), option.getConsumerId(),
                 option.getSubType(), option.getPriorityLevel(), option.getConsumerName(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -120,6 +120,7 @@ import org.apache.pulsar.broker.stats.ClusterReplicationMetrics;
 import org.apache.pulsar.broker.stats.NamespaceStats;
 import org.apache.pulsar.broker.stats.ReplicationMetrics;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBuffer;
+import org.apache.pulsar.broker.transaction.buffer.impl.TopicTransactionBuffer;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferDisable;
 import org.apache.pulsar.broker.transaction.pendingack.impl.MLPendingAckStore;
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
@@ -320,10 +321,12 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         checkReplicatedSubscriptionControllerState();
         TopicName topicName = TopicName.get(topic);
-        if (brokerService.getPulsar().getConfiguration().isTransactionCoordinatorEnabled()
-                && !isEventSystemTopic(topicName)) {
+        PositionImpl startUsedPosition = getPositionFromString(
+                getManagedLedger().getProperties().get(TopicTransactionBuffer.MAX_READ_POSITION));
+        if (brokerService.pulsar().getConfiguration().isTransactionCoordinatorEnabled()
+                && !isEventSystemTopic(topicName) || startUsedPosition != null) {
             this.transactionBuffer = brokerService.getPulsar()
-                    .getTransactionBufferProvider().newTransactionBuffer(this);
+                    .getTransactionBufferProvider().newTransactionBuffer(this, startUsedPosition);
         } else {
             this.transactionBuffer = new TransactionBufferDisable();
         }
@@ -409,14 +412,30 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         this.compactedTopic = new CompactedTopicImpl(brokerService.pulsar().getBookKeeperClient());
         this.backloggedCursorThresholdEntries =
                 brokerService.pulsar().getConfiguration().getManagedLedgerCursorBackloggedThreshold();
-
-        if (brokerService.pulsar().getConfiguration().isTransactionCoordinatorEnabled()) {
+        PositionImpl startUsedPosition = getPositionFromString(
+                getManagedLedger().getProperties().get(TopicTransactionBuffer.MAX_READ_POSITION));
+        TopicName topicName = TopicName.get(topic);
+        if (brokerService.pulsar().getConfiguration().isTransactionCoordinatorEnabled()
+                && !isEventSystemTopic(topicName) || startUsedPosition != null) {
             this.transactionBuffer = brokerService.getPulsar()
-                    .getTransactionBufferProvider().newTransactionBuffer(this);
+                    .getTransactionBufferProvider().newTransactionBuffer(this, startUsedPosition);
         } else {
             this.transactionBuffer = new TransactionBufferDisable();
         }
         shadowSourceTopic = null;
+    }
+
+    private PositionImpl getPositionFromString(String positionStr) {
+        if (positionStr == null) {
+            return null;
+        }
+        String[] strs = positionStr.split(":");
+        if (strs.length != 2) {
+            log.error("receive a error start position {} from topic {} metadata",
+                    positionStr, topic);
+            return PositionImpl.EARLIEST;
+        }
+        return new PositionImpl(Integer.parseInt(strs[0]), Integer.parseInt(strs[1]));
     }
 
     private void initializeDispatchRateLimiterIfNeeded() {
@@ -684,11 +703,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             // Start replication producers if not already
             return startReplProducers().thenApply(__ -> topicEpoch);
         });
-    }
-
-    @Override
-    public CompletableFuture<Void> checkIfTransactionBufferRecoverCompletely(boolean isTxnEnabled) {
-        return getTransactionBuffer().checkIfTBRecoverCompletely(isTxnEnabled);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
@@ -170,16 +170,6 @@ public interface TransactionBuffer {
      */
     TransactionBufferStats getStats(boolean lowWaterMarks);
 
-    /**
-     * Wait TransactionBuffer Recovers completely.
-     * Take snapshot after TB Recovers completely.
-     * @param isTxn
-     * @return a future which has completely if isTxn = false. Or a future return by takeSnapshot.
-     */
-    CompletableFuture<Void> checkIfTBRecoverCompletely(boolean isTxn);
-
-
-
     long getOngoingTxnCount();
 
     long getAbortedTxnCount();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferProvider.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.transaction.buffer;
 
 import com.google.common.annotations.Beta;
 import java.io.IOException;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.common.util.Reflections;
 
@@ -51,5 +52,5 @@ public interface TransactionBufferProvider {
      * @param originTopic
      * @return
      */
-    TransactionBuffer newTransactionBuffer(Topic originTopic);
+    TransactionBuffer newTransactionBuffer(Topic originTopic, PositionImpl startUsedPosition);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBuffer.java
@@ -385,11 +385,6 @@ class InMemTransactionBuffer implements TransactionBuffer {
     }
 
     @Override
-    public CompletableFuture<Void> checkIfTBRecoverCompletely(boolean isTxn) {
-        return CompletableFuture.completedFuture(null);
-    }
-
-    @Override
     public long getOngoingTxnCount() {
         return this.buffers.values().stream()
                 .filter(txnBuffer -> txnBuffer.status.equals(TxnStatus.OPEN)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBufferProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBufferProvider.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.transaction.buffer.impl;
 
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBuffer;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBufferProvider;
@@ -28,7 +29,7 @@ import org.apache.pulsar.broker.transaction.buffer.TransactionBufferProvider;
 public class InMemTransactionBufferProvider implements TransactionBufferProvider {
 
     @Override
-    public TransactionBuffer newTransactionBuffer(Topic originTopic) {
+    public TransactionBuffer newTransactionBuffer(Topic originTopic, PositionImpl startUsedPosition) {
         return new InMemTransactionBuffer(originTopic);
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -23,7 +23,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.util.Timeout;
 import io.netty.util.Timer;
 import io.netty.util.TimerTask;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
@@ -37,6 +39,7 @@ import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.collections4.map.LinkedMap;
 import org.apache.pulsar.broker.service.BrokerServiceException;
@@ -65,6 +68,8 @@ import org.jctools.queues.SpscArrayQueue;
  */
 @Slf4j
 public class TopicTransactionBuffer extends TopicTransactionBufferState implements TransactionBuffer, TimerTask {
+
+    public static final String MAX_READ_POSITION = "maxReadPosition";
 
     private final PersistentTopic topic;
 
@@ -101,7 +106,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
     private final AbortedTxnProcessor snapshotAbortedTxnProcessor;
 
-    public TopicTransactionBuffer(PersistentTopic topic) {
+    public TopicTransactionBuffer(PersistentTopic topic, PositionImpl startUsedPosition) {
         super(State.None);
         this.topic = topic;
         this.timer = topic.getBrokerService().getPulsar().getTransactionTimer();
@@ -109,13 +114,20 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                 .getConfiguration().getTransactionBufferSnapshotMaxTransactionCount();
         this.takeSnapshotIntervalTime = topic.getBrokerService().getPulsar()
                 .getConfiguration().getTransactionBufferSnapshotMinTimeInMillis();
-        this.maxReadPosition = (PositionImpl) topic.getManagedLedger().getLastConfirmedEntry();
         if (topic.getBrokerService().getPulsar().getConfiguration().isTransactionBufferSegmentedSnapshotEnabled()) {
             snapshotAbortedTxnProcessor = new SnapshotSegmentAbortedTxnProcessorImpl(topic);
         } else {
             snapshotAbortedTxnProcessor = new SingleSnapshotAbortedTxnProcessorImpl(topic);
         }
-        this.recover();
+        // TransactionBuffer need to handle transaction messages for consumer.
+        // If the transaction buffer had been used, we always need to recover it.
+        if (startUsedPosition != null) {
+            this.maxReadPosition = startUsedPosition;
+            changeToInitializingState();
+            recover();
+        } else {
+            this.maxReadPosition = (PositionImpl) topic.getManagedLedger().getLastConfirmedEntry();
+        }
     }
 
     private void recover() {
@@ -204,37 +216,6 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
     }
 
     @Override
-    public CompletableFuture<Void> checkIfTBRecoverCompletely(boolean isTxnEnabled) {
-        if (!isTxnEnabled) {
-            return CompletableFuture.completedFuture(null);
-        } else {
-            CompletableFuture<Void> completableFuture = new CompletableFuture<>();
-            transactionBufferFuture.thenRun(() -> {
-                if (checkIfNoSnapshot()) {
-                    snapshotAbortedTxnProcessor.takeAbortedTxnsSnapshot(maxReadPosition).thenRun(() -> {
-                        if (changeToReadyStateFromNoSnapshot()) {
-                            timer.newTimeout(TopicTransactionBuffer.this,
-                                    takeSnapshotIntervalTime, TimeUnit.MILLISECONDS);
-                        }
-                        completableFuture.complete(null);
-                    }).exceptionally(exception -> {
-                        log.error("Topic {} failed to take snapshot", this.topic.getName());
-                        completableFuture.completeExceptionally(exception);
-                        return null;
-                    });
-                } else {
-                    completableFuture.complete(null);
-                }
-            }).exceptionally(exception -> {
-                log.error("Topic {}: TransactionBuffer recover failed", this.topic.getName(), exception.getCause());
-                completableFuture.completeExceptionally(exception.getCause());
-                return null;
-            });
-            return completableFuture;
-        }
-    }
-
-    @Override
     public long getOngoingTxnCount() {
         return this.ongoingTxns.size();
     }
@@ -250,7 +231,54 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
     }
 
     @Override
+/**
+ * If it's the first time using the transaction buffer, the method records the max read position of the topic
+ * to metadata of the topic at the time of the first write. If the transaction buffer has been used before,
+ * it writes the message after recovering the transaction buffer.
+ */
     public CompletableFuture<Position> appendBufferToTxn(TxnID txnId, long sequenceId, ByteBuf buffer) {
+        ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) topic.getManagedLedger();
+        if (checkIfReady()) {
+            // Transaction buffer is ready, directly append the buffer
+            return internalAppendBufferToTxn(txnId, sequenceId, buffer);
+        } else if (changeToInitializingState()) {
+            // Transition to initializing state and record max read position if it's the first usage
+            Position firstMaxReadPosition = topic.getManagedLedger().getLastConfirmedEntry();
+            if (managedLedger.getProperties().get(MAX_READ_POSITION) == null) {
+                HashMap<String, String> hashMap = new HashMap<>();
+                hashMap.put(MAX_READ_POSITION, firstMaxReadPosition.toString());
+                managedLedger.asyncSetProperties(hashMap, new AsyncCallbacks.UpdatePropertiesCallback() {
+                    @Override
+                    public void updatePropertiesComplete(Map<String, String> properties, Object ctx) {
+                        changeToReadyState();
+                        transactionBufferFuture.complete(null);
+                    }
+
+                    @Override
+                    public void updatePropertiesFailed(ManagedLedgerException exception, Object ctx) {
+                        log.error("Failed to set first max read position to topic {}", topic.getName(), exception);
+                        changeToCloseState();
+                        transactionBufferFuture.completeExceptionally(exception);
+                    }
+                }, null);
+            }
+        }
+        // Return a CompletableFuture that will complete after recovering the transaction buffer,
+        // then append the buffer
+        return transactionBufferFuture.thenCompose(ignore -> internalAppendBufferToTxn(txnId, sequenceId, buffer));
+    }
+
+    private PositionImpl getPositionFromString(String positionStr) {
+        String[] strs = positionStr.split(":");
+        if (strs.length != 2) {
+            log.error("TransactionBufferRecover receive a start position {} from topic {} properties",
+                    positionStr, topic.getName());
+            return PositionImpl.EARLIEST;
+        }
+        return new PositionImpl(Integer.parseInt(strs[0]), Integer.parseInt(strs[1]));
+    }
+
+    private CompletableFuture<Position> internalAppendBufferToTxn(TxnID txnId, long sequenceId, ByteBuf buffer) {
         CompletableFuture<Position> completableFuture = new CompletableFuture<>();
         Long lowWaterMark = lowWaterMarks.get(txnId.getMostSigBits());
         if (lowWaterMark != null && lowWaterMark >= txnId.getLeastSigBits()) {
@@ -567,16 +595,10 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
         @SneakyThrows
         @Override
         public void run() {
-            if (!this.topicTransactionBuffer.changeToInitializingState()) {
-                log.warn("TransactionBuffer {} of topic {} can not change state to Initializing",
-                        this, topic.getName());
-                return;
-            }
             abortedTxnProcessor.recoverFromSnapshot().thenAcceptAsync(startReadCursorPosition -> {
                 //Transaction is not use for this topic, so just make maxReadPosition as LAC.
                 if (startReadCursorPosition == null) {
-                    callBack.noNeedToRecover();
-                    return;
+                    this.startReadCursorPosition = topicTransactionBuffer.maxReadPosition;
                 } else {
                     this.startReadCursorPosition = startReadCursorPosition;
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferProvider.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.transaction.buffer.impl;
 
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBuffer;
@@ -29,7 +30,7 @@ import org.apache.pulsar.broker.transaction.buffer.TransactionBufferProvider;
 public class TopicTransactionBufferProvider implements TransactionBufferProvider {
 
     @Override
-    public TransactionBuffer newTransactionBuffer(Topic originTopic) {
-        return new TopicTransactionBuffer((PersistentTopic) originTopic);
+    public TransactionBuffer newTransactionBuffer(Topic originTopic, PositionImpl startUsedPosition) {
+        return new TopicTransactionBuffer((PersistentTopic) originTopic, startUsedPosition);
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferDisable.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferDisable.java
@@ -104,11 +104,6 @@ public class TransactionBufferDisable implements TransactionBuffer {
     }
 
     @Override
-    public CompletableFuture<Void> checkIfTBRecoverCompletely(boolean isTxn) {
-        return CompletableFuture.completedFuture(null);
-    }
-
-    @Override
     public long getOngoingTxnCount() {
         return 0;
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
@@ -663,7 +663,7 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
         field.set(getPulsarServiceList().get(0), transactionBufferSnapshotServiceFactory);
 
         // recover again will throw then close topic
-        new TopicTransactionBuffer(originalTopic);
+        new TopicTransactionBuffer(originalTopic, PositionImpl.EARLIEST);
         Awaitility.await().untilAsserted(() -> {
             // isFenced means closed
             Field close = AbstractTopic.class.getDeclaredField("isFenced");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.transaction.buffer;
 import static org.mockito.ArgumentMatchers.anyString;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import io.jsonwebtoken.lang.Assert;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.HashedWheelTimer;
@@ -36,20 +37,28 @@ import java.util.concurrent.ExecutionException;
 
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.stats.PrometheusMetricsTest;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.broker.transaction.TransactionTestBase;
+import org.apache.pulsar.broker.transaction.buffer.impl.TopicTransactionBuffer;
+import org.apache.pulsar.broker.transaction.buffer.impl.TopicTransactionBufferState;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferClientImpl;
+import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferDisable;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferHandlerImpl;
+import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.client.api.transaction.TransactionBufferClient;
 import org.apache.pulsar.client.api.transaction.TransactionBufferClientException;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.ClientCnx;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.api.proto.TxnAction;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
@@ -370,4 +379,122 @@ public class TransactionBufferClientTest extends TransactionTestBase {
         tbClient.abortTxnOnSubscription(topic + "_abort_topic", sub, 1L, 1L, -1L).get();
         tbClient.abortTxnOnSubscription(topic + "_commit_topic", sub, 1L, 1L, -1L).get();
     }
+
+    /**
+     * This unit test verifies the lazy loading behavior of the transaction buffer in the following scenarios:
+     * 1. Normal message sending is not affected.
+     * 2. The transaction buffer is now lazily loaded.
+     * 3. Loading of the transaction buffer occurs only after sending the first transactional message.
+     * 4. The buffer is not loaded when a consumer connects to the topic.
+     * 5. Topics that have used transactions will be loaded regardless of enabling transaction coordinator
+     * during topic load.
+     */
+    @Test
+    public void testTransactionBufferLazyLoad() throws Exception {
+        // Prepare environment
+        admin.tenants().createTenant(NamespaceName.SYSTEM_NAMESPACE.getTenant(),
+                new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet(CLUSTER_NAME)));
+        admin.namespaces().createNamespace(NamespaceName.SYSTEM_NAMESPACE.toString());
+        createTransactionCoordinatorAssign(16);
+        String topic1 = "persistent://" + namespace + "/testTransactionLazyLoad-1";
+        String topic2 = "persistent://" + namespace + "/testTransactionLazyLoad-2";
+        String topic3 = "persistent://" + namespace + "/testTransactionLazyLoad-3";
+
+        // Step 1: Disabling transaction, create topic1. Consumer and producer of topic1 can work normally.
+        setTransactionCoordinatorEnabled(false);
+        admin.topics().createNonPartitionedTopic(topic1);
+        @Cleanup
+        Consumer<byte[]> consumer1 = pulsarClient.newConsumer()
+                .topic(topic1)
+                .subscriptionName("my-sub")
+                .subscribe();
+        @Cleanup
+        Producer<byte[]> producer1 = pulsarClient.newProducer()
+                .topic(topic1)
+                .create();
+        producer1.newMessage().send();
+        Assert.notNull(consumer1.receive(5, TimeUnit.SECONDS));
+        assertTransactionBufferState(topic1, TransactionBufferDisable.class);
+
+        // Step 2: Enabling transaction, create topic2.
+        setTransactionCoordinatorEnabled(true);
+
+        // Step 2.1: Verify the initial state of the transactionBuffer for topic2 is NONE.
+        admin.topics().createNonPartitionedTopic(topic2);
+        TransactionBuffer transactionBuffer2 = assertTransactionBufferState(topic2, TopicTransactionBuffer.class);
+        assertEquals(((TopicTransactionBuffer) transactionBuffer2).getState(), TopicTransactionBufferState.State.None);
+
+        // Step 2.2: Create a producer for topic2. The state should still be NONE.
+        pulsarClient = PulsarClient.builder().serviceUrl(pulsarServiceList.get(0).getBrokerServiceUrl())
+                .enableTransaction(true)
+                .build();
+        @Cleanup
+        Producer<byte[]> producer2 = pulsarClient.newProducer()
+                .topic(topic2)
+                .create();
+        assertEquals(((TopicTransactionBuffer) transactionBuffer2).getState(), TopicTransactionBufferState.State.None);
+
+        // Step 2.3: Send a transaction message to topic2. The state should change to READY.
+        Transaction transaction = pulsarClient.newTransaction()
+                .withTransactionTimeout(5, TimeUnit.HOURS).build().get();
+        producer2.newMessage(transaction).send();
+        assertEquals(((TopicTransactionBuffer) transactionBuffer2).getState(), TopicTransactionBufferState.State.Ready);
+
+        // Step 2.4: Unload topic2 and create a consumer for topic2 without sending transactional messages.
+        // The state should become READY after some time.
+        @Cleanup
+        Consumer<byte[]> consumer2 = pulsarClient.newConsumer()
+                .topic(topic2)
+                .subscriptionName("my-sub")
+                .subscribe();
+        Awaitility.await().untilAsserted(() -> assertTransactionBufferState(topic2,
+                TopicTransactionBuffer.class, TopicTransactionBufferState.State.Ready));
+
+        // Step 2.5: Disable transaction, unload topic1 and topic2.
+        // topic1, which hasn't sent transaction messages, should have TransactionBufferDisable.
+        // topic2, which has sent transaction messages, should have TopicTransactionBuffer.
+        setTransactionCoordinatorEnabled(false);
+        admin.topics().unload(topic1);
+        admin.topics().unload(topic2);
+        assertTransactionBufferState(topic2, TopicTransactionBuffer.class);
+        assertTransactionBufferState(topic1, TransactionBufferDisable.class);
+        Awaitility.await().untilAsserted(() -> assertTransactionBufferState(topic2,
+                TopicTransactionBuffer.class, TopicTransactionBufferState.State.Ready));
+
+        // Step 3: Recover environment.
+        setTransactionCoordinatorEnabled(true);
+    }
+
+    private void setTransactionCoordinatorEnabled(boolean enabled) {
+        pulsarServiceList.forEach(pulsarService -> {
+            pulsarService.getConfig().setTransactionCoordinatorEnabled(enabled);
+        });
+    }
+
+    private TransactionBuffer assertTransactionBufferState(String topic, Class<?> expectedClass) throws Exception {
+        return assertTransactionBufferState(topic, expectedClass, null);
+    }
+
+    private TransactionBuffer assertTransactionBufferState(
+            String topic, Class<?> expectedClass, TopicTransactionBufferState.State expectedState) throws Exception {
+        Field tBField = PersistentTopic.class.getDeclaredField("transactionBuffer");
+        tBField.setAccessible(true);
+        TransactionBuffer transactionBuffer = null;
+        for (int i = 0; i < 3; i++) {
+            if (pulsarServiceList.get(i).getNamespaceService().checkTopicOwnership(TopicName.get(topic)).get()) {
+                transactionBuffer = (TransactionBuffer) tBField.get(
+                        pulsarServiceList.get(i)
+                                .getBrokerService()
+                                .getTopic(topic, false).get()
+                                .get());
+                assertTrue(expectedClass.isInstance(transactionBuffer));
+                if (expectedState != null) {
+                    assertEquals(((TopicTransactionBuffer) transactionBuffer).getState(), expectedState);
+                }
+                break;
+            }
+        }
+        return transactionBuffer;
+    }
+
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferTest.java
@@ -31,6 +31,7 @@ import io.netty.buffer.Unpooled;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.transaction.exception.buffer.TransactionBufferException;
 import org.apache.pulsar.broker.transaction.buffer.impl.InMemTransactionBufferProvider;
@@ -69,7 +70,7 @@ public class TransactionBufferTest {
     @BeforeMethod
     public void setup() throws Exception {
         PersistentTopic persistentTopic = mock(PersistentTopic.class);
-        this.buffer = this.provider.newTransactionBuffer(persistentTopic);
+        this.buffer = this.provider.newTransactionBuffer(persistentTopic, PositionImpl.LATEST);
     }
 
     @AfterMethod(alwaysRun = true)


### PR DESCRIPTION
## Motivation
This PR introduces lazy loading for the transaction buffer, improving efficiency and resource utilization. It includes the following modifications:

1. Implement lazy loading for the transaction buffer, ensuring it is loaded only when necessary.
2. Always load the transaction buffer if it has been used before, regardless of the transaction coordinator's state. ## Modification
1. Modify the topic metadata when the transaction buffer is used for the first time.
2. Determine the type of transaction buffer based on whether the topic buffer has been used and whether the transaction coordinator is enabled.
3. Remove the checkIfTBRecoverCompletely function, as it is no longer required. It eliminates the need to take a snapshot when a producer connects. These changes optimize the behavior of the transaction buffer, improving performance and resource management.


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
