### PR TITLE
[fix][broker] Fix compaction subscription delete by inactive subscription check.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2738,7 +2738,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     .toMillis(nsExpirationTime == null ? defaultExpirationTime : nsExpirationTime);
             if (expirationTimeMillis > 0) {
                 subscriptions.forEach((subName, sub) -> {
-                    if (sub.dispatcher != null && sub.dispatcher.isConsumerConnected() || sub.isReplicated()) {
+                    if (sub.dispatcher != null && sub.dispatcher.isConsumerConnected()
+                            || sub.isReplicated()
+                            || isCompactionSubscription(subName)) {
                         return;
                     }
                     if (System.currentTimeMillis() - sub.cursor.getLastActive() > expirationTimeMillis) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2730,21 +2730,28 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             final long expirationTimeMillis = TimeUnit.MINUTES
                     .toMillis(nsExpirationTime == null ? defaultExpirationTime : nsExpirationTime);
             if (expirationTimeMillis > 0) {
-                subscriptions.forEach((subName, sub) -> {
-                    if (sub.dispatcher != null && sub.dispatcher.isConsumerConnected() || sub.isReplicated()) {
-                        return;
-                    }
-                    if (System.currentTimeMillis() - sub.cursor.getLastActive() > expirationTimeMillis) {
-                        sub.delete().thenAccept(v -> log.info("[{}][{}] The subscription was deleted due to expiration "
-                                + "with last active [{}]", topic, subName, sub.cursor.getLastActive()));
-                    }
-                });
+                checkInactiveSubscriptionsWithExpirationTime(expirationTimeMillis);
             }
         } catch (Exception e) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Error getting policies", topic);
             }
         }
+    }
+
+    @VisibleForTesting
+    public void checkInactiveSubscriptionsWithExpirationTime(long expirationTimeMillis) {
+        subscriptions.forEach((subName, sub) -> {
+            if (sub.dispatcher != null && sub.dispatcher.isConsumerConnected() || sub.isReplicated()
+                    || isCompactionSubscription(subName)) {
+                return;
+            }
+
+            if (System.currentTimeMillis() - sub.cursor.getLastActive() > expirationTimeMillis) {
+                sub.delete().thenAccept(v -> log.info("[{}][{}] The subscription was deleted due to expiration "
+                        + "with last active [{}]", topic, subName, sub.cursor.getLastActive()));
+            }
+        });
     }
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -1236,6 +1236,8 @@ public class BrokerServiceTest extends BrokerTestBase {
             // Ok.. (if test fails intermittently and namespace is already created)
         }
 
+        admin.namespaces().setSubscriptionExpirationTime(namespace, 1);
+
         String compactionInactiveTestTopic = "persistent://prop/test/testCompactionCursorShouldNotDelete";
 
         admin.topics().createNonPartitionedTopic(compactionInactiveTestTopic);
@@ -1272,7 +1274,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         // if subscription deleted the result should be zero
         assertEquals(0, topic.getExpiredSubscriptionNumbers());
 
-        // check if the subscription is exist.
+        // check if the subscription exist.
         assertNotNull(topic.getSubscription(Compactor.COMPACTION_SUBSCRIPTION));
 
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -1225,7 +1225,7 @@ public class BrokerServiceTest extends BrokerTestBase {
     public void testCheckInactiveSubscriptionsShouldNotDeleteCompactionCursor() throws Exception {
         String namespace = "prop/test";
 
-        // set up broker disable auto create and set concurrent load to 1 qps.
+        // set up broker set compaction threshold.
         cleanup();
         conf.setBrokerServiceCompactionThresholdInBytes(8);
         setup();
@@ -1236,6 +1236,7 @@ public class BrokerServiceTest extends BrokerTestBase {
             // Ok.. (if test fails intermittently and namespace is already created)
         }
 
+        // set enable subscription expiration.
         admin.namespaces().setSubscriptionExpirationTime(namespace, 1);
 
         String compactionInactiveTestTopic = "persistent://prop/test/testCompactionCursorShouldNotDelete";


### PR DESCRIPTION
Fixes #20982

### Motivation
do not delete compaction cursor when enable subscription inactive check.

### Modifications

if subscription is compaction subscription skip check inactive check.

### Verifying this change

add unit test to check this. see `testCheckInactiveSubscriptionsShouldNotDeleteCompactionCursor`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
