### PR TITLE
[fix][broker] fix topic policy is updated incorrectly when continuously use pulsar-admin to set policy

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.admin.impl;
 
+import static org.apache.pulsar.broker.service.TopicPoliciesService.DEFAULT_GET_TOPIC_POLICY_TIMEOUT;
 import static org.apache.pulsar.common.naming.SystemTopicNames.isSystemTopic;
 import static org.apache.pulsar.common.naming.SystemTopicNames.isTransactionCoordinatorAssign;
 import static org.apache.pulsar.common.naming.SystemTopicNames.isTransactionInternalName;
@@ -77,6 +78,7 @@ import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authorization.AuthorizationService;
 import org.apache.pulsar.broker.service.AnalyzeBacklogResult;
+import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.BrokerServiceException.AlreadyRunningException;
 import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionBusyException;
 import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionInvalidCursorPosition;
@@ -96,8 +98,11 @@ import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedExc
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.impl.Backoff;
+import org.apache.pulsar.client.impl.BackoffBuilder;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.client.util.RetryUtil;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.proto.BrokerEntryMetadata;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
@@ -3470,7 +3475,7 @@ public class PersistentTopicsBase extends AdminResource {
         }
         return getTopicPoliciesAsyncWithRetry(topicName, isGlobal)
             .thenCompose(op -> {
-                TopicPolicies topicPolicies = op.orElseGet(TopicPolicies::new);
+                TopicPolicies topicPolicies = op.map(TopicPolicies::new).orElseGet(TopicPolicies::new);
                 for (BacklogQuota.BacklogQuotaType backlogQuotaType : BacklogQuota.BacklogQuotaType.values()) {
                     BacklogQuota backlogQuota = topicPolicies.getBackLogQuotaMap().get(backlogQuotaType.name());
                     if (backlogQuota == null) {
@@ -3490,7 +3495,43 @@ public class PersistentTopicsBase extends AdminResource {
                 topicPolicies.setRetentionPolicies(retention);
                 topicPolicies.setIsGlobal(isGlobal);
                 return pulsar().getTopicPoliciesService().updateTopicPoliciesAsync(topicName, topicPolicies);
-            });
+            }).thenCompose(__ -> isRetentionUpdateSuccess(isGlobal, retention));
+    }
+
+    private CompletableFuture<Void> isRetentionUpdateSuccess(boolean isGlobal, RetentionPolicies retention) {
+
+        CompletableFuture<Void> response = new CompletableFuture<>();
+        Backoff usedBackoff = new BackoffBuilder()
+                .setInitialTime(500, TimeUnit.MILLISECONDS)
+                .setMandatoryStop(DEFAULT_GET_TOPIC_POLICY_TIMEOUT, TimeUnit.MILLISECONDS)
+                .setMax(DEFAULT_GET_TOPIC_POLICY_TIMEOUT, TimeUnit.MILLISECONDS)
+                .create();
+        log.info("start currentTime:{}", System.currentTimeMillis());
+        try {
+            RetryUtil.retryWithoutLogAsynchronously(() -> {
+                log.info("end currentTime:{}", System.currentTimeMillis());
+                CompletableFuture<Void> future = new CompletableFuture<>();
+                getTopicPoliciesAsyncWithRetry(topicName, isGlobal)
+                        .thenApply(op -> op.map(TopicPolicies::getRetentionPolicies))
+                        .thenAccept(retentionPolicies -> {
+                            if (retentionPolicies.isPresent() && retentionPolicies.get().equals(retention)) {
+                                future.complete(null);
+                            } else if (!retentionPolicies.isPresent() && retention == null) {
+                                future.complete(null);
+                            } else {
+                                log.info("retentionPolicies:{}, retention:{}", retentionPolicies.orElse(null), retention);
+                                future.completeExceptionally(new BrokerServiceException.TopicPoliciesCacheNotUpdateAfterSetException());
+                            }
+                        }).exceptionally(ex -> {
+                            future.completeExceptionally(ex);
+                            return null;
+                        });
+                return future;
+            }, usedBackoff, pulsar().getExecutor(), response);
+        } catch (Exception e) {
+            response.completeExceptionally(e);
+        }
+        return response;
     }
 
     protected CompletableFuture<Void> internalRemoveRetention(boolean isGlobal) {
@@ -3499,9 +3540,10 @@ public class PersistentTopicsBase extends AdminResource {
                     if (!op.isPresent()) {
                         return CompletableFuture.completedFuture(null);
                     }
-                    op.get().setRetentionPolicies(null);
-                    return pulsar().getTopicPoliciesService().updateTopicPoliciesAsync(topicName, op.get());
-                });
+                    TopicPolicies topicPolicies = op.map(TopicPolicies::new).get();
+                    topicPolicies.setRetentionPolicies(null);
+                    return pulsar().getTopicPoliciesService().updateTopicPoliciesAsync(topicName, topicPolicies);
+                }).thenCompose(__ -> isRetentionUpdateSuccess(isGlobal, null));
     }
 
     protected CompletableFuture<PersistencePolicies> internalGetPersistence(boolean applied, boolean isGlobal) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
@@ -220,6 +220,12 @@ public class BrokerServiceException extends Exception {
         }
     }
 
+    public static class TopicPoliciesCacheNotUpdateAfterSetException extends BrokerServiceException {
+        public TopicPoliciesCacheNotUpdateAfterSetException() {
+            super("Topic policies cache have not update after set.");
+        }
+    }
+
     public static class TopicBacklogQuotaExceededException extends BrokerServiceException {
         @Getter
         private final BacklogQuota.RetentionPolicy retentionPolicy;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -615,33 +615,33 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testSetRetention() throws Exception {
-        RetentionPolicies retention = new RetentionPolicies(60, 1024);
-        log.info("Retention: {} will set to the topic: {}", retention, testTopic);
+        for (int i = 0; i < 10; i++) {
+            RetentionPolicies retention = new RetentionPolicies(i, 1024);
+            log.info("Retention: {} will set to the topic: {}", retention, testTopic);
 
-        admin.topicPolicies().setRetention(testTopic, retention);
-        log.info("Retention set success on topic: {}", testTopic);
+            admin.topicPolicies().setRetention(testTopic, retention);
+            log.info("Retention set success on topic: {}", testTopic);
 
-        Awaitility.await()
-                .untilAsserted(() -> Assert.assertEquals(admin.topicPolicies().getRetention(testTopic), retention));
+            Assert.assertEquals(admin.topicPolicies().getRetention(testTopic), retention);
+        }
 
         admin.topics().deletePartitionedTopic(testTopic, true);
     }
 
     @Test
     public void testRemoveRetention() throws Exception {
+        for (int i = 0; i < 10; i++) {
+            RetentionPolicies retention = new RetentionPolicies(i, 1024);
+            log.info("Retention: {} will set to the topic: {}", retention, testTopic);
 
-        RetentionPolicies retention = new RetentionPolicies(60, 1024);
-        log.info("Retention: {} will set to the topic: {}", retention, testTopic);
+            admin.topicPolicies().setRetention(testTopic, retention);
+            log.info("Retention set success on topic: {}", testTopic);
 
-        admin.topicPolicies().setRetention(testTopic, retention);
-        log.info("Retention set success on topic: {}", testTopic);
+            Assert.assertEquals(admin.topicPolicies().getRetention(testTopic), retention);
 
-        Awaitility.await()
-                .untilAsserted(() -> Assert.assertEquals(admin.topicPolicies().getRetention(testTopic), retention));
-
-        admin.topicPolicies().removeRetention(testTopic);
-        Awaitility.await()
-                .untilAsserted(() -> Assert.assertNull(admin.topicPolicies().getRetention(testTopic)));
+            admin.topicPolicies().removeRetention(testTopic);
+            Assert.assertNull(admin.topicPolicies().getRetention(testTopic));
+        }
 
         admin.topics().deletePartitionedTopic(testTopic, true);
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TopicPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TopicPolicies.java
@@ -78,6 +78,39 @@ public class TopicPolicies {
     // If set, it will override the namespace settings for allowing auto subscription creation
     private AutoSubscriptionCreationOverrideImpl autoSubscriptionCreationOverride;
 
+    public TopicPolicies(TopicPolicies policies) {
+        this.backLogQuotaMap = policies.backLogQuotaMap;
+        this.subscriptionTypesEnabled = policies.subscriptionTypesEnabled;
+        this.replicationClusters = policies.replicationClusters;
+        this.shadowTopics = policies.shadowTopics;
+        this.isGlobal = policies.isGlobal;
+        this.persistence = policies.persistence;
+        this.retentionPolicies = policies.retentionPolicies;
+        this.deduplicationEnabled = policies.deduplicationEnabled;
+        this.messageTTLInSeconds = policies.messageTTLInSeconds;
+        this.maxProducerPerTopic = policies.maxProducerPerTopic;
+        this.maxConsumerPerTopic = policies.maxConsumerPerTopic;
+        this.maxConsumersPerSubscription = policies.maxConsumersPerSubscription;
+        this.maxUnackedMessagesOnConsumer = policies.maxUnackedMessagesOnConsumer;
+        this.maxUnackedMessagesOnSubscription = policies.maxUnackedMessagesOnSubscription;
+        this.delayedDeliveryTickTimeMillis = policies.delayedDeliveryTickTimeMillis;
+        this.delayedDeliveryEnabled = policies.delayedDeliveryEnabled;
+        this.offloadPolicies = policies.offloadPolicies;
+        this.inactiveTopicPolicies = policies.inactiveTopicPolicies;
+        this.dispatchRate = policies.dispatchRate;
+        this.subscriptionDispatchRate = policies.subscriptionDispatchRate;
+        this.compactionThreshold = policies.compactionThreshold;
+        this.publishRate = policies.publishRate;
+        this.subscribeRate = policies.subscribeRate;
+        this.deduplicationSnapshotIntervalSeconds = policies.deduplicationSnapshotIntervalSeconds;
+        this.maxMessageSize = policies.maxMessageSize;
+        this.maxSubscriptionsPerTopic = policies.maxSubscriptionsPerTopic;
+        this.replicatorDispatchRate = policies.replicatorDispatchRate;
+        this.schemaCompatibilityStrategy = policies.schemaCompatibilityStrategy;
+        this.entryFilters = policies.entryFilters;
+        this.autoSubscriptionCreationOverride = policies.autoSubscriptionCreationOverride;
+    }
+
     /**
      * Subscription level policies for specific subscription.
      */


### PR DESCRIPTION
Fixes #21024 

### Motivation

Modify the process of update topic policy. 

Make topic policy can be updated correctly when user use pulsar-admin to set policy 

### Modifications

1. Construct a new topicPolicy in internalSetRetention(), which make sure we do not update the value of policiesCache in two area. We only update policiesCache by SystemTopicBasedTopicPoliciesService#refreshTopicPoliciesCache
2. All the method about update topicPolicy in pulsar-admin,  should respond success to client after policy is actually updated in policiesCache. 
3. Retry in isRetentionUpdateSuccess(), because systemTopicReader maybe can not immediately read next PulsarEvent message.
4. Improve the test in TopicPoliciesTest to make the test cover more complicated pulsar-admin operation. 


### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/TakaHiR07/pulsar/pull/13

