### PR TITLE
[fix][broker] Fix missing generate some metrics in BrokerOperabilityMetrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
@@ -59,6 +59,7 @@ public class BrokerOperabilityMetrics {
     }
 
     private void generate() {
+        reset();
         metricsList.add(getTopicLoadMetrics());
         metricsList.add(getConnectionMetrics());
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -34,7 +34,6 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -243,8 +243,8 @@ public class PrometheusMetricsGenerator {
                     clusterName, Collector.Type.GAUGE, stream);
         }
 
-        parseMetricsToPrometheusMetrics(Collections.singletonList(pulsar.getBrokerService()
-                        .getPulsarStats().getBrokerOperabilityMetrics().generateConnectionMetrics()),
+        parseMetricsToPrometheusMetrics(pulsar.getBrokerService()
+                        .getPulsarStats().getBrokerOperabilityMetrics().getMetrics(),
                 clusterName, Collector.Type.GAUGE, stream);
 
         // generate loadBalance metrics

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -253,7 +253,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         assertEquals(pulsarTopicLoadTimesCountMetrics.size(), 1);
         Collection<Metric> topicLoadTimeP999Metrics = metrics.get("pulsar_topic_load_time_99_9_percentile_ms");
         Collection<Metric> topicLoadTimeFailedCountMetrics = metrics.get("pulsar_topic_load_failed_count");
-        assertEquals(topicLoadTimeP999Metrics.size(), 2);
+        assertEquals(topicLoadTimeP999Metrics.size(), 1);
         assertEquals(topicLoadTimeFailedCountMetrics.size(), 1);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -251,6 +251,10 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         Collection<Metric> pulsarTopicLoadTimesCountMetrics = metrics.get("pulsar_topic_load_times_count");
         assertEquals(pulsarTopicLoadTimesMetrics.size(), 6);
         assertEquals(pulsarTopicLoadTimesCountMetrics.size(), 1);
+        Collection<Metric> topicLoadTimeP999Metrics = metrics.get("pulsar_topic_load_time_99_9_percentile_ms");
+        Collection<Metric> topicLoadTimeFailedCountMetrics = metrics.get("pulsar_topic_load_failed_count");
+        assertEquals(topicLoadTimeP999Metrics.size(), 2);
+        assertEquals(topicLoadTimeFailedCountMetrics.size(), 1);
     }
 
     @Test


### PR DESCRIPTION
### Motivation

When generating broker basic metrics, it misses some metrics in the BrokerOperabilityMetrics.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


