### PR TITLE
[fix][broker] revert remove duplicate topics name when deleteNamespace

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -279,12 +279,6 @@ public abstract class NamespacesBase extends AdminResource {
                                         return old;
                                     });
                                 }
-                                allUserCreatedTopics.removeIf(t ->
-                                        allPartitionedTopics.contains(TopicName.get(t).getPartitionedTopicName()));
-                                allSystemTopics.removeIf(t ->
-                                        allPartitionedTopics.contains(TopicName.get(t).getPartitionedTopicName()));
-                                topicPolicy.removeIf(t ->
-                                        allPartitionedTopics.contains(TopicName.get(t).getPartitionedTopicName()));
                                 return markDeleteFuture.thenCompose(__ ->
                                                 internalDeleteTopicsAsync(allUserCreatedTopics))
                                         .thenCompose(ignore ->


### PR DESCRIPTION
### Motivation

Related to https://github.com/apache/pulsar/pull/20683. When reading the code of master-branch and branch-2.10, I found we can not remove duplicate topics name when deleteNamespace, because the implementation of internalDeletePartitionedTopicsAsync() is different in two branch. In master-branch, if we remove topics name in allUserCreatedTopics and allSystemTopic, we actually not delete the topic. So the first time delete namespace will throw exception exactly. 


#### branch-2.10 :
![企业微信截图_66a5038c-ac55-48ab-a4fe-9f01d0f5a1ce](https://github.com/apache/pulsar/assets/13505225/0f3eebf6-cec7-43ff-bce7-64b17d276a2d)

#### master-branch :
![企业微信截图_97cd2e4a-0e65-47ce-97f9-271302b28fd2](https://github.com/apache/pulsar/assets/13505225/62a44f76-2f94-41bb-904f-d4966c05cb8a)


### Modifications

revert the modification.


### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/TakaHiR07/pulsar/pull/14


