### PR TITLE
[improve] [broker] Verify at least one URL is present for cluster creation

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -2099,26 +2099,26 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
     @Test
     public void testUpdateClusterServiceUrl() throws Exception {
         String clusterName = "test_cluster";
-        clusterDataImpl initialCluster = new clusterDataImpl();
+        ClusterDataImpl initialCluster = new ClusterDataImpl();
         initialCluster.setServiceUrl("http://example.com");
         admin.clusters().createCluster(clusterName, initialCluster);
-        clusterDataImpl updatedCluster = new clusterDataImpl();
+        ClusterDataImpl updatedCluster = new ClusterDataImpl();
         updatedCluster.setServiceUrl("http://new-example.com");
         admin.clusters().updateCluster(clusterName, updatedCluster);
-        clusterDataImpl retrievedCluster = (ClusterDataImpl) admin.clusters().getCluster(ClusterName);
+        ClusterDataImpl retrievedCluster = (ClusterDataImpl) admin.clusters().getCluster(clusterName);
         Assert.assertEquals(retrievedCluster.getServiceUrl(), updatedCluster.getServiceUrl());
     }
 
     @Test
     public void testUpdateClusterBrokerServiceUrl() throws Exception {
         String clusterName = "test_cluster";
-        clusterDataImpl initialCluster = new clusterDataImpl();
+        ClusterDataImpl initialCluster = new ClusterDataImpl();
         initialCluster.setBrokerServiceUrl("pulsar://broker.example.com:6650");
         admin.clusters().createCluster(clusterName, initialCluster);
-        clusterDataImpl updatedCluster = new clusterDataImpl();
+        ClusterDataImpl updatedCluster = new ClusterDataImpl();
         updatedCluster.setBrokerServiceUrl("pulsar://new-broker.example.com:6650");
         admin.clusters().updateCluster(clusterName, updatedCluster);
-        clusterDataImpl retrievedCluster = (ClusterDataImpl) admin.clusters().getCluster(ClusterName);
+        ClusterDataImpl retrievedCluster = (ClusterDataImpl) admin.clusters().getCluster(clusterName);
         Assert.assertEquals(retrievedCluster.getBrokerServiceUrl(), updatedCluster.getBrokerServiceUrl());
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -2096,6 +2096,32 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
     }
 
     @Test
+    public void testUpdateClusterServiceUrl() throws Exception {
+        String clusterName = "test_cluster";
+        clusterDataImpl initialCluster = new clusterDataImpl();
+        initialCluster.setServiceUrl("http://example.com");
+        admin.clusters().createCluster(clusterName, initialCluster);
+        clusterDataImpl updatedCluster = new clusterDataImpl();
+        updatedCluster.setServiceUrl("http://new-example.com");
+        admin.clusters().updateCluster(clusterName, updatedCluster);
+        clusterDataImpl retrievedCluster = (ClusterDataImpl) admin.clusters().getCluster(ClusterName);
+        Assert.assertEquals(retrievedCluster.getServiceUrl(), updatedCluster.getServiceUrl());
+    }
+
+    @Test
+    public void testUpdateClusterBrokerServiceUrl() throws Exception {
+        String clusterName = "test_cluster";
+        clusterDataImpl initialCluster = new clusterDataImpl();
+        initialCluster.setBrokerServiceUrl("pulsar://broker.example.com:6650");
+        admin.clusters().createCluster(clusterName, initialCluster);
+        clusterDataImpl updatedCluster = new clusterDataImpl();
+        updatedCluster.setBrokerServiceUrl("pulsar://new-broker.example.com:6650");
+        admin.clusters().updateCluster(clusterName, updatedCluster);
+        clusterDataImpl retrievedCluster = (ClusterDataImpl) admin.clusters().getCluster(ClusterName);
+        Assert.assertEquals(retrievedCluster.getBrokerServiceUrl(), updatedCluster.getBrokerServiceUrl());
+    }
+
+    @Test
     public void testMaxNamespacesPerTenant() throws Exception {
         restartClusterAfterTest();
         cleanup();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -110,6 +110,7 @@ import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationData;
 import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationDataImpl;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.ClusterDataImpl;
 import org.apache.pulsar.common.policies.data.ConsumerStats;
 import org.apache.pulsar.common.policies.data.EntryFilters;
 import org.apache.pulsar.common.policies.data.FailureDomain;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
@@ -413,31 +413,29 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
      * @throws IllegalArgumentException exist illegal property.
      */
          public void checkPropertiesIfPresent() throws IllegalArgumentException {
+             if (StringUtils.isEmpty(getServiceUrl()) && StringUtils.isEmpty(getServiceUrlTls())) {
+                 throw new IllegalArgumentException("At least one of ServiceUrl or ServiceUrlTls must be set.");
+             }  
+             if (StringUtils.isEmpty(getBrokerServiceUrl()) && StringUtils.isEmpty(getBrokerServiceUrlTls())) {
+                throw new IllegalArgumentException("At least one of BrokerServiceUrl or BrokerServiceUrlTls must be set.");
+             }
                  
-                 if (StringUtils.isEmpty(getServiceUrl()) && StringUtils.isEmpty(getServiceUrlTls())) {
-                         throw new IllegalArgumentException("At least one of ServiceUrl or ServiceUrlTls must be set.");
-                 }
-                 
-                 if (StringUtils.isEmpty(getBrokerServiceUrl()) && StringUtils.isEmpty(getBrokerServiceUrlTls())) {
-                         throw new IllegalArgumentException("At least one of BrokerServiceUrl or BrokerServiceUrlTls must be set.");
-                 }
-                 
-                 URIPreconditions.checkURIIfPresent(getServiceUrl(),
-                        uri -> Objects.equals(uri.getScheme(), "http"),
-                        "Illegal service url, example: http://pulsar.example.com:8080");
-                URIPreconditions.checkURIIfPresent(getServiceUrlTls(),
-                        uri -> Objects.equals(uri.getScheme(), "https"),
-                        "Illegal service tls url, example: https://pulsar.example.com:8443");
-                URIPreconditions.checkURIIfPresent(getBrokerServiceUrl(),
-                        uri -> Objects.equals(uri.getScheme(), "pulsar"),
-                        "Illegal broker service url, example: pulsar://pulsar.example.com:6650");
-                URIPreconditions.checkURIIfPresent(getBrokerServiceUrlTls(),
-                        uri -> Objects.equals(uri.getScheme(), "pulsar+ssl"),
-                        "Illegal broker service tls url, example: pulsar+ssl://pulsar.example.com:6651");
-                URIPreconditions.checkURIIfPresent(getProxyServiceUrl(),
-                        uri -> Objects.equals(uri.getScheme(), "pulsar")
-                                || Objects.equals(uri.getScheme(), "pulsar+ssl"),
-                        "Illegal proxy service url, example: pulsar+ssl://ats-proxy.example.com:4443 "
-                                + "or pulsar://ats-proxy.example.com:4080");
+             URIPreconditions.checkURIIfPresent(getServiceUrl(),
+                    uri -> Objects.equals(uri.getScheme(), "http"),
+                    "Illegal service url, example: http://pulsar.example.com:8080");
+             URIPreconditions.checkURIIfPresent(getServiceUrlTls(),
+                    uri -> Objects.equals(uri.getScheme(), "https"),
+                    "Illegal service tls url, example: https://pulsar.example.com:8443");
+             URIPreconditions.checkURIIfPresent(getBrokerServiceUrl(),
+                    uri -> Objects.equals(uri.getScheme(), "pulsar"),
+                    "Illegal broker service url, example: pulsar://pulsar.example.com:6650");
+             URIPreconditions.checkURIIfPresent(getBrokerServiceUrlTls(),
+                    uri -> Objects.equals(uri.getScheme(), "pulsar+ssl"),
+                    "Illegal broker service tls url, example: pulsar+ssl://pulsar.example.com:6651");
+             URIPreconditions.checkURIIfPresent(getProxyServiceUrl(),
+                    uri -> Objects.equals(uri.getScheme(), "pulsar")
+                            || Objects.equals(uri.getScheme(), "pulsar+ssl"),
+                    "Illegal proxy service url, example: pulsar+ssl://ats-proxy.example.com:4443 "
+                            + "or pulsar://ats-proxy.example.com:4080");
          }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
@@ -415,11 +415,12 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
          public void checkPropertiesIfPresent() throws IllegalArgumentException {
              if (StringUtils.isEmpty(getServiceUrl()) && StringUtils.isEmpty(getServiceUrlTls())) {
                  throw new IllegalArgumentException("At least one of ServiceUrl or ServiceUrlTls must be set.");
-             }  
-             if (StringUtils.isEmpty(getBrokerServiceUrl()) && StringUtils.isEmpty(getBrokerServiceUrlTls())) {
-                throw new IllegalArgumentException("At least one of BrokerServiceUrl or BrokerServiceUrlTls must be set.");
              }
-                 
+             if (StringUtils.isEmpty(getBrokerServiceUrl()) && StringUtils.isEmpty(getBrokerServiceUrlTls())) {
+                throw new IllegalArgumentException("At least one of BrokerServiceUrl or BrokerServiceUrlTls"
+                        + " must be set.");
+             }
+
              URIPreconditions.checkURIIfPresent(getServiceUrl(),
                     uri -> Objects.equals(uri.getScheme(), "http"),
                     "Illegal service url, example: http://pulsar.example.com:8080");

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
@@ -412,32 +412,32 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
      *
      * @throws IllegalArgumentException exist illegal property.
      */
-       public void checkPropertiesIfPresent() throws IllegalArgumentException {
-
-        if (StringUtils.isEmpty(getServiceUrl()) && StringUtils.isEmpty(getServiceUrlTls())) {
-            throw new IllegalArgumentException("At least one of ServiceUrl or ServiceUrlTls must be set.");
-        }
-
-        if (StringUtils.isEmpty(getBrokerServiceUrl()) && StringUtils.isEmpty(getBrokerServiceUrlTls())) {
-            throw new IllegalArgumentException("At least one of BrokerServiceUrl or BrokerServiceUrlTls must be set.");
-        }
-             
-        URIPreconditions.checkURIIfPresent(getServiceUrl(),
-                uri -> Objects.equals(uri.getScheme(), "http"),
-                "Illegal service url, example: http://pulsar.example.com:8080");
-        URIPreconditions.checkURIIfPresent(getServiceUrlTls(),
-                uri -> Objects.equals(uri.getScheme(), "https"),
-                "Illegal service tls url, example: https://pulsar.example.com:8443");
-        URIPreconditions.checkURIIfPresent(getBrokerServiceUrl(),
-                uri -> Objects.equals(uri.getScheme(), "pulsar"),
-                "Illegal broker service url, example: pulsar://pulsar.example.com:6650");
-        URIPreconditions.checkURIIfPresent(getBrokerServiceUrlTls(),
-                uri -> Objects.equals(uri.getScheme(), "pulsar+ssl"),
-                "Illegal broker service tls url, example: pulsar+ssl://pulsar.example.com:6651");
-        URIPreconditions.checkURIIfPresent(getProxyServiceUrl(),
-                uri -> Objects.equals(uri.getScheme(), "pulsar")
-                        || Objects.equals(uri.getScheme(), "pulsar+ssl"),
-                "Illegal proxy service url, example: pulsar+ssl://ats-proxy.example.com:4443 "
-                        + "or pulsar://ats-proxy.example.com:4080");
-    }
+         public void checkPropertiesIfPresent() throws IllegalArgumentException {
+                 
+                 if (StringUtils.isEmpty(getServiceUrl()) && StringUtils.isEmpty(getServiceUrlTls())) {
+                         throw new IllegalArgumentException("At least one of ServiceUrl or ServiceUrlTls must be set.");
+                 }
+                 
+                 if (StringUtils.isEmpty(getBrokerServiceUrl()) && StringUtils.isEmpty(getBrokerServiceUrlTls())) {
+                         throw new IllegalArgumentException("At least one of BrokerServiceUrl or BrokerServiceUrlTls must be set.");
+                 }
+                 
+                 URIPreconditions.checkURIIfPresent(getServiceUrl(),
+                        uri -> Objects.equals(uri.getScheme(), "http"),
+                        "Illegal service url, example: http://pulsar.example.com:8080");
+                URIPreconditions.checkURIIfPresent(getServiceUrlTls(),
+                        uri -> Objects.equals(uri.getScheme(), "https"),
+                        "Illegal service tls url, example: https://pulsar.example.com:8443");
+                URIPreconditions.checkURIIfPresent(getBrokerServiceUrl(),
+                        uri -> Objects.equals(uri.getScheme(), "pulsar"),
+                        "Illegal broker service url, example: pulsar://pulsar.example.com:6650");
+                URIPreconditions.checkURIIfPresent(getBrokerServiceUrlTls(),
+                        uri -> Objects.equals(uri.getScheme(), "pulsar+ssl"),
+                        "Illegal broker service tls url, example: pulsar+ssl://pulsar.example.com:6651");
+                URIPreconditions.checkURIIfPresent(getProxyServiceUrl(),
+                        uri -> Objects.equals(uri.getScheme(), "pulsar")
+                                || Objects.equals(uri.getScheme(), "pulsar+ssl"),
+                        "Illegal proxy service url, example: pulsar+ssl://ats-proxy.example.com:4443 "
+                                + "or pulsar://ats-proxy.example.com:4080");
+         }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
@@ -413,16 +413,12 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
      * @throws IllegalArgumentException exist illegal property.
      */
      public void checkPropertiesIfPresent() throws IllegalArgumentException {
-        boolean hasServiceUrl = getServiceUrl() != null;
-        boolean hasServiceUrlTls = getServiceUrlTls() != null;
-        boolean hasBrokerServiceUrl = getBrokerServiceUrl() != null;
-        boolean hasBrokerServiceUrlTls = getBrokerServiceUrlTls() != null;
 
-        if (!hasServiceUrl && !hasServiceUrlTls) {
+        if (StringUtils.isEmpty(getServiceUrl()) && StringUtils.isEmpty(getServiceUrlTls())) {
                 throw new IllegalArgumentException("At least one of ServiceUrl or ServiceUrlTls must be set.");
         }
 
-        if (!hasBrokerServiceUrl && !hasBrokerServiceUrlTls) {
+        if (StringUtils.isEmpty(getBrokerServiceUrl()) && StringUtils.isEmpty(getBrokerServiceUrlTls())) {
                 throw new IllegalArgumentException("At least one of BrokerServiceUrl or BrokerServiceUrlTls must be set.");
         }
              

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
@@ -419,11 +419,11 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
         boolean hasBrokerServiceUrlTls = getBrokerServiceUrlTls() != null;
 
         if (!hasServiceUrl && !hasServiceUrlTls) {
-                throw new IllegalArgumentException("Atleast one of ServiceUrl or ServiceUrlTls must be set.");
+                throw new IllegalArgumentException("At least one of ServiceUrl or ServiceUrlTls must be set.");
         }
 
         if (!hasBrokerServiceUrl && !hasBrokerServiceUrlTls) {
-                throw new IllegalArgumentException("Atleast one of BrokerServiceUrl or BrokerServiceUrlTls must be set.");
+                throw new IllegalArgumentException("At least one of BrokerServiceUrl or BrokerServiceUrlTls must be set.");
         }
              
         URIPreconditions.checkURIIfPresent(getServiceUrl(),

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
@@ -412,7 +412,20 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
      *
      * @throws IllegalArgumentException exist illegal property.
      */
-    public void checkPropertiesIfPresent() throws IllegalArgumentException {
+     public void checkPropertiesIfPresent() throws IllegalArgumentException {
+        boolean hasServiceUrl = getServiceUrl() != null;
+        boolean hasServiceUrlTls = getServiceUrlTls() != null;
+        boolean hasBrokerServiceUrl = getBrokerServiceUrl() != null;
+        boolean hasBrokerServiceUrlTls = getBrokerServiceUrlTls() != null;
+
+        if (!hasServiceUrl && !hasServiceUrlTls) {
+                throw new IllegalArgumentException("Atleast one of ServiceUrl or ServiceUrlTls must be set.");
+        }
+
+        if (!hasBrokerServiceUrl && !hasBrokerServiceUrlTls) {
+                throw new IllegalArgumentException("Atleast one of BrokerServiceUrl or BrokerServiceUrlTls must be set.");
+        }
+             
         URIPreconditions.checkURIIfPresent(getServiceUrl(),
                 uri -> Objects.equals(uri.getScheme(), "http"),
                 "Illegal service url, example: http://pulsar.example.com:8080");
@@ -430,20 +443,5 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
                         || Objects.equals(uri.getScheme(), "pulsar+ssl"),
                 "Illegal proxy service url, example: pulsar+ssl://ats-proxy.example.com:4443 "
                         + "or pulsar://ats-proxy.example.com:4080");
-
-        warnIfUrlIsNotPresent();
-    }
-
-    private void warnIfUrlIsNotPresent() {
-        if (StringUtils.isEmpty(getServiceUrl()) && StringUtils.isEmpty(getServiceUrlTls())) {
-            log.warn("Service url not found, "
-                    + "please provide either service url, example: http://pulsar.example.com:8080 "
-                    + "or service tls url, example: https://pulsar.example.com:8443");
-        }
-        if (StringUtils.isEmpty(getBrokerServiceUrl()) && StringUtils.isEmpty(getBrokerServiceUrlTls())) {
-            log.warn("Broker service url not found, "
-                    + "please provide either broker service url, example: pulsar://pulsar.example.com:6650 "
-                    + "or broker service tls url, example: pulsar+ssl://pulsar.example.com:6651.");
-        }
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
@@ -412,7 +412,7 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
      *
      * @throws IllegalArgumentException exist illegal property.
      */
-     public void checkPropertiesIfPresent() throws IllegalArgumentException {
+       public void checkPropertiesIfPresent() throws IllegalArgumentException {
 
         if (StringUtils.isEmpty(getServiceUrl()) && StringUtils.isEmpty(getServiceUrlTls())) {
             throw new IllegalArgumentException("At least one of ServiceUrl or ServiceUrlTls must be set.");

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
@@ -415,11 +415,11 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
      public void checkPropertiesIfPresent() throws IllegalArgumentException {
 
         if (StringUtils.isEmpty(getServiceUrl()) && StringUtils.isEmpty(getServiceUrlTls())) {
-                throw new IllegalArgumentException("At least one of ServiceUrl or ServiceUrlTls must be set.");
+            throw new IllegalArgumentException("At least one of ServiceUrl or ServiceUrlTls must be set.");
         }
 
         if (StringUtils.isEmpty(getBrokerServiceUrl()) && StringUtils.isEmpty(getBrokerServiceUrlTls())) {
-                throw new IllegalArgumentException("At least one of BrokerServiceUrl or BrokerServiceUrlTls must be set.");
+            throw new IllegalArgumentException("At least one of BrokerServiceUrl or BrokerServiceUrlTls must be set.");
         }
              
         URIPreconditions.checkURIIfPresent(getServiceUrl(),

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataImplTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataImplTest.java
@@ -20,10 +20,6 @@ package org.apache.pulsar.common.policies.data;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotSame;
-import static org.junit.jupiter.api.Assertions.*;
-
-import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.Test;
 
 import org.apache.pulsar.client.api.ProxyProtocol;
 import org.testng.annotations.Test;

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataImplTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataImplTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.common.policies.data;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertThrows;
 
 import org.apache.pulsar.client.api.ProxyProtocol;
 import org.testng.annotations.Test;
@@ -64,32 +65,28 @@ public class ClusterDataImplTest {
     }
     
     @Test
-    public void testBothServiceUrlsisEmpty(){
+    public void testBothServiceUrlsIsEmpty(){
         ClusterDataImpl clusterData = new ClusterDataImpl();
         clusterData.setServiceUrl("");
         clusterData.setServiceUrlTls("");
         clusterData.setBrokerServiceUrl("pulsar://pulsar.example.com:6650");
         clusterData.setBrokerServiceUrlTls("pulsar+ssl://pulsar.example.com:6651");
 
-        IllegalArgumentException exception = assertThrows(
+        assertThrows("At least one of ServiceUrl or ServiceUrlTls must be set.",
             IllegalArgumentException.class, clusterData::checkPropertiesIfPresent
         );
-        
-        assertEquals("At least one of ServiceUrl or ServiceUrlTls must be set.", exception.getMessage());
     }
 
     @Test
-    public void testBothBrokerServiceUrlsisEmpty(){
+    public void testBothBrokerServiceUrlsIsEmpty(){
         ClusterDataImpl clusterData = new ClusterDataImpl();
         clusterData.setServiceUrl("http://pulsar.example.com:8080");
         clusterData.setServiceUrlTls("https://pulsar.example.com:8443");
         clusterData.setBrokerServiceUrl("");
         clusterData.setBrokerServiceUrlTls("");
         
-        IllegalArgumentException exception = assertThrows(
+        assertThrows("At least one of BrokerServiceUrl or BrokerServiceUrlTls must be set.",
             IllegalArgumentException.class, clusterData::checkPropertiesIfPresent
         );
-        
-        assertEquals("At least one of BrokerServiceUrl or BrokerServiceUrlTls must be set.", exception.getMessage());
     }
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataImplTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataImplTest.java
@@ -62,4 +62,34 @@ public class ClusterDataImplTest {
         assertEquals(clone, originalData, "Clones should have object equality.");
         assertNotSame(clone, originalData, "Clones should not be the same reference.");
     }
+    
+    @Test
+    public void testBothServiceUrlsisEmpty(){
+        ClusterDataImpl clusterData = new ClusterDataImpl();
+        clusterData.setServiceUrl("");
+        clusterData.setServiceUrlTls("");
+        clusterData.setBrokerServiceUrl("pulsar://pulsar.example.com:6650");
+        clusterData.setBrokerServiceUrlTls("pulsar+ssl://pulsar.example.com:6651");
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class, clusterData::checkPropertiesIfPresent
+        );
+        
+        assertEquals("At least one of ServiceUrl or ServiceUrlTls must be set.", exception.getMessage());
+    }
+
+    @Test
+    public void testBothBrokerServiceUrlsisEmpty(){
+        ClusterDataImpl clusterData = new ClusterDataImpl();
+        clusterData.setServiceUrl("http://pulsar.example.com:8080");
+        clusterData.setServiceUrlTls("https://pulsar.example.com:8443");
+        clusterData.setBrokerServiceUrl("");
+        clusterData.setBrokerServiceUrlTls("");
+        
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class, clusterData::checkPropertiesIfPresent
+        );
+        
+        assertEquals("At least one of BrokerServiceUrl or BrokerServiceUrlTls must be set.", exception.getMessage());
+    }
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataImplTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataImplTest.java
@@ -20,6 +20,10 @@ package org.apache.pulsar.common.policies.data;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
 
 import org.apache.pulsar.client.api.ProxyProtocol;
 import org.testng.annotations.Test;


### PR DESCRIPTION
Fixes [#5638](https://github.com/streamnative/pulsar/issues/5638)

Main/Original Issue: [apache#19866](https://github.com/apache/pulsar/issues/19866)

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

Checking if `serviceUrl`, `serviceUrlTls`, `brokerServiceUrl`, or `brokerServiceUrlTls` are not null. Then proceeds to throw `IllegalArgumentException` if either of `serviceUrl`, `serviceUrlTls` or `brokerServiceUrl`,  `brokerServiceUrlTls` has not been set.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->