### PR TITLE
[improve] [broker] Follower do not need to retrieve load data in zk.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -857,8 +857,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
             log.info("LoadData is old, need to update loadData before make decision");
             updateAll();
             if (!isLeader()) {
-                log.info("Not leader broker, need to evict the cache after some times" +
-                        " in case of updating loadData continuously.");
+                log.info("Not leader broker, need to evict the cache after some times"
+                        + " in case of updating loadData continuously.");
                 // invalidate all cache after some times in case of non-leader broker requesting
                 // metadata store continuously.
                 scheduler.schedule(() -> {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCache.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCache.java
@@ -154,4 +154,9 @@ public interface MetadataCache<T> {
      * @param path the path of the object in the metadata store
      */
     void refresh(String path);
+
+    /**
+     * Force the invalidation of all objects in the metadata cache.
+     */
+    public void invalidateAll();
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCache.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCache.java
@@ -158,5 +158,5 @@ public interface MetadataCache<T> {
     /**
      * Force the invalidation of all objects in the metadata cache.
      */
-    public void invalidateAll();
+    void invalidateAll();
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/coordination/LockManager.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/coordination/LockManager.java
@@ -92,4 +92,9 @@ public interface LockManager<T> extends AutoCloseable {
      */
     CompletableFuture<Void> asyncClose();
 
+    /**
+     * release all resources in cache.
+     * @return
+     */
+    void releaseAllResourcesInCache();
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
@@ -179,4 +179,9 @@ class LockManagerImpl<T> implements LockManager<T> {
                 .map(ResourceLock::release)
                 .collect(Collectors.toList()));
     }
+
+    @Override
+    public void releaseAllResourcesInCache() {
+        cache.invalidateAll();
+    }
 }


### PR DESCRIPTION
### Motivation
Load balance module in pulsar broker pose greate pressure on zk.
<img width="288" alt="image" src="https://github.com/apache/pulsar/assets/52550727/f85fad25-5d11-4b01-a325-d2d784360413">
<img width="299" alt="image" src="https://github.com/apache/pulsar/assets/52550727/75178de4-d7d9-4522-8af5-b23415560b78">

Currently,  `ModularLoadManagerImpl` is the main `LoadManager` in 2.x version, which work as a centralized way.  Most of the time, leader broker take the responsibility of shedding and assignning, while followers update their load data to zk for leader. Leader broker retrieve load data of all brokers in the cluster to make decision. 
**But, i found that not only leader will retrieve all load data (include LocalBrokerData and BundleData), but also followers, which is unnecessary and pose greate pressure to zk.**

### Modifications
Disable load data retrieve for followers.

Result as follows, only the zk instance that serve for leader broker present high throught.
![image](https://github.com/apache/pulsar/assets/52550727/d7c13024-a8b0-437b-afdf-a101ecf52b8e)
The peak total read traffic of the zk cluster has decreased from 24kb/s to 10kb/s.
<img width="956" alt="image" src="https://github.com/apache/pulsar/assets/52550727/c9be33b3-0f17-4805-b85a-acd2a57152cd">


### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*
This change is already covered by existing tests, such as *(please describe tests)*.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/23
