### PR TITLE
[improve][broker] Pass role and auth data parameters to the get permission method

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationProvider.java
@@ -441,10 +441,14 @@ public interface AuthorizationProvider extends Closeable {
 
     /**
      * Get authorization-action permissions on a topic.
-     * @param topicName
+     * @param topicName topic name
+     * @param role role name
+     * @param authData authenticated data
      * @return CompletableFuture<Map<String, Set<AuthAction>>>
      */
-    default CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(TopicName topicName) {
+    default CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(TopicName topicName,
+                                                                                String role,
+                                                                                AuthenticationDataSource authData) {
         return FutureUtil.failedFuture(new IllegalStateException(
                 String.format("getPermissionsAsync on topicName %s is not supported by the Authorization",
                         topicName)));
@@ -452,10 +456,13 @@ public interface AuthorizationProvider extends Closeable {
 
     /**
      * Get authorization-action permissions on a topic.
-     * @param namespaceName
-     * @return CompletableFuture<Map<String, Set<String>>>
+     * @param namespaceName  namespace name
+     * @param role role name
+     * @param authData authenticated data
+     * @return CompletableFuture<Map<String, Set<String>>> <subscriptionName, Set<roles>>
      */
-    default CompletableFuture<Map<String, Set<String>>> getSubscriptionPermissionsAsync(NamespaceName namespaceName) {
+    default CompletableFuture<Map<String, Set<String>>> getSubscriptionPermissionsAsync(
+            NamespaceName namespaceName, String role, AuthenticationDataSource authData) {
         return FutureUtil.failedFuture(new IllegalStateException(
                 String.format("getSubscriptionPermissionsAsync on namespace %s is not supported by the Authorization",
                         namespaceName)));
@@ -463,10 +470,14 @@ public interface AuthorizationProvider extends Closeable {
 
     /**
      * Get authorization-action permissions on a namespace.
-     * @param namespaceName
+     * @param namespaceName namespace name
+     * @param role role name
+     * @param authData authenticated data
      * @return CompletableFuture<Map<String, Set<AuthAction>>>
      */
-    default CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(NamespaceName namespaceName) {
+    default CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(NamespaceName namespaceName,
+                                                                                String role,
+                                                                                AuthenticationDataSource authData) {
         return FutureUtil.failedFuture(new IllegalStateException(
                 String.format("getPermissionsAsync on namespaceName %s is not supported by the Authorization",
                         namespaceName)));

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -821,15 +821,19 @@ public class AuthorizationService {
         return provider.removePermissionsAsync(topicName);
     }
 
-    public CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(TopicName topicName) {
-        return provider.getPermissionsAsync(topicName);
+    public CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(NamespaceName namespaceName,
+                                                                               String role,
+                                                                               AuthenticationDataSource autData) {
+        return provider.getPermissionsAsync(namespaceName, role, autData);
     }
 
-    public CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(NamespaceName namespaceName) {
-        return provider.getPermissionsAsync(namespaceName);
+    public CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(TopicName topicName, String role,
+                                                                               AuthenticationDataSource autData) {
+        return provider.getPermissionsAsync(topicName, role, autData);
     }
 
-    public CompletableFuture<Map<String, Set<String>>> getSubscriptionPermissionsAsync(NamespaceName namespaceName) {
-        return provider.getSubscriptionPermissionsAsync(namespaceName);
+    public CompletableFuture<Map<String, Set<String>>> getSubscriptionPermissionsAsync(
+            NamespaceName namespaceName, String role, AuthenticationDataSource autData) {
+        return provider.getSubscriptionPermissionsAsync(namespaceName, role, autData);
     }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -675,7 +675,9 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
     }
 
     @Override
-    public CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(TopicName topicName) {
+    public CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(TopicName topicName,
+                                                                               String role,
+                                                                               AuthenticationDataSource authData) {
         return getPoliciesReadOnlyAsync().thenCompose(readonly -> {
             if (readonly) {
                 if (log.isDebugEnabled()) {
@@ -697,15 +699,15 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                         if (auth.getTopicAuthentication().containsKey(topicUri)) {
                             for (Map.Entry<String, Set<AuthAction>> entry :
                                     auth.getTopicAuthentication().get(topicUri).entrySet()) {
-                                String role = entry.getKey();
+                                String roleKey = entry.getKey();
                                 Set<AuthAction> topicPermissions = entry.getValue();
 
-                                if (!permissions.containsKey(role)) {
-                                    permissions.put(role, topicPermissions);
+                                if (!permissions.containsKey(roleKey)) {
+                                    permissions.put(roleKey, topicPermissions);
                                 } else {
                                     // Do the union between namespace and topic level
-                                    Set<AuthAction> union = Sets.union(permissions.get(role), topicPermissions);
-                                    permissions.put(role, union);
+                                    Set<AuthAction> union = Sets.union(permissions.get(roleKey), topicPermissions);
+                                    permissions.put(roleKey, union);
                                 }
                             }
                         }
@@ -721,7 +723,8 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
     }
 
     @Override
-    public CompletableFuture<Map<String, Set<String>>> getSubscriptionPermissionsAsync(NamespaceName namespaceName) {
+    public CompletableFuture<Map<String, Set<String>>> getSubscriptionPermissionsAsync(
+            NamespaceName namespaceName, String role, AuthenticationDataSource authData) {
         return getPoliciesReadOnlyAsync().thenCompose(readonly -> {
             if (readonly) {
                 if (log.isDebugEnabled()) {
@@ -747,7 +750,9 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
     }
 
     @Override
-    public CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(NamespaceName namespaceName) {
+    public CompletableFuture<Map<String, Set<AuthAction>>> getPermissionsAsync(NamespaceName namespaceName,
+                                                                               String role,
+                                                                               AuthenticationDataSource authData) {
         return getPoliciesReadOnlyAsync().thenCompose(readonly -> {
             if (readonly) {
                 if (log.isDebugEnabled()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -293,7 +293,7 @@ public class Namespaces extends NamespacesBase {
                                @PathParam("namespace") String namespace) {
         validateNamespaceName(property, cluster, namespace);
         validateNamespaceOperationAsync(NamespaceName.get(property, namespace), NamespaceOperation.GET_PERMISSION)
-                .thenCompose(__ -> getAuthorizationService().getPermissionsAsync(namespaceName))
+                .thenCompose(__ -> getAuthorizationService().getPermissionsAsync(namespaceName, clientAppId(), clientAuthData()))
                 .thenAccept(permissions -> response.resume(permissions))
                 .exceptionally(ex -> {
                     log.error("Failed to get permissions for namespace {}", namespaceName, ex);
@@ -314,7 +314,8 @@ public class Namespaces extends NamespacesBase {
                                             @PathParam("namespace") String namespace) {
         validateNamespaceName(property, cluster, namespace);
         validateNamespaceOperationAsync(NamespaceName.get(property, namespace), NamespaceOperation.GET_PERMISSION)
-                .thenCompose(__ -> getAuthorizationService().getSubscriptionPermissionsAsync(namespaceName))
+                .thenCompose(__ -> getAuthorizationService().getSubscriptionPermissionsAsync(namespaceName,
+                        getRealClientRole(), clientAuthData()))
                 .thenAccept(permissions -> response.resume(permissions))
                 .exceptionally(ex -> {
                     log.error("[{}] Failed to get permissions on subscription for namespace {}: {} ",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -240,7 +240,7 @@ public class Namespaces extends NamespacesBase {
                                                        @PathParam("namespace") String namespace) {
         validateNamespaceName(tenant, namespace);
         validateNamespaceOperationAsync(NamespaceName.get(tenant, namespace), NamespaceOperation.GET_PERMISSION)
-                .thenCompose(__ -> getAuthorizationService().getPermissionsAsync(namespaceName))
+                .thenCompose(__ -> getAuthorizationService().getPermissionsAsync(namespaceName, getRealClientRole(), clientAuthData()))
                 .thenAccept(permissions -> response.resume(permissions))
                 .exceptionally(ex -> {
                     log.error("Failed to get permissions for namespace {}", namespaceName, ex);
@@ -260,7 +260,8 @@ public class Namespaces extends NamespacesBase {
                                             @PathParam("namespace") String namespace) {
         validateNamespaceName(tenant, namespace);
         validateNamespaceOperationAsync(NamespaceName.get(tenant, namespace), NamespaceOperation.GET_PERMISSION)
-                .thenCompose(__ -> getAuthorizationService().getSubscriptionPermissionsAsync(namespaceName))
+                .thenCompose(__ -> getAuthorizationService()
+                        .getSubscriptionPermissionsAsync(namespaceName, getRealClientRole(), clientAuthData()))
                 .thenAccept(permissions -> response.resume(permissions))
                 .exceptionally(ex -> {
                     log.error("[{}] Failed to get permissions on subscription for namespace {}: {} ", clientAppId(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -1302,4 +1302,23 @@ public abstract class PulsarWebResource {
             asyncResponse.resume(new RestException(realCause));
         }
     }
+
+    /**
+     * Gets the real client role.<br/>
+     *
+     * When authentication is enabled, if the original principal (the role forwarded by the proxy) is not null,
+     * the original principal is returned, otherwise the client ID is returned.<br/>
+     *
+     * When authentication is disabled, returns null.
+     */
+    protected String getRealClientRole() {
+        if (!pulsar().getConfiguration().isAuthorizationEnabled()) {
+            return null;
+        }
+        String original = originalPrincipal();
+        if (original != null) {
+            return original;
+        }
+        return clientAppId();
+    }
 }


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/20496 introduces `getPermissionsAsync()` and `getSubscriptionPermissionsAsync()`, which without role and auth data parameters, I don't think this is the correct design in some scenarios.

In the `AuthorizationProvider.java`, both grant and revoke permission methods have the role and auth data parameters, so I believe the get permission method also requires these parameters. 

For the current implement(`PulsarAuthorizationProvider.java`), #20496 is correct, because we don't depend on the role, but we have to consider how third-party plugins store policy.

### Modifications

- Add role and auth data parameters to `getPermissionsAsync()` and `getSubscriptionPermissionsAsync()` in the `AuthorizationProvider.java`
- Fix method calls in the `v1/Namespaces.java` and `v1/Namespaces.java`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
