### PR TITLE
[improve][offload] Add offload metrics of offloadDataLatency

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderStats.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderStats.java
@@ -50,6 +50,8 @@ public interface LedgerOffloaderStats extends AutoCloseable {
 
     void recordDeleteOffloadOps(String topic, boolean succeed);
 
+    void recordOffloadDataLatency(String topic, long latency, TimeUnit unit);
+
 
     static LedgerOffloaderStats create(boolean exposeManagedLedgerStats, boolean exposeTopicLevelMetrics,
                                        ScheduledExecutorService scheduler, int interval) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderStatsDisable.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderStatsDisable.java
@@ -74,6 +74,11 @@ public class LedgerOffloaderStatsDisable implements LedgerOffloaderStats {
     }
 
     @Override
+    public void recordOffloadDataLatency(String topic, long latency, TimeUnit unit) {
+
+    }
+
+    @Override
     public void close() throws Exception {
 
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
@@ -75,6 +75,7 @@ public class LedgerOffloaderMetricsTest extends BrokerTestBase {
             offloaderStats.recordReadOffloadBytes(topicName, 100000);
             offloaderStats.recordWriteToStorageError(topicName);
             offloaderStats.recordWriteToStorageError(topicName);
+            offloaderStats.recordOffloadDataLatency(topicName, 2000L, TimeUnit.NANOSECONDS);
         }
 
         for (String topicName : topics) {
@@ -85,6 +86,7 @@ public class LedgerOffloaderMetricsTest extends BrokerTestBase {
             assertEquals((long) offloaderStats.getReadOffloadIndexLatency(topicName).sum, 1000);
             assertEquals(offloaderStats.getReadOffloadBytes(topicName), 100000);
             assertEquals(offloaderStats.getWriteStorageError(topicName), 2);
+            assertEquals((long) offloaderStats.getOffloadDataLatency(topicName).sum, 2);
         }
     }
 
@@ -118,6 +120,7 @@ public class LedgerOffloaderMetricsTest extends BrokerTestBase {
                 offloaderStats.recordReadOffloadIndexLatency(topicName, 1000000L, TimeUnit.NANOSECONDS);
                 offloaderStats.recordReadOffloadBytes(topicName, 100000);
                 offloaderStats.recordWriteToStorageError(topicName);
+                offloaderStats.recordOffloadDataLatency(topicName, 2000L, TimeUnit.NANOSECONDS);
             }
         }
 
@@ -132,6 +135,7 @@ public class LedgerOffloaderMetricsTest extends BrokerTestBase {
             assertEquals((long) offloaderStats.getReadOffloadIndexLatency(topicName).sum, 6000);
             assertEquals(offloaderStats.getReadOffloadBytes(topicName), 600000);
             assertEquals(offloaderStats.getWriteStorageError(topicName), 6);
+            assertEquals((long) offloaderStats.getOffloadDataLatency(topicName).sum, 12);
         }
     }
 

--- a/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloader.java
+++ b/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloader.java
@@ -311,6 +311,11 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
             String topicName = TopicName.fromPersistenceNamingEncoding(managedLedgerName);
             if (ledgerReader.fileSystemWriteException == null) {
                 Iterator<LedgerEntry> iterator = ledgerEntriesOnce.iterator();
+                long startOffloadTime = System.currentTimeMillis();
+                long ledgerCreateTime = ledgerReader.readHandle.getLedgerMetadata().getCtime();
+                long ledgerOffloadLatencyTime = startOffloadTime - ledgerCreateTime;
+                ledgerReader.offloaderStats.recordOffloadDataLatency(topicName, ledgerOffloadLatencyTime,
+                        TimeUnit.MILLISECONDS);
                 while (iterator.hasNext()) {
                     LedgerEntry entry = iterator.next();
                     long entryId = entry.getEntryId();

--- a/tiered-storage/file-system/src/test/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloaderTest.java
+++ b/tiered-storage/file-system/src/test/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloaderTest.java
@@ -131,6 +131,7 @@ public class FileSystemManagedLedgerOffloaderTest extends FileStoreTestBase {
         assertTrue(offloaderStats.getOffloadBytes(topicName) > 0);
         assertTrue(offloaderStats.getReadLedgerLatency(topicName).count > 0);
         assertTrue(offloaderStats.getWriteStorageError(topicName) == 0);
+        assertTrue(offloaderStats.getOffloadDataLatency(topicName).count > 0);
 
         ReadHandle toTest = offloader.readOffloaded(toWrite.getId(), uuid, map).get();
         LedgerEntries toTestEntries = toTest.read(0, numberOfEntries - 1);

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloader.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloader.java
@@ -229,6 +229,11 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
                 int partId = 1;
                 long start = System.nanoTime();
                 long entryBytesWritten = 0;
+                long startOffloadTime = System.currentTimeMillis();
+                long ledgerCreateTime = readHandle.getLedgerMetadata().getCtime();
+                long ledgerOffloadLatencyTime = startOffloadTime - ledgerCreateTime;
+                this.offloaderStats.recordOffloadDataLatency(topicName, ledgerOffloadLatencyTime,
+                        TimeUnit.MILLISECONDS);
                 while (startEntry <= readHandle.getLastAddConfirmed()) {
                     int blockSize = BlockAwareSegmentInputStreamImpl
                         .calculateBlockSize(config.getMaxBlockSizeInBytes(), readHandle, startEntry, entryBytesWritten);

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTest.java
@@ -185,6 +185,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
         assertTrue(offloaderStats.getOffloadBytes(topic) > 0 );
         assertTrue(offloaderStats.getReadLedgerLatency(topic).count > 0);
         assertEquals(offloaderStats.getWriteStorageError(topic), 0);
+        assertTrue(offloaderStats.getOffloadDataLatency(topic).count > 0);
 
         Map<String, String> map = new HashMap<>();
         map.putAll(offloader.getOffloadDriverMetadata());


### PR DESCRIPTION
### Motivation
Lack of a metric to characterize the latency of offload: 
the time interval between when a ledger starts offloading and its creation time. 
Ideally, in an online production environment, this delay should be slightly greater than managedLedgerMinLedgerRolloverTimeMinutes（default 10min）
The display of metrics is as follows：
![image](https://github.com/apache/pulsar/assets/16517186/3701164b-50ac-4018-8cd8-004362516c85)

This metric can help us track the timeliness of topic offloading. 


### Modifications
update `LedgerOffloaderStats` with `recordOffloadDataLatency` to record offloadDataLatency metrics.(The time interval between ledger creation and the start of offloading, means the delay of offloading)

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository:  https://github.com/ethqunzhong/pulsar/pull/9
