### PR TITLE
[fix][test]Fix resource not close after method

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PublishRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PublishRateLimiterTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.service;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.PublishRate;
 import org.apache.pulsar.common.util.RateLimiter;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -49,6 +50,14 @@ public class PublishRateLimiterTest {
 
         precisePublishLimiter = new PrecisePublishLimiter(policies, CLUSTER_NAME, () -> System.out.print("Refresh permit"));
         publishRateLimiter = new PublishRateLimiterImpl(policies, CLUSTER_NAME);
+    }
+
+    @AfterMethod
+    public void cleanup() throws Exception {
+        policies.publishMaxMessageRate.clear();
+        policies.publishMaxMessageRate = null;
+        precisePublishLimiter.close();
+        publishRateLimiter.close();
     }
 
     @Test


### PR DESCRIPTION
### Motivation
The resources were not released after the test, resulting in "Refresh permit" keep printing on the console

### Modifications
release the resource after method

### Verifying this change
- [x] Make sure that the change passes the CI checks.

### Documentation
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->

### Matching PR in forked repository
https://github.com/315157973/pulsar/pull/11
