### PR TITLE
[improve] Add bookkeeper DirectIO conf

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -634,6 +634,32 @@ diskUsageThreshold=0.95
 # Default is 10000
 diskCheckInterval=10000
 
+#############################################################################
+## DirectIO entry logger configuration
+#############################################################################
+# DirectIO entry logger only support DbLedgerStorage
+
+# Enable/Disable directIO entry logger.
+dbStorage_directIOEntryLogger=false
+
+# Total write buffer size in megabytes for all the entry directories.
+# The write buffer size of each entry directory needs to be divided by the number of entry directories.
+# By default it will be allocated to 12.5% of the available direct memory.
+dbStorage_directIOEntryLoggerTotalWriteBufferSizeMB=
+
+# Total read buffer size in megabytes for all the entry directories.
+# The read buffer size of each entry directory needs to be divided by the number of entry directories.
+# By default it will be allocated to 12.5% of the available direct memory.
+dbStorage_directIOEntryLoggerTotalReadBufferSizeMB=
+
+# The buffer size, in megabytes, for each direct reader to read data from the entry log file.
+# An entry log file will have only one direct reader.
+# By default it will be set to 8MB
+dbStorage_directIOEntryLoggerReadBufferSizeMB=8
+
+# Maximum cache time after a direct reader is accessed.
+dbStorage_directIOEntryLoggerMaxFdCacheTimeSeconds=300
+
 
 ############################################## Metadata Services ##############################################
 


### PR DESCRIPTION
### Motivation

Make the bookeeper DirectIO parameter active.
it is unable to write to the bookkeeper.conf configuration file When we want to enable the DirectIO using helm

### Modifications

add DirectIO entry logger configuration

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [x] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
