### PR TITLE
[fix][broker] Fix the built-in admin failed to delete a topic with a custom authz provider

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
@@ -436,9 +436,7 @@ public interface AuthorizationProvider extends Closeable {
      * @return CompletableFuture<Void>
      */
     default CompletableFuture<Void> removePermissionsAsync(TopicName topicName) {
-        return FutureUtil.failedFuture(new IllegalStateException(
-                String.format("removePermissionsAsync on topicName %s is not supported by the Authorization",
-                        topicName)));
+        return CompletableFuture.completedFuture(null);
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationWithAuthDataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationWithAuthDataTest.java
@@ -270,6 +270,7 @@ public class AuthorizationWithAuthDataTest extends MockedPulsarServiceBaseTest {
         admin.topics().createNonPartitionedTopic(nonPartitionedTopic);
         admin.lookups().lookupPartitionedTopic(partitionedTopic);
         admin.lookups().lookupTopic(nonPartitionedTopic);
+        admin.topics().delete(nonPartitionedTopic);
     }
 
     @Test


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/20496 introduced a breaking change that if the custom authz provider does not implement the `removePermissionsAsync` method, the built-in admin will fail to delete a topic. It's because `BrokerService#deleteTopicAuthenticationWithRetry` calls `authorizationService.removePermissionsAsync`.

### Modifications

To make it backward compatible, return a normal completed future in `removePermissionsAsync`. Verify the change by deleting a topic in `AuthorizationWithAuthDataTest#testAdmin`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
