### PR TITLE
[improve][io] Add notifyError method on PushSource.

### DIFF
--- a/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/AbstractPushSource.java
+++ b/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/AbstractPushSource.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.core;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import org.apache.pulsar.functions.api.Record;
+
+/**
+ * Pulsar's Push Source Abstract.
+ */
+public abstract class AbstractPushSource<T> {
+
+    private static class NullRecord implements Record {
+        @Override
+        public Object getValue() {
+            return null;
+        }
+    }
+
+    private static class ErrorNotifierRecord implements Record {
+        private final Exception e;
+        public ErrorNotifierRecord(Exception e) {
+            this.e = e;
+        }
+        @Override
+        public Object getValue() {
+            return null;
+        }
+
+        public Exception getException() {
+            return e;
+        }
+    }
+
+    private LinkedBlockingQueue<Record<T>> queue;
+    private static final int DEFAULT_QUEUE_LENGTH = 1000;
+    private final NullRecord nullRecord = new NullRecord();
+
+    public AbstractPushSource() {
+        this.queue = new LinkedBlockingQueue<>(this.getQueueLength());
+    }
+
+    protected Record<T> readNext() throws Exception {
+        Record<T> record = queue.take();
+        if (record instanceof ErrorNotifierRecord) {
+            throw ((ErrorNotifierRecord) record).getException();
+        }
+        if (record instanceof NullRecord) {
+            return null;
+        } else {
+            return record;
+        }
+    }
+
+    /**
+     * Send this message to be written to Pulsar.
+     * Pass null if you you are done with this task
+     * @param record next message from source which should be sent to a Pulsar topic
+     */
+    public void consume(Record<T> record) {
+        try {
+            if (record != null) {
+                queue.put(record);
+            } else {
+                queue.put(nullRecord);
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Get length of the queue that records are push onto.
+     * Users can override this method to customize the queue length
+     * @return queue length
+     */
+    public int getQueueLength() {
+        return DEFAULT_QUEUE_LENGTH;
+    }
+
+    /**
+     * Allows the source to notify errors asynchronously.
+     * @param ex
+     */
+    public void notifyError(Exception ex) {
+        consume(new ErrorNotifierRecord(ex));
+    }
+}

--- a/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/PushSource.java
+++ b/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/PushSource.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pulsar.io.core;
 
-import java.util.Map;
-import java.util.concurrent.LinkedBlockingQueue;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
 import org.apache.pulsar.functions.api.Record;
@@ -38,49 +36,10 @@ import org.apache.pulsar.functions.api.Record;
  */
 @InterfaceAudience.Public
 @InterfaceStability.Stable
-public abstract class PushSource<T> implements Source<T> {
-
-    private LinkedBlockingQueue<Record<T>> queue;
-    private static final int DEFAULT_QUEUE_LENGTH = 1000;
-
-    public PushSource() {
-        this.queue = new LinkedBlockingQueue<>(this.getQueueLength());
-    }
+public abstract class PushSource<T> extends AbstractPushSource<T> implements Source<T> {
 
     @Override
     public Record<T> read() throws Exception {
-        return queue.take();
-    }
-
-    /**
-     * Open connector with configuration.
-     *
-     * @param config initialization config
-     * @param sourceContext environment where the source connector is running
-     * @throws Exception IO type exceptions when opening a connector
-     */
-    public abstract void open(Map<String, Object> config, SourceContext sourceContext) throws Exception;
-
-    /**
-     * Attach a consumer function to this Source. This is invoked by the implementation
-     * to pass messages whenever there is data to be pushed to Pulsar.
-     *
-     * @param record next message from source which should be sent to a Pulsar topic
-     */
-    public void consume(Record<T> record) {
-        try {
-            queue.put(record);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
-     * Get length of the queue that records are push onto.
-     * Users can override this method to customize the queue length
-     * @return queue length
-     */
-    public int getQueueLength() {
-        return DEFAULT_QUEUE_LENGTH;
+        return super.readNext();
     }
 }

--- a/pulsar-io/core/src/test/java/org/apache/pulsar/io/core/PushSourceTest.java
+++ b/pulsar-io/core/src/test/java/org/apache/pulsar/io/core/PushSourceTest.java
@@ -18,22 +18,26 @@
  */
 package org.apache.pulsar.io.core;
 
-import org.apache.pulsar.common.classification.InterfaceAudience;
-import org.apache.pulsar.common.classification.InterfaceStability;
-import org.apache.pulsar.functions.api.Record;
+import java.util.Map;
+import org.testng.annotations.Test;
 
-/**
- * Pulsar's Batch Push Source interface. Batch Push Sources have the same lifecycle
- * as the regular BatchSource, aka discover, prepare. The reason its called Push is
- * because BatchPushSource can emit a record using the consume method that they
- * invoke whenever they have data to be published to Pulsar.
- */
-@InterfaceAudience.Public
-@InterfaceStability.Evolving
-public abstract class BatchPushSource<T> extends AbstractPushSource<T> implements BatchSource<T> {
+public class PushSourceTest {
+
+  PushSource testBatchSource = new PushSource() {
+    @Override
+    public void open(Map config, SourceContext context) throws Exception {
+
+    }
 
     @Override
-    public Record<T> readNext() throws Exception {
-        return super.readNext();
+    public void close() throws Exception {
+
     }
+  };
+
+  @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "test exception")
+  public void testNotifyErrors() throws Exception {
+    testBatchSource.notifyError(new RuntimeException("test exception"));
+    testBatchSource.readNext();
+  }
 }


### PR DESCRIPTION
### Motivation

If one source connector extends `PushSource`. An exception was encountered when this source connector consumed the source system data, it had no way to notify the function framework to restart this connector.


### Modifications

- Abstract `BatchPushSource` logic to `AbstractPushSource`.
- Let `PushSource` to extends `AbstractPushSource` to extend a new method(**notifyError**).

### Verifying this change

- Add `PushSourceTest` to cover it.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository


