### PR TITLE
[improve][broker] Make ExtensibleLoadManagerImpl's broker filter pure async

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -477,7 +477,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
                                                            Set<String> excludeBrokerSet) {
         BrokerRegistry brokerRegistry = getBrokerRegistry();
         return brokerRegistry.getAvailableBrokerLookupDataAsync()
-                .thenCompose(availableBrokers -> {
+                .thenComposeAsync(availableBrokers -> {
                     LoadManagerContext context = this.getContext();
 
                     Map<String, BrokerLookupData> availableBrokerCandidates = new ConcurrentHashMap<>(availableBrokers);
@@ -499,6 +499,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
                     CompletableFuture<Optional<String>> result = new CompletableFuture<>();
                     FutureUtil.waitForAll(futures).whenComplete((__, ex) -> {
                         if (ex != null) {
+                            // TODO: We may need to revisit this error case.
                             log.error("Failed to filter out brokers when select bundle: {}", bundle, ex);
                         }
                         if (availableBrokerCandidates.isEmpty()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -708,7 +708,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         var getOwnerRequest = getOwnerRequests.get(serviceUnit);
         if (getOwnerRequest != null) {
             var data = tableview.get(serviceUnit);
-            if (data.state() == Owned) {
+            if (data != null && data.state() == Owned) {
                 getOwnerRequest.complete(data.dstBroker());
                 getOwnerRequests.remove(serviceUnit);
                 stateChangeListeners.notify(serviceUnit, data, null);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -619,7 +619,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
 
     private void handle(String serviceUnit, ServiceUnitStateData data) {
         long totalHandledRequests = getHandlerTotalCounter(data).incrementAndGet();
-        if (log.isDebugEnabled()) {
+        if (debug()) {
             log.info("{} received a handle request for serviceUnit:{}, data:{}. totalHandledRequests:{}",
                     lookupServiceAddress, serviceUnit, data, totalHandledRequests);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/AntiAffinityGroupPolicyFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/AntiAffinityGroupPolicyFilter.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.loadbalance.extensions.filter;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.loadbalance.extensions.policies.AntiAffinityGroupPolicyHelper;
@@ -38,10 +39,9 @@ public class AntiAffinityGroupPolicyFilter implements BrokerFilter {
     }
 
     @Override
-    public Map<String, BrokerLookupData> filter(
+    public CompletableFuture<Map<String, BrokerLookupData>> filter(
             Map<String, BrokerLookupData> brokers, ServiceUnitId serviceUnitId, LoadManagerContext context) {
-        helper.filter(brokers, serviceUnitId.toString());
-        return brokers;
+        return helper.filterAsync(brokers, serviceUnitId.toString()).thenApply(__ -> brokers);
     }
 
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/AntiAffinityGroupPolicyFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/AntiAffinityGroupPolicyFilter.java
@@ -41,7 +41,7 @@ public class AntiAffinityGroupPolicyFilter implements BrokerFilter {
     @Override
     public CompletableFuture<Map<String, BrokerLookupData>> filter(
             Map<String, BrokerLookupData> brokers, ServiceUnitId serviceUnitId, LoadManagerContext context) {
-        return helper.filterAsync(brokers, serviceUnitId.toString()).thenApply(__ -> brokers);
+        return helper.filterAsync(brokers, serviceUnitId.toString());
     }
 
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerFilter.java
@@ -19,7 +19,7 @@
 package org.apache.pulsar.broker.loadbalance.extensions.filter;
 
 import java.util.Map;
-import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
+import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.common.naming.ServiceUnitId;
@@ -42,9 +42,8 @@ public interface BrokerFilter {
      * @param context The load manager context.
      * @return Filtered broker list.
      */
-    Map<String, BrokerLookupData> filter(Map<String, BrokerLookupData> brokers,
-                                         ServiceUnitId serviceUnit,
-                                         LoadManagerContext context)
-            throws BrokerFilterException;
+    CompletableFuture<Map<String, BrokerLookupData>> filter(Map<String, BrokerLookupData> brokers,
+                                                            ServiceUnitId serviceUnit,
+                                                            LoadManagerContext context);
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerIsolationPoliciesFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerIsolationPoliciesFilter.java
@@ -19,9 +19,8 @@
 package org.apache.pulsar.broker.loadbalance.extensions.filter;
 
 import java.util.Map;
-import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.loadbalance.extensions.policies.IsolationPoliciesHelper;
@@ -45,13 +44,13 @@ public class BrokerIsolationPoliciesFilter implements BrokerFilter {
     }
 
     @Override
-    public Map<String, BrokerLookupData> filter(Map<String, BrokerLookupData> availableBrokers,
-                                                ServiceUnitId serviceUnit,
-                                                LoadManagerContext context)
-            throws BrokerFilterException {
-        Set<String> brokerCandidateCache =
-                isolationPoliciesHelper.applyIsolationPolicies(availableBrokers, serviceUnit);
-        availableBrokers.keySet().retainAll(brokerCandidateCache);
-        return availableBrokers;
+    public CompletableFuture<Map<String, BrokerLookupData>> filter(Map<String, BrokerLookupData> availableBrokers,
+                                    ServiceUnitId serviceUnit,
+                                    LoadManagerContext context) {
+        return isolationPoliciesHelper.applyIsolationPoliciesAsync(availableBrokers, serviceUnit)
+                .thenApply(brokerCandidateCache -> {
+                    availableBrokers.keySet().retainAll(brokerCandidateCache);
+                    return availableBrokers;
+                });
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerLoadManagerClassFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerLoadManagerClassFilter.java
@@ -20,7 +20,7 @@ package org.apache.pulsar.broker.loadbalance.extensions.filter;
 
 import java.util.Map;
 import java.util.Objects;
-import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
+import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.common.naming.ServiceUnitId;
@@ -34,13 +34,12 @@ public class BrokerLoadManagerClassFilter implements BrokerFilter {
     }
 
     @Override
-    public Map<String, BrokerLookupData> filter(
+    public CompletableFuture<Map<String, BrokerLookupData>> filter(
             Map<String, BrokerLookupData> brokers,
             ServiceUnitId serviceUnit,
-            LoadManagerContext context)
-            throws BrokerFilterException {
+            LoadManagerContext context) {
         if (brokers.isEmpty()) {
-            return brokers;
+            return CompletableFuture.completedFuture(brokers);
         }
         brokers.entrySet().removeIf(entry -> {
             BrokerLookupData v = entry.getValue();
@@ -48,6 +47,6 @@ public class BrokerLoadManagerClassFilter implements BrokerFilter {
             return !Objects.equals(v.getLoadManagerClassName(),
                     context.brokerConfiguration().getLoadManagerClassName());
         });
-        return brokers;
+        return CompletableFuture.completedFuture(brokers);
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerMaxTopicCountFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerMaxTopicCountFilter.java
@@ -20,7 +20,7 @@ package org.apache.pulsar.broker.loadbalance.extensions.filter;
 
 import java.util.Map;
 import java.util.Optional;
-import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
+import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLoadData;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
@@ -36,9 +36,9 @@ public class BrokerMaxTopicCountFilter implements BrokerFilter {
     }
 
     @Override
-    public Map<String, BrokerLookupData> filter(Map<String, BrokerLookupData> brokers,
-                                                ServiceUnitId serviceUnit,
-                                                LoadManagerContext context) throws BrokerFilterException {
+    public CompletableFuture<Map<String, BrokerLookupData>> filter(Map<String, BrokerLookupData> brokers,
+                                                                   ServiceUnitId serviceUnit,
+                                                                   LoadManagerContext context) {
         int loadBalancerBrokerMaxTopics = context.brokerConfiguration().getLoadBalancerBrokerMaxTopics();
         brokers.keySet().removeIf(broker -> {
             Optional<BrokerLoadData> brokerLoadDataOpt = context.brokerLoadDataStore().get(broker);
@@ -46,6 +46,6 @@ public class BrokerMaxTopicCountFilter implements BrokerFilter {
             // TODO: The broker load data might be delayed, so the max topic check might not accurate.
             return topics >= loadBalancerBrokerMaxTopics;
         });
-        return brokers;
+        return CompletableFuture.completedFuture(brokers);
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerVersionFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerVersionFilter.java
@@ -21,13 +21,14 @@ package org.apache.pulsar.broker.loadbalance.extensions.filter;
 import com.github.zafarkhaja.semver.Version;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.BrokerFilterBadVersionException;
-import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.common.naming.ServiceUnitId;
+import org.apache.pulsar.common.util.FutureUtil;
 
 /**
  * Filter by broker version.
@@ -46,13 +47,12 @@ public class BrokerVersionFilter implements BrokerFilter {
      *
      */
     @Override
-    public Map<String, BrokerLookupData> filter(Map<String, BrokerLookupData> brokers,
-                                                ServiceUnitId serviceUnit,
-                                                LoadManagerContext context)
-            throws BrokerFilterException {
+    public CompletableFuture<Map<String, BrokerLookupData>> filter(Map<String, BrokerLookupData> brokers,
+                                                                   ServiceUnitId serviceUnit,
+                                                                   LoadManagerContext context) {
         ServiceConfiguration conf = context.brokerConfiguration();
         if (!conf.isPreferLaterVersions() || brokers.isEmpty()) {
-            return brokers;
+            return CompletableFuture.completedFuture(brokers);
         }
 
         Version latestVersion;
@@ -63,7 +63,8 @@ public class BrokerVersionFilter implements BrokerFilter {
             }
         } catch (Exception ex) {
             log.warn("Disabling PreferLaterVersions feature; reason: " + ex.getMessage());
-            throw new BrokerFilterBadVersionException("Cannot determine newest broker version: " + ex.getMessage());
+            return FutureUtil.failedFuture(
+                    new BrokerFilterBadVersionException("Cannot determine newest broker version: " + ex.getMessage()));
         }
 
         int numBrokersLatestVersion = 0;
@@ -88,7 +89,7 @@ public class BrokerVersionFilter implements BrokerFilter {
         if (numBrokersOlderVersion == 0) {
             log.info("All {} brokers are running the latest version [{}]", numBrokersLatestVersion, latestVersion);
         }
-        return brokers;
+        return CompletableFuture.completedFuture(brokers);
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/policies/AntiAffinityGroupPolicyHelper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/policies/AntiAffinityGroupPolicyHelper.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.loadbalance.extensions.policies;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannel;
@@ -46,6 +47,11 @@ public class AntiAffinityGroupPolicyHelper {
         LoadManagerShared.filterAntiAffinityGroupOwnedBrokers(pulsar, bundle,
                 brokers.keySet(),
                 channel.getOwnershipEntrySet(), brokerToFailureDomainMap);
+    }
+
+    public CompletableFuture<Void> filterAsync(Map<String, BrokerLookupData> brokers, String bundle) {
+        return LoadManagerShared.filterAntiAffinityGroupOwnedBrokersAsync(pulsar, bundle,
+                brokers.keySet(), channel.getOwnershipEntrySet(), brokerToFailureDomainMap);
     }
 
     public boolean hasAntiAffinityGroupPolicy(String bundle) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/policies/AntiAffinityGroupPolicyHelper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/policies/AntiAffinityGroupPolicyHelper.java
@@ -42,16 +42,11 @@ public class AntiAffinityGroupPolicyHelper {
         this.channel = channel;
     }
 
-    public void filter(
-            Map<String, BrokerLookupData> brokers, String bundle) {
-        LoadManagerShared.filterAntiAffinityGroupOwnedBrokers(pulsar, bundle,
-                brokers.keySet(),
-                channel.getOwnershipEntrySet(), brokerToFailureDomainMap);
-    }
-
-    public CompletableFuture<Void> filterAsync(Map<String, BrokerLookupData> brokers, String bundle) {
+    public CompletableFuture<Map<String, BrokerLookupData>> filterAsync(Map<String, BrokerLookupData> brokers,
+                                                                        String bundle) {
         return LoadManagerShared.filterAntiAffinityGroupOwnedBrokersAsync(pulsar, bundle,
-                brokers.keySet(), channel.getOwnershipEntrySet(), brokerToFailureDomainMap);
+                brokers.keySet(), channel.getOwnershipEntrySet(), brokerToFailureDomainMap)
+                .thenApply(__ -> brokers);
     }
 
     public boolean hasAntiAffinityGroupPolicy(String bundle) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedder.java
@@ -47,7 +47,6 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannel;
@@ -720,8 +719,8 @@ public class TransferShedder implements NamespaceUnloadStrategy {
         Map<String, BrokerLookupData> candidates = new HashMap<>(availableBrokers);
         for (var filter : brokerFilterPipeline) {
             try {
-                filter.filter(candidates, namespaceBundle, context);
-            } catch (BrokerFilterException e) {
+                filter.filter(candidates, namespaceBundle, context).get();
+            } catch (InterruptedException | ExecutionException e) {
                 log.error("Failed to filter brokers with filter: {}", filter.getClass().getName(), e);
                 return false;
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedder.java
@@ -719,8 +719,10 @@ public class TransferShedder implements NamespaceUnloadStrategy {
         Map<String, BrokerLookupData> candidates = new HashMap<>(availableBrokers);
         for (var filter : brokerFilterPipeline) {
             try {
-                filter.filter(candidates, namespaceBundle, context).get();
-            } catch (InterruptedException | ExecutionException e) {
+                filter.filter(candidates, namespaceBundle, context)
+                        .get(context.brokerConfiguration().getMetadataStoreOperationTimeoutSeconds(),
+                                TimeUnit.SECONDS);
+            } catch (InterruptedException | ExecutionException | TimeoutException e) {
                 log.error("Failed to filter brokers with filter: {}", filter.getClass().getName(), e);
                 return false;
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
@@ -181,6 +181,98 @@ public class LoadManagerShared {
         }
     }
 
+    public static CompletableFuture<Void> applyNamespacePoliciesAsync(
+            final ServiceUnitId serviceUnit,
+            final SimpleResourceAllocationPolicies policies, final Set<String> brokerCandidateCache,
+            final Set<String> availableBrokers, final BrokerTopicLoadingPredicate brokerTopicLoadingPredicate) {
+        Set<String> primariesCache = localPrimariesCache.get();
+        primariesCache.clear();
+
+        Set<String> secondaryCache = localSecondaryCache.get();
+        secondaryCache.clear();
+
+        NamespaceName namespace = serviceUnit.getNamespaceObject();
+        return policies.areIsolationPoliciesPresentAsync(namespace).thenAccept(isIsolationPoliciesPresent -> {
+            boolean isNonPersistentTopic = (serviceUnit instanceof NamespaceBundle)
+                    ? ((NamespaceBundle) serviceUnit).hasNonPersistentTopic() : false;
+            if (isIsolationPoliciesPresent) {
+                LOG.debug("Isolation Policies Present for namespace - [{}]", namespace.toString());
+            }
+            for (final String broker : availableBrokers) {
+                final String brokerUrlString = String.format("http://%s", broker);
+                URL brokerUrl;
+                try {
+                    brokerUrl = new URL(brokerUrlString);
+                } catch (MalformedURLException e) {
+                    LOG.error("Unable to parse brokerUrl from ResourceUnitId", e);
+                    continue;
+                }
+                // todo: in future check if the resource unit has resources to take the namespace
+                if (isIsolationPoliciesPresent) {
+                    // note: serviceUnitID is namespace name and ResourceID is brokerName
+                    if (policies.isPrimaryBroker(namespace, brokerUrl.getHost())) {
+                        primariesCache.add(broker);
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Added Primary Broker - [{}] as possible Candidates for"
+                                    + " namespace - [{}] with policies", brokerUrl.getHost(), namespace.toString());
+                        }
+                    } else if (policies.isSecondaryBroker(namespace, brokerUrl.getHost())) {
+                        secondaryCache.add(broker);
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug(
+                                    "Added Shared Broker - [{}] as possible "
+                                            + "Candidates for namespace - [{}] with policies",
+                                    brokerUrl.getHost(), namespace.toString());
+                        }
+                    } else {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Skipping Broker - [{}] not primary broker and not shared"
+                                            + " for namespace - [{}] ", brokerUrl.getHost(), namespace.toString());
+                        }
+
+                    }
+                } else {
+                    // non-persistent topic can be assigned to only those brokers that enabled for non-persistent topic
+                    if (isNonPersistentTopic
+                            && !brokerTopicLoadingPredicate.isEnableNonPersistentTopics(brokerUrlString)) {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Filter broker- [{}] because it doesn't support non-persistent namespace - [{}]",
+                                    brokerUrl.getHost(), namespace.toString());
+                        }
+                    } else if (!isNonPersistentTopic
+                            && !brokerTopicLoadingPredicate.isEnablePersistentTopics(brokerUrlString)) {
+                        // persistent topic can be assigned to only brokers that enabled for persistent-topic
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Filter broker- [{}] because broker only supports non-persistent "
+                                            + "namespace - [{}]", brokerUrl.getHost(), namespace.toString());
+                        }
+                    } else if (policies.isSharedBroker(brokerUrl.getHost())) {
+                        secondaryCache.add(broker);
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Added Shared Broker - [{}] as possible Candidates for namespace - [{}]",
+                                    brokerUrl.getHost(), namespace.toString());
+                        }
+                    }
+                }
+            }
+            if (isIsolationPoliciesPresent) {
+                brokerCandidateCache.addAll(primariesCache);
+                if (policies.shouldFailoverToSecondaries(namespace, primariesCache.size())) {
+                    LOG.debug(
+                            "Not enough of primaries [{}] available for namespace - [{}], "
+                                    + "adding shared [{}] as possible candidate owners",
+                            primariesCache.size(), namespace.toString(), secondaryCache.size());
+                    brokerCandidateCache.addAll(secondaryCache);
+                }
+            } else {
+                LOG.debug(
+                        "Policies not present for namespace - [{}] so only "
+                                + "considering shared [{}] brokers for possible owner",
+                        namespace.toString(), secondaryCache.size());
+                brokerCandidateCache.addAll(secondaryCache);
+            }
+        });
+    }
     /**
      * Using the given bundles, populate the namespace to bundle range map.
      *
@@ -406,6 +498,22 @@ public class LoadManagerShared {
         } catch (Exception e) {
             LOG.error("Failed to filter anti-affinity group namespace {}", e.getMessage());
         }
+    }
+
+    public static CompletableFuture<Void> filterAntiAffinityGroupOwnedBrokersAsync(
+            final PulsarService pulsar, final String assignedBundleName,
+            final Set<String> candidates,
+            Set<Map.Entry<String, ServiceUnitStateData>> bundleOwnershipData,
+            Map<String, String> brokerToDomainMap
+    ) {
+        if (candidates.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        final String namespaceName = getNamespaceNameFromBundleName(assignedBundleName);
+        return getAntiAffinityNamespaceOwnedBrokers(pulsar, namespaceName, bundleOwnershipData)
+                .thenAccept(brokerToAntiAffinityNamespaceCount ->
+                        filterAntiAffinityGroupOwnedBrokers(pulsar, candidates,
+                                brokerToDomainMap, brokerToAntiAffinityNamespaceCount));
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
@@ -181,18 +181,17 @@ public class LoadManagerShared {
         }
     }
 
-    public static CompletableFuture<Void> applyNamespacePoliciesAsync(
-            final ServiceUnitId serviceUnit,
-            final SimpleResourceAllocationPolicies policies, final Set<String> brokerCandidateCache,
+    public static CompletableFuture<Set<String>> applyNamespacePoliciesAsync(
+            final ServiceUnitId serviceUnit, final SimpleResourceAllocationPolicies policies,
             final Set<String> availableBrokers, final BrokerTopicLoadingPredicate brokerTopicLoadingPredicate) {
-        Set<String> primariesCache = localPrimariesCache.get();
-        primariesCache.clear();
-
-        Set<String> secondaryCache = localSecondaryCache.get();
-        secondaryCache.clear();
-
         NamespaceName namespace = serviceUnit.getNamespaceObject();
-        return policies.areIsolationPoliciesPresentAsync(namespace).thenAccept(isIsolationPoliciesPresent -> {
+        return policies.areIsolationPoliciesPresentAsync(namespace).thenApply(isIsolationPoliciesPresent -> {
+            final Set<String> brokerCandidateCache = new HashSet<>();
+            Set<String> primariesCache = localPrimariesCache.get();
+            primariesCache.clear();
+
+            Set<String> secondaryCache = localSecondaryCache.get();
+            secondaryCache.clear();
             boolean isNonPersistentTopic = (serviceUnit instanceof NamespaceBundle)
                     ? ((NamespaceBundle) serviceUnit).hasNonPersistentTopic() : false;
             if (isIsolationPoliciesPresent) {
@@ -271,6 +270,7 @@ public class LoadManagerShared {
                         namespace.toString(), secondaryCache.size());
                 brokerCandidateCache.addAll(secondaryCache);
             }
+            return brokerCandidateCache;
         });
     }
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
@@ -195,7 +195,9 @@ public class LoadManagerShared {
             boolean isNonPersistentTopic = (serviceUnit instanceof NamespaceBundle)
                     ? ((NamespaceBundle) serviceUnit).hasNonPersistentTopic() : false;
             if (isIsolationPoliciesPresent) {
-                LOG.debug("Isolation Policies Present for namespace - [{}]", namespace.toString());
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Isolation Policies Present for namespace - [{}]", namespace.toString());
+                }
             }
             for (final String broker : availableBrokers) {
                 final String brokerUrlString = String.format("http://%s", broker);
@@ -257,17 +259,21 @@ public class LoadManagerShared {
             if (isIsolationPoliciesPresent) {
                 brokerCandidateCache.addAll(primariesCache);
                 if (policies.shouldFailoverToSecondaries(namespace, primariesCache.size())) {
-                    LOG.debug(
-                            "Not enough of primaries [{}] available for namespace - [{}], "
-                                    + "adding shared [{}] as possible candidate owners",
-                            primariesCache.size(), namespace.toString(), secondaryCache.size());
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug(
+                                "Not enough of primaries [{}] available for namespace - [{}], "
+                                        + "adding shared [{}] as possible candidate owners",
+                                primariesCache.size(), namespace.toString(), secondaryCache.size());
+                    }
                     brokerCandidateCache.addAll(secondaryCache);
                 }
             } else {
-                LOG.debug(
-                        "Policies not present for namespace - [{}] so only "
-                                + "considering shared [{}] brokers for possible owner",
-                        namespace.toString(), secondaryCache.size());
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(
+                            "Policies not present for namespace - [{}] so only "
+                                    + "considering shared [{}] brokers for possible owner",
+                            namespace.toString(), secondaryCache.size());
+                }
                 brokerCandidateCache.addAll(secondaryCache);
             }
             return brokerCandidateCache;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleResourceAllocationPolicies.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleResourceAllocationPolicies.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.loadbalance.impl;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.LoadReport;
 import org.apache.pulsar.broker.loadbalance.ResourceUnit;
@@ -51,6 +52,20 @@ public class SimpleResourceAllocationPolicies {
             LOG.warn("GetIsolationPolicies: Unable to get the namespaceIsolationPolicies", e);
             return Optional.empty();
         }
+    }
+
+    private CompletableFuture<Optional<NamespaceIsolationPolicies>> getIsolationPoliciesAsync(String clusterName) {
+        return this.pulsar.getPulsarResources().getNamespaceResources()
+                .getIsolationPolicies().getIsolationDataPoliciesAsync(clusterName);
+    }
+
+    public CompletableFuture<Boolean> areIsolationPoliciesPresentAsync(NamespaceName namespace) {
+        return getIsolationPoliciesAsync(pulsar.getConfiguration().getClusterName())
+                .thenApply(policies -> {
+                    return policies.filter(isolationPolicies ->
+                                    isolationPolicies.getPolicyByNamespace(namespace) != null)
+                            .isPresent();
+                });
     }
 
     public boolean areIsolationPoliciesPresent(NamespaceName namespace) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/AntiAffinityNamespaceGroupExtensionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/AntiAffinityNamespaceGroupExtensionTest.java
@@ -131,7 +131,7 @@ public class AntiAffinityNamespaceGroupExtensionTest extends AntiAffinityNamespa
 
         var expected = new HashMap<>(brokers);
         var actual = antiAffinityGroupPolicyFilter.filter(
-                brokers, namespaceBundle, context);
+                brokers, namespaceBundle, context).get();
         assertEquals(actual, expected);
 
         doReturn(antiAffinityEnabledNameSpace + "/" + bundle).when(namespaceBundle).toString();
@@ -142,7 +142,7 @@ public class AntiAffinityNamespaceGroupExtensionTest extends AntiAffinityNamespa
                 .get(5, TimeUnit.SECONDS).get();
         expected.remove(srcBroker);
         actual = antiAffinityGroupPolicyFilter.filter(
-                brokers, namespaceBundle, context);
+                brokers, namespaceBundle, context).get();
         assertEquals(actual, expected);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -106,6 +106,7 @@ import org.apache.pulsar.common.policies.data.NamespaceOwnershipStatus;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.common.stats.Metrics;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.policies.data.loadbalancer.ResourceUsage;
 import org.apache.pulsar.policies.data.loadbalancer.SystemResourceUsage;
 import org.awaitility.Awaitility;
@@ -267,11 +268,11 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
             }
 
             @Override
-            public Map<String, BrokerLookupData> filter(Map<String, BrokerLookupData> brokers,
-                                                        ServiceUnitId serviceUnit,
-                                                        LoadManagerContext context) throws BrokerFilterException {
+            public CompletableFuture<Map<String, BrokerLookupData>> filter(Map<String, BrokerLookupData> brokers,
+                                                                           ServiceUnitId serviceUnit,
+                                                                           LoadManagerContext context) {
                 brokers.remove(pulsar1.getLookupServiceAddress());
-                return brokers;
+                return CompletableFuture.completedFuture(brokers);
             }
 
         })).when(primaryLoadManager).getBrokerFilterPipeline();
@@ -288,11 +289,11 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
 
         doReturn(List.of(new MockBrokerFilter() {
             @Override
-            public Map<String, BrokerLookupData> filter(Map<String, BrokerLookupData> brokers,
-                                                        ServiceUnitId serviceUnit,
-                                                        LoadManagerContext context) throws BrokerFilterException {
+            public CompletableFuture<Map<String, BrokerLookupData>> filter(Map<String, BrokerLookupData> brokers,
+                                                                           ServiceUnitId serviceUnit,
+                                                                           LoadManagerContext context) {
                 brokers.clear();
-                throw new BrokerFilterException("Test");
+                return FutureUtil.failedFuture(new BrokerFilterException("Test"));
             }
         })).when(primaryLoadManager).getBrokerFilterPipeline();
 
@@ -531,19 +532,19 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
         String lookupServiceAddress1 = pulsar1.getLookupServiceAddress();
         doReturn(List.of(new MockBrokerFilter() {
             @Override
-            public Map<String, BrokerLookupData> filter(Map<String, BrokerLookupData> brokers,
-                                                        ServiceUnitId serviceUnit,
-                                                        LoadManagerContext context) throws BrokerFilterException {
+            public CompletableFuture<Map<String, BrokerLookupData>> filter(Map<String, BrokerLookupData> brokers,
+                                                                           ServiceUnitId serviceUnit,
+                                                                           LoadManagerContext context) {
                 brokers.remove(lookupServiceAddress1);
-                return brokers;
+                return CompletableFuture.completedFuture(brokers);
             }
         },new MockBrokerFilter() {
             @Override
-            public Map<String, BrokerLookupData> filter(Map<String, BrokerLookupData> brokers,
-                                                        ServiceUnitId serviceUnit,
-                                                        LoadManagerContext context) throws BrokerFilterException {
+            public CompletableFuture<Map<String, BrokerLookupData>> filter(Map<String, BrokerLookupData> brokers,
+                                                                           ServiceUnitId serviceUnit,
+                                                                           LoadManagerContext context) {
                 brokers.clear();
-                throw new BrokerFilterException("Test");
+                return FutureUtil.failedFuture(new BrokerFilterException("Test"));
             }
         })).when(primaryLoadManager).getBrokerFilterPipeline();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -292,7 +292,7 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
             public CompletableFuture<Map<String, BrokerLookupData>> filter(Map<String, BrokerLookupData> brokers,
                                                                            ServiceUnitId serviceUnit,
                                                                            LoadManagerContext context) {
-                brokers.clear();
+                brokers.remove(brokers.keySet().iterator().next());
                 return FutureUtil.failedFuture(new BrokerFilterException("Test"));
             }
         })).when(primaryLoadManager).getBrokerFilterPipeline();
@@ -543,7 +543,6 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
             public CompletableFuture<Map<String, BrokerLookupData>> filter(Map<String, BrokerLookupData> brokers,
                                                                            ServiceUnitId serviceUnit,
                                                                            LoadManagerContext context) {
-                brokers.clear();
                 return FutureUtil.failedFuture(new BrokerFilterException("Test"));
             }
         })).when(primaryLoadManager).getBrokerFilterPipeline();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerIsolationPoliciesFilterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerIsolationPoliciesFilterTest.java
@@ -31,6 +31,8 @@ import static org.testng.Assert.assertTrue;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
@@ -67,7 +69,7 @@ public class BrokerIsolationPoliciesFilterTest {
      */
     @Test
     public void testFilterWithNamespaceIsolationPoliciesForPrimaryAndSecondaryBrokers()
-            throws IllegalAccessException, BrokerFilterException {
+            throws IllegalAccessException, BrokerFilterException, ExecutionException, InterruptedException {
         var namespace = "my-tenant/my-ns";
         NamespaceName namespaceName = NamespaceName.get(namespace);
 
@@ -83,18 +85,18 @@ public class BrokerIsolationPoliciesFilterTest {
         Map<String, BrokerLookupData> result = filter.filter(new HashMap<>(Map.of(
                 "broker1", getLookupData(),
                 "broker2", getLookupData(),
-                "broker3", getLookupData())), namespaceName, getContext());
+                "broker3", getLookupData())), namespaceName, getContext()).get();
         assertEquals(result.keySet(), Set.of("broker1"));
 
         // b. available-brokers: broker2, broker3          => result: broker2
         result = filter.filter(new HashMap<>(Map.of(
                 "broker2", getLookupData(),
-                "broker3", getLookupData())), namespaceName, getContext());
+                "broker3", getLookupData())), namespaceName, getContext()).get();
         assertEquals(result.keySet(), Set.of("broker2"));
 
         // c. available-brokers: broker3                   => result: NULL
         result = filter.filter(new HashMap<>(Map.of(
-                "broker3", getLookupData())), namespaceName, getContext());
+                "broker3", getLookupData())), namespaceName, getContext()).get();
         assertTrue(result.isEmpty());
 
         // 2. Namespace: primary=broker1, secondary=broker2, shared=broker3, min_limit = 2
@@ -104,24 +106,24 @@ public class BrokerIsolationPoliciesFilterTest {
         result = filter.filter(new HashMap<>(Map.of(
                 "broker1", getLookupData(),
                 "broker2", getLookupData(),
-                "broker3", getLookupData())), namespaceName, getContext());
+                "broker3", getLookupData())), namespaceName, getContext()).get();
         assertEquals(result.keySet(), Set.of("broker1", "broker2"));
 
         // b. available-brokers: broker2, broker3          => result: broker2
         result = filter.filter(new HashMap<>(Map.of(
                 "broker2", getLookupData(),
-                "broker3", getLookupData())), namespaceName, getContext());
+                "broker3", getLookupData())), namespaceName, getContext()).get();
         assertEquals(result.keySet(), Set.of("broker2"));
 
         // c. available-brokers: broker3                   => result: NULL
         result = filter.filter(new HashMap<>(Map.of(
-                "broker3", getLookupData())), namespaceName, getContext());
+                "broker3", getLookupData())), namespaceName, getContext()).get();
         assertTrue(result.isEmpty());
     }
 
     @Test
     public void testFilterWithPersistentOrNonPersistentDisabled()
-            throws IllegalAccessException, BrokerFilterException {
+            throws IllegalAccessException, BrokerFilterException, ExecutionException, InterruptedException {
         var namespace = "my-tenant/my-ns";
         NamespaceName namespaceName = NamespaceName.get(namespace);
         NamespaceBundle namespaceBundle = mock(NamespaceBundle.class);
@@ -140,14 +142,14 @@ public class BrokerIsolationPoliciesFilterTest {
         Map<String, BrokerLookupData> result = filter.filter(new HashMap<>(Map.of(
                 "broker1", getLookupData(),
                 "broker2", getLookupData(),
-                "broker3", getLookupData())), namespaceBundle, getContext());
+                "broker3", getLookupData())), namespaceBundle, getContext()).get();
         assertEquals(result.keySet(), Set.of("broker1", "broker2", "broker3"));
 
 
         result = filter.filter(new HashMap<>(Map.of(
                 "broker1", getLookupData(true, false),
                 "broker2", getLookupData(true, false),
-                "broker3", getLookupData())), namespaceBundle, getContext());
+                "broker3", getLookupData())), namespaceBundle, getContext()).get();
         assertEquals(result.keySet(), Set.of("broker3"));
 
         doReturn(false).when(namespaceBundle).hasNonPersistentTopic();
@@ -155,13 +157,13 @@ public class BrokerIsolationPoliciesFilterTest {
         result = filter.filter(new HashMap<>(Map.of(
                 "broker1", getLookupData(),
                 "broker2", getLookupData(),
-                "broker3", getLookupData())), namespaceBundle, getContext());
+                "broker3", getLookupData())), namespaceBundle, getContext()).get();
         assertEquals(result.keySet(), Set.of("broker1", "broker2", "broker3"));
 
         result = filter.filter(new HashMap<>(Map.of(
                 "broker1", getLookupData(false, true),
                 "broker2", getLookupData(),
-                "broker3", getLookupData())), namespaceBundle, getContext());
+                "broker3", getLookupData())), namespaceBundle, getContext()).get();
         assertEquals(result.keySet(), Set.of("broker2", "broker3"));
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerIsolationPoliciesFilterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerIsolationPoliciesFilterTest.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertTrue;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -131,7 +132,8 @@ public class BrokerIsolationPoliciesFilterTest {
         doReturn(namespaceName).when(namespaceBundle).getNamespaceObject();
 
         var policies = mock(SimpleResourceAllocationPolicies.class);
-        doReturn(false).when(policies).areIsolationPoliciesPresent(eq(namespaceName));
+        doReturn(CompletableFuture.completedFuture(false))
+                .when(policies).areIsolationPoliciesPresentAsync(eq(namespaceName));
         doReturn(true).when(policies).isSharedBroker(any());
         IsolationPoliciesHelper isolationPoliciesHelper = new IsolationPoliciesHelper(policies);
 
@@ -174,7 +176,8 @@ public class BrokerIsolationPoliciesFilterTest {
                                       Set<String> shared,
                                       int min_limit) {
         reset(policies);
-        doReturn(true).when(policies).areIsolationPoliciesPresent(eq(namespaceName));
+        doReturn(CompletableFuture.completedFuture(true))
+                .when(policies).areIsolationPoliciesPresentAsync(eq(namespaceName));
         doReturn(false).when(policies).isPrimaryBroker(eq(namespaceName), any());
         doReturn(false).when(policies).isSecondaryBroker(eq(namespaceName), any());
         doReturn(false).when(policies).isSharedBroker(any());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerLoadManagerClassFilterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerLoadManagerClassFilterTest.java
@@ -27,6 +27,7 @@ import org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl;
 import org.testng.annotations.Test;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 
 /**
@@ -35,7 +36,7 @@ import java.util.Map;
 public class BrokerLoadManagerClassFilterTest extends BrokerFilterTestBase {
 
     @Test
-    public void test() throws BrokerFilterException {
+    public void test() throws BrokerFilterException, ExecutionException, InterruptedException {
         LoadManagerContext context = getContext();
         context.brokerConfiguration().setLoadManagerClassName(ExtensibleLoadManagerImpl.class.getName());
         BrokerLoadManagerClassFilter filter = new BrokerLoadManagerClassFilter();
@@ -48,14 +49,14 @@ public class BrokerLoadManagerClassFilterTest extends BrokerFilterTestBase {
                 "broker5", getLookupData("3.0.0", null)
         );
 
-        Map<String, BrokerLookupData> result = filter.filter(new HashMap<>(originalBrokers), null, context);
+        Map<String, BrokerLookupData> result = filter.filter(new HashMap<>(originalBrokers), null, context).get();
         assertEquals(result, Map.of(
                 "broker1", getLookupData("3.0.0", ExtensibleLoadManagerImpl.class.getName()),
                 "broker2", getLookupData("3.0.0", ExtensibleLoadManagerImpl.class.getName())
         ));
 
         context.brokerConfiguration().setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
-        result = filter.filter(new HashMap<>(originalBrokers), null, context);
+        result = filter.filter(new HashMap<>(originalBrokers), null, context).get();
 
         assertEquals(result, Map.of(
                 "broker3", getLookupData("3.0.0", ModularLoadManagerImpl.class.getName()),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerMaxTopicCountFilterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerMaxTopicCountFilterTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 import static org.testng.Assert.assertEquals;
 
@@ -38,7 +39,7 @@ import static org.testng.Assert.assertEquals;
 public class BrokerMaxTopicCountFilterTest extends BrokerFilterTestBase {
 
     @Test
-    public void test() throws IllegalAccessException, BrokerFilterException {
+    public void test() throws IllegalAccessException, BrokerFilterException, ExecutionException, InterruptedException {
         LoadManagerContext context = getContext();
         LoadDataStore<BrokerLoadData> store = context.brokerLoadDataStore();
         BrokerLoadData maxTopicLoadData = new BrokerLoadData();
@@ -58,7 +59,8 @@ public class BrokerMaxTopicCountFilterTest extends BrokerFilterTestBase {
                 "broker3", getLookupData(),
                 "broker4", getLookupData()
         );
-        Map<String, BrokerLookupData> result = filter.filter(new HashMap<>(originalBrokers), null, context);
+        Map<String, BrokerLookupData> result =
+                filter.filter(new HashMap<>(originalBrokers), null, context).get();
         assertEquals(result, Map.of(
                 "broker2", getLookupData(),
                 "broker4", getLookupData()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerVersionFilterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerVersionFilterTest.java
@@ -24,6 +24,8 @@ import static org.testng.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.BrokerFilterBadVersionException;
 import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
@@ -39,14 +41,14 @@ public class BrokerVersionFilterTest extends BrokerFilterTestBase {
 
 
     @Test
-    public void testFilterEmptyBrokerList() throws BrokerFilterException {
+    public void testFilterEmptyBrokerList() throws BrokerFilterException, ExecutionException, InterruptedException {
         BrokerVersionFilter brokerVersionFilter = new BrokerVersionFilter();
-        Map<String, BrokerLookupData> result = brokerVersionFilter.filter(new HashMap<>(), null, getContext());
+        Map<String, BrokerLookupData> result = brokerVersionFilter.filter(new HashMap<>(), null, getContext()).get();
         assertTrue(result.isEmpty());
     }
 
     @Test
-    public void testDisabledFilter() throws BrokerFilterException {
+    public void testDisabledFilter() throws BrokerFilterException, ExecutionException, InterruptedException {
         LoadManagerContext context = getContext();
         ServiceConfiguration configuration = new ServiceConfiguration();
         configuration.setPreferLaterVersions(false);
@@ -58,12 +60,12 @@ public class BrokerVersionFilterTest extends BrokerFilterTestBase {
         );
         Map<String, BrokerLookupData> brokers = new HashMap<>(originalBrokers);
         BrokerVersionFilter brokerVersionFilter = new BrokerVersionFilter();
-        Map<String, BrokerLookupData> result = brokerVersionFilter.filter(brokers, null, context);
+        Map<String, BrokerLookupData> result = brokerVersionFilter.filter(brokers, null, context).get();
         assertEquals(result, originalBrokers);
     }
 
     @Test
-    public void testFilter() throws BrokerFilterException {
+    public void testFilter() throws BrokerFilterException, ExecutionException, InterruptedException {
         Map<String, BrokerLookupData> originalBrokers = Map.of(
                 "localhost:6650", getLookupData("2.10.0"),
                 "localhost:6651", getLookupData("2.10.1"),
@@ -72,7 +74,7 @@ public class BrokerVersionFilterTest extends BrokerFilterTestBase {
         );
         BrokerVersionFilter brokerVersionFilter = new BrokerVersionFilter();
         Map<String, BrokerLookupData> result = brokerVersionFilter.filter(
-                new HashMap<>(originalBrokers), null, getContext());
+                new HashMap<>(originalBrokers), null, getContext()).get();
         assertEquals(result, Map.of(
                 "localhost:6651", getLookupData("2.10.1"),
                 "localhost:6652", getLookupData("2.10.1"),
@@ -85,7 +87,7 @@ public class BrokerVersionFilterTest extends BrokerFilterTestBase {
                 "localhost:6652", getLookupData("2.10.1"),
                 "localhost:6653", getLookupData("2.10.1")
         );
-        result = brokerVersionFilter.filter(new HashMap<>(originalBrokers), null, getContext());
+        result = brokerVersionFilter.filter(new HashMap<>(originalBrokers), null, getContext()).get();
 
         assertEquals(result, Map.of(
                 "localhost:6652", getLookupData("2.10.1"),
@@ -99,7 +101,7 @@ public class BrokerVersionFilterTest extends BrokerFilterTestBase {
                 "localhost:6653", getLookupData("2.10.2-SNAPSHOT")
         );
 
-        result = brokerVersionFilter.filter(new HashMap<>(originalBrokers), null, getContext());
+        result = brokerVersionFilter.filter(new HashMap<>(originalBrokers), null, getContext()).get();
         assertEquals(result, Map.of(
                 "localhost:6653", getLookupData("2.10.2-SNAPSHOT")
         ));
@@ -107,11 +109,11 @@ public class BrokerVersionFilterTest extends BrokerFilterTestBase {
     }
 
     @Test(expectedExceptions = BrokerFilterBadVersionException.class)
-    public void testInvalidVersionString() throws BrokerFilterException {
+    public void testInvalidVersionString() throws BrokerFilterException, ExecutionException, InterruptedException {
         Map<String, BrokerLookupData> originalBrokers = Map.of(
                 "localhost:6650", getLookupData("xxx")
         );
         BrokerVersionFilter brokerVersionFilter = new BrokerVersionFilter();
-        brokerVersionFilter.filter(new HashMap<>(originalBrokers), null, getContext());
+        brokerVersionFilter.filter(new HashMap<>(originalBrokers), null, getContext()).get();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerVersionFilterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerVersionFilterTest.java
@@ -21,11 +21,11 @@ package org.apache.pulsar.broker.loadbalance.extensions.filter;
 import static org.mockito.Mockito.doReturn;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.BrokerFilterBadVersionException;
 import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
@@ -108,12 +108,17 @@ public class BrokerVersionFilterTest extends BrokerFilterTestBase {
 
     }
 
-    @Test(expectedExceptions = BrokerFilterBadVersionException.class)
-    public void testInvalidVersionString() throws BrokerFilterException, ExecutionException, InterruptedException {
+    @Test
+    public void testInvalidVersionString() {
         Map<String, BrokerLookupData> originalBrokers = Map.of(
                 "localhost:6650", getLookupData("xxx")
         );
         BrokerVersionFilter brokerVersionFilter = new BrokerVersionFilter();
-        brokerVersionFilter.filter(new HashMap<>(originalBrokers), null, getContext()).get();
+        try {
+            brokerVersionFilter.filter(new HashMap<>(originalBrokers), null, getContext()).get();
+            fail();
+        } catch (Exception ex) {
+            assertEquals(ex.getCause().getClass(), BrokerFilterBadVersionException.class);
+        }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedderTest.java
@@ -761,10 +761,10 @@ public class TransferShedderTest {
             }
 
             @Override
-            public Map<String, BrokerLookupData> filter(Map<String, BrokerLookupData> brokers,
-                                                        ServiceUnitId serviceUnit,
-                                                        LoadManagerContext context) throws BrokerFilterException {
-                throw new BrokerFilterException("test");
+            public CompletableFuture<Map<String, BrokerLookupData>> filter(Map<String, BrokerLookupData> brokers,
+                                                                           ServiceUnitId serviceUnit,
+                                                                           LoadManagerContext context) {
+                return FutureUtil.failedFuture(new BrokerFilterException("test"));
             }
         };
         filters.add(filter);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedderTest.java
@@ -634,7 +634,8 @@ public class TransferShedderTest {
 
 
         // test setLoadBalancerSheddingBundlesWithPoliciesEnabled=false;
-        doReturn(true).when(allocationPoliciesSpy).areIsolationPoliciesPresent(any());
+        doReturn(CompletableFuture.completedFuture(true))
+                .when(allocationPoliciesSpy).areIsolationPoliciesPresentAsync(any());
         ctx.brokerConfiguration().setLoadBalancerTransferEnabled(true);
         ctx.brokerConfiguration().setLoadBalancerSheddingBundlesWithPoliciesEnabled(false);
         res = transferShedder.findBundlesForUnloading(ctx, Map.of(), Map.of());
@@ -679,12 +680,14 @@ public class TransferShedderTest {
         NamespaceBundle namespaceBundle = mock(NamespaceBundle.class);
         doReturn(true).when(namespaceBundle).hasNonPersistentTopic();
         doReturn(namespaceName).when(namespaceBundle).getNamespaceObject();
-        doReturn(false).when(policies).areIsolationPoliciesPresent(any());
+        doReturn(CompletableFuture.completedFuture(false))
+                .when(policies).areIsolationPoliciesPresentAsync(any());
         doReturn(false).when(policies).isPrimaryBroker(any(), any());
         doReturn(false).when(policies).isSecondaryBroker(any(), any());
         doReturn(true).when(policies).isSharedBroker(any());
 
-        doReturn(true).when(policies).areIsolationPoliciesPresent(eq(namespaceName));
+        doReturn(CompletableFuture.completedFuture(true))
+                .when(policies).areIsolationPoliciesPresentAsync(eq(namespaceName));
 
         primary.forEach(broker -> {
             doReturn(true).when(policies).isPrimaryBroker(eq(namespaceName), eq(broker));
@@ -723,8 +726,8 @@ public class TransferShedderTest {
         doAnswer(invocationOnMock -> {
             Map<String, BrokerLookupData> brokers = invocationOnMock.getArgument(0);
             brokers.clear();
-            return brokers;
-        }).when(antiAffinityGroupPolicyHelper).filter(any(), any());
+            return CompletableFuture.completedFuture(brokers);
+        }).when(antiAffinityGroupPolicyHelper).filterAsync(any(), any());
         var res = transferShedder.findBundlesForUnloading(ctx, Map.of(), Map.of());
 
         assertTrue(res.isEmpty());
@@ -737,11 +740,11 @@ public class TransferShedderTest {
             String bundle = invocationOnMock.getArgument(1, String.class);
 
             if (bundle.equalsIgnoreCase(bundleE1)) {
-                return brokers;
+                return CompletableFuture.completedFuture(brokers);
             }
             brokers.clear();
-            return brokers;
-        }).when(antiAffinityGroupPolicyHelper).filter(any(), any());
+            return CompletableFuture.completedFuture(brokers);
+        }).when(antiAffinityGroupPolicyHelper).filterAsync(any(), any());
         var res2 = transferShedder.findBundlesForUnloading(ctx, Map.of(), Map.of());
         var expected2 = new HashSet<>();
         expected2.add(new UnloadDecision(new Unload("broker5", bundleE1, Optional.of("broker1")),

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
@@ -262,7 +262,7 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
     }
 
     // TODO: This test is very flaky and it's disabled for now to unblock CI
-    @Test(timeOut = 40 * 1000, enabled = false)
+    @Test(timeOut = 40 * 1000)
     public void testAntiaffinityPolicy() throws PulsarAdminException {
         final String namespaceAntiAffinityGroup = "my-anti-affinity-filter";
         final String antiAffinityEnabledNameSpace = DEFAULT_TENANT + "/my-ns-filter" + nsSuffix;

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
@@ -261,7 +261,6 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
         assertNotEquals(broker1, broker);
     }
 
-    // TODO: This test is very flaky and it's disabled for now to unblock CI
     @Test(timeOut = 40 * 1000)
     public void testAntiaffinityPolicy() throws PulsarAdminException {
         final String namespaceAntiAffinityGroup = "my-anti-affinity-filter";


### PR DESCRIPTION
### Motivation

Currently, the filter has some block methods, e.g.,`getIsolationDataPolicies` method. When calling the block method in the metadata-store thread, it might cause a deadlock. For more detail, see: https://github.com/apache/pulsar/pull/20130

```
"configuration-metadata-store-186-1@14606" prio=5 tid=0x175 nid=NA runnable
  java.lang.Thread.State: RUNNABLE
	  at org.apache.pulsar.broker.resources.BaseResources.get(BaseResources.java:88)
	  at org.apache.pulsar.broker.resources.NamespaceResources$IsolationPolicyResources.getIsolationDataPolicies(NamespaceResources.java:177)
	  at org.apache.pulsar.broker.loadbalance.impl.SimpleResourceAllocationPolicies.getIsolationPolicies(SimpleResourceAllocationPolicies.java:49)
	  at org.apache.pulsar.broker.loadbalance.impl.SimpleResourceAllocationPolicies.areIsolationPoliciesPresent(SimpleResourceAllocationPolicies.java:59)
	  at org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared.applyNamespacePolicies(LoadManagerShared.java:103)
	  at org.apache.pulsar.broker.loadbalance.extensions.policies.IsolationPoliciesHelper.applyIsolationPolicies(IsolationPoliciesHelper.java:52)
	  at org.apache.pulsar.broker.loadbalance.extensions.filter.BrokerIsolationPoliciesFilter.filter(BrokerIsolationPoliciesFilter.java:53)
	  at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.lambda$selectAsync$12(ExtensibleLoadManagerImpl.java:394)
	  at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl$$Lambda$1347/0x0000000801645428.apply(Unknown Source:-1)
	  at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187)
	  at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309)
	  at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.selectAsync(ExtensibleLoadManagerImpl.java:385)
	  at java.lang.invoke.LambdaForm$DMH/0x0000000800e1d000.invokeVirtual(LambdaForm$DMH:-1)
	  at java.lang.invoke.LambdaForm$MH/0x0000000800fac800.invoke(LambdaForm$MH:-1)
	  at java.lang.invoke.LambdaForm$MH/0x0000000800f46000.invoke(LambdaForm$MH:-1)
	  at java.lang.invoke.LambdaForm$MH/0x0000000800c14400.invokeExact_MT(LambdaForm$MH:-1)
	  at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:732)
	  at org.mockito.internal.util.reflection.InstrumentationMemberAccessor$Dispatcher$ByteBuddy$MBY4HIiM.invokeWithArguments(Unknown Source:-1)
	  at org.mockito.internal.util.reflection.InstrumentationMemberAccessor.invoke(InstrumentationMemberAccessor.java:239)
	  at org.mockito.internal.util.reflection.ModuleMemberAccessor.invoke(ModuleMemberAccessor.java:55)
	  at org.mockito.internal.creation.bytebuddy.MockMethodAdvice.tryInvoke(MockMethodAdvice.java:333)
	  at org.mockito.internal.creation.bytebuddy.MockMethodAdvice.access$500(MockMethodAdvice.java:60)
	  at org.mockito.internal.creation.bytebuddy.MockMethodAdvice$RealMethodCall.invoke(MockMethodAdvice.java:253)
	  at org.mockito.internal.invocation.InterceptedInvocation.callRealMethod(InterceptedInvocation.java:142)
	  at org.mockito.internal.stubbing.answers.CallsRealMethods.answer(CallsRealMethods.java:45)
	  at org.mockito.Answers.answer(Answers.java:99)
	  at org.mockito.internal.handler.MockHandlerImpl.handle(MockHandlerImpl.java:110)
	  at org.mockito.internal.handler.NullResultGuardian.handle(NullResultGuardian.java:29)
	  at org.mockito.internal.handler.InvocationNotifierHandler.handle(InvocationNotifierHandler.java:34)
	  at org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.doIntercept(MockMethodInterceptor.java:82)
	  at org.mockito.internal.creation.bytebuddy.MockMethodAdvice.handle(MockMethodAdvice.java:151)
	  at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.selectAsync(ExtensibleLoadManagerImpl.java:383)
	  at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.lambda$assign$6(ExtensibleLoadManagerImpl.java:336)
	  at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl$$Lambda$1343/0x0000000801644b18.apply(Unknown Source:-1)
	  at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187)
	  at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309)
	  at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.lambda$assign$10(ExtensibleLoadManagerImpl.java:333)
	  at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl$$Lambda$1342/0x00000008016446c8.apply(Unknown Source:-1)
	  at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.put(ConcurrentOpenHashMap.java:409)
	  at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.computeIfAbsent(ConcurrentOpenHashMap.java:243)
	  at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.assign(ExtensibleLoadManagerImpl.java:327)
	  at java.lang.invoke.LambdaForm$DMH/0x00000008013ac800.invokeVirtual(LambdaForm$DMH:-1)
	  at java.lang.invoke.LambdaForm$MH/0x00000008013ad400.invoke(LambdaForm$MH:-1)
	  at java.lang.invoke.LambdaForm$MH/0x0000000800f44800.invoke(LambdaForm$MH:-1)
	  at java.lang.invoke.LambdaForm$MH/0x0000000800c14400.invokeExact_MT(LambdaForm$MH:-1)
	  at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:732)
	  at org.mockito.internal.util.reflection.InstrumentationMemberAccessor$Dispatcher$ByteBuddy$MBY4HIiM.invokeWithArguments(Unknown Source:-1)
	  at org.mockito.internal.util.reflection.InstrumentationMemberAccessor.invoke(InstrumentationMemberAccessor.java:239)
	  at org.mockito.internal.util.reflection.ModuleMemberAccessor.invoke(ModuleMemberAccessor.java:55)
	  at org.mockito.internal.creation.bytebuddy.MockMethodAdvice.tryInvoke(MockMethodAdvice.java:333)
	  at org.mockito.internal.creation.bytebuddy.MockMethodAdvice.access$500(MockMethodAdvice.java:60)
	  at org.mockito.internal.creation.bytebuddy.MockMethodAdvice$RealMethodCall.invoke(MockMethodAdvice.java:253)
	  at org.mockito.internal.invocation.InterceptedInvocation.callRealMethod(InterceptedInvocation.java:142)
	  at org.mockito.internal.stubbing.answers.CallsRealMethods.answer(CallsRealMethods.java:45)
	  at org.mockito.Answers.answer(Answers.java:99)
	  at org.mockito.internal.handler.MockHandlerImpl.handle(MockHandlerImpl.java:110)
	  at org.mockito.internal.handler.NullResultGuardian.handle(NullResultGuardian.java:29)
	  at org.mockito.internal.handler.InvocationNotifierHandler.handle(InvocationNotifierHandler.java:34)
	  at org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.doIntercept(MockMethodInterceptor.java:82)
	  at org.mockito.internal.creation.bytebuddy.MockMethodAdvice.handle(MockMethodAdvice.java:151)
	  at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.assign(ExtensibleLoadManagerImpl.java:325)
	  at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerWrapper.findBrokerServiceUrl(ExtensibleLoadManagerWrapper.java:66)
	  at org.apache.pulsar.broker.namespace.NamespaceService.lambda$internalGetWebServiceUrl$9(NamespaceService.java:302)
	  at org.apache.pulsar.broker.namespace.NamespaceService$$Lambda$1337/0x000000080163bb68.apply(Unknown Source:-1)
	  at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187)
	  at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309)
	  at org.apache.pulsar.broker.namespace.NamespaceService.internalGetWebServiceUrl(NamespaceService.java:285)
	  at org.apache.pulsar.broker.namespace.NamespaceService.getWebServiceUrlAsync(NamespaceService.java:265)
```


### Modifications

* Make the broker filter pure async to avoid block operation.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
