### PR TITLE
[fix][build] Fix generating javadoc issue

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
@@ -190,12 +190,12 @@ public class ReaderConfigurationData<T> implements Serializable, Cloneable {
         }
     }
 
-    @SuppressFBWarnings({"EI_EXPOSE_REP2", "EI_EXPOSE_REP"})
+    @SuppressFBWarnings({"EI_EXPOSE_REP"})
     public MessageCrypto getMessageCrypto() {
         return messageCrypto;
     }
 
-    @SuppressFBWarnings({"EI_EXPOSE_REP"})
+    @SuppressFBWarnings({"EI_EXPOSE_REP2"})
     public void setMessageCrypto(MessageCrypto messageCrypto) {
         this.messageCrypto = messageCrypto;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
@@ -190,7 +190,7 @@ public class ReaderConfigurationData<T> implements Serializable, Cloneable {
         }
     }
 
-    @SuppressFBWarnings({"EI_EXPOSE_REP2"})
+    @SuppressFBWarnings({"EI_EXPOSE_REP2", "EI_EXPOSE_REP"})
     public MessageCrypto getMessageCrypto() {
         return messageCrypto;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
@@ -27,8 +27,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
 import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.MessageCrypto;
@@ -118,8 +116,6 @@ public class ReaderConfigurationData<T> implements Serializable, Cloneable {
     private ConsumerCryptoFailureAction cryptoFailureAction = ConsumerCryptoFailureAction.FAIL;
 
     @JsonIgnore
-    @Setter(onMethod_ = @SuppressFBWarnings({"EI_EXPOSE_REP2"}))
-    @Getter(onMethod_ = @SuppressFBWarnings({"EI_EXPOSE_REP"}))
     private transient MessageCrypto messageCrypto = null;
 
     @ApiModelProperty(
@@ -192,5 +188,15 @@ public class ReaderConfigurationData<T> implements Serializable, Cloneable {
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException("Failed to clone ReaderConfigurationData");
         }
+    }
+
+    @SuppressFBWarnings({"EI_EXPOSE_REP2"})
+    public MessageCrypto getMessageCrypto() {
+        return messageCrypto;
+    }
+
+    @SuppressFBWarnings({"EI_EXPOSE_REP"})
+    public void setMessageCrypto(MessageCrypto messageCrypto) {
+        this.messageCrypto = messageCrypto;
     }
 }


### PR DESCRIPTION
### Motivation
When releasing 3.1.0, it occurs below error:
<img width="1361" alt="image" src="https://github.com/apache/pulsar/assets/6297296/aa7d294d-4d2e-4706-92ac-4fdd3cde4a46">



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

