### PR TITLE
[Revert][Build] Ubuntu 22.04 was not compatible with Python Client Wheel

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 # prepare the directory for pulsar related files
 RUN mkdir /pulsar

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -49,7 +49,7 @@ RUN chmod g+w /pulsar/lib/presto
 ### Create 2nd stage from Ubuntu image
 ### and add OpenJDK and Python dependencies (for Pulsar functions)
 
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG UBUNTU_MIRROR=mirror://mirrors.ubuntu.com/mirrors.txt

--- a/docker/pulsar/scripts/install-pulsar-client.sh
+++ b/docker/pulsar/scripts/install-pulsar-client.sh
@@ -20,6 +20,8 @@
 
 set -x
 
-PYTHON_MAJOR_MINOR=$(python3 -V | sed -E 's/.* ([[:digit:]]+)\.([[:digit:]]+).*/\1\2/')
+#PYTHON_MAJOR_MINOR=$(python3 -V | sed -E 's/.* ([[:digit:]]+)\.([[:digit:]]+).*/\1\2/')
+# force to python 3.8
+PYTHON_MAJOR_MINOR=38
 WHEEL_FILE=$(ls /pulsar/pulsar-client | grep "cp${PYTHON_MAJOR_MINOR}")
 pip3 install /pulsar/pulsar-client/${WHEEL_FILE}[all]

--- a/docker/pulsar/scripts/install-pulsar-client.sh
+++ b/docker/pulsar/scripts/install-pulsar-client.sh
@@ -23,8 +23,7 @@ set -x
 PYTHON_MAJOR_MINOR=$(python3 -V | sed -E 's/.* ([[:digit:]]+)\.([[:digit:]]+).*/\1\2/')
 echo $PYTHON_MAJOR_MINOR
 ls /pulsar/pulsar-client
-# force to python 3.9
-PYTHON_MAJOR_MINOR=38
+uname -a
 WHEEL_FILE=$(ls /pulsar/pulsar-client | grep "cp${PYTHON_MAJOR_MINOR}")
-echo $WHEEL_FILE
+echo WHEEL_FILE=$WHEEL_FILE
 pip3 install /pulsar/pulsar-client/${WHEEL_FILE}[all]

--- a/docker/pulsar/scripts/install-pulsar-client.sh
+++ b/docker/pulsar/scripts/install-pulsar-client.sh
@@ -21,7 +21,7 @@
 set -x
 
 #PYTHON_MAJOR_MINOR=$(python3 -V | sed -E 's/.* ([[:digit:]]+)\.([[:digit:]]+).*/\1\2/')
-# force to python 3.8
-PYTHON_MAJOR_MINOR=38
+# force to python 3.9
+PYTHON_MAJOR_MINOR=39
 WHEEL_FILE=$(ls /pulsar/pulsar-client | grep "cp${PYTHON_MAJOR_MINOR}")
 pip3 install /pulsar/pulsar-client/${WHEEL_FILE}[all]

--- a/docker/pulsar/scripts/install-pulsar-client.sh
+++ b/docker/pulsar/scripts/install-pulsar-client.sh
@@ -20,8 +20,11 @@
 
 set -x
 
-#PYTHON_MAJOR_MINOR=$(python3 -V | sed -E 's/.* ([[:digit:]]+)\.([[:digit:]]+).*/\1\2/')
+PYTHON_MAJOR_MINOR=$(python3 -V | sed -E 's/.* ([[:digit:]]+)\.([[:digit:]]+).*/\1\2/')
+echo $PYTHON_MAJOR_MINOR
+ls /pulsar/pulsar-client
 # force to python 3.9
-PYTHON_MAJOR_MINOR=39
+PYTHON_MAJOR_MINOR=38
 WHEEL_FILE=$(ls /pulsar/pulsar-client | grep "cp${PYTHON_MAJOR_MINOR}")
+echo $WHEEL_FILE
 pip3 install /pulsar/pulsar-client/${WHEEL_FILE}[all]

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 RUN groupadd -g 10001 pulsar
 RUN adduser -u 10000 --gid 10001 --disabled-login --disabled-password --gecos '' pulsar


### PR DESCRIPTION
Fixes #20725

### Motivation

Building the Docker image of Pulsar 2.11 was broken due to an incompatible wheel file. The wheel made on the manylinuz apachepulsar/pulsar-build image is compatible with Ubuntu 20.04, but is not compatible with Ubuntu 22.04.

### Modifications

Reverting the changes to use Ubuntu 22.04 in Dockerfiles back to Ubuntu 20.04.
Added some print.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

