### PR TITLE
[fix][broker] Fix direct memory leak by delayed index OutOfDirectMemory

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -1065,7 +1065,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
             delayedDeliveryTracker.get().resetTickTime(topic.getDelayedDeliveryTickTimeMillis());
 
             long deliverAtTime = msgMetadata.hasDeliverAtTime() ? msgMetadata.getDeliverAtTime() : -1L;
-                return delayedDeliveryTracker.get().addMessage(ledgerId, entryId, deliverAtTime);
+            return delayedDeliveryTracker.get().addMessage(ledgerId, entryId, deliverAtTime);
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.broker.service.persistent;
 import static org.apache.pulsar.broker.service.persistent.PersistentTopic.MESSAGE_RATE_BACKOFF_MS;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
-import io.netty.util.internal.OutOfDirectMemoryError;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -1066,17 +1066,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
             delayedDeliveryTracker.get().resetTickTime(topic.getDelayedDeliveryTickTimeMillis());
 
             long deliverAtTime = msgMetadata.hasDeliverAtTime() ? msgMetadata.getDeliverAtTime() : -1L;
-            try {
                 return delayedDeliveryTracker.get().addMessage(ledgerId, entryId, deliverAtTime);
-            } catch (OutOfDirectMemoryError ex) {
-                log.error("Out of direct memory while trying add message index to delayed tracker."
-                        + " fallback to redelivery messages(heap) and waiting for enough direct memory space."
-                        + " error info: {}", ex.getMessage());
-                // fall back to redelivery queue(heap) waiting for enough direct memory.
-                redeliveryMessages.add(ledgerId, entryId);
-                Thread.yield(); // Avoid falling into the dead loop.
-                return true;
-            }
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -1070,8 +1070,9 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
             try {
                 return delayedDeliveryTracker.get().addMessage(ledgerId, entryId, deliverAtTime);
             } catch (OutOfDirectMemoryError ex) {
-                log.warn("Out of direct memory while trying add message index to delayed tracker."
-                        + " fallback to redelivery messages(heap) and waiting for enough direct memory space.");
+                log.error("Out of direct memory while trying add message index to delayed tracker."
+                        + " fallback to redelivery messages(heap) and waiting for enough direct memory space."
+                        + " error info: {}", ex.getMessage());
                 // fall back to redelivery queue(heap) waiting for enough direct memory.
                 redeliveryMessages.add(ledgerId, entryId);
                 Thread.yield(); // Avoid falling into the dead loop.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.service.persistent;
 import static org.apache.pulsar.broker.service.persistent.PersistentTopic.MESSAGE_RATE_BACKOFF_MS;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
+import io.netty.util.internal.OutOfDirectMemoryError;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -37,8 +38,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Predicate;
-
-import io.netty.util.internal.OutOfDirectMemoryError;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/SegmentedLongArray.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/SegmentedLongArray.java
@@ -19,11 +19,11 @@
 package org.apache.pulsar.common.util.collections;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.concurrent.NotThreadSafe;
 import lombok.Getter;
+import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 
 @NotThreadSafe
 public class SegmentedLongArray implements AutoCloseable {
@@ -44,14 +44,14 @@ public class SegmentedLongArray implements AutoCloseable {
 
         // Add first segment
         int sizeToAdd = (int) Math.min(remainingToAdd, MAX_SEGMENT_SIZE);
-        ByteBuf buffer = PooledByteBufAllocator.DEFAULT.directBuffer(sizeToAdd * SIZE_OF_LONG);
+        ByteBuf buffer = PulsarByteBufAllocator.DEFAULT.directBuffer(sizeToAdd * SIZE_OF_LONG);
         buffer.writerIndex(sizeToAdd * SIZE_OF_LONG);
         buffers.add(buffer);
         remainingToAdd -= sizeToAdd;
 
         // Add the remaining segments, all at full segment size, if necessary
         while (remainingToAdd > 0) {
-            buffer = PooledByteBufAllocator.DEFAULT.directBuffer(MAX_SEGMENT_SIZE * SIZE_OF_LONG);
+            buffer = PulsarByteBufAllocator.DEFAULT.directBuffer(MAX_SEGMENT_SIZE * SIZE_OF_LONG);
             buffer.writerIndex(MAX_SEGMENT_SIZE * SIZE_OF_LONG);
             buffers.add(buffer);
             remainingToAdd -= MAX_SEGMENT_SIZE;
@@ -83,7 +83,7 @@ public class SegmentedLongArray implements AutoCloseable {
         } else {
             // Let's add 1 mode buffer to the list
             int bufferSize = MAX_SEGMENT_SIZE * SIZE_OF_LONG;
-            ByteBuf buffer = PooledByteBufAllocator.DEFAULT.directBuffer(bufferSize, bufferSize);
+            ByteBuf buffer = PulsarByteBufAllocator.DEFAULT.directBuffer(bufferSize, bufferSize);
             buffer.writerIndex(bufferSize);
             buffers.add(buffer);
             capacity += MAX_SEGMENT_SIZE;
@@ -107,7 +107,7 @@ public class SegmentedLongArray implements AutoCloseable {
             // We should also reduce the capacity of the first buffer
             capacity -= sizeToReduce;
             ByteBuf oldBuffer = buffers.get(0);
-            ByteBuf newBuffer = PooledByteBufAllocator.DEFAULT.directBuffer((int) capacity * SIZE_OF_LONG);
+            ByteBuf newBuffer = PulsarByteBufAllocator.DEFAULT.directBuffer((int) capacity * SIZE_OF_LONG);
             oldBuffer.getBytes(0, newBuffer, (int) capacity * SIZE_OF_LONG);
             oldBuffer.release();
             buffers.set(0, newBuffer);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/SegmentedLongArray.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/SegmentedLongArray.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.common.util.collections;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -107,7 +108,7 @@ public class SegmentedLongArray implements AutoCloseable {
             // We should also reduce the capacity of the first buffer
             capacity -= sizeToReduce;
             ByteBuf oldBuffer = buffers.get(0);
-            ByteBuf newBuffer = PulsarByteBufAllocator.DEFAULT.directBuffer((int) capacity * SIZE_OF_LONG);
+            ByteBuf newBuffer = PooledByteBufAllocator.DEFAULT.directBuffer((int) capacity * SIZE_OF_LONG);
             oldBuffer.getBytes(0, newBuffer, (int) capacity * SIZE_OF_LONG);
             oldBuffer.release();
             buffers.set(0, newBuffer);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/SegmentedLongArray.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/SegmentedLongArray.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.common.util.collections;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -108,7 +107,7 @@ public class SegmentedLongArray implements AutoCloseable {
             // We should also reduce the capacity of the first buffer
             capacity -= sizeToReduce;
             ByteBuf oldBuffer = buffers.get(0);
-            ByteBuf newBuffer = PooledByteBufAllocator.DEFAULT.directBuffer((int) capacity * SIZE_OF_LONG);
+            ByteBuf newBuffer = PulsarByteBufAllocator.DEFAULT.directBuffer((int) capacity * SIZE_OF_LONG);
             oldBuffer.getBytes(0, newBuffer, (int) capacity * SIZE_OF_LONG);
             oldBuffer.release();
             buffers.set(0, newBuffer);


### PR DESCRIPTION
### Motivation

[There](https://github.com/apache/pulsar/blob/57fbee446aebb5c9f4db3bed559cb7bef3749731/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java#L205C16-L205C16) is a memory leak if the delayed tracker throws an `OutOfDirectMemory` exception. The entries will never release. 

Plus, with the OOM exception thrown in the thread, the broker will not shut down.

```

Jul 16, 2023 @ 18:35:58.575 | 2023-07-16T10:35:58,574+0000 [broker-topic-workers-OrderedExecutor-0-0] ERROR org.apache.bookkeeper.common.util.SingleThreadExecutor - Error while running task: failed to allocate 16777216 byte(s) of direct memory (used: 847249415, max: 858993459)
  | Jul 16, 2023 @ 18:35:58.575 | at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]
  | Jul 16, 2023 @ 18:35:58.575 | at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.trySendMessagesToConsumers(PersistentDispatcherMultipleConsumers.java:717) ~[io.streamnative-pulsar-broker-3.0.0.4.jar:3.0.0.4]
  | Jul 16, 2023 @ 18:35:58.575 | at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.trackDelayedDelivery(PersistentDispatcherMultipleConsumers.java:1068) ~[io.streamnative-pulsar-broker-3.0.0.4.jar:3.0.0.4]
  | Jul 16, 2023 @ 18:35:58.575 | at io.netty.buffer.PoolArena.allocate(PoolArena.java:144) ~[io.netty-netty-buffer-4.1.93.Final.jar:4.1.93.Final]
  | Jul 16, 2023 @ 18:35:58.575 | at io.netty.util.internal.PlatformDependent.allocateDirectNoCleaner(PlatformDependent.java:774) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]
  | Jul 16, 2023 @ 18:35:58.575 | at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.sendMessagesToConsumers(PersistentDispatcherMultipleConsumers.java:622) ~[io.streamnative-pulsar-broker-3.0.0.4.jar:3.0.0.4]
  | Jul 16, 2023 @ 18:35:58.575 | at org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker.addMessage(InMemoryDelayedDeliveryTracker.java:81) ~[io.streamnative-pulsar-broker-3.0.0.4.jar:3.0.0.4]
  | Jul 16, 2023 @ 18:35:58.575 | at io.netty.buffer.PoolArena.allocate(PoolArena.java:129) ~[io.netty-netty-buffer-4.1.93.Final.jar:4.1.93.Final]
  | Jul 16, 2023 @ 18:35:58.575 | at io.netty.buffer.PoolArena$DirectArena.newUnpooledChunk(PoolArena.java:690) ~[io.netty-netty-buffer-4.1.93.Final.jar:4.1.93.Final]
  | Jul 16, 2023 @ 18:35:58.575 | io.netty.util.internal.OutOfDirectMemoryError: failed to allocate 16777216 byte(s) of direct memory (used: 847249415, max: 858993459)
  | Jul 16, 2023 @ 18:35:58.575 | at org.apache.bookkeeper.common.util.SingleThreadExecutor.safeRunTask(SingleThreadExecutor.java:137) ~[org.apache.bookkeeper-bookkeeper-common-4.16.2.jar:4.16.2] 
  | Jul 16, 2023 @ 18:35:58.575 | at org.apache.pulsar.common.util.collections.TripleLongPriorityQueue.add(TripleLongPriorityQueue.java:94) ~[io.streamnative-pulsar-common-3.0.0.4.jar:3.0.0.4]
  | Jul 16, 2023 @ 18:35:58.575 | at io.netty.buffer.PoolArena.allocateHuge(PoolArena.java:226) ~[io.netty-netty-buffer-4.1.93.Final.jar:4.1.93.Final]
  | Jul 16, 2023 @ 18:35:58.575 | at org.apache.bookkeeper.common.util.SingleThreadExecutor.run(SingleThreadExecutor.java:113) ~[org.apache.bookkeeper-bookkeeper-common-4.16.2.jar:4.16.2]
```


### Modifications

- Using `PulsarByteBufAllocator` instead `PooledByteBufAllocator` to have better OOM control.


### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
