### PR TITLE
[fix][broker] Fix the publish latency spike from the contention of MessageDeduplication

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -127,7 +127,7 @@ public class MessageDeduplication {
     private final int maxNumberOfProducers;
 
     // Map used to track the inactive producer along with the timestamp of their last activity
-    private final ConcurrentHashMap<String, Long> inactiveProducers = new ConcurrentHashMap<>();
+    private final Map<String, Long> inactiveProducers = new ConcurrentHashMap<>();
 
     private final String replicatorPrefix;
 
@@ -456,6 +456,7 @@ public class MessageDeduplication {
     public synchronized void purgeInactiveProducers() {
         long minimumActiveTimestamp = System.currentTimeMillis() - TimeUnit.MINUTES
                 .toMillis(pulsar.getConfiguration().getBrokerDeduplicationProducerInactivityTimeoutMinutes());
+
         Iterator<Map.Entry<String, Long>> mapIterator = inactiveProducers.entrySet().iterator();
         boolean hasInactive = false;
         while (mapIterator.hasNext()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.broker.service.persistent;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
-
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
@@ -35,7 +35,6 @@ import static org.testng.Assert.assertNotNull;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.EventLoopGroup;
 import java.lang.reflect.Field;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
@@ -35,6 +35,8 @@ import static org.testng.Assert.assertNotNull;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.EventLoopGroup;
 import java.lang.reflect.Field;
+import java.util.concurrent.ConcurrentHashMap;
+
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;
@@ -173,7 +175,7 @@ public class MessageDuplicationTest {
 
         Field field = MessageDeduplication.class.getDeclaredField("inactiveProducers");
         field.setAccessible(true);
-        ConcurrentOpenHashMap<String, Long> inactiveProducers = (ConcurrentOpenHashMap<String, Long>) field.get(messageDeduplication);
+        ConcurrentHashMap<String, Long> inactiveProducers = (ConcurrentHashMap<String, Long>) field.get(messageDeduplication);
 
         String producerName1 = "test1";
         when(publishContext.getHighestSequenceId()).thenReturn(2L);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
@@ -174,7 +174,7 @@ public class MessageDuplicationTest {
 
         Field field = MessageDeduplication.class.getDeclaredField("inactiveProducers");
         field.setAccessible(true);
-        Map<String, Long> inactiveProducers = (Map<String, Long>) field.get(messageDeduplication);
+        ConcurrentOpenHashMap<String, Long> inactiveProducers = (ConcurrentOpenHashMap<String, Long>) field.get(messageDeduplication);
 
         String producerName1 = "test1";
         when(publishContext.getHighestSequenceId()).thenReturn(2L);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
@@ -35,8 +35,8 @@ import static org.testng.Assert.assertNotNull;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.EventLoopGroup;
 import java.lang.reflect.Field;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;
@@ -175,7 +175,7 @@ public class MessageDuplicationTest {
 
         Field field = MessageDeduplication.class.getDeclaredField("inactiveProducers");
         field.setAccessible(true);
-        ConcurrentHashMap<String, Long> inactiveProducers = (ConcurrentHashMap<String, Long>) field.get(messageDeduplication);
+        Map<String, Long> inactiveProducers = (ConcurrentHashMap<String, Long>) field.get(messageDeduplication);
 
         String producerName1 = "test1";
         when(publishContext.getHighestSequenceId()).thenReturn(2L);


### PR DESCRIPTION
### Motivation

This issue has occurred with a topic that has many producers, where the P99 publish latency of the broker will increase to hundreds of milliseconds when many producers connect or disconnect from the topic. This level of latency is unacceptable for a messaging system.

In this case, each producer add or remove operation goes to MessageDeduplication to update a map for inactive producers, regardless of whether message deduplication is enabled or disabled. My initial impression is that if message deduplication is disabled, it should not go to MessageDeduplication. However, users can enable message deduplication for an active topic, which may be the reason why this is happening. @merlimat, do you have any additional context on this matter? We may also need to find a solution to avoid any operations to MessageDeduplication if message deduplication is disabled in the future.

This PR provides a fix without introducing any changes in behavior, which will give us more confidence to cherry-pick it to release branches.

<img width="1900" alt="image" src="https://github.com/apache/pulsar/assets/12592133/87c22ac2-2af9-4190-a1f2-1872477dd0c4">

[broker_lock_0621_1.html.txt](https://github.com/apache/pulsar/files/11863016/broker_lock_0621_1.html.txt)


### Modifications

Use ConcurrentHashMap instead of synchronized HashMap to reduce the contention between IO threads.

Here is the benchmark result from [benchmark test](https://github.com/apache/pulsar/pull/20648/files)
CLHM_CON (ConcurrentOpenHashMap)
CHM_CON(ConcurrentHashMap)
HM_CON(SynchronizedHashMap)

```
CLHM_CON::Thread-3::put: 422ms
CLHM_CON::Thread-5::put: 422ms
CLHM_CON::Thread-4::put: 422ms
CLHM_CON::Thread-0::put: 423ms
CLHM_CON::Thread-2::put: 422ms
CLHM_CON::Thread-1::put: 423ms
CLHM_CON::Thread-0::get: 786ms
CLHM_CON::Thread-1::get: 805ms
CLHM_CON::Thread-4::get: 839ms
CLHM_CON::Thread-5::get: 840ms
CLHM_CON::Thread-3::get: 854ms
CLHM_CON::Thread-2::get: 855ms
CLHM_CON::Thread-0::remove: 112ms
CLHM_CON::Thread-1::remove: 123ms
CLHM_CON::Thread-4::remove: 97ms
CLHM_CON::Thread-5::remove: 97ms
CLHM_CON::Thread-2::remove: 84ms
CLHM_CON::Thread-3::remove: 85ms
CLHM_CON: 1367 ms
CHM_CON::Thread-7::put: 33ms
CHM_CON::Thread-6::put: 35ms
CHM_CON::Thread-9::put: 37ms
CHM_CON::Thread-8::put: 38ms
CHM_CON::Thread-11::put: 38ms
CHM_CON::Thread-10::put: 39ms
CHM_CON::Thread-9::get: 630ms
CHM_CON::Thread-10::get: 629ms
CHM_CON::Thread-7::get: 635ms
CHM_CON::Thread-11::get: 630ms
CHM_CON::Thread-8::get: 631ms
CHM_CON::Thread-6::get: 635ms
CHM_CON::Thread-10::remove: 11ms
CHM_CON::Thread-6::remove: 9ms
CHM_CON::Thread-7::remove: 11ms
CHM_CON::Thread-8::remove: 10ms
CHM_CON::Thread-11::remove: 11ms
CHM_CON::Thread-9::remove: 12ms
CHM_CON: 680 ms
HM_CON::Thread-16::put: 643ms
HM_CON::Thread-15::put: 664ms
HM_CON::Thread-14::put: 670ms
HM_CON::Thread-13::put: 674ms
HM_CON::Thread-17::put: 687ms
HM_CON::Thread-12::put: 715ms
HM_CON::Thread-16::get: 61876ms
HM_CON::Thread-15::get: 62214ms
HM_CON::Thread-13::get: 62312ms
HM_CON::Thread-17::get: 62309ms
HM_CON::Thread-14::get: 62450ms
HM_CON::Thread-16::remove: 638ms
HM_CON::Thread-15::remove: 555ms
HM_CON::Thread-13::remove: 521ms
HM_CON::Thread-17::remove: 522ms
HM_CON::Thread-14::remove: 411ms
HM_CON::Thread-12::get: 62816ms
HM_CON::Thread-12::remove: 8ms
HM_CON: 63538 ms
```

### Verifying this change

The existing tests can cover the new changes.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
