### PR TITLE
[improve][pip] PIP-294: Filter out the bundles with low throughput in Bundle load report

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2492,6 +2492,21 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "maximum number of bundles in a namespace"
     )
     private int loadBalancerNamespaceMaximumBundles = 128;
+
+    @FieldContext(
+            dynamic = true,
+            category = CATEGORY_LOAD_BALANCER,
+            doc = "minimum throughput in of bundle to be considered for updating data in metadata store"
+    )
+    private int loadBalancerBundleThroughputThresholdInByte = 0;
+
+    @FieldContext(
+            dynamic = true,
+            category = CATEGORY_LOAD_BALANCER,
+            doc = "minimum message rate in of bundle to be considered for updating data in metadata store"
+    )
+    private int loadBalancerBundleMsgThreshold = 0;
+
     @FieldContext(
         dynamic = true,
         category = CATEGORY_LOAD_BALANCER,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/models/TopKBundles.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/models/TopKBundles.java
@@ -68,12 +68,25 @@ public class TopKBundles {
         try {
             var isLoadBalancerSheddingBundlesWithPoliciesEnabled =
                     pulsar.getConfiguration().isLoadBalancerSheddingBundlesWithPoliciesEnabled();
+            var loadBalancerBundleThroughputThresholdInByte =
+                    pulsar.getConfiguration().getLoadBalancerBundleThroughputThresholdInByte();
+            var loadBalancerBundleMsgRateThreshold =
+                    pulsar.getConfiguration().getLoadBalancerBundleMsgThreshold();
+
             for (var etr : bundleStats.entrySet()) {
                 String bundle = etr.getKey();
                 if (bundle.startsWith(NamespaceName.SYSTEM_NAMESPACE.toString())) {
                     continue;
                 }
                 if (!isLoadBalancerSheddingBundlesWithPoliciesEnabled && hasPolicies(bundle)) {
+                    continue;
+                }
+                if (loadBalancerBundleThroughputThresholdInByte > 0
+                        && etr.getValue().msgThroughputIn < loadBalancerBundleThroughputThresholdInByte) {
+                    continue;
+                }
+                if (loadBalancerBundleMsgRateThreshold > 0
+                        && etr.getValue().msgRateIn < loadBalancerBundleMsgRateThreshold) {
                     continue;
                 }
                 arr.add(etr);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -1153,7 +1153,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
             final String bundle = entry.getKey();
             final BundleData data = entry.getValue();
             if ((data.getLongTermData().getMsgThroughputIn() < conf.getLoadBalancerBundleThroughputThresholdInByte()
-                    || data.getLongTermData().getMsgThroughputIn() < conf.getLoadBalancerBundleMsgThreshold())
+                    || data.getLongTermData().getMsgRateIn() < conf.getLoadBalancerBundleMsgThreshold())
                     && bundlesCache.exists(getBundleDataPath(bundle)).join()) {
                 // Skip writing bundle data if throughput is too low and bundle data already exists.
                 log.debug("Skip updating bundle data for bundle {} because throughput/msg is too low", bundle);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -1152,8 +1152,11 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         for (Map.Entry<String, BundleData> entry : loadData.getBundleData().entrySet()) {
             final String bundle = entry.getKey();
             final BundleData data = entry.getValue();
-            if ((data.getLongTermData().getMsgThroughputIn() < conf.getLoadBalancerBundleThroughputThresholdInByte()
-                    || data.getLongTermData().getMsgRateIn() < conf.getLoadBalancerBundleMsgThreshold())
+            if (((conf.getLoadBalancerBundleThroughputThresholdInByte() > 0
+                    && data.getLongTermData().getMsgThroughputIn()
+                    < conf.getLoadBalancerBundleThroughputThresholdInByte())
+                    || (conf.getLoadBalancerBundleMsgThreshold() > 0
+                    && data.getLongTermData().getMsgRateIn() < conf.getLoadBalancerBundleMsgThreshold()))
                     && bundlesCache.exists(getBundleDataPath(bundle)).join()) {
                 // Skip writing bundle data if throughput is too low and bundle data already exists.
                 log.debug("Skip updating bundle data for bundle {} because throughput/msg is too low", bundle);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -1153,7 +1153,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
             final String bundle = entry.getKey();
             final BundleData data = entry.getValue();
             if ((data.getLongTermData().getMsgThroughputIn() < conf.getLoadBalancerBundleThroughputThresholdInByte()
-                    || data.getLongTermData().getMsgThroughputOut() < conf.getLoadBalancerBundleThroughputThresholdInByte())
+                    || data.getLongTermData().getMsgThroughputIn() < conf.getLoadBalancerBundleMsgThreshold())
                     && bundlesCache.exists(getBundleDataPath(bundle)).join()) {
                 // Skip writing bundle data if throughput is too low and bundle data already exists.
                 log.debug("Skip updating bundle data for bundle {} because throughput/msg is too low", bundle);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -1152,6 +1152,13 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         for (Map.Entry<String, BundleData> entry : loadData.getBundleData().entrySet()) {
             final String bundle = entry.getKey();
             final BundleData data = entry.getValue();
+            if ((data.getLongTermData().getMsgThroughputIn() < conf.getLoadBalancerBundleThroughputThresholdInByte()
+                    || data.getLongTermData().getMsgThroughputOut() < conf.getLoadBalancerBundleThroughputThresholdInByte())
+                    && bundlesCache.exists(getBundleDataPath(bundle)).join()) {
+                // Skip writing bundle data if throughput is too low and bundle data already exists.
+                log.debug("Skip updating bundle data for bundle {} because throughput/msg is too low", bundle);
+                continue;
+            }
             futures.add(bundlesCache.readModifyUpdateOrCreate(getBundleDataPath(bundle), __ -> data)
                     .thenApply(__ -> null));
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/models/TopKBundlesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/models/TopKBundlesTest.java
@@ -113,6 +113,40 @@ public class TopKBundlesTest {
     }
 
     @Test
+    public void testFilterLowThroughputBundle() {
+        Map<String, NamespaceBundleStats> bundleStats = new HashMap<>();
+        var topKBundles = new TopKBundles(pulsar);
+        pulsar.getConfiguration().setLoadBalancerBundleThroughputThresholdInByte(1000);
+        pulsar.getConfiguration().setLoadBalancerBundleMsgThreshold(1000);
+
+        NamespaceBundleStats stats1 = new NamespaceBundleStats();
+        stats1.msgRateIn = 100000;
+        stats1.msgThroughputIn = 100000;
+        bundleStats.put(bundle1, stats1);
+
+        NamespaceBundleStats stats2 = new NamespaceBundleStats();
+        stats2.msgRateIn = 500;
+        stats2.msgThroughputIn = 500;
+        bundleStats.put(bundle2, stats2);
+
+        NamespaceBundleStats stats3 = new NamespaceBundleStats();
+        stats3.msgRateIn = 10000;
+        stats3.msgThroughputIn = 10;
+        bundleStats.put(bundle3, stats3);
+
+        NamespaceBundleStats stats4 = new NamespaceBundleStats();
+        stats4.msgRateIn = 10;
+        stats4.msgThroughputIn = 10000;
+        bundleStats.put(bundle4, stats4);
+
+        topKBundles.update(bundleStats, 3);
+        assertEquals(topKBundles.getLoadData().getTopBundlesLoadData().size(), 1);
+        var top0 = topKBundles.getLoadData().getTopBundlesLoadData().get(0);
+
+        assertEquals(top0.bundleName(), bundle1);
+    }
+
+    @Test
     public void testSystemNamespace() {
         Map<String, NamespaceBundleStats> bundleStats = new HashMap<>();
         var topKBundles = new TopKBundles(pulsar);


### PR DESCRIPTION
### Motivation
Load balance module in pulsar broker pose greate pressure on zk, because broker will write and read lots of znode corresponding to every bundle. As there are hundreds of thousands of bundles in clusters, broker will write and read hundreds of thousands of znode, which pose greate pressure on zk.

**As All Load Shedding Algorithm pick bundles from top to bottom based on throughput/msgRate, bundles with low throughput/msgRate can barely be selected for shedding. So there is no need to update these bundleData to zk frequently.**


### Modifications
add configuration:
```
    @FieldContext(
            dynamic = true,
            category = CATEGORY_LOAD_BALANCER,
            doc = "minimum throughput in of bundle to be considered for updating data in metadata store"
    )
    private int loadBalancerBundleThroughputThresholdInByte = 0;

    @FieldContext(
            dynamic = true,
            category = CATEGORY_LOAD_BALANCER,
            doc = "minimum message rate in of bundle to be considered for updating data in metadata store"
    )
    private int loadBalancerBundleMsgThreshold = 0;
```

Let's see the effect:
First, analyze the throughput distributions of bundles in cluster.
![image](https://github.com/apache/pulsar/assets/52550727/e1a400a5-c027-48fb-91f9-6d20864138c1)
There are about 1k bundles in the cluster, but there are only 24 bundles whose throughput in is higher than 1MB. There are more than 80% bundles whose throughput in is lower than 0.1MB, which is barely useful in shedding algorithm.
So we can configure broker.conf:
```
loadBalancerBundleThroughputThresholdInByte=100*1024  # 100Kb
```

Results as follows:
<img width="945" alt="image" src="https://github.com/apache/pulsar/assets/52550727/50825aee-f919-417c-9735-cf393738dea1">
Total write throughput to /loadbalance namespace of zk decrease from 8kb/s to 3kb/s.

![image](https://github.com/apache/pulsar/assets/52550727/92fddecd-a9e2-4f3c-99d7-338058314ea3)

Update Latency decrease from 200ms to 4ms!

<img width="950" alt="image" src="https://github.com/apache/pulsar/assets/52550727/bc08ca28-09ba-40dd-89c3-3e0f3b5c2227">
<img width="638" alt="image" src="https://github.com/apache/pulsar/assets/52550727/40a22f3b-a44b-4eac-9135-b479d52bca20">

As the write throughput decrease, the read throughput and latency will also decrease significantly.


### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/24

