### PR TITLE
[fix][broker] Fix unack count when mixing non batch index and batch index acks

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -487,7 +487,6 @@ public class Consumer {
     private CompletableFuture<Long> individualAckNormal(CommandAck ack, Map<String, Long> properties) {
         List<Position> positionsAcked = new ArrayList<>();
         long totalAckCount = 0;
-        boolean individualAck = false;
         for (int i = 0; i < ack.getMessageIdsCount(); i++) {
             MessageIdData msgId = ack.getMessageIdAt(i);
             PositionImpl position;
@@ -508,19 +507,15 @@ public class Consumer {
                                 .syncBatchPositionBitSetForPendingAck(position);
                     }
                 }
+                addAndGetUnAckedMsgs(ackOwnerConsumer, -(int) ackedCount);
             } else {
                 position = PositionImpl.get(msgId.getLedgerId(), msgId.getEntryId());
                 ackedCount = getAckedCountForMsgIdNoAckSets(batchSize, position, ackOwnerConsumer);
-                individualAck = true;
-            }
-
-            if (individualAck) {
                 if (checkCanRemovePendingAcksAndHandle(position, msgId)) {
                     addAndGetUnAckedMsgs(ackOwnerConsumer, -(int) ackedCount);
                 }
-            } else {
-                addAndGetUnAckedMsgs(ackOwnerConsumer, -(int) ackedCount);
             }
+
             positionsAcked.add(position);
 
             checkAckValidationError(ack, position);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageWithBatchIndexLevelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageWithBatchIndexLevelTest.java
@@ -365,4 +365,40 @@ public class BatchMessageWithBatchIndexLevelTest extends BatchMessageTest {
         consumer.close();
         admin.topics().delete(topicName);
     }
+
+    @Test
+    public void testMixIndexAndNonIndexUnAckMessageCount() throws Exception {
+        final String topicName = "persistent://prop/ns-abc/testMixIndexAndNonIndexUnAckMessageCount-";
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topicName)
+                .enableBatching(true)
+                .batchingMaxPublishDelay(100, TimeUnit.MILLISECONDS)
+                .create();
+        @Cleanup
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic(topicName)
+                .subscriptionName("sub")
+                .subscriptionType(SubscriptionType.Shared)
+                .acknowledgmentGroupTime(100, TimeUnit.MILLISECONDS)
+                .enableBatchIndexAcknowledgment(true)
+                .isAckReceiptEnabled(true)
+                .subscribe();
+
+        // send two batch messages: [(1), (2,3)]
+        producer.send("1".getBytes());
+        producer.sendAsync("2".getBytes());
+        producer.send("3".getBytes());
+
+        Message<byte[]> message1 = consumer.receive();
+        Message<byte[]> message2 = consumer.receive();
+        Message<byte[]> message3 = consumer.receive();
+        consumer.acknowledgeAsync(message1);
+        consumer.acknowledge(message2);  // send group ack: non-index ack for 1, index ack for 2
+        consumer.acknowledge(message3);  // index ack for 3
+
+        assertEquals(admin.topics().getStats(topicName).getSubscriptions()
+                .get("sub").getUnackedMessages(), 0);
+    }
 }


### PR DESCRIPTION
### Motivation

Unack count is wrong when mixing non batch index and batch index acks in one CommandAck.

### Modifications

Check ack type for every MessageIdData.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - Added test testMixIndexAndNonIndexUnAckMessageCount

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/erobot/pulsar/pull/3

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
