### PR TITLE
[improve] [ws] add cryptoKeyReaderFactoryClassName into the file websocket.conf

### DIFF
--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -194,3 +194,6 @@ zooKeeperSessionTimeoutMillis=-1
 # ZooKeeper cache expiry time in seconds
 # Deprecated: use metadataStoreCacheExpirySeconds
 zooKeeperCacheExpirySeconds=-1
+
+# CryptoKeyReader factory classname to support encryption at websocket.
+cryptoKeyReaderFactoryClassName=

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/WebSocketProxyConfigurationTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/WebSocketProxyConfigurationTest.java
@@ -34,6 +34,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 public class WebSocketProxyConfigurationTest {
 
@@ -64,6 +65,7 @@ public class WebSocketProxyConfigurationTest {
             printWriter.println("metadataStoreCacheExpirySeconds=500");
             printWriter.println("zooKeeperSessionTimeoutMillis=-1");
             printWriter.println("zooKeeperCacheExpirySeconds=-1");
+            printWriter.println("cryptoKeyReaderFactoryClassName=");
         }
         testConfigFile.deleteOnExit();
         stream = new FileInputStream(testConfigFile);
@@ -71,6 +73,7 @@ public class WebSocketProxyConfigurationTest {
         stream.close();
         assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 60);
         assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 500);
+        assertNull(serviceConfig.getCryptoKeyReaderFactoryClassName());
 
         testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
         if (testConfigFile.exists()) {
@@ -81,6 +84,7 @@ public class WebSocketProxyConfigurationTest {
             printWriter.println("metadataStoreCacheExpirySeconds=30");
             printWriter.println("zooKeeperSessionTimeoutMillis=100");
             printWriter.println("zooKeeperCacheExpirySeconds=300");
+            printWriter.println("cryptoKeyReaderFactoryClassName=A.class");
         }
         testConfigFile.deleteOnExit();
         stream = new FileInputStream(testConfigFile);
@@ -88,6 +92,7 @@ public class WebSocketProxyConfigurationTest {
         stream.close();
         assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 100);
         assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 300);
+        assertEquals(serviceConfig.getCryptoKeyReaderFactoryClassName(), "A.class");
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Since the PR https://github.com/apache/pulsar/pull/16234 add the prop `cryptoKeyReaderFactoryClassName` for the WebSocket Proxy, but did not add this prop to `websocket.conf`.  This can make the script which try to replacement attribute a bit difficult to write

### Modifications

add the conf `cryptoKeyReaderFactoryClassName` into the file `websocket.conf`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
