### PR TITLE
[fix][broker] Use expireAfterAccess instead of expireAfterWrite for metadata cache

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCacheConfig.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCacheConfig.java
@@ -46,5 +46,12 @@ public class MetadataCacheConfig {
      * A negative or zero value disables automatic expiration.
      */
     @Builder.Default
-    private final long expireAfterWriteMillis = 2 * DEFAULT_CACHE_REFRESH_TIME_MILLIS;
+    private final long expireAfterWriteMillis = 0L;
+
+    /**
+     * Specifies that each entry should be automatically removed from the cache once a fixed duration
+     * has elapsed after the entry's creation, the most recent replacement of its value, or its last access.
+     * A negative or zero value disables automatic expiration.
+     */
+    private final long expireAfterAccessMillis = 2 * DEFAULT_CACHE_REFRESH_TIME_MILLIS;
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
@@ -76,6 +76,9 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
         if (cacheConfig.getExpireAfterWriteMillis() > 0) {
             cacheBuilder.expireAfterWrite(cacheConfig.getExpireAfterWriteMillis(), TimeUnit.MILLISECONDS);
         }
+        if (cacheConfig.getExpireAfterAccessMillis() > 0) {
+            cacheBuilder.expireAfterAccess(cacheConfig.getExpireAfterAccessMillis(), TimeUnit.MILLISECONDS);
+        }
         this.objCache = cacheBuilder
                 .buildAsync(new AsyncCacheLoader<String, Optional<CacheGetResult<T>>>() {
                     @Override


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/14154 introduced a metadata cache expiration policy to avoid a potential memory leak in the Metadata caches. But it uses the `expireAfterWrite` to force expire the caches no matter if the entry has been actively accessed or not. 

We also found another related regression from 2.9 to 2.10. The BookKeeper placement policy doesn't work as expected if the cache expires. The code itself also has the problem, but without the `expireAfterWrite`, it works great.

https://github.com/apache/pulsar/blob/b69f4efa6058c3f51885a61a2b3acb46f8b730f4/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicy.java#L189-L198

For most cases, disabling the `expireAfterWrite` and enabling `expireAfterAccess` will resolve the issue because the new ledgers will happen more frequently than 10 mins if have some topics.

### Modification

- Disable `expireAfterWrite` by default
- Enable `expireAfterAccess` by default

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
