### PR TITLE
[fix][broker] Fix Filter NPE

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ProcessHandlerFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ProcessHandlerFilter.java
@@ -37,7 +37,7 @@ public class ProcessHandlerFilter implements Filter {
 
     public ProcessHandlerFilter(PulsarService pulsar) {
         this.interceptor = pulsar.getBrokerInterceptor();
-        this.interceptorEnabled = !pulsar.getConfig().getBrokerInterceptors().isEmpty();
+        this.interceptorEnabled = interceptor != null && !pulsar.getConfig().isDisableBrokerInterceptors();
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ResponseHandlerFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ResponseHandlerFilter.java
@@ -51,7 +51,7 @@ public class ResponseHandlerFilter implements Filter {
     public ResponseHandlerFilter(PulsarService pulsar) {
         this.brokerAddress = pulsar.getAdvertisedAddress();
         this.interceptor = pulsar.getBrokerInterceptor();
-        this.interceptorEnabled = !pulsar.getConfig().getBrokerInterceptors().isEmpty();
+        this.interceptorEnabled = interceptor != null && !pulsar.getConfig().isDisableBrokerInterceptors();
     }
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/InterceptFilterOutTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/InterceptFilterOutTest.java
@@ -151,7 +151,7 @@ public class InterceptFilterOutTest {
         Mockito.doReturn(interceptor).when(pulsarService).getBrokerInterceptor();
         ServiceConfiguration conf = Mockito.mock(ServiceConfiguration.class);
         // Disable the broker interceptor
-        Mockito.doReturn(Sets.newHashSet()).when(conf).getBrokerInterceptors();
+        Mockito.doReturn(true).when(conf).isDisableBrokerInterceptors();
         Mockito.doReturn(conf).when(pulsarService).getConfig();
         ResponseHandlerFilter filter = new ResponseHandlerFilter(pulsarService);
 


### PR DESCRIPTION

### Motivation

After merging #20422 , the broker may encounter NPE when config :
```
brokerInterceptors = xxx-interceptor
disableBrokerInterceptors = true
```

<img width="1211" alt="image" src="https://github.com/apache/pulsar/assets/6297296/3bb41b64-ded2-492b-b872-1a48a6a805ab">

```
2023-07-03T10:26:00,507+0000 [main] INFO  org.apache.pulsar.broker.intercept.BrokerInterceptors - Skip loading the broker interceptors when disableBrokerInterceptors is true
```

See 
https://github.com/apache/pulsar/blob/dc258107d5019f513e2242eccb1551c956c72fed/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ProcessHandlerFilter.java#L38-L53

https://github.com/apache/pulsar/blob/dc258107d5019f513e2242eccb1551c956c72fed/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptors.java#L60-L64

The master branch has fixed this by #19376

For the judgment of interceptors, we need to be consistent with the master, that is, to use the `disableBrokerInterceptors` judgment first

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

