### PR TITLE
[fix][offload] Support offload prefetchrounds & assignmentThreads adjustable

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -3004,6 +3004,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int managedLedgerOffloadPrefetchRounds = 1;
 
     @FieldContext(
+            category = CATEGORY_STORAGE_OFFLOADING,
+            doc = "The number of threads used for offloading the execution of assignments"
+    )
+    private int managedLedgerAssignmentOffloadThreads = 2;
+
+    @FieldContext(
         dynamic = true,
         category = CATEGORY_STORAGE_ML,
         doc = "Time to rollover ledger for inactive topic (duration without any publish on that topic). "

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/OffloadPolicies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/OffloadPolicies.java
@@ -27,6 +27,7 @@ public interface OffloadPolicies {
 
     Integer getManagedLedgerOffloadMaxThreads();
 
+    Integer getManagedLedgerAssignmentOffloadThreads();
     Integer getManagedLedgerOffloadPrefetchRounds();
 
     Long getManagedLedgerOffloadThresholdInBytes();
@@ -86,6 +87,7 @@ public interface OffloadPolicies {
         Builder managedLedgerOffloadDriver(String managedLedgerOffloadDriver);
 
         Builder managedLedgerOffloadMaxThreads(Integer managedLedgerOffloadMaxThreads);
+        Builder managedLedgerAssignmentOffloadThreads(Integer managedLedgerAssignmentOffloadThreads);
 
         Builder managedLedgerOffloadPrefetchRounds(Integer managedLedgerOffloadPrefetchRounds);
 

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -366,11 +366,11 @@ public class PulsarAdminToolTest {
         // filesystem offload
         CmdNamespaces namespaces = new CmdNamespaces(() -> admin);
         namespaces.run(split(
-          "set-offload-policies myprop/clust/ns2 -d filesystem -oat 100M -oats 1h -oae 1h -orp bookkeeper-first"));
+          "set-offload-policies myprop/clust/ns2 -d filesystem -oat 100M -oats 1h -oae 1h -orp bookkeeper-first -aot 100 -opr 200"));
         verify(mockNamespaces).setOffloadPolicies("myprop/clust/ns2",
           OffloadPoliciesImpl.create("filesystem", null, null,
             null, null, null, null, null, 64 * 1024 * 1024, 1024 * 1024,
-            100 * 1024 * 1024L, 3600L, 3600 * 1000L, OffloadedReadPriority.BOOKKEEPER_FIRST));
+            100 * 1024 * 1024L, 3600L, 3600 * 1000L, OffloadedReadPriority.BOOKKEEPER_FIRST, 100, 200));
 
         // S3 offload
         CmdNamespaces namespaces2 = new CmdNamespaces(() -> admin);
@@ -1494,10 +1494,10 @@ public class PulsarAdminToolTest {
 
         // filesystem offload
         CmdTopics cmdTopics = new CmdTopics(() -> admin);
-        cmdTopics.run(split("set-offload-policies persistent://myprop/clust/ns1/ds1 -d filesystem -oat 100M -oats 1h -oae 1h -orp bookkeeper-first"));
+        cmdTopics.run(split("set-offload-policies persistent://myprop/clust/ns1/ds1 -d filesystem -oat 100M -oats 1h -oae 1h -orp bookkeeper-first -aot 100 -opr 200"));
         OffloadPoliciesImpl offloadPolicies = OffloadPoliciesImpl.create("filesystem", null, null
           , null, null, null, null, null, 64 * 1024 * 1024, 1024 * 1024,
-          100 * 1024 * 1024L, 3600L, 3600 * 1000L, OffloadedReadPriority.BOOKKEEPER_FIRST);
+          100 * 1024 * 1024L, 3600L, 3600 * 1000L, OffloadedReadPriority.BOOKKEEPER_FIRST, 100, 200);
         verify(mockTopics).setOffloadPolicies("persistent://myprop/clust/ns1/ds1", offloadPolicies);
 
 //         S3 offload

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -2307,6 +2307,15 @@ public class CmdNamespaces extends CmdBase {
                 required = false
         )
         private String offloadReadPriorityStr;
+        @Parameter(names = {"--assignmentOffloadThreads", "-aot"}, description =
+                "The number of threads used for offloading the execution of assignments. "
+                        + "The default value is 2.", required = false)
+        private String assignmentOffloadThreadsStr;
+
+        @Parameter(names = {"--offloadPrefetchRounds", "-opr"}, description =
+                "Maximum prefetch rounds for ledger reading for offloading."
+                        + "The default value is 1.", required = false)
+        private String offloadPrefetchRoundsStr;
 
         public final List<String> driverNames = OffloadPoliciesImpl.DRIVER_NAMES;
 
@@ -2405,11 +2414,30 @@ public class CmdNamespaces extends CmdBase {
                 }
             }
 
+            int assignmentOffloadThreads = OffloadPoliciesImpl.DEFAULT_ASSIGNMENT_OFFLOAD_THREADS;
+            if (StringUtils.isNotEmpty(assignmentOffloadThreadsStr)) {
+                long assignmentOffloadThreadsNumber = validateSizeString(assignmentOffloadThreadsStr);
+                if (positiveCheck("AssignmentOffloadThreads", assignmentOffloadThreadsNumber) && maxValueCheck(
+                        "AssignmentOffloadThreads", assignmentOffloadThreadsNumber, Integer.MAX_VALUE)) {
+                    assignmentOffloadThreads = Long.valueOf(assignmentOffloadThreadsNumber).intValue();
+                }
+            }
+
+            int offloadPrefetchRounds = OffloadPoliciesImpl.DEFAULT_OFFLOAD_MAX_PREFETCH_ROUNDS;
+            if (StringUtils.isNotEmpty(offloadPrefetchRoundsStr)) {
+                long offloadPrefetchRoundsNumber = validateSizeString(offloadPrefetchRoundsStr);
+                if (positiveCheck("OffloadPrefetchRounds", offloadPrefetchRoundsNumber) && maxValueCheck(
+                        "OffloadPrefetchRounds", offloadPrefetchRoundsNumber, Integer.MAX_VALUE)) {
+                    offloadPrefetchRounds = Long.valueOf(offloadPrefetchRoundsNumber).intValue();
+                }
+            }
+
             OffloadPolicies offloadPolicies = OffloadPoliciesImpl.create(driver, region, bucket, endpoint,
                     s3Role, s3RoleSessionName,
                     awsId, awsSecret,
                     maxBlockSizeInBytes, readBufferSizeInBytes, offloadAfterThresholdInBytes,
-                    offloadThresholdInSeconds, offloadAfterElapsedInMillis, offloadedReadPriority);
+                    offloadThresholdInSeconds, offloadAfterElapsedInMillis, offloadedReadPriority,
+                    assignmentOffloadThreads, offloadPrefetchRounds);
 
             getAdmin().namespaces().setOffloadPolicies(namespace, offloadPolicies);
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
@@ -1800,12 +1800,12 @@ public class CmdTopicPolicies extends CmdBase {
         @Parameter(names = {"--assignmentOffloadThreads", "-aot"}, description =
                 "The number of threads used for offloading the execution of assignments. "
                         + "The default value is 2.", required = false)
-        private int assignmentOffloadThreads;
+        private String assignmentOffloadThreadsStr;
 
         @Parameter(names = {"--offloadPrefetchRounds", "-opr"}, description =
                 "Maximum prefetch rounds for ledger reading for offloading."
                         + "The default value is 1.", required = false)
-        private int offloadPrefetchRounds;
+        private String offloadPrefetchRoundsStr;
 
         @Parameter(names = { "--global", "-g" }, description = "Whether to set this policy globally. "
                 + "If set to true, the policy will be replicate to other clusters asynchronously")
@@ -1854,6 +1854,24 @@ public class CmdTopicPolicies extends CmdBase {
                             .map(OffloadedReadPriority::toString)
                             .collect(Collectors.joining(","))
                             + " but got: " + this.offloadReadPriorityStr, e);
+                }
+            }
+
+            int assignmentOffloadThreads = OffloadPoliciesImpl.DEFAULT_ASSIGNMENT_OFFLOAD_THREADS;
+            if (StringUtils.isNotEmpty(assignmentOffloadThreadsStr)) {
+                long assignmentOffloadThreadsNumber = validateSizeString(assignmentOffloadThreadsStr);
+                if (positiveCheck("AssignmentOffloadThreads", assignmentOffloadThreadsNumber) && maxValueCheck(
+                        "AssignmentOffloadThreads", assignmentOffloadThreadsNumber, Integer.MAX_VALUE)) {
+                    assignmentOffloadThreads = Long.valueOf(assignmentOffloadThreadsNumber).intValue();
+                }
+            }
+
+            int offloadPrefetchRounds = OffloadPoliciesImpl.DEFAULT_OFFLOAD_MAX_PREFETCH_ROUNDS;
+            if (StringUtils.isNotEmpty(offloadPrefetchRoundsStr)) {
+                long offloadPrefetchRoundsNumber = validateSizeString(offloadPrefetchRoundsStr);
+                if (positiveCheck("OffloadPrefetchRounds", offloadPrefetchRoundsNumber) && maxValueCheck(
+                        "OffloadPrefetchRounds", offloadPrefetchRoundsNumber, Integer.MAX_VALUE)) {
+                    offloadPrefetchRounds = Long.valueOf(offloadPrefetchRoundsNumber).intValue();
                 }
             }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
@@ -1797,6 +1797,16 @@ public class CmdTopicPolicies extends CmdBase {
         )
         private String offloadReadPriorityStr;
 
+        @Parameter(names = {"--assignmentOffloadThreads", "-aot"}, description =
+                "The number of threads used for offloading the execution of assignments. "
+                        + "The default value is 2.", required = false)
+        private int assignmentOffloadThreads;
+
+        @Parameter(names = {"--offloadPrefetchRounds", "-opr"}, description =
+                "Maximum prefetch rounds for ledger reading for offloading."
+                        + "The default value is 1.", required = false)
+        private int offloadPrefetchRounds;
+
         @Parameter(names = { "--global", "-g" }, description = "Whether to set this policy globally. "
                 + "If set to true, the policy will be replicate to other clusters asynchronously")
         private boolean isGlobal = false;
@@ -1852,7 +1862,7 @@ public class CmdTopicPolicies extends CmdBase {
                     awsId, awsSecret,
                     maxBlockSizeInBytes,
                     readBufferSizeInBytes, offloadThresholdInBytes, offloadThresholdInSeconds,
-                    offloadDeletionLagInMillis, offloadedReadPriority);
+                    offloadDeletionLagInMillis, offloadedReadPriority, assignmentOffloadThreads, offloadPrefetchRounds);
 
             getTopicPolicies(isGlobal).setOffloadPolicies(persistentTopic, offloadPolicies);
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -2183,6 +2183,16 @@ public class CmdTopics extends CmdBase {
         )
         private String offloadReadPriorityStr;
 
+        @Parameter(names = {"--assignmentOffloadThreads", "-aot"}, description =
+                "The number of threads used for offloading the execution of assignments. "
+                        + "The default value is 2.", required = false)
+        private String assignmentOffloadThreadsStr;
+
+        @Parameter(names = {"--offloadPrefetchRounds", "-opr"}, description =
+                "Maximum prefetch rounds for ledger reading for offloading."
+                        + "The default value is 1.", required = false)
+        private String offloadPrefetchRoundsStr;
+
         public final List<String> driverNames = OffloadPoliciesImpl.DRIVER_NAMES;
 
         public boolean driverSupported(String driver) {
@@ -2293,11 +2303,30 @@ public class CmdTopics extends CmdBase {
                 }
             }
 
+            int assignmentOffloadThreads = OffloadPoliciesImpl.DEFAULT_ASSIGNMENT_OFFLOAD_THREADS;
+            if (StringUtils.isNotEmpty(assignmentOffloadThreadsStr)) {
+                long assignmentOffloadThreadsNumber = validateSizeString(assignmentOffloadThreadsStr);
+                if (positiveCheck("AssignmentOffloadThreads", assignmentOffloadThreadsNumber) && maxValueCheck(
+                        "AssignmentOffloadThreads", assignmentOffloadThreadsNumber, Integer.MAX_VALUE)) {
+                    assignmentOffloadThreads = Long.valueOf(assignmentOffloadThreadsNumber).intValue();
+                }
+            }
+
+            int offloadPrefetchRounds = OffloadPoliciesImpl.DEFAULT_OFFLOAD_MAX_PREFETCH_ROUNDS;
+            if (StringUtils.isNotEmpty(offloadPrefetchRoundsStr)) {
+                long offloadPrefetchRoundsNumber = validateSizeString(offloadPrefetchRoundsStr);
+                if (positiveCheck("OffloadPrefetchRounds", offloadPrefetchRoundsNumber) && maxValueCheck(
+                        "OffloadPrefetchRounds", offloadPrefetchRoundsNumber, Integer.MAX_VALUE)) {
+                    offloadPrefetchRounds = Long.valueOf(offloadPrefetchRoundsNumber).intValue();
+                }
+            }
+
             OffloadPolicies offloadPolicies = OffloadPoliciesImpl.create(driver, region, bucket, endpoint,
                     s3Role, s3RoleSessionName,
                     awsId, awsSecret,
                     maxBlockSizeInBytes, readBufferSizeInBytes, offloadAfterThresholdInBytes,
-                    offloadThresholdInSeconds, offloadAfterElapsedInMillis, offloadedReadPriority);
+                    offloadThresholdInSeconds, offloadAfterElapsedInMillis, offloadedReadPriority,
+                    assignmentOffloadThreads, offloadPrefetchRounds);
 
             getTopics().setOffloadPolicies(persistentTopic, offloadPolicies);
         }

--- a/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloader.java
+++ b/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloader.java
@@ -109,7 +109,7 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
         this.scheduler = scheduler;
         this.fileSystem = FileSystem.get(configuration);
         this.assignmentScheduler = OrderedScheduler.newSchedulerBuilder()
-                .numThreads(conf.getManagedLedgerOffloadMaxThreads())
+                .numThreads(conf.getManagedLedgerAssignmentOffloadThreads())
                 .name("offload-assignment").build();
         this.offloaderStats = offloaderStats;
     }
@@ -131,7 +131,7 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
         this.scheduler = scheduler;
         this.fileSystem = FileSystem.get(configuration);
         this.assignmentScheduler = OrderedScheduler.newSchedulerBuilder()
-                .numThreads(conf.getManagedLedgerOffloadMaxThreads())
+                .numThreads(conf.getManagedLedgerAssignmentOffloadThreads())
                 .name("offload-assignment").build();
         this.offloaderStats = offloaderStats;
     }


### PR DESCRIPTION
Related issue #20734

### Motivation

The current implementation has the following issues:
1. `managedLedgerOffloadMaxThreads` is a broker level parameter . In the situation of using assignmentScheduler in a filesystem offloader, this is not reasonable. 
2. `managedLedgerOffloadMaxThreads` and `managedLedgerOffloadPrefetchRounds` always default values as #20734 described.

### Modifications
1. add a new config: `managedLedgerAssignmentOffloadThreads` use for filesystem-offloader's assignmentScheduler to adjust thread number.
2. support admin api to adjust `managedLedgerOffloadMaxThreads` and `managedLedgerOffloadPrefetchRounds` while set-offload-policies.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [x] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/ethqunzhong/pulsar/pull/8
