### PR TITLE
[fix][meta] Fix deadlock in AutoRecovery.

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerUnderreplicationManager.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerUnderreplicationManager.java
@@ -978,11 +978,13 @@ public class PulsarLedgerUnderreplicationManager implements LedgerUnderreplicati
     @Override
     public void notifyUnderReplicationLedgerChanged(BookkeeperInternalCallbacks.GenericCallback<Void> cb)
             throws ReplicationException.UnavailableException {
-        log.debug("notifyUnderReplicationLedgerChanged()");
-        store.registerListener(e -> {
-            if (e.getType() == NotificationType.Deleted && ID_EXTRACTION_PATTERN.matcher(e.getPath()).find()) {
-                cb.operationComplete(0, null);
-            }
-        });
+        //The store listener callback executor is metadata-store executor,
+        //in cb.operationComplete(0, null), it will get all underreplication ledgers from metadata-store, it's sync
+        //operation. So it's a deadlock.
+//        store.registerListener(e -> {
+//            if (e.getType() == NotificationType.Deleted && ID_EXTRACTION_PATTERN.matcher(e.getPath()).find()) {
+//                cb.operationComplete(0, null);
+//            }
+//        });
     }
 }


### PR DESCRIPTION
### Motivation
When the user config `-Dbookkeeper.metadata.client.drivers=org.apache.pulsar.metadata.bookkeeper.PulsarMetadataClientDriver`, the AutoRecovery will use PulsarLedgerUnderreplicationManager.


https://github.com/apache/bookkeeper/blob/f30ff4f2ad4778f1f73b29872e2a95adb22ca116/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java#L396-L397.

In Auditor start, it will register a UnderReplicatedLedgersChangedCb to PulsarLedgerUnderreplicationManager,
PulsarLedgerUnderreplicationManager will register a watcher to watch the zk event. 

When the event path matches `underreplication`, callback UnderReplicatedLedgersChangedCb, the callback executor is metadata-store executor.
https://github.com/apache/pulsar/blob/0cb1c780412ca3cc1d421fe6ebb5de95cf7392fa/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java#L307-L323


In UnderReplicatedLedgersChangedCb, it will get all the `underreplication` ledgers from the metadata store, and this is a sync operation. 

https://github.com/apache/bookkeeper/blob/f30ff4f2ad4778f1f73b29872e2a95adb22ca116/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/Auditor.java#L561-L569


https://github.com/apache/pulsar/blob/0cb1c780412ca3cc1d421fe6ebb5de95cf7392fa/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerUnderreplicationManager.java#L427-L479

line_448, use future.get(), it's sync.

There is the stack file:
[jastack.txt](https://github.com/apache/pulsar/files/12366413/jastack.txt)

### Motivation
The UnderReplicatedLedgersChangedCb is aim to record metrics, it is unnecessary and brings heavy pressure for the zookeeper, so here we cancel the UnderReplicatedLedgersChangedCb.
And we discuss to revert 
 UnderReplicatedLedgersChangedCb,.https://github.com/apache/bookkeeper/pull/2805#pullrequestreview-1581866097


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

