### PR TITLE
[fix][broker] Fix get outdated compactedTopicContext after compactionHorizon has been updated

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
@@ -70,10 +70,10 @@ public class CompactedTopicImpl implements CompactedTopic {
     @Override
     public CompletableFuture<CompactedTopicContext> newCompactedLedger(Position p, long compactedLedgerId) {
         synchronized (this) {
-            compactionHorizon = (PositionImpl) p;
-
             CompletableFuture<CompactedTopicContext> previousContext = compactedTopicContext;
             compactedTopicContext = openCompactedLedger(bk, compactedLedgerId);
+
+            compactionHorizon = (PositionImpl) p;
 
             // delete the ledger from the old context once the new one is open
             return compactedTopicContext.thenCompose(__ ->

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
@@ -69,16 +69,14 @@ public class CompactedTopicImpl implements CompactedTopic {
 
     @Override
     public CompletableFuture<CompactedTopicContext> newCompactedLedger(Position p, long compactedLedgerId) {
-        synchronized (this) {
-            CompletableFuture<CompactedTopicContext> previousContext = compactedTopicContext;
-            compactedTopicContext = openCompactedLedger(bk, compactedLedgerId);
+        CompletableFuture<CompactedTopicContext> previousContext = compactedTopicContext;
+        compactedTopicContext = openCompactedLedger(bk, compactedLedgerId);
 
-            compactionHorizon = (PositionImpl) p;
+        compactionHorizon = (PositionImpl) p;
 
-            // delete the ledger from the old context once the new one is open
-            return compactedTopicContext.thenCompose(__ ->
-                    previousContext != null ? previousContext : CompletableFuture.completedFuture(null));
-        }
+        // delete the ledger from the old context once the new one is open
+        return compactedTopicContext.thenCompose(__ ->
+                previousContext != null ? previousContext : CompletableFuture.completedFuture(null));
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
@@ -53,6 +53,10 @@ import org.apache.pulsar.common.api.proto.MessageIdData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Note: If you want to guarantee that strong consistency between `compactionHorizon` and `compactedTopicContext`,
+ * you need to call getting them method in "synchronized(CompactedTopicImpl){ ... }" lock block.
+ */
 public class CompactedTopicImpl implements CompactedTopic {
     static final long NEWER_THAN_COMPACTED = -0xfeed0fbaL;
     static final long COMPACT_LEDGER_EMPTY = -0xfeed0fbbL;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -96,8 +96,6 @@ public class TransactionEndToEndTest extends TransactionTestBase {
     protected static final String TOPIC_OUTPUT = NAMESPACE1 + "/output";
     protected static final String TOPIC_MESSAGE_ACK_TEST = NAMESPACE1 + "/message-ack-test";
     protected static final int NUM_PARTITIONS = 16;
-    private static final int waitTimeForCanReceiveMSgInSec = 5;
-    private static final int waitTimeForCannotReceiveMSgInSec = 1;
     @BeforeClass
     protected void setup() throws Exception {
         conf.setAcknowledgmentAtBatchIndexLevelEnabled(true);
@@ -175,7 +173,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         }
 
         // can't receive message anymore
-        assertNull(consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS));
+        assertNull(consumer.receive(1, TimeUnit.SECONDS));
     }
 
 
@@ -242,14 +240,14 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 .enableBatchIndexAcknowledgment(true)
                 .subscribe();
 
-        Message<Integer> message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
+        Message<Integer> message = consumer.receive(1, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         // abort txn1
         txn1.abort().get();
         // after txn1 aborted, consumer will receive messages txn1 contains
         int receiveCounter = 0;
-        while((message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS)) != null) {
+        while((message = consumer.receive(5, TimeUnit.SECONDS)) != null) {
             Assert.assertEquals(message.getValue().intValue(), receiveCounter);
             receiveCounter ++;
         }
@@ -290,7 +288,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         }
 
         // Can't receive transaction messages before commit.
-        Message<byte[]> message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
+        Message<byte[]> message = consumer.receive(1, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         txn1.commit().get();
@@ -298,13 +296,13 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         int receiveCnt = 0;
         for (int i = 0; i < txnMessageCnt; i++) {
-            message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+            message = consumer.receive(5, TimeUnit.SECONDS);
             Assert.assertNotNull(message);
             receiveCnt ++;
         }
         Assert.assertEquals(txnMessageCnt, receiveCnt);
 
-        message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
+        message = consumer.receive(1, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         // cleanup.
@@ -341,13 +339,13 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         Awaitility.await().until(consumer::isConnected);
 
         // Can't receive transaction messages before abort.
-        Message<byte[]> message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
+        Message<byte[]> message = consumer.receive(1, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         txn.abort().get();
 
         // Cant't receive transaction messages after abort.
-        message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
+        message = consumer.receive(1, TimeUnit.SECONDS);
         Assert.assertNull(message);
         Awaitility.await().until(() -> {
             boolean flag = true;
@@ -435,7 +433,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         Transaction txn = getTxn();
 
         for (int i = 0; i < messageCount / 2; i++) {
-            Message<byte[]> message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+            Message<byte[]> message = consumer.receive(5, TimeUnit.SECONDS);
             consumer.acknowledgeAsync(message.getMessageId(), txn).get();
         }
 
@@ -515,14 +513,14 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
             // consume and ack messages with txn
             for (int i = 0; i < messageCnt; i++) {
-                Message<byte[]> message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+                Message<byte[]> message = consumer.receive(5, TimeUnit.SECONDS);
                 Assert.assertNotNull(message);
                 log.info("receive msgId: {}, count : {}", message.getMessageId(), i);
                 consumer.acknowledgeAsync(message.getMessageId(), txn).get();
             }
 
             // the messages are pending ack state and can't be received
-            Message<byte[]> message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
+            Message<byte[]> message = consumer.receive(1, TimeUnit.SECONDS);
             Assert.assertNull(message);
 
             // 1) txn abort
@@ -531,7 +529,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             // after transaction abort, the messages could be received
             Transaction commitTxn = getTxn();
             for (int i = 0; i < messageCnt; i++) {
-                message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+                message = consumer.receive(5, TimeUnit.SECONDS);
                 Assert.assertNotNull(message);
                 consumer.acknowledgeAsync(message.getMessageId(), commitTxn).get();
                 log.info("receive msgId: {}, count: {}", message.getMessageId(), i);
@@ -541,7 +539,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             commitTxn.commit().get();
 
             // after transaction commit, the messages can't be received
-            message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
+            message = consumer.receive(1, TimeUnit.SECONDS);
             Assert.assertNull(message);
 
             Field field = TransactionImpl.class.getDeclaredField("state");
@@ -578,7 +576,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 .topic(topicTwo).subscriptionName(sub).subscribe();
         String content = "test";
         producer.send(content);
-        assertEquals(consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS).getValue(), content);
+        assertEquals(consumer.receive(5, TimeUnit.SECONDS).getValue(), content);
 
         // cleanup.
         producer.close();
@@ -617,7 +615,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         log.info("produce transaction messages finished");
 
         // Can't receive transaction messages before commit.
-        Message<byte[]> message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
+        Message<byte[]> message = consumer.receive(1, TimeUnit.SECONDS);
         Assert.assertNull(message);
         log.info("transaction messages can't be received before transaction committed");
 
@@ -626,7 +624,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         int ackedMessageCount = 0;
         int receiveCnt = 0;
         for (int i = 0; i < messageCnt; i++) {
-            message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+            message = consumer.receive(5, TimeUnit.SECONDS);
             Assert.assertNotNull(message);
             receiveCnt ++;
             if (i % 2 == 0) {
@@ -636,7 +634,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         }
         Assert.assertEquals(messageCnt, receiveCnt);
 
-        message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
+        message = consumer.receive(1, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         String checkTopic = TopicName.get(topic).getPartition(0).toString();
@@ -648,14 +646,14 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         receiveCnt = 0;
         for (int i = 0; i < messageCnt - ackedMessageCount; i++) {
-            message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+            message = consumer.receive(5, TimeUnit.SECONDS);
             Assert.assertNotNull(message);
             consumer.acknowledge(message);
             receiveCnt ++;
         }
         Assert.assertEquals(messageCnt - ackedMessageCount, receiveCnt);
 
-        message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
+        message = consumer.receive(1, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         topic = TopicName.get(topic).getPartition(0).toString();
@@ -746,7 +744,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             Message<byte[]> message = null;
             Thread.sleep(1000L);
             for (int i = 0; i < messageCnt; i++) {
-                message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+                message = consumer.receive(5, TimeUnit.SECONDS);
                 Assert.assertNotNull(message);
                 if (i % 3 == 0) {
                     consumer.acknowledgeCumulativeAsync(message.getMessageId(), abortTxn).get();
@@ -771,14 +769,14 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             }
 
             // the messages are pending ack state and can't be received
-            message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
+            message = consumer.receive(1, TimeUnit.SECONDS);
             Assert.assertNull(message);
 
             abortTxn.abort().get();
             consumer.redeliverUnacknowledgedMessages();
             Transaction commitTxn = getTxn();
             for (int i = 0; i < messageCnt; i++) {
-                message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+                message = consumer.receive(5, TimeUnit.SECONDS);
                 Assert.assertNotNull(message);
                 if (i % 3 == 0) {
                     consumer.acknowledgeCumulativeAsync(message.getMessageId(), commitTxn).get();
@@ -800,7 +798,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 Assert.assertTrue(reCommitError.getCause() instanceof TransactionNotFoundException);
             }
 
-            message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
+            message = consumer.receive(1, TimeUnit.SECONDS);
             Assert.assertNull(message);
         }
 
@@ -862,7 +860,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         Awaitility.await().until(consumer::isConnected);
 
         for (int i = 0; i < txnCnt * messageCnt; i++) {
-            Message<byte[]> message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+            Message<byte[]> message = consumer.receive(5, TimeUnit.SECONDS);
             Assert.assertNotNull(message);
         }
 
@@ -903,7 +901,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             txn.commit().get();
 
             for (int i = 0; i < 1000; i++) {
-                Message<byte[]> message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+                Message<byte[]> message = consumer.receive(5, TimeUnit.SECONDS);
                 Assert.assertNotNull(message);
                 Assert.assertEquals(Integer.valueOf(new String(message.getData())), Integer.valueOf(i));
             }
@@ -959,7 +957,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         }
 
 
-        Message<byte[]> message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+        Message<byte[]> message = consumer.receive(5, TimeUnit.SECONDS);
         consumer.acknowledgeAsync(message.getMessageId(), consumeTxn).get();
         consumeTxn.commit().get();
         try {
@@ -1005,7 +1003,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         constructor.setAccessible(true);
 
         TransactionImpl timeoutTxnSkipClientTimeout = constructor.newInstance(pulsarClient, 5,
-                timeoutTxn.getTxnID().getLeastSigBits(), timeoutTxn.getTxnID().getMostSigBits());
+                        timeoutTxn.getTxnID().getLeastSigBits(), timeoutTxn.getTxnID().getMostSigBits());
 
         try {
             timeoutTxnSkipClientTimeout.commit().get();
@@ -1035,7 +1033,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 .newTransaction(new TransactionCoordinatorID(0), 1, null).get();
         Awaitility.await().until(() -> {
             try {
-                getPulsarServiceList().get(0).getTransactionMetadataStoreService().getTxnMeta(txnID).get();
+               getPulsarServiceList().get(0).getTransactionMetadataStoreService().getTxnMeta(txnID).get();
                 return false;
             } catch (Exception e) {
                 return true;
@@ -1071,14 +1069,14 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 .withTransactionTimeout(3, TimeUnit.SECONDS)
                 .build().get();
 
-        Message<String> message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+        Message<String> message = consumer.receive(5, TimeUnit.SECONDS);
 
         consumer.acknowledgeAsync(message.getMessageId(), consumeTimeoutTxn).get();
 
-        Message<String> reReceiveMessage = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
+        Message<String> reReceiveMessage = consumer.receive(1, TimeUnit.SECONDS);
         assertNull(reReceiveMessage);
 
-        reReceiveMessage = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+        reReceiveMessage = consumer.receive(5, TimeUnit.SECONDS);
 
         assertEquals(reReceiveMessage.getValue(), message.getValue());
 
@@ -1125,9 +1123,9 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         }
         Transaction txn = getTxn();
         if (ackType == CommandAck.AckType.Individual) {
-            consumer.acknowledgeAsync(consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS).getMessageId(), txn);
+            consumer.acknowledgeAsync(consumer.receive(5, TimeUnit.SECONDS).getMessageId(), txn);
         } else {
-            consumer.acknowledgeCumulativeAsync(consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS).getMessageId(), txn);
+            consumer.acknowledgeCumulativeAsync(consumer.receive(5, TimeUnit.SECONDS).getMessageId(), txn);
         }
         topic = TopicName.get(topic).toString();
         boolean exist = false;
@@ -1250,7 +1248,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                     .InvalidTxnStatusException);
         }
         try {
-            Message<String> message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+            Message<String> message = consumer.receive(5, TimeUnit.SECONDS);
             consumer.acknowledgeAsync(message.getMessageId(), transaction).get();
             Assert.fail();
         } catch (Exception e) {
@@ -1292,7 +1290,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         Message<byte[]> message = null;
         for (int i = 0; i < transactionCumulativeAck; i++) {
-            message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+            message = consumer.receive(5, TimeUnit.SECONDS);
         }
 
         // receive transaction in order
@@ -1315,7 +1313,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         // receive the rest of the message
         for (int i = 0; i < count; i++) {
-            message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+            message = consumer.receive(5, TimeUnit.SECONDS);
         }
 
         Transaction commitTransaction = getTxn();
@@ -1328,7 +1326,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         commitTransaction.commit().get();
 
         // then redeliver will not receive any message
-        message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
+        message = consumer.receive(1, TimeUnit.SECONDS);
         assertNull(message);
 
         // cleanup.
@@ -1403,7 +1401,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         // receive the batch messages add to a list
         for (int i = 0; i < 5; i++) {
-            messageIds.add(consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS).getMessageId());
+            messageIds.add(consumer.receive(5, TimeUnit.SECONDS).getMessageId());
         }
 
         MessageIdImpl messageId = (MessageIdImpl) messageIds.get(0);
@@ -1463,7 +1461,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 .build().get();
 
         // consumer receive the message the first time, redeliverCount = 0
-        consumer.acknowledgeAsync(consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS).getMessageId(), transaction).get();
+        consumer.acknowledgeAsync(consumer.receive(5, TimeUnit.SECONDS).getMessageId(), transaction).get();
 
         transaction.abort().get();
 
@@ -1471,17 +1469,17 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 .build().get();
 
         // consumer receive the message the second time, redeliverCount = 1, also can be received
-        consumer.acknowledgeAsync(consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS).getMessageId(), transaction).get();
+        consumer.acknowledgeAsync(consumer.receive(5, TimeUnit.SECONDS).getMessageId(), transaction).get();
 
         transaction.abort().get();
 
         // consumer receive the message the third time, redeliverCount = 2,
         // the message will be sent to DLQ, can't receive
-        assertNull(consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS));
+        assertNull(consumer.receive(1, TimeUnit.SECONDS));
 
         assertEquals(((ConsumerImpl<?>) consumer).getAvailablePermits(), 3);
 
-        assertEquals(value, new String(deadLetterConsumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS).getValue()));
+        assertEquals(value, new String(deadLetterConsumer.receive(5, TimeUnit.SECONDS).getValue()));
 
         // cleanup.
         consumer.close();
@@ -1527,7 +1525,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         Transaction transaction = pulsarClient.newTransaction().withTransactionTimeout(1, TimeUnit.MINUTES)
                 .build().get();
 
-        Message<byte[]> message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+        Message<byte[]> message = consumer.receive(5, TimeUnit.SECONDS);
         assertEquals(value1, new String(message.getValue()));
         // consumer receive the batch message one the first time, redeliverCount = 0
         consumer.acknowledgeAsync(message.getMessageId(), transaction).get();
@@ -1537,7 +1535,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         // consumer will receive the batch message two and then receive
         // the message one and message two again, redeliverCount = 1
         for (int i = 0; i < 3; i ++) {
-            message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+            message = consumer.receive(5, TimeUnit.SECONDS);
         }
 
         transaction = pulsarClient.newTransaction().withTransactionTimeout(5, TimeUnit.MINUTES)
@@ -1551,12 +1549,12 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         // consumer receive the batch message the third time, redeliverCount = 2,
         // the message will be sent to DLQ, can't receive
-        assertNull(consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS));
+        assertNull(consumer.receive(1, TimeUnit.SECONDS));
 
         assertEquals(((ConsumerImpl<?>) consumer).getAvailablePermits(), 6);
 
-        assertEquals(value1, new String(deadLetterConsumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS).getValue()));
-        assertEquals(value2, new String(deadLetterConsumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS).getValue()));
+        assertEquals(value1, new String(deadLetterConsumer.receive(5, TimeUnit.SECONDS).getValue()));
+        assertEquals(value2, new String(deadLetterConsumer.receive(5, TimeUnit.SECONDS).getValue()));
 
         // cleanup.
         consumer.close();
@@ -1606,17 +1604,17 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         // Failover consumer will receive the messages immediately while
         // the shared consumer will get them after the delay
-        Message<String> msg = sharedConsumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
+        Message<String> msg = sharedConsumer.receive(1, TimeUnit.SECONDS);
         assertNull(msg);
 
         for (int i = 0; i < 10; i++) {
-            msg = failoverConsumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+            msg = failoverConsumer.receive(5, TimeUnit.SECONDS);
             assertEquals(msg.getValue(), "msg-" + i);
         }
 
         Set<String> receivedMsgs = new TreeSet<>();
         for (int i = 0; i < 10; i++) {
-            msg = sharedConsumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
+            msg = sharedConsumer.receive(5, TimeUnit.SECONDS);
             receivedMsgs.add(msg.getValue());
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -173,7 +173,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         }
 
         // can't receive message anymore
-        assertNull(consumer.receive(2, TimeUnit.SECONDS));
+        assertNull(consumer.receive(1, TimeUnit.SECONDS));
     }
 
 
@@ -240,14 +240,14 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 .enableBatchIndexAcknowledgment(true)
                 .subscribe();
 
-        Message<Integer> message = consumer.receive(3, TimeUnit.SECONDS);
+        Message<Integer> message = consumer.receive(1, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         // abort txn1
         txn1.abort().get();
         // after txn1 aborted, consumer will receive messages txn1 contains
         int receiveCounter = 0;
-        while((message = consumer.receive(3, TimeUnit.SECONDS)) != null) {
+        while((message = consumer.receive(5, TimeUnit.SECONDS)) != null) {
             Assert.assertEquals(message.getValue().intValue(), receiveCounter);
             receiveCounter ++;
         }
@@ -288,7 +288,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         }
 
         // Can't receive transaction messages before commit.
-        Message<byte[]> message = consumer.receive(300, TimeUnit.MILLISECONDS);
+        Message<byte[]> message = consumer.receive(1, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         txn1.commit().get();
@@ -302,7 +302,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         }
         Assert.assertEquals(txnMessageCnt, receiveCnt);
 
-        message = consumer.receive(300, TimeUnit.MILLISECONDS);
+        message = consumer.receive(1, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         // cleanup.
@@ -339,13 +339,13 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         Awaitility.await().until(consumer::isConnected);
 
         // Can't receive transaction messages before abort.
-        Message<byte[]> message = consumer.receive(300, TimeUnit.MILLISECONDS);
+        Message<byte[]> message = consumer.receive(1, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         txn.abort().get();
 
         // Cant't receive transaction messages after abort.
-        message = consumer.receive(300, TimeUnit.MILLISECONDS);
+        message = consumer.receive(1, TimeUnit.SECONDS);
         Assert.assertNull(message);
         Awaitility.await().until(() -> {
             boolean flag = true;
@@ -520,7 +520,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             }
 
             // the messages are pending ack state and can't be received
-            Message<byte[]> message = consumer.receive(300, TimeUnit.MILLISECONDS);
+            Message<byte[]> message = consumer.receive(1, TimeUnit.SECONDS);
             Assert.assertNull(message);
 
             // 1) txn abort
@@ -529,7 +529,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             // after transaction abort, the messages could be received
             Transaction commitTxn = getTxn();
             for (int i = 0; i < messageCnt; i++) {
-                message = consumer.receive(2, TimeUnit.SECONDS);
+                message = consumer.receive(5, TimeUnit.SECONDS);
                 Assert.assertNotNull(message);
                 consumer.acknowledgeAsync(message.getMessageId(), commitTxn).get();
                 log.info("receive msgId: {}, count: {}", message.getMessageId(), i);
@@ -539,7 +539,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             commitTxn.commit().get();
 
             // after transaction commit, the messages can't be received
-            message = consumer.receive(300, TimeUnit.MILLISECONDS);
+            message = consumer.receive(1, TimeUnit.SECONDS);
             Assert.assertNull(message);
 
             Field field = TransactionImpl.class.getDeclaredField("state");
@@ -576,7 +576,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 .topic(topicTwo).subscriptionName(sub).subscribe();
         String content = "test";
         producer.send(content);
-        assertEquals(consumer.receive(3, TimeUnit.SECONDS).getValue(), content);
+        assertEquals(consumer.receive(5, TimeUnit.SECONDS).getValue(), content);
 
         // cleanup.
         producer.close();
@@ -615,7 +615,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         log.info("produce transaction messages finished");
 
         // Can't receive transaction messages before commit.
-        Message<byte[]> message = consumer.receive(300, TimeUnit.MILLISECONDS);
+        Message<byte[]> message = consumer.receive(1, TimeUnit.SECONDS);
         Assert.assertNull(message);
         log.info("transaction messages can't be received before transaction committed");
 
@@ -634,7 +634,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         }
         Assert.assertEquals(messageCnt, receiveCnt);
 
-        message = consumer.receive(300, TimeUnit.MILLISECONDS);
+        message = consumer.receive(1, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         String checkTopic = TopicName.get(topic).getPartition(0).toString();
@@ -646,14 +646,14 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         receiveCnt = 0;
         for (int i = 0; i < messageCnt - ackedMessageCount; i++) {
-            message = consumer.receive(2, TimeUnit.SECONDS);
+            message = consumer.receive(5, TimeUnit.SECONDS);
             Assert.assertNotNull(message);
             consumer.acknowledge(message);
             receiveCnt ++;
         }
         Assert.assertEquals(messageCnt - ackedMessageCount, receiveCnt);
 
-        message = consumer.receive(300, TimeUnit.MILLISECONDS);
+        message = consumer.receive(1, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         topic = TopicName.get(topic).getPartition(0).toString();
@@ -744,7 +744,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             Message<byte[]> message = null;
             Thread.sleep(1000L);
             for (int i = 0; i < messageCnt; i++) {
-                message = consumer.receive(1, TimeUnit.SECONDS);
+                message = consumer.receive(5, TimeUnit.SECONDS);
                 Assert.assertNotNull(message);
                 if (i % 3 == 0) {
                     consumer.acknowledgeCumulativeAsync(message.getMessageId(), abortTxn).get();
@@ -769,14 +769,14 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             }
 
             // the messages are pending ack state and can't be received
-            message = consumer.receive(300, TimeUnit.MILLISECONDS);
+            message = consumer.receive(1, TimeUnit.SECONDS);
             Assert.assertNull(message);
 
             abortTxn.abort().get();
             consumer.redeliverUnacknowledgedMessages();
             Transaction commitTxn = getTxn();
             for (int i = 0; i < messageCnt; i++) {
-                message = consumer.receive(1, TimeUnit.SECONDS);
+                message = consumer.receive(5, TimeUnit.SECONDS);
                 Assert.assertNotNull(message);
                 if (i % 3 == 0) {
                     consumer.acknowledgeCumulativeAsync(message.getMessageId(), commitTxn).get();
@@ -798,7 +798,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 Assert.assertTrue(reCommitError.getCause() instanceof TransactionNotFoundException);
             }
 
-            message = consumer.receive(300, TimeUnit.MILLISECONDS);
+            message = consumer.receive(1, TimeUnit.SECONDS);
             Assert.assertNull(message);
         }
 
@@ -1073,7 +1073,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         consumer.acknowledgeAsync(message.getMessageId(), consumeTimeoutTxn).get();
 
-        Message<String> reReceiveMessage = consumer.receive(300, TimeUnit.MILLISECONDS);
+        Message<String> reReceiveMessage = consumer.receive(1, TimeUnit.SECONDS);
         assertNull(reReceiveMessage);
 
         reReceiveMessage = consumer.receive(5, TimeUnit.SECONDS);
@@ -1326,7 +1326,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         commitTransaction.commit().get();
 
         // then redeliver will not receive any message
-        message = consumer.receive(300, TimeUnit.MILLISECONDS);
+        message = consumer.receive(1, TimeUnit.SECONDS);
         assertNull(message);
 
         // cleanup.
@@ -1475,11 +1475,11 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         // consumer receive the message the third time, redeliverCount = 2,
         // the message will be sent to DLQ, can't receive
-        assertNull(consumer.receive(300, TimeUnit.MILLISECONDS));
+        assertNull(consumer.receive(1, TimeUnit.SECONDS));
 
         assertEquals(((ConsumerImpl<?>) consumer).getAvailablePermits(), 3);
 
-        assertEquals(value, new String(deadLetterConsumer.receive(3, TimeUnit.SECONDS).getValue()));
+        assertEquals(value, new String(deadLetterConsumer.receive(5, TimeUnit.SECONDS).getValue()));
 
         // cleanup.
         consumer.close();
@@ -1549,12 +1549,12 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         // consumer receive the batch message the third time, redeliverCount = 2,
         // the message will be sent to DLQ, can't receive
-        assertNull(consumer.receive(300, TimeUnit.MILLISECONDS));
+        assertNull(consumer.receive(1, TimeUnit.SECONDS));
 
         assertEquals(((ConsumerImpl<?>) consumer).getAvailablePermits(), 6);
 
-        assertEquals(value1, new String(deadLetterConsumer.receive(3, TimeUnit.SECONDS).getValue()));
-        assertEquals(value2, new String(deadLetterConsumer.receive(3, TimeUnit.SECONDS).getValue()));
+        assertEquals(value1, new String(deadLetterConsumer.receive(5, TimeUnit.SECONDS).getValue()));
+        assertEquals(value2, new String(deadLetterConsumer.receive(5, TimeUnit.SECONDS).getValue()));
 
         // cleanup.
         consumer.close();
@@ -1604,17 +1604,17 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         // Failover consumer will receive the messages immediately while
         // the shared consumer will get them after the delay
-        Message<String> msg = sharedConsumer.receive(300, TimeUnit.MILLISECONDS);
+        Message<String> msg = sharedConsumer.receive(1, TimeUnit.SECONDS);
         assertNull(msg);
 
         for (int i = 0; i < 10; i++) {
-            msg = failoverConsumer.receive(100, TimeUnit.MILLISECONDS);
+            msg = failoverConsumer.receive(5, TimeUnit.SECONDS);
             assertEquals(msg.getValue(), "msg-" + i);
         }
 
         Set<String> receivedMsgs = new TreeSet<>();
         for (int i = 0; i < 10; i++) {
-            msg = sharedConsumer.receive(10, TimeUnit.SECONDS);
+            msg = sharedConsumer.receive(5, TimeUnit.SECONDS);
             receivedMsgs.add(msg.getValue());
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -96,6 +96,8 @@ public class TransactionEndToEndTest extends TransactionTestBase {
     protected static final String TOPIC_OUTPUT = NAMESPACE1 + "/output";
     protected static final String TOPIC_MESSAGE_ACK_TEST = NAMESPACE1 + "/message-ack-test";
     protected static final int NUM_PARTITIONS = 16;
+    private static final int waitTimeForCanReceiveMSgInSec = 5;
+    private static final int waitTimeForCannotReceiveMSgInSec = 1;
     @BeforeClass
     protected void setup() throws Exception {
         conf.setAcknowledgmentAtBatchIndexLevelEnabled(true);
@@ -173,7 +175,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         }
 
         // can't receive message anymore
-        assertNull(consumer.receive(1, TimeUnit.SECONDS));
+        assertNull(consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS));
     }
 
 
@@ -240,14 +242,14 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 .enableBatchIndexAcknowledgment(true)
                 .subscribe();
 
-        Message<Integer> message = consumer.receive(1, TimeUnit.SECONDS);
+        Message<Integer> message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         // abort txn1
         txn1.abort().get();
         // after txn1 aborted, consumer will receive messages txn1 contains
         int receiveCounter = 0;
-        while((message = consumer.receive(5, TimeUnit.SECONDS)) != null) {
+        while((message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS)) != null) {
             Assert.assertEquals(message.getValue().intValue(), receiveCounter);
             receiveCounter ++;
         }
@@ -288,7 +290,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         }
 
         // Can't receive transaction messages before commit.
-        Message<byte[]> message = consumer.receive(1, TimeUnit.SECONDS);
+        Message<byte[]> message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         txn1.commit().get();
@@ -296,13 +298,13 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         int receiveCnt = 0;
         for (int i = 0; i < txnMessageCnt; i++) {
-            message = consumer.receive(5, TimeUnit.SECONDS);
+            message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
             Assert.assertNotNull(message);
             receiveCnt ++;
         }
         Assert.assertEquals(txnMessageCnt, receiveCnt);
 
-        message = consumer.receive(1, TimeUnit.SECONDS);
+        message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         // cleanup.
@@ -339,13 +341,13 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         Awaitility.await().until(consumer::isConnected);
 
         // Can't receive transaction messages before abort.
-        Message<byte[]> message = consumer.receive(1, TimeUnit.SECONDS);
+        Message<byte[]> message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         txn.abort().get();
 
         // Cant't receive transaction messages after abort.
-        message = consumer.receive(1, TimeUnit.SECONDS);
+        message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
         Assert.assertNull(message);
         Awaitility.await().until(() -> {
             boolean flag = true;
@@ -433,7 +435,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         Transaction txn = getTxn();
 
         for (int i = 0; i < messageCount / 2; i++) {
-            Message<byte[]> message = consumer.receive(5, TimeUnit.SECONDS);
+            Message<byte[]> message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
             consumer.acknowledgeAsync(message.getMessageId(), txn).get();
         }
 
@@ -513,14 +515,14 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
             // consume and ack messages with txn
             for (int i = 0; i < messageCnt; i++) {
-                Message<byte[]> message = consumer.receive(5, TimeUnit.SECONDS);
+                Message<byte[]> message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
                 Assert.assertNotNull(message);
                 log.info("receive msgId: {}, count : {}", message.getMessageId(), i);
                 consumer.acknowledgeAsync(message.getMessageId(), txn).get();
             }
 
             // the messages are pending ack state and can't be received
-            Message<byte[]> message = consumer.receive(1, TimeUnit.SECONDS);
+            Message<byte[]> message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
             Assert.assertNull(message);
 
             // 1) txn abort
@@ -529,7 +531,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             // after transaction abort, the messages could be received
             Transaction commitTxn = getTxn();
             for (int i = 0; i < messageCnt; i++) {
-                message = consumer.receive(5, TimeUnit.SECONDS);
+                message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
                 Assert.assertNotNull(message);
                 consumer.acknowledgeAsync(message.getMessageId(), commitTxn).get();
                 log.info("receive msgId: {}, count: {}", message.getMessageId(), i);
@@ -539,7 +541,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             commitTxn.commit().get();
 
             // after transaction commit, the messages can't be received
-            message = consumer.receive(1, TimeUnit.SECONDS);
+            message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
             Assert.assertNull(message);
 
             Field field = TransactionImpl.class.getDeclaredField("state");
@@ -576,7 +578,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 .topic(topicTwo).subscriptionName(sub).subscribe();
         String content = "test";
         producer.send(content);
-        assertEquals(consumer.receive(5, TimeUnit.SECONDS).getValue(), content);
+        assertEquals(consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS).getValue(), content);
 
         // cleanup.
         producer.close();
@@ -615,7 +617,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         log.info("produce transaction messages finished");
 
         // Can't receive transaction messages before commit.
-        Message<byte[]> message = consumer.receive(1, TimeUnit.SECONDS);
+        Message<byte[]> message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
         Assert.assertNull(message);
         log.info("transaction messages can't be received before transaction committed");
 
@@ -624,7 +626,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         int ackedMessageCount = 0;
         int receiveCnt = 0;
         for (int i = 0; i < messageCnt; i++) {
-            message = consumer.receive(5, TimeUnit.SECONDS);
+            message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
             Assert.assertNotNull(message);
             receiveCnt ++;
             if (i % 2 == 0) {
@@ -634,7 +636,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         }
         Assert.assertEquals(messageCnt, receiveCnt);
 
-        message = consumer.receive(1, TimeUnit.SECONDS);
+        message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         String checkTopic = TopicName.get(topic).getPartition(0).toString();
@@ -646,14 +648,14 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         receiveCnt = 0;
         for (int i = 0; i < messageCnt - ackedMessageCount; i++) {
-            message = consumer.receive(5, TimeUnit.SECONDS);
+            message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
             Assert.assertNotNull(message);
             consumer.acknowledge(message);
             receiveCnt ++;
         }
         Assert.assertEquals(messageCnt - ackedMessageCount, receiveCnt);
 
-        message = consumer.receive(1, TimeUnit.SECONDS);
+        message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         topic = TopicName.get(topic).getPartition(0).toString();
@@ -744,7 +746,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             Message<byte[]> message = null;
             Thread.sleep(1000L);
             for (int i = 0; i < messageCnt; i++) {
-                message = consumer.receive(5, TimeUnit.SECONDS);
+                message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
                 Assert.assertNotNull(message);
                 if (i % 3 == 0) {
                     consumer.acknowledgeCumulativeAsync(message.getMessageId(), abortTxn).get();
@@ -769,14 +771,14 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             }
 
             // the messages are pending ack state and can't be received
-            message = consumer.receive(1, TimeUnit.SECONDS);
+            message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
             Assert.assertNull(message);
 
             abortTxn.abort().get();
             consumer.redeliverUnacknowledgedMessages();
             Transaction commitTxn = getTxn();
             for (int i = 0; i < messageCnt; i++) {
-                message = consumer.receive(5, TimeUnit.SECONDS);
+                message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
                 Assert.assertNotNull(message);
                 if (i % 3 == 0) {
                     consumer.acknowledgeCumulativeAsync(message.getMessageId(), commitTxn).get();
@@ -798,7 +800,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 Assert.assertTrue(reCommitError.getCause() instanceof TransactionNotFoundException);
             }
 
-            message = consumer.receive(1, TimeUnit.SECONDS);
+            message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
             Assert.assertNull(message);
         }
 
@@ -860,7 +862,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         Awaitility.await().until(consumer::isConnected);
 
         for (int i = 0; i < txnCnt * messageCnt; i++) {
-            Message<byte[]> message = consumer.receive(5, TimeUnit.SECONDS);
+            Message<byte[]> message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
             Assert.assertNotNull(message);
         }
 
@@ -901,7 +903,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             txn.commit().get();
 
             for (int i = 0; i < 1000; i++) {
-                Message<byte[]> message = consumer.receive(5, TimeUnit.SECONDS);
+                Message<byte[]> message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
                 Assert.assertNotNull(message);
                 Assert.assertEquals(Integer.valueOf(new String(message.getData())), Integer.valueOf(i));
             }
@@ -957,7 +959,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         }
 
 
-        Message<byte[]> message = consumer.receive(5, TimeUnit.SECONDS);
+        Message<byte[]> message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
         consumer.acknowledgeAsync(message.getMessageId(), consumeTxn).get();
         consumeTxn.commit().get();
         try {
@@ -1003,7 +1005,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         constructor.setAccessible(true);
 
         TransactionImpl timeoutTxnSkipClientTimeout = constructor.newInstance(pulsarClient, 5,
-                        timeoutTxn.getTxnID().getLeastSigBits(), timeoutTxn.getTxnID().getMostSigBits());
+                timeoutTxn.getTxnID().getLeastSigBits(), timeoutTxn.getTxnID().getMostSigBits());
 
         try {
             timeoutTxnSkipClientTimeout.commit().get();
@@ -1033,7 +1035,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 .newTransaction(new TransactionCoordinatorID(0), 1, null).get();
         Awaitility.await().until(() -> {
             try {
-               getPulsarServiceList().get(0).getTransactionMetadataStoreService().getTxnMeta(txnID).get();
+                getPulsarServiceList().get(0).getTransactionMetadataStoreService().getTxnMeta(txnID).get();
                 return false;
             } catch (Exception e) {
                 return true;
@@ -1069,14 +1071,14 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 .withTransactionTimeout(3, TimeUnit.SECONDS)
                 .build().get();
 
-        Message<String> message = consumer.receive(5, TimeUnit.SECONDS);
+        Message<String> message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
 
         consumer.acknowledgeAsync(message.getMessageId(), consumeTimeoutTxn).get();
 
-        Message<String> reReceiveMessage = consumer.receive(1, TimeUnit.SECONDS);
+        Message<String> reReceiveMessage = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
         assertNull(reReceiveMessage);
 
-        reReceiveMessage = consumer.receive(5, TimeUnit.SECONDS);
+        reReceiveMessage = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
 
         assertEquals(reReceiveMessage.getValue(), message.getValue());
 
@@ -1123,9 +1125,9 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         }
         Transaction txn = getTxn();
         if (ackType == CommandAck.AckType.Individual) {
-            consumer.acknowledgeAsync(consumer.receive(5, TimeUnit.SECONDS).getMessageId(), txn);
+            consumer.acknowledgeAsync(consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS).getMessageId(), txn);
         } else {
-            consumer.acknowledgeCumulativeAsync(consumer.receive(5, TimeUnit.SECONDS).getMessageId(), txn);
+            consumer.acknowledgeCumulativeAsync(consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS).getMessageId(), txn);
         }
         topic = TopicName.get(topic).toString();
         boolean exist = false;
@@ -1248,7 +1250,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                     .InvalidTxnStatusException);
         }
         try {
-            Message<String> message = consumer.receive(5, TimeUnit.SECONDS);
+            Message<String> message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
             consumer.acknowledgeAsync(message.getMessageId(), transaction).get();
             Assert.fail();
         } catch (Exception e) {
@@ -1290,7 +1292,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         Message<byte[]> message = null;
         for (int i = 0; i < transactionCumulativeAck; i++) {
-            message = consumer.receive(5, TimeUnit.SECONDS);
+            message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
         }
 
         // receive transaction in order
@@ -1313,7 +1315,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         // receive the rest of the message
         for (int i = 0; i < count; i++) {
-            message = consumer.receive(5, TimeUnit.SECONDS);
+            message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
         }
 
         Transaction commitTransaction = getTxn();
@@ -1326,7 +1328,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         commitTransaction.commit().get();
 
         // then redeliver will not receive any message
-        message = consumer.receive(1, TimeUnit.SECONDS);
+        message = consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
         assertNull(message);
 
         // cleanup.
@@ -1401,7 +1403,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         // receive the batch messages add to a list
         for (int i = 0; i < 5; i++) {
-            messageIds.add(consumer.receive(5, TimeUnit.SECONDS).getMessageId());
+            messageIds.add(consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS).getMessageId());
         }
 
         MessageIdImpl messageId = (MessageIdImpl) messageIds.get(0);
@@ -1461,7 +1463,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 .build().get();
 
         // consumer receive the message the first time, redeliverCount = 0
-        consumer.acknowledgeAsync(consumer.receive(5, TimeUnit.SECONDS).getMessageId(), transaction).get();
+        consumer.acknowledgeAsync(consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS).getMessageId(), transaction).get();
 
         transaction.abort().get();
 
@@ -1469,17 +1471,17 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 .build().get();
 
         // consumer receive the message the second time, redeliverCount = 1, also can be received
-        consumer.acknowledgeAsync(consumer.receive(5, TimeUnit.SECONDS).getMessageId(), transaction).get();
+        consumer.acknowledgeAsync(consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS).getMessageId(), transaction).get();
 
         transaction.abort().get();
 
         // consumer receive the message the third time, redeliverCount = 2,
         // the message will be sent to DLQ, can't receive
-        assertNull(consumer.receive(1, TimeUnit.SECONDS));
+        assertNull(consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS));
 
         assertEquals(((ConsumerImpl<?>) consumer).getAvailablePermits(), 3);
 
-        assertEquals(value, new String(deadLetterConsumer.receive(5, TimeUnit.SECONDS).getValue()));
+        assertEquals(value, new String(deadLetterConsumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS).getValue()));
 
         // cleanup.
         consumer.close();
@@ -1525,7 +1527,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         Transaction transaction = pulsarClient.newTransaction().withTransactionTimeout(1, TimeUnit.MINUTES)
                 .build().get();
 
-        Message<byte[]> message = consumer.receive(5, TimeUnit.SECONDS);
+        Message<byte[]> message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
         assertEquals(value1, new String(message.getValue()));
         // consumer receive the batch message one the first time, redeliverCount = 0
         consumer.acknowledgeAsync(message.getMessageId(), transaction).get();
@@ -1535,7 +1537,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         // consumer will receive the batch message two and then receive
         // the message one and message two again, redeliverCount = 1
         for (int i = 0; i < 3; i ++) {
-            message = consumer.receive(5, TimeUnit.SECONDS);
+            message = consumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
         }
 
         transaction = pulsarClient.newTransaction().withTransactionTimeout(5, TimeUnit.MINUTES)
@@ -1549,12 +1551,12 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         // consumer receive the batch message the third time, redeliverCount = 2,
         // the message will be sent to DLQ, can't receive
-        assertNull(consumer.receive(1, TimeUnit.SECONDS));
+        assertNull(consumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS));
 
         assertEquals(((ConsumerImpl<?>) consumer).getAvailablePermits(), 6);
 
-        assertEquals(value1, new String(deadLetterConsumer.receive(5, TimeUnit.SECONDS).getValue()));
-        assertEquals(value2, new String(deadLetterConsumer.receive(5, TimeUnit.SECONDS).getValue()));
+        assertEquals(value1, new String(deadLetterConsumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS).getValue()));
+        assertEquals(value2, new String(deadLetterConsumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS).getValue()));
 
         // cleanup.
         consumer.close();
@@ -1604,17 +1606,17 @@ public class TransactionEndToEndTest extends TransactionTestBase {
 
         // Failover consumer will receive the messages immediately while
         // the shared consumer will get them after the delay
-        Message<String> msg = sharedConsumer.receive(1, TimeUnit.SECONDS);
+        Message<String> msg = sharedConsumer.receive(waitTimeForCannotReceiveMSgInSec, TimeUnit.SECONDS);
         assertNull(msg);
 
         for (int i = 0; i < 10; i++) {
-            msg = failoverConsumer.receive(5, TimeUnit.SECONDS);
+            msg = failoverConsumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
             assertEquals(msg.getValue(), "msg-" + i);
         }
 
         Set<String> receivedMsgs = new TreeSet<>();
         for (int i = 0; i < 10; i++) {
-            msg = sharedConsumer.receive(5, TimeUnit.SECONDS);
+            msg = sharedConsumer.receive(waitTimeForCanReceiveMSgInSec, TimeUnit.SECONDS);
             receivedMsgs.add(msg.getValue());
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicTest.java
@@ -23,6 +23,7 @@ import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.google.common.collect.Sets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,6 +39,7 @@ import lombok.Cleanup;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.lang3.tuple.Pair;
@@ -62,6 +64,7 @@ import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.awaitility.Awaitility;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -839,5 +842,69 @@ public class CompactedTopicTest extends MockedPulsarServiceBaseTest {
 
         Assert.assertTrue(reader.hasMessageAvailable());
         Assert.assertEquals(reader.readNext().getMessageId(), lastMessage.get());
+    }
+
+    @Test
+    public void testCompactWithConcurrentGetCompactionHorizonAndCompactedTopicContext() throws Exception {
+        BookKeeper bk0 = pulsar.getBookKeeperClientFactory().create(
+                this.conf, null, null, Optional.empty(), null);
+
+        final BookKeeper bk = Mockito.spy(bk0);
+
+        Mockito.doAnswer(invocation -> {
+            Thread.sleep(1500);
+            invocation.callRealMethod();
+            return null;
+        }).when(bk).asyncOpenLedger(Mockito.anyLong(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+
+        LedgerHandle oldCompactedLedger = bk.createLedger(1, 1,
+                Compactor.COMPACTED_TOPIC_LEDGER_DIGEST_TYPE,
+                Compactor.COMPACTED_TOPIC_LEDGER_PASSWORD);
+        oldCompactedLedger.close();
+        LedgerHandle newCompactedLedger = bk.createLedger(1, 1,
+                Compactor.COMPACTED_TOPIC_LEDGER_DIGEST_TYPE,
+                Compactor.COMPACTED_TOPIC_LEDGER_PASSWORD);
+        newCompactedLedger.close();
+
+        CompactedTopicImpl compactedTopic = new CompactedTopicImpl(bk);
+
+        PositionImpl oldHorizon = new PositionImpl(1, 2);
+        var future = CompletableFuture.supplyAsync(() -> {
+            // set the compacted topic ledger
+            return compactedTopic.newCompactedLedger(oldHorizon, oldCompactedLedger.getId());
+        });
+        Thread.sleep(500);
+
+        Optional<Position> compactionHorizon = compactedTopic.getCompactionHorizon();
+        CompletableFuture<CompactedTopicContext> compactedTopicContext =
+                compactedTopic.getCompactedTopicContextFuture();
+
+        if (compactedTopicContext != null) {
+            Assert.assertEquals(compactionHorizon.get(), oldHorizon);
+            Assert.assertNotNull(compactedTopicContext);
+            Assert.assertEquals(compactedTopicContext.join().ledger.getId(), oldCompactedLedger.getId());
+        } else {
+            Assert.assertTrue(compactionHorizon.isEmpty());
+        }
+
+        future.join();
+
+        PositionImpl newHorizon = new PositionImpl(1, 3);
+        var future2 = CompletableFuture.supplyAsync(() -> {
+            // update the compacted topic ledger
+            return compactedTopic.newCompactedLedger(newHorizon, newCompactedLedger.getId());
+        });
+        Thread.sleep(500);
+
+        compactionHorizon = compactedTopic.getCompactionHorizon();
+        compactedTopicContext = compactedTopic.getCompactedTopicContextFuture();
+
+        if (compactedTopicContext.join().ledger.getId() == newCompactedLedger.getId()) {
+            Assert.assertEquals(compactionHorizon.get(), newHorizon);
+        } else {
+            Assert.assertEquals(compactionHorizon.get(), oldHorizon);
+        }
+
+        future2.join();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicTest.java
@@ -23,7 +23,6 @@ import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.google.common.collect.Sets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;


### PR DESCRIPTION
### Motivation

In #20697, we remove the lock of get compactedTopicContext and asyncReadEntries, but `compactionHorizon` has been updated before  `compactedTopicContext` is updated. In concurrent cases, this may lead to cursor skip messages of newly compacted or getting an NPE when reading compacted entries.

### Modifications

Ensure `compactionHorizon` is updated after `compactedTopicContext`.


### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
