### PR TITLE
[improve][test] Fix flaky test SimpleProducerConsumerStatTest#testMsgRateExpired

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
@@ -545,18 +545,19 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
         admin.topics().expireMessages(topicName, subName, 1);
         pulsar.getBrokerService().updateRates();
 
-        Awaitility.await().ignoreExceptions().timeout(5, TimeUnit.SECONDS)
-                .until(() -> admin.topics().getStats(topicName).getSubscriptions().get(subName).getMsgRateExpired() > 0.001);
+        Awaitility.await().ignoreExceptions().timeout(10, TimeUnit.SECONDS)
+                .until(() -> pulsar.getBrokerService().getTopicStats().get(topicName).getSubscriptions().get(subName).getTotalMsgExpired() > 0);
 
         Thread.sleep(2000);
-        pulsar.getBrokerService().updateRates();
 
-        Awaitility.await().ignoreExceptions().timeout(5, TimeUnit.SECONDS)
-                .until(() -> admin.topics().getStats(topicName).getSubscriptions().get(subName).getMsgRateExpired() < 0.001);
+        Awaitility.await().ignoreExceptions().timeout(10, TimeUnit.SECONDS).until(() -> {
+            pulsar.getBrokerService().updateRates();
+            return pulsar.getBrokerService().getTopicStats().get(topicName).getSubscriptions().get(subName).getMsgRateExpired() < 0.001;
+        });
 
-        assertEquals(admin.topics().getStats(topicName).getSubscriptions().get(subName).getMsgRateExpired(), 0.0,
-                0.001);
-        assertEquals(admin.topics().getStats(topicName).getSubscriptions().get(subName).getTotalMsgExpired(),
+        assertEquals(pulsar.getBrokerService().getTopicStats().get(topicName).getSubscriptions().get(subName).getMsgRateExpired(),
+                0.0, 0.001);
+        assertEquals(pulsar.getBrokerService().getTopicStats().get(topicName).getSubscriptions().get(subName).getTotalMsgExpired(),
                 numMessages);
 
         log.info("-- Exiting {} test --", methodName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
@@ -548,8 +548,6 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
         Awaitility.await().ignoreExceptions().timeout(10, TimeUnit.SECONDS)
                 .until(() -> pulsar.getBrokerService().getTopicStats().get(topicName).getSubscriptions().get(subName).getTotalMsgExpired() > 0);
 
-        Thread.sleep(2000);
-
         Awaitility.await().ignoreExceptions().timeout(10, TimeUnit.SECONDS).until(() -> {
             pulsar.getBrokerService().updateRates();
             return pulsar.getBrokerService().getTopicStats().get(topicName).getSubscriptions().get(subName).getMsgRateExpired() < 0.001;


### PR DESCRIPTION
Fixes #20615

### Motivation

`SimpleProducerConsumerStatTest#testMsgRateExpired` seems flakey, so I'll try to improve it.

### Modifications

Before this fix, we checked if the messages expired by referring to the `msgRateExpired` value in the subscription stats. However, this value resets to 0 over time, so we instead refer to the `totalMsgExpired` value, which never resets.

Additionally, we get the stats directly from the instances in the broker server and not from the admin API.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->