### PR TITLE
[improve][client] Add readAllExistingMessages API for TableView

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TableView.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TableView.java
@@ -110,4 +110,11 @@ public interface TableView<T> extends Closeable {
      * @return a future that can used to track when the table view has been closed.
      */
     CompletableFuture<Void> closeAsync();
+
+    /**
+     * Triggers reading all existing messages, updates the TableView, and waits for the read to complete.
+     * @return a CompletableFuture that completes when all existing messages have been read
+     * and the TableView has been updated
+     */
+    CompletableFuture<Void> readAllExistingMessages();
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -93,7 +93,7 @@ public class TableViewImpl<T> implements TableView<T> {
         return reader.thenCompose((reader) -> {
             if (!isPersistentTopic) {
                 readTailMessages(reader);
-                return CompletableFuture.completedFuture(reader);
+                return CompletableFuture.completedFuture(null);
             }
             return this.readAllExistingMessages(reader);
         }).thenApply(__ -> this);
@@ -230,16 +230,16 @@ public class TableViewImpl<T> implements TableView<T> {
         }
     }
 
-    private CompletableFuture<Reader<T>> readAllExistingMessages(Reader<T> reader) {
+    private CompletableFuture<Void> readAllExistingMessages(Reader<T> reader) {
         long startTime = System.nanoTime();
         AtomicLong messagesRead = new AtomicLong();
 
-        CompletableFuture<Reader<T>> future = new CompletableFuture<>();
+        CompletableFuture<Void> future = new CompletableFuture<>();
         readAllExistingMessages(reader, future, startTime, messagesRead);
         return future;
     }
 
-    private void readAllExistingMessages(Reader<T> reader, CompletableFuture<Reader<T>> future, long startTime,
+    private void readAllExistingMessages(Reader<T> reader, CompletableFuture<Void> future, long startTime,
                                          AtomicLong messagesRead) {
         reader.hasMessageAvailableAsync()
                 .thenAccept(hasMessage -> {
@@ -268,7 +268,7 @@ public class TableViewImpl<T> implements TableView<T> {
                                reader.getTopic(),
                                messagesRead,
                                durationMillis / 1000.0);
-                       future.complete(reader);
+                       future.complete(null);
                        readTailMessages(reader);
                    }
                 });

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -291,4 +291,9 @@ public class TableViewImpl<T> implements TableView<T> {
                     return null;
                 });
     }
+
+    @Override
+    public CompletableFuture<Void> readAllExistingMessages() {
+        return reader.thenCompose(this::readAllExistingMessages);
+    }
 }


### PR DESCRIPTION
PIP:  https://github.com/apache/pulsar/pull/21166
### Motivation
In the context of utilizing the TableView component, there are instances where we aspire to consistently retrieve the most up-to-date value associated with a given key. To accomplish this, we can employ an API that allows us to wait until all data has been fully retrieved before accessing the value corresponding to the desired key.

### Modifications
Add an API waiting for data update completion.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
