### PR TITLE
[fix][broker] Revert "Skip loading broker interceptor when disableBrokerInterceptors is true #20422"

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1356,7 +1356,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_SERVER,
-        doc = "Enable or disable the broker interceptor"
+        doc = "Enable or disable the broker interceptor, which is only used for testing for now"
     )
     private boolean disableBrokerInterceptors = true;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptors.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptors.java
@@ -59,11 +59,6 @@ public class BrokerInterceptors implements BrokerInterceptor {
      * @return the collection of broker event interceptor
      */
     public static BrokerInterceptor load(ServiceConfiguration conf) throws IOException {
-        if (conf.isDisableBrokerInterceptors()) {
-            log.info("Skip loading the broker interceptors when disableBrokerInterceptors is true");
-            return null;
-        }
-
         BrokerInterceptorDefinitions definitions =
                 BrokerInterceptorUtils.searchForInterceptors(conf.getBrokerInterceptorsDirectory(),
                         conf.getNarExtractionDirectory());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorTest.java
@@ -20,12 +20,9 @@ package org.apache.pulsar.broker.intercept;
 
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -39,7 +36,6 @@ import okhttp3.Callback;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
@@ -311,25 +307,4 @@ public class BrokerInterceptorTest extends ProducerConsumerBase {
         }
     }
 
-    @Test
-    public void testLoadWhenDisableBrokerInterceptorsIsTrue() throws IOException {
-        ServiceConfiguration serviceConfiguration = spy(ServiceConfiguration.class);
-        serviceConfiguration.setDisableBrokerInterceptors(true);
-        BrokerInterceptor brokerInterceptor = BrokerInterceptors.load(serviceConfiguration);
-        assertNull(brokerInterceptor);
-
-        verify(serviceConfiguration, times(1)).isDisableBrokerInterceptors();
-        verify(serviceConfiguration, times(0)).getBrokerInterceptorsDirectory();
-    }
-
-    @Test
-    public void testLoadWhenDisableBrokerInterceptorsIsFalse() throws IOException {
-        ServiceConfiguration serviceConfiguration = spy(ServiceConfiguration.class);
-        serviceConfiguration.setDisableBrokerInterceptors(false);
-        BrokerInterceptor brokerInterceptor = BrokerInterceptors.load(serviceConfiguration);
-        assertNull(brokerInterceptor);
-
-        verify(serviceConfiguration, times(1)).isDisableBrokerInterceptors();
-        verify(serviceConfiguration, times(1)).getBrokerInterceptorsDirectory();
-    }
 }


### PR DESCRIPTION
### Motivation

After merging #20422 , the 2.11 may encounter NPE when config :
```
brokerInterceptors = xxx-interceptor
disableBrokerInterceptors = true
```

<img width="1211" alt="image" src="https://github.com/apache/pulsar/assets/6297296/3bb41b64-ded2-492b-b872-1a48a6a805ab">

```
2023-07-03T10:26:00,507+0000 [main] INFO  org.apache.pulsar.broker.intercept.BrokerInterceptors - Skip loading the broker interceptors when disableBrokerInterceptors is true
```

See code of branch-2.11
https://github.com/apache/pulsar/blob/dc258107d5019f513e2242eccb1551c956c72fed/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ProcessHandlerFilter.java#L38-L53

https://github.com/apache/pulsar/blob/dc258107d5019f513e2242eccb1551c956c72fed/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptors.java#L60-L64

The master branch has fixed the NPE by #19376. it's hard to cherry-pick that to branch-2.11.
So in order to keep the same logic, we need to revert #20422 first and then discuss if we should keep `disableBrokerInterceptors ` in the mail list.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

