### PR TITLE
[fix][fn] Fix using the correct admin and broker urls

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1766,12 +1766,12 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                                     AuthorizationService authorizationService)
             throws Exception {
         if (functionWorkerService.isPresent()) {
-            if (workerConfig.isUseTls() || brokerServiceUrl == null) {
+            if (config.isBrokerClientTlsEnabled() || brokerServiceUrl == null) {
                 workerConfig.setPulsarServiceUrl(brokerServiceUrlTls);
             } else {
                 workerConfig.setPulsarServiceUrl(brokerServiceUrl);
             }
-            if (workerConfig.isUseTls() || webServiceAddress == null) {
+            if (config.isBrokerClientTlsEnabled() || webServiceAddress == null) {
                 workerConfig.setPulsarWebServiceUrl(webServiceAddressTls);
                 workerConfig.setFunctionWebServiceUrl(webServiceAddressTls);
             } else {
@@ -1866,7 +1866,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         workerConfig.setMetadataStoreOperationTimeoutSeconds(brokerConfig.getMetadataStoreOperationTimeoutSeconds());
         workerConfig.setMetadataStoreCacheExpirySeconds(brokerConfig.getMetadataStoreCacheExpirySeconds());
         workerConfig.setTlsAllowInsecureConnection(brokerConfig.isTlsAllowInsecureConnection());
-        workerConfig.setTlsEnabled(brokerConfig.isTlsEnabled());
+        workerConfig.setTlsEnabled(brokerConfig.getWebServicePortTls().isPresent());
         workerConfig.setTlsEnableHostnameVerification(brokerConfig.isTlsHostnameVerificationEnabled());
         workerConfig.setBrokerClientTrustCertsFilePath(brokerConfig.getBrokerClientTrustCertsFilePath());
         workerConfig.setTlsTrustCertsFilePath(brokerConfig.getTlsTrustCertsFilePath());
@@ -1874,6 +1874,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         // client in worker will use this config to authenticate with broker
         workerConfig.setBrokerClientAuthenticationPlugin(brokerConfig.getBrokerClientAuthenticationPlugin());
         workerConfig.setBrokerClientAuthenticationParameters(brokerConfig.getBrokerClientAuthenticationParameters());
+        workerConfig.setBrokerClientAuthenticationEnabled(brokerConfig.isAuthenticationEnabled()
+                || StringUtils.isNotBlank(brokerConfig.getBrokerClientAuthenticationPlugin()));
 
         // inherit super users
         workerConfig.setSuperUserRoles(brokerConfig.getSuperUserRoles());

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -423,7 +423,6 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
         category = CATEGORY_WORKER_SECURITY,
         doc = "Enable TLS"
     )
-    @Deprecated
     private boolean tlsEnabled = false;
     @FieldContext(
         category = CATEGORY_WORKER_SECURITY,

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerService.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerService.java
@@ -162,7 +162,6 @@ public class PulsarWorkerService implements WorkerService {
                         pulsarServiceUrl,
                         brokerClientAuthenticationPlugin,
                         brokerClientAuthenticationParameters,
-                        workerConfig.isUseTls(),
                         workerConfig.getBrokerClientTrustCertsFilePath(),
                         workerConfig.isTlsAllowInsecureConnection(),
                         workerConfig.isTlsEnableHostnameVerification(),

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
@@ -274,8 +274,18 @@ public final class WorkerUtils {
                 allowTlsInsecureConnection, enableTlsHostnameVerificationEnable, null);
     }
 
+    @Deprecated
     public static PulsarClient getPulsarClient(String pulsarServiceUrl, String authPlugin, String authParams,
                                                Boolean useTls, String tlsTrustCertsFilePath,
+                                               Boolean allowTlsInsecureConnection,
+                                               Boolean enableTlsHostnameVerificationEnable,
+                                               WorkerConfig workerConfig) {
+        return getPulsarClient(pulsarServiceUrl, authPlugin, authParams, tlsTrustCertsFilePath,
+                allowTlsInsecureConnection, enableTlsHostnameVerificationEnable, workerConfig);
+    }
+
+    public static PulsarClient getPulsarClient(String pulsarServiceUrl, String authPlugin, String authParams,
+                                               String tlsTrustCertsFilePath,
                                                Boolean allowTlsInsecureConnection,
                                                Boolean enableTlsHostnameVerificationEnable,
                                                WorkerConfig workerConfig) {
@@ -295,9 +305,6 @@ public final class WorkerUtils {
             if (isNotBlank(authPlugin)
                     && isNotBlank(authParams)) {
                 clientBuilder.authentication(authPlugin, authParams);
-            }
-            if (useTls != null) {
-                clientBuilder.enableTls(useTls);
             }
             if (allowTlsInsecureConnection != null) {
                 clientBuilder.allowTlsInsecureConnection(allowTlsInsecureConnection);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/StandaloneContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/StandaloneContainer.java
@@ -30,22 +30,15 @@ public class StandaloneContainer extends PulsarContainer<StandaloneContainer> {
 
     public static final String NAME = "standalone";
 
-    public StandaloneContainer(String clusterName) {
-        super(clusterName,
-            NAME,
-            NAME + "-cluster",
-            "bin/pulsar",
-            BROKER_PORT,
-            BROKER_HTTP_PORT);
-    }
-
     public StandaloneContainer(String clusterName, String pulsarImageName) {
         super(clusterName,
                 NAME,
                 NAME + "-cluster",
-                "bin/pulsar",
+                "/bin/sh",
                 BROKER_PORT,
+                BROKER_PORT_TLS,
                 BROKER_HTTP_PORT,
+                BROKER_HTTPS_PORT,
                 "",
                 pulsarImageName);
     }
@@ -53,7 +46,8 @@ public class StandaloneContainer extends PulsarContainer<StandaloneContainer> {
     @Override
     protected void configure() {
         super.configure();
-        setCommand("standalone");
+        setCommand("-c", "bin/apply-config-from-env.py conf/standalone.conf "
+                + "&& bin/apply-config-from-env.py conf/pulsar_env.sh && bin/pulsar standalone");
         addEnv("PULSAR_MEM", "-Xms128M -Xmx1g -XX:MaxDirectMemorySize=1g");
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/tls/StandaloneWithTlsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/tls/StandaloneWithTlsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.tests.integration.tls;
+
+import lombok.Cleanup;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.auth.AuthenticationTls;
+import org.apache.pulsar.tests.integration.suites.PulsarStandaloneTestSuite;
+import org.testng.annotations.Test;
+
+public class StandaloneWithTlsTest extends PulsarStandaloneTestSuite {
+
+    @Override
+    public void setUpCluster() throws Exception {
+        setupTLS();
+        standaloneEnvs.put("PULSAR_PREFIX_loadManagerClassName","org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl");
+        super.setUpCluster();
+    }
+
+    @Test
+    public void testTlsTransportByAuthenticationTls() throws PulsarAdminException, PulsarClientException {
+        @Cleanup PulsarAdmin admin = PulsarAdmin.builder()
+                .serviceHttpUrl(container.getHttpsServiceUrl())
+                .tlsTrustCertsFilePath(clientTlsTrustCertsFilePath)
+                .authentication(new AuthenticationTls(clientTlsCertificateFilePath, clientTlsKeyFilePath))
+                .build();
+
+        admin.functions().getBuiltInFunctions();
+    }
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarStandaloneTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarStandaloneTestBase.java
@@ -18,7 +18,12 @@
  */
 package org.apache.pulsar.tests.integration.topologies;
 
+import static org.apache.pulsar.tests.integration.containers.PulsarContainer.BROKER_HTTPS_PORT;
+import static org.apache.pulsar.tests.integration.containers.PulsarContainer.BROKER_PORT_TLS;
 import static org.testng.Assert.assertEquals;
+import com.google.common.io.Resources;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
@@ -37,6 +42,17 @@ import org.testng.annotations.DataProvider;
  */
 @Slf4j
 public abstract class PulsarStandaloneTestBase extends PulsarTestBase {
+
+    protected final static String clientTlsTrustCertsFilePath = loadCertificateAuthorityFile("certs/ca.cert.pem");
+    protected final static String clientTlsKeyFilePath = loadCertificateAuthorityFile("client-keys/admin.key-pk8.pem");
+    protected final static String clientTlsCertificateFilePath = loadCertificateAuthorityFile("client-keys/admin.cert.pem");
+
+
+    private static String loadCertificateAuthorityFile(String name) {
+        return Resources.getResource("certificate-authority/" + name).getPath();
+    }
+
+    protected final Map<String, String> standaloneEnvs = new HashMap<>();
 
     @DataProvider(name = "StandaloneServiceUrlAndTopics")
     public Object[][] serviceUrlAndTopics() {
@@ -84,6 +100,7 @@ public abstract class PulsarStandaloneTestBase extends PulsarTestBase {
             .withNetworkAliases(StandaloneContainer.NAME + "-" + clusterName)
             .withEnv("PF_stateStorageServiceUrl", "bk://localhost:4181")
             .withEnv("PULSAR_STANDALONE_USE_ZOOKEEPER", "true");
+        container.withEnv(standaloneEnvs);
         container.start();
         log.info("Pulsar cluster {} is up running:", clusterName);
         log.info("\tBinary Service Url : {}", container.getPlainTextServiceUrl());
@@ -121,4 +138,28 @@ public abstract class PulsarStandaloneTestBase extends PulsarTestBase {
         }
     }
 
+    protected void setupTLS () {
+        standaloneEnvs.put("PULSAR_PREFIX_webServicePortTls", String.valueOf(BROKER_HTTPS_PORT));
+        standaloneEnvs.put("PULSAR_PREFIX_brokerServicePortTls", String.valueOf(BROKER_PORT_TLS));
+        standaloneEnvs.put("PULSAR_PREFIX_brokerClientTlsEnabled", "true");
+        standaloneEnvs.put("PULSAR_PREFIX_tlsRequireTrustedClientCertOnConnect", "true");
+        standaloneEnvs.put("PULSAR_PREFIX_tlsAllowInsecureConnection", "false");
+        standaloneEnvs.put("PULSAR_PREFIX_tlsCertificateFilePath",
+                "/pulsar/certificate-authority/server-keys/broker.cert.pem");
+        standaloneEnvs.put("PULSAR_PREFIX_tlsKeyFilePath",
+                "/pulsar/certificate-authority/server-keys/broker.key-pk8.pem");
+        standaloneEnvs.put("PULSAR_PREFIX_tlsTrustCertsFilePath",
+                "/pulsar/certificate-authority/certs/ca.cert.pem");
+        standaloneEnvs.put("PULSAR_PREFIX_brokerClientCertificateFilePath",
+                "/pulsar/certificate-authority/client-keys/admin.cert.pem");
+        standaloneEnvs.put("PULSAR_PREFIX_brokerClientKeyFilePath",
+                "/pulsar/certificate-authority/client-keys/admin.key-pk8.pem");
+        standaloneEnvs.put("PULSAR_PREFIX_brokerClientTrustCertsFilePath",
+                "/pulsar/certificate-authority/certs/ca.cert.pem");
+        standaloneEnvs.put("PULSAR_PREFIX_brokerClientAuthenticationPlugin",
+                "org.apache.pulsar.client.impl.auth.AuthenticationTls");
+        standaloneEnvs.put("PULSAR_PREFIX_brokerClientAuthenticationParameters",
+                "{\"tlsCertFile\":\"/pulsar/certificate-authority/client-keys/admin.cert.pem\","
+                        + "\"tlsKeyFile\":\"/pulsar/certificate-authority/client-keys/admin.key-pk8.pem\"}");
+    }
 }


### PR DESCRIPTION
### Motivation

When tls transport is enabled, the standalone cannot be running:
```
2023-08-15T15:23:26,736+0200 [main] INFO  org.apache.pulsar.functions.worker.WorkerUtils - Create Pulsar Admin to service url http://localhost:8080/: authPlugin = org.apache.pulsar.client.impl.auth.AuthenticationTls, authParams = {"tlsCertFile":"/Users/alex/Desktop/pulsar/apache-pulsar-3.0.0-tls/conf/tls-certs/client.cert.pem","tlsKeyFile":"/Users/alex/Desktop/pulsar/apache-pulsar-3.0.0-tls/conf/tls-certs/client.key-pk8.pem"}, tlsTrustCerts = /Users/alex/Desktop/pulsar/apache-pulsar-3.0.0-tls/conf/tls-certs/ca.cert.pem, allowTlsInsecureConnection = false, enableTlsHostnameVerification = false
2023-08-15T15:23:26,910+0200 [pulsar-web-48-15] WARN  org.apache.pulsar.broker.web.AuthenticationFilter - [127.0.0.1] Failed to authenticate HTTP request: Authentication required
2023-08-15T15:23:26,918+0200 [pulsar-web-48-15] INFO  org.eclipse.jetty.server.RequestLog - 127.0.0.1 - - [15/Aug./2023:15:23:26 +0200] "PUT /admin/v2/persistent/public/functions/assignments HTTP/1.1" 401 0 "-" "Pulsar-Java-v3.0.0" 12
```

The service URL is incorrect, which should be https://localhost:8081, not http://localhost:8080.

### Modifications

- Fix check URL condition

### Verifying this change

- [x] Make sure that the change passes the CI checks.

Added  test.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->