### PR TITLE
[fix][test] Remove timeout for `deleteTopicCloseTransactionBufferTest`

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferCloseTest.java
@@ -61,7 +61,7 @@ public class TransactionBufferCloseTest extends TransactionTestBase {
         };
     }
 
-    @Test(timeOut = 10_000, dataProvider = "isPartition")
+    @Test(dataProvider = "isPartition")
     public void deleteTopicCloseTransactionBufferTest(boolean isPartition) throws Exception {
         int partitionCount = isPartition ? 30 : 1;
         List<TopicName> topicNames = createAndLoadTopics(isPartition, partitionCount);


### PR DESCRIPTION
Fixes #20673

### Motivation

`deleteTopicCloseTransactionBufferTest`  will create and then delete 60 topics if `isPartition=true`.

And `checkSnapshotPublisherCount` will execute 3 times with a 5s timeout per time. 

So it's better to set the `timeOut=15_000` or remove it (fast fail by checkSnapshotPublisherCount timeout).

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


