### PR TITLE
[fix] [broker] Ensure policy cache is updated before updateTopicPoliciesAsync returns.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -24,9 +24,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
@@ -84,6 +86,8 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
     @VisibleForTesting
     final Map<TopicName, List<TopicPolicyListener<TopicPolicies>>> listeners = new ConcurrentHashMap<>();
 
+    final Map<TopicName, BlockingDeque<CompletableFuture>> results = new ConcurrentHashMap<>();
+
     public SystemTopicBasedTopicPoliciesService(PulsarService pulsarService) {
         this.pulsarService = pulsarService;
         this.clusterName = pulsarService.getConfiguration().getClusterName();
@@ -97,7 +101,10 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
 
     @Override
     public CompletableFuture<Void> updateTopicPoliciesAsync(TopicName topicName, TopicPolicies policies) {
-        return sendTopicPolicyEvent(topicName, ActionType.UPDATE, policies);
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        results.computeIfAbsent(topicName, k -> new LinkedBlockingDeque<>()).add(result);
+        return sendTopicPolicyEvent(topicName, ActionType.UPDATE, policies)
+                .thenCombine(result, (__, ___) -> null);
     }
 
     private CompletableFuture<Void> sendTopicPolicyEvent(TopicName topicName, ActionType actionType,
@@ -420,11 +427,26 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         });
     }
 
+    private void completeResults(TopicName topicName) {
+        if (results.get(topicName) != null) {
+            BlockingDeque<CompletableFuture> futures = results.get(topicName);
+            CompletableFuture<Void> future;
+            while (true) {
+                future = futures.poll();
+                if (future == null) {
+                    break;
+                }
+                future.complete(null);
+            }
+        }
+    }
+
     private void readMorePolicies(SystemTopicClient.Reader<PulsarEvent> reader) {
         reader.readNextAsync()
                 .thenAccept(msg -> {
                     refreshTopicPoliciesCache(msg);
                     notifyListener(msg);
+                    completeResults(TopicName.get(TopicName.get(msg.getKey()).getPartitionedTopicName()));
                 })
                 .whenComplete((__, ex) -> {
                     if (ex == null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
@@ -240,6 +240,36 @@ public class SystemTopicBasedTopicPoliciesServiceTest extends MockedPulsarServic
     }
 
     @Test
+    public void testUpdateAndGetPolicy() throws ExecutionException, InterruptedException, TopicPoliciesCacheNotInitException {
+        // Init topic policies
+        TopicPolicies initPolicy = TopicPolicies.builder()
+                .maxConsumerPerTopic(10)
+                .build();
+        systemTopicBasedTopicPoliciesService.updateTopicPoliciesAsync(TOPIC1, initPolicy).get();
+
+        // Wait for all topic policies updated.
+        Awaitility.await().untilAsserted(() ->
+                Assert.assertTrue(systemTopicBasedTopicPoliciesService
+                        .getPoliciesCacheInit(TOPIC1.getNamespaceObject())));
+
+        // Assert broker is cache all topic policies
+        Awaitility.await().untilAsserted(() ->
+                Assert.assertEquals(systemTopicBasedTopicPoliciesService.getTopicPolicies(TOPIC1)
+                        .getMaxConsumerPerTopic().intValue(), 10));
+
+        // Update policy for TOPIC1
+        TopicPolicies policies1 = TopicPolicies.builder()
+                .maxProducerPerTopic(1)
+                .build();
+        systemTopicBasedTopicPoliciesService.updateTopicPoliciesAsync(TOPIC1, policies1).get();
+
+        // Ensure that the cache is updated before updateTopicPoliciesAsync returns.
+        TopicPolicies policiesGet1 = systemTopicBasedTopicPoliciesService.getTopicPolicies(TOPIC1);
+        Assert.assertEquals(policiesGet1, policies1);
+    }
+
+
+    @Test
     public void testCacheCleanup() throws Exception {
         final String topic = "persistent://" + NAMESPACE1 + "/test" + UUID.randomUUID();
         TopicName topicName = TopicName.get(topic);


### PR DESCRIPTION
### Motivation

Calling these two method synchronously to set the retention and ttl of one topic will result into unexpected results.
```
admin.topics().setRetention
admin.topics().setMessageTTL
```
For example, if we call 
```
int retentionTimeInMinutes = 2880;
int messageTTLInSecond = retentionTimeInMinutes * 60;
admin.topics().setRetention(topic,new RetentionPolicies(retentionTimeInMinute, -1));
admin.topics().setMessageTTL(topic, messageTTLInSecond);
```

We expect that the retention is set to 2880 minutes, ttl is set to `2880*16=172800` seconds. But the result is that the retention policy is null !
We read the messages from `__change_events` derectly and find out the reason:
```
TimeStamp:1692157480789 ,Message received: PulsarEvent(eventType=TOPIC_POLICY, actionType=UPDATE, topicPoliciesEvent=TopicPoliciesEvent(, policies=TopicPolicies(backLogQuotaMap={}, subscriptionTypesEnabled=[], persistence=null, **retentionPolicies=RetentionPolicies{retentionTimeInMinutes=2880, retentionSizeInMB=-1},** deduplicationEnabled=null, **messageTTLInSeconds=null**, maxProducerPerTopic=null, maxConsumerPerTopic=null, maxConsumersPerSubscription=null, maxUnackedMessagesOnConsumer=null, maxUnackedMessagesOnSubscription=null, delayedDeliveryTickTimeMillis=null, delayedDeliveryEnabled=null, offloadPolicies=null, inactiveTopicPolicies=null, dispatchRate=null, subscriptionDispatchRate=null, compactionThreshold=null, publishRate=null, subscribeRate=null, deduplicationSnapshotIntervalSeconds=null, maxMessageSize=null, maxSubscriptionsPerTopic=null, replicatorDispatchRate=null)))

TimeStamp:1692157480811 ,Message received: PulsarEvent(eventType=TOPIC_POLICY, actionType=UPDATE, topicPoliciesEvent=TopicPoliciesEvent(, policies=TopicPolicies(backLogQuotaMap={}, subscriptionTypesEnabled=[], persistence=null, **retentionPolicies=null**, deduplicationEnabled=null, **messageTTLInSeconds=172800**, maxProducerPerTopic=null, maxConsumerPerTopic=null, maxConsumersPerSubscription=null, maxUnackedMessagesOnConsumer=null, maxUnackedMessagesOnSubscription=null, delayedDeliveryTickTimeMillis=null, delayedDeliveryEnabled=null, offloadPolicies=null, inactiveTopicPolicies=null, dispatchRate=null, subscriptionDispatchRate=null, compactionThreshold=null, publishRate=null, subscribeRate=null, deduplicationSnapshotIntervalSeconds=null, maxMessageSize=null, maxSubscriptionsPerTopic=null, replicatorDispatchRate=null)))
```
We can see that the retention policy in the second message is null, which result into the null retention policy. 

Diving into the implementation of `SystemTopicBasedTopicPoliciesService`, we can see that `org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService#updateTopicPoliciesAsync` returns as soon as the message is written into `__change_events`, but do not guranteen that the topic policy in cache is updated. However, topic policy setting api will retrieve the topic policy from cache.
```
org.apache.pulsar.broker.admin.v2.PersistentTopics#setRetention
org.apache.pulsar.broker.admin.v2.PersistentTopics#setMessageTTL
```
Before the cache is updated, the second rest api for setting ttl arrived, and change the topic policy based on the old one, which result into the problem.

### Modifications

The solution is:  Ensure policy cache is updated before updateTopicPoliciesAsync returns.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added tests and can be verified as follows:


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
