### PR TITLE
[improve][broker] Make get list from bundle Admin API async

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
@@ -51,7 +51,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.web.RestException;
-import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.EntryFilters;
 import org.apache.pulsar.common.policies.data.NamespaceOperation;
@@ -449,35 +448,34 @@ public class NonPersistentTopics extends PersistentTopics {
                         bundleRange);
                 asyncResponse.resume(Response.noContent().build());
             } else {
-                NamespaceBundle nsBundle;
-                try {
-                    nsBundle = validateNamespaceBundleOwnership(namespaceName, policies.bundles,
-                        bundleRange, true, true);
-                } catch (WebApplicationException wae) {
-                    asyncResponse.resume(wae);
-                    return;
-                }
-                try {
-                    ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, Topic>> bundleTopics =
-                            pulsar().getBrokerService().getMultiLayerTopicsMap().get(namespaceName.toString());
-                    if (bundleTopics == null || bundleTopics.isEmpty()) {
-                        asyncResponse.resume(Collections.emptyList());
-                        return;
-                    }
-                    final List<String> topicList = new ArrayList<>();
-                    String bundleKey = namespaceName.toString() + "/" + nsBundle.getBundleRange();
-                    ConcurrentOpenHashMap<String, Topic> topicMap = bundleTopics.get(bundleKey);
-                    if (topicMap != null) {
-                        topicList.addAll(topicMap.keys().stream()
-                                .filter(name -> !TopicName.get(name).isPersistent())
-                                .collect(Collectors.toList()));
-                    }
-                    asyncResponse.resume(topicList);
-                } catch (Exception e) {
-                    log.error("[{}] Failed to list topics on namespace bundle {}/{}", clientAppId(),
-                            namespaceName, bundleRange, e);
-                    asyncResponse.resume(new RestException(e));
-                }
+                validateNamespaceBundleOwnershipAsync(namespaceName, policies.bundles, bundleRange, true, true)
+                        .thenAccept(nsBundle -> {
+                            try {
+                                ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, Topic>> bundleTopics =
+                                        pulsar().getBrokerService()
+                                                .getMultiLayerTopicsMap().get(namespaceName.toString());
+                                if (bundleTopics == null || bundleTopics.isEmpty()) {
+                                    asyncResponse.resume(Collections.emptyList());
+                                    return;
+                                }
+                                final List<String> topicList = new ArrayList<>();
+                                String bundleKey = namespaceName.toString() + "/" + nsBundle.getBundleRange();
+                                ConcurrentOpenHashMap<String, Topic> topicMap = bundleTopics.get(bundleKey);
+                                if (topicMap != null) {
+                                    topicList.addAll(topicMap.keys().stream()
+                                            .filter(name -> !TopicName.get(name).isPersistent())
+                                            .collect(Collectors.toList()));
+                                }
+                                asyncResponse.resume(topicList);
+                            } catch (Exception e) {
+                                log.error("[{}] Failed to list topics on namespace bundle {}/{}", clientAppId(),
+                                        namespaceName, bundleRange, e);
+                                asyncResponse.resume(new RestException(e));
+                            }
+                        }).exceptionally(ex -> {
+                            asyncResponse.resume(ex);
+                            return null;
+                        });
             }
         }).exceptionally(ex -> {
             log.error("[{}] Failed to list topics on namespace bundle {}/{}", clientAppId(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
@@ -473,7 +473,12 @@ public class NonPersistentTopics extends PersistentTopics {
                                 asyncResponse.resume(new RestException(e));
                             }
                         }).exceptionally(ex -> {
-                            asyncResponse.resume(ex);
+                            Throwable realCause = FutureUtil.unwrapCompletionException(ex);
+                            if (realCause instanceof WebApplicationException) {
+                                asyncResponse.resume(realCause);
+                            } else {
+                                asyncResponse.resume(new RestException(realCause));
+                            }
                             return null;
                         });
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -718,28 +718,19 @@ public abstract class PulsarWebResource {
                         throw new RestException(Status.PRECONDITION_FAILED,
                                 "Failed to find ownership for ServiceUnit:" + bundle.toString());
                     }
-                    // If the load manager is extensible load manager, and is transfer operation,
-                    // we don't need check the authoritative.
-                    if (uri != null) {
-                        MultivaluedMap<String, String> queryParameters = uri.getQueryParameters();
-                        if (queryParameters != null && !queryParameters.isEmpty()
-                                && ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(config())) {
-                            List<String> destinationBroker = uri.getQueryParameters().get("destinationBroker");
-                            if (destinationBroker != null && !destinationBroker.isEmpty()) {
-                                // If the request is already redirected, we don't need check the authoritative.
-                                return CompletableFuture.completedFuture(null);
-                            }
-                        }
-                    }
                     return nsService.isServiceUnitOwnedAsync(bundle)
                             .thenAccept(owned -> {
                                 if (!owned) {
                                     boolean newAuthoritative = this.isLeaderBroker();
                                     // Replace the host and port of the current request and redirect
-                                    URI redirect = UriBuilder.fromUri(uri.getRequestUri()).host(webUrl.get().getHost())
-                                            .port(webUrl.get().getPort()).replaceQueryParam("authoritative",
-                                                    newAuthoritative).replaceQueryParam("destinationBroker",
-                                                    null).build();
+                                    UriBuilder uriBuilder = UriBuilder.fromUri(uri.getRequestUri())
+                                            .host(webUrl.get().getHost())
+                                            .port(webUrl.get().getPort())
+                                            .replaceQueryParam("authoritative", newAuthoritative);
+                                    if (!ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(config())) {
+                                        uriBuilder.replaceQueryParam("destinationBroker", null);
+                                    }
+                                    URI redirect = uriBuilder.build();
                                     log.debug("{} is not a service unit owned", bundle);
                                     // Redirect
                                     log.debug("Redirecting the rest call to {}", redirect);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -45,7 +45,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -964,7 +964,10 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
         defaultConf.setAllowAutoTopicCreation(true);
         defaultConf.setForceDeleteNamespaceAllowed(true);
         defaultConf.setLoadManagerClassName(ExtensibleLoadManagerImpl.class.getName());
+        defaultConf.setLoadBalancerLoadSheddingStrategy(TransferShedder.class.getName());
         defaultConf.setLoadBalancerSheddingEnabled(false);
+        defaultConf.setLoadBalancerDebugModeEnabled(true);
+        defaultConf.setTopicLevelPoliciesEnabled(false);
         try (var additionalPulsarTestContext = createAdditionalPulsarTestContext(defaultConf)) {
             var pulsar3 = additionalPulsarTestContext.getPulsarService();
             ExtensibleLoadManagerImpl ternaryLoadManager = spy((ExtensibleLoadManagerImpl)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -1005,7 +1005,7 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
     @Test(timeOut = 30 * 1000)
     public void testListTopic() throws Exception {
         final String namespace = "public/testListTopic";
-        admin.namespaces().createNamespace(namespace, 3);
+        admin.namespaces().createNamespace(namespace, 9);
 
         final String persistentTopicName = TopicName.get(
                 "persistent", NamespaceName.get(namespace),
@@ -1014,8 +1014,8 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
         final String nonPersistentTopicName = TopicName.get(
                 "non-persistent", NamespaceName.get(namespace),
                 "get_topics_mode_" + UUID.randomUUID()).toString();
-        admin.topics().createPartitionedTopic(persistentTopicName, 3);
-        admin.topics().createPartitionedTopic(nonPersistentTopicName, 3);
+        admin.topics().createPartitionedTopic(persistentTopicName, 9);
+        admin.topics().createPartitionedTopic(nonPersistentTopicName, 9);
         pulsarClient.newProducer().topic(persistentTopicName).create().close();
         pulsarClient.newProducer().topic(nonPersistentTopicName).create().close();
 
@@ -1033,10 +1033,10 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
                 assertFalse(TopicName.get(s).isPersistent());
             }
         }
-        assertEquals(topicNum, 3);
+        assertEquals(topicNum, 9);
 
         List<String> list = admin.topics().getList(namespace);
-        assertEquals(list.size(), 6);
+        assertEquals(list.size(), 18);
         admin.namespaces().deleteNamespace(namespace, true);
     }
 


### PR DESCRIPTION
### Motivation

See: https://github.com/apache/pulsar/issues/14365, and fix when using `ExtensibleLoadManagerImpl` and `validateNamespaceBundleOwnershipAsync` methods. It should redirect to the owner broker.

### Modifications

Make `NonPersistentTopics#getListFromBundle` to pure async.

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->