### PR TITLE
[fix][sec] Upgrade Bouncycastle to 1.75 to address CVE-2023-33201

### DIFF
--- a/bouncy-castle/bc/LICENSE
+++ b/bouncy-castle/bc/LICENSE
@@ -205,6 +205,6 @@
 This projects includes binary packages with the following licenses:
 Bouncy Castle License
  * Bouncy Castle -- licenses/LICENSE-bouncycastle.txt
-    - org.bouncycastle-bcpkix-jdk15on-1.60.jar
-    - org.bouncycastle-bcprov-jdk15on-1.60.jar
-    - org.bouncycastle-bcprov-ext-jdk15on-1.60.jar
+    - org.bouncycastle-bcpkix-jdk18on-1.75.jar
+    - org.bouncycastle-bcprov-jdk18on-1.75.jar
+    - org.bouncycastle-bcprov-ext-jdk18on-1.75.jar

--- a/bouncy-castle/bc/pom.xml
+++ b/bouncy-castle/bc/pom.xml
@@ -42,13 +42,13 @@
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <version>${bouncycastle.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-ext-jdk15on</artifactId>
+      <artifactId>bcprov-ext-jdk18on</artifactId>
       <version>${bouncycastle.version}</version>
     </dependency>
   </dependencies>

--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -253,6 +253,10 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-all</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.perfmark</groupId>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -574,10 +574,10 @@ Creative Commons Attribution License
 
 Bouncy Castle License
  * Bouncy Castle -- ../licenses/LICENSE-bouncycastle.txt
-    - org.bouncycastle-bcpkix-jdk15on-1.69.jar
-    - org.bouncycastle-bcprov-ext-jdk15on-1.69.jar
-    - org.bouncycastle-bcprov-jdk15on-1.69.jar
-    - org.bouncycastle-bcutil-jdk15on-1.69.jar
+    - org.bouncycastle-bcpkix-jdk18on-1.75.jar
+    - org.bouncycastle-bcprov-ext-jdk18on-1.75.jar
+    - org.bouncycastle-bcprov-jdk18on-1.75.jar
+    - org.bouncycastle-bcutil-jdk18on-1.75.jar
 
 ------------------------
 

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -470,10 +470,10 @@ Creative Commons Attribution License
 
 Bouncy Castle License
  * Bouncy Castle -- ../licenses/LICENSE-bouncycastle.txt
-    - bcpkix-jdk15on-1.69.jar
-    - bcprov-ext-jdk15on-1.69.jar
-    - bcprov-jdk15on-1.69.jar
-    - bcutil-jdk15on-1.69.jar
+    - bcpkix-jdk18on-1.75.jar
+    - bcprov-ext-jdk18on-1.75.jar
+    - bcprov-jdk18on-1.75.jar
+    - bcutil-jdk18on-1.75.jar
 
 ------------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@ flexible messaging model and an intuitive client API.</description>
     <slf4j.version>1.7.32</slf4j.version>
     <commons.collections4.version>4.4</commons.collections4.version>
     <log4j2.version>2.18.0</log4j2.version>
-    <bouncycastle.version>1.69</bouncycastle.version>
+    <bouncycastle.version>1.75</bouncycastle.version>
     <bouncycastle.bcpkix-fips.version>1.0.6</bouncycastle.bcpkix-fips.version>
     <bouncycastle.bc-fips.version>1.0.2.3</bouncycastle.bc-fips.version>
     <jackson.version>2.14.2</jackson.version>
@@ -817,9 +817,15 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-         <groupId>com.github.docker-java</groupId>
-         <artifactId>docker-java-core</artifactId>
-         <version>${docker-java.version}</version>
+        <groupId>com.github.docker-java</groupId>
+        <artifactId>docker-java-core</artifactId>
+        <version>${docker-java.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.github.docker-java</groupId>
@@ -885,7 +891,7 @@ flexible messaging model and an intuitive client API.</description>
 
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
+        <artifactId>bcpkix-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
       </dependency>
 
@@ -917,6 +923,24 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>com.yahoo.athenz</groupId>
         <artifactId>athenz-cert-refresher</artifactId>
         <version>${athenz.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>com.yahoo.athenz</groupId>
+        <artifactId>athenz-auth-core</artifactId>
+        <version>${athenz.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -1057,6 +1081,18 @@ flexible messaging model and an intuitive client API.</description>
           <exclusion>
             <groupId>com.squareup.okio</groupId>
             <artifactId>okio</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-xds</artifactId>
+        <version>${grpc.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>*</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/pulsar-broker-auth-athenz/pom.xml
+++ b/pulsar-broker-auth-athenz/pom.xml
@@ -53,6 +53,11 @@
       <artifactId>athenz-zpe-java-client</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/pulsar-client-auth-athenz/pom.xml
+++ b/pulsar-client-auth-athenz/pom.xml
@@ -53,6 +53,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
+++ b/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
@@ -352,7 +352,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         EncryptionKeyInfo eki = new EncryptionKeyInfo(encryptedKey, keyInfo.getMetadata());
         encryptedDataKeyMap.put(keyName, eki);
     }
-    
+
     // required since Bouncycastle 1.72 when using ECIES, it is required to pass in an IESParameterSpec
     private IESParameterSpec createIESParameterSpec() {
         // the IESParameterSpec to use was discovered by debugging BouncyCastle 1.69 and running the

--- a/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
+++ b/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
@@ -352,13 +352,12 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         EncryptionKeyInfo eki = new EncryptionKeyInfo(encryptedKey, keyInfo.getMetadata());
         encryptedDataKeyMap.put(keyName, eki);
     }
-
-    // required since Bouncycastle 1.72 when using ECIES
-    // automatic generation of nonces with IED is disabled and they have to be passed in using an IESParameterSpec
+    
+    // required since Bouncycastle 1.72 when using ECIES, it is required to pass in an IESParameterSpec
     private IESParameterSpec createIESParameterSpec() {
-        byte[] nonce = new byte[16];
-        secureRandom.nextBytes(nonce);
-        return new IESParameterSpec(null, null, 128, 256, nonce);
+        // the IESParameterSpec to use was discovered by debugging BouncyCastle 1.69 and running the
+        // test org.apache.pulsar.client.api.SimpleProducerConsumerTest#testCryptoWithChunking
+        return new IESParameterSpec(null, null, 128);
     }
 
     /*

--- a/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
+++ b/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
@@ -35,6 +35,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.Security;
+import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidKeySpecException;
 import java.util.HashMap;
 import java.util.List;
@@ -73,6 +74,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jce.spec.ECParameterSpec;
 import org.bouncycastle.jce.spec.ECPrivateKeySpec;
 import org.bouncycastle.jce.spec.ECPublicKeySpec;
+import org.bouncycastle.jce.spec.IESParameterSpec;
 import org.bouncycastle.openssl.PEMException;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
@@ -172,6 +174,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         dataKey = keyGenerator.generateKey();
 
         iv = new byte[IV_LEN];
+
     }
 
     private PublicKey loadPublicKey(byte[] keyBytes) throws Exception {
@@ -322,27 +325,40 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         byte[] encryptedKey;
 
         try {
-
+            AlgorithmParameterSpec params = null;
             // Encrypt data key using public key
             if (RSA.equals(pubKey.getAlgorithm())) {
                 dataKeyCipher = Cipher.getInstance(RSA_TRANS, BouncyCastleProvider.PROVIDER_NAME);
             } else if (ECDSA.equals(pubKey.getAlgorithm())) {
                 dataKeyCipher = Cipher.getInstance(ECIES, BouncyCastleProvider.PROVIDER_NAME);
+                params = createIESParameterSpec();
             } else {
                 String msg = logCtx + "Unsupported key type " + pubKey.getAlgorithm() + " for key " + keyName;
                 log.error(msg);
                 throw new PulsarClientException.CryptoException(msg);
             }
-            dataKeyCipher.init(Cipher.ENCRYPT_MODE, pubKey);
+            if (params != null) {
+                dataKeyCipher.init(Cipher.ENCRYPT_MODE, pubKey, params);
+            } else {
+                dataKeyCipher.init(Cipher.ENCRYPT_MODE, pubKey);
+            }
             encryptedKey = dataKeyCipher.doFinal(dataKey.getEncoded());
 
         } catch (IllegalBlockSizeException | BadPaddingException | NoSuchAlgorithmException | NoSuchProviderException
-                | NoSuchPaddingException | InvalidKeyException e) {
+                 | NoSuchPaddingException | InvalidKeyException | InvalidAlgorithmParameterException e) {
             log.error("{} Failed to encrypt data key {}. {}", logCtx, keyName, e.getMessage());
             throw new PulsarClientException.CryptoException(e.getMessage());
         }
         EncryptionKeyInfo eki = new EncryptionKeyInfo(encryptedKey, keyInfo.getMetadata());
         encryptedDataKeyMap.put(keyName, eki);
+    }
+
+    // required since Bouncycastle 1.72 when using ECIES
+    // automatic generation of nonces with IED is disabled and they have to be passed in using an IESParameterSpec
+    private IESParameterSpec createIESParameterSpec() {
+        byte[] nonce = new byte[16];
+        secureRandom.nextBytes(nonce);
+        return new IESParameterSpec(null, null, 128, 256, nonce);
     }
 
     /*
@@ -474,23 +490,28 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         byte[] keyDigest = null;
 
         try {
-
+            AlgorithmParameterSpec params = null;
             // Decrypt data key using private key
             if (RSA.equals(privateKey.getAlgorithm())) {
                 dataKeyCipher = Cipher.getInstance(RSA_TRANS, BouncyCastleProvider.PROVIDER_NAME);
             } else if (ECDSA.equals(privateKey.getAlgorithm())) {
                 dataKeyCipher = Cipher.getInstance(ECIES, BouncyCastleProvider.PROVIDER_NAME);
+                params = createIESParameterSpec();
             } else {
                 log.error("Unsupported key type {} for key {}.", privateKey.getAlgorithm(), keyName);
                 return false;
             }
-            dataKeyCipher.init(Cipher.DECRYPT_MODE, privateKey);
+            if (params != null) {
+                dataKeyCipher.init(Cipher.DECRYPT_MODE, privateKey, params);
+            } else {
+                dataKeyCipher.init(Cipher.DECRYPT_MODE, privateKey);
+            }
             dataKeyValue = dataKeyCipher.doFinal(encryptedDataKey);
 
             keyDigest = digest.digest(encryptedDataKey);
 
         } catch (IllegalBlockSizeException | BadPaddingException | NoSuchAlgorithmException | NoSuchProviderException
-                | NoSuchPaddingException | InvalidKeyException e) {
+                | NoSuchPaddingException | InvalidKeyException | InvalidAlgorithmParameterException e) {
             log.error("{} Failed to decrypt data key {} to decrypt messages {}", logCtx, keyName, e.getMessage());
             return false;
         }

--- a/pulsar-io/aerospike/pom.xml
+++ b/pulsar-io/aerospike/pom.xml
@@ -52,6 +52,16 @@
       <groupId>com.aerospike</groupId>
       <artifactId>aerospike-client-bc</artifactId>
       <version>${aerospike-client.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
     </dependency>
 
   </dependencies>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -592,7 +592,7 @@ Creative Commons Attribution License
 
 Bouncy Castle License
  * Bouncy Castle -- licenses/LICENSE-bouncycastle.txt
-   - bcpkix-jdk15on-1.69.jar
-   - bcprov-ext-jdk15on-1.69.jar
-   - bcprov-jdk15on-1.69.jar
-   - bcutil-jdk15on-1.69.jar
+   - bcpkix-jdk18on-1.75.jar
+   - bcprov-ext-jdk18on-1.75.jar
+   - bcprov-jdk18on-1.75.jar
+   - bcutil-jdk18on-1.75.jar

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -126,6 +126,11 @@
       <artifactId>docker-java-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.pulsar</groupId>

--- a/tiered-storage/file-system/pom.xml
+++ b/tiered-storage/file-system/pom.xml
@@ -110,11 +110,21 @@
             <version>${hdfs-offload-version3}</version>
             <scope>test</scope>
             <exclusions>
-              <exclusion>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-all</artifactId>
-              </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-all</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### Motivation

OWASP Dependency Check fails
```
Error:  bcprov-ext-jdk15on-1.69.jar: CVE-2023-33201(6.5)
Error:  bcprov-jdk15on-1.69.jar: CVE-2023-33201(6.5)
```

Upgrade Bouncycastle to 1.75 to address [CVE-2023-33201](https://github.com/bcgit/bc-java/wiki/CVE-2023-33201).

### Modifications

Bouncycastle has switched to Java 8 (1.8) as the baseline since 1.71. When upgrading to 1.75, it is necessary to
exclude the`bc*-jdk15on` dependencies and instead use the `bc*-jdk18on` dependencies. Since many libraries 
have the jdk15on dependency as a transient dependency, it is necessary to handle the exclusions while upgrading.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->