### PR TITLE
Enable kv logs in log4j configuration

### DIFF
--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -56,7 +56,7 @@ Configuration:
       name: Console
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"
+        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} %X - %msg%n"
 
     # Rolling file appender configuration
     RollingFile:
@@ -65,7 +65,7 @@ Configuration:
       filePattern: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}-%d{MM-dd-yyyy}-%i.log.gz"
       immediateFlush: ${sys:pulsar.log.immediateFlush}
       PatternLayout:
-        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"
+        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} %X - %msg%n"
       Policies:
         TimeBasedTriggeringPolicy:
           interval: 1


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Master Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

We introduced DirectIO since BookKeeper 4.16.0, and the DirectIO classes use KV-based Slf4jSlogger. https://github.com/apache/bookkeeper/blob/master/bookkeeper-slogger/slf4j/src/main/java/org/apache/bookkeeper/slogger/slf4j/Slf4jSlogger.java 

In order to print the KV out, we need to add `%X` flag in log4j2.yaml, otherwise the log will miss the detailed key and values.

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

Add `%X` for log4j2.yaml Appender PatternLayout. 

One Behavior change is that the command log will contain `{}` string if the key value is empty.
For example, between `org.apache.bookkeeper.replication.Auditor` and ` - I'm starting as Auditor Bookie. ID: 10.25.14.105:3181`, it contains and extra `{}`
```
2023-06-14T16:36:32,563+0800 [AuditorElector-10.25.14.105:3181] INFO  org.apache.bookkeeper.replication.Auditor {} - I'm starting as Auditor Bookie. ID: 10.25.14.105:3181
2023-06-14T16:36:32,566+0800 [AuditorElector-10.25.14.105:3181] INFO  org.apache.bookkeeper.replication.Auditor {} - Auditor periodic bookie checking enabled 'auditorPeriodicBookieCheckInterval' 86400 seconds
2023-06-14T16:36:32,566+0800 [AuditorElector-10.25.14.105:3181] INFO  org.apache.bookkeeper.replication.Auditor {} - Auditor periodic ledger checking enabled 'auditorPeriodicCheckInterval' 604800 seconds
2023-06-14T16:36:32,567+0800 [AuditorBookie-10.25.14.105:3181] INFO  org.apache.bookkeeper.replication.AuditorBookieCheckTask {} - Starting auditBookies
```


If the key value has items, the log will looks like:
```
2023-06-14T16:36:30,507+0800 [main] INFO  org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage {dirs=[data/bookkeeper/ledgers/current], durationMs=0, event=ENTRYLOG_IDS_CANDIDATES_SELECTED, maxId=2147483647, nextId=7}
- ENTRYLOG_IDS_CANDIDATES_SELECTED
2023-06-14T16:36:30,543+0800 [main] INFO  org.apache.bookkeeper.slogger.slf4j.Slf4jSlogger {directory=data/bookkeeper/ledgers/current, event=ENTRYLOGGER_CREATED, maxCachedReaders=32, maxCachedReadersPerThread=4, maxFileSiz
e=1073741824, maxSaneEntrySize=5252620, perThreadBufferSize=33554432, readBufferSize=8388608, singleWriteBufferSize=33554432, totalReadBufferSize=268435456, totalWriteBufferSize=268435456} - ENTRYLOGGER_CREATED
```

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
