### PR TITLE
[improve][broker] Heartbeat topic enable checkMessageExpire

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SystemTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SystemTopic.java
@@ -57,7 +57,10 @@ public class SystemTopic extends PersistentTopic {
 
     @Override
     public void checkMessageExpiry() {
-        // do nothing for system topic
+        if (NamespaceService.isHeartbeatNamespace(TopicName.get(topic))) {
+            super.checkMessageExpiry();
+        }
+        // do nothing for system topic except `HealthCheck`
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Running pulsar cluster for a long time, we found there are thousands of ledgers of heartbeat topic. The reason is heartbeat topic do not clean the expired message because it is systemTopic. The behaviour change since this pr https://github.com/apache/pulsar/pull/13611.

I think it is no need to keep heartbeat topic message permanently and we'd better clean the expired message and the ledger.

### Modifications

modify checkMessageExpire()

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

