### PR TITLE
[improve][client] Add jitter redelivery backoff composition

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/JitterRedeliveryBackoff.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/JitterRedeliveryBackoff.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import org.apache.pulsar.client.api.RedeliveryBackoff;
+
+import java.util.concurrent.ThreadLocalRandom;
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class JitterRedeliveryBackoff implements RedeliveryBackoff {
+
+    private final MultiplierRedeliveryBackoff multiplierBackoff;
+    private final double jitterFactor;
+
+    public JitterRedeliveryBackoff(
+            MultiplierRedeliveryBackoff multiplierBackoff,
+            double jitterFactor
+    ) {
+        this.multiplierBackoff = multiplierBackoff;
+        this.jitterFactor = jitterFactor;
+    }
+
+    public static JitterRedeliveryBackoff.JitterRedeliveryBackoffBuilder builder() {
+        return new JitterRedeliveryBackoff.JitterRedeliveryBackoffBuilder();
+    }
+
+    @Override
+    public long next(int redeliveryCount) {
+        long nextBackoff = multiplierBackoff.next(redeliveryCount);
+
+        long jitterOffset = Math.round((nextBackoff * jitterFactor));
+        long lowBound = Math.max(multiplierBackoff.getMinDelayMs() - nextBackoff, -jitterOffset);
+        long highBound = Math.min(multiplierBackoff.getMaxDelayMs() - nextBackoff, jitterOffset);
+
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        long jitter;
+        if (highBound == lowBound) {
+            if (highBound == 0) jitter = 0;
+            else jitter = random.nextLong(highBound);
+        } else {
+            jitter = random.nextLong(lowBound, highBound);
+        }
+
+        return nextBackoff + jitter;
+    }
+
+    public static class JitterRedeliveryBackoffBuilder {
+
+        private MultiplierRedeliveryBackoff multiplierBackoff;
+        private double jitterFactor = 0.5D;
+
+        public JitterRedeliveryBackoff.JitterRedeliveryBackoffBuilder multiplierBackoff(
+                MultiplierRedeliveryBackoff multiplierBackoff
+        ) {
+            this.multiplierBackoff = multiplierBackoff;
+            return this;
+        }
+
+        /**
+         * Set a jitter factor for exponential backoffs that adds randomness to each backoff. This can
+         * be helpful in reducing cascading failure due to retry-storms. This method switches to an
+         * exponential backoff strategy with a zero minimum backoff if not already a backoff strategy.
+         * Defaults to {@code 0.5} (a jitter of at most 50% of the computed delay).
+         *
+         * @param jitterFactor the new jitter factor as a {@code double} between {@code 0d} and {@code 1d}
+         */
+        public JitterRedeliveryBackoff.JitterRedeliveryBackoffBuilder jitter(double jitterFactor) {
+            this.jitterFactor = jitterFactor;
+            return this;
+        }
+
+        public JitterRedeliveryBackoff build() {
+            checkArgument(jitterFactor > 0 || jitterFactor < 1, "jitterFactor must be between 0 and 1 (default 0.5)");
+            return new JitterRedeliveryBackoff(this.multiplierBackoff, this.jitterFactor);
+        }
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiplierRedeliveryBackoff.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiplierRedeliveryBackoff.java
@@ -42,6 +42,14 @@ public class MultiplierRedeliveryBackoff implements RedeliveryBackoff {
         return new MultiplierRedeliveryBackoff.MultiplierRedeliveryBackoffBuilder();
     }
 
+    public long getMinDelayMs() {
+        return this.minDelayMs;
+    }
+
+    public long getMaxDelayMs() {
+        return this.maxDelayMs;
+    }
+
     @Override
     public long next(int redeliveryCount) {
         if (redeliveryCount <= 0 || minDelayMs <= 0) {
@@ -57,8 +65,8 @@ public class MultiplierRedeliveryBackoff implements RedeliveryBackoff {
      * Builder of MultiplierRedeliveryBackoff.
      */
     public static class MultiplierRedeliveryBackoffBuilder {
-        private long minDelayMs = 1000 * 10;
-        private long maxDelayMs = 1000 * 60 * 10;
+        private long minDelayMs = 10_000;
+        private long maxDelayMs = 600_000;
         private double multiplier = 2.0;
 
         public MultiplierRedeliveryBackoffBuilder minDelayMs(long minDelayMs) {


### PR DESCRIPTION
<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation
This can be helpful in reducing cascading failure due to retry-storms. This method switches to an exponential backoff strategy with a zero minimum backoff if not already a backoff strategy.

### Modifications

Added new implementation of RedeliveryBackoff 

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

### Documentation
- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
