### PR TITLE
[feat][fn] Add option to merge secrets into config for sink/source

### DIFF
--- a/pulsar-functions/instance/pom.xml
+++ b/pulsar-functions/instance/pom.xml
@@ -269,6 +269,15 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <environmentVariables>
+            <TEST_JAVA_INSTANCE_PARSE_ENV_VAR>some-configuration</TEST_JAVA_INSTANCE_PARSE_ENV_VAR>
+          </environmentVariables>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -137,9 +137,29 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
 
     private final Function.FunctionDetails.ComponentType componentType;
 
+    private static Map<String, Object> buildSecretsMap(InstanceConfig config) {
+        if (!StringUtils.isEmpty(config.getFunctionDetails().getSecretsMap())) {
+            return new Gson().fromJson(config.getFunctionDetails().getSecretsMap(),
+                    new TypeToken<Map<String, Object>>() {
+                    }.getType());
+        } else {
+            return new HashMap<>();
+        }
+    }
+
     public ContextImpl(InstanceConfig config, Logger logger, PulsarClient client,
                        SecretsProvider secretsProvider, FunctionCollectorRegistry collectorRegistry,
                        String[] metricsLabels,
+                       Function.FunctionDetails.ComponentType componentType, ComponentStatsManager statsManager,
+                       StateManager stateManager, PulsarAdmin pulsarAdmin, ClientBuilder clientBuilder)
+            throws PulsarClientException {
+        this(config, logger, client, secretsProvider, collectorRegistry, metricsLabels, buildSecretsMap(config),
+                componentType, statsManager, stateManager, pulsarAdmin, clientBuilder);
+    }
+
+    public ContextImpl(InstanceConfig config, Logger logger, PulsarClient client,
+                       SecretsProvider secretsProvider, FunctionCollectorRegistry collectorRegistry,
+                       String[] metricsLabels, Map<String, Object> secretsMap,
                        Function.FunctionDetails.ComponentType componentType, ComponentStatsManager statsManager,
                        StateManager stateManager, PulsarAdmin pulsarAdmin, ClientBuilder clientBuilder)
             throws PulsarClientException {
@@ -186,13 +206,7 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
                     }.getType());
         }
         this.secretsProvider = secretsProvider;
-        if (!StringUtils.isEmpty(config.getFunctionDetails().getSecretsMap())) {
-            secretsMap = new Gson().fromJson(config.getFunctionDetails().getSecretsMap(),
-                    new TypeToken<Map<String, Object>>() {
-                    }.getType());
-        } else {
-            secretsMap = new HashMap<>();
-        }
+        this.secretsMap = secretsMap == null ? new HashMap<>() : secretsMap;
 
         this.metricsLabels = metricsLabels;
         String prefix;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/InstanceConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/InstanceConfig.java
@@ -49,6 +49,7 @@ public class InstanceConfig {
     private int metricsPort;
     private List<String> additionalJavaRuntimeArguments = Collections.emptyList();
     private boolean ignoreUnknownConfigFields;
+    private boolean mergeSecretsIntoConfigMap;
 
     /**
      * Get the string representation of {@link #getInstanceId()}.

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceStarter.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceStarter.java
@@ -158,6 +158,15 @@ public class JavaInstanceStarter implements AutoCloseable {
             required = false)
     public Boolean ignoreUnknownConfigFields = false;
 
+    @Parameter(names = "--merge_secrets_into_config_map", arity = 1,
+            description = "Whether to merge secrets into the connector's configuration. Only affects Sinks and Sources."
+                    + " When true, the SecretsProvider will materialize secrets from the connector's secrets argument"
+                    + " and then the resulting values will be put into the connector's configuration."
+                    + " In the event of a key collision, the sink or source configuration will take precedence."
+                    + " Secrets are merged into config map before unknown fields are filtered out when"
+                    + " ignoreUnknownConfigFields is true. Defaults to false.",
+            required = false)
+    public boolean mergeSecretsIntoConfigMap = false;
 
     private Server server;
     private RuntimeSpawner runtimeSpawner;
@@ -187,6 +196,7 @@ public class JavaInstanceStarter implements AutoCloseable {
         instanceConfig.setMaxPendingAsyncRequests(maxPendingAsyncRequests);
         instanceConfig.setExposePulsarAdminClientEnabled(exposePulsarAdminClientEnabled);
         instanceConfig.setIgnoreUnknownConfigFields(ignoreUnknownConfigFields);
+        instanceConfig.setMergeSecretsIntoConfigMap(mergeSecretsIntoConfigMap);
         Function.FunctionDetails.Builder functionDetailsBuilder = Function.FunctionDetails.newBuilder();
         if (functionDetailsJsonString.charAt(0) == '\'') {
             functionDetailsJsonString = functionDetailsJsonString.substring(1);

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -481,6 +481,9 @@ public class RuntimeUtils {
             if (instanceConfig.isIgnoreUnknownConfigFields()) {
                 args.add("--ignore_unknown_config_fields");
             }
+
+            args.add("--merge_secrets_into_config_map");
+            args.add(Boolean.toString(instanceConfig.isMergeSecretsIntoConfigMap()));
         }
 
         // state storage configs

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -749,6 +749,18 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
     )
     private boolean ignoreUnknownConfigFields = false;
 
+    @FieldContext(
+            category = CATEGORY_CONNECTORS,
+            doc = "Whether to merge secrets into the connector's configuration. Only affects Sinks and Sources."
+                    + " Applies to all connectors deployed by this function worker."
+                    + " When true, the SecretsProvider will materialize secrets from the connector's secrets argument"
+                    + " and then the resulting values will be put into the connector's configuration."
+                    + " In the event of a key collision, the sink or source configuration will take precedence."
+                    + " Secrets are merged into config map before unknown fields are filtered out when"
+                    + " ignoreUnknownConfigFields is true. Defaults to false."
+    )
+    private boolean mergeSecretsIntoConfigMap = false;
+
     public String getFunctionMetadataTopic() {
         return String.format("persistent://%s/%s", pulsarFunctionsNamespace, functionMetadataTopicName);
     }

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
@@ -441,14 +441,14 @@ public class KubernetesRuntimeTest {
         if (null != depsDir) {
             extraDepsEnv = " -Dpulsar.functions.extra.dependencies.dir=" + depsDir;
             classpath = classpath + ":" + depsDir + "/*";
-            totalArgs = 46;
+            totalArgs = 48;
             portArg = 33;
             metricsPortArg = 35;
         } else {
             extraDepsEnv = "";
             portArg = 32;
             metricsPortArg = 34;
-            totalArgs = 45;
+            totalArgs = 47;
         }
         if (secretsAttached) {
             totalArgs += 4;
@@ -493,6 +493,7 @@ public class KubernetesRuntimeTest {
                 + pulsarAdminArg
                 + " --max_buffered_tuples 1024 --port " + args.get(portArg) + " --metrics_port " + args.get(metricsPortArg)
                 + " --pending_async_requests 200"
+                + " --merge_secrets_into_config_map " + config.isMergeSecretsIntoConfigMap()
                 + " --state_storage_serviceurl " + stateStorageServiceUrl
                 + " --expected_healthcheck_interval -1";
         if (secretsAttached) {

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/process/ProcessRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/process/ProcessRuntimeTest.java
@@ -297,7 +297,7 @@ public class ProcessRuntimeTest {
         String extraDepsEnv;
         int portArg;
         int metricsPortArg;
-        int totalArgCount = 48;
+        int totalArgCount = 50;
         if (webServiceUrl != null && config.isExposePulsarAdminClientEnabled()) {
             totalArgCount += 3;
         }
@@ -341,6 +341,7 @@ public class ProcessRuntimeTest {
                 + pulsarAdminArg
                 + " --max_buffered_tuples 1024 --port " + args.get(portArg) + " --metrics_port " + args.get(metricsPortArg)
                 + " --pending_async_requests 200"
+                + " --merge_secrets_into_config_map " + config.isMergeSecretsIntoConfigMap()
                 + " --state_storage_serviceurl " + stateStorageServiceUrl
                 + " --expected_healthcheck_interval 30"
                 + " --secrets_provider org.apache.pulsar.functions.secretsprovider.ClearTextSecretsProvider"

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
@@ -222,6 +222,7 @@ public class FunctionActioner {
             instanceConfig.setAdditionalJavaRuntimeArguments(workerConfig.getAdditionalJavaRuntimeArguments());
         }
         instanceConfig.setIgnoreUnknownConfigFields(workerConfig.isIgnoreUnknownConfigFields());
+        instanceConfig.setMergeSecretsIntoConfigMap(workerConfig.isMergeSecretsIntoConfigMap());
         return instanceConfig;
     }
 


### PR DESCRIPTION
Fixes #20862 

### Motivation

See the issue for detailed motivation. Briefly, the current solution for configuring sinks and sources requires each sink and source to implement calls to materialize secrets using the `SecretsProvider`. Instead of relying on each connector to implement this feature, this PR introduces an option to pass the configuration into the sink and source `open` method call, so that the secrets are available without needing them to be passed in as plain text.

One major benefit of this solution is that it integrates with the existing functionality to pass in secrets.

In order to be backwards compatible, I followed the approach used by https://github.com/apache/pulsar/pull/20116 to add a configuration to the function worker that will apply to all sinks/sources created by the function worker.

Example for old configuration and new configuration:

```bash
 bin/pulsar-admin sinks create --input-specs "spec with secret"
```

```bash
bin/pulsar-admin sinks create --input-specs "spec without secret" --secrets "secret reference"
```

### Modifications

* Add the option to merge a connector's `secrets` map into the config map that is subsequently passed to the sink or source when calling `open`.
* Add a new configuration to the function worker (`mergeSecretsIntoConfigMap`) and an associated new parameter to the `JavaInstanceStarter` (`--merge_secrets_into_config_map`) to enable this feature. The default value keeps the current behavior.

### Verifying this change

This change added tests.

### Does this pull request potentially affect one of the following parts:

Adds a new configuration option. It is backwards compatible and defaults to use the old behavior.

### Documentation

- [x] `doc-required`

I'll need a PR to add docs for this feature.

### Matching PR in forked repository

PR in forked repository: https://github.com/michaeljmarshall/pulsar/pull/53