### PR TITLE
Revert "[fix][build] Update Python Wheel to 3.10"

### DIFF
--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -74,8 +74,8 @@
                   <workingDirectory>${project.basedir}/target</workingDirectory>
                   <executable>${project.basedir}/../../pulsar-client-cpp/docker/build-wheels.sh</executable>
                   <arguments>
-                    <!-- build python 3.10 -->
-                    <argument>3.10 cp310-cp310 manylinux2014 x86_64</argument>
+                    <!-- build python 3.8 -->
+                    <argument>3.8 cp38-cp38 manylinux2014 x86_64</argument>
                   </arguments>
                 </configuration>
               </execution>


### PR DESCRIPTION
Reverts apache/pulsar#20728

This setup is too intertwined with the `apachepulsar/pulsar-build` docker image

```
- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
```