### PR TITLE
[improve] [broker] apply topK machanism to ModularLoadManagerImpl.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/models/TopKBundles.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/models/TopKBundles.java
@@ -96,7 +96,7 @@ public class TopKBundles {
         }
     }
 
-    static void partitionSort(List<Map.Entry<String, ? extends Comparable>> arr, int k) {
+    public static void partitionSort(List<Map.Entry<String, ? extends Comparable>> arr, int k) {
         int start = 0;
         int end = arr.size() - 1;
         int target = k - 1;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -1147,20 +1147,23 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
      * sort bundles by load and select topK bundles for each broker.
      * @return the number of bundles selected
      */
-    private int selectTopKBundle() {
-        bundleArr.clear();
-
-        // select topK bundle for each broker, so select topK * brokerCount bundle in total
-        int brokerCount = Math.max(1, loadData.getBrokerData().size());
-        int updateBundleCount = Math.min(pulsar.getConfiguration()
-                .getLoadBalancerMaxNumberOfBundlesInBundleLoadReport() * brokerCount, bundleArr.size());
+    private CompletableFuture<Integer> selectTopKBundle() {
+        CompletableFuture completableFuture = new CompletableFuture();
 
         executors.execute(() -> {
             // make the bundle-data update and sorting executed in single thread
+            bundleArr.clear();
             bundleArr.addAll(loadData.getBundleData().entrySet());
+
+            // select topK bundle for each broker, so select topK * brokerCount bundle in total
+            int brokerCount = Math.max(1, loadData.getBrokerData().size());
+            int updateBundleCount = Math.min(pulsar.getConfiguration()
+                    .getLoadBalancerMaxNumberOfBundlesInBundleLoadReport() * brokerCount, bundleArr.size());
+
             TopKBundles.partitionSort(bundleArr, updateBundleCount);
+            completableFuture.complete(updateBundleCount);
         });
-        return updateBundleCount;
+        return completableFuture;
     }
 
     /**
@@ -1172,7 +1175,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         // Write the bundle data to metadata store.
         List<CompletableFuture<Void>> futures = new ArrayList<>();
 
-        int updateBundleCount = selectTopKBundle();
+        int updateBundleCount = selectTopKBundle().join();
         for (int i = 0; i < updateBundleCount; i++) {
             final Map.Entry<String, BundleData> entry = (Map.Entry<String, BundleData>) bundleArr.get(i);
             final String bundle = entry.getKey();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -1152,7 +1152,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
 
         bundleArr.addAll(loadData.getBundleData().entrySet());
         // select topK bundle for each broker, so select topK * brokerCount bundle in total
-        int brokerCount = loadData.getBrokerData().size();
+        int brokerCount = Math.max(1, loadData.getBrokerData().size());
         int updateBundleCount = pulsar.getConfiguration()
                 .getLoadBalancerMaxNumberOfBundlesInBundleLoadReport() * brokerCount;
         updateBundleCount = Math.min(updateBundleCount, bundleArr.size());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -1148,7 +1148,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
      * @return the number of bundles selected
      */
     private CompletableFuture<Integer> selectTopKBundle() {
-        CompletableFuture completableFuture = new CompletableFuture();
+        CompletableFuture<Integer> completableFuture = new CompletableFuture<>();
 
         executors.execute(() -> {
             // make the bundle-data update and sorting executed in single thread

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -1144,7 +1144,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
     }
 
     /**
-     * sort bundles by load and select topK bundles for each broker
+     * sort bundles by load and select topK bundles for each broker.
      * @return the number of bundles selected
      */
     private int selectTopKBundle() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
@@ -39,6 +39,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -398,6 +399,60 @@ public class ModularLoadManagerImplTest {
 
         for (int i = 1; i < totalBundles; i++) {
             assertNotEquals(primaryLoadManager.selectBrokerForAssignment(bundles[i]), maxTopicOwnedBroker);
+        }
+    }
+
+    /**
+     * It verifies that the load-manager of leader broker only write topK * brokerCount bundles to zk.
+     */
+    @Test
+    public void testFilterBundlesWhileWritingToMetadataStore() throws Exception {
+        Map<String, PulsarService> pulsarServices = new HashMap<>();
+        pulsarServices.put(pulsar1.getWebServiceAddress(), pulsar1);
+        pulsarServices.put(pulsar2.getWebServiceAddress(), pulsar2);
+        MetadataCache<BundleData> metadataCache = pulsar1.getLocalMetadataStore().getMetadataCache(BundleData.class);
+        PulsarService leaderBroker = pulsarServices.get(pulsar1.getLeaderElectionService().getCurrentLeader().get().getServiceUrl());
+        ModularLoadManagerImpl loadManager = (ModularLoadManagerImpl) getField(
+                leaderBroker.getLoadManager().get(), "loadManager");
+        int topK = 1;
+        leaderBroker.getConfiguration().setLoadBalancerMaxNumberOfBundlesInBundleLoadReport(topK);
+        int exportBundleCount = topK * 2;
+
+        // create and configure bundle-data
+        final int totalBundles = 5;
+        final NamespaceBundle[] bundles = LoadBalancerTestingUtils.makeBundles(
+                nsFactory, "test", "test", "test", totalBundles);
+        LoadData loadData = (LoadData) getField(loadManager, "loadData");
+        String protocol = "http://";
+        for (int i = 0; i < totalBundles; i++) {
+            final BundleData bundleData = new BundleData(10, 1000);
+            final String bundleDataPath = String.format("%s/%s", ModularLoadManagerImpl.BUNDLE_DATA_PATH, bundles[i]);
+            final TimeAverageMessageData longTermMessageData = new TimeAverageMessageData(1000);
+            longTermMessageData.setMsgThroughputIn(1000 * i);
+            longTermMessageData.setMsgThroughputOut(1000 * i);
+            longTermMessageData.setMsgRateIn(1000 * i);
+            longTermMessageData.setNumSamples(1000);
+            bundleData.setLongTermData(longTermMessageData);
+            loadData.getBundleData().put(bundles[i].toString(), bundleData);
+            loadData.getBrokerData().get(leaderBroker.getWebServiceAddress().substring(protocol.length()))
+                    .getLocalData().getLastStats().put(bundles[i].toString(), new NamespaceBundleStats());
+            metadataCache.create(bundleDataPath, bundleData).join();
+        }
+        for (int i = 0; i < totalBundles; i++) {
+            final String bundleDataPath = String.format("%s/%s", ModularLoadManagerImpl.BUNDLE_DATA_PATH, bundles[i]);
+            assertEquals(metadataCache.getWithStats(bundleDataPath).get().get().getStat().getVersion(), 0);
+        }
+
+        // update bundle data to zk and verify
+        loadManager.writeBundleDataOnZooKeeper();
+        int filterBundleCount = totalBundles - exportBundleCount;
+        for (int i = 0; i < filterBundleCount; i++) {
+            final String bundleDataPath = String.format("%s/%s", ModularLoadManagerImpl.BUNDLE_DATA_PATH, bundles[i]);
+            assertEquals(metadataCache.getWithStats(bundleDataPath).get().get().getStat().getVersion(), 0);
+        }
+        for (int i = filterBundleCount; i < totalBundles; i++) {
+            final String bundleDataPath = String.format("%s/%s", ModularLoadManagerImpl.BUNDLE_DATA_PATH, bundles[i]);
+            assertEquals(metadataCache.getWithStats(bundleDataPath).get().get().getStat().getVersion(), 1);
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
@@ -416,6 +416,7 @@ public class ModularLoadManagerImplTest {
                 leaderBroker.getLoadManager().get(), "loadManager");
         int topK = 1;
         leaderBroker.getConfiguration().setLoadBalancerMaxNumberOfBundlesInBundleLoadReport(topK);
+        // there are two broker in cluster, so total bundle count will be topK * 2
         int exportBundleCount = topK * 2;
 
         // create and configure bundle-data

--- a/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/BundleData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/BundleData.java
@@ -103,9 +103,9 @@ public class BundleData implements Comparable<BundleData> {
 
     @Override
     public int compareTo(BundleData o) {
-        int result = this.longTermData.compareTo(o.longTermData);
+        int result = this.shortTermData.compareTo(o.shortTermData);
         if (result == 0) {
-            result = this.shortTermData.compareTo(o.shortTermData);
+            result = this.longTermData.compareTo(o.longTermData);
         }
         return result;
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/BundleData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/BundleData.java
@@ -21,7 +21,7 @@ package org.apache.pulsar.policies.data.loadbalancer;
 /**
  * Data class comprising the short term and long term historical data for this bundle.
  */
-public class BundleData {
+public class BundleData implements Comparable<BundleData> {
     // Short term data for this bundle. The time frame of this data is
     // determined by the number of short term samples
     // and the bundle update period.
@@ -42,10 +42,8 @@ public class BundleData {
     /**
      * Initialize the bundle data.
      *
-     * @param numShortSamples
-     *            Number of short term samples to use.
-     * @param numLongSamples
-     *            Number of long term samples to use.
+     * @param numShortSamples Number of short term samples to use.
+     * @param numLongSamples  Number of long term samples to use.
      */
     public BundleData(final int numShortSamples, final int numLongSamples) {
         shortTermData = new TimeAverageMessageData(numShortSamples);
@@ -56,12 +54,9 @@ public class BundleData {
      * Initialize this bundle data and have its histories default to the given stats before the first sample is
      * received.
      *
-     * @param numShortSamples
-     *            Number of short term samples to use.
-     * @param numLongSamples
-     *            Number of long term samples to use.
-     * @param defaultStats
-     *            The stats to default to before the first sample is received.
+     * @param numShortSamples Number of short term samples to use.
+     * @param numLongSamples  Number of long term samples to use.
+     * @param defaultStats    The stats to default to before the first sample is received.
      */
     public BundleData(final int numShortSamples, final int numLongSamples, final NamespaceBundleStats defaultStats) {
         shortTermData = new TimeAverageMessageData(numShortSamples, defaultStats);
@@ -71,8 +66,7 @@ public class BundleData {
     /**
      * Update the historical data for this bundle.
      *
-     * @param newSample
-     *            The bundle stats to update this data with.
+     * @param newSample The bundle stats to update this data with.
      */
     public void update(final NamespaceBundleStats newSample) {
         shortTermData.update(newSample);
@@ -102,5 +96,14 @@ public class BundleData {
 
     public void setTopics(int topics) {
         this.topics = topics;
+    }
+
+    @Override
+    public int compareTo(BundleData o) {
+        int result = this.longTermData.compareTo(o.longTermData);
+        if (result == 0) {
+            result = this.shortTermData.compareTo(o.shortTermData);
+        }
+        return result;
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/BundleData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/BundleData.java
@@ -18,9 +18,12 @@
  */
 package org.apache.pulsar.policies.data.loadbalancer;
 
+import lombok.EqualsAndHashCode;
+
 /**
  * Data class comprising the short term and long term historical data for this bundle.
  */
+@EqualsAndHashCode
 public class BundleData implements Comparable<BundleData> {
     // Short term data for this bundle. The time frame of this data is
     // determined by the number of short term samples

--- a/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/TimeAverageMessageData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/TimeAverageMessageData.java
@@ -18,9 +18,12 @@
  */
 package org.apache.pulsar.policies.data.loadbalancer;
 
+import lombok.EqualsAndHashCode;
+
 /**
  * Data class comprising the average message data over a fixed period of time.
  */
+@EqualsAndHashCode
 public class TimeAverageMessageData implements Comparable<TimeAverageMessageData> {
     // The maximum number of samples this data will consider.
     private int maxSamples;


### PR DESCRIPTION
### Motivation

As the discussion of https://github.com/apache/pulsar/pull/21011 , we decide to reuse the configuration `loadBalancerMaxNumberOfBundlesInBundleLoadReport` in `ExtensibleLoadManager`, apply the topK mechanism to `ModularLoadManagerImpl`.

### Modifications
Apply the topK mechanism to `ModularLoadManagerImpl` to relieve the pressure of zk.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*
This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/28
