### PR TITLE
Add set output producer to the Go function context

### DIFF
--- a/pulsar-function-go/pf/context.go
+++ b/pulsar-function-go/pf/context.go
@@ -161,6 +161,13 @@ func (c *FunctionContext) NewOutputMessage(topicName string) pulsar.Producer {
 	return c.outputMessage(topicName)
 }
 
+// SetOutputProducer allows us to manually set an output producer on the function.
+func (c *FunctionContext) SetOutputProducer(producer pulsar.Producer) {
+	c.outputMessage = func(topic string) pulsar.Producer {
+		return producer
+	}
+}
+
 // SetCurrentRecord sets the current message into the function context called
 // for each message before executing a handler function
 func (c *FunctionContext) SetCurrentRecord(record pulsar.Message) {


### PR DESCRIPTION
<!--
### Motivation

I've been trying to unit-test Pulsar Go functions and I'm struggling to set the output producer within my tests without starting up the function & spinning up a Pulsar instance. I would like to set the output producer with a mock and then be able to unit test my `HandleRequest` functions using that mock.

### Modifications

Add a `SetOutputProducer` on the Go function context that allows me to set the output producer in tests.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
