### PR TITLE
[fix][test] Fix RangeConvert parse issue in the PerformanceProducer

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -205,7 +205,7 @@ public class PerformanceProducer {
 
         @Parameter(names = { "-dr", "--delay-range"}, description = "Mark messages with a given delay by a random"
                 + " number of seconds. this value between the specified origin (inclusive) and the specified bound"
-                + " (exclusive). e.g. \"1,300\"", converter = RangeConvert.class)
+                + " (exclusive). e.g. 1,300", converter = RangeConvert.class)
         public Range<Long> delayRange = null;
 
         @Parameter(names = { "-set",
@@ -801,7 +801,7 @@ public class PerformanceProducer {
         public Range<Long> convert(String rangeStr) {
             try {
                 requireNonNull(rangeStr);
-                final String[] facts = rangeStr.substring(1, rangeStr.length() - 1).split(",");
+                final String[] facts = rangeStr.split(",");
                 final long min = Long.parseLong(facts[0].trim());
                 final long max = Long.parseLong(facts[1].trim());
                 return Range.closedOpen(min, max);

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
@@ -18,7 +18,14 @@
  */
 package org.apache.pulsar.testclient;
 
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.client.api.ClientBuilder;
@@ -34,13 +41,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.fail;
 
 @Slf4j
 public class PerformanceProducerTest extends MockedPulsarServiceBaseTest {
@@ -236,5 +236,13 @@ public class PerformanceProducerTest extends MockedPulsarServiceBaseTest {
                     assertNotNull(message);
                 });
         consumer.close();
+    }
+
+    @Test
+    public void testRangeConvert() {
+        PerformanceProducer.RangeConvert rangeConvert = new PerformanceProducer.RangeConvert();
+        Range<Long> range = rangeConvert.convert("100,200");
+        Assert.assertEquals(range.lowerEndpoint(), 100);
+        Assert.assertEquals(range.upperEndpoint(), 200);
     }
 }


### PR DESCRIPTION
### Motivation

![image](https://github.com/apache/pulsar/assets/26179648/f76a2b75-2869-4523-83b8-9091243260e7)


### Modifications

Fix the RangeConvert parse issue in the PerformanceProducer

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
