### PR TITLE
[fix][sql] Add SQL query checks for schema compatibility

### DIFF
--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarDispatchingRowDecoderFactory.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarDispatchingRowDecoderFactory.java
@@ -68,8 +68,17 @@ public class PulsarDispatchingRowDecoderFactory {
 
     public PulsarRowDecoder createRowDecoder(TopicName topicName, SchemaInfo schemaInfo,
                                              Set<DecoderColumnHandle> columns) {
+        PulsarRowDecoder rowDecoder;
         PulsarRowDecoderFactory rowDecoderFactory = createDecoderFactory(schemaInfo);
-        return rowDecoderFactory.createRowDecoder(topicName, schemaInfo, columns);
+        try {
+            rowDecoder = rowDecoderFactory.createRowDecoder(topicName, schemaInfo, columns);
+        } catch (Exception e){
+            log.error("Failed to create row decoder for topic:{} ", topicName, e);
+            rowDecoderFactory = new PulsarPrimitiveRowDecoderFactory();
+            schemaInfo = PulsarSqlSchemaInfoProvider.defaultSchema();
+            rowDecoder = rowDecoderFactory.createRowDecoder(topicName, schemaInfo, columns);
+        }
+        return rowDecoder;
     }
 
     public List<ColumnMetadata> extractColumnMetadata(TopicName topicName, SchemaInfo schemaInfo,

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarMetadata.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarMetadata.java
@@ -310,9 +310,18 @@ public class PulsarMetadata implements ConnectorMetadata {
                         + topicName + ": " + ExceptionUtils.getRootCause(e).getLocalizedMessage(), e);
             }
         }
-        List<ColumnMetadata> handles = getPulsarColumns(
-                topicName, schemaInfo, withInternalColumns, PulsarColumnHandle.HandleKeyValueType.NONE
-        );
+        List<ColumnMetadata> handles;
+        try {
+            handles = getPulsarColumns(
+                    topicName, schemaInfo, withInternalColumns, PulsarColumnHandle.HandleKeyValueType.NONE
+            );
+        } catch (Exception e){
+            log.error(e, "Failed to get pulsar columns");
+            schemaInfo = PulsarSqlSchemaInfoProvider.defaultSchema();
+            handles = getPulsarColumns(
+                    topicName, schemaInfo, withInternalColumns, PulsarColumnHandle.HandleKeyValueType.NONE
+            );
+        }
 
 
         return new ConnectorTableMetadata(schemaTableName, handles);

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarMetadata.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarMetadata.java
@@ -55,6 +55,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import org.apache.avro.AvroRuntimeException;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -315,7 +316,7 @@ public class PulsarMetadata implements ConnectorMetadata {
             handles = getPulsarColumns(
                     topicName, schemaInfo, withInternalColumns, PulsarColumnHandle.HandleKeyValueType.NONE
             );
-        } catch (Exception e){
+        } catch (AvroRuntimeException | UnsupportedOperationException e) {
             log.error(e, "Failed to get pulsar columns");
             schemaInfo = PulsarSqlSchemaInfoProvider.defaultSchema();
             handles = getPulsarColumns(


### PR DESCRIPTION


<!-- Either this PR fixes an issue, -->

Fixes #20945


<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

When the schema was incorrect, data can still be queried.

### Modifications

<!-- Describe the modifications you've done. -->
When parsing the Schema encounters exceptions, use defaultSchema to regenerate.

Here are two situations:

#### AvroRuntimeException

https://github.com/apache/pulsar/blob/2ab184e49a036a1dd10dc537bef4ab034a5ad5e0/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericSchemaImpl.java#L43-L46

When `schema` do not have `type` field, will get `AvroRuntimeException` in `schema.getFields()` method.

#### UnsupportedOperationException

When schema:
```
{
"name": "create",
"type": [
"null",
{
"type": "record",
"name": "Date",
"namespace": "java.util",
"fields": []
}
]
},
```
Will get `UnsupportedOperationException`

https://github.com/apache/pulsar/blob/2ab184e49a036a1dd10dc537bef4ab034a5ad5e0/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/decoder/json/PulsarJsonRowDecoderFactory.java#L167-L177


### Verifying this change

- [x] Make sure that the change passes the CI checks.



### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/crossoverJie/pulsar/pull/12

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
