### PR TITLE
[fix] [broker] Fix isolated group not work problem.

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicy.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicy.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BKException.BKNotEnoughBookiesException;
 import org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicy;
@@ -48,8 +47,6 @@ import org.apache.pulsar.common.policies.data.BookiesRackConfiguration;
 import org.apache.pulsar.common.policies.data.EnsemblePlacementPolicyConfig;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStore;
-import org.apache.pulsar.zookeeper.ZkBookieRackAffinityMapping;
-import org.apache.zookeeper.KeeperException;
 
 @Slf4j
 public class IsolatedBookieEnsemblePlacementPolicy extends RackawareEnsemblePlacementPolicy {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicy.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicy.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.bookie.rackawareness;
 
 import static org.apache.pulsar.bookie.rackawareness.BookieRackAffinityMapping.METADATA_STORE_INSTANCE;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import io.netty.util.HashedWheelTimer;
 import java.util.Collections;
@@ -62,6 +63,9 @@ public class IsolatedBookieEnsemblePlacementPolicy extends RackawareEnsemblePlac
     private ImmutablePair<Set<String>, Set<String>> defaultIsolationGroups;
 
     private MetadataCache<BookiesRackConfiguration> bookieMappingCache;
+
+    @VisibleForTesting
+    long metaOpTimeout = AbstractMetadataDriver.BLOCKING_CALL_TIMEOUT;
 
     private static final String PULSAR_SYSTEM_TOPIC_ISOLATION_GROUP = "*";
 
@@ -183,7 +187,8 @@ public class IsolatedBookieEnsemblePlacementPolicy extends RackawareEnsemblePlac
         return pair;
     }
 
-    private Set<BookieId> getExcludedBookiesWithIsolationGroups(int ensembleSize,
+    @VisibleForTesting
+    Set<BookieId> getExcludedBookiesWithIsolationGroups(int ensembleSize,
         Pair<Set<String>, Set<String>> isolationGroups) {
         Set<BookieId> excludedBookies = new HashSet<>();
         if (isolationGroups != null && isolationGroups.getLeft().contains(PULSAR_SYSTEM_TOPIC_ISOLATION_GROUP)) {
@@ -193,7 +198,7 @@ public class IsolatedBookieEnsemblePlacementPolicy extends RackawareEnsemblePlac
             if (bookieMappingCache != null) {
                 Optional<BookiesRackConfiguration> optional =
                         bookieMappingCache.get(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH).get(
-                                AbstractMetadataDriver.BLOCKING_CALL_TIMEOUT, TimeUnit.MILLISECONDS);
+                                metaOpTimeout, TimeUnit.MILLISECONDS);
 
                 if (!optional.isPresent()) {
                     throw new KeeperException.NoNodeException(ZkBookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH);

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
@@ -152,14 +152,14 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
         CompletableFuture<Optional<BookiesRackConfiguration>> timeoutFuture = new CompletableFuture<>();
         new Thread(() -> {
             try {
-                Thread.sleep(metaOpTimeout + 1000);
+                Thread.sleep(metaOpTimeout + 5000);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
             BookiesRackConfiguration rackConfiguration = new BookiesRackConfiguration();
             rackConfiguration.put("group1", mainBookieGroup);
             rackConfiguration.put("group2", secondaryBookieGroup);
-            waitingCompleteFuture.complete(Optional.of(rackConfiguration));
+            timeoutFuture.complete(Optional.of(rackConfiguration));
         }).start();
 
 

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
@@ -127,9 +127,10 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
         Map<String, BookieInfo> mainBookieGroup = new HashMap<>();
         mainBookieGroup.put(BOOKIE1, BookieInfo.builder().rack("rack0").build());
         mainBookieGroup.put(BOOKIE2, BookieInfo.builder().rack("rack1").build());
+        mainBookieGroup.put(BOOKIE3, BookieInfo.builder().rack("rack1").build());
+        mainBookieGroup.put(BOOKIE4, BookieInfo.builder().rack("rack0").build());
 
         Map<String, BookieInfo> secondaryBookieGroup = new HashMap<>();
-        secondaryBookieGroup.put(BOOKIE3, BookieInfo.builder().rack("rack0").build());
 
         store = mock(MetadataStoreExtended.class);
         MetadataCacheImpl cache = mock(MetadataCacheImpl.class);
@@ -138,6 +139,7 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
         //The initialFuture only has group1.
         BookiesRackConfiguration rackConfiguration1 = new BookiesRackConfiguration();
         rackConfiguration1.put("group1", mainBookieGroup);
+        rackConfiguration1.put("group2", secondaryBookieGroup);
         initialFuture.complete(Optional.of(rackConfiguration1));
 
         long waitTime = 2000;
@@ -150,8 +152,15 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
             }
             //The waitingCompleteFuture has group1 and group2.
             BookiesRackConfiguration rackConfiguration2 = new BookiesRackConfiguration();
-            rackConfiguration2.put("group1", mainBookieGroup);
-            rackConfiguration2.put("group2", secondaryBookieGroup);
+            Map<String, BookieInfo> mainBookieGroup2 = new HashMap<>();
+            mainBookieGroup2.put(BOOKIE1, BookieInfo.builder().rack("rack0").build());
+            mainBookieGroup2.put(BOOKIE2, BookieInfo.builder().rack("rack1").build());
+            mainBookieGroup2.put(BOOKIE4, BookieInfo.builder().rack("rack0").build());
+
+            Map<String, BookieInfo> secondaryBookieGroup2 = new HashMap<>();
+            secondaryBookieGroup2.put(BOOKIE3, BookieInfo.builder().rack("rack0").build());
+            rackConfiguration2.put("group1", mainBookieGroup2);
+            rackConfiguration2.put("group2", secondaryBookieGroup2);
             waitingCompleteFuture.complete(Optional.of(rackConfiguration2));
         }).start();
 

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
@@ -123,7 +123,7 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
     }
 
     @Test
-    public void testMetadataStoreCases() {
+    public void testMetadataStoreCases() throws Exception {
         Map<String, BookieInfo> mainBookieGroup = new HashMap<>();
         mainBookieGroup.put(BOOKIE1, BookieInfo.builder().rack("rack0").build());
         mainBookieGroup.put(BOOKIE2, BookieInfo.builder().rack("rack1").build());
@@ -134,40 +134,31 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
         store = mock(MetadataStoreExtended.class);
         MetadataCacheImpl cache = mock(MetadataCacheImpl.class);
         when(store.getMetadataCache(BookiesRackConfiguration.class)).thenReturn(cache);
-        CompletableFuture<Object> completableFuture = CompletableFuture.completedFuture(null);
-        long metaOpTimeout = 3000;
+        CompletableFuture<Optional<BookiesRackConfiguration>> initialFuture = new CompletableFuture<>();
+        //The initialFuture only has group1.
+        BookiesRackConfiguration rackConfiguration1 = new BookiesRackConfiguration();
+        rackConfiguration1.put("group1", mainBookieGroup);
+        initialFuture.complete(Optional.of(rackConfiguration1));
+
+        long waitTime = 2000;
         CompletableFuture<Optional<BookiesRackConfiguration>> waitingCompleteFuture = new CompletableFuture<>();
         new Thread(() -> {
             try {
-                Thread.sleep(metaOpTimeout - 1000);
+                Thread.sleep(waitTime);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
-            BookiesRackConfiguration rackConfiguration = new BookiesRackConfiguration();
-            rackConfiguration.put("group1", mainBookieGroup);
-            rackConfiguration.put("group2", secondaryBookieGroup);
-            waitingCompleteFuture.complete(Optional.of(rackConfiguration));
+            //The waitingCompleteFuture has group1 and group2.
+            BookiesRackConfiguration rackConfiguration2 = new BookiesRackConfiguration();
+            rackConfiguration2.put("group1", mainBookieGroup);
+            rackConfiguration2.put("group2", secondaryBookieGroup);
+            waitingCompleteFuture.complete(Optional.of(rackConfiguration2));
         }).start();
 
-        CompletableFuture<Optional<BookiesRackConfiguration>> timeoutFuture = new CompletableFuture<>();
-        new Thread(() -> {
-            try {
-                Thread.sleep(metaOpTimeout + 5000);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-            BookiesRackConfiguration rackConfiguration = new BookiesRackConfiguration();
-            rackConfiguration.put("group1", mainBookieGroup);
-            rackConfiguration.put("group2", secondaryBookieGroup);
-            timeoutFuture.complete(Optional.of(rackConfiguration));
-        }).start();
-
-
-        when(cache.get(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH)).thenReturn(completableFuture)
-                .thenReturn(waitingCompleteFuture).thenReturn(timeoutFuture);
+        when(cache.get(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH)).thenReturn(initialFuture)
+                .thenReturn(waitingCompleteFuture);
 
         IsolatedBookieEnsemblePlacementPolicy isolationPolicy = new IsolatedBookieEnsemblePlacementPolicy();
-        isolationPolicy.metaOpTimeout = metaOpTimeout;
         ClientConfiguration bkClientConf = new ClientConfiguration();
         bkClientConf.setProperty(BookieRackAffinityMapping.METADATA_STORE_INSTANCE, store);
         bkClientConf.setProperty(IsolatedBookieEnsemblePlacementPolicy.ISOLATION_BOOKIE_GROUPS, isolationGroups);
@@ -178,13 +169,20 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
         groups.setLeft(Sets.newHashSet("group1"));
         groups.setRight(new HashSet<>());
 
+        //The future is waiting done, so use the cached rack config.
         Set<BookieId> blacklist =
                 isolationPolicy.getExcludedBookiesWithIsolationGroups(2, groups);
-        assertFalse(blacklist.isEmpty());
+        assertTrue(blacklist.isEmpty());
 
+        Thread.sleep(waitTime);
+
+        //The future is already done, use the newest rack config.
         blacklist =
                 isolationPolicy.getExcludedBookiesWithIsolationGroups(2, groups);
-        assertTrue(blacklist.isEmpty());
+        assertFalse(blacklist.isEmpty());
+        assertEquals(blacklist.size(), 1);
+        BookieId excludeBookie = blacklist.iterator().next();
+        assertEquals(excludeBookie.toString(), BOOKIE3);
     }
 
     @Test


### PR DESCRIPTION

### Modifications
When upgraded the pulsar version from 2.9.2 to 2.10.3, and the isolated group feature not work anymore.
Finally, we found the problem. In IsolatedBookieEnsemblePlacementPolicy, when it gets the bookie rack from the metadata store cache, uses future.isDone() to avoid sync operation. If the future is incomplete, return empty blacklists. 
The cache may expire due to the caffeine cache `getExpireAfterWriteMillis` config, if the cache expires, the future may be incomplete. (#21095 will correct the behavior)

In 2.9.2, it uses the sync to get data from the metadata store, we should also keep the behavior.



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
