### PR TITLE
[fix][client] Avoid ack hole for chunk message

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
@@ -427,7 +427,7 @@ public class MessageChunkingTest extends ProducerConsumerBase {
         receivedMsg = consumer.receive(5, TimeUnit.SECONDS);
         assertEquals(receivedMsg.getValue(), "chunk-1-0|chunk-1-1|chunk-1-2|");
         consumer.acknowledge(receivedMsg);
-        Assert.assertEquals(((ConsumerImpl<String>) consumer).getAvailablePermits(), 10);
+        Assert.assertEquals(((ConsumerImpl<String>) consumer).getAvailablePermits(), 8);
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
@@ -427,6 +427,7 @@ public class MessageChunkingTest extends ProducerConsumerBase {
         receivedMsg = consumer.receive(5, TimeUnit.SECONDS);
         assertEquals(receivedMsg.getValue(), "chunk-1-0|chunk-1-1|chunk-1-2|");
         consumer.acknowledge(receivedMsg);
+        Assert.assertEquals(((ConsumerImpl<String>) consumer).getAvailablePermits(), 10);
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
@@ -357,6 +357,38 @@ public class MessageChunkingTest extends ProducerConsumerBase {
     }
 
     @Test
+    public void testResendChunkMessagesWithoutAckHole() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+        final String topicName = "persistent://my-property/my-ns/testResendChunkMessagesWithoutAckHole";
+        final String subName = "my-subscriber-name";
+        @Cleanup
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topicName)
+                .subscriptionName(subName)
+                .maxPendingChunkedMessage(10)
+                .autoAckOldestChunkedMessageOnQueueFull(true)
+                .subscribe();
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topicName)
+                .chunkMaxMessageSize(100)
+                .enableChunking(true)
+                .enableBatching(false)
+                .create();
+
+        sendSingleChunk(producer, "0", 0, 2);
+
+        sendSingleChunk(producer, "0", 0, 2); // Resending the first chunk
+        sendSingleChunk(producer, "0", 1, 2);
+
+        Message<String> receivedMsg = consumer.receive(5, TimeUnit.SECONDS);
+        assertEquals(receivedMsg.getValue(), "chunk-0-0|chunk-0-1|");
+        consumer.acknowledge(receivedMsg);
+        assertEquals(admin.topics().getStats(topicName).getSubscriptions().get(subName)
+                .getNonContiguousDeletedMessagesRanges(), 0);
+    }
+
+    @Test
     public void testResendChunkMessages() throws Exception {
         log.info("-- Starting {} test --", methodName);
         final String topicName = "persistent://my-property/my-ns/testResendChunkMessages";

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1437,6 +1437,24 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
         if (msgMetadata.getChunkId() == 0) {
             if (chunkedMsgCtx != null) {
+                // Handle ack hole case:
+                // For example:
+                //     Chunk-1 sequence ID: 0, chunk ID: 0, msgID: 1:1
+                //     Chunk-2 sequence ID: 0, chunk ID: 1, msgID: 1:2
+                //     Chunk-3 sequence ID: 0, chunk ID: 0, msgID: 1:3
+                //     Chunk-4 sequence ID: 0, chunk ID: 1, msgID: 1:4
+                //     Chunk-5 sequence ID: 0, chunk ID: 2, msgID: 1:5
+                // Consumer ack chunk message via ChunkMessageIdImpl that is consist of all the chunks in this chunk
+                // message(Chunk-3, Chunk-4, Chunk-5). The Chunk-1 and Chunk-2 are not included in the
+                // ChunkMessageIdImpl, so we should process here.
+                boolean repeatedlyReceived = Arrays.stream(chunkedMsgCtx.chunkedMessageIds)
+                        .anyMatch(messageId1 -> messageId1 != null && messageId1.ledgerId == messageId.getLedgerId()
+                                && messageId1.entryId == messageId.getEntryId());
+                if (!repeatedlyReceived) {
+                    Arrays.stream(chunkedMsgCtx.chunkedMessageIds).forEach(messageId1 -> {
+                        doAcknowledge(messageId1, AckType.Individual, Collections.emptyMap(), null);
+                    });
+                }
                 // The first chunk of a new chunked-message received before receiving other chunks of previous
                 // chunked-message
                 // so, remove previous chunked-message from map and release buffer

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1444,15 +1444,17 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 //     Chunk-3 sequence ID: 0, chunk ID: 0, msgID: 1:3
                 //     Chunk-4 sequence ID: 0, chunk ID: 1, msgID: 1:4
                 //     Chunk-5 sequence ID: 0, chunk ID: 2, msgID: 1:5
-                // Consumer ack chunk message via ChunkMessageIdImpl that is consist of all the chunks in this chunk
+                // Consumer ack chunk message via ChunkMessageIdImpl that consists of all the chunks in this chunk
                 // message(Chunk-3, Chunk-4, Chunk-5). The Chunk-1 and Chunk-2 are not included in the
-                // ChunkMessageIdImpl, so we should process here.
+                // ChunkMessageIdImpl, so we should process it here.
                 boolean repeatedlyReceived = Arrays.stream(chunkedMsgCtx.chunkedMessageIds)
                         .anyMatch(messageId1 -> messageId1 != null && messageId1.ledgerId == messageId.getLedgerId()
                                 && messageId1.entryId == messageId.getEntryId());
                 if (!repeatedlyReceived) {
                     Arrays.stream(chunkedMsgCtx.chunkedMessageIds).forEach(messageId1 -> {
-                        doAcknowledge(messageId1, AckType.Individual, Collections.emptyMap(), null);
+                        if (messageId1 != null) {
+                            doAcknowledge(messageId1, AckType.Individual, Collections.emptyMap(), null);
+                        }
                     });
                 }
                 // The first chunk of a new chunked-message received before receiving other chunks of previous

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1448,22 +1448,20 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 //     Chunk-5 sequence ID: 0, chunk ID: 2, msgID: 1:3
                 // In this case, chunk-3 and chunk-4 have the same msgID with chunk-1 and chunk-2.
                 // This may be caused by message redeliver, we can't ack any chunk in this case here.
-                // Situation 2 - Message duplication:
+                // Situation 2 - Corrupted chunk message
                 // For example:
                 //     Chunk-1 sequence ID: 0, chunk ID: 0, msgID: 1:1
                 //     Chunk-2 sequence ID: 0, chunk ID: 1, msgID: 1:2
                 //     Chunk-3 sequence ID: 0, chunk ID: 0, msgID: 1:3
                 //     Chunk-4 sequence ID: 0, chunk ID: 1, msgID: 1:4
                 //     Chunk-5 sequence ID: 0, chunk ID: 2, msgID: 1:5
-                // In this case, all the chunks have the different msgID. Chunk-1, Chunk-2, Chunk-3, Chunk-4 are
-                // duplicated persisting in the topic.
-                // Consumer ack chunk message via ChunkMessageIdImpl that consists of all the chunks in this chunk
-                // message(Chunk-3, Chunk-4, Chunk-5). The Chunk-1 and Chunk-2 would not be included in the
-                // ChunkMessageIdImpl, so we should ack them here to avoid ack hole.
-                boolean messageDuplication = Arrays.stream(chunkedMsgCtx.chunkedMessageIds)
+                // In this case, all the chunks with different msgIDs and are persistent in the topic.
+                // But Chunk-1 and Chunk-2 belong to a corrupted chunk message that must be skipped since
+                // they will not be delivered to end users. So we should ack them here to avoid ack hole.
+                boolean isCorruptedChunkMessageDetected = Arrays.stream(chunkedMsgCtx.chunkedMessageIds)
                         .noneMatch(messageId1 -> messageId1 != null && messageId1.ledgerId == messageId.getLedgerId()
                                 && messageId1.entryId == messageId.getEntryId());
-                if (messageDuplication) {
+                if (isCorruptedChunkMessageDetected) {
                     Arrays.stream(chunkedMsgCtx.chunkedMessageIds).forEach(messageId1 -> {
                         if (messageId1 != null) {
                             doAcknowledge(messageId1, AckType.Individual, Collections.emptyMap(), null);
@@ -1513,10 +1511,10 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 increaseAvailablePermits(cnx);
                 // Just like the above logic of receiving the first chunk again. We only ack this chunk in the message
                 // duplication case.
-                boolean messageDuplication = Arrays.stream(chunkedMsgCtx.chunkedMessageIds)
+                boolean isDuplicatedChunk = Arrays.stream(chunkedMsgCtx.chunkedMessageIds)
                         .noneMatch(messageId1 -> messageId1 != null && messageId1.ledgerId == messageId.getLedgerId()
                                 && messageId1.entryId == messageId.getEntryId());
-                if (messageDuplication) {
+                if (isDuplicatedChunk) {
                     doAcknowledge(msgId, AckType.Individual, Collections.emptyMap(), null);
                 }
                 return null;


### PR DESCRIPTION
## Motivation
Handle ack hole case:
For example:
```markdown
                     Chunk-1 sequence ID: 0, chunk ID: 0, msgID: 1:1
                     Chunk-2 sequence ID: 0, chunk ID: 1, msgID: 1:2
                     Chunk-3 sequence ID: 0, chunk ID: 0, msgID: 1:3
                     Chunk-4 sequence ID: 0, chunk ID: 1, msgID: 1:4
                     Chunk-5 sequence ID: 0, chunk ID: 2, msgID: 1:5
```
 Consumer ack chunk message via ChunkMessageIdImpl that consists of all the chunks in this chunk
 message(Chunk-3, Chunk-4, Chunk-5). The Chunk-1 and Chunk-2 are not included in the
 ChunkMessageIdImpl, so we should process it here.
## Modification
Ack chunk-1 and chunk-2.


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
