### PR TITLE
[cleanup][misc] Delete .github/ISSUE_TEMPLATE/pip.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/pip.md
+++ b/.github/ISSUE_TEMPLATE/pip.md
@@ -1,9 +1,0 @@
----
-name: PIP
-about: '[DEPRECATED. see pip folder] Submit a Pulsar Improvement Proposal (PIP)'
-title: 'DEPRECATED - Read https://github.com/apache/pulsar/blob/master/pip/README.md'
-labels: PIP
----
-
-We have stopped using GitHub issues to hold the PIP content.
-Please read [here](https://github.com/apache/pulsar/blob/master/pip/README.md) how to submit a PIP


### PR DESCRIPTION
### Motivation

No need for that anymore. We have moved to submitting PIPs using PRs.

### Modifications

Delete issue template named PIP.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

