### PR TITLE
[fix][txn]Remove subscription after transaction pending ack init failed.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
@@ -49,6 +49,7 @@ import org.apache.pulsar.broker.service.BrokerServiceException.NotAllowedExcepti
 import org.apache.pulsar.broker.service.BrokerServiceException.ServiceUnitNotReadyException;
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.transaction.pendingack.PendingAckHandle;
 import org.apache.pulsar.broker.transaction.pendingack.PendingAckHandleStats;
 import org.apache.pulsar.broker.transaction.pendingack.PendingAckStore;
@@ -946,7 +947,9 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
 
     public void exceptionHandleFuture(Throwable t) {
         final boolean completedNow = this.pendingAckHandleCompletableFuture.completeExceptionally(t);
-        persistentSubscription.getTopic().getSubscriptions().remove(subName);
+        log.error("[{}][{}] Failed to init transaction pending ack handler",
+                persistentSubscription.getTopic().getName(), subName, t);
+        ((PersistentTopic)persistentSubscription.getTopic()).unloadSubscription(subName);
         if (completedNow) {
             recoverTime.setRecoverEndTime(System.currentTimeMillis());
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
@@ -946,6 +946,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
 
     public void exceptionHandleFuture(Throwable t) {
         final boolean completedNow = this.pendingAckHandleCompletableFuture.completeExceptionally(t);
+        persistentSubscription.getTopic().getSubscriptions().remove(subName);
         if (completedNow) {
             recoverTime.setRecoverEndTime(System.currentTimeMillis());
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckPersistentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckPersistentTest.java
@@ -21,7 +21,9 @@ package org.apache.pulsar.broker.transaction.pendingack;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
@@ -44,6 +46,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.collections4.map.LinkedMap;
+import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.AbstractTopic;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.BrokerServiceException;
@@ -97,6 +100,42 @@ public class PendingAckPersistentTest extends TransactionTestBase {
     @AfterMethod(alwaysRun = true)
     protected void cleanup() {
         super.internalCleanup();
+    }
+
+    @Test
+    public void testUnloadSubscriptionWhenFailedInitPendingAck() throws Exception {
+        String topic = NAMESPACE1 + "/testUnloadSubscriptionWhenFailedInitPendingAck";
+        Consumer<byte[]> consumer1 = pulsarClient.newConsumer()
+                .subscriptionName("subName1")
+                .topic(topic)
+                .subscribe();
+        // Fail at transactionPendingAckStoreProvider::checkInitializedBefore.
+        Field transactionPendingAckStoreProviderField = PulsarService.class
+                .getDeclaredField("transactionPendingAckStoreProvider");
+        transactionPendingAckStoreProviderField.setAccessible(true);
+        TransactionPendingAckStoreProvider pendingAckStoreProvider =
+                (TransactionPendingAckStoreProvider) transactionPendingAckStoreProviderField
+                        .get(pulsarServiceList.get(0));
+        TransactionPendingAckStoreProvider mockProvider = mock(pendingAckStoreProvider.getClass());
+        when(mockProvider.checkInitializedBefore(any())).thenReturn(FutureUtil.failedFuture(new Exception()));
+        transactionPendingAckStoreProviderField.set(pulsarServiceList.get(0), mockProvider);
+        try {
+            Awaitility.await().atMost(1, TimeUnit.SECONDS).until(() -> {
+                pulsarClient.newConsumer()
+                        .subscriptionName("subName2")
+                        .topic(topic)
+                        .subscribe();
+                return true;
+            });
+            fail();
+        } catch (Exception e) {
+        }
+        // Correct the transactionPendingAckStoreProvider::checkInitializedBefore.
+        when(mockProvider.checkInitializedBefore(any())).thenReturn(CompletableFuture.completedFuture(false));
+        pulsarClient.newConsumer()
+                .subscriptionName("subName2")
+                .topic(topic)
+                .subscribe();
     }
 
     @Test


### PR DESCRIPTION
### Motivation
During the process of creating a subscription, when checking if the transaction pending has been initialized using `return store.exists(PREFIX + path);`, a connection failure error occurred while connecting to ZooKeeper. However, the created subscription continues to exist in the PersistentTopic, which causes subsequent retries to keep using the same subscription. 
### Modification
Remove the subscription, if its PendingAckHandle init failed.


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
