### PR TITLE
[fix][txn] Use PulsarResource  check for topic existence instead of brokerservice.getTopic()

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -385,8 +385,8 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
         return topic.getBrokerService().getPulsar().getPulsarResources().getTopicResources()
                 .listPersistentTopicsAsync(NamespaceName.get(TopicName.get(topic.getName()).getNamespace()))
                 .thenCompose(topics -> {
-                    if (!topics.contains(TopicDomain.persistent + "://" +
-                            TopicName.get(topic.getName()).getNamespace() + "/"
+                    if (!topics.contains(TopicDomain.persistent + "://"
+                            + TopicName.get(topic.getName()).getNamespace() + "/"
                             + SystemTopicNames.TRANSACTION_BUFFER_SNAPSHOT)) {
                         return CompletableFuture.completedFuture(null);
                     } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -58,6 +58,7 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
@@ -381,10 +382,11 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
 
     // This method will be deprecated and removed in version 4.x.0
     private CompletableFuture<PositionImpl> recoverOldSnapshot() {
-        return topic.getBrokerService().getTopic(TopicName.get(topic.getName()).getNamespace() + "/"
-                        + SystemTopicNames.TRANSACTION_BUFFER_SNAPSHOT, false)
-                .thenCompose(topicOption -> {
-                    if (!topicOption.isPresent()) {
+        return topic.getBrokerService().getPulsar().getPulsarResources().getTopicResources()
+                .listPersistentTopicsAsync(NamespaceName.get(TopicName.get(topic.getName()).getNamespace()))
+                .thenCompose(topics -> {
+                    if (!topics.contains(TopicName.get(topic.getName()).getNamespace() + "/"
+                            + SystemTopicNames.TRANSACTION_BUFFER_SNAPSHOT)) {
                         return CompletableFuture.completedFuture(null);
                     } else {
                         return topic.getBrokerService().getPulsar().getTransactionBufferSnapshotServiceFactory()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -385,7 +385,8 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
         return topic.getBrokerService().getPulsar().getPulsarResources().getTopicResources()
                 .listPersistentTopicsAsync(NamespaceName.get(TopicName.get(topic.getName()).getNamespace()))
                 .thenCompose(topics -> {
-                    if (!topics.contains(TopicName.get(topic.getName()).getNamespace() + "/"
+                    if (!topics.contains(TopicDomain.persistent + "://" +
+                            TopicName.get(topic.getName()).getNamespace() + "/"
                             + SystemTopicNames.TRANSACTION_BUFFER_SNAPSHOT)) {
                         return CompletableFuture.completedFuture(null);
                     } else {


### PR DESCRIPTION
## Motivation
During the recovery process, if the system topic `__transaction_buffer_snapshot` is not located on the same broker as the common topic, it can cause issues and result in a `ServiceUnitNotReadyException`, leading to recovery failure. The current approach of using `topic.getBrokerService().getTopic()` to check the existence of the system topic can trigger errors during the `checkTopicNsOwnership` step. 
## Modification
To avoid potential recovery failures and ensure a reliable check for topic existence, we should use the `pulsarResource` feature. By utilizing `pulsarResource`, we can list the persistent topics in the namespace and verify whether the system topic exists on any broker. This approach provides a more robust solution, preventing the occurrence of `ServiceUnitNotReadyException` and ensuring successful recovery in scenarios where the system topic is not located on the same broker as the common topic.


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
