### PR TITLE
[feat][test] Support delay messages in a random number of seconds by the range

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -24,7 +24,6 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_BATCHING_MAX_MESSAGES;
 import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_MAX_PENDING_MESSAGES;
 import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_MAX_PENDING_MESSAGES_ACROSS_PARTITIONS;
-
 import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.testclient;
 
-import static java.util.Objects.*;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -202,8 +202,7 @@ public class PerformanceProducer {
                 "--delay" }, description = "Mark messages with a given delay in seconds")
         public long delay = 0;
 
-        @Parameter(names = { "-dr", "--delay-range"}, description = "Mark messages with a given delay in a random"
-                + " number of seconds by the range. e.g. \"[1,2]\"", converter = RangeConvert.class)
+        @Parameter(names = { "-dr", "--delay-range"}, description = "Mark messages with a given delay by a random number of seconds. this value between the specified origin (inclusive) and the specified bound (exclusive). e.g. \"1,300\"", converter = RangeConvert.class)
         public Range<Long> delayRange = null;
 
         @Parameter(names = { "-set",
@@ -793,22 +792,10 @@ public class PerformanceProducer {
                 final String[] facts = rangeStr.substring(1, rangeStr.length() - 1).split(",");
                 long min = Long.parseLong(facts[0].trim());
                 long max = Long.parseLong(facts[1].trim());
-                if (rangeStr.startsWith("(")) {
-                    if (rangeStr.endsWith(")")) {
-                        return Range.open(min, max);
-                    } else if (rangeStr.endsWith("]")) {
-                        return Range.openClosed(min, max);
-                    }
-                } else if (rangeStr.startsWith("[")) {
-                    if (rangeStr.endsWith(")")) {
-                        return Range.closedOpen(min, max);
-                    } else if (rangeStr.endsWith("]")) {
-                        return Range.closed(min, max);
-                    }
-                }
-                throw new IllegalArgumentException("Unknown range interval. " + rangeStr);
+                return Range.openClosed(min, max);
             } catch (Throwable ex) {
-                throw new IllegalArgumentException("Unknown range interval. " + rangeStr);
+                throw new IllegalArgumentException("Unknown delay range interval,"
+                        + " the format should be \"<origin>,<bound>\". error message: " + rangeStr);
             }
         }
     }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -621,12 +621,10 @@ public class PerformanceProducer {
                     }
                     if (arguments.delay > 0) {
                         messageBuilder.deliverAfter(arguments.delay, TimeUnit.SECONDS);
-                    } else {
-                        if (arguments.delayRange != null) {
-                            final long deliverAfter = ThreadLocalRandom.current()
-                                    .nextLong(arguments.delayRange.lowerEndpoint(), arguments.delayRange.upperEndpoint());
-                            messageBuilder.deliverAfter(deliverAfter, TimeUnit.SECONDS);
-                        }
+                    } else if (arguments.delayRange != null) {
+                        final long deliverAfter = ThreadLocalRandom.current()
+                                .nextLong(arguments.delayRange.lowerEndpoint(), arguments.delayRange.upperEndpoint());
+                        messageBuilder.deliverAfter(deliverAfter, TimeUnit.SECONDS);
                     }
                     if (arguments.setEventTime) {
                         messageBuilder.eventTime(System.currentTimeMillis());

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -625,8 +625,7 @@ public class PerformanceProducer {
                         messageBuilder.deliverAfter(arguments.delay, TimeUnit.SECONDS);
                     } else if (arguments.delayRange != null) {
                         final long deliverAfter = ThreadLocalRandom.current()
-                                .nextLong(arguments.delayRange.lowerEndpoint(),
-                                        arguments.delayRange.upperEndpoint());
+                                .nextLong(arguments.delayRange.lowerEndpoint(), arguments.delayRange.upperEndpoint());
                         messageBuilder.deliverAfter(deliverAfter, TimeUnit.SECONDS);
                     }
                     if (arguments.setEventTime) {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.testclient;
 
+import static java.util.Objects.*;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -202,7 +203,9 @@ public class PerformanceProducer {
                 "--delay" }, description = "Mark messages with a given delay in seconds")
         public long delay = 0;
 
-        @Parameter(names = { "-dr", "--delay-range"}, description = "Mark messages with a given delay by a random number of seconds. this value between the specified origin (inclusive) and the specified bound (exclusive). e.g. \"1,300\"", converter = RangeConvert.class)
+        @Parameter(names = { "-dr", "--delay-range"}, description = "Mark messages with a given delay by a random"
+                + " number of seconds. this value between the specified origin (inclusive) and the specified bound"
+                + " (exclusive). e.g. \"1,300\"", converter = RangeConvert.class)
         public Range<Long> delayRange = null;
 
         @Parameter(names = { "-set",
@@ -789,9 +792,10 @@ public class PerformanceProducer {
         @Override
         public Range<Long> convert(String rangeStr) {
             try {
+                requireNonNull(rangeStr);
                 final String[] facts = rangeStr.substring(1, rangeStr.length() - 1).split(",");
-                long min = Long.parseLong(facts[0].trim());
-                long max = Long.parseLong(facts[1].trim());
+                final long min = Long.parseLong(facts[0].trim());
+                final long max = Long.parseLong(facts[1].trim());
                 return Range.openClosed(min, max);
             } catch (Throwable ex) {
                 throw new IllegalArgumentException("Unknown delay range interval,"

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -796,7 +796,7 @@ public class PerformanceProducer {
                 final String[] facts = rangeStr.substring(1, rangeStr.length() - 1).split(",");
                 final long min = Long.parseLong(facts[0].trim());
                 final long max = Long.parseLong(facts[1].trim());
-                return Range.openClosed(min, max);
+                return Range.closedOpen(min, max);
             } catch (Throwable ex) {
                 throw new IllegalArgumentException("Unknown delay range interval,"
                         + " the format should be \"<origin>,<bound>\". error message: " + rangeStr);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -623,7 +623,8 @@ public class PerformanceProducer {
                         messageBuilder.deliverAfter(arguments.delay, TimeUnit.SECONDS);
                     } else if (arguments.delayRange != null) {
                         final long deliverAfter = ThreadLocalRandom.current()
-                                .nextLong(arguments.delayRange.lowerEndpoint(), arguments.delayRange.upperEndpoint());
+                                .nextLong(arguments.delayRange.lowerEndpoint(),
+                                        arguments.delayRange.upperEndpoint() + 1);
                         messageBuilder.deliverAfter(deliverAfter, TimeUnit.SECONDS);
                     }
                     if (arguments.setEventTime) {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -626,7 +626,7 @@ public class PerformanceProducer {
                     } else if (arguments.delayRange != null) {
                         final long deliverAfter = ThreadLocalRandom.current()
                                 .nextLong(arguments.delayRange.lowerEndpoint(),
-                                        arguments.delayRange.upperEndpoint() + 1);
+                                        arguments.delayRange.upperEndpoint());
                         messageBuilder.deliverAfter(deliverAfter, TimeUnit.SECONDS);
                     }
                     if (arguments.setEventTime) {


### PR DESCRIPTION
### Motivation

Support delay messages in a random number of seconds by the range for our testing performance producer.

### Modifications

- Support delay messages in a random number of seconds by the range for our testing performance producer.


### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
