### PR TITLE
[improve][test] add a test to ensure the exclusive consumer will reconnect even if received ConsumerBusy error

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerConsumerInternalTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerConsumerInternalTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.testng.Assert.assertEquals;
+import java.util.concurrent.CountDownLatch;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.service.ServerCnx;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker-api")
+public class SimpleProducerConsumerTest extends ProducerConsumerBase {
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testExclusiveConsumerWillAlwaysRetryEvenIfReceivedConsumerBusyError() throws Exception {
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://my-property/my-ns/tp_");
+        final String subscriptionName = "subscription1";
+        admin.topics().createNonPartitionedTopic(topicName);
+
+        final ConsumerImpl consumer = (ConsumerImpl) pulsarClient.newConsumer().topic(topicName.toString())
+                .subscriptionType(SubscriptionType.Exclusive).subscriptionName(subscriptionName).subscribe();
+
+        ClientCnx clientCnx = consumer.getClientCnx();
+        ServerCnx serverCnx = (ServerCnx) pulsar.getBrokerService()
+                .getTopic(topicName,false).join().get().getSubscription(subscriptionName)
+                .getDispatcher().getConsumers().get(0).cnx();
+
+        // Make a disconnect to trigger broker remove the consumer which related this connection.
+        // Make the second subscribe runs after the broker removing the old consumer, then it will receive
+        // an error: "Exclusive consumer is already connected"
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        serverCnx.execute(() -> {
+            try {
+                countDownLatch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        clientCnx.close();
+        Thread.sleep(1000);
+        countDownLatch.countDown();
+
+        // Verify the consumer will always retry subscribe event received ConsumerBusy error.
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(consumer.getState(), HandlerState.State.Ready);
+        });
+
+        // cleanup.
+        consumer.close();
+        admin.topics().delete(topicName, false);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerConsumerInternalTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerConsumerInternalTest.java
@@ -29,8 +29,12 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+/**
+ * Different with {@link org.apache.pulsar.client.api.SimpleProducerConsumerTest}, this class can visit the variables
+ * of {@link ConsumerImpl} which are modified `protected`.
+ */
 @Test(groups = "broker-api")
-public class SimpleProducerConsumerTest extends ProducerConsumerBase {
+public class ProducerConsumerInternalTest extends ProducerConsumerBase {
 
     @BeforeClass(alwaysRun = true)
     @Override


### PR DESCRIPTION
### Motivation

**Background**
- When the customer disconnects, the consumer automatically tries to reconnect.
- When a connection is disconnected, the broker will remove the consumer related to this connection.
- The client does not reconnect when it receives a `ConsumerBusyException`.

---

**Issue**
| time | `client disconnect` | `broker disconnect` |
| --- | --- | --- |
| 1 | disconnect | 
| 2 | reconnect |
| 3 | Send `cmd-sub` to the broker | disconnect |
| 4 | Since the old consumer has not been removed in the broker memory, get a consumer busy error |
| 5 | | Remove the old consumer in memory |
| 6 | Stop reconnect |

At this time, there is no consumer under this subscription.

---

**A mechanism to fix the issue above**
Once a consumer has subscribed successfully, the consumer will try to retry regardless of any exceptions received. see: https://github.com/apache/pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java#L875

### Modifications

Add a test to ensure that the above issue has been fixed

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x