### PR TITLE
[improve][bk] Improve getIsolationGroup by avoid creating arrayList

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicy.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicy.java
@@ -19,8 +19,8 @@
 package org.apache.pulsar.bookie.rackawareness;
 
 import static org.apache.pulsar.bookie.rackawareness.BookieRackAffinityMapping.METADATA_STORE_INSTANCE;
+import com.google.common.collect.Sets;
 import io.netty.util.HashedWheelTimer;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -166,12 +166,12 @@ public class IsolatedBookieEnsemblePlacementPolicy extends RackawareEnsemblePlac
             String secondaryIsolationGroupString = ConfigurationStringUtil
                     .castToString(properties.getOrDefault(SECONDARY_ISOLATION_BOOKIE_GROUPS, ""));
             if (!primaryIsolationGroupString.isEmpty()) {
-                pair.setLeft(new HashSet<>(Arrays.asList(primaryIsolationGroupString.split(","))));
+                pair.setLeft(Sets.newHashSet(primaryIsolationGroupString.split(",")));
             } else {
                 pair.setLeft(Collections.emptySet());
             }
             if (!secondaryIsolationGroupString.isEmpty()) {
-                pair.setRight(new HashSet<>(Arrays.asList(secondaryIsolationGroupString.split(","))));
+                pair.setRight(Sets.newHashSet(secondaryIsolationGroupString.split(",")));
             } else {
                 pair.setRight(Collections.emptySet());
             }


### PR DESCRIPTION
### Motivation

Minor improve `getIsolationGroup` by avoid creating arrayList. And it'  beneficial to GC

### Modifications

`new HashSet<>(Arrays.asList(...))` -> `Sets.newHashSet(...)`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/AnonHxy/pulsar/pull/43
