### PR TITLE
[improve][broker] Follow up #4196 use `PulsarByteBufAllocator` handle OOM

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Markers.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Markers.java
@@ -19,13 +19,13 @@
 package org.apache.pulsar.common.protocol;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import lombok.SneakyThrows;
 import lombok.experimental.UtilityClass;
+import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.proto.MarkerType;
 import org.apache.pulsar.common.api.proto.MarkersMessageIdData;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
@@ -109,7 +109,7 @@ public class Markers {
                 .clear()
                 .setSnapshotId(snapshotId)
                 .setSourceCluster(sourceCluster);
-        ByteBuf payload = PooledByteBufAllocator.DEFAULT.buffer(req.getSerializedSize());
+        ByteBuf payload = PulsarByteBufAllocator.DEFAULT.buffer(req.getSerializedSize());
 
         try {
             req.writeTo(payload);
@@ -138,7 +138,7 @@ public class Markers {
                 .setLedgerId(ledgerId)
                 .setEntryId(entryId);
 
-        ByteBuf payload = PooledByteBufAllocator.DEFAULT.buffer(response.getSerializedSize());
+        ByteBuf payload = PulsarByteBufAllocator.DEFAULT.buffer(response.getSerializedSize());
         try {
             response.writeTo(payload);
             return newMessage(MarkerType.REPLICATED_SUBSCRIPTION_SNAPSHOT_RESPONSE, Optional.of(replyToCluster),
@@ -172,7 +172,7 @@ public class Markers {
         });
 
         int size = snapshot.getSerializedSize();
-        ByteBuf payload = PooledByteBufAllocator.DEFAULT.buffer(size);
+        ByteBuf payload = PulsarByteBufAllocator.DEFAULT.buffer(size);
         try {
             snapshot.writeTo(payload);
             return newMessage(MarkerType.REPLICATED_SUBSCRIPTION_SNAPSHOT, Optional.of(sourceCluster), payload);
@@ -201,7 +201,7 @@ public class Markers {
                     .setMessageId().copyFrom(msgId);
         });
 
-        ByteBuf payload = PooledByteBufAllocator.DEFAULT.buffer(update.getSerializedSize());
+        ByteBuf payload = PulsarByteBufAllocator.DEFAULT.buffer(update.getSerializedSize());
 
         try {
             update.writeTo(payload);
@@ -258,7 +258,7 @@ public class Markers {
                 .setTxnidMostBits(txnMostBits)
                 .setTxnidLeastBits(txnLeastBits);
 
-        ByteBuf payload = PooledByteBufAllocator.DEFAULT.buffer(0);
+        ByteBuf payload = PulsarByteBufAllocator.DEFAULT.buffer(0);
 
         try {
             return Commands.serializeMetadataAndPayload(ChecksumType.Crc32c,

--- a/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileStoreBackedReadHandleImpl.java
+++ b/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileStoreBackedReadHandleImpl.java
@@ -20,7 +20,6 @@ package org.apache.bookkeeper.mledger.offload.filesystem.impl;
 
 import static org.apache.bookkeeper.mledger.offload.OffloadUtils.parseLedgerMetadata;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +39,7 @@ import org.apache.bookkeeper.mledger.LedgerOffloaderStats;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.MapFile;
+import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.naming.TopicName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -133,7 +133,7 @@ public class FileStoreBackedReadHandleImpl implements ReadHandle {
                     int length = value.getLength();
                     long entryId = key.get();
                     if (entryId == nextExpectedId) {
-                        ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer(length, length);
+                        ByteBuf buf = PulsarByteBufAllocator.DEFAULT.buffer(length, length);
                         entries.add(LedgerEntryImpl.create(ledgerId, entryId, length, buf));
                         buf.writeBytes(value.copyBytes());
                         entriesToRead--;


### PR DESCRIPTION
### Motivation

Follow up PR #4196 to use `PulsarByteBufAllocator` handle OOM

### Modifications

- Use `PulsarByteBufAllocator` to instead `PooledBytebufAllocator`

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->