### PR TITLE
[fix][client]Fix deadlock issue of consumer while using multiple IO threads

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -1405,10 +1405,10 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                                 newConsumer.resume();
                             }
                             consumers.putIfAbsent(newConsumer.getTopic(), newConsumer);
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] create consumer {} for partitionName: {}",
-                                        topicName, newConsumer.getTopic(), partitionName);
-                            }
+                        }
+                        if (log.isDebugEnabled()) {
+                            log.debug("[{}] create consumer {} for partitionName: {}",
+                                    topicName, newConsumer.getTopic(), partitionName);
                         }
                         return subFuture;
                     })

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -1049,8 +1049,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                             } else {
                                 newConsumer.resume();
                             }
-                            consumers.putIfAbsent(newConsumer.getTopic(), newConsumer);
                         }
+                        consumers.putIfAbsent(newConsumer.getTopic(), newConsumer);
                         return subFuture;
                     })
                 .collect(Collectors.toList());
@@ -1070,7 +1070,6 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     internalConfig.setStartPaused(paused);
                     ConsumerImpl<T> newConsumer = createInternalConsumer(internalConfig, topicName,
                             -1, subFuture, createIfDoesNotExist, schema);
-
                     synchronized (pauseMutex) {
                         if (paused) {
                             newConsumer.pause();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -1040,10 +1040,10 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     partitionIndex -> {
                         CompletableFuture<Consumer<T>> subFuture = new CompletableFuture<>();
                         String partitionName = TopicName.get(topicName).getPartition(partitionIndex).toString();
+                        configurationData.setStartPaused(paused);
+                        ConsumerImpl<T> newConsumer = createInternalConsumer(configurationData, partitionName,
+                                partitionIndex, subFuture, createIfDoesNotExist, schema);
                         synchronized (pauseMutex) {
-                            configurationData.setStartPaused(paused);
-                            ConsumerImpl<T> newConsumer = createInternalConsumer(configurationData, partitionName,
-                                    partitionIndex, subFuture, createIfDoesNotExist, schema);
                             if (paused) {
                                 newConsumer.pause();
                             } else {
@@ -1062,7 +1062,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             synchronized (pauseMutex) {
                 consumers.compute(topicName, (key, existingValue) -> {
                     if (existingValue != null) {
-                        String errorMessage = String.format("[%s] Failed to subscribe for topic [%s] in topics consumer. "
+                        String errorMessage =
+                                String.format("[%s] Failed to subscribe for topic [%s] in topics consumer. "
                                 + "Topic is already being subscribed for in other thread.", topic, topicName);
                         log.warn(errorMessage);
                         subscribeResult.completeExceptionally(new PulsarClientException(errorMessage));
@@ -1404,10 +1405,10 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                                 newConsumer.resume();
                             }
                             consumers.putIfAbsent(newConsumer.getTopic(), newConsumer);
-                        }
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] create consumer {} for partitionName: {}",
-                                topicName, newConsumer.getTopic(), partitionName);
+                            if (log.isDebugEnabled()) {
+                                log.debug("[{}] create consumer {} for partitionName: {}",
+                                        topicName, newConsumer.getTopic(), partitionName);
+                            }
                         }
                         return subFuture;
                     })

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -1038,8 +1038,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 .range(0, numPartitions)
                 .mapToObj(
                     partitionIndex -> {
-                        CompletableFuture<Consumer<T>> subFuture = new CompletableFuture<>();
                         String partitionName = TopicName.get(topicName).getPartition(partitionIndex).toString();
+                        CompletableFuture<Consumer<T>> subFuture = new CompletableFuture<>();
                         configurationData.setStartPaused(paused);
                         ConsumerImpl<T> newConsumer = createInternalConsumer(configurationData, partitionName,
                                 partitionIndex, subFuture, createIfDoesNotExist, schema);


### PR DESCRIPTION
### Motivation

Fix a deadlock of the consumer when the consumer tries to subscribe to partitioned topics and non-partitioned topics if the Pulsar Client uses multiple IO threads (default is 1 thread).

```
Found one Java-level deadlock:
=============================
"pulsar-client-io-1-2":
  waiting to lock monitor 0x00007f716c00ae80 (object 0x00000004312d0940, a java.util.concurrent.ConcurrentHashMap$Node),
  which is held by "pulsar-client-io-1-3"
"pulsar-client-io-1-3":
  waiting to lock monitor 0x00007f6f8c009900 (object 0x000000042cf2ed28, a java.lang.Object),
  which is held by "pulsar-client-io-1-4"
"pulsar-client-io-1-4":
  waiting to lock monitor 0x00007f716c00ae80 (object 0x00000004312d0940, a java.util.concurrent.ConcurrentHashMap$Node),
  which is held by "pulsar-client-io-1-3"

Java stack information for the threads listed above:
===================================================
"pulsar-client-io-1-2":
	at java.util.concurrent.ConcurrentHashMap.compute(java.base@11.0.18/ConcurrentHashMap.java:1923)
	- waiting to lock <0x00000004312d0940> (a java.util.concurrent.ConcurrentHashMap$Node)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl.doSubscribeTopicPartitions(MultiTopicsConsumerImpl.java:1051)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl.lambda$subscribeTopicPartitions$43(MultiTopicsConsumerImpl.java:993)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl$$Lambda$4606/0x0000000841779840.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniWhenComplete(java.base@11.0.18/CompletableFuture.java:859)
	at java.util.concurrent.CompletableFuture.uniWhenCompleteStage(java.base@11.0.18/CompletableFuture.java:883)
	at java.util.concurrent.CompletableFuture.whenComplete(java.base@11.0.18/CompletableFuture.java:2251)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl.subscribeTopicPartitions(MultiTopicsConsumerImpl.java:991)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl.lambda$subscribeAsync$38(MultiTopicsConsumerImpl.java:917)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl$$Lambda$4600/0x0000000841777040.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture$UniAccept.tryFire(java.base@11.0.18/CompletableFuture.java:714)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@11.0.18/CompletableFuture.java:506)
	at java.util.concurrent.CompletableFuture.complete(java.base@11.0.18/CompletableFuture.java:2073)
	at org.apache.pulsar.client.impl.PulsarClientImpl$$Lambda$4598/0x0000000841775440.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture$UniAccept.tryFire(java.base@11.0.18/CompletableFuture.java:714)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@11.0.18/CompletableFuture.java:506)
	at java.util.concurrent.CompletableFuture.complete(java.base@11.0.18/CompletableFuture.java:2073)
	at org.apache.pulsar.client.impl.BinaryProtoLookupService.lambda$getPartitionedTopicMetadata$4(BinaryProtoLookupService.java:199)
	at org.apache.pulsar.client.impl.BinaryProtoLookupService$$Lambda$4605/0x0000000841779040.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniWhenComplete(java.base@11.0.18/CompletableFuture.java:859)
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(java.base@11.0.18/CompletableFuture.java:837)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@11.0.18/CompletableFuture.java:506)
	at java.util.concurrent.CompletableFuture.complete(java.base@11.0.18/CompletableFuture.java:2073)
	at org.apache.pulsar.client.impl.ClientCnx.handlePartitionResponse(ClientCnx.java:618)
	at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:130)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:327)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:314)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:435)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:279)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.apache.pulsar.shade.io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1372)
	at org.apache.pulsar.shade.io.netty.handler.ssl.SslHandler.decodeNonJdkCompatible(SslHandler.java:1246)
	at org.apache.pulsar.shade.io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1286)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:510)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:449)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:279)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.apache.pulsar.shade.io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at org.apache.pulsar.shade.io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at org.apache.pulsar.shade.io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:800)
	at org.apache.pulsar.shade.io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:487)
	at org.apache.pulsar.shade.io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:385)
	at org.apache.pulsar.shade.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:995)
	at org.apache.pulsar.shade.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at org.apache.pulsar.shade.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(java.base@11.0.18/Thread.java:829)
"pulsar-client-io-1-3":
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl.lambda$doSubscribeTopicPartitions$45(MultiTopicsConsumerImpl.java:1062)
	- waiting to lock <0x000000042cf2ed28> (a java.lang.Object)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl$$Lambda$4607/0x000000084177a840.apply(Unknown Source)
	at java.util.concurrent.ConcurrentHashMap.compute(java.base@11.0.18/ConcurrentHashMap.java:1947)
	- locked <0x00000004312d0940> (a java.util.concurrent.ConcurrentHashMap$Node)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl.doSubscribeTopicPartitions(MultiTopicsConsumerImpl.java:1051)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl.lambda$subscribeTopicPartitions$43(MultiTopicsConsumerImpl.java:993)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl$$Lambda$4606/0x0000000841779840.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniWhenComplete(java.base@11.0.18/CompletableFuture.java:859)
	at java.util.concurrent.CompletableFuture.uniWhenCompleteStage(java.base@11.0.18/CompletableFuture.java:883)
	at java.util.concurrent.CompletableFuture.whenComplete(java.base@11.0.18/CompletableFuture.java:2251)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl.subscribeTopicPartitions(MultiTopicsConsumerImpl.java:991)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl.lambda$subscribeAsync$38(MultiTopicsConsumerImpl.java:917)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl$$Lambda$4600/0x0000000841777040.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture$UniAccept.tryFire(java.base@11.0.18/CompletableFuture.java:714)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@11.0.18/CompletableFuture.java:506)
	at java.util.concurrent.CompletableFuture.complete(java.base@11.0.18/CompletableFuture.java:2073)
	at org.apache.pulsar.client.impl.PulsarClientImpl$$Lambda$4598/0x0000000841775440.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture$UniAccept.tryFire(java.base@11.0.18/CompletableFuture.java:714)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@11.0.18/CompletableFuture.java:506)
	at java.util.concurrent.CompletableFuture.complete(java.base@11.0.18/CompletableFuture.java:2073)
	at org.apache.pulsar.client.impl.BinaryProtoLookupService.lambda$getPartitionedTopicMetadata$4(BinaryProtoLookupService.java:199)
	at org.apache.pulsar.client.impl.BinaryProtoLookupService$$Lambda$4605/0x0000000841779040.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniWhenComplete(java.base@11.0.18/CompletableFuture.java:859)
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(java.base@11.0.18/CompletableFuture.java:837)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@11.0.18/CompletableFuture.java:506)
	at java.util.concurrent.CompletableFuture.complete(java.base@11.0.18/CompletableFuture.java:2073)
	at org.apache.pulsar.client.impl.ClientCnx.handlePartitionResponse(ClientCnx.java:618)
	at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:130)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:327)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:314)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:435)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:279)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.apache.pulsar.shade.io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1372)
	at org.apache.pulsar.shade.io.netty.handler.ssl.SslHandler.decodeNonJdkCompatible(SslHandler.java:1246)
	at org.apache.pulsar.shade.io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1286)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:510)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:449)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:279)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.apache.pulsar.shade.io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at org.apache.pulsar.shade.io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at org.apache.pulsar.shade.io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:800)
	at org.apache.pulsar.shade.io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:487)
	at org.apache.pulsar.shade.io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:385)
	at org.apache.pulsar.shade.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:995)
	at org.apache.pulsar.shade.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at org.apache.pulsar.shade.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(java.base@11.0.18/Thread.java:829)
"pulsar-client-io-1-4":
	at java.util.concurrent.ConcurrentHashMap.transfer(java.base@11.0.18/ConcurrentHashMap.java:2475)
	- waiting to lock <0x00000004312d0940> (a java.util.concurrent.ConcurrentHashMap$Node)
	at java.util.concurrent.ConcurrentHashMap.addCount(java.base@11.0.18/ConcurrentHashMap.java:2346)
	at java.util.concurrent.ConcurrentHashMap.putVal(java.base@11.0.18/ConcurrentHashMap.java:1075)
	at java.util.concurrent.ConcurrentHashMap.putIfAbsent(java.base@11.0.18/ConcurrentHashMap.java:1541)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl.lambda$doSubscribeTopicPartitions$44(MultiTopicsConsumerImpl.java:1041)
	- locked <0x000000042cf2ed28> (a java.lang.Object)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl$$Lambda$7535/0x0000000841fba040.apply(Unknown Source)
	at java.util.stream.IntPipeline$1$1.accept(java.base@11.0.18/IntPipeline.java:180)
	at java.util.stream.Streams$RangeIntSpliterator.forEachRemaining(java.base@11.0.18/Streams.java:104)
	at java.util.Spliterator$OfInt.forEachRemaining(java.base@11.0.18/Spliterator.java:699)
	at java.util.stream.AbstractPipeline.copyInto(java.base@11.0.18/AbstractPipeline.java:484)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(java.base@11.0.18/AbstractPipeline.java:474)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(java.base@11.0.18/ReduceOps.java:913)
	at java.util.stream.AbstractPipeline.evaluate(java.base@11.0.18/AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(java.base@11.0.18/ReferencePipeline.java:578)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl.doSubscribeTopicPartitions(MultiTopicsConsumerImpl.java:1045)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl.lambda$subscribeTopicPartitions$43(MultiTopicsConsumerImpl.java:993)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl$$Lambda$4606/0x0000000841779840.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniWhenComplete(java.base@11.0.18/CompletableFuture.java:859)
	at java.util.concurrent.CompletableFuture.uniWhenCompleteStage(java.base@11.0.18/CompletableFuture.java:883)
	at java.util.concurrent.CompletableFuture.whenComplete(java.base@11.0.18/CompletableFuture.java:2251)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl.subscribeTopicPartitions(MultiTopicsConsumerImpl.java:991)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl.lambda$subscribeAsync$38(MultiTopicsConsumerImpl.java:917)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl$$Lambda$4600/0x0000000841777040.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture$UniAccept.tryFire(java.base@11.0.18/CompletableFuture.java:714)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@11.0.18/CompletableFuture.java:506)
	at java.util.concurrent.CompletableFuture.complete(java.base@11.0.18/CompletableFuture.java:2073)
	at org.apache.pulsar.client.impl.PulsarClientImpl$$Lambda$4598/0x0000000841775440.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture$UniAccept.tryFire(java.base@11.0.18/CompletableFuture.java:714)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@11.0.18/CompletableFuture.java:506)
	at java.util.concurrent.CompletableFuture.complete(java.base@11.0.18/CompletableFuture.java:2073)
	at org.apache.pulsar.client.impl.BinaryProtoLookupService.lambda$getPartitionedTopicMetadata$4(BinaryProtoLookupService.java:199)
	at org.apache.pulsar.client.impl.BinaryProtoLookupService$$Lambda$4605/0x0000000841779040.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniWhenComplete(java.base@11.0.18/CompletableFuture.java:859)
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(java.base@11.0.18/CompletableFuture.java:837)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@11.0.18/CompletableFuture.java:506)
	at java.util.concurrent.CompletableFuture.complete(java.base@11.0.18/CompletableFuture.java:2073)
	at org.apache.pulsar.client.impl.ClientCnx.handlePartitionResponse(ClientCnx.java:618)
	at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:130)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:327)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:314)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:435)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:279)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.apache.pulsar.shade.io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1372)
	at org.apache.pulsar.shade.io.netty.handler.ssl.SslHandler.decodeNonJdkCompatible(SslHandler.java:1246)
	at org.apache.pulsar.shade.io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1286)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:510)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:449)
	at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:279)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.apache.pulsar.shade.io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at org.apache.pulsar.shade.io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at org.apache.pulsar.shade.io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:800)
	at org.apache.pulsar.shade.io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:487)
	at org.apache.pulsar.shade.io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:385)
	at org.apache.pulsar.shade.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:995)
	at org.apache.pulsar.shade.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at org.apache.pulsar.shade.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(java.base@11.0.18/Thread.java:829)

Found 1 deadlock.
```

### Modifications

This PR just makes a hotfix for the problem. It will not introduce any behavior changes, so we will be more confident to cherry-pick to release branches. And we should also try to see if there is a lock-free solution for long-term solution.

### Verifying this change

New test is added

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
