### PR TITLE
[improve][doc] Improve JavaDoc of TopicName methods isPartitioned() and getPartitionedTopicName()

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
@@ -85,6 +85,23 @@ public class TopicName implements ServiceUnitId {
         }
     }
 
+    /**
+     * Note: Pulsar uses a unique approach in the context of partitioned topics (or topic partitions)
+     * compared to other messaging systems. For better understanding of this concept in Pulsar,
+     * refer to the <a href="https://pulsar.apache.org/docs/concepts-messaging#partitioned-topics">
+     * documentation</a>.
+     *
+     * <p><strong>Example:</strong>
+     * <pre>
+     *  String result1 = getPartitionedTopicName("persistent://prop/cluster/ns/my-topic-partition-1");
+     *  // result1 now holds "persistent://prop/cluster/ns/my-topic"
+     *
+     *  String result2 = getPartitionedTopicName("persistent://prop/cluster/ns/my-topic");
+     *  // result2 now holds "persistent://prop/cluster/ns/my-topic"
+     * </pre>
+     *
+     * @return The base topic name. For partitions in a topic, by parsing the current {@link #completeTopicName}.
+     */
     public static TopicName getPartitionedTopicName(String topic) {
         TopicName topicName = TopicName.get(topic);
         if (topicName.isPartitioned()) {


### PR DESCRIPTION
Main Issue: #20622

### Motivation

Provide consistent concept around partitioned topic and topic partition/internal topic. Tried my best not to introduce any additional definition. Just redirect to site links.

### Modifications

Improve JavaDoc to `TopicName` methods `isPartitioned()` and `getPartitionedTopicName()`. Below are preview in IntelliJ. Hopefully dark-mode does not bother anybody 😆

![image](https://github.com/apache/pulsar/assets/61615301/4432bae1-b47b-4e19-b51a-ddf4ca896d65)

![image](https://github.com/apache/pulsar/assets/61615301/5e1b8a15-6b77-4c58-8226-f04e8ed6df6b)


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/JooHyukKim/pulsar/pull/10

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
