### PR TITLE
[fix][fn] Pulsar Function Kubernetes Runtime fails to start function that contains parenthesis in original jar filename

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -37,6 +37,7 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.URL;
+import java.text.Normalizer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -558,5 +559,16 @@ public class RuntimeUtils {
         new ThreadExports().register(registry);
         new ClassLoadingExports().register(registry);
         new VersionInfoExports().register(registry);
+    }
+
+    public static String sanitizeFileName(String fileName) {
+        if (fileName == null) {
+            return null;
+        }
+        // converts a unicode string to plain ascii
+        String asciiFileName = Normalizer.normalize(fileName, Normalizer.Form.NFD)
+                .replaceAll("[^\\p{ASCII}]", "");
+        // replaces all non-alphanumeric characters (excluding -_.) with _
+        return asciiFileName.replaceAll("[^a-zA-Z0-9-_.]", "_");
     }
 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -205,9 +205,9 @@ public class KubernetesRuntime implements Runtime {
         this.userCodePkgUrl = userCodePkgUrl;
         this.downloadDirectory =
                 isNotEmpty(downloadDirectory) ? downloadDirectory : this.pulsarRootDir; // for backward comp
-        this.originalCodeFileName = this.downloadDirectory + "/" + originalCodeFileName;
+        this.originalCodeFileName = this.downloadDirectory + "/" + RuntimeUtils.sanitizeFileName(originalCodeFileName);
         this.originalTransformFunctionFileName = isNotEmpty(originalTransformFunctionFileName)
-                ? this.downloadDirectory + "/" + originalTransformFunctionFileName
+                ? this.downloadDirectory + "/" + RuntimeUtils.sanitizeFileName(originalTransformFunctionFileName)
                 : originalTransformFunctionFileName;
         this.pulsarAdminUrl = pulsarAdminUrl;
         this.secretsProviderConfigurator = secretsProviderConfigurator;

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
@@ -18,8 +18,14 @@
  */
 package org.apache.pulsar.functions.runtime;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.functions.instance.AuthenticationConfig;
 import org.apache.pulsar.functions.instance.InstanceConfig;
@@ -28,13 +34,6 @@ import org.jose4j.json.internal.json_simple.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-
-import static org.testng.AssertJUnit.assertTrue;
 
 @Slf4j
 public class RuntimeUtilsTest {
@@ -234,5 +233,13 @@ public class RuntimeUtilsTest {
         assertTrue(indexJavaClass > 0);
         assertTrue(indexAdditionalArguments > 0);
         assertTrue(indexAdditionalArguments < indexJavaClass);
+    }
+
+    @Test
+    public void testSanitizeFileName() {
+        assertEquals(RuntimeUtils.sanitizeFileName("file(1).jar"), "file_1_.jar");
+        assertEquals(RuntimeUtils.sanitizeFileName("äöå.txt"), "aoa.txt");
+        assertEquals(RuntimeUtils.sanitizeFileName("ÄÖÅ.txt"), "AOA.txt");
+        assertNull(RuntimeUtils.sanitizeFileName(null));
     }
 }


### PR DESCRIPTION
Fixes #20789

### Motivation

See #20789

### Modifications

Sanitize the original code filename and tranformer file name in Kubernetes Runtime.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
