### PR TITLE
[improve][admin] Clusters list API return clusters with local flag

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
@@ -88,7 +88,9 @@ public class ClustersBase extends AdminResource {
                 .thenApply(clusters -> clusters.stream()
                         // Remove "global" cluster from returned list
                         .filter(cluster -> !Constants.GLOBAL_CLUSTER.equals(cluster))
-                        .collect(Collectors.toSet()))
+                        .map(cluster -> pulsar().getConfig().getClusterName().equalsIgnoreCase(cluster)
+                                ? cluster + "(local)" : cluster
+                        ).collect(Collectors.toSet()))
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     log.error("[{}] Failed to get clusters {}", clientAppId(), ex);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -250,6 +250,10 @@ public class ReplicatorTest extends ReplicatorTestBase {
         assertEquals(list.get(0), url2.toString().replace("http://", ""));
         //restore configuration
         pulsar1.getConfiguration().setAuthorizationEnabled(false);
+        final List<String> clusters = admin1.clusters().getClusters();
+        assertEquals(clusters.stream().filter(c -> c.contains("r1")).findFirst().get(), "r1(local)");
+        final List<String> clusters2 = admin2.clusters().getClusters();
+        assertEquals(clusters2.stream().filter(c -> c.contains("r2")).findFirst().get(), "r2(local)");
     }
 
     @SuppressWarnings("unchecked")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -250,10 +250,6 @@ public class ReplicatorTest extends ReplicatorTestBase {
         assertEquals(list.get(0), url2.toString().replace("http://", ""));
         //restore configuration
         pulsar1.getConfiguration().setAuthorizationEnabled(false);
-        final List<String> clusters = admin1.clusters().getClusters();
-        assertEquals(clusters.stream().filter(c -> c.contains("r1")).findFirst().get(), "r1(local)");
-        final List<String> clusters2 = admin2.clusters().getClusters();
-        assertEquals(clusters2.stream().filter(c -> c.contains("r2")).findFirst().get(), "r2(local)");
     }
 
     @SuppressWarnings("unchecked")

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
@@ -24,6 +24,8 @@ import com.beust.jcommander.Parameters;
 import com.google.common.collect.Sets;
 import java.util.Arrays;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.admin.cli.utils.CmdUtils;
@@ -41,8 +43,18 @@ public class CmdClusters extends CmdBase {
 
     @Parameters(commandDescription = "List the existing clusters")
     private class List extends CliCommand {
+
+        @Parameter(names = { "-c", "--current" },
+                description = "Print the current cluster with (*)", required = false)
+        private boolean current = false;
+
         void run() throws PulsarAdminException {
-            print(getAdmin().clusters().getClusters());
+            java.util.List<String> clusters = getAdmin().clusters().getClusters();
+            String clusterName = getAdmin().brokers().getRuntimeConfigurations().get("clusterName");
+            final java.util.List<String> result = clusters.stream().map(c ->
+                    c.equals(clusterName) ? (current ? c + "(*)" : c) : c
+            ).collect(Collectors.toList());
+            print(result);
         }
     }
 


### PR DESCRIPTION
Fixes #20581
PIP: #20614

### Motivation
After configuring the geo-replication on Pulsar clusters, the `clusters list` API will return multiple clusters, including the local Pulsar cluster and remote clusters like 

```
bin/pulsar-admin clusters list
us-west
us-east
us-cent
```
But in this return, you can't distinguish the local and the remote cluster. When you need to remove the geo-replication configuration, it will be hard to decide which cluster should be removed on replicated tenants and namespaces unless you record the cluster information. 


### Modification
Add `local` flag to distinguish clusters
```
bin/pulsar-admin clusters list
us-west(local)
us-east
us-cent
```



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


