### PR TITLE
[fix] [io] elastic-search sink connector not support JSON.String schema.

### DIFF
--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.io.elasticsearch;
 
 import co.elastic.clients.transport.ElasticsearchTransport;
+import com.fasterxml.jackson.core.JsonParseException;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
@@ -281,6 +282,45 @@ public abstract class ElasticSearchSinkTests extends ElasticSearchTestBase {
         sink.open(map, mockSinkContext);
         sink.write(mockRecord);
         verify(mockRecord, times(1)).ack();
+    }
+
+    @Test(expectedExceptions = JsonParseException.class)
+    public final void sendJsonStringSchemaErrorTest() throws Exception {
+
+        when(mockRecord.getMessage()).thenAnswer(new Answer<Optional<Message<String>>>() {
+            @Override
+            public Optional<Message<String>> answer(InvocationOnMock invocation) throws Throwable {
+                final MessageImpl mock = mock(MessageImpl.class);
+                when(mock.getData()).thenReturn("no-json-format".getBytes(StandardCharsets.UTF_8));
+                return Optional.of(mock);
+            }
+        });
+
+        when(mockRecord.getKey()).thenAnswer(new Answer<Optional<String>>() {
+            public Optional<String> answer(InvocationOnMock invocation) throws Throwable {
+                return Optional.empty();
+            }
+        });
+
+        GenericRecord genericRecord = mock(GenericRecord.class);
+        when(genericRecord.getNativeObject()).thenReturn("no-json-format");
+        when(genericRecord.getSchemaType()).thenReturn(SchemaType.JSON);
+        when(mockRecord.getValue()).thenAnswer(new Answer<GenericRecord>() {
+            public GenericRecord answer(InvocationOnMock invocation) throws Throwable {
+                return genericRecord;
+            }
+        });
+
+        when(mockRecord.getSchema()).thenAnswer(new Answer<Schema>() {
+            public Schema answer(InvocationOnMock invocation) throws Throwable {
+                return Schema.JSON(String.class);
+            }
+        });
+
+        map.put("indexName", "test-index");
+        map.put("schemaEnable", "true");
+        sink.open(map, mockSinkContext);
+        sink.write(mockRecord);
     }
 
     @Test(enabled = true)


### PR DESCRIPTION
### Motivation

If a producer use `Schema.JSON(String.class)` schema, es sink connector will throw `ClassCastException`.

1. Create a producer.
```java
Producer<String> producer = client.newProducer(Schema.JSON(String.class))
        .topic("test-es")
        .create();
MessageId msgID = producer.send({\"a\":1});
```

2. When es sink connector handle this message, it will throw `ClassCastException`.
```
java.lang.ClassCastException: class java.lang.String cannot be cast to class com.fasterxml.jackson.databind.JsonNode (java.lang.String is in module java.base of loader 'bootstrap'; com.fasterxml.jackson.databind.JsonNode is in unnamed module of loader 'app')
```
Exception throws on here:
https://github.com/apache/pulsar/blob/593fcb87b6d3bd6401eb4ffa4c25d8b3f724e49d/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSink.java#L382

The root cause is when the schema is not `RECORD` type, it will not transfer to `JsonNode`.
https://github.com/apache/pulsar/blob/af1360fb167c1f9484fda5771df3ea9b21d1440b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java#L204-L220

### Modifications

- When `navtiveObject` is String, try to transfer it to JsonNode.

### Verifying this change

- Add `sendJsonStringSchemaTest ` to cover it.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/shibd/pulsar/pull/22
