### PR TITLE
[fix] [admin] set ns level backlog quota does not take effect if retention exists

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -1323,6 +1323,7 @@ public abstract class NamespacesBase extends AdminResource {
                         "Backlog Quota exceeds configured retention quota for namespace."
                                 + " Please increase retention quota and retry");
             }
+            policies.backlog_quota_map.put(quotaType, quota);
             return policies;
         });
     }


### PR DESCRIPTION
### Motivation

When a retention policy exists, the command `pulsar-admin namespaces set-backlog-quota` does not take effect.

In the PR https://github.com/apache/pulsar/pull/17383: it only checked the compatibility of `retention` and `backlog quota`, and it was not set.

### Modifications

Fix the bug.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
