### PR TITLE
[fix][broker] Fix get owned service units NPE

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -169,7 +169,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
 
     private SplitManager splitManager;
 
-    private boolean started = false;
+    private volatile boolean started = false;
 
     private final AssignCounter assignCounter = new AssignCounter();
     @Getter

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -191,6 +191,10 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
      * Get all the bundles that are owned by this broker.
      */
     public Set<NamespaceBundle> getOwnedServiceUnits() {
+        if (!started) {
+            log.warn("Failed to get owned service units, load manager is not started.");
+            return Collections.emptySet();
+        }
         Set<Map.Entry<String, ServiceUnitStateData>> entrySet = serviceUnitStateChannel.getOwnershipEntrySet();
         String brokerId = brokerRegistry.getBrokerId();
         return entrySet.stream()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -1116,6 +1116,14 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test(timeOut = 30 * 1000)
+    public void testGetOwnedServiceUnitsWhenLoadManagerNotStart() {
+        ExtensibleLoadManagerImpl loadManager = new ExtensibleLoadManagerImpl();
+        Set<NamespaceBundle> ownedServiceUnits = loadManager.getOwnedServiceUnits();
+        assertNotNull(ownedServiceUnits);
+        assertTrue(ownedServiceUnits.isEmpty());
+    }
+
+    @Test(timeOut = 30 * 1000)
     public void testTryAcquiringOwnership()
             throws PulsarAdminException, ExecutionException, InterruptedException {
         final String namespace = "public/testTryAcquiringOwnership";


### PR DESCRIPTION
### Motivation

When using KoP protocol, the KoP will `NamespaceService#addNamespaceBundleOwnershipListener` before the broker start, however, at this time, the `ExtensibleLoadManagerImpl` not start yet. So it will cause NPE.

We should return an empty set when `ExtensibleLoadManagerImpl` does not start.

### Modifications

* Add a check when `getOwnedServiceUnits`.
* Add units test to cover this case.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->