### PR TITLE
[fix][broker] Pass `bytesToRead` when reading compacted entries

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -351,7 +351,7 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
                 if (consumer.readCompacted()) {
                     boolean readFromEarliest = isFirstRead && MessageId.earliest.equals(consumer.getStartMessageId());
                     CompactedTopicUtils.readCompactedEntries(topic.getTopicCompactionService(), cursor, messagesToRead,
-                            readFromEarliest, this, consumer);
+                            bytesToRead, readFromEarliest, this, consumer);
                 } else {
                     ReadEntriesCtx readEntriesCtx =
                             ReadEntriesCtx.create(consumer, consumer.getConsumerEpoch());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -350,8 +350,8 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
                 havePendingRead = true;
                 if (consumer.readCompacted()) {
                     boolean readFromEarliest = isFirstRead && MessageId.earliest.equals(consumer.getStartMessageId());
-                    CompactedTopicUtils.asyncReadCompactedEntriesOrWait(topic.getTopicCompactionService(), cursor,
-                            messagesToRead, bytesToRead, readFromEarliest, this, consumer);
+                    CompactedTopicUtils.asyncReadCompactedEntries(topic.getTopicCompactionService(), cursor,
+                            messagesToRead, bytesToRead, readFromEarliest, this, true, consumer);
                 } else {
                     ReadEntriesCtx readEntriesCtx =
                             ReadEntriesCtx.create(consumer, consumer.getConsumerEpoch());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -350,8 +350,8 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
                 havePendingRead = true;
                 if (consumer.readCompacted()) {
                     boolean readFromEarliest = isFirstRead && MessageId.earliest.equals(consumer.getStartMessageId());
-                    CompactedTopicUtils.readCompactedEntries(topic.getTopicCompactionService(), cursor, messagesToRead,
-                            bytesToRead, readFromEarliest, this, consumer);
+                    CompactedTopicUtils.asyncReadCompactedEntriesOrWait(topic.getTopicCompactionService(), cursor,
+                            messagesToRead, bytesToRead, readFromEarliest, this, consumer);
                 } else {
                     ReadEntriesCtx readEntriesCtx =
                             ReadEntriesCtx.create(consumer, consumer.getConsumerEpoch());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopic.java
@@ -34,7 +34,7 @@ public interface CompactedTopic {
      * Read entries from compacted topic.
      *
      * @deprecated Use {@link CompactedTopicUtils#readCompactedEntries(TopicCompactionService, ManagedCursor,
-     * int, boolean, ReadEntriesCallback, Consumer)} instead.
+     * int, long, boolean, ReadEntriesCallback, Consumer)} instead.
      */
     @Deprecated
     void asyncReadEntriesOrWait(ManagedCursor cursor,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopic.java
@@ -33,8 +33,8 @@ public interface CompactedTopic {
     /**
      * Read entries from compacted topic.
      *
-     * @deprecated Use {@link CompactedTopicUtils#asyncReadCompactedEntriesOrWait(TopicCompactionService, ManagedCursor,
-     * int, long, boolean, ReadEntriesCallback, Consumer)} instead.
+     * @deprecated Use {@link CompactedTopicUtils#asyncReadCompactedEntries(TopicCompactionService, ManagedCursor,
+     * int, long, boolean, ReadEntriesCallback, boolean, Consumer)} instead.
      */
     @Deprecated
     void asyncReadEntriesOrWait(ManagedCursor cursor,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopic.java
@@ -33,7 +33,7 @@ public interface CompactedTopic {
     /**
      * Read entries from compacted topic.
      *
-     * @deprecated Use {@link CompactedTopicUtils#readCompactedEntries(TopicCompactionService, ManagedCursor,
+     * @deprecated Use {@link CompactedTopicUtils#asyncReadCompactedEntriesOrWait(TopicCompactionService, ManagedCursor,
      * int, long, boolean, ReadEntriesCallback, Consumer)} instead.
      */
     @Deprecated

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicUtils.java
@@ -40,7 +40,7 @@ public class CompactedTopicUtils {
 
     @Beta
     public static void readCompactedEntries(TopicCompactionService topicCompactionService, ManagedCursor cursor,
-                                            int numberOfEntriesToRead, boolean readFromEarliest,
+                                            int numberOfEntriesToRead, long bytesToRead, boolean readFromEarliest,
                                             AsyncCallbacks.ReadEntriesCallback callback, @Nullable Consumer consumer) {
         Objects.requireNonNull(topicCompactionService);
         Objects.requireNonNull(cursor);
@@ -64,7 +64,8 @@ public class CompactedTopicUtils {
             if (lastCompactedPosition == null
                     || readPosition.compareTo(
                     lastCompactedPosition.getLedgerId(), lastCompactedPosition.getEntryId()) > 0) {
-                cursor.asyncReadEntriesOrWait(numberOfEntriesToRead, callback, readEntriesCtx, PositionImpl.LATEST);
+                cursor.asyncReadEntriesOrWait(numberOfEntriesToRead, bytesToRead, callback, readEntriesCtx,
+                        PositionImpl.LATEST);
                 return CompletableFuture.completedFuture(null);
             }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicUtils.java
@@ -39,11 +39,11 @@ import org.apache.pulsar.common.util.FutureUtil;
 public class CompactedTopicUtils {
 
     @Beta
-    public static void asyncReadCompactedEntriesOrWait(TopicCompactionService topicCompactionService,
-                                                       ManagedCursor cursor, int numberOfEntriesToRead,
-                                                       long bytesToRead, boolean readFromEarliest,
-                                                       AsyncCallbacks.ReadEntriesCallback callback,
-                                                       @Nullable Consumer consumer) {
+    public static void asyncReadCompactedEntries(TopicCompactionService topicCompactionService,
+                                                 ManagedCursor cursor, int numberOfEntriesToRead,
+                                                 long bytesToRead, boolean readFromEarliest,
+                                                 AsyncCallbacks.ReadEntriesCallback callback,
+                                                 boolean wait, @Nullable Consumer consumer) {
         Objects.requireNonNull(topicCompactionService);
         Objects.requireNonNull(cursor);
         checkArgument(numberOfEntriesToRead > 0);
@@ -66,8 +66,13 @@ public class CompactedTopicUtils {
             if (lastCompactedPosition == null
                     || readPosition.compareTo(
                     lastCompactedPosition.getLedgerId(), lastCompactedPosition.getEntryId()) > 0) {
-                cursor.asyncReadEntriesOrWait(numberOfEntriesToRead, bytesToRead, callback, readEntriesCtx,
+                if (wait) {
+                    cursor.asyncReadEntriesOrWait(numberOfEntriesToRead, bytesToRead, callback, readEntriesCtx,
                         PositionImpl.LATEST);
+                } else {
+                    cursor.asyncReadEntries(numberOfEntriesToRead, bytesToRead, callback, readEntriesCtx,
+                        PositionImpl.LATEST);
+                }
                 return CompletableFuture.completedFuture(null);
             }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicUtils.java
@@ -39,9 +39,11 @@ import org.apache.pulsar.common.util.FutureUtil;
 public class CompactedTopicUtils {
 
     @Beta
-    public static void readCompactedEntries(TopicCompactionService topicCompactionService, ManagedCursor cursor,
-                                            int numberOfEntriesToRead, long bytesToRead, boolean readFromEarliest,
-                                            AsyncCallbacks.ReadEntriesCallback callback, @Nullable Consumer consumer) {
+    public static void asyncReadCompactedEntriesOrWait(TopicCompactionService topicCompactionService,
+                                                       ManagedCursor cursor, int numberOfEntriesToRead,
+                                                       long bytesToRead, boolean readFromEarliest,
+                                                       AsyncCallbacks.ReadEntriesCallback callback,
+                                                       @Nullable Consumer consumer) {
         Objects.requireNonNull(topicCompactionService);
         Objects.requireNonNull(cursor);
         checkArgument(numberOfEntriesToRead > 0);


### PR DESCRIPTION
### Motivation

When we read compacted entries, we miss `bytesToRead`, we should pass it.

### Modifications

Pass `bytesToRead` when reading compacted entries.

Add wait parameter to make the method support non-wait mode.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
