### PR TITLE
[improve][broker] Unload concurrency limit during graceful shutdown

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -488,6 +488,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private long brokerShutdownTimeoutMs = 60000;
 
     @FieldContext(
+            category = CATEGORY_SERVER,
+            dynamic = true,
+            doc = "The max bundle unload concurrency limit when broker shutdown. Set to 0 means no limit."
+    )
+    private int brokerShutdownMaxBundleUnloadPerMinute = 0;
+
+    @FieldContext(
         category = CATEGORY_SERVER,
         dynamic = true,
         doc = "Flag to skip broker shutdown when broker handles Out of memory error"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -553,7 +553,8 @@ public class BrokersBase extends AdminResource {
 
     private void doShutDownBrokerGracefully(int maxConcurrentUnloadPerSec,
                                             boolean forcedTerminateTopic) {
-        pulsar().getBrokerService().unloadNamespaceBundlesGracefully(maxConcurrentUnloadPerSec, forcedTerminateTopic);
+        pulsar().getBrokerService().unloadNamespaceBundlesGracefully(
+                maxConcurrentUnloadPerSec * 60, forcedTerminateTopic);
         pulsar().closeAsync();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -789,7 +789,8 @@ public class BrokerService implements Closeable {
             log.info("Shutting down Pulsar Broker service");
 
             // unloads all namespaces gracefully without disrupting mutually
-            unloadNamespaceBundlesGracefully();
+            unloadNamespaceBundlesGracefully(
+                    pulsar.getConfiguration().getBrokerShutdownMaxBundleUnloadPerMinute(), true);
 
             // close replication clients
             replicationClients.forEach((cluster, client) -> {
@@ -941,9 +942,11 @@ public class BrokerService implements Closeable {
         unloadNamespaceBundlesGracefully(0, true);
     }
 
-    public void unloadNamespaceBundlesGracefully(int maxConcurrentUnload, boolean closeWithoutWaitingClientDisconnect) {
+    public void unloadNamespaceBundlesGracefully(
+            int maxConcurrentUnloadPreMinute, boolean closeWithoutWaitingClientDisconnect) {
         try {
-            log.info("Unloading namespace-bundles...");
+            log.info(String.format(
+                    "Unloading namespace-bundles, maxConcurrentUnloadPreMinute: %d", maxConcurrentUnloadPreMinute));
             // make broker-node unavailable from the cluster
             if (pulsar.getLoadManager() != null && pulsar.getLoadManager().get() != null) {
                 try {
@@ -959,10 +962,10 @@ public class BrokerService implements Closeable {
             Set<NamespaceBundle> serviceUnits =
                     pulsar.getNamespaceService() != null ? pulsar.getNamespaceService().getOwnedServiceUnits() : null;
             if (serviceUnits != null) {
-                try (RateLimiter rateLimiter = maxConcurrentUnload > 0 ? RateLimiter.builder()
+                try (RateLimiter rateLimiter = maxConcurrentUnloadPreMinute > 0 ? RateLimiter.builder()
                         .scheduledExecutorService(pulsar.getExecutor())
-                        .rateTime(1).timeUnit(TimeUnit.SECONDS)
-                        .permits(maxConcurrentUnload).build() : null) {
+                        .rateTime(1).timeUnit(TimeUnit.MINUTES)
+                        .permits(maxConcurrentUnloadPreMinute).build() : null) {
                     serviceUnits.forEach(su -> {
                         if (su != null) {
                             try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -608,26 +608,19 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
      */
     @Test
     public void testUpdateDynamicConfigurationWithZkWatch() throws Exception {
-        final int initValue = 30000;
-        pulsar.getConfiguration().setBrokerShutdownTimeoutMs(initValue);
+        pulsar.getConfiguration().setBrokerShutdownTimeoutMs(30000);
+        pulsar.getConfiguration().setBrokerShutdownMaxBundleUnloadPerMinute(0);
         // (1) try to update dynamic field
         final long shutdownTime = 10;
+        final int unloadPerMinute = 60;
         // update configuration
         admin.brokers().updateDynamicConfiguration("brokerShutdownTimeoutMs", Long.toString(shutdownTime));
-        // sleep incrementally as zk-watch notification is async and may take some time
-        for (int i = 0; i < 5; i++) {
-            if (pulsar.getConfiguration().getBrokerShutdownTimeoutMs() != initValue) {
-                Thread.sleep(50 + (i * 10));
-            }
-        }
-        // wait config to be updated
-        for (int i = 0; i < 5; i++) {
-            if (pulsar.getConfiguration().getBrokerShutdownTimeoutMs() != shutdownTime) {
-                Thread.sleep(100 + (i * 10));
-            } else {
-                break;
-            }
-        }
+        admin.brokers().updateDynamicConfiguration("brokerShutdownMaxBundleUnloadPerMinute", Integer.toString(unloadPerMinute));
+
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).until(() -> {
+            return pulsar.getConfiguration().getBrokerShutdownTimeoutMs() == shutdownTime
+                    && pulsar.getConfiguration().getBrokerShutdownMaxBundleUnloadPerMinute() == unloadPerMinute;
+        });
         // verify value is updated
         assertEquals(pulsar.getConfiguration().getBrokerShutdownTimeoutMs(), shutdownTime);
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #20753

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

1. Add a **dynamic** config named `brokerShutdownMaxBundleUnloadPerMinute`  to the Pulsar broker to control the concurrency of unloading.

2. Modify [this code](https://github.com/apache/pulsar/blob/7636e8989f4d3fc24fce69a356d54e1c550945ed/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java#L557) to use [this function](https://github.com/apache/pulsar/blob/7636e8989f4d3fc24fce69a356d54e1c550945ed/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java#L790-L791) with the concurrency parameter for unloading.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [x] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/apache/pulsar/pull/20765

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
