### PR TITLE
[fix][build] Mongo is fixed for 2.10.5

### DIFF
--- a/pulsar-io/mongo/pom.xml
+++ b/pulsar-io/mongo/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
       <artifactId>pulsar-io</artifactId>
-      <version>2.10.5-SNAPSHOT</version>
+      <version>2.10.5</version>
   </parent>
 
   <artifactId>pulsar-io-mongo</artifactId>


### PR DESCRIPTION
### Motivation

After updating the branch to 2.10.5 to prepare for release cycle the build fails.

### Modifications

Update the missed change to `pulsar-io/mongo/pom.xml`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->