### PR TITLE
[fix][sec] Upgrade snappy-java to address multiple CVEs

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -480,7 +480,7 @@ The Apache Software License, Version 2.0
     - org.apache.zookeeper-zookeeper-jute-3.8.1.jar
     - org.apache.zookeeper-zookeeper-prometheus-metrics-3.8.1.jar
   * Snappy Java
-    - org.xerial.snappy-snappy-java-1.1.8.4.jar
+    - org.xerial.snappy-snappy-java-1.1.10.1.jar
   * Google HTTP Client
     - com.google.http-client-google-http-client-gson-1.41.0.jar
     - com.google.http-client-google-http-client-1.41.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@ flexible messaging model and an intuitive client API.</description>
     <zookeeper.version>3.8.1</zookeeper.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <commons-text.version>1.10.0</commons-text.version>
-    <snappy.version>1.1.8.4</snappy.version> <!-- ZooKeeper server -->
+    <snappy.version>1.1.10.1</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
     <netty.version>4.1.93.Final</netty.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -458,7 +458,7 @@ The Apache Software License, Version 2.0
   * JSON Simple
     - json-simple-1.1.1.jar
   * Snappy
-    - snappy-java-1.1.8.4.jar
+    - snappy-java-1.1.10.1.jar
   * Jackson
     - jackson-module-parameter-names-2.14.2.jar
   * Java Assist


### PR DESCRIPTION
### Motivation

OWASP dependency check has detected multiple CVEs in snappy-java

### Modifications

- Upgrade snappy-java to 1.1.10.1 to address multiple CVEs:
  - CVE-2023-34453 
  - CVE-2023-34454
  - CVE-2023-34455

See https://github.com/xerial/snappy-java/releases/tag/v1.1.10.1

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->