### PR TITLE
[fix][build] Upgrade PyYaml version to 6.0.1

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -81,7 +81,7 @@ RUN apt-get -y --purge autoremove \
      && apt-get clean \
      && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install pyyaml==5.4.1
+RUN pip3 install pyyaml==6.0.1
 
 # Pulsar currently writes to the below directories, assuming the default configuration.
 # Note that number 4 is the reason that pulsar components need write access to the /pulsar directory.

--- a/docker/pulsar/scripts/gen-yml-from-env.py
+++ b/docker/pulsar/scripts/gen-yml-from-env.py
@@ -61,7 +61,7 @@ if len(sys.argv) < 2:
 conf_files = sys.argv[1:]
 
 for conf_filename in conf_files:
-    conf = yaml.load(open(conf_filename))
+    conf = yaml.load(open(conf_filename), Loader=yaml.FullLoader)
 
     # update the config
     modified = False


### PR DESCRIPTION
### Motivation



See https://github.com/yaml/pyyaml/issues/724 .

We need to upgrade pyyaml to 6.0.1 to resolve this issue .

```
[INFO] DOCKER> Step 21/30 : RUN pip3 install pyyaml==5.4.1
[INFO] DOCKER> 
[INFO] DOCKER> ---> Running in ef1c59ec2468
[INFO] DOCKER> Collecting pyyaml==5.4.1
[INFO] DOCKER> Downloading PyYAML-5.4.1.tar.gz (175 kB)
[INFO] DOCKER> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 175.1/175.1 KB 4.4 MB/s eta 0:00:00
[INFO] DOCKER> 
[INFO] DOCKER> Installing build dependencies: started
[INFO] DOCKER> Installing build dependencies: finished with status 'done'
[INFO] DOCKER> Getting requirements to build wheel: started
[INFO] DOCKER> Getting requirements to build wheel: finished with status 'error'
[INFO] DOCKER> [91m  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [43 lines of output]
      running egg_info
      Traceback (most recent call last):
        File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
          main()
        File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 130, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 162, in get_requires_for_build_wheel
          return self._get_build_requires(
        File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 143, in _get_build_requires
          self.run_setup()
        File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 158, in run_setup
          exec(compile(code, __file__, 'exec'), locals())
        File "setup.py", line 271, in <module>
          setup(
        File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 153, in setup
          return distutils.core.setup(**attrs)
        File "/usr/lib/python3/dist-packages/setuptools/_distutils/core.py", line 148, in setup
          return run_commands(dist)
        File "/usr/lib/python3/dist-packages/setuptools/_distutils/core.py", line 163, in run_commands
          dist.run_commands()
        File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 967, in run_commands
          self.run_command(cmd)
        File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 986, in run_command
          cmd_obj.run()
        File "/usr/lib/python3/dist-packages/setuptools/command/egg_info.py", line 299, in run
          self.find_sources()
        File "/usr/lib/python3/dist-packages/setuptools/command/egg_info.py", line 306, in find_sources
          mm.run()
        File "/usr/lib/python3/dist-packages/setuptools/command/egg_info.py", line 541, in run
          self.add_defaults()
        File "/usr/lib/python3/dist-packages/setuptools/command/egg_info.py", line 578, in add_defaults
          sdist.add_defaults(self)
        File "/usr/lib/python3/dist-packages/setuptools/_distutils/command/sdist.py", line 228, in add_defaults
          self._add_defaults_ext()
        File "/usr/lib/python3/dist-packages/setuptools/_distutils/command/sdist.py", line 312, in _add_defaults_ext
          self.filelist.extend(build_ext.get_source_files())
        File "setup.py", line 201, in get_source_files
          self.cython_sources(ext.sources, ext)
        File "/usr/lib/python3/dist-packages/setuptools/_distutils/cmd.py", line 103, in __getattr__
          raise AttributeError(attr)
      AttributeError: cython_sources
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.

[INFO] DOCKER> [91merror: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.

[INFO] DOCKER> Removing intermediate container ef1c59ec2468
Error:  DOCKER> Unable to build image [apachepulsar/pulsar] : "The command '/bin/sh -c pip3 install pyyaml==5.4.1' returned a non-zero code: 1"  ["The command '/bin/sh -c pip3 install pyyaml==5.4.1' returned a non-zero code: 1" ]

```

### Modifications

Dockerfile 

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/yaalsn/pulsar/pull/2
