### PR TITLE
[fix][sec] Suppress false positive CVE-2023-35116 in jackson-databind

### DIFF
--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -433,5 +433,11 @@
        ]]></notes>
         <cve>CVE-2020-8908</cve>
     </suppress>
-
+    <suppress>
+        <notes><![CDATA[
+       This is a false positive in jackson-databind.
+       See https://github.com/FasterXML/jackson-databind/issues/3972#issuecomment-1596604021
+       ]]></notes>
+        <cve>CVE-2023-35116</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### Motivation

OWASP dependency check is failing because of CVE-2023-35116 in jackson-databind

### Modifications

Suppress false positive CVE-2023-35116 in jackson-databind
- see https://github.com/FasterXML/jackson-databind/issues/3972#issuecomment-1596604021

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->