### PR TITLE
[fix][misc] Bump GRPC version to 1.55.3 to fix CVE

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -418,21 +418,21 @@ The Apache Software License, Version 2.0
      - org.jetbrains.kotlin-kotlin-stdlib-jdk8-1.8.20.jar
      - org.jetbrains-annotations-13.0.jar
  * gRPC
-    - io.grpc-grpc-all-1.45.1.jar
-    - io.grpc-grpc-auth-1.45.1.jar
-    - io.grpc-grpc-context-1.45.1.jar
-    - io.grpc-grpc-core-1.45.1.jar
-    - io.grpc-grpc-netty-1.45.1.jar
-    - io.grpc-grpc-protobuf-1.45.1.jar
-    - io.grpc-grpc-protobuf-lite-1.45.1.jar
-    - io.grpc-grpc-stub-1.45.1.jar
-    - io.grpc-grpc-alts-1.45.1.jar
-    - io.grpc-grpc-api-1.45.1.jar
-    - io.grpc-grpc-grpclb-1.45.1.jar
-    - io.grpc-grpc-netty-shaded-1.45.1.jar
-    - io.grpc-grpc-services-1.45.1.jar
-    - io.grpc-grpc-xds-1.45.1.jar
-    - io.grpc-grpc-rls-1.45.1.jar
+    - io.grpc-grpc-all-1.55.0.jar
+    - io.grpc-grpc-auth-1.55.0.jar
+    - io.grpc-grpc-context-1.55.0.jar
+    - io.grpc-grpc-core-1.55.0.jar
+    - io.grpc-grpc-netty-1.55.0.jar
+    - io.grpc-grpc-protobuf-1.55.0.jar
+    - io.grpc-grpc-protobuf-lite-1.55.0.jar
+    - io.grpc-grpc-stub-1.55.0.jar
+    - io.grpc-grpc-alts-1.55.0.jar
+    - io.grpc-grpc-api-1.55.0.jar
+    - io.grpc-grpc-grpclb-1.55.0.jar
+    - io.grpc-grpc-netty-shaded-1.55.0.jar
+    - io.grpc-grpc-services-1.55.0.jar
+    - io.grpc-grpc-xds-1.55.0.jar
+    - io.grpc-grpc-rls-1.55.0.jar
   * Perfmark
     - io.perfmark-perfmark-api-0.19.0.jar
   * OpenCensus

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -259,7 +259,7 @@ The Apache Software License, Version 2.0
      - com.fasterxml.jackson.module-jackson-module-parameter-names-2.14.2.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.9.1.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
- * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-2.0.1.jar
+ * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-2.9.0.jar
  * Bitbucket -- org.bitbucket.b_c-jose4j-0.9.3.jar
  * Gson
     - com.google.code.gson-gson-2.8.9.jar
@@ -433,6 +433,8 @@ The Apache Software License, Version 2.0
     - io.grpc-grpc-services-1.55.3.jar
     - io.grpc-grpc-xds-1.55.3.jar
     - io.grpc-grpc-rls-1.55.3.jar
+    - io.grpc-grpc-servlet-1.55.3.jar
+    - io.grpc-grpc-servlet-jakarta-1.55.3.jar
   * Perfmark
     - io.perfmark-perfmark-api-0.19.0.jar
   * OpenCensus
@@ -485,7 +487,7 @@ The Apache Software License, Version 2.0
     - com.google.http-client-google-http-client-gson-1.41.0.jar
     - com.google.http-client-google-http-client-1.41.0.jar
     - com.google.auto.value-auto-value-annotations-1.9.jar
-    - com.google.re2j-re2j-1.5.jar
+    - com.google.re2j-re2j-1.6.jar
   * Jetcd
     - io.etcd-jetcd-api-0.7.5.jar
     - io.etcd-jetcd-common-0.7.5.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -436,7 +436,7 @@ The Apache Software License, Version 2.0
     - io.grpc-grpc-servlet-1.55.3.jar
     - io.grpc-grpc-servlet-jakarta-1.55.3.jar
   * Perfmark
-    - io.perfmark-perfmark-api-0.19.0.jar
+    - io.perfmark-perfmark-api-0.26.0.jar
   * OpenCensus
     - io.opencensus-opencensus-api-0.28.0.jar
     - io.opencensus-opencensus-contrib-http-util-0.28.0.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -418,21 +418,21 @@ The Apache Software License, Version 2.0
      - org.jetbrains.kotlin-kotlin-stdlib-jdk8-1.8.20.jar
      - org.jetbrains-annotations-13.0.jar
  * gRPC
-    - io.grpc-grpc-all-1.55.0.jar
-    - io.grpc-grpc-auth-1.55.0.jar
-    - io.grpc-grpc-context-1.55.0.jar
-    - io.grpc-grpc-core-1.55.0.jar
-    - io.grpc-grpc-netty-1.55.0.jar
-    - io.grpc-grpc-protobuf-1.55.0.jar
-    - io.grpc-grpc-protobuf-lite-1.55.0.jar
-    - io.grpc-grpc-stub-1.55.0.jar
-    - io.grpc-grpc-alts-1.55.0.jar
-    - io.grpc-grpc-api-1.55.0.jar
-    - io.grpc-grpc-grpclb-1.55.0.jar
-    - io.grpc-grpc-netty-shaded-1.55.0.jar
-    - io.grpc-grpc-services-1.55.0.jar
-    - io.grpc-grpc-xds-1.55.0.jar
-    - io.grpc-grpc-rls-1.55.0.jar
+    - io.grpc-grpc-all-1.55.3.jar
+    - io.grpc-grpc-auth-1.55.3.jar
+    - io.grpc-grpc-context-1.55.3.jar
+    - io.grpc-grpc-core-1.55.3.jar
+    - io.grpc-grpc-netty-1.55.3.jar
+    - io.grpc-grpc-protobuf-1.55.3.jar
+    - io.grpc-grpc-protobuf-lite-1.55.3.jar
+    - io.grpc-grpc-stub-1.55.3.jar
+    - io.grpc-grpc-alts-1.55.3.jar
+    - io.grpc-grpc-api-1.55.3.jar
+    - io.grpc-grpc-grpclb-1.55.3.jar
+    - io.grpc-grpc-netty-shaded-1.55.3.jar
+    - io.grpc-grpc-services-1.55.3.jar
+    - io.grpc-grpc-xds-1.55.3.jar
+    - io.grpc-grpc-rls-1.55.3.jar
   * Perfmark
     - io.perfmark-perfmark-api-0.19.0.jar
   * OpenCensus

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@ flexible messaging model and an intuitive client API.</description>
     <typetools.version>0.5.0</typetools.version>
     <protobuf3.version>3.19.6</protobuf3.version>
     <protoc3.version>${protobuf3.version}</protoc3.version>
-    <grpc.version>1.53.0</grpc.version>
+    <grpc.version>1.55.0</grpc.version>
     <google-http-client.version>1.41.0</google-http-client.version>
     <perfmark.version>0.19.0</perfmark.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@ flexible messaging model and an intuitive client API.</description>
     <typetools.version>0.5.0</typetools.version>
     <protobuf3.version>3.19.6</protobuf3.version>
     <protoc3.version>${protobuf3.version}</protoc3.version>
-    <grpc.version>1.45.1</grpc.version>
+    <grpc.version>1.53.0</grpc.version>
     <google-http-client.version>1.41.0</google-http-client.version>
     <perfmark.version>0.19.0</perfmark.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@ flexible messaging model and an intuitive client API.</description>
     <protoc3.version>${protobuf3.version}</protoc3.version>
     <grpc.version>1.55.3</grpc.version>
     <google-http-client.version>1.41.0</google-http-client.version>
-    <perfmark.version>0.19.0</perfmark.version>
+    <perfmark.version>0.26.0</perfmark.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     <gson.version>2.8.9</gson.version>
     <system-lambda.version>1.2.1</system-lambda.version>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@ flexible messaging model and an intuitive client API.</description>
     <typetools.version>0.5.0</typetools.version>
     <protobuf3.version>3.19.6</protobuf3.version>
     <protoc3.version>${protobuf3.version}</protoc3.version>
-    <grpc.version>1.55.0</grpc.version>
+    <grpc.version>1.55.3</grpc.version>
     <google-http-client.version>1.41.0</google-http-client.version>
     <perfmark.version>0.19.0</perfmark.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -95,7 +95,6 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
         @Cleanup
         MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(),
                 MetadataStoreConfig.builder().fsyncEnable(false).build());
-
         String data = "data";
         String path = "/non-existing-key";
         int concurrent = 50;

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -95,6 +95,7 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
         @Cleanup
         MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(),
                 MetadataStoreConfig.builder().fsyncEnable(false).build());
+
         String data = "data";
         String path = "/non-existing-key";
         int concurrent = 50;

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -263,14 +263,14 @@ The Apache Software License, Version 2.0
     - netty-incubator-transport-native-io_uring-0.0.21.Final-linux-x86_64.jar
     - netty-incubator-transport-native-io_uring-0.0.21.Final-linux-aarch_64.jar
  * GRPC
-    - grpc-api-1.45.1.jar
-    - grpc-context-1.45.1.jar
-    - grpc-core-1.45.1.jar
-    - grpc-grpclb-1.45.1.jar
-    - grpc-netty-1.45.1.jar
-    - grpc-protobuf-1.45.1.jar
-    - grpc-protobuf-lite-1.45.1.jar
-    - grpc-stub-1.45.1.jar
+    - grpc-api-1.55.0.jar
+    - grpc-context-1.55.0.jar
+    - grpc-core-1.55.0.jar
+    - grpc-grpclb-1.55.0.jar
+    - grpc-netty-1.55.0.jar
+    - grpc-protobuf-1.55.0.jar
+    - grpc-protobuf-lite-1.55.0.jar
+    - grpc-stub-1.55.0.jar
   * JEtcd
     - jetcd-api-0.7.5.jar
     - jetcd-common-0.7.5.jar

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -477,7 +477,7 @@ The Apache Software License, Version 2.0
   * Apache Yetus Audience Annotations
     - audience-annotations-0.12.0.jar
   * Perfmark
-    - perfmark-api-0.19.0.jar
+    - perfmark-api-0.26.0.jar
   * RabbitMQ Java Client
     - amqp-client-5.5.3.jar
   * Stream Lib
@@ -490,7 +490,7 @@ Protocol Buffers License
  * Protocol Buffers
    - protobuf-java-3.19.6.jar
    - protobuf-java-util-3.19.6.jar
-   - proto-google-common-protos-2.0.1.jar
+   - proto-google-common-protos-2.9.0.jar
 
 BSD 3-clause "New" or "Revised" License
   *  RE2J TD -- re2j-td-1.4.jar

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -263,14 +263,14 @@ The Apache Software License, Version 2.0
     - netty-incubator-transport-native-io_uring-0.0.21.Final-linux-x86_64.jar
     - netty-incubator-transport-native-io_uring-0.0.21.Final-linux-aarch_64.jar
  * GRPC
-    - grpc-api-1.55.0.jar
-    - grpc-context-1.55.0.jar
-    - grpc-core-1.55.0.jar
-    - grpc-grpclb-1.55.0.jar
-    - grpc-netty-1.55.0.jar
-    - grpc-protobuf-1.55.0.jar
-    - grpc-protobuf-lite-1.55.0.jar
-    - grpc-stub-1.55.0.jar
+    - grpc-api-1.55.3.jar
+    - grpc-context-1.55.3.jar
+    - grpc-core-1.55.3.jar
+    - grpc-grpclb-1.55.3.jar
+    - grpc-netty-1.55.3.jar
+    - grpc-protobuf-1.55.3.jar
+    - grpc-protobuf-lite-1.55.3.jar
+    - grpc-stub-1.55.3.jar
   * JEtcd
     - jetcd-api-0.7.5.jar
     - jetcd-common-0.7.5.jar


### PR DESCRIPTION
### Motivation

- [CVE-2023-1428](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-1428) 
- [CVE-2023-32731](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-32731)
- [CVE-2023-32732](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-32732)

### Modifications

- Upgrade `GRPC` version to 1.53.0
- Upgrade `io.perfmark-perfmark-api` to 0.26.0
### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
