### PR TITLE
[branch-2.11] [fix] [broker] fix multiple versions of bouncy-castle

### DIFF
--- a/bouncy-castle/bc/LICENSE
+++ b/bouncy-castle/bc/LICENSE
@@ -205,6 +205,6 @@
 This projects includes binary packages with the following licenses:
 Bouncy Castle License
  * Bouncy Castle -- licenses/LICENSE-bouncycastle.txt
-    - org.bouncycastle-bcpkix-jdk15on-1.60.jar
-    - org.bouncycastle-bcprov-jdk15on-1.60.jar
-    - org.bouncycastle-bcprov-ext-jdk15on-1.60.jar
+    - org.bouncycastle-bcpkix-jdk15on-1.69.jar
+    - org.bouncycastle-bcprov-jdk15on-1.69.jar
+    - org.bouncycastle-bcprov-ext-jdk15on-1.69.jar

--- a/pom.xml
+++ b/pom.xml
@@ -848,12 +848,24 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>com.yahoo.athenz</groupId>
         <artifactId>athenz-zts-java-client-core</artifactId>
         <version>${athenz.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
         <groupId>com.yahoo.athenz</groupId>
         <artifactId>athenz-zpe-java-client</artifactId>
         <version>${athenz.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -994,6 +1006,10 @@ flexible messaging model and an intuitive client API.</description>
           <exclusion>
             <groupId>com.squareup.okio</groupId>
             <artifactId>okio</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>*</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -1330,6 +1346,12 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-reflect</artifactId>
         <version>${scala-library.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.kubernetes</groupId>
+        <artifactId>client-java</artifactId>
+        <version>${kubernetesclient.version}</version>
       </dependency>
 
     </dependencies>

--- a/pulsar-functions/secrets/pom.xml
+++ b/pulsar-functions/secrets/pom.xml
@@ -35,20 +35,6 @@
       <groupId>io.kubernetes</groupId>
       <artifactId>client-java</artifactId>
       <version>${kubernetesclient.version}</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>bcpkix-jdk18on</artifactId>
-          <groupId>org.bouncycastle</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>bcutil-jdk18on</artifactId>
-          <groupId>org.bouncycastle</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>bcprov-jdk18on</artifactId>
-          <groupId>org.bouncycastle</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/pulsar-io/aerospike/pom.xml
+++ b/pulsar-io/aerospike/pom.xml
@@ -52,6 +52,12 @@
       <groupId>com.aerospike</groupId>
       <artifactId>aerospike-client-bc</artifactId>
       <version>${aerospike-client.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>

--- a/tiered-storage/file-system/pom.xml
+++ b/tiered-storage/file-system/pom.xml
@@ -114,6 +114,10 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>*</artifactId>
+              </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
### Motivation

There are multiple versions of bouncy-castle libraries.
<img width="480" alt="截屏2023-08-09 10 01 48" src="https://github.com/apache/pulsar/assets/25195800/c3528b48-0a43-411a-9a09-93188e3f0503">

```
[INFO] |  +- io.grpc:grpc-all:jar:1.45.1:compile
[INFO] |  |  +- io.grpc:grpc-api:jar:1.45.1:compile
[INFO] |  |  +- io.grpc:grpc-auth:jar:1.45.1:compile
[INFO] |  |  |  \- com.google.auth:google-auth-library-credentials:jar:1.4.0:compile
[INFO] |  |  +- io.grpc:grpc-context:jar:1.45.1:compile
[INFO] |  |  +- io.grpc:grpc-core:jar:1.45.1:compile
[INFO] |  |  |  +- com.google.code.gson:gson:jar:2.8.9:compile
[INFO] |  |  |  +- com.google.android:annotations:jar:4.1.1.4:runtime
[INFO] |  |  |  \- org.codehaus.mojo:animal-sniffer-annotations:jar:1.19:runtime
[INFO] |  |  +- io.grpc:grpc-grpclb:jar:1.45.1:compile
[INFO] |  |  |  \- com.google.protobuf:protobuf-java-util:jar:3.19.6:compile
[INFO] |  |  +- io.grpc:grpc-netty:jar:1.45.1:compile
[INFO] |  |  |  +- io.netty:netty-codec-http2:jar:4.1.93.Final:compile
[INFO] |  |  |  \- io.netty:netty-handler-proxy:jar:4.1.93.Final:compile
[INFO] |  |  +- io.grpc:grpc-protobuf:jar:1.45.1:compile
[INFO] |  |  |  +- com.google.api.grpc:proto-google-common-protos:jar:2.0.1:compile
[INFO] |  |  |  \- io.grpc:grpc-protobuf-lite:jar:1.45.1:compile
[INFO] |  |  +- io.grpc:grpc-rls:jar:1.45.1:compile
[INFO] |  |  |  \- com.google.auto.value:auto-value-annotations:jar:1.9:compile
[INFO] |  |  +- io.grpc:grpc-services:jar:1.45.1:compile
[INFO] |  |  +- io.grpc:grpc-stub:jar:1.45.1:compile
[INFO] |  |  \- io.grpc:grpc-xds:jar:1.45.1:compile
[INFO] |  |     +- io.grpc:grpc-alts:jar:1.45.1:compile
[INFO] |  |     +- com.google.re2j:re2j:jar:1.5:compile
[INFO] |  |     +- org.bouncycastle:bcpkix-jdk15on:jar:1.67:compile
[INFO] |  |     |  \- org.bouncycastle:bcprov-jdk15on:jar:1.67:compile
[INFO] |  +- org.apache.pulsar:pulsar-functions-worker:jar:2.11.2:test
[INFO] |  |  +- org.apache.pulsar:pulsar-functions-runtime:jar:2.11.2:test
[INFO] |  |  |  +- org.apache.pulsar:pulsar-functions-instance:jar:2.11.2:test
[INFO] |  |  |  |  +- org.apache.pulsar:pulsar-functions-utils:jar:2.11.2:test
[INFO] |  |  |  |  |  \- org.apache.pulsar:pulsar-config-validation:jar:2.11.2:test
[INFO] |  |  |  |  +- org.apache.pulsar:pulsar-client-messagecrypto-bc:jar:2.11.2:test
[INFO] |  |  |  |  +- io.grpc:grpc-all:jar:1.45.1:test
[INFO] |  |  |  |  +- net.jodah:typetools:jar:0.5.0:test
[INFO] |  |  |  |  +- io.prometheus:simpleclient_httpserver:jar:0.16.0:test
[INFO] |  |  |  |  \- io.prometheus.jmx:collector:jar:0.16.1:test
[INFO] |  |  |  +- org.apache.pulsar:pulsar-functions-secrets:jar:2.11.2:test
[INFO] |  |  |  |  \- org.apache.pulsar:pulsar-functions-proto:jar:2.11.2:test
[INFO] |  |  |  \- io.kubernetes:client-java:jar:18.0.0:test
[INFO] |  |  |     +- io.kubernetes:client-java-api:jar:18.0.0:test
[INFO] |  |  |     |  +- com.squareup.okhttp3:okhttp:jar:4.9.3:test
[INFO] |  |  |     |  |  +- com.squareup.okio:okio:jar:2.8.0:test
[INFO] |  |  |     |  |  |  \- org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.8.20:test
[INFO] |  |  |     |  |  \- org.jetbrains.kotlin:kotlin-stdlib:jar:1.8.20:test
[INFO] |  |  |     |  |     \- org.jetbrains:annotations:jar:13.0:test
[INFO] |  |  |     |  +- com.squareup.okhttp3:logging-interceptor:jar:4.9.3:test
[INFO] |  |  |     |  |  \- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.8.20:test
[INFO] |  |  |     |  |     \- org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.8.20:test
[INFO] |  |  |     |  \- io.gsonfire:gson-fire:jar:1.8.5:test
[INFO] |  |  |     +- io.kubernetes:client-java-proto:jar:18.0.0:test
[INFO] |  |  |     +- org.bouncycastle:bcpkix-jdk18on:jar:1.72:test
[INFO] |  |  |     |  +- org.bouncycastle:bcprov-jdk18on:jar:1.72:test
```

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

fix multiple versions of bouncy-castle libraries

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x