### PR TITLE
[fix] Upgrade to pyyaml 6.0.1 in docker image

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -81,7 +81,7 @@ RUN apt-get -y --purge autoremove \
      && apt-get clean \
      && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install pyyaml==5.4.1
+RUN pip3 install pyyaml==6.0.1
 
 # Pulsar currently writes to the below directories, assuming the default configuration.
 # Note that number 4 is the reason that pulsar components need write access to the /pulsar directory.


### PR DESCRIPTION
Fixes #20839

### Motivation

Our docker builds are failing because of a transitive dependency that is now broken. See https://github.com/yaml/pyyaml/pull/702 for more information.

Note: I am not sure what consequences might come from going from 5.4.1 to 6.0.1. The change log seems pretty tame https://github.com/yaml/pyyaml/blob/master/CHANGES. The biggest change is dropping support for python 2.7.

### Modifications

* Upgrade pyyaml from 5.4.1 to 6.0.1

### Verifying this change

This is a relatively minor change. My understanding is that we use this to format the function configuration yaml file.

### Documentation

- [x] `doc-not-needed`

### Matching PR in forked repository

PR in forked repository: Skipping personal testing since this is a hot fix to unblock builds.