### PR TITLE
[fix][fn] Exit JVM when main thread throws exception

### DIFF
--- a/pulsar-functions/runtime-all/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceMain.java
+++ b/pulsar-functions/runtime-all/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceMain.java
@@ -54,6 +54,20 @@ public class JavaInstanceMain {
 
     private static final String FUNCTIONS_INSTANCE_CLASSPATH = "pulsar.functions.instance.classpath";
 
+    private static final Method log4j2ShutdownMethod;
+
+    static {
+        // use reflection to find org.apache.logging.log4j.LogManager.shutdown method
+        Method shutdownMethod = null;
+        try {
+            shutdownMethod = Class.forName("org.apache.logging.log4j.LogManager")
+                    .getMethod("shutdown");
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            // ignore
+        }
+        log4j2ShutdownMethod = shutdownMethod;
+    }
+
     public JavaInstanceMain() {
     }
 
@@ -91,22 +105,26 @@ public class JavaInstanceMain {
 
         System.out.println("Using function root classloader: " + root);
         System.out.println("Using function instance classloader: " + functionInstanceClsLoader);
-
-        // use the function instance classloader to create org.apache.pulsar.functions.runtime.JavaInstanceStarter
-        Object main =
-                createInstance("org.apache.pulsar.functions.runtime.JavaInstanceStarter", functionInstanceClsLoader);
-
-        // Invoke start method of JavaInstanceStarter to start the function instance code
-        Method method =
-                main.getClass().getDeclaredMethod("start", String[].class, ClassLoader.class, ClassLoader.class);
-
-        System.out.println("Starting function instance...");
         try {
+            // use the function instance classloader to create org.apache.pulsar.functions.runtime.JavaInstanceStarter
+            Object main =
+                    createInstance("org.apache.pulsar.functions.runtime.JavaInstanceStarter",
+                            functionInstanceClsLoader);
+
+            // Invoke start method of JavaInstanceStarter to start the function instance code
+            Method method =
+                    main.getClass().getDeclaredMethod("start", String[].class, ClassLoader.class, ClassLoader.class);
+
+            System.out.println("Starting function instance...");
             method.invoke(main, args, functionInstanceClsLoader, root);
-        } catch (InvocationTargetException e) {
-            System.out.println("Failed to start function instance.");
-            e.printStackTrace();
-            System.exit(1);
+        } catch (Throwable e) {
+            try {
+                shutdownLogging();
+            } finally {
+                System.out.println("Failed to start function instance.");
+                e.printStackTrace();
+                Runtime.getRuntime().halt(1);
+            }
         }
     }
 
@@ -156,6 +174,18 @@ public class JavaInstanceMain {
             return true;
         } else {
             return true;
+        }
+    }
+
+    private static void shutdownLogging() {
+        // flush log buffers and shutdown log4j2 logging to prevent log truncation
+        if (log4j2ShutdownMethod != null) {
+            try {
+                // use reflection to call org.apache.logging.log4j.LogManager.shutdown()
+                log4j2ShutdownMethod.invoke(null);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                // ignore
+            }
         }
     }
 }

--- a/pulsar-functions/runtime-all/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceMain.java
+++ b/pulsar-functions/runtime-all/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceMain.java
@@ -101,7 +101,13 @@ public class JavaInstanceMain {
                 main.getClass().getDeclaredMethod("start", String[].class, ClassLoader.class, ClassLoader.class);
 
         System.out.println("Starting function instance...");
-        method.invoke(main, args, functionInstanceClsLoader, root);
+        try {
+            method.invoke(main, args, functionInstanceClsLoader, root);
+        } catch (InvocationTargetException e) {
+            System.out.println("Failed to start function instance.");
+            e.printStackTrace();
+            System.exit(1);
+        }
     }
 
     public static Object createInstance(String userClassName,


### PR DESCRIPTION
Fixes: https://github.com/apache/pulsar/issues/20688

### Motivation

When a function throws an exception that ends processing, we should exit the JVM.

### Modifications

* Update `JavaInstanceMain` so that an exception leads to exiting the JVM. Since the class does not use any dependencies (see the class's Javadoc), we use reflection to shutdown logging.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [x] `doc-not-needed`