### PR TITLE
[improve][broker] Avoid print redirect exception log when get list from bundle

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
@@ -467,25 +467,20 @@ public class NonPersistentTopics extends PersistentTopics {
                             }
                             asyncResponse.resume(topicList);
                         }).exceptionally(ex -> {
-                            Throwable realCause = FutureUtil.unwrapCompletionException(ex);
-                            log.error("[{}] Failed to list topics on namespace bundle {}/{}", clientAppId(),
-                                    namespaceName, bundleRange, realCause);
-                            if (realCause instanceof WebApplicationException) {
-                                asyncResponse.resume(realCause);
-                            } else {
-                                asyncResponse.resume(new RestException(realCause));
+                            if (!isRedirectException(ex)) {
+                                log.error("[{}] Failed to list topics on namespace bundle {}/{}", clientAppId(),
+                                        namespaceName, bundleRange, ex);
                             }
+                            resumeAsyncResponseExceptionally(asyncResponse, ex);
                             return null;
                         });
             }
         }).exceptionally(ex -> {
-            log.error("[{}] Failed to list topics on namespace bundle {}/{}", clientAppId(),
-                namespaceName, bundleRange, ex);
-            if (ex.getCause() instanceof WebApplicationException) {
-                asyncResponse.resume(ex.getCause());
-            } else {
-                asyncResponse.resume(new RestException(ex.getCause()));
+            if (!isRedirectException(ex)) {
+                log.error("[{}] Failed to list topics on namespace bundle {}/{}", clientAppId(),
+                        namespaceName, bundleRange, ex);
             }
+            resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
         });
     }


### PR DESCRIPTION
### Motivation

Avoid printing redirect exception log when get list from bundle.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->