### PR TITLE
[improve][pip] PIP-286: Make the TopicCompactionService to support find entry based on publishTime or index

### DIFF
--- a/pip/pip-286.md
+++ b/pip/pip-286.md
@@ -2,39 +2,55 @@
 
 In https://github.com/apache/pulsar/pull/11139 we support get position based on timestamp, but it doesn't work well with topic compaction enabled because the data may have been move to the compacted ledger.
 
-In PIP-278 we introduced the pluggable topic compaction service to extend the compaction.
+In [PIP-278](https://github.com/apache/pulsar/pull/20624) we introduced the pluggable topic compaction service to extend the compaction.
 
 # Motivation
 
-In order for `get-message-id` to work well with topic compaction enabled we need to find the position according to publishTime from topic compaction service,
-but `TopicCompactionService` missing find positions method, so we should add it.
+In order for `get-message-id` to work well with topic compaction enabled we need to find the position according to publish time from topic compaction service,
+but `TopicCompactionService` missing a method that find positions according to publish time or other metadata, so we should add it.
 
-In addition, this method can also be used to find the position according to offset in the KoP.
+In addition, this method can also be used to find the position/offset according to offset/timestamp in the KoP.
 
 # Goals
 
 # High Level Design
 
+We need to add a method to `Topic Compaction Service` that can find the matching position and other metadata information according to a given condition.
+
 # Detailed Design
 
-Add `findNewestPosition` in the `TopicCompactionService` API.
+Add `RawEntryMetadata` interface.
+
+Add `findFirstEntryMetadata` in the `TopicCompactionService` API.
 
 Implement it in the `PulsarTopicCompactionService` using binary search.
 
-When get last messageId, find position from topicCompactionService if can't find position in the manageLedger.
+When get messageId by timestamp, find position from topicCompactionService if we can't find position in the manageLedger.
 
 ## Public-facing Changes
 
  ```java
+  /**
+   * Raw entry metadata object with position / messageMetadata / brokerEntryMetadata
+   */
+  public interface RawEntryMetadata {
+      PositionImpl getPosition();
+      
+      MessageMetadata getMessageMetadata();
+      
+      @javax.annotation.Nullable 
+      BrokerEntryMetadata getBrokerEntryMetadata();
+  }
+
   public interface TopicCompactionService extends AutoCloseable { 
+
    /**
-     * Find the newest Position that matches the given predicate.
-     *
-     * @param condition
-     *  predicate that reads an entry an applies a condition
-     * @return a future that will be completed with the result position, this position can be null.
-     */
-    CompletableFuture<Position> findNewestPosition(@Nonnull Predicate<Entry> condition);
+    * Find the first raw entry metadata that matches the given condition.
+    *
+    * @param condition  the condition to match.
+    * @return the first entry metadata that matches the given condition, this raw entry metadata can be null.
+    */
+    CompletableFuture<RawEntryMetadata> findFirstEntryMetadata(@Nonnull Predicate<RawEntryMetadata> condition);
   }
   ```
 

--- a/pip/pip-286.md
+++ b/pip/pip-286.md
@@ -39,7 +39,7 @@ When get messageId by timestamp, find position from topicCompactionService if we
     * Find the first entry that greater or equal to target publishTime.
     *
     * @param publishTime  the publish time of entry.
-    * @return the first entry metadata that matches the given publishTime, this entry can be null.
+    * @return the first entry that greater or equal to target publishTime, this entry can be null.
     */
     CompletableFuture<Entry> findEntryByPublishTime(long publishTime);
     
@@ -47,7 +47,7 @@ When get messageId by timestamp, find position from topicCompactionService if we
     * Find the first entry that greater or equal to target entryIndex.
     *
     * @param entryIndex  the index of entry.
-    * @return the first entry metadata that matches the given condition, this entry can be null.
+    * @return the first entry that greater or equal to target entryIndex, this entry can be null.
     */
     CompletableFuture<Entry> findEntryByEntryIndex(long entryIndex);
   }

--- a/pip/pip-286.md
+++ b/pip/pip-286.md
@@ -15,42 +15,39 @@ In addition, this method can also be used to find the position/offset according 
 
 # High Level Design
 
-We need to add a method to `Topic Compaction Service` that can find the matching position and other metadata information according to a given condition.
+We need to add a method to `Topic Compaction Service` that can find the matching position and other metadata information according to publishTime/index.
 
 # Detailed Design
 
-Add `RawEntryMetadata` interface.
+Add `findEntryByPublishTime` in the `TopicCompactionService` API.
 
-Add `findFirstEntryMetadata` in the `TopicCompactionService` API.
+Add `findEntryByEntryIndex` in the `TopicCompactionService` API.
 
-Implement it in the `PulsarTopicCompactionService` using binary search.
+Implement them in the `PulsarTopicCompactionService` using binary search.
 
 When get messageId by timestamp, find position from topicCompactionService if we can't find position in the manageLedger.
 
 ## Public-facing Changes
 
  ```java
-  /**
-   * Raw entry metadata object with position / messageMetadata / brokerEntryMetadata
-   */
-  public interface RawEntryMetadata {
-      PositionImpl getPosition();
-      
-      MessageMetadata getMessageMetadata();
-      
-      @javax.annotation.Nullable 
-      BrokerEntryMetadata getBrokerEntryMetadata();
-  }
 
   public interface TopicCompactionService extends AutoCloseable { 
 
    /**
-    * Find the first raw entry metadata that matches the given condition.
+    * Find the first entry that greater or equal to target publishTime.
     *
-    * @param condition  the condition to match.
-    * @return the first entry metadata that matches the given condition, this raw entry metadata can be null.
+    * @param publishTime  the publish time of entry.
+    * @return the first entry metadata that matches the given publishTime, this entry can be null.
     */
-    CompletableFuture<RawEntryMetadata> findFirstEntryMetadata(@Nonnull Predicate<RawEntryMetadata> condition);
+    CompletableFuture<Entry> findEntryByPublishTime(long publishTime);
+    
+    /**
+    * Find the first entry that greater or equal to target entryIndex.
+    *
+    * @param entryIndex  the index of entry.
+    * @return the first entry metadata that matches the given condition, this entry can be null.
+    */
+    CompletableFuture<Entry> findEntryByEntryIndex(long entryIndex);
   }
   ```
 

--- a/pip/pip-286.md
+++ b/pip/pip-286.md
@@ -15,7 +15,8 @@ In addition, this method can also be used to find the position/offset according 
 
 # High Level Design
 
-We need to add a method to `Topic Compaction Service` that can find the matching position and other metadata information according to publishTime/index.
+We need to add a method to `Topic Compaction Service` that can find the matching position and other metadata information according to publishTime/index,
+since the `TopicCompactionService` interface already has `@InterfaceStability.Evolving` annotation, so that we are able to add new methods directly. 
 
 # Detailed Design
 
@@ -30,7 +31,8 @@ When get messageId by timestamp, find position from topicCompactionService if we
 ## Public-facing Changes
 
  ```java
-
+  @InterfaceAudience.Public
+  @InterfaceStability.Evolving
   public interface TopicCompactionService extends AutoCloseable { 
 
    /**

--- a/pip/pip-286.md
+++ b/pip/pip-286.md
@@ -56,4 +56,4 @@ When get messageId by timestamp, find position from topicCompactionService if we
 # Links
 
 * Mailing List discussion thread: https://lists.apache.org/thread/85o3sx6rhohvc370j4r7yd2nb1tx736c
-* Mailing List voting thread: 
+* Mailing List voting thread: https://lists.apache.org/thread/q27zg49mpr8otwh29s3sncdcx8ly7ws6

--- a/pip/pip-286.md
+++ b/pip/pip-286.md
@@ -1,0 +1,44 @@
+# Background knowledge
+
+In https://github.com/apache/pulsar/pull/11139 we support get position based on timestamp, but it doesn't work well with topic compaction enabled because the data may have been move to the compacted ledger.
+
+In PIP-278 we introduced the pluggable topic compaction service to extend the compaction.
+
+# Motivation
+
+In order for `get-message-id` to work well with topic compaction enabled we need to find the position according to publishTime from topic compaction service,
+but `TopicCompactionService` missing find positions method, so we should add it.
+
+In addition, this method can also be used to find the position according to offset in the KoP.
+
+# Goals
+
+# High Level Design
+
+# Detailed Design
+
+Add `findNewestPosition` in the `TopicCompactionService` API.
+
+Implement it in the `PulsarTopicCompactionService` using binary search.
+
+When get last messageId, find position from topicCompactionService if can't find position in the manageLedger.
+
+## Public-facing Changes
+
+ ```java
+  public interface TopicCompactionService extends AutoCloseable { 
+   /**
+     * Find the newest Position that matches the given predicate.
+     *
+     * @param condition
+     *  predicate that reads an entry an applies a condition
+     * @return a future that will be completed with the result position, this position can be null.
+     */
+    CompletableFuture<Position> findNewestPosition(@Nonnull Predicate<Entry> condition);
+  }
+  ```
+
+# Links
+
+* Mailing List discussion thread: https://lists.apache.org/thread/85o3sx6rhohvc370j4r7yd2nb1tx736c
+* Mailing List voting thread: 


### PR DESCRIPTION

* Mailing List discussion thread: https://lists.apache.org/thread/85o3sx6rhohvc370j4r7yd2nb1tx736c
* Mailing List voting thread: https://lists.apache.org/thread/q27zg49mpr8otwh29s3sncdcx8ly7ws6

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
