### PR TITLE
[fix] [log] fix the vague response if topic not found

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TransactionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TransactionsBase.java
@@ -501,11 +501,13 @@ public abstract class TransactionsBase extends AdminResource {
             CompletableFuture<Optional<Topic>> topicFuture = pulsar().getBrokerService()
                     .getTopics().get(topicName.toString());
             if (topicFuture == null) {
-                return FutureUtil.failedFuture(new RestException(NOT_FOUND, "Topic not found"));
+                return FutureUtil.failedFuture(new RestException(NOT_FOUND,
+                        String.format("Topic not found %s", topicName)));
             }
             return topicFuture.thenCompose(optionalTopic -> {
                 if (!optionalTopic.isPresent()) {
-                    return FutureUtil.failedFuture(new RestException(NOT_FOUND, "Topic not found"));
+                    return FutureUtil.failedFuture(new RestException(NOT_FOUND,
+                            String.format("Topic not found %s", topicName)));
                 }
                 return CompletableFuture.completedFuture((PersistentTopic) optionalTopic.get());
             });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TransactionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TransactionsBase.java
@@ -502,12 +502,12 @@ public abstract class TransactionsBase extends AdminResource {
                     .getTopics().get(topicName.toString());
             if (topicFuture == null) {
                 return FutureUtil.failedFuture(new RestException(NOT_FOUND,
-                        String.format("Topic not found %s", topicName)));
+                        String.format("Topic not found %s", topicName.toString())));
             }
             return topicFuture.thenCompose(optionalTopic -> {
                 if (!optionalTopic.isPresent()) {
                     return FutureUtil.failedFuture(new RestException(NOT_FOUND,
-                            String.format("Topic not found %s", topicName)));
+                            String.format("Topic not found %s", topicName.toString())));
                 }
                 return CompletableFuture.completedFuture((PersistentTopic) optionalTopic.get());
             });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/NonPersistentTopics.java
@@ -284,12 +284,12 @@ public class NonPersistentTopics extends PersistentTopics {
         }
     }
 
-    private Topic getTopicReference(TopicName topicName) {
+    private Topic getTopicReference(final TopicName topicName) {
         try {
             return pulsar().getBrokerService().getTopicIfExists(topicName.toString())
                     .get(config().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS)
                     .orElseThrow(() -> new RestException(Status.NOT_FOUND,
-                            String.format("Topic not found %s", topicName)));
+                            String.format("Topic not found %s", topicName.toString())));
         } catch (ExecutionException e) {
             throw new RuntimeException(e.getCause());
         } catch (InterruptedException | TimeoutException e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/NonPersistentTopics.java
@@ -288,7 +288,8 @@ public class NonPersistentTopics extends PersistentTopics {
         try {
             return pulsar().getBrokerService().getTopicIfExists(topicName.toString())
                     .get(config().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS)
-                    .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Topic not found"));
+                    .orElseThrow(() -> new RestException(Status.NOT_FOUND,
+                            String.format("Topic not found %s", topicName)));
         } catch (ExecutionException e) {
             throw new RuntimeException(e.getCause());
         } catch (InterruptedException | TimeoutException e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
@@ -233,7 +233,8 @@ public class NonPersistentTopics extends PersistentTopics {
             getPartitionedTopicMetadataAsync(topicName,
                     authoritative, false).thenAccept(partitionMetadata -> {
                 if (partitionMetadata.partitions == 0) {
-                    asyncResponse.resume(new RestException(Status.NOT_FOUND, "Partitioned Topic not found"));
+                    asyncResponse.resume(new RestException(Status.NOT_FOUND,
+                            String.format("Partitioned topic not found %s", topicName)));
                     return;
                 }
                 NonPersistentPartitionedTopicStatsImpl stats =

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
@@ -234,7 +234,7 @@ public class NonPersistentTopics extends PersistentTopics {
                     authoritative, false).thenAccept(partitionMetadata -> {
                 if (partitionMetadata.partitions == 0) {
                     asyncResponse.resume(new RestException(Status.NOT_FOUND,
-                            String.format("Partitioned topic not found %s", topicName)));
+                            String.format("Partitioned topic not found %s", topicName.toString())));
                     return;
                 }
                 NonPersistentPartitionedTopicStatsImpl stats =

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -56,7 +56,7 @@ public class TopicLookupBase extends PulsarWebResource {
     private static final String LOOKUP_PATH_V1 = "/lookup/v2/destination/";
     private static final String LOOKUP_PATH_V2 = "/lookup/v2/topic/";
 
-    protected CompletableFuture<LookupData> internalLookupTopicAsync(TopicName topicName, boolean authoritative,
+    protected CompletableFuture<LookupData> internalLookupTopicAsync(final TopicName topicName, boolean authoritative,
                                                                      String listenerName) {
         if (!pulsar().getBrokerService().getLookupRequestSemaphore().tryAcquire()) {
             log.warn("No broker was found available for topic {}", topicName);
@@ -79,7 +79,8 @@ public class TopicLookupBase extends PulsarWebResource {
                 })
                 .thenCompose(exist -> {
                     if (!exist) {
-                        throw new RestException(Response.Status.NOT_FOUND, "Topic not found.");
+                        throw new RestException(Response.Status.NOT_FOUND,
+                                String.format("Topic not found %s", topicName));
                     }
                     CompletableFuture<Optional<LookupResult>> lookupFuture = pulsar().getNamespaceService()
                             .getBrokerServiceUrlAsync(topicName,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -80,7 +80,7 @@ public class TopicLookupBase extends PulsarWebResource {
                 .thenCompose(exist -> {
                     if (!exist) {
                         throw new RestException(Response.Status.NOT_FOUND,
-                                String.format("Topic not found %s", topicName));
+                                String.format("Topic not found %s", topicName.toString()));
                     }
                     CompletableFuture<Optional<LookupResult>> lookupFuture = pulsar().getNamespaceService()
                             .getBrokerServiceUrlAsync(topicName,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1607,7 +1607,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
                 // Do not print stack traces for expected exceptions
                 if (cause instanceof NoSuchElementException) {
-                    cause = new TopicNotFoundException(String.format("Topic not found %s", topicName));
+                    cause = new TopicNotFoundException(String.format("Topic not found %s", topicName.toString()));
                     log.warn("[{}] Failed to load topic {}, producerId={}: Topic not found", remoteAddress, topicName,
                             producerId);
                 } else if (!Exceptions.areExceptionsPresentInChain(cause,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1398,7 +1398,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 cmdProducer.hasInitialSubscriptionName() ? cmdProducer.getInitialSubscriptionName() : null;
         final boolean supportsPartialProducer = supportsPartialProducer();
 
-        TopicName topicName = validateTopicName(cmdProducer.getTopic(), requestId, cmdProducer);
+        final TopicName topicName = validateTopicName(cmdProducer.getTopic(), requestId, cmdProducer);
         if (topicName == null) {
             return;
         }
@@ -1607,7 +1607,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
                 // Do not print stack traces for expected exceptions
                 if (cause instanceof NoSuchElementException) {
-                    cause = new TopicNotFoundException("Topic Not Found.");
+                    cause = new TopicNotFoundException(String.format("Topic not found %s", topicName));
                     log.warn("[{}] Failed to load topic {}, producerId={}: Topic not found", remoteAddress, topicName,
                             producerId);
                 } else if (!Exceptions.areExceptionsPresentInChain(cause,
@@ -2439,7 +2439,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         schemaService.getSchema(schemaName, schemaVersion).thenAccept(schemaAndMetadata -> {
             if (schemaAndMetadata == null) {
                 commandSender.sendGetSchemaErrorResponse(requestId, ServerError.TopicNotFound,
-                        "Topic not found or no-schema");
+                        String.format("Topic not found or no-schema %s", commandGetSchema.getTopic()));
             } else {
                 commandSender.sendGetSchemaResponse(requestId,
                         SchemaInfoUtil.newSchemaInfo(schemaName, schemaAndMetadata.schema), schemaAndMetadata.version);
@@ -2457,7 +2457,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             log.debug("Received CommandGetOrCreateSchema call from {}", remoteAddress);
         }
         long requestId = commandGetOrCreateSchema.getRequestId();
-        String topicName = commandGetOrCreateSchema.getTopic();
+        final String topicName = commandGetOrCreateSchema.getTopic();
         SchemaData schemaData = getSchema(commandGetOrCreateSchema.getSchema());
         SchemaData schema = schemaData.getType() == SchemaType.NONE ? null : schemaData;
         service.getTopicIfExists(topicName).thenAccept(topicOpt -> {
@@ -2477,7 +2477,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 });
             } else {
                 commandSender.sendGetOrCreateSchemaErrorResponse(requestId, ServerError.TopicNotFound,
-                        "Topic not found");
+                        String.format("Topic not found %s", topicName));
             }
         }).exceptionally(ex -> {
             ServerError errorCode = BrokerServiceException.getClientErrorCode(ex);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiGetLastMessageIdTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiGetLastMessageIdTest.java
@@ -168,7 +168,7 @@ public class AdminApiGetLastMessageIdTest extends MockedPulsarServiceBaseTest {
                     testNamespace, "my-topic", true);
         } catch (Exception e) {
             //System.out.println(e.getMessage());
-            Assert.assertEquals("Topic not found", e.getMessage());
+            Assert.assertTrue(e.getMessage().contains("Topic not found"));
         }
 
         String key = "legendtkl";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -77,6 +77,7 @@ import org.apache.pulsar.common.stats.PositionInPendingAckStats;
 import org.apache.pulsar.packages.management.core.MockedPackagesStorageProvider;
 import org.apache.pulsar.transaction.coordinator.impl.MLTransactionLogImpl;
 import org.awaitility.Awaitility;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -163,7 +164,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            assertEquals(cause.getMessage(), "Topic not found");
+            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
         }
         try {
             pulsar.getBrokerService().getTopic(topic, false);
@@ -173,7 +174,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            assertEquals(cause.getMessage(), "Topic not found");
+            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
         }
         admin.topics().createNonPartitionedTopic(topic);
         Producer<byte[]> producer = pulsarClient.newProducer(Schema.BYTES).topic(topic).sendTimeout(0, TimeUnit.SECONDS).create();
@@ -208,7 +209,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            assertEquals(cause.getMessage(), "Topic not found");
+            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
         }
         try {
             pulsar.getBrokerService().getTopic(topic, false);
@@ -219,7 +220,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            assertEquals(cause.getMessage(), "Topic not found");
+            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
         }
         admin.topics().createNonPartitionedTopic(topic);
         Producer<byte[]> producer = pulsarClient.newProducer(Schema.BYTES).topic(topic).create();
@@ -334,7 +335,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            assertEquals(cause.getMessage(), "Topic not found");
+            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
         }
         try {
             pulsar.getBrokerService().getTopic(topic, false);
@@ -344,7 +345,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            assertEquals(cause.getMessage(), "Topic not found");
+            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
         }
         admin.topics().createNonPartitionedTopic(topic);
         Producer<byte[]> producer = pulsarClient.newProducer(Schema.BYTES)
@@ -392,7 +393,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            assertEquals(cause.getMessage(), "Topic not found");
+            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
         }
         try {
             pulsar.getBrokerService().getTopic(topic, false);
@@ -402,7 +403,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            assertEquals(cause.getMessage(), "Topic not found");
+            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
         }
         admin.topics().createNonPartitionedTopic(topic);
 
@@ -541,7 +542,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            assertEquals(cause.getMessage(), "Topic not found");
+            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
         }
         try {
             pulsar.getBrokerService().getTopic(topic, false);
@@ -551,7 +552,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            assertEquals(cause.getMessage(), "Topic not found");
+            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
         }
         admin.topics().createNonPartitionedTopic(topic);
         Producer<byte[]> producer = pulsarClient.newProducer(Schema.BYTES).topic(topic).create();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -164,7 +164,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
+            assertTrue(cause.getMessage().contains("Topic not found"));
         }
         try {
             pulsar.getBrokerService().getTopic(topic, false);
@@ -174,7 +174,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
+            assertTrue(cause.getMessage().contains("Topic not found"));
         }
         admin.topics().createNonPartitionedTopic(topic);
         Producer<byte[]> producer = pulsarClient.newProducer(Schema.BYTES).topic(topic).sendTimeout(0, TimeUnit.SECONDS).create();
@@ -209,7 +209,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
+            assertTrue(cause.getMessage().contains("Topic not found"));
         }
         try {
             pulsar.getBrokerService().getTopic(topic, false);
@@ -220,7 +220,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
+            assertTrue(cause.getMessage().contains("Topic not found"));
         }
         admin.topics().createNonPartitionedTopic(topic);
         Producer<byte[]> producer = pulsarClient.newProducer(Schema.BYTES).topic(topic).create();
@@ -335,7 +335,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
+            assertTrue(cause.getMessage().contains("Topic not found"));
         }
         try {
             pulsar.getBrokerService().getTopic(topic, false);
@@ -345,7 +345,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
+            assertTrue(cause.getMessage().contains("Topic not found"));
         }
         admin.topics().createNonPartitionedTopic(topic);
         Producer<byte[]> producer = pulsarClient.newProducer(Schema.BYTES)
@@ -393,7 +393,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
+            assertTrue(cause.getMessage().contains("Topic not found"));
         }
         try {
             pulsar.getBrokerService().getTopic(topic, false);
@@ -403,7 +403,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
+            assertTrue(cause.getMessage().contains("Topic not found"));
         }
         admin.topics().createNonPartitionedTopic(topic);
 
@@ -542,7 +542,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
+            assertTrue(cause.getMessage().contains("Topic not found"));
         }
         try {
             pulsar.getBrokerService().getTopic(topic, false);
@@ -552,7 +552,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof PulsarAdminException.NotFoundException);
             PulsarAdminException.NotFoundException cause = (PulsarAdminException.NotFoundException)ex.getCause();
-            Assert.assertTrue(cause.getMessage().contains("Topic not found"));
+            assertTrue(cause.getMessage().contains("Topic not found"));
         }
         admin.topics().createNonPartitionedTopic(topic);
         Producer<byte[]> producer = pulsarClient.newProducer(Schema.BYTES).topic(topic).create();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -77,7 +77,6 @@ import org.apache.pulsar.common.stats.PositionInPendingAckStats;
 import org.apache.pulsar.packages.management.core.MockedPackagesStorageProvider;
 import org.apache.pulsar.transaction.coordinator.impl.MLTransactionLogImpl;
 import org.awaitility.Awaitility;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerDisallowAutoCreateTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerDisallowAutoCreateTopicTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import static org.apache.pulsar.client.util.RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker-api")
+public class SimpleProducerConsumerDisallowAutoCreateTopicTest extends ProducerConsumerBase {
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Override
+    protected void doInitConf() throws Exception {
+        super.doInitConf();
+        conf.setAllowAutoTopicCreation(false);
+    }
+
+    @Test
+    public void testClearErrorIfRetryTopicNotExists() throws Exception {
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://public/default/tp_");
+        final String subName = "sub";
+        final String retryTopicName = topicName + "-" + subName + RETRY_GROUP_TOPIC_SUFFIX;
+        admin.topics().createNonPartitionedTopic(topicName);
+        Consumer consumer = null;
+        try {
+            consumer = pulsarClient.newConsumer()
+                    .topic(topicName)
+                    .subscriptionName(subName)
+                    .enableRetry(true)
+                    .subscribe();
+            fail("");
+        } catch (Exception ex) {
+            log.info("got an expected error", ex);
+            assertTrue(ex.getMessage().contains("Not found:"));
+            assertTrue(ex.getMessage().contains(retryTopicName));
+        } finally {
+            // cleanup.
+            if (consumer != null) {
+                consumer.close();
+            }
+            admin.topics().delete(topicName);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

When I did this test below and got the error "Topic not found".

```java
pulsarAdmin.topics().createNonPartitionedTopic("persistent://public/default/tp_1");
Consumer consumer = null;
Consumer consumer = pulsarClient.newConsumer()
          .topic("persistent://public/default/tp_1")
          .subscriptionName("s1")
          .enableRetry(true)
          .subscribe();
```

I do create the topic `persistent://public/default/tp_1` first but got a response "Topic not found", it is confusing. 

The root cause is the retry letter topic `persistent://public/default/tp_1-sub1-RETRY` was not created. 

### Modifications

clear the vague response if the topic is not founded.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
