### PR TITLE
[pip][design] PIP-279: Reformat property in generateResponseWithEntry

### DIFF
--- a/pip/pip-279.md
+++ b/pip/pip-279.md
@@ -7,8 +7,6 @@ for example:
 when we run `bin/pulsar-admin topics get-message-by-id `, it will throw exception, the exception is:
 `Reason: java.util.concurrent.CompletionException: org.apache.pulsar.client.admin.internal.http.AsyncHttpConnector$RetryException: Could not complete the operation. Number of retries has been exhausted. Failed reason: a header name cannot contain the following prohibited characters: =,;: \t\r\n\v\f: =`
 
-<img width="1288" alt="image" src="https://github.com/StevenLuMT/pulsar/assets/42990025/973d95b9-4ac2-4977-b160-162c4b53a613">
-
 # High Level Design
 
 In master branch, 

--- a/pip/pip-279.md
+++ b/pip/pip-279.md
@@ -21,4 +21,4 @@ After release-3.1.0, this feature begins to take effect.
 Updated afterwards
 -->
 * Mailing List discussion thread: https://lists.apache.org/thread/vfc99mbj2z2xgwfs1hq1zxrow13qm2n7
-* Mailing List voting thread: 
+* Mailing List voting thread: https://lists.apache.org/thread/g354684m9h495o3p0kmzb7fh7vfxhddx

--- a/pip/pip-279.md
+++ b/pip/pip-279.md
@@ -1,0 +1,26 @@
+# Motivation
+
+reformat property,for a http header name cannot contain the following prohibited characters: =,;: \t\r\n\v\f
+
+for example:
+{"city=shanghai":"tag"}
+when we run `bin/pulsar-admin topics get-message-by-id `, it will throw exception, the exception is:
+`Reason: java.util.concurrent.CompletionException: org.apache.pulsar.client.admin.internal.http.AsyncHttpConnector$RetryException: Could not complete the operation. Number of retries has been exhausted. Failed reason: a header name cannot contain the following prohibited characters: =,;: \t\r\n\v\f: =`
+
+<img width="1288" alt="image" src="https://github.com/StevenLuMT/pulsar/assets/42990025/973d95b9-4ac2-4977-b160-162c4b53a613">
+
+# High Level Design
+
+In master branch, 
+in an http request:getMessageById("/{tenant}/{namespace}/{topic}/ledger/{ledgerId}/entry/{entryId}"),
+replace `"X-Pulsar-PROPERTY-" + msgProperties.getKey()` with `"X-Pulsar-PROPERTY"`
+
+After release-3.1.0, this feature begins to take effect.
+
+# Links
+
+<!--
+Updated afterwards
+-->
+* Mailing List discussion thread: https://lists.apache.org/thread/vfc99mbj2z2xgwfs1hq1zxrow13qm2n7
+* Mailing List voting thread: 

--- a/pip/pip-279.md
+++ b/pip/pip-279.md
@@ -15,6 +15,34 @@ replace `"X-Pulsar-PROPERTY-" + msgProperties.getKey()` with `"X-Pulsar-PROPERTY
 
 After release-3.1.0, this feature begins to take effect.
 
+# Concrete Example
+
+for example, the current message's properties likes this:
+```
+"name": "James"
+"gender": "man"
+"details=man": "good at playing basketball"
+```
+
+## BEFORE
+old response header format:
+```
+headers: {
+  "X-Pulsar-PROPERTY-name": "James",
+  "X-Pulsar-PROPERTY-gender": "man",
+  "X-Pulsar-PROPERTY-details=man": "good at playing basketball"
+}
+```
+but it will throw exception in the end check
+
+## AFTER
+new response header format:
+```
+headers: {
+"X-Pulsar-PROPERTY": '{"name": "James", "gender": "man", "details=man": "good at playing basketball"}'
+}
+```
+
 # Links
 
 <!--


### PR DESCRIPTION

### Motivation

This is a PIP to reformat property in generateResponseWithEntry. The PR contents have the motivation.

### Documentation
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->

### Matching PR in forked repository
PR in forked repository: #20481