### PR TITLE
[improve][ci]Add "pip" into the scope of the pull request title check rule

### DIFF
--- a/.github/workflows/ci-semantic-pull-request.yml
+++ b/.github/workflows/ci-semantic-pull-request.yml
@@ -47,6 +47,7 @@ jobs:
             improve
             refactor
             revert
+            pip
           # Scope abbreviation comments:
           # cli     -> command line interface
           # fn      -> Pulsar Functions
@@ -85,6 +86,7 @@ jobs:
             txn
             ws
             zk
+            design
           # The pull request's title should be fulfilled the following pattern:
           #
           #     [<type>][<optional scope>] <description>

--- a/.github/workflows/ci-semantic-pull-request.yml
+++ b/.github/workflows/ci-semantic-pull-request.yml
@@ -47,7 +47,6 @@ jobs:
             improve
             refactor
             revert
-            pip
           # Scope abbreviation comments:
           # cli     -> command line interface
           # fn      -> Pulsar Functions
@@ -86,7 +85,7 @@ jobs:
             txn
             ws
             zk
-            design
+            pip
           # The pull request's title should be fulfilled the following pattern:
           #
           #     [<type>][<optional scope>] <description>


### PR DESCRIPTION
### Motivation

Per the PIP process (new) as you see [here](https://github.com/apache/pulsar/blob/master/pip/README.md) title should start with "|[pip][design] PIP- -"  But the check rule of PR title is not supported

### Modifications

Add new a scope `pip` for the check pull request title


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
