### PR TITLE
[fix][test] Close the resource after the test

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
@@ -163,6 +163,8 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
         for (int i = 1; i < admins.size(); i++) {
             assertEquals(result.get(i - 1), result.get(i));
         }
+        admins.forEach(a -> a.close());
+        executor.shutdown();
     }
 
     @Test(timeOut = 30 * 1000)


### PR DESCRIPTION
### Motivation

```
2023-07-10T09:35:33,940 - INFO  - [main:ThreadLeakDetectorListener@40] - Capturing identifiers of running threads.
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 406 with name 'Thread[jersey-client-async-executor-7,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 407 with name 'Thread[jersey-client-async-executor-5,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 408 with name 'Thread[jersey-client-async-executor-6,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 409 with name 'Thread[jersey-client-async-executor-7,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 410 with name 'Thread[jersey-client-async-executor-5,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 411 with name 'Thread[jersey-client-async-executor-6,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 412 with name 'Thread[jersey-client-async-executor-7,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 413 with name 'Thread[jersey-client-async-executor-5,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 415 with name 'Thread[delayer-122-1,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 414 with name 'Thread[jersey-client-async-executor-3,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 416 with name 'Thread[jersey-client-async-executor-1,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 417 with name 'Thread[jersey-client-async-executor-3,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 418 with name 'Thread[jersey-client-async-executor-6,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 419 with name 'Thread[jersey-client-async-executor-1,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 420 with name 'Thread[AsyncHttpClient-143-2,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 421 with name 'Thread[jersey-client-async-executor-2,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 422 with name 'Thread[jersey-client-async-executor-4,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 423 with name 'Thread[jersey-client-async-executor-3,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 424 with name 'Thread[jersey-client-async-executor-7,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 425 with name 'Thread[jersey-client-async-executor-2,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 426 with name 'Thread[jersey-client-async-executor-3,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 427 with name 'Thread[AsyncHttpClient-155-2,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 428 with name 'Thread[jersey-client-async-executor-4,5,main]'
  2023-07-10T09:35:33,957 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 429 with name 'Thread[jersey-client-async-executor-5,5,main]'
  2023-07-10T09:35:33,958 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 430 with name 'Thread[jersey-client-async-executor-1,5,main]'
  2023-07-10T09:35:33,958 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 431 with name 'Thread[jersey-client-async-executor-6,5,main]'
  2023-07-10T09:35:33,958 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 432 with name 'Thread[jersey-client-async-executor-7,5,main]'
  2023-07-10T09:35:33,958 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 433 with name 'Thread[jersey-client-async-executor-4,5,main]'
  2023-07-10T09:35:33,958 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 434 with name 'Thread[jersey-client-async-executor-5,5,main]'
  2023-07-10T09:35:33,961 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 435 with name 'Thread[jersey-client-async-executor-6,5,main]'
  2023-07-10T09:35:33,961 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 436 with name 'Thread[jersey-client-async-executor-7,5,main]'
  2023-07-10T09:35:33,961 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 437 with name 'Thread[jersey-client-async-executor-5,5,main]'
  2023-07-10T09:35:33,961 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 438 with name 'Thread[jersey-client-async-executor-4,5,main]'
  2023-07-10T09:35:33,961 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 439 with name 'Thread[jersey-client-async-executor-2,5,main]'
  2023-07-10T09:35:33,961 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 440 with name 'Thread[AsyncHttpClient-154-2,5,main]'
  2023-07-10T09:35:33,961 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 441 with name 'Thread[jersey-client-async-executor-6,5,main]'
  2023-07-10T09:35:33,961 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 442 with name 'Thread[jersey-client-async-executor-7,5,main]'
  2023-07-10T09:35:33,961 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 443 with name 'Thread[jersey-client-async-executor-3,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 444 with name 'Thread[AsyncHttpClient-151-2,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 445 with name 'Thread[jersey-client-async-executor-5,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 446 with name 'Thread[jersey-client-async-executor-4,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 447 with name 'Thread[jersey-client-async-executor-5,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 448 with name 'Thread[jersey-client-async-executor-6,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 449 with name 'Thread[jersey-client-async-executor-6,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 450 with name 'Thread[jersey-client-async-executor-7,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 451 with name 'Thread[jersey-client-async-executor-7,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 452 with name 'Thread[jersey-client-async-executor-1,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 453 with name 'Thread[jersey-client-async-executor-2,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 454 with name 'Thread[jersey-client-async-executor-3,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 455 with name 'Thread[AsyncHttpClient-134-2,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 456 with name 'Thread[jersey-client-async-executor-4,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 457 with name 'Thread[jersey-client-async-executor-1,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 458 with name 'Thread[jersey-client-async-executor-5,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 459 with name 'Thread[jersey-client-async-executor-2,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 460 with name 'Thread[jersey-client-async-executor-3,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 461 with name 'Thread[AsyncHttpClient-152-2,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 462 with name 'Thread[jersey-client-async-executor-4,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 463 with name 'Thread[jersey-client-async-executor-5,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 464 with name 'Thread[jersey-client-async-executor-6,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 465 with name 'Thread[jersey-client-async-executor-6,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 466 with name 'Thread[jersey-client-async-executor-7,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 467 with name 'Thread[jersey-client-async-executor-7,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 468 with name 'Thread[jersey-client-async-executor-1,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 469 with name 'Thread[jersey-client-async-executor-2,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 470 with name 'Thread[jersey-client-async-executor-3,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 471 with name 'Thread[AsyncHttpClient-187-2,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 472 with name 'Thread[jersey-client-async-executor-4,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 473 with name 'Thread[jersey-client-async-executor-5,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 474 with name 'Thread[jersey-client-async-executor-6,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 475 with name 'Thread[jersey-client-async-executor-7,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 476 with name 'Thread[jersey-client-async-executor-1,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 477 with name 'Thread[jersey-client-async-executor-2,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 478 with name 'Thread[jersey-client-async-executor-3,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 479 with name 'Thread[jersey-client-async-executor-4,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 480 with name 'Thread[AsyncHttpClient-182-2,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 481 with name 'Thread[jersey-client-async-executor-5,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 482 with name 'Thread[jersey-client-async-executor-6,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 483 with name 'Thread[jersey-client-async-executor-7,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 560 with name 'Thread[ForkJoinPool.commonPool-worker-5,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 577 with name 'Thread[AsyncHttpClient-190-1,5,main]'
  2023-07-10T09:35:33,962 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 578 with name 'Thread[AsyncHttpClient-190-2,5,main]'
  2023-07-10T09:35:33,963 - WARN  - [main:ThreadLeakDetectorListener@55] - Tests in class ExtensibleLoadManagerTest created thread id 27 with name 'Thread[testcontainers-ryuk,5,testcontainers]'
  2023-07-10T09:35:33,963 - WARN  - [main:ThreadLeakDetectorListener@60] - Summary: Tests in class org.apache.pulsar.tests.integration.loadbalance.ExtensibleLoadManagerTest created 425 new threads
```

Close the resource after the test.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

