### PR TITLE
[improve][sql] Support add pulsar admin JWT token

### DIFF
--- a/pulsar-sql/presto-distribution/src/main/resources/conf/catalog/pulsar.properties
+++ b/pulsar-sql/presto-distribution/src/main/resources/conf/catalog/pulsar.properties
@@ -73,6 +73,9 @@ pulsar.rewrite-namespace-delimiter=/
 ## the authentication parameter to be used to authenticate to Pulsar cluster
 #pulsar.auth-params=
 
+## the authentication token for JWT
+#pulsar.auth-token=
+
 ## Accept untrusted TLS certificate
 #pulsar.tls-allow-insecure-connection =
 

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorConfig.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorConfig.java
@@ -31,6 +31,7 @@ import org.apache.bookkeeper.stats.NullStatsProvider;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
+import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.naming.NamedEntity;
 import org.apache.pulsar.common.nar.NarClassLoader;
@@ -59,6 +60,8 @@ public class PulsarConnectorConfig implements AutoCloseable {
     private Map<String, String> statsProviderConfigs = new HashMap<>();
     private String authPluginClassName;
     private String authParams;
+
+    private String authToken;
     private String tlsTrustCertsFilePath;
     private Boolean tlsAllowInsecureConnection;
     private Boolean tlsHostnameVerificationEnable;
@@ -381,6 +384,16 @@ public class PulsarConnectorConfig implements AutoCloseable {
         return this;
     }
 
+    public String getAuthToken() {
+        return this.authToken;
+    }
+
+    @Config("pulsar.auth-token")
+    public PulsarConnectorConfig setAuthToken(String authToken) throws IOException {
+        this.authToken = authToken;
+        return this;
+    }
+
     public Boolean isTlsAllowInsecureConnection() {
         return tlsAllowInsecureConnection;
     }
@@ -500,8 +513,17 @@ public class PulsarConnectorConfig implements AutoCloseable {
         if (this.pulsarAdmin == null) {
             PulsarAdminBuilder builder = PulsarAdmin.builder();
 
+            if (getAuthPlugin() != null && getAuthToken() != null) {
+                throw new IllegalArgumentException("Either pulsar.auth-plugin or pulsar.auth-token can be used,"
+                        + " but not both at the same time");
+            }
+
             if (getAuthPlugin() != null) {
                 builder.authentication(getAuthPlugin(), getAuthParams());
+            }
+
+            if (getAuthToken() != null){
+                builder.authentication(AuthenticationFactory.token(getAuthToken()));
             }
 
             if (isTlsAllowInsecureConnection() != null) {


### PR DESCRIPTION

### Motivation

Pulsar admin supports JWT authentication.

### Modifications

Add `pulsar.auth-token` conf.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


This change added tests and can be verified as follows:

  - org.apache.pulsar.sql.presto.TestPulsarConnectorConfig#testAnnotatedConfigurationsExceptions

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/crossoverJie/pulsar/pull/9
