### PR TITLE
[fix][sec] Upgrade org.bouncycastle:bc-fips to 1.0.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@ flexible messaging model and an intuitive client API.</description>
     <log4j2.version>2.18.0</log4j2.version>
     <bouncycastle.version>1.75</bouncycastle.version>
     <bouncycastle.bcpkix-fips.version>1.0.6</bouncycastle.bcpkix-fips.version>
-    <bouncycastle.bc-fips.version>1.0.2.3</bouncycastle.bc-fips.version>
+    <bouncycastle.bc-fips.version>1.0.2.4</bouncycastle.bc-fips.version>
     <jackson.version>2.14.2</jackson.version>
     <reflections.version>0.10.2</reflections.version>
     <swagger.version>1.6.2</swagger.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.bouncycastle:bc-fips 1.0.2.3
- [CVE-2022-45146](https://www.oscs1024.com/hd/CVE-2022-45146)


### What did I do？
Upgrade org.bouncycastle:bc-fips from 1.0.2.3 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS