### PR TITLE
[fix] Ignore openIDTokenIssuerTrustCertsFilePath conf when blank

### DIFF
--- a/pulsar-broker-auth-oidc/src/main/java/org/apache/pulsar/broker/authentication/oidc/AuthenticationProviderOpenID.java
+++ b/pulsar-broker-auth-oidc/src/main/java/org/apache/pulsar/broker/authentication/oidc/AuthenticationProviderOpenID.java
@@ -52,6 +52,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import javax.naming.AuthenticationException;
 import javax.net.ssl.SSLSession;
+import org.apache.commons.lang.StringUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
@@ -163,7 +164,9 @@ public class AuthenticationProviderOpenID implements AuthenticationProvider {
         int readTimeout = getConfigValueAsInt(config, HTTP_READ_TIMEOUT_MILLIS, HTTP_READ_TIMEOUT_MILLIS_DEFAULT);
         String trustCertsFilePath = getConfigValueAsString(config, ISSUER_TRUST_CERTS_FILE_PATH, null);
         SslContext sslContext = null;
-        if (trustCertsFilePath != null) {
+        // When config is in the conf file but is empty, it defaults to the empty string, which is not meaningful and
+        // should be ignored.
+        if (StringUtils.isNotBlank(trustCertsFilePath)) {
             // Use default settings for everything but the trust store.
             sslContext = SslContextBuilder.forClient()
                     .trustManager(new File(trustCertsFilePath))


### PR DESCRIPTION
### Motivation

In https://stackoverflow.com/questions/76631732/apache-pulsar-unable-to-validate-issuer-certificate-when-attempting-to-load-open, a user ran into the following stack trace:

`Caused by: java.lang.IllegalArgumentException: File does not contain valid certificates:`

The filename should have been included at the end of the line, but it wasn't because it was an empty string. Here is an example of what happens when you referenced a file that does not exist:

```
java.lang.IllegalArgumentException: File does not contain valid certificates: /tmp/broker.keystore.jks

	at io.netty.handler.ssl.SslContextBuilder.trustManager(SslContextBuilder.java:261)
	at org.apache.pulsar.broker.authentication.oidc.AuthenticationProviderOpenID.initialize(AuthenticationProviderOpenID.java:172)
	at org.apache.pulsar.broker.authentication.oidc.AuthenticationProviderOpenIDIntegrationTest.testKidCacheMissWhenRefreshConfigZero(AuthenticationProviderOpenIDIntegrationTest.java:347)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:139)
	at org.testng.internal.invokers.TestInvoker.invokeMethod(TestInvoker.java:677)
	at org.testng.internal.invokers.TestInvoker.invokeTestMethod(TestInvoker.java:221)
	at org.testng.internal.invokers.MethodRunner.runInSequence(MethodRunner.java:50)
	at org.testng.internal.invokers.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:969)
	at org.testng.internal.invokers.TestInvoker.invokeTestMethods(TestInvoker.java:194)
	at org.testng.internal.invokers.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:148)
	at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:128)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.testng.TestRunner.privateRun(TestRunner.java:829)
	at org.testng.TestRunner.run(TestRunner.java:602)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:437)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:431)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:391)
	at org.testng.SuiteRunner.run(SuiteRunner.java:330)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:95)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1256)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1176)
	at org.testng.TestNG.runSuites(TestNG.java:1099)
	at org.testng.TestNG.run(TestNG.java:1067)
	at com.intellij.rt.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:66)
	at com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:105)
Caused by: java.security.cert.CertificateException: found no certificates in input stream
	at io.netty.handler.ssl.PemReader.readCertificates(PemReader.java:107)
	at io.netty.handler.ssl.PemReader.readCertificates(PemReader.java:63)
	at io.netty.handler.ssl.SslContext.toX509Certificates(SslContext.java:1219)
	at io.netty.handler.ssl.SslContextBuilder.trustManager(SslContextBuilder.java:259)
	... 29 more
```

I propose we ignore "blank" inputs for the `openIDTokenIssuerTrustCertsFilePath` setting.

### Modifications

* When `openIDTokenIssuerTrustCertsFilePath` is blank, do not attempt to configure a custom trust manager. Instead, use the default trust manager.

### Verifying this change

The risk here is very low since an empty string is invalid. The change in behavior will move from a failure at startup to using the OS's default trust store.

### Documentation

- [x] `doc-not-needed`

Docs are not needed for this change because it makes the configuration harder to break.