### PR TITLE
[fix][misc] Bump broker okio version to 3.4.0

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -409,7 +409,7 @@ The Apache Software License, Version 2.0
  * OkHttp3
      - com.squareup.okhttp3-logging-interceptor-4.9.3.jar
      - com.squareup.okhttp3-okhttp-4.9.3.jar
- * Okio - com.squareup.okio-okio-2.8.0.jar
+ * Okio - com.squareup.okio-okio-3.4.0.jar
  * Javassist -- org.javassist-javassist-3.25.0-GA.jar
  * Kotlin Standard Lib
      - org.jetbrains.kotlin-kotlin-stdlib-1.8.20.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -409,7 +409,9 @@ The Apache Software License, Version 2.0
  * OkHttp3
      - com.squareup.okhttp3-logging-interceptor-4.9.3.jar
      - com.squareup.okhttp3-okhttp-4.9.3.jar
- * Okio - com.squareup.okio-okio-3.4.0.jar
+ * Okio
+     - com.squareup.okio-okio-3.4.0.jar
+     - com.squareup.okio-okio-jvm-3.4.0.jar
  * Javassist -- org.javassist-javassist-3.25.0-GA.jar
  * Kotlin Standard Lib
      - org.jetbrains.kotlin-kotlin-stdlib-1.8.20.jar

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@ flexible messaging model and an intuitive client API.</description>
     <kubernetesclient.version>18.0.0</kubernetesclient.version>
     <okhttp3.version>4.9.3</okhttp3.version>
     <!-- use okio version that matches the okhttp3 version -->
-    <okio.version>2.8.0</okio.version>
+    <okio.version>3.4.0</okio.version>
     <!-- override kotlin-stdlib used by okio in order to address CVE-2020-29582 -->
     <kotlin-stdlib.version>1.8.20</kotlin-stdlib.version>
     <nsq-client.version>1.0</nsq-client.version>


### PR DESCRIPTION
### Motivation

- [CVE-2023-3635](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-3635)

### Modifications

- Updated okio version to 3.4.0

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
