### PR TITLE
[fix][io] Close the kafka source connector got stuck

### DIFF
--- a/pulsar-io/kafka/pom.xml
+++ b/pulsar-io/kafka/pom.xml
@@ -109,6 +109,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSource.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSource.java
@@ -68,7 +68,7 @@ public abstract class KafkaAbstractSource<V> extends PushSource<V> {
     private KafkaSourceConfig kafkaSourceConfig;
     private Thread runnerThread;
     private final static Executor executor = Executors.newSingleThreadExecutor(
-            new DefaultThreadFactory("Kafka_source_close_task_thread"));
+            new DefaultThreadFactory("Kafka Source Close Task Thread"));
 
     @Override
     public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSource.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSource.java
@@ -67,7 +67,7 @@ public abstract class KafkaAbstractSource<V> extends PushSource<V> {
     private volatile boolean running = false;
     private KafkaSourceConfig kafkaSourceConfig;
     private Thread runnerThread;
-    private final static Executor executor = Executors.newSingleThreadExecutor(
+    private final static Executor EXECUTOR = Executors.newSingleThreadExecutor(
             new DefaultThreadFactory("Kafka Source Close Task Thread"));
 
     @Override
@@ -195,7 +195,7 @@ public abstract class KafkaAbstractSource<V> extends PushSource<V> {
         });
         runnerThread.setUncaughtExceptionHandler(
                 (t, e) -> {
-                    executor.execute(() -> {
+                    EXECUTOR.execute(() -> {
                         LOG.error("[{}] Error while consuming records", t.getName(), e);
                         try {
                             this.close();

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSource.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSource.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.io.kafka;
 
 import io.jsonwebtoken.io.Encoders;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
@@ -66,7 +67,8 @@ public abstract class KafkaAbstractSource<V> extends PushSource<V> {
     private volatile boolean running = false;
     private KafkaSourceConfig kafkaSourceConfig;
     private Thread runnerThread;
-    private final Executor executor = Executors.newSingleThreadExecutor();
+    private final static Executor executor = Executors.newSingleThreadExecutor(
+            new DefaultThreadFactory("Kafka_source_close_task_thread"));
 
     @Override
     public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {

--- a/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/source/KafkaAbstractSourceTest.java
+++ b/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/source/KafkaAbstractSourceTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.io.core.SourceContext;
+import org.apache.pulsar.io.kafka.KafkaAbstractSource;
 import org.apache.pulsar.io.kafka.KafkaSourceConfig;
 import org.awaitility.Awaitility;
 import org.mockito.Mockito;

--- a/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/source/KafkaAbstractSourceTest.java
+++ b/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/source/KafkaAbstractSourceTest.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.io.kafka.source;
 
 
 import com.google.common.collect.ImmutableMap;
-import io.netty.handler.codec.spdy.DefaultSpdyGoAwayFrame;
 import java.util.Collection;
 import java.util.Collections;
 import java.lang.reflect.Field;
@@ -30,7 +29,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.io.core.SourceContext;
-import org.apache.pulsar.io.kafka.KafkaAbstractSource;
 import org.apache.pulsar.io.kafka.KafkaSourceConfig;
 import org.awaitility.Awaitility;
 import org.mockito.Mockito;

--- a/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/source/KafkaAbstractSourceTest.java
+++ b/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/source/KafkaAbstractSourceTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.io.kafka.source;
 
 
 import com.google.common.collect.ImmutableMap;
+import io.netty.handler.codec.spdy.DefaultSpdyGoAwayFrame;
 import java.util.Collection;
 import java.util.Collections;
 import java.lang.reflect.Field;
@@ -31,6 +32,7 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.io.core.SourceContext;
 import org.apache.pulsar.io.kafka.KafkaAbstractSource;
 import org.apache.pulsar.io.kafka.KafkaSourceConfig;
+import org.awaitility.Awaitility;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -173,7 +175,10 @@ public class KafkaAbstractSourceTest {
         Field runningField = KafkaAbstractSource.class.getDeclaredField("running");
         runningField.setAccessible(true);
 
-        Assert.assertFalse((boolean) runningField.get(source));
+        Awaitility.await().untilAsserted(() -> {
+            Assert.assertFalse((boolean) runningField.get(source));
+            Assert.assertNull(consumerField.get(source));
+        });
     }
 
     private File getFile(String name) {


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/discussions/19880#discussioncomment-6026807 When Kafka connector is closing, it waits for the `runnerThread` to stop, but the task-close is running at the same thread, so it will be stuck.

### Modifications

run `close` in another thread.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
