### PR TITLE
[improve] [doc] Add doc for customized util class 

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMap.java
@@ -38,8 +38,8 @@ import java.util.function.LongFunction;
  *
  * <b>WARN: method forEach do not guarantee thread safety, nor do the keys and values method.</b>
  * <br>
- * The forEach method is specifically designed for single-threaded usage.
- * When iterating over a map with concurrent writes, it becomes possible for new values to be either observed or not observed.
+ * The forEach method is specifically designed for single-threaded usage. When iterating over a map
+ * with concurrent writes, it becomes possible for new values to be either observed or not observed.
  * There is no guarantee that if we write value1 and value2, and are able to see value2, then we will also see value1.
  * In some cases, it is even possible to encounter two mappings with the same key,
  * leading the keys method to return a List containing two identical keys.

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMap.java
@@ -37,6 +37,18 @@ import java.util.function.LongFunction;
  * </ol>
  *
  * <b>WARN: method forEach do not guarantee thread safety, nor do the keys and values method.</b>
+ * <br>
+ * The forEach method is specifically designed for single-threaded usage.
+ * When iterating over a map with concurrent writes, it becomes possible for new values to be either observed or not observed.
+ * There is no guarantee that if we write value1 and value2, and are able to see value2, then we will also see value1.
+ * In some cases, it is even possible to encounter two mappings with the same key,
+ * leading the keys method to return a List containing two identical keys.
+ *
+ * <br>
+ * It is crucial to understand that the results obtained from aggregate status methods such as keys and values
+ * are typically reliable only when the map is not undergoing concurrent updates from other threads.
+ * When concurrent updates are involved, the results of these methods reflect transient states
+ * that may be suitable for monitoring or estimation purposes, but not for program control.
  * @param <V>
  */
 @SuppressWarnings("unchecked")

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMap.java
@@ -237,6 +237,12 @@ public class ConcurrentLongHashMap<V> {
         }
     }
 
+    /**
+     * Iterate over all the entries in the map and apply the processor function to each of them.
+     * <p>
+     * <b>Warning: Do Not Guarantee Thread-Safety.</b>
+     * @param processor the processor to apply to each entry
+     */
     public void forEach(EntryProcessor<V> processor) {
         for (int i = 0; i < sections.length; i++) {
             sections[i].forEach(processor);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongHashMap.java
@@ -36,6 +36,7 @@ import java.util.function.LongFunction;
  * <li>Open hash map with linear probing, no node allocations to store the values
  * </ol>
  *
+ * <b>WARN: method forEach do not guarantee thread safety, nor do the keys and values method.</b>
  * @param <V>
  */
 @SuppressWarnings("unchecked")

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongLongPairHashMap.java
@@ -254,6 +254,12 @@ public class ConcurrentLongLongPairHashMap {
         }
     }
 
+    /**
+     * Iterate over all the entries in the map and apply the processor function to each of them.
+     * <p>
+     * <b>Warning: Do Not Guarantee Thread-Safety.</b>
+     * @param processor the processor to process the elements.
+     */
     public void forEach(BiConsumerLongPair processor) {
         for (Section s : sections) {
             s.forEach(processor);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongLongPairHashMap.java
@@ -39,8 +39,8 @@ import java.util.concurrent.locks.StampedLock;
  * <br>
  * <b>WARN: method forEach do not guarantee thread safety, nor do the keys, values and asMap method.</b>
  * <br>
- * The forEach method is specifically designed for single-threaded usage.
- * When iterating over a map with concurrent writes, it becomes possible for new values to be either observed or not observed.
+ * The forEach method is specifically designed for single-threaded usage. When iterating over a map
+ * with concurrent writes, it becomes possible for new values to be either observed or not observed.
  * There is no guarantee that if we write value1 and value2, and are able to see value2, then we will also see value1.
  * In some cases, it is even possible to encounter two mappings with the same key,
  * leading the keys method to return a List containing two identical keys.

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongLongPairHashMap.java
@@ -36,6 +36,8 @@ import java.util.concurrent.locks.StampedLock;
  * no node allocations are required to store the keys and values, and no boxing is required.
  *
  * <p>Keys <strong>MUST</strong> be &gt;= 0.
+ * <br>
+ * <b>WARN: method forEach do not guarantee thread safety, nor do the keys and values method.</b>
  */
 public class ConcurrentLongLongPairHashMap {
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongLongPairHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongLongPairHashMap.java
@@ -37,7 +37,19 @@ import java.util.concurrent.locks.StampedLock;
  *
  * <p>Keys <strong>MUST</strong> be &gt;= 0.
  * <br>
- * <b>WARN: method forEach do not guarantee thread safety, nor do the keys and values method.</b>
+ * <b>WARN: method forEach do not guarantee thread safety, nor do the keys, values and asMap method.</b>
+ * <br>
+ * The forEach method is specifically designed for single-threaded usage.
+ * When iterating over a map with concurrent writes, it becomes possible for new values to be either observed or not observed.
+ * There is no guarantee that if we write value1 and value2, and are able to see value2, then we will also see value1.
+ * In some cases, it is even possible to encounter two mappings with the same key,
+ * leading the keys method to return a List containing two identical keys.
+ *
+ * <br>
+ * It is crucial to understand that the results obtained from aggregate status methods such as keys, values, and asMap
+ * are typically reliable only when the map is not undergoing concurrent updates from other threads.
+ * When concurrent updates are involved, the results of these methods reflect transient states
+ * that may be suitable for monitoring or estimation purposes, but not for program control.
  */
 public class ConcurrentLongLongPairHashMap {
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongPairSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongPairSet.java
@@ -37,8 +37,8 @@ import java.util.concurrent.locks.StampedLock;
  * <br>
  * <b>WARN: method forEach do not guarantee thread safety, nor does the items method.</b>
  * <br>
- * The forEach method is specifically designed for single-threaded usage.
- * When iterating over a set with concurrent writes, it becomes possible for new values to be either observed or not observed.
+ * The forEach method is specifically designed for single-threaded usage. When iterating over a set
+ * with concurrent writes, it becomes possible for new values to be either observed or not observed.
  * There is no guarantee that if we write value1 and value2, and are able to see value2, then we will also see value1.
  *
  * <br>

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongPairSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongPairSet.java
@@ -36,6 +36,16 @@ import java.util.concurrent.locks.StampedLock;
  * <p>Values <b>MUST</b> be &gt;= 0.
  * <br>
  * <b>WARN: method forEach do not guarantee thread safety, nor does the items method.</b>
+ * <br>
+ * The forEach method is specifically designed for single-threaded usage.
+ * When iterating over a set with concurrent writes, it becomes possible for new values to be either observed or not observed.
+ * There is no guarantee that if we write value1 and value2, and are able to see value2, then we will also see value1.
+ *
+ * <br>
+ * It is crucial to understand that the results obtained from aggregate status methods such as items
+ * are typically reliable only when the map is not undergoing concurrent updates from other threads.
+ * When concurrent updates are involved, the results of these methods reflect transient states
+ * that may be suitable for monitoring or estimation purposes, but not for program control.
  */
 public class ConcurrentLongPairSet implements LongPairSet {
 
@@ -268,7 +278,7 @@ public class ConcurrentLongPairSet implements LongPairSet {
     }
 
     /**
-     * @return a new list of all keys (makes a copy)
+     * @return a new set of all keys (makes a copy)
      */
     public Set<LongPair> items() {
         Set<LongPair> items = new HashSet<>();

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongPairSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongPairSet.java
@@ -34,6 +34,8 @@ import java.util.concurrent.locks.StampedLock;
  * no node allocations are required to store the keys and values, and no boxing is required.
  *
  * <p>Values <b>MUST</b> be &gt;= 0.
+ * <br>
+ * <b>WARN: method forEach do not guarantee thread safety, nor does the items method.</b>
  */
 public class ConcurrentLongPairSet implements LongPairSet {
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongPairSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongPairSet.java
@@ -237,6 +237,12 @@ public class ConcurrentLongPairSet implements LongPairSet {
         }
     }
 
+    /**
+     * Iterate over all the elements in the set and apply the provided function.
+     * <p>
+     * <b>Warning: Do Not Guarantee Thread-Safety.</b>
+     * @param processor the processor to process the elements
+     */
     public void forEach(LongPairConsumer processor) {
         for (int i = 0; i < sections.length; i++) {
             sections[i].forEach(processor);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
@@ -35,7 +35,20 @@ import java.util.function.Function;
  * <p>Provides similar methods as a {@code ConcurrentMap<K,V>} but since it's an open hash map with linear probing,
  * no node allocations are required to store the values.
  *
+ * <br>
  * <b>WARN: method forEach do not guarantee thread safety, nor do the keys and values method.</b>
+ * <br>
+ * The forEach method is specifically designed for single-threaded usage.
+ * When iterating over a map with concurrent writes, it becomes possible for new values to be either observed or not observed.
+ * There is no guarantee that if we write value1 and value2, and are able to see value2, then we will also see value1.
+ * In some cases, it is even possible to encounter two mappings with the same key,
+ * leading the keys method to return a List containing two identical keys.
+ *
+ * <br>
+ * It is crucial to understand that the results obtained from aggregate status methods such as keys and values
+ * are typically reliable only when the map is not undergoing concurrent updates from other threads.
+ * When concurrent updates are involved, the results of these methods reflect transient states
+ * that may be suitable for monitoring or estimation purposes, but not for program control.
  * @param <V>
  */
 @SuppressWarnings("unchecked")

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
@@ -38,8 +38,8 @@ import java.util.function.Function;
  * <br>
  * <b>WARN: method forEach do not guarantee thread safety, nor do the keys and values method.</b>
  * <br>
- * The forEach method is specifically designed for single-threaded usage.
- * When iterating over a map with concurrent writes, it becomes possible for new values to be either observed or not observed.
+ * The forEach method is specifically designed for single-threaded usage. When iterating over a map
+ * with concurrent writes, it becomes possible for new values to be either observed or not observed.
  * There is no guarantee that if we write value1 and value2, and are able to see value2, then we will also see value1.
  * In some cases, it is even possible to encounter two mappings with the same key,
  * leading the keys method to return a List containing two identical keys.

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
@@ -276,7 +276,7 @@ public class ConcurrentOpenHashMap<K, V> {
      * Iterate over all the entries in the map and apply the processor function to each of them.
      * <p>
      * <b>Warning: Do Not Guarantee Thread-Safety.</b>
-     * @param processor
+     * @param processor the function to apply to each entry
      */
     public void forEach(BiConsumer<? super K, ? super V> processor) {
         for (int i = 0; i < sections.length; i++) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
@@ -272,6 +272,12 @@ public class ConcurrentOpenHashMap<K, V> {
         }
     }
 
+    /**
+     * Iterate over all the entries in the map and apply the processor function to each of them.
+     * <p>
+     * <b>Warning: Do Not Guarantee Thread-Safety.</b>
+     * @param processor
+     */
     public void forEach(BiConsumer<? super K, ? super V> processor) {
         for (int i = 0; i < sections.length; i++) {
             sections[i].forEach(processor);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashMap.java
@@ -35,6 +35,7 @@ import java.util.function.Function;
  * <p>Provides similar methods as a {@code ConcurrentMap<K,V>} but since it's an open hash map with linear probing,
  * no node allocations are required to store the values.
  *
+ * <b>WARN: method forEach do not guarantee thread safety, nor do the keys and values method.</b>
  * @param <V>
  */
 @SuppressWarnings("unchecked")

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSet.java
@@ -35,6 +35,8 @@ import java.util.function.Predicate;
  * <p>Provides similar methods as a {@code ConcurrentMap<K,V>} but since it's an open hash map with linear probing,
  * no node allocations are required to store the values.
  *
+ * <br>
+ * <b>WARN: method forEach do not guarantee thread safety, nor does the items method.</b>
  * @param <V>
  */
 @SuppressWarnings("unchecked")

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSet.java
@@ -216,6 +216,12 @@ public class ConcurrentOpenHashSet<V> {
         }
     }
 
+    /**
+     * Iterate over all the elements in the set and apply the provided function.
+     * <p>
+     * <b>Warning: Do Not Guarantee Thread-Safety.</b>
+     * @param processor
+     */
     public void forEach(Consumer<? super V> processor) {
         for (int i = 0; i < sections.length; i++) {
             sections[i].forEach(processor);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSet.java
@@ -38,8 +38,8 @@ import java.util.function.Predicate;
  * <br>
  * <b>WARN: method forEach do not guarantee thread safety, nor does the values method.</b>
  * <br>
- * The forEach method is specifically designed for single-threaded usage.
- * When iterating over a set with concurrent writes, it becomes possible for new values to be either observed or not observed.
+ * The forEach method is specifically designed for single-threaded usage. When iterating over a set
+ * with concurrent writes, it becomes possible for new values to be either observed or not observed.
  * There is no guarantee that if we write value1 and value2, and are able to see value2, then we will also see value1.
  *
  * <br>

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSet.java
@@ -220,7 +220,7 @@ public class ConcurrentOpenHashSet<V> {
      * Iterate over all the elements in the set and apply the provided function.
      * <p>
      * <b>Warning: Do Not Guarantee Thread-Safety.</b>
-     * @param processor
+     * @param processor the function to apply to each element
      */
     public void forEach(Consumer<? super V> processor) {
         for (int i = 0; i < sections.length; i++) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentOpenHashSet.java
@@ -36,7 +36,17 @@ import java.util.function.Predicate;
  * no node allocations are required to store the values.
  *
  * <br>
- * <b>WARN: method forEach do not guarantee thread safety, nor does the items method.</b>
+ * <b>WARN: method forEach do not guarantee thread safety, nor does the values method.</b>
+ * <br>
+ * The forEach method is specifically designed for single-threaded usage.
+ * When iterating over a set with concurrent writes, it becomes possible for new values to be either observed or not observed.
+ * There is no guarantee that if we write value1 and value2, and are able to see value2, then we will also see value1.
+ *
+ * <br>
+ * It is crucial to understand that the results obtained from aggregate status methods such as values
+ * are typically reliable only when the map is not undergoing concurrent updates from other threads.
+ * When concurrent updates are involved, the results of these methods reflect transient states
+ * that may be suitable for monitoring or estimation purposes, but not for program control.
  * @param <V>
  */
 @SuppressWarnings("unchecked")


### PR DESCRIPTION
Fixes #21109 
Fixes #21113

### Motivation

There is bug in `forEach` method in util class like `ConcurrentLongLongPairHashMap`.
When it detect there is another thread acquire the write lock, it will fall back to acquire the read lock, which is right. But, it will continue to iterate the array from the last time. 
1. As another thread may write the new value before the current index for iterate, it may miss the new value.
There are posibilities that it may read the new value or can't read the new value, which may volilate the consistence of data. This is the problem discribed in #21109.
2. As the time spent on 
https://github.com/apache/pulsar/blob/master/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentLongLongPairHashMap.java#561
```
processor.accept(storedKey1, storedKey2, storedValue1, storedValue2);
```
is unpredictable. There may be lots of write/remove/clear operations executed in other threads before `foreach` method fall back to acquire the read lock. After the update from other threads, the `foreach` method will still iterate the array from the index(bucket) last time, whose result is completly unpredictable.
For example in #21113.
In the case of `capacity=4`, the bucket calculated for key `(9,9)` and `(10,10)` is 1.  So, if we put into pair (9,9,99,99) before (10,10,1010,1010), the array content:
```
-1 -1 -1 -1 9 9 99 99 10 10 1010 1010 ....
```
if we put into pair (10,10,1010,1010) before (9,9,99,99), the array content:
```
-1 -1 -1 -1 10 10 1010 1010 9 9 99 99 ....
```
Given above, i construct a test: `writer` thread put into pair `(9,9,99,99)`, `(10,10,1010,1010)` first. When the `foreach` thread read to `bucket 1`(that is `9 9 99 99`), `writer` thread clear all the content and put into pair `(10,10,1010,1010)`, `(9,9,99,99)`. Then the `foreach` thread continue to read the array from `bucket 2`, so it will read `9 9 99 99`, which is the case where key and value are both same.

### Modifications
~~We can not allow update while we iterate the array, or we can not provide any consistence gurantee. We have to remove the optimistic read logic from `forEach` method in all util class.~~
Add warning in javadocs for these util class.
```
ConcurrentLongHashMap
ConcurrentLongLongPairHashMap
ConcurrentLongPairSet
ConcurrentOpenHashMap
ConcurrentOpenHashSet
```

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/29
