### PR TITLE
[fix][proxy] Fix breaking change of proxy status/stats endpoint

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
@@ -247,7 +247,7 @@ public class WebServer {
         servletHolder.setAsyncSupported(true);
         // This method has not historically checked for existing paths, so we don't check here either. The
         // method call is added to reduce code duplication.
-        addServlet(basePath, servletHolder, Collections.singletonList(Pair.of(attribute, attributeValue)), true, false);
+        addServlet(basePath, servletHolder, Collections.singletonList(Pair.of(attribute, attributeValue)), false, false);
     }
 
     public int getExternalServicePort() {


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/21031 introduce a breaking change of status/stats endpoint by authentication covered. we should revert this part of the change to keep the compatibility.

### Modifications

- Revert part of the change of auth.
- Add some tests to cover this change. 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [x] The REST endpoints

### Documentation

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->

### Other

If we consider moving these endpoints to authentication covered. we should introduce a new configuration like `authenticateMetricsEndpoint`