### PR TITLE
[fix][client] Fix cannot retry chunk messages and send to DLQ

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
@@ -43,7 +43,6 @@ import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.impl.ConsumerBuilderImpl;
 import org.apache.pulsar.client.util.RetryMessageUtil;
 import org.awaitility.Awaitility;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -200,13 +199,13 @@ public class DeadLetterTopicTest extends ProducerConsumerBase {
         int totalInDeadLetter = 0;
         do {
             Message message = deadLetterConsumer.receive();
-            Assert.assertEquals(new String(message.getData()), messageContent.get(Integer.parseInt(message.getKey())));
+            assertEquals(new String(message.getData()), messageContent.get(Integer.parseInt(message.getKey())));
             messageContent.remove(Integer.parseInt(message.getKey()));
             log.info("dead letter consumer received message : {}", message.getMessageId());
             deadLetterConsumer.acknowledge(message);
             totalInDeadLetter++;
         } while (totalInDeadLetter < sendMessages);
-        Assert.assertTrue(messageContent.isEmpty());
+        assertTrue(messageContent.isEmpty());
 
         deadLetterConsumer.close();
         consumer.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
@@ -50,7 +50,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-@Test(groups = "flaky")
+@Test(groups = "broker-impl")
 public class DeadLetterTopicTest extends ProducerConsumerBase {
 
     private static final Logger log = LoggerFactory.getLogger(DeadLetterTopicTest.class);
@@ -142,7 +142,7 @@ public class DeadLetterTopicTest extends ProducerConsumerBase {
         return new Object[][] { { false }, { true } };
     }
 
-    @Test(groups = "quarantine", dataProvider = "produceLargeMessages")
+    @Test(dataProvider = "produceLargeMessages")
     public void testDeadLetterTopic(boolean produceLargeMessages) throws Exception {
         final String topic = "persistent://my-property/my-ns/dead-letter-topic";
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
@@ -191,14 +191,16 @@ public class DeadLetterTopicTest extends ProducerConsumerBase {
 
         int totalReceived = 0;
         do {
-            Message<byte[]> message = consumer.receive();
+            Message<byte[]> message = consumer.receive(5, TimeUnit.SECONDS);
+            assertNotNull(message, "The consumer should be able to receive messages.");
             log.info("consumer received message : {}", message.getMessageId());
             totalReceived++;
         } while (totalReceived < sendMessages * (maxRedeliveryCount + 1));
 
         int totalInDeadLetter = 0;
         do {
-            Message message = deadLetterConsumer.receive();
+            Message message = deadLetterConsumer.receive(5, TimeUnit.SECONDS);
+            assertNotNull(message, "the deadLetterConsumer should receive messages.");
             assertEquals(new String(message.getData()), messageContent.get(Integer.parseInt(message.getKey())));
             messageContent.remove(Integer.parseInt(message.getKey()));
             log.info("dead letter consumer received message : {}", message.getMessageId());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -613,6 +613,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                     retryLetterProducer = client.newProducer(Schema.AUTO_PRODUCE_BYTES(schema))
                             .topic(this.deadLetterPolicy.getRetryLetterTopic())
                             .enableBatching(false)
+                            .enableChunking(true)
                             .blockIfQueueFull(false)
                             .create();
                 }
@@ -1450,7 +1451,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         if (chunkedMsgCtx == null || chunkedMsgCtx.chunkedMsgBuffer == null
                 || msgMetadata.getChunkId() != (chunkedMsgCtx.lastChunkedMessageId + 1)) {
             // means we lost the first chunk: should never happen
-            log.info("Received unexpected chunk messageId {}, last-chunk-id{}, chunkId = {}", msgId,
+            log.info("[{}] [{}] Received unexpected chunk messageId {}, last-chunk-id = {}, chunkId = {}", topic,
+                    subscription, msgId,
                     (chunkedMsgCtx != null ? chunkedMsgCtx.lastChunkedMessageId : null), msgMetadata.getChunkId());
             if (chunkedMsgCtx != null) {
                 if (chunkedMsgCtx.chunkedMsgBuffer != null) {
@@ -2094,6 +2096,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                                     .initialSubscriptionName(this.deadLetterPolicy.getInitialSubscriptionName())
                                     .topic(this.deadLetterPolicy.getDeadLetterTopic())
                                     .blockIfQueueFull(false)
+                                    .enableBatching(false)
+                                    .enableChunking(true)
                                     .createAsync();
                 }
             } finally {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdAdvUtils.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdAdvUtils.java
@@ -64,6 +64,9 @@ public class MessageIdAdvUtils {
     }
 
     static MessageIdAdv discardBatch(MessageId messageId) {
+        if (messageId instanceof ChunkMessageIdImpl) {
+            return (MessageIdAdv) messageId;
+        }
         MessageIdAdv msgId = (MessageIdAdv) messageId;
         return new MessageIdImpl(msgId.getLedgerId(), msgId.getEntryId(), msgId.getPartitionIndex());
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -695,6 +695,12 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 op = OpSendMsg.create(msg, null, sequenceId, callback);
                 final MessageMetadata finalMsgMetadata = msgMetadata;
                 op.rePopulate = () -> {
+                    if (msgMetadata.hasChunkId()) {
+                        // The message metadata is shared between all chunks in a large message
+                        // We need to reset the chunk id for each call of this method
+                        // It's safe to do that because there is only 1 thread to manipulate this message metadata
+                        finalMsgMetadata.setChunkId(chunkId);
+                    }
                     op.cmd = sendMessage(producerId, sequenceId, numMessages, messageId, finalMsgMetadata,
                             encryptedPayload);
                 };

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
@@ -138,8 +138,11 @@ public class UnAckedMessageTracker implements Closeable {
                         if (!headPartition.isEmpty()) {
                             log.info("[{}] {} messages will be re-delivered", consumerBase, headPartition.size());
                             headPartition.forEach(messageId -> {
-                                addChunkedMessageIdsAndRemoveFromSequenceMap(messageId, messageIds, consumerBase);
-                                messageIds.add(messageId);
+                                if (messageId instanceof ChunkMessageIdImpl) {
+                                    addChunkedMessageIdsAndRemoveFromSequenceMap(messageId, messageIds, consumerBase);
+                                } else {
+                                    messageIds.add(messageId);
+                                }
                                 messageIdPartitionMap.remove(messageId);
                             });
                         }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/UnAckedMessageTrackerTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/UnAckedMessageTrackerTest.java
@@ -29,12 +29,15 @@ import static org.mockito.Mockito.when;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
 import io.netty.util.concurrent.DefaultThreadFactory;
-
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.MessageIdAdv;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
+import org.awaitility.Awaitility;
 import org.testng.annotations.Test;
 
 public class UnAckedMessageTrackerTest  {
@@ -73,6 +76,50 @@ public class UnAckedMessageTrackerTest  {
         assertTrue(tracker.remove(mid));
         assertTrue(tracker.isEmpty());
         assertEquals(tracker.size(), 0);
+
+        timer.stop();
+    }
+
+    @Test
+    public void testTrackChunkedMessageId() {
+        PulsarClientImpl client = mock(PulsarClientImpl.class);
+        Timer timer = new HashedWheelTimer(new DefaultThreadFactory("pulsar-timer", Thread.currentThread().isDaemon()),
+                1, TimeUnit.MILLISECONDS);
+        when(client.timer()).thenReturn(timer);
+
+        ConsumerBase<byte[]> consumer = mock(ConsumerBase.class);
+        doNothing().when(consumer).onAckTimeoutSend(any());
+        doNothing().when(consumer).redeliverUnacknowledgedMessages(any());
+        ConsumerConfigurationData<?> conf = new ConsumerConfigurationData<>();
+        conf.setAckTimeoutMillis(1000);
+        conf.setTickDurationMillis(1000);
+        UnAckedMessageTracker tracker = new UnAckedMessageTracker(client, consumer, conf);
+
+        assertTrue(tracker.isEmpty());
+        assertEquals(tracker.size(), 0);
+
+        // Build chunked message ID
+        MessageIdImpl[] chunkMsgIds = new MessageIdImpl[5];
+        for (int i = 0; i < 5; i++) {
+            chunkMsgIds[i] = new MessageIdImpl(1L, i, -1);
+        }
+        ChunkMessageIdImpl chunkedMessageId =
+                new ChunkMessageIdImpl(chunkMsgIds[0], chunkMsgIds[chunkMsgIds.length - 1]);
+
+        consumer.unAckedChunkedMessageIdSequenceMap =
+                ConcurrentOpenHashMap.<MessageIdAdv, MessageIdImpl[]>newBuilder().build();
+        consumer.unAckedChunkedMessageIdSequenceMap.put(chunkedMessageId, chunkMsgIds);
+
+        // Redeliver chunked message
+        tracker.add(chunkedMessageId);
+
+        Awaitility.await()
+                .pollInterval(Duration.ofMillis(200))
+                .atMost(Duration.ofSeconds(3))
+                .untilAsserted(() -> assertEquals(tracker.size(), 0));
+
+        // Assert that all chunk message ID are removed from unAckedChunkedMessageIdSequenceMap
+        assertEquals(consumer.unAckedChunkedMessageIdSequenceMap.size(), 0);
 
         timer.stop();
     }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

Fixes https://github.com/apache/pulsar/issues/20934

## Motivation

If the consumer receives a chunked message, it currently couldn't retry it or send it to the DLQ. It will throw an exception like this:
```
java.util.concurrent.CompletionException: org.apache.pulsar.client.api.PulsarClientException$InvalidMessageException: The producer xxx of the topic persistent://a/b/c sends a message with 8085120 bytes that exceeds 5242880 bytes
```

This is because we don't enable the chunking for the retry producer and the DLQ producer in the consumer.

This PR enables the chunking feature for retry and DLQ producers. However, we cannot enable both chunking and batching simultaneously. Therefore, the trade-off of this change is that we have to turn off the batching for the DLQ producer, while the retry producer has already done so. This is acceptable because the DLQ producer usually has low traffic. It does not have a significant impact on the performance.

This PR also addresses the following two issues:

### Issue A: Consumers cannot redeliver chunked messages
When the consumer attempts to redeliver a chunked message, the message ID is reconstructed in `discardBatch`, which causes this message ID to lose the chunk information. The comparison in the `unAckedChunkedMessageIdSequenceMap` will fail. The consumer will never be able to redeliver chunked messages.

We should not reconstruct the chunked message ID in `discardBatch`. The chunk message ID does not contain any batch information.

### Issue B: The chunked message cannot be resent
When the producer resends the chunked message, the chunk id in the message metadata of all subsequent chunks will be set to the last chunk id.

The root cause is that the producer shares the same MessageMetadata for all chunks in a chunked message.

https://github.com/apache/pulsar/blob/4634311e75176f9acec16e37e2900945a8e2040e/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java#L696-L700

Therefore, when `op.rePopulate` is called, the chunk id in `finalMsgMetadata` is pointed to the last chunk. Suppose we have a large message with 3 chunks. The producer may end up sending all 3 messages with the same chunk id `3`. The consumer will treat these messages as corrupted and ignore them, preventing it from receiving any of these messages.


## Modification
- Enable chunking and disable batching for retry and DLQ producers.
- Don't discard the batch for the chunked message ID to fix Issue A.
- Don't redeliver the chunk message ID itself when redelivering unacked messages. Just need to redeliver the message ID for all single chunks.
- Reset the chunkID when resending the chunk message to fix Issue B.
- Add chunk messages test case for `testDeadLetterTopic`. 


### Verifying this change


This change added tests.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
