### PR TITLE
[improve][cli] pulsar-client produce: allow to produce AVRO message from strings

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduce.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduce.java
@@ -26,6 +26,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.gson.JsonParseException;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -35,10 +38,17 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.io.JsonDecoder;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.api.ClientBuilder;
@@ -48,6 +58,7 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
 import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.schema.KeyValue;
@@ -176,11 +187,18 @@ public class CmdProduce {
      *
      * @return list of message bodies
      */
-    private List<byte[]> generateMessageBodies(List<String> stringMessages, List<String> messageFileNames) {
+    static List<byte[]> generateMessageBodies(List<String> stringMessages, List<String> messageFileNames, Schema schema) {
         List<byte[]> messageBodies = new ArrayList<>();
 
         for (String m : stringMessages) {
-            messageBodies.add(m.getBytes());
+            if (schema.getSchemaInfo().getType() == SchemaType.AVRO) {
+                // JSON TO AVRO
+                org.apache.avro.Schema avroSchema = ((Optional<org.apache.avro.Schema>) schema.getNativeSchema()).get();
+                byte[] encoded = jsonToAvro(m, avroSchema);
+                messageBodies.add(encoded);
+            } else {
+                messageBodies.add(m.getBytes());
+            }
         }
 
         try {
@@ -193,6 +211,29 @@ public class CmdProduce {
         }
 
         return messageBodies;
+    }
+
+    private static byte[] jsonToAvro(String m, org.apache.avro.Schema avroSchema){
+        try {
+            GenericDatumReader<Object> reader = new GenericDatumReader<>(avroSchema);
+            JsonDecoder jsonDecoder = DecoderFactory.get().jsonDecoder(avroSchema, m);
+            GenericDatumWriter<Object> writer = new GenericDatumWriter<>(avroSchema);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            Encoder e = EncoderFactory.get().binaryEncoder(out, null);
+            Object datum = null;
+            while (true) {
+                try {
+                    datum = reader.read(datum, jsonDecoder);
+                } catch (EOFException eofException) {
+                    break;
+                }
+                writer.write(datum, e);
+                e.flush();
+            }
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot convert " + m +" to AVRO " + e.getMessage(), e);
+        }
     }
 
     /**
@@ -264,8 +305,9 @@ public class CmdProduce {
                 producerBuilder.defaultCryptoKeyReader(this.encKeyValue);
             }
             try (Producer<?> producer = producerBuilder.create();) {
-
-                List<byte[]> messageBodies = generateMessageBodies(this.messages, this.messageFileNames);
+                Schema<?> schemaForPayload = schema.getSchemaInfo().getType() == SchemaType.KEY_VALUE
+                        ? ((KeyValueSchema) schema).getValueSchema() : schema;
+                List<byte[]> messageBodies = generateMessageBodies(this.messages, this.messageFileNames, schemaForPayload);
                 RateLimiter limiter = (this.publishRate > 0) ? RateLimiter.create(this.publishRate) : null;
 
                 Map<String, String> kvMap = new HashMap<>();
@@ -456,7 +498,7 @@ public class CmdProduce {
         }
 
         try {
-            List<byte[]> messageBodies = generateMessageBodies(this.messages, this.messageFileNames);
+            List<byte[]> messageBodies = generateMessageBodies(this.messages, this.messageFileNames, Schema.BYTES);
             RateLimiter limiter = (this.publishRate > 0) ? RateLimiter.create(this.publishRate) : null;
             for (int i = 0; i < this.numTimesProduce; i++) {
                 int index = i * 10;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduce.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduce.java
@@ -187,7 +187,8 @@ public class CmdProduce {
      *
      * @return list of message bodies
      */
-    static List<byte[]> generateMessageBodies(List<String> stringMessages, List<String> messageFileNames, Schema schema) {
+    static List<byte[]> generateMessageBodies(List<String> stringMessages, List<String> messageFileNames,
+                                              Schema schema) {
         List<byte[]> messageBodies = new ArrayList<>();
 
         for (String m : stringMessages) {
@@ -232,7 +233,7 @@ public class CmdProduce {
             }
             return out.toByteArray();
         } catch (IOException e) {
-            throw new RuntimeException("Cannot convert " + m +" to AVRO " + e.getMessage(), e);
+            throw new RuntimeException("Cannot convert " + m + " to AVRO " + e.getMessage(), e);
         }
     }
 
@@ -307,7 +308,8 @@ public class CmdProduce {
             try (Producer<?> producer = producerBuilder.create();) {
                 Schema<?> schemaForPayload = schema.getSchemaInfo().getType() == SchemaType.KEY_VALUE
                         ? ((KeyValueSchema) schema).getValueSchema() : schema;
-                List<byte[]> messageBodies = generateMessageBodies(this.messages, this.messageFileNames, schemaForPayload);
+                List<byte[]> messageBodies = generateMessageBodies(this.messages, this.messageFileNames,
+                        schemaForPayload);
                 RateLimiter limiter = (this.publishRate > 0) ? RateLimiter.create(this.publishRate) : null;
 
                 Map<String, String> kvMap = new HashMap<>();

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/TestCmdProduce.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/TestCmdProduce.java
@@ -20,12 +20,24 @@ package org.apache.pulsar.client.cli;
 
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.KeyValueSchema;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
 
 
 public class TestCmdProduce {
@@ -71,5 +83,27 @@ public class TestCmdProduce {
         assertEquals(KeyValueEncodingType.INLINE, composite2.getKeyValueEncodingType());
         assertEquals(SchemaType.JSON, composite2.getKeySchema().getSchemaInfo().getType());
         assertEquals(SchemaType.AVRO, composite2.getValueSchema().getSchemaInfo().getType());
+    }
+
+    @Test
+    public void generateAvroMessageBodies() throws Exception {
+
+        Schema<?> schema = CmdProduce.buildSchema(
+                null,
+                "avro:{\"type\": \"record\",\"namespace\": \"com.example\",\"name\": \"FullName\", \"fields\": [" +
+                        "{ \"name\": \"a\", \"type\": \"string\" }," +
+                        "{ \"name\": \"b\", \"type\": \"int\" }" +
+                        "]}",
+                "");
+
+        List<byte[]> bytes = CmdProduce.generateMessageBodies(List.of("{\"a\":\"stringValue\",\"b\":123}"), Collections.emptyList(), schema);
+        assertEquals(bytes.size(), 1);
+
+        org.apache.avro.Schema avro = (org.apache.avro.Schema) schema.getNativeSchema().get();
+        GenericDatumReader<GenericRecord> reader = new GenericDatumReader<>(avro);
+        GenericRecord record = reader.read(null, DecoderFactory.get().binaryDecoder(bytes.get(0), null));
+        assertEquals("stringValue", record.get("a").toString());
+        assertEquals(123, record.get("b"));
+
     }
 }

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/TestCmdProduce.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/TestCmdProduce.java
@@ -20,14 +20,8 @@ package org.apache.pulsar.client.cli;
 
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
-
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.KeyValueSchema;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceBytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceBytesSchema.java
@@ -105,7 +105,10 @@ public class AutoProduceBytesSchema<T> implements Schema<byte[]> {
 
     @Override
     public Optional<Object> getNativeSchema() {
-        return Optional.ofNullable(schema);
+        return Optional
+                .ofNullable(schema)
+                .map(s->s.getNativeSchema())
+                .orElse(Optional.empty());
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Currently you can produce AVRO messages only by passing a binary payload. This is pretty awkward.
It would be very nice to allow users to encode the AVRO message using JSON when passing the payload from the CLI.

### Modifications

- When you send a message using `bin/pulsar-client produce -m` decode the string using the AVRO JSONDecoder utility and set the result into the payload
- Fix a big in AutoProducesByteSchema#getNativeSchema

### Example

```
# Produce
bin/pulsar-client produce  -vs 'avro:{"type":"record","namespace":"com.example","name": "FullName", "fields": [{"name":"a","type":"string"},{"name":"b","type":"int" }]}' -s NOSEPARATOR -m '{"a":"b","b":1}' test
```


```
# Read
bin/pulsar-client consume -st auto_consume -s sub -p Earliest test 
```


### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [x] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/eolivelli/pulsar/pull/23

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
