### PR TITLE
[fix][sql] Remove useless configuration for Pulsar SQL

### DIFF
--- a/pulsar-sql/presto-distribution/src/main/resources/conf/catalog/pulsar.properties
+++ b/pulsar-sql/presto-distribution/src/main/resources/conf/catalog/pulsar.properties
@@ -113,10 +113,6 @@ pulsar.bookkeeper-explicit-interval=0
 # running in same sql worker. 0 is represents disable the cache, default is 0.
 pulsar.managed-ledger-cache-size-MB = 0
 
-# Number of threads to be used for managed ledger tasks dispatching,
-# default is Runtime.getRuntime().availableProcessors().
-# pulsar.managed-ledger-num-worker-threads =
-
 # Number of threads to be used for managed ledger scheduled tasks,
 # default is Runtime.getRuntime().availableProcessors().
 # pulsar.managed-ledger-num-scheduler-threads =

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnectorConfig.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnectorConfig.java
@@ -18,9 +18,21 @@
  */
 package org.apache.pulsar.sql.presto;
 
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.json.JsonModule;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeId;
+import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.TypeOperators;
+import io.trino.spi.type.TypeSignature;
 import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class TestPulsarConnectorConfig {
 
@@ -98,6 +110,36 @@ public class TestPulsarConnectorConfig {
         Assert.assertEquals(offloadPolicies.getS3ManagedLedgerOffloadBucket(), bucket);
         Assert.assertEquals(offloadPolicies.getS3ManagedLedgerOffloadRegion(), region);
         Assert.assertEquals(offloadPolicies.getS3ManagedLedgerOffloadServiceEndpoint(), endpoint);
+    }
+
+    @Test
+    public void testAnnotatedConfigurations() {
+        Bootstrap app = new Bootstrap(
+                new JsonModule(),
+                new PulsarConnectorModule("connectorId", Mockito.mock(TypeManager.class)));
+
+        Map<String, String> config = new HashMap<>();
+
+        config.put("pulsar.managed-ledger-offload-driver", "aws-s3");
+        config.put("pulsar.offloaders-directory", "/pulsar/offloaders");
+        config.put("pulsar.managed-ledger-offload-max-threads", "2");
+        config.put("pulsar.offloader-properties", "{\"s3ManagedLedgerOffloadBucket\":\"offload-bucket\","
+                + "\"s3ManagedLedgerOffloadRegion\":\"us-west-2\","
+                + "\"s3ManagedLedgerOffloadServiceEndpoint\":\"http://s3.amazonaws.com\"}");
+        config.put("pulsar.auth-plugin", "org.apache.pulsar.client.impl.auth.AuthenticationToken");
+        config.put("pulsar.auth-params", "params");
+        config.put("pulsar.tls-allow-insecure-connection", "true");
+        config.put("pulsar.tls-hostname-verification-enable", "true");
+        config.put("pulsar.tls-trust-cert-file-path", "/path");
+        config.put("pulsar.bookkeeper-num-io-threads", "10");
+        config.put("pulsar.bookkeeper-num-worker-threads", "10");
+        config.put("pulsar.managed-ledger-num-scheduler-threads", "10");
+        config.put("pulsar.stats-provider", "org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider");
+        config.put("pulsar.stats-provider-configs", "{\"httpServerEnabled\":\"false\","
+                + "\"prometheusStatsHttpPort\":\"9092\","
+                + "\"prometheusStatsHttpEnable\":\"true\"}");
+
+        app.doNotInitializeLogging().setRequiredConfigurationProperties(config).initialize();
     }
 
 }

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnectorConfig.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarConnectorConfig.java
@@ -18,21 +18,15 @@
  */
 package org.apache.pulsar.sql.presto;
 
-import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
-import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeId;
 import io.trino.spi.type.TypeManager;
-import io.trino.spi.type.TypeOperators;
-import io.trino.spi.type.TypeSignature;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class TestPulsarConnectorConfig {
 


### PR DESCRIPTION
### Motivation

In PR https://github.com/apache/pulsar/pull/14506, we remove the useless config `managedLedgerNumWorkerThreads` 
 but we didn't remove the config from the config file, if users use this configuration, the Pulsar SQL can't startup due to `strictConfig` mode, remove this useless configuration for Pulsar SQL.

<img width="763" alt="image" src="https://github.com/apache/pulsar/assets/15029908/d43f20db-d4df-4644-a618-801f6daee5f5">

```
// at this point all config file properties should be used
// so we can calculate the unused properties
unusedProperties.keySet().removeAll(configurationFactory.getUsedProperties());

for (String key : unusedProperties.keySet()) {
    Message message = new Message(format("Configuration property '%s' was not used", key));
    (strictConfig ? errors : warnings).add(message);
}

// If there are configuration errors, fail-fast to keep output clean
if (!errors.isEmpty()) {
    throw new ApplicationConfigurationException(errors, warnings);
}
```

### Modifications

Remove useless configuration `pulsar.managed-ledger-num-worker-threads` from the config file.

### Verifying this change

Add tests for the annotated configurations.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/gaoran10/pulsar/pull/28

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
