### PR TITLE
[draft] [fix] [broker] Revert #19446  to fix the send message future never complete

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -46,7 +46,6 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -186,7 +185,6 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     private final BrokerService service;
     private final SchemaRegistryService schemaService;
     private final String listenerName;
-    private final HashMap<Long, Long> recentlyClosedProducers;
     private final ConcurrentLongHashMap<CompletableFuture<Producer>> producers;
     private final ConcurrentLongHashMap<CompletableFuture<Consumer>> consumers;
     private final boolean enableSubscriptionPatternEvaluation;
@@ -291,7 +289,6 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 .expectedItems(8)
                 .concurrencyLevel(1)
                 .build();
-        this.recentlyClosedProducers = new HashMap<>();
         this.replicatorPrefix = conf.getReplicatorPrefix();
         this.maxNonPersistentPendingMessages = conf.getMaxConcurrentNonPersistentMessagePerConnection();
         this.schemaValidationEnforced = conf.isSchemaValidationEnforced();
@@ -1696,14 +1693,6 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         CompletableFuture<Producer> producerFuture = producers.get(send.getProducerId());
 
         if (producerFuture == null || !producerFuture.isDone() || producerFuture.isCompletedExceptionally()) {
-            if (recentlyClosedProducers.containsKey(send.getProducerId())) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Received message, but the producer was recently closed : {}. Ignoring message.",
-                            remoteAddress, send.getProducerId());
-                }
-                // We expect these messages because we recently closed the producer. Do not close the connection.
-                return;
-            }
             log.warn("[{}] Received message, but the producer is not ready : {}. Closing the connection.",
                     remoteAddress, send.getProducerId());
             close();
@@ -2972,17 +2961,6 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         safelyRemoveProducer(producer);
         if (getRemoteEndpointProtocolVersion() >= v5.getValue()) {
             writeAndFlush(Commands.newCloseProducer(producer.getProducerId(), -1L));
-            // The client does not necessarily know that the producer is closed, but the connection is still
-            // active, and there could be messages in flight already. We want to ignore these messages for a time
-            // because they are expected. Once the interval has passed, the client should have received the
-            // CloseProducer command and should not send any additional messages until it sends a create Producer
-            // command.
-            final long epoch = producer.getEpoch();
-            final long producerId = producer.getProducerId();
-            recentlyClosedProducers.put(producerId, epoch);
-            ctx.executor().schedule(() -> {
-                recentlyClosedProducers.remove(producerId, epoch);
-            }, service.getKeepAliveIntervalSeconds(), TimeUnit.SECONDS);
         } else {
             close();
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -103,7 +103,6 @@ import org.apache.pulsar.common.api.proto.CommandAddPartitionToTxnResponse;
 import org.apache.pulsar.common.api.proto.CommandAddSubscriptionToTxnResponse;
 import org.apache.pulsar.common.api.proto.CommandAuthChallenge;
 import org.apache.pulsar.common.api.proto.CommandAuthResponse;
-import org.apache.pulsar.common.api.proto.CommandCloseProducer;
 import org.apache.pulsar.common.api.proto.CommandConnected;
 import org.apache.pulsar.common.api.proto.CommandEndTxnOnPartitionResponse;
 import org.apache.pulsar.common.api.proto.CommandEndTxnOnSubscriptionResponse;
@@ -1405,7 +1404,15 @@ public class ServerCnxTest {
         assertTrue(getResponse() instanceof CommandProducerSuccess);
 
         // test SEND success
-        sendMessage();
+        MessageMetadata messageMetadata = new MessageMetadata()
+                .setPublishTime(System.currentTimeMillis())
+                .setProducerName("prod-name")
+                .setSequenceId(0);
+        ByteBuf data = Unpooled.buffer(1024);
+
+        clientCommand = ByteBufPair.coalesce(Commands.newSend(1, 0, 1, ChecksumType.None, messageMetadata, data));
+        channel.writeInbound(Unpooled.copiedBuffer(clientCommand));
+        clientCommand.release();
 
         assertTrue(getResponse() instanceof CommandSendReceipt);
         channel.finish();
@@ -1417,115 +1424,6 @@ public class ServerCnxTest {
         setChannelConnected();
 
         // test SEND before producer is created
-        sendMessage();
-
-        // Then expect channel to close
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> !channel.isActive());
-        channel.finish();
-    }
-
-    @Test(timeOut = 30000)
-    public void testSendCommandAfterBrokerClosedProducer() throws Exception {
-        resetChannel();
-        setChannelConnected();
-        setConnectionVersion(ProtocolVersion.v5.getValue());
-        serverCnx.cancelKeepAliveTask();
-
-        String producerName = "my-producer";
-
-        ByteBuf clientCommand1 = Commands.newProducer(successTopicName, 1 /* producer id */, 1 /* request id */,
-                producerName, Collections.emptyMap(), false);
-        channel.writeInbound(clientCommand1);
-        assertTrue(getResponse() instanceof CommandProducerSuccess);
-
-        // Call disconnect method on producer to trigger activity similar to unloading
-        Producer producer = serverCnx.getProducers().get(1).get();
-        assertNotNull(producer);
-        producer.disconnect();
-        channel.runPendingTasks();
-        assertTrue(getResponse() instanceof CommandCloseProducer);
-
-        // Send message and expect no response
-        sendMessage();
-
-        // Move clock forward to trigger scheduled clean up task
-        channel.advanceTimeBy(svcConfig.getKeepAliveIntervalSeconds(), TimeUnit.SECONDS);
-        channel.runScheduledPendingTasks();
-        assertTrue(channel.outboundMessages().isEmpty());
-        assertTrue(channel.isActive());
-
-        // Send message and expect closed connection
-        sendMessage();
-
-        // Then expect channel to close
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> !channel.isActive());
-        channel.finish();
-    }
-
-    @Test(timeOut = 30000)
-    public void testBrokerClosedProducerClientRecreatesProducerThenSendCommand() throws Exception {
-        resetChannel();
-        setChannelConnected();
-        setConnectionVersion(ProtocolVersion.v5.getValue());
-        serverCnx.cancelKeepAliveTask();
-
-        String producerName = "my-producer";
-
-        ByteBuf clientCommand1 = Commands.newProducer(successTopicName, 1 /* producer id */, 1 /* request id */,
-                producerName, Collections.emptyMap(), false);
-        channel.writeInbound(clientCommand1);
-        assertTrue(getResponse() instanceof CommandProducerSuccess);
-
-        // Call disconnect method on producer to trigger activity similar to unloading
-        Producer producer = serverCnx.getProducers().get(1).get();
-        assertNotNull(producer);
-        producer.disconnect();
-        channel.runPendingTasks();
-        assertTrue(getResponse() instanceof CommandCloseProducer);
-
-        // Send message and expect no response
-        sendMessage();
-
-        assertTrue(channel.outboundMessages().isEmpty());
-
-        // Move clock forward to trigger scheduled clean up task
-        ByteBuf createProducer2 = Commands.newProducer(successTopicName, 1 /* producer id */, 1 /* request id */,
-                producerName, Collections.emptyMap(), false);
-        channel.writeInbound(createProducer2);
-        assertTrue(getResponse() instanceof CommandProducerSuccess);
-
-        // Send message and expect success
-        sendMessage();
-
-        assertTrue(getResponse() instanceof CommandSendReceipt);
-        channel.finish();
-    }
-
-    @Test(timeOut = 30000)
-    public void testClientClosedProducerThenSendsMessageAndGetsClosed() throws Exception {
-        resetChannel();
-        setChannelConnected();
-        setConnectionVersion(ProtocolVersion.v5.getValue());
-        serverCnx.cancelKeepAliveTask();
-
-        String producerName = "my-producer";
-
-        ByteBuf clientCommand1 = Commands.newProducer(successTopicName, 1 /* producer id */, 1 /* request id */,
-                producerName, Collections.emptyMap(), false);
-        channel.writeInbound(clientCommand1);
-        assertTrue(getResponse() instanceof CommandProducerSuccess);
-
-        ByteBuf closeProducer = Commands.newCloseProducer(1,2);
-        channel.writeInbound(closeProducer);
-        assertTrue(getResponse() instanceof CommandSuccess);
-
-        // Send message and get disconnected
-        sendMessage();
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> !channel.isActive());
-        channel.finish();
-    }
-
-    private void sendMessage() {
         MessageMetadata messageMetadata = new MessageMetadata()
                 .setPublishTime(System.currentTimeMillis())
                 .setProducerName("prod-name")
@@ -1536,6 +1434,10 @@ public class ServerCnxTest {
                 ChecksumType.None, messageMetadata, data));
         channel.writeInbound(Unpooled.copiedBuffer(clientCommand));
         clientCommand.release();
+
+        // Then expect channel to close
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> !channel.isActive());
+        channel.finish();
     }
 
     @Test(timeOut = 30000)


### PR DESCRIPTION
### Motivation

#### Before #19446
If producer sending and topic unloading are executed at the same time, there are two scenarios:
- The Broker receives the send command before unloading the topic
  - Broker responds successfully after writing even if the Producer is already marked closed.
  - The client marks the send command as finished even if the connection is transferred to another one.
- The Broker receives the send command after unloading the topic
  - Broker trigger close the socket
  - The client marks all pending requests as failed after the socket closed. 

#### After #19446, scenario 2 changed
- The Broker receives the send command after unloading the topic
  - Broker discards this send command and responds nothing.
  - The send command will not finish until the timeout

---

We received more than `20,000` errors in three hours.

![image](https://github.com/apache/pulsar/assets/25195800/c2fb303b-acd9-49ac-aa41-069d21976ae2)

```
[Pulsar][Producer]Asynchronous message sending failed:
org.apache.pulsar.client.api.PulsarClientException$TimeoutException: The producer service-TestProducer-02586a can not send message to the topic persistent://public/default/test-partition-2 within given timeout : createdAt 22.195 seconds ago, firstSentAt 7484.289 seconds ago, lastSentAt 7484.289 seconds ago, retryCount 0
	at org.apache.pulsar.client.impl.ProducerImpl$OpSendMsg.sendComplete(ProducerImpl.java:1386)
	at org.apache.pulsar.client.impl.ProducerImpl.lambda$failPendingMessages$19(ProducerImpl.java:1931)
	at java.base/java.util.ArrayDeque.forEach(ArrayDeque.java:889)
	at org.apache.pulsar.client.impl.ProducerImpl$OpSendMsgQueue.forEach(ProducerImpl.java:1476)
	at org.apache.pulsar.client.impl.ProducerImpl.failPendingMessages(ProducerImpl.java:1921)
	at org.apache.pulsar.client.impl.ProducerImpl.run(ProducerImpl.java:1900)
	at org.apache.pulsar.shade.io.netty.util.HashedWheelTimer$HashedWheelTimeout.run(HashedWheelTimer.java:715)
	at org.apache.pulsar.shade.io.netty.util.concurrent.ImmediateExecutor.execute(ImmediateExecutor.java:34)
	at org.apache.pulsar.shade.io.netty.util.HashedWheelTimer$HashedWheelTimeout.expire(HashedWheelTimer.java:703)
	at org.apache.pulsar.shade.io.netty.util.HashedWheelTimer$HashedWheelBucket.expireTimeouts(HashedWheelTimer.java:790)
	at org.apache.pulsar.shade.io.netty.util.HashedWheelTimer$Worker.run(HashedWheelTimer.java:503)
	at org.apache.pulsar.shade.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:955)
```

---

### Modifications

Revert #19446

---

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x