### PR TITLE
[fix][broker] Avoid splitting one batch message into two entries in StrategicTwoPhaseCompactor

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -98,7 +98,6 @@ import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.common.topics.TopicCompactionStrategy;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
-import org.apache.pulsar.compaction.StrategicTwoPhaseCompactor;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.NotificationType;
 import org.apache.pulsar.metadata.api.extended.SessionEvent;
@@ -301,9 +300,6 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
 
             producer = pulsar.getClient().newProducer(schema)
                     .enableBatching(true)
-                    // Make sure input batch size =< compacted output batch,
-                    // Otherwise, the compactor will split the batch to multiple batches.
-                    .batchingMaxMessages(StrategicTwoPhaseCompactor.MAX_NUM_MESSAGES_IN_BATCH)
                     .compressionType(MSG_COMPRESSION_TYPE)
                     .maxPendingMessages(MAX_OUTSTANDING_PUB_MESSAGES)
                     .blockIfQueueFull(true)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -299,7 +299,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             ExtensibleLoadManagerImpl.createSystemTopic(pulsar, TOPIC);
 
             producer = pulsar.getClient().newProducer(schema)
-                    .enableBatching(true)
+                    .enableBatching(false)
                     .compressionType(MSG_COMPRESSION_TYPE)
                     .maxPendingMessages(MAX_OUTSTANDING_PUB_MESSAGES)
                     .blockIfQueueFull(true)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -98,6 +98,7 @@ import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.common.topics.TopicCompactionStrategy;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
+import org.apache.pulsar.compaction.StrategicTwoPhaseCompactor;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.NotificationType;
 import org.apache.pulsar.metadata.api.extended.SessionEvent;
@@ -299,7 +300,10 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             ExtensibleLoadManagerImpl.createSystemTopic(pulsar, TOPIC);
 
             producer = pulsar.getClient().newProducer(schema)
-                    .enableBatching(false)
+                    .enableBatching(true)
+                    // Make sure input batch size =< compacted output batch,
+                    // Otherwise, the compactor will split the batch to multiple batches.
+                    .batchingMaxMessages(StrategicTwoPhaseCompactor.MAX_NUM_MESSAGES_IN_BATCH)
                     .compressionType(MSG_COMPRESSION_TYPE)
                     .maxPendingMessages(MAX_OUTSTANDING_PUB_MESSAGES)
                     .blockIfQueueFull(true)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchMessageContainerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchMessageContainerImpl.java
@@ -49,12 +49,12 @@ public class RawBatchMessageContainerImpl extends BatchMessageContainerImpl {
     private CryptoKeyReader cryptoKeyReader;
     private MessageIdImpl lastAddedMessageId;
 
-    public RawBatchMessageContainerImpl(int maxNumMessagesInBatch, int maxBytesInBatch) {
+    public RawBatchMessageContainerImpl() {
         super();
         this.compressionType = CompressionType.NONE;
         this.compressor = new CompressionCodecNone();
-        this.maxNumMessagesInBatch = maxNumMessagesInBatch;
-        this.maxBytesInBatch = maxBytesInBatch;
+        this.maxNumMessagesInBatch = Integer.MAX_VALUE;
+        this.maxBytesInBatch = Integer.MAX_VALUE;
     }
     private ByteBuf encrypt(ByteBuf compressedPayload) {
         if (msgCrypto == null) {
@@ -100,15 +100,12 @@ public class RawBatchMessageContainerImpl extends BatchMessageContainerImpl {
     @Override
     public boolean haveEnoughSpace(MessageImpl<?> msg) {
         if (lastAddedMessageId == null) {
-            return super.haveEnoughSpace(msg);
+            return true;
         }
         // Keep same batch compact to same batch.
         MessageIdImpl msgId = (MessageIdImpl) msg.getMessageId();
-        if (msgId.getLedgerId() != lastAddedMessageId.getLedgerId()
-                || msgId.getEntryId() != lastAddedMessageId.getEntryId()) {
-            return false;
-        }
-        return super.haveEnoughSpace(msg);
+        return msgId.getLedgerId() == lastAddedMessageId.getLedgerId()
+                && msgId.getEntryId() == lastAddedMessageId.getEntryId();
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchMessageContainerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchMessageContainerImpl.java
@@ -54,9 +54,8 @@ public class RawBatchMessageContainerImpl extends BatchMessageContainerImpl {
         super();
         this.compressionType = CompressionType.NONE;
         this.compressor = new CompressionCodecNone();
-        this.maxNumMessagesInBatch = Integer.MAX_VALUE;
-        this.maxBytesInBatch = Integer.MAX_VALUE;
     }
+
     private ByteBuf encrypt(ByteBuf compressedPayload) {
         if (msgCrypto == null) {
             return compressedPayload;
@@ -96,6 +95,11 @@ public class RawBatchMessageContainerImpl extends BatchMessageContainerImpl {
     public boolean add(MessageImpl<?> msg, SendCallback callback) {
         this.lastAddedMessageId = (MessageIdAdv) msg.getMessageId();
         return super.add(msg, callback);
+    }
+
+    @Override
+    protected boolean isBatchFull() {
+        return false;
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchMessageContainerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchMessageContainerImpl.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.util.Set;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.MessageCrypto;
+import org.apache.pulsar.client.api.MessageIdAdv;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.crypto.MessageCryptoBc;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
@@ -47,7 +48,7 @@ public class RawBatchMessageContainerImpl extends BatchMessageContainerImpl {
     private MessageCrypto<MessageMetadata, MessageMetadata> msgCrypto;
     private Set<String> encryptionKeys;
     private CryptoKeyReader cryptoKeyReader;
-    private MessageIdImpl lastAddedMessageId;
+    private MessageIdAdv lastAddedMessageId;
 
     public RawBatchMessageContainerImpl() {
         super();
@@ -93,7 +94,7 @@ public class RawBatchMessageContainerImpl extends BatchMessageContainerImpl {
 
     @Override
     public boolean add(MessageImpl<?> msg, SendCallback callback) {
-        this.lastAddedMessageId = (MessageIdImpl) msg.getMessageId();
+        this.lastAddedMessageId = (MessageIdAdv) msg.getMessageId();
         return super.add(msg, callback);
     }
 
@@ -103,7 +104,7 @@ public class RawBatchMessageContainerImpl extends BatchMessageContainerImpl {
             return true;
         }
         // Keep same batch compact to same batch.
-        MessageIdImpl msgId = (MessageIdImpl) msg.getMessageId();
+        MessageIdAdv msgId = (MessageIdAdv) msg.getMessageId();
         return msgId.getLedgerId() == lastAddedMessageId.getLedgerId()
                 && msgId.getEntryId() == lastAddedMessageId.getEntryId();
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchMessageContainerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchMessageContainerImpl.java
@@ -189,4 +189,10 @@ public class RawBatchMessageContainerImpl extends BatchMessageContainerImpl {
         clear();
         return buf;
     }
+
+    @Override
+    public void clear() {
+        this.lastAddedMessageId = null;
+        super.clear();
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/StrategicTwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/StrategicTwoPhaseCompactor.java
@@ -346,7 +346,7 @@ public class StrategicTwoPhaseCompactor extends TwoPhaseCompactor {
         CompletableFuture<Void> loopPromise = new CompletableFuture<>();
         phaseTwoLoop(phaseOneResult.topic, phaseOneResult.cache.values().iterator(), ledger,
                 outstanding, loopPromise);
-        loopPromise.thenComposeAsync((v) -> {
+        loopPromise.thenCompose((v) -> {
                     log.info("Flushing batch container numMessagesInBatch:{}",
                             batchMessageContainer.getNumMessagesInBatch());
                     return addToCompactedLedger(ledger, null, reader.getTopic(), outstanding)
@@ -356,7 +356,7 @@ public class StrategicTwoPhaseCompactor extends TwoPhaseCompactor {
                                     return;
                                 }
                             });
-                }, scheduler)
+                })
                 .thenCompose(v -> {
                     log.info("Acking ledger id {}", phaseOneResult.lastId);
                     return ((CompactionReaderImpl<T>) reader)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/StrategicTwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/StrategicTwoPhaseCompactor.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.compaction;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import java.time.Duration;
 import java.util.Iterator;
@@ -61,39 +60,19 @@ import org.slf4j.LoggerFactory;
  * this compaction could be memory intensive if the message payload is large.
  */
 public class StrategicTwoPhaseCompactor extends TwoPhaseCompactor {
-    public static final int MAX_NUM_MESSAGES_IN_BATCH = 1000;
     private static final Logger log = LoggerFactory.getLogger(StrategicTwoPhaseCompactor.class);
     private static final int MAX_OUTSTANDING = 500;
-    private static final int MAX_BYTES_IN_BATCH = 128 * 1024;
     private static final int MAX_READER_RECONNECT_WAITING_TIME_IN_MILLIS = 20 * 1000;
     private final Duration phaseOneLoopReadTimeout;
     private final RawBatchMessageContainerImpl batchMessageContainer;
-
-    @VisibleForTesting
-    public StrategicTwoPhaseCompactor(ServiceConfiguration conf,
-                                      PulsarClient pulsar,
-                                      BookKeeper bk,
-                                      ScheduledExecutorService scheduler,
-                                      int maxNumMessagesInBatch) {
-        this(conf, pulsar, bk, scheduler, maxNumMessagesInBatch, MAX_BYTES_IN_BATCH);
-    }
-
-    private StrategicTwoPhaseCompactor(ServiceConfiguration conf,
-                                      PulsarClient pulsar,
-                                      BookKeeper bk,
-                                      ScheduledExecutorService scheduler,
-                                      int maxNumMessagesInBatch,
-                                      int maxBytesInBatch) {
-        super(conf, pulsar, bk, scheduler);
-        batchMessageContainer = new RawBatchMessageContainerImpl(maxNumMessagesInBatch, maxBytesInBatch);
-        phaseOneLoopReadTimeout = Duration.ofSeconds(conf.getBrokerServiceCompactionPhaseOneLoopTimeInSeconds());
-    }
 
     public StrategicTwoPhaseCompactor(ServiceConfiguration conf,
                                       PulsarClient pulsar,
                                       BookKeeper bk,
                                       ScheduledExecutorService scheduler) {
-        this(conf, pulsar, bk, scheduler, MAX_NUM_MESSAGES_IN_BATCH, MAX_BYTES_IN_BATCH);
+        super(conf, pulsar, bk, scheduler);
+        batchMessageContainer = new RawBatchMessageContainerImpl();
+        phaseOneLoopReadTimeout = Duration.ofSeconds(conf.getBrokerServiceCompactionPhaseOneLoopTimeInSeconds());
     }
 
     public CompletableFuture<Long> compact(String topic) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/StrategicTwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/StrategicTwoPhaseCompactor.java
@@ -425,17 +425,12 @@ public class StrategicTwoPhaseCompactor extends TwoPhaseCompactor {
             return flushBatchMessage(lh, topic, outstanding);
         }
         if (batchMessageContainer.haveEnoughSpace((MessageImpl<?>) m)) {
-            if (batchMessageContainer.add((MessageImpl<?>) m, null)) {
-                return flushBatchMessage(lh, topic, outstanding);
-            }
+            batchMessageContainer.add((MessageImpl<?>) m, null);
             return CompletableFuture.completedFuture(false);
         }
         CompletableFuture<Boolean> f = flushBatchMessage(lh, topic, outstanding);
-        if (batchMessageContainer.add((MessageImpl<?>) m, null)) {
-            return flushBatchMessage(lh, topic, outstanding).thenCombine(f, (a, b) -> a && b);
-        } else {
-            return f;
-        }
+        batchMessageContainer.add((MessageImpl<?>) m, null);
+        return f;
     }
 
     private CompletableFuture<Boolean> flushBatchMessage(LedgerHandle lh, String topic,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/StrategicTwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/StrategicTwoPhaseCompactor.java
@@ -444,6 +444,8 @@ public class StrategicTwoPhaseCompactor extends TwoPhaseCompactor {
     <T> CompletableFuture<Boolean> addToCompactedLedger(
             LedgerHandle lh, Message<T> m, String topic, Semaphore outstanding) {
         CompletableFuture<Boolean> bkf = new CompletableFuture<>();
+        // TODO: Support add batch message. Currently it might split a batch message into multiple batch.
+        // So the message id will be same.
         if (m == null || batchMessageContainer.add((MessageImpl<?>) m, null)) {
             if (batchMessageContainer.getNumMessagesInBatch() > 0) {
                 try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -81,7 +81,6 @@ import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.ConsumerImpl;
-import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
@@ -542,14 +541,8 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
             Assert.assertEquals(message2.getKey(), "key2");
             Assert.assertEquals(new String(message2.getData()), "my-message-3");
             if (getCompactor() instanceof StrategicTwoPhaseCompactor) {
-                MessageIdImpl id = (MessageIdImpl) messages.get(0).getMessageId();
-                MessageIdImpl id1 = new MessageIdImpl(
-                        id.getLedgerId(), id.getEntryId(), id.getPartitionIndex());
-                Assert.assertEquals(message1.getMessageId(), id1);
-                id = (MessageIdImpl) messages.get(2).getMessageId();
-                MessageIdImpl id2 = new MessageIdImpl(
-                        id.getLedgerId(), id.getEntryId(), id.getPartitionIndex());
-                Assert.assertEquals(message2.getMessageId(), id2);
+                Assert.assertEquals(message1.getMessageId(), messages.get(0).getMessageId());
+                Assert.assertEquals(message2.getMessageId(), messages.get(1).getMessageId());
             } else {
                 Assert.assertEquals(message1.getMessageId(), messages.get(0).getMessageId());
                 Assert.assertEquals(message2.getMessageId(), messages.get(2).getMessageId());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionRetentionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionRetentionTest.java
@@ -34,7 +34,7 @@ public class StrategicCompactionRetentionTest extends CompactionRetentionTest {
     @Override
     public void setup() throws Exception {
         super.setup();
-        compactor = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler, 1);
+        compactor = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler);
         strategy = new TopicCompactionStrategyTest.DummyTopicCompactionStrategy();
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionTest.java
@@ -18,22 +18,33 @@
  */
 package org.apache.pulsar.compaction;
 
+import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelImpl.MSG_COMPRESSION_TYPE;
+import static org.testng.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.TableView;
+import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.topics.TopicCompactionStrategy;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -148,24 +159,56 @@ public class StrategicCompactionTest extends CompactionTest {
         Assert.assertEquals(tableView.entrySet(), expectedCopy.entrySet());
     }
 
-    @Override
-    public void testCompactCompressedBatching() throws Exception {
-        compactor = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler, 10);
-        super.testCompactCompressedBatching();
-        compactor = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler, 1);
+    @Test(timeOut = 20000)
+    public void testSameBatchCompactToSameBatch() throws Exception {
+        final String topic =
+                "persistent://my-property/use/my-ns/testSameBatchCompactToSameBatch" + UUID.randomUUID();
+
+        final int messages = 10;
+
+        // 1.create producer and publish message to the topic.
+        ProducerBuilder<Integer> builder = pulsarClient.newProducer(Schema.INT32)
+                .compressionType(MSG_COMPRESSION_TYPE).topic(topic);
+        builder.batchingMaxMessages(2)
+                .batchingMaxPublishDelay(10, TimeUnit.MILLISECONDS);
+
+        Producer<Integer> producer = builder.create();
+
+        List<CompletableFuture<MessageId>> futures = new ArrayList<>(messages);
+        for (int i = 0; i < messages; i++) {
+            futures.add(producer.newMessage().key(String.valueOf(i))
+                    .value(i)
+                    .sendAsync());
+        }
+
+        FutureUtil.waitForAll(futures).get();
+
+        // 2.compact the topic.
+        StrategicTwoPhaseCompactor compactor
+                = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler, 3);
+        compactor.compact(topic, strategy).get();
+
+        // consumer with readCompacted enabled only get compacted entries
+        try (Consumer<Integer> consumer = pulsarClient
+                .newConsumer(Schema.INT32)
+                .topic(topic)
+                .subscriptionName("sub1")
+                .readCompacted(true)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe()) {
+            int received = 0;
+            while(true) {
+                Message<Integer> m = consumer.receive(2, TimeUnit.SECONDS);
+                if (m == null) {
+                    break;
+                }
+                MessageIdImpl messageId = (MessageIdImpl) m.getMessageId();
+                assertEquals(messageId.getBatchSize(), 2);
+                received++;
+            }
+            assertEquals(received, messages);
+        }
+
     }
 
-    @Override
-    public void testCompactEncryptedAndCompressedBatching() throws Exception {
-        compactor = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler, 10);
-        super.testCompactEncryptedAndCompressedBatching();
-        compactor = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler, 1);
-    }
 
-    @Override
-    public void testCompactEncryptedBatching() throws Exception {
-        compactor = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler, 10);
-        super.testCompactEncryptedBatching();
-        compactor = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler, 1);
-    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionTest.java
@@ -58,7 +58,7 @@ public class StrategicCompactionTest extends CompactionTest {
     @Override
     public void setup() throws Exception {
         super.setup();
-        compactor = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler, 1);
+        compactor = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler);
         strategy = new TopicCompactionStrategyTest.DummyTopicCompactionStrategy();
     }
 
@@ -185,7 +185,7 @@ public class StrategicCompactionTest extends CompactionTest {
 
         // 2.compact the topic.
         StrategicTwoPhaseCompactor compactor
-                = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler, 3);
+                = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler);
         compactor.compact(topic, strategy).get();
 
         // consumer with readCompacted enabled only get compacted entries

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionTest.java
@@ -42,7 +42,6 @@ import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.TableView;
-import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.topics.TopicCompactionStrategy;
 import org.apache.pulsar.common.util.FutureUtil;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionTest.java
@@ -35,6 +35,7 @@ import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.MessageIdAdv;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
@@ -180,6 +181,7 @@ public class StrategicCompactionTest extends CompactionTest {
                     .value(i)
                     .sendAsync());
         }
+        // Add additional message to make sure the last batch is not full and test flush this batch.
         futures.add(producer.newMessage().key(String.valueOf(messages))
                 .value(messages)
                 .sendAsync());
@@ -205,10 +207,10 @@ public class StrategicCompactionTest extends CompactionTest {
                     break;
                 }
                 if (received <= messages - 1) {
-                    MessageIdImpl messageId = (MessageIdImpl) m.getMessageId();
+                    MessageIdAdv messageId = (MessageIdAdv) m.getMessageId();
                     assertEquals(messageId.getBatchSize(), 2);
                 } else {
-                    MessageIdImpl messageId = (MessageIdImpl) m.getMessageId();
+                    MessageIdAdv messageId = (MessageIdAdv) m.getMessageId();
                     assertEquals(messageId.getBatchSize(), 0);
                 }
                 received++;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionTest.java
@@ -180,6 +180,9 @@ public class StrategicCompactionTest extends CompactionTest {
                     .value(i)
                     .sendAsync());
         }
+        futures.add(producer.newMessage().key(String.valueOf(messages))
+                .value(messages)
+                .sendAsync());
 
         FutureUtil.waitForAll(futures).get();
 
@@ -201,11 +204,16 @@ public class StrategicCompactionTest extends CompactionTest {
                 if (m == null) {
                     break;
                 }
-                MessageIdImpl messageId = (MessageIdImpl) m.getMessageId();
-                assertEquals(messageId.getBatchSize(), 2);
+                if (received <= messages - 1) {
+                    MessageIdImpl messageId = (MessageIdImpl) m.getMessageId();
+                    assertEquals(messageId.getBatchSize(), 2);
+                } else {
+                    MessageIdImpl messageId = (MessageIdImpl) m.getMessageId();
+                    assertEquals(messageId.getBatchSize(), 0);
+                }
                 received++;
             }
-            assertEquals(received, messages);
+            assertEquals(received, messages + 1);
         }
 
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactorTest.java
@@ -33,7 +33,7 @@ public class StrategicCompactorTest extends CompactorTest {
     @Override
     public void setup() throws Exception {
         super.setup();
-        compactor = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler, 1);
+        compactor = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler);
         strategy = new TopicCompactionStrategyTest.DummyTopicCompactionStrategy();
     }
 


### PR DESCRIPTION
### Motivation

Currently, the `ServiceUnitStateChannelImpl` will send batch messages to `loadbalancer-service-unit-state` topic,
and the `StrategicTwoPhaseCompactor` will consume the message and rebatch the message to a new batch.

However, the `StrategicTwoPhaseCompactor` may write messages from the same batch into different entries, which will result in skipping some messages when reading compacted entries.

For example, we have a batch: `[(3:0:-1:0, k1), (3:0:-1:1, k2)]`, after compact, the batch maybe `[3:0:-1:0, k1]` and `[3:0:-1:0, k2]` , then if we only read one entry, the `readPosition` will be updated to `3:1` , so the `[3:0:-1:0, k2]` will be skipped.

### Modifications

* Check the add message `entryId` and `ledgerId` before adding a message to `RawBatchMessageContainerImpl`.
* Remove size limit for `RawBatchMessageContainerImpl` to let input batch decide.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->