### PR TITLE
[cleanup][test] Remove and prevent junit

### DIFF
--- a/buildtools/src/main/resources/pulsar/checkstyle.xml
+++ b/buildtools/src/main/resources/pulsar/checkstyle.xml
@@ -137,7 +137,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
 
         <module name="IllegalImport">
             <property name="illegalPkgs"
-                      value="autovalue.shaded, avro.shaded, bk-shade, com.google.api.client.repackaged, com.google.appengine.repackaged, org.apache.curator.shaded, org.testcontainers.shaded" />
+                      value="autovalue.shaded, avro.shaded, bk-shade, com.google.api.client.repackaged, com.google.appengine.repackaged, org.apache.curator.shaded, org.testcontainers.shaded, org.junit" />
         </module>
 
         <module name="RedundantModifier">

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/EmbeddedPulsarCluster.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/EmbeddedPulsarCluster.java
@@ -24,11 +24,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.Builder;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.metadata.bookkeeper.BKCluster;
-import org.junit.platform.commons.util.StringUtils;
 
 
 public class EmbeddedPulsarCluster implements AutoCloseable {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMultiBrokersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMultiBrokersTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.broker.admin;
 
-import static org.junit.Assert.assertFalse;
+import static org.testng.Assert.assertFalse;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
@@ -37,9 +37,9 @@ import static org.apache.pulsar.metadata.api.extended.SessionEvent.SessionReesta
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.AssertJUnit.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateCompactionStrategyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateCompactionStrategyTest.java
@@ -25,7 +25,7 @@ import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUni
 import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Owned;
 import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Releasing;
 import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Splitting;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import org.testng.annotations.Test;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupDataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupDataTest.java
@@ -18,14 +18,15 @@
  */
 package org.apache.pulsar.broker.loadbalance.extensions.data;
 
-import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
-import org.apache.pulsar.broker.lookup.LookupResult;
-import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
-import org.junit.Assert;
-import org.testng.annotations.Test;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
+import org.apache.pulsar.broker.lookup.LookupResult;
+import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
+import org.testng.annotations.Test;
 
 @Test(groups = "broker")
 public class BrokerLookupDataTest {
@@ -44,21 +45,21 @@ public class BrokerLookupDataTest {
                 webServiceUrl, webServiceUrlTls, pulsarServiceUrl,
                 pulsarServiceUrlTls, advertisedListeners, protocols, true, true,
                 ExtensibleLoadManagerImpl.class.getName(), System.currentTimeMillis(),"3.0");
-        Assert.assertEquals(webServiceUrl, lookupData.webServiceUrl());
-        Assert.assertEquals(webServiceUrlTls, lookupData.webServiceUrlTls());
-        Assert.assertEquals(pulsarServiceUrl, lookupData.pulsarServiceUrl());
-        Assert.assertEquals(pulsarServiceUrlTls, lookupData.pulsarServiceUrlTls());
-        Assert.assertEquals(Optional.of("9092"), lookupData.getProtocol("kafka"));
-        Assert.assertEquals(Optional.empty(), lookupData.getProtocol("echo"));
-        Assert.assertTrue(lookupData.persistentTopicsEnabled());
-        Assert.assertTrue(lookupData.nonPersistentTopicsEnabled());
-        Assert.assertEquals("3.0", lookupData.brokerVersion());
+        assertEquals(webServiceUrl, lookupData.webServiceUrl());
+        assertEquals(webServiceUrlTls, lookupData.webServiceUrlTls());
+        assertEquals(pulsarServiceUrl, lookupData.pulsarServiceUrl());
+        assertEquals(pulsarServiceUrlTls, lookupData.pulsarServiceUrlTls());
+        assertEquals(Optional.of("9092"), lookupData.getProtocol("kafka"));
+        assertEquals(Optional.empty(), lookupData.getProtocol("echo"));
+        assertTrue(lookupData.persistentTopicsEnabled());
+        assertTrue(lookupData.nonPersistentTopicsEnabled());
+        assertEquals("3.0", lookupData.brokerVersion());
 
 
         LookupResult lookupResult = lookupData.toLookupResult();
-        Assert.assertEquals(webServiceUrl, lookupResult.getLookupData().getHttpUrl());
-        Assert.assertEquals(webServiceUrlTls, lookupResult.getLookupData().getHttpUrlTls());
-        Assert.assertEquals(pulsarServiceUrl, lookupResult.getLookupData().getBrokerUrl());
-        Assert.assertEquals(pulsarServiceUrlTls, lookupResult.getLookupData().getBrokerUrlTls());
+        assertEquals(webServiceUrl, lookupResult.getLookupData().getHttpUrl());
+        assertEquals(webServiceUrlTls, lookupResult.getLookupData().getHttpUrlTls());
+        assertEquals(pulsarServiceUrl, lookupResult.getLookupData().getBrokerUrl());
+        assertEquals(pulsarServiceUrlTls, lookupResult.getLookupData().getBrokerUrlTls());
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -19,13 +19,13 @@
 package org.apache.pulsar.broker.service;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.common.policies.data.TopicStats;
-import org.junit.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -65,7 +65,7 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
 
         // Verify there has one item in the attribute "publishers" or "replications"
         TopicStats topicStats2 = admin2.topics().getStats(topicName);
-        Assert.assertTrue(topicStats2.getPublishers().size() + topicStats2.getReplication().size() > 0);
+        assertTrue(topicStats2.getPublishers().size() + topicStats2.getReplication().size() > 0);
 
         // cleanup.
         consumer2.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
@@ -37,7 +37,6 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.awaitility.Awaitility;
-import org.junit.Assert;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -126,7 +125,7 @@ public class NonPersistentTopicTest extends BrokerTestBase {
         } catch (PulsarClientException.TopicDoesNotExistException ignored) {
 
         }
-        Assert.assertEquals(admin.topics().getPartitionedTopicMetadata(topicName).partitions, 4);
+        assertEquals(admin.topics().getPartitionedTopicMetadata(topicName).partitions, 4);
     }
 
 
@@ -212,41 +211,41 @@ public class NonPersistentTopicTest extends BrokerTestBase {
                 .subscribe();
 
         ConcurrentOpenHashMap<String, NonPersistentSubscription> subscriptionMap = mockTopic.getSubscriptions();
-        Assert.assertEquals(subscriptionMap.size(), 4);
+        assertEquals(subscriptionMap.size(), 4);
 
         // Check exclusive subscription
         NonPersistentSubscription exclusiveSub = subscriptionMap.get(exclusiveSubName);
-        Assert.assertNotNull(exclusiveSub);
+        assertNotNull(exclusiveSub);
         exclusiveConsumer.close();
         Awaitility.waitAtMost(10, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS)
                 .until(() -> subscriptionMap.get(exclusiveSubName) == null);
 
         // Check failover subscription
         NonPersistentSubscription failoverSub = subscriptionMap.get(failoverSubName);
-        Assert.assertNotNull(failoverSub);
+        assertNotNull(failoverSub);
         failoverConsumer1.close();
         failoverSub = subscriptionMap.get(failoverSubName);
-        Assert.assertNotNull(failoverSub);
+        assertNotNull(failoverSub);
         failoverConsumer2.close();
         Awaitility.waitAtMost(10, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS)
                 .until(() -> subscriptionMap.get(failoverSubName) == null);
 
         // Check shared subscription
         NonPersistentSubscription sharedSub = subscriptionMap.get(sharedSubName);
-        Assert.assertNotNull(sharedSub);
+        assertNotNull(sharedSub);
         sharedConsumer1.close();
         sharedSub = subscriptionMap.get(sharedSubName);
-        Assert.assertNotNull(sharedSub);
+        assertNotNull(sharedSub);
         sharedConsumer2.close();
         Awaitility.waitAtMost(10, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS)
                 .until(() -> subscriptionMap.get(sharedSubName) == null);
 
         // Check KeyShared subscription
         NonPersistentSubscription keySharedSub = subscriptionMap.get(keySharedSubName);
-        Assert.assertNotNull(keySharedSub);
+        assertNotNull(keySharedSub);
         keySharedConsumer1.close();
         keySharedSub = subscriptionMap.get(keySharedSubName);
-        Assert.assertNotNull(keySharedSub);
+        assertNotNull(keySharedSub);
         keySharedConsumer2.close();
         Awaitility.waitAtMost(10, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS)
                 .until(() -> subscriptionMap.get(keySharedSubName) == null);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -80,7 +80,7 @@ import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.awaitility.Awaitility;
-import org.junit.Assert;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/SegmentAbortedTxnProcessorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/SegmentAbortedTxnProcessorTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.broker.transaction;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import java.lang.reflect.Field;
@@ -152,7 +152,7 @@ public class SegmentAbortedTxnProcessorTest extends TransactionTestBase {
                 .getDeclaredField("taskQueue");
         taskQueueField.setAccessible(true);
         Queue queue = (Queue) taskQueueField.get(persistentWorker);
-        Awaitility.await().untilAsserted(() -> Assert.assertEquals(queue.size(), 0));
+        Awaitility.await().untilAsserted(() -> assertEquals(queue.size(), 0));
     }
 
     private void verifyAbortedTxnIDAndSegmentIndex(AbortedTxnProcessor processor, int begin, int txnIdSize)
@@ -170,8 +170,8 @@ public class SegmentAbortedTxnProcessorTest extends TransactionTestBase {
         indexField.setAccessible(true);
         LinkedList<TxnID> unsealedSegment = (LinkedList<TxnID>) unsealedSegmentField.get(processor);
         LinkedMap<PositionImpl, TxnID> indexes = (LinkedMap<PositionImpl, TxnID>) indexField.get(processor);
-        Assert.assertEquals(unsealedSegment.size(), txnIdSize % SEGMENT_SIZE);
-        Assert.assertEquals(indexes.size(), txnIdSize / SEGMENT_SIZE);
+        assertEquals(unsealedSegment.size(), txnIdSize % SEGMENT_SIZE);
+        assertEquals(indexes.size(), txnIdSize / SEGMENT_SIZE);
     }
 
     // Verify the update index future can be completed when the queue has other tasks.
@@ -269,7 +269,7 @@ public class SegmentAbortedTxnProcessorTest extends TransactionTestBase {
                 segmentCount++;
             }
         }
-        Assert.assertEquals(segmentCount, size);
+        assertEquals(segmentCount, size);
     }
 
     private void verifySnapshotSegmentsIndexSize(String topic, int size) throws Exception {
@@ -286,7 +286,7 @@ public class SegmentAbortedTxnProcessorTest extends TransactionTestBase {
             }
             System.out.printf("message.getValue().getTopicName() :" + message.getValue().getTopicName());
         }
-        Assert.assertEquals(indexCount, size);
+        assertEquals(indexCount, size);
     }
 
     private void doCompaction(TopicName topic) throws Exception {


### PR DESCRIPTION
### Motivation

We have been away from `JUnit` for a long time, and use `TestNG` instead, but the `testcontainers` library includes `JUnit` library, so we can still use `JUnit` in our project. 

Let's use `TestNG` uniformly.

Prevent `JUnit` by `checkstyle`:
```
[INFO] --- maven-checkstyle-plugin:3.1.2:check (default-cli) @ pulsar-broker ---
[INFO] There are 11 errors reported by Checkstyle 8.37 with /pulsar/buildtools/src/main/resources/pulsar/checkstyle.xml ruleset.
[ERROR] src/test/java/org/apache/pulsar/broker/transaction/SegmentAbortedTxnProcessorTest.java:[21,1] (imports) IllegalImport: org.junit.Assert.assertEquals 。
[ERROR] src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java:[40,1] (imports) IllegalImport: org.junit.Assert.assertEquals 。
[ERROR] src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java:[41,1] (imports) IllegalImport: org.junit.Assert.assertNotEquals 。
[ERROR] src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java:[42,1] (imports) IllegalImport: org.junit.Assert.assertThrows 。
[ERROR] src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateCompactionStrategyTest.java:[28,1] (imports) IllegalImport: org.junit.jupiter.api.Assertions.assertFalse 。
[ERROR] src/test/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupDataTest.java:[24,1] (imports) IllegalImport: org.junit.Assert 。
[ERROR] src/test/java/org/apache/pulsar/broker/EmbeddedPulsarCluster.java:[31,1] (imports) IllegalImport: org.junit.platform.commons.util.StringUtils 。
[ERROR] src/test/java/org/apache/pulsar/broker/admin/AdminApiMultiBrokersTest.java:[21,1] (imports) IllegalImport: org.junit.Assert.assertFalse 。
[ERROR] src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java:[83,1] (imports) IllegalImport: org.junit.Assert 。
[ERROR] src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java:[28,1] (imports) IllegalImport: org.junit.Assert 。
[ERROR] src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java:[40,1] (imports) IllegalImport: org.junit.Assert 。
```

### Modifications

- Prevent `JUnit` by the `checkstyle` file
- Use `org.testng` instead `org.junit`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
