### PR TITLE
[fix] [broker]Consumption stuck due to orphan consumers after the connection reconnect

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1244,7 +1244,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             }
                         })
                         .thenAcceptAsync(consumer -> {
-                            if (consumerFuture.complete(consumer) || !isActive()) {
+                            if (!consumerFuture.complete(consumer) || !isActive()) {
                                 // Two cases:
                                 // 1. The consumer future was completed before by a close command.
                                 // 2. The consumer future was completed after the ServerCnx closed.


### PR DESCRIPTION
### Motivation

There may leave an orphan consumer after the `ServerCnx` closed, which would cause consumption to get stuck. For example:

| time | `add a new consumer` | `connection health check` |
| --- | --- | --- |
| 1 | | Health check is failed |
| 2 | | Push the task `ServerCnx.close` into the `eventLoop` |
| 3 | Push a task typed `cmd subscribe` into the `eventLoop` |
| 4 | | connection inactive |
| 5 | | Close all consumers bound to this connection |
| 6 | Register new consumers into the subscription |
| 7 | send messages to this consumer(the send will fail, but no warn log<sup>[1]</sup>) |
| 8 | These messages can not be delivered until the topic is unloaded |

**[1]**: see [[improve] [broker] Improve dispatcher log to trace io error that may cause consumption stuck #20568](https://github.com/apache/pulsar/pull/20568)

### Modifications
Just like producer registration<sup>[2]</sup>: add a checker `connection.isAtive` after the consumer created complete.

**[2]**: https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java#LL1601C45-L1601C45
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
