### PR TITLE
[fix][broker] Broker failed to load v1 namespace resources cache

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -62,7 +62,7 @@ public class NamespaceResources extends BaseResources<Policies> {
     }
 
     public CompletableFuture<List<String>> listNamespacesAsync(String tenant) {
-        return getChildrenAsync(joinPath(BASE_POLICIES_PATH, tenant));
+        return getChildrenRecursiveAsync(joinPath(BASE_POLICIES_PATH, tenant));
     }
 
     public CompletableFuture<Boolean> getPoliciesReadOnlyAsync() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -1699,5 +1700,18 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
 
         // verify we only call getReplicatedSubscriptionStatusAsync once.
         verify(topics, times(1)).getReplicatedSubscriptionStatusAsync(any(), any());
+    }
+
+    @Test
+    public void testNamespaceResources() throws Exception {
+        String ns1V1 = "test/" + testNamespace + "v1";
+        String ns1V2 = testNamespace + "v2";
+        admin.namespaces().createNamespace(testTenant+"/"+ns1V1);
+        admin.namespaces().createNamespace(testTenant+"/"+ns1V2);
+
+        List<String> namespaces = pulsar.getPulsarResources().getNamespaceResources().listNamespacesAsync(testTenant)
+                .get();
+        assertTrue(namespaces.contains(ns1V2));
+        assertTrue(namespaces.contains(ns1V1));
     }
 }


### PR DESCRIPTION
### Motivation

Right now, Pulsar service loads namespace policies cache on startup or namespace policy update. However, it doesn't consider v1 namespaces, don't load v1 namespace policy cache and also try to deserialize incorrect znode of v1 namespace policy path which causes below exception during server startup if you have v1 namespace: `/admin/policies/prop/us-east1/nsv1`
```
00:57:11.633 [ForkJoinPool.commonPool-worker-23] ERROR org.apache.pulsar.broker.resourcegroup.ResourceGroupNamespaceConfigListener - Exception when getting namespace weather/global
java.util.concurrent.CompletionException: org.apache.pulsar.metadata.api.MetadataStoreException$ContentDeserializationException: Failed to deserialize payload for key '/admin/policies/prop/us-east1'
        at java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367) ~[?:?]
        at java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376) ~[?:?]
        at java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:1074) ~[?:?]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
        at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073) ~[?:?]
        at org.apache.pulsar.metadata.impl.ZKMetadataStore.handleGetResult(ZKMetadataStore.java:244) ~[pulsar-metadata.jar]
        at org.apache.pulsar.metadata.impl.ZKMetadataStore.lambda$batchOperation$7(ZKMetadataStore.java:188) ~[pulsar-metadata.jar]
        at org.apache.pulsar.metadata.impl.PulsarZooKeeperClient$3$1.processResult(PulsarZooKeeperClient.java:490) ~[pulsar-metadata.jar]
        at org.apache.zookeeper.ClientCnxn$EventThread.processEvent(ClientCnxn.java:721) ~[zookeeper-3.6.2.jar:3.6.2]
        at org.apache.zookeeper.ClientCnxn$EventThread.run(ClientCnxn.java:562) ~[zookeeper-3.6.2.jar:3.6.2]

```

Therefore, broker should traverse v1 namespace policies correctly to load v1 namespace policy cache and avoid deserialization failure for v1 namespace policy path.

### Modifications

- introduce metadata-store recursive traversal till leaf nodes
- namespace resources traverse and retrieve v1 namespace policy nodes and caches v1 namespace policy 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
