### PR TITLE
[improve][admin] Remove duplicate topics name when `deleteNamespace`

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -233,14 +233,14 @@ public abstract class NamespacesBase extends AdminResource {
                                     }))
                             .thenCompose(topics -> {
                                 List<String> allTopics = topics.get(0);
-                                ArrayList<String> allUserCreatedTopics = new ArrayList<>();
+                                Set<String> allUserCreatedTopics = new HashSet<>();
                                 List<String> allPartitionedTopics = topics.get(1);
-                                ArrayList<String> allUserCreatedPartitionTopics = new ArrayList<>();
+                                Set<String> allUserCreatedPartitionTopics = new HashSet<>();
                                 boolean hasNonSystemTopic = false;
-                                List<String> allSystemTopics = new ArrayList<>();
-                                List<String> allPartitionedSystemTopics = new ArrayList<>();
-                                List<String> topicPolicy = new ArrayList<>();
-                                List<String> partitionedTopicPolicy = new ArrayList<>();
+                                Set<String> allSystemTopics = new HashSet<>();
+                                Set<String> allPartitionedSystemTopics = new HashSet<>();
+                                Set<String> topicPolicy = new HashSet<>();
+                                Set<String> partitionedTopicPolicy = new HashSet<>();
                                 for (String topic : allTopics) {
                                     if (!pulsar().getBrokerService().isSystemTopic(TopicName.get(topic))) {
                                         hasNonSystemTopic = true;
@@ -354,7 +354,7 @@ public abstract class NamespacesBase extends AdminResource {
         return topic.endsWith(SystemTopicNames.PENDING_ACK_STORE_SUFFIX);
     }
 
-    private CompletableFuture<Void> internalDeletePartitionedTopicsAsync(List<String> topicNames) {
+    private CompletableFuture<Void> internalDeletePartitionedTopicsAsync(Set<String> topicNames) {
         if (CollectionUtils.isEmpty(topicNames)) {
             return CompletableFuture.completedFuture(null);
         }
@@ -368,7 +368,7 @@ public abstract class NamespacesBase extends AdminResource {
         return FutureUtil.waitForAll(futures);
     }
 
-    private CompletableFuture<Void> internalDeleteTopicsAsync(List<String> topicNames) {
+    private CompletableFuture<Void> internalDeleteTopicsAsync(Set<String> topicNames) {
         if (CollectionUtils.isEmpty(topicNames)) {
             return CompletableFuture.completedFuture(null);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -279,6 +279,9 @@ public abstract class NamespacesBase extends AdminResource {
                                         return old;
                                     });
                                 }
+                                allUserCreatedTopics.removeAll(allUserCreatedPartitionTopics);
+                                allSystemTopics.removeAll(allPartitionedSystemTopics);
+                                topicPolicy.removeAll(partitionedTopicPolicy);
                                 return markDeleteFuture.thenCompose(__ ->
                                                 internalDeleteTopicsAsync(allUserCreatedTopics))
                                         .thenCompose(ignore ->

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -279,9 +279,9 @@ public abstract class NamespacesBase extends AdminResource {
                                         return old;
                                     });
                                 }
-                                allUserCreatedTopics.removeAll(allUserCreatedPartitionTopics);
-                                allSystemTopics.removeAll(allPartitionedSystemTopics);
-                                topicPolicy.removeAll(partitionedTopicPolicy);
+                                allUserCreatedTopics.removeIf(t -> allPartitionedTopics.contains(TopicName.get(t).getPartitionedTopicName()));
+                                allSystemTopics.removeIf(t -> allPartitionedTopics.contains(TopicName.get(t).getPartitionedTopicName()));
+                                topicPolicy.removeIf(t -> allPartitionedTopics.contains(TopicName.get(t).getPartitionedTopicName()));
                                 return markDeleteFuture.thenCompose(__ ->
                                                 internalDeleteTopicsAsync(allUserCreatedTopics))
                                         .thenCompose(ignore ->

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -279,9 +279,12 @@ public abstract class NamespacesBase extends AdminResource {
                                         return old;
                                     });
                                 }
-                                allUserCreatedTopics.removeIf(t -> allPartitionedTopics.contains(TopicName.get(t).getPartitionedTopicName()));
-                                allSystemTopics.removeIf(t -> allPartitionedTopics.contains(TopicName.get(t).getPartitionedTopicName()));
-                                topicPolicy.removeIf(t -> allPartitionedTopics.contains(TopicName.get(t).getPartitionedTopicName()));
+                                allUserCreatedTopics.removeIf(t ->
+                                        allPartitionedTopics.contains(TopicName.get(t).getPartitionedTopicName()));
+                                allSystemTopics.removeIf(t ->
+                                        allPartitionedTopics.contains(TopicName.get(t).getPartitionedTopicName()));
+                                topicPolicy.removeIf(t ->
+                                        allPartitionedTopics.contains(TopicName.get(t).getPartitionedTopicName()));
                                 return markDeleteFuture.thenCompose(__ ->
                                                 internalDeleteTopicsAsync(allUserCreatedTopics))
                                         .thenCompose(ignore ->


### PR DESCRIPTION
### Motivation

When `deleteNamespace`,  we will get all the topics, see:
https://github.com/apache/pulsar/blob/1211b14820467750af77a1b28cf0ba9c468d374c/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java#L216-L234

if the topic is partitioned-topic, eg :  "persistent://public/default/__change_events" with 3 partitions,
then the `topicsSum` will contain:
```
persistent://public/default/__change_events-partition-0
persistent://public/default/__change_events-partition-1
persistent://public/default/__change_events-partition-2
persistent://public/default/__change_events
```

So cause `topicPolicy` with :
```
persistent://public/default/__change_events-partition-0
persistent://public/default/__change_events-partition-1
persistent://public/default/__change_events-partition-2
```
`partitionedTopicPolicy` with :
```
persistent://public/default/__change_events
```

https://github.com/apache/pulsar/blob/1211b14820467750af77a1b28cf0ba9c468d374c/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java#L282-L293

So make the duplicate deleting.

![image](https://github.com/apache/pulsar/assets/6297296/ba2727a3-fd1c-49b5-afc8-c9bc7f2a7cc8)


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


