### PR TITLE
[fix][broker] Avoid splitting one batch message into two entries in StrategicTwoPhaseCompactor

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchMessageContainerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchMessageContainerImpl.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.util.Set;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.MessageCrypto;
+import org.apache.pulsar.client.api.MessageIdAdv;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.crypto.MessageCryptoBc;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
@@ -44,17 +45,17 @@ import org.apache.pulsar.common.protocol.Commands;
  * [(k1, v1), (k2, v1), (k3, v1), (k1, v2), (k2, v2), (k3, v2), (k1, v3), (k2, v3), (k3, v3)]
  */
 public class RawBatchMessageContainerImpl extends BatchMessageContainerImpl {
-    MessageCrypto msgCrypto;
-    Set<String> encryptionKeys;
-    CryptoKeyReader cryptoKeyReader;
+    private MessageCrypto<MessageMetadata, MessageMetadata> msgCrypto;
+    private Set<String> encryptionKeys;
+    private CryptoKeyReader cryptoKeyReader;
+    private MessageIdAdv lastAddedMessageId;
 
-    public RawBatchMessageContainerImpl(int maxNumMessagesInBatch, int maxBytesInBatch) {
+    public RawBatchMessageContainerImpl() {
         super();
         this.compressionType = CompressionType.NONE;
         this.compressor = new CompressionCodecNone();
-        this.maxNumMessagesInBatch = maxNumMessagesInBatch;
-        this.maxBytesInBatch = maxBytesInBatch;
     }
+
     private ByteBuf encrypt(ByteBuf compressedPayload) {
         if (msgCrypto == null) {
             return compressedPayload;
@@ -88,6 +89,28 @@ public class RawBatchMessageContainerImpl extends BatchMessageContainerImpl {
      */
     public void setCryptoKeyReader(CryptoKeyReader cryptoKeyReader) {
         this.cryptoKeyReader = cryptoKeyReader;
+    }
+
+    @Override
+    public boolean add(MessageImpl<?> msg, SendCallback callback) {
+        this.lastAddedMessageId = (MessageIdAdv) msg.getMessageId();
+        return super.add(msg, callback);
+    }
+
+    @Override
+    protected boolean isBatchFull() {
+        return false;
+    }
+
+    @Override
+    public boolean haveEnoughSpace(MessageImpl<?> msg) {
+        if (lastAddedMessageId == null) {
+            return true;
+        }
+        // Keep same batch compact to same batch.
+        MessageIdAdv msgId = (MessageIdAdv) msg.getMessageId();
+        return msgId.getLedgerId() == lastAddedMessageId.getLedgerId()
+                && msgId.getEntryId() == lastAddedMessageId.getEntryId();
     }
 
     /**
@@ -167,5 +190,11 @@ public class RawBatchMessageContainerImpl extends BatchMessageContainerImpl {
         encryptedPayload.release();
         clear();
         return buf;
+    }
+
+    @Override
+    public void clear() {
+        this.lastAddedMessageId = null;
+        super.clear();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/StrategicTwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/StrategicTwoPhaseCompactor.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.compaction;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import java.time.Duration;
 import java.util.Iterator;
@@ -63,37 +62,17 @@ import org.slf4j.LoggerFactory;
 public class StrategicTwoPhaseCompactor extends TwoPhaseCompactor {
     private static final Logger log = LoggerFactory.getLogger(StrategicTwoPhaseCompactor.class);
     private static final int MAX_OUTSTANDING = 500;
-    private static final int MAX_NUM_MESSAGES_IN_BATCH = 1000;
-    private static final int MAX_BYTES_IN_BATCH = 128 * 1024;
     private static final int MAX_READER_RECONNECT_WAITING_TIME_IN_MILLIS = 20 * 1000;
     private final Duration phaseOneLoopReadTimeout;
     private final RawBatchMessageContainerImpl batchMessageContainer;
-
-    @VisibleForTesting
-    public StrategicTwoPhaseCompactor(ServiceConfiguration conf,
-                                      PulsarClient pulsar,
-                                      BookKeeper bk,
-                                      ScheduledExecutorService scheduler,
-                                      int maxNumMessagesInBatch) {
-        this(conf, pulsar, bk, scheduler, maxNumMessagesInBatch, MAX_BYTES_IN_BATCH);
-    }
-
-    private StrategicTwoPhaseCompactor(ServiceConfiguration conf,
-                                      PulsarClient pulsar,
-                                      BookKeeper bk,
-                                      ScheduledExecutorService scheduler,
-                                      int maxNumMessagesInBatch,
-                                      int maxBytesInBatch) {
-        super(conf, pulsar, bk, scheduler);
-        batchMessageContainer = new RawBatchMessageContainerImpl(maxNumMessagesInBatch, maxBytesInBatch);
-        phaseOneLoopReadTimeout = Duration.ofSeconds(conf.getBrokerServiceCompactionPhaseOneLoopTimeInSeconds());
-    }
 
     public StrategicTwoPhaseCompactor(ServiceConfiguration conf,
                                       PulsarClient pulsar,
                                       BookKeeper bk,
                                       ScheduledExecutorService scheduler) {
-        this(conf, pulsar, bk, scheduler, MAX_NUM_MESSAGES_IN_BATCH, MAX_BYTES_IN_BATCH);
+        super(conf, pulsar, bk, scheduler);
+        batchMessageContainer = new RawBatchMessageContainerImpl();
+        phaseOneLoopReadTimeout = Duration.ofSeconds(conf.getBrokerServiceCompactionPhaseOneLoopTimeInSeconds());
     }
 
     public CompletableFuture<Long> compact(String topic) {
@@ -418,7 +397,6 @@ public class StrategicTwoPhaseCompactor extends TwoPhaseCompactor {
                                 .whenComplete((res, exception2) -> {
                                     if (exception2 != null) {
                                         promise.completeExceptionally(exception2);
-                                        return;
                                     }
                                 });
                         phaseTwoLoop(topic, reader, lh, outstanding, promise);
@@ -443,35 +421,45 @@ public class StrategicTwoPhaseCompactor extends TwoPhaseCompactor {
 
     <T> CompletableFuture<Boolean> addToCompactedLedger(
             LedgerHandle lh, Message<T> m, String topic, Semaphore outstanding) {
-        CompletableFuture<Boolean> bkf = new CompletableFuture<>();
-        if (m == null || batchMessageContainer.add((MessageImpl<?>) m, null)) {
-            if (batchMessageContainer.getNumMessagesInBatch() > 0) {
-                try {
-                    ByteBuf serialized = batchMessageContainer.toByteBuf();
-                    outstanding.acquire();
-                    mxBean.addCompactionWriteOp(topic, serialized.readableBytes());
-                    long start = System.nanoTime();
-                    lh.asyncAddEntry(serialized,
-                            (rc, ledger, eid, ctx) -> {
-                                outstanding.release();
-                                mxBean.addCompactionLatencyOp(topic, System.nanoTime() - start, TimeUnit.NANOSECONDS);
-                                if (rc != BKException.Code.OK) {
-                                    bkf.completeExceptionally(BKException.create(rc));
-                                } else {
-                                    bkf.complete(true);
-                                }
-                            }, null);
+        if (m == null) {
+            return flushBatchMessage(lh, topic, outstanding);
+        }
+        if (batchMessageContainer.haveEnoughSpace((MessageImpl<?>) m)) {
+            batchMessageContainer.add((MessageImpl<?>) m, null);
+            return CompletableFuture.completedFuture(false);
+        }
+        CompletableFuture<Boolean> f = flushBatchMessage(lh, topic, outstanding);
+        batchMessageContainer.add((MessageImpl<?>) m, null);
+        return f;
+    }
 
-                } catch (Throwable t) {
-                    log.error("Failed to add entry", t);
-                    batchMessageContainer.discard((Exception) t);
-                    return FutureUtil.failedFuture(t);
-                }
-            } else {
-                bkf.complete(false);
-            }
-        } else {
-            bkf.complete(false);
+    private CompletableFuture<Boolean> flushBatchMessage(LedgerHandle lh, String topic,
+                                                         Semaphore outstanding) {
+        if (batchMessageContainer.getNumMessagesInBatch() <= 0) {
+            return CompletableFuture.completedFuture(false);
+        }
+        CompletableFuture<Boolean> bkf = new CompletableFuture<>();
+        try {
+            ByteBuf serialized = batchMessageContainer.toByteBuf();
+            outstanding.acquire();
+            mxBean.addCompactionWriteOp(topic, serialized.readableBytes());
+            long start = System.nanoTime();
+            lh.asyncAddEntry(serialized,
+                    (rc, ledger, eid, ctx) -> {
+                        outstanding.release();
+                        mxBean.addCompactionLatencyOp(topic, System.nanoTime() - start, TimeUnit.NANOSECONDS);
+                        if (rc != BKException.Code.OK) {
+                            bkf.completeExceptionally(BKException.create(rc));
+                        } else {
+                            bkf.complete(true);
+                        }
+                    }, null);
+
+        } catch (Throwable t) {
+            log.error("Failed to add entry", t);
+            batchMessageContainer.discard((Exception) t);
+            bkf.completeExceptionally(t);
+            return bkf;
         }
         return bkf;
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -80,7 +80,6 @@ import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.ConsumerImpl;
-import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
@@ -540,14 +539,8 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
             Assert.assertEquals(message2.getKey(), "key2");
             Assert.assertEquals(new String(message2.getData()), "my-message-3");
             if (getCompactor() instanceof StrategicTwoPhaseCompactor) {
-                MessageIdImpl id = (MessageIdImpl) messages.get(0).getMessageId();
-                MessageIdImpl id1 = new MessageIdImpl(
-                        id.getLedgerId(), id.getEntryId(), id.getPartitionIndex());
-                Assert.assertEquals(message1.getMessageId(), id1);
-                id = (MessageIdImpl) messages.get(2).getMessageId();
-                MessageIdImpl id2 = new MessageIdImpl(
-                        id.getLedgerId(), id.getEntryId(), id.getPartitionIndex());
-                Assert.assertEquals(message2.getMessageId(), id2);
+                Assert.assertEquals(message1.getMessageId(), messages.get(0).getMessageId());
+                Assert.assertEquals(message2.getMessageId(), messages.get(1).getMessageId());
             } else {
                 Assert.assertEquals(message1.getMessageId(), messages.get(0).getMessageId());
                 Assert.assertEquals(message2.getMessageId(), messages.get(2).getMessageId());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionRetentionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionRetentionTest.java
@@ -34,7 +34,7 @@ public class StrategicCompactionRetentionTest extends CompactionRetentionTest {
     @Override
     public void setup() throws Exception {
         super.setup();
-        compactor = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler, 1);
+        compactor = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler);
         strategy = new TopicCompactionStrategyTest.DummyTopicCompactionStrategy();
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionTest.java
@@ -18,22 +18,33 @@
  */
 package org.apache.pulsar.compaction;
 
+import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelImpl.MSG_COMPRESSION_TYPE;
+import static org.testng.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.MessageIdAdv;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.TableView;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.topics.TopicCompactionStrategy;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -47,7 +58,7 @@ public class StrategicCompactionTest extends CompactionTest {
     @Override
     public void setup() throws Exception {
         super.setup();
-        compactor = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler, 1);
+        compactor = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler);
         strategy = new TopicCompactionStrategyTest.DummyTopicCompactionStrategy();
     }
 
@@ -148,5 +159,58 @@ public class StrategicCompactionTest extends CompactionTest {
         Assert.assertEquals(tableView.entrySet(), expectedCopy.entrySet());
     }
 
+    @Test(timeOut = 20000)
+    public void testSameBatchCompactToSameBatch() throws Exception {
+        final String topic =
+                "persistent://my-property/use/my-ns/testSameBatchCompactToSameBatch" + UUID.randomUUID();
 
+        // Use odd number to make sure the last message is flush by `reader.hasNext() == false`.
+        final int messages = 11;
+
+        // 1.create producer and publish message to the topic.
+        ProducerBuilder<Integer> builder = pulsarClient.newProducer(Schema.INT32)
+                .compressionType(MSG_COMPRESSION_TYPE).topic(topic);
+        builder.batchingMaxMessages(2)
+                .batchingMaxPublishDelay(10, TimeUnit.MILLISECONDS);
+
+        Producer<Integer> producer = builder.create();
+
+        List<CompletableFuture<MessageId>> futures = new ArrayList<>(messages);
+        for (int i = 0; i < messages; i++) {
+            futures.add(producer.newMessage().key(String.valueOf(i))
+                    .value(i)
+                    .sendAsync());
+        }
+        FutureUtil.waitForAll(futures).get();
+
+        // 2.compact the topic.
+        StrategicTwoPhaseCompactor compactor
+                = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler);
+        compactor.compact(topic, strategy).get();
+
+        // consumer with readCompacted enabled only get compacted entries
+        try (Consumer<Integer> consumer = pulsarClient
+                .newConsumer(Schema.INT32)
+                .topic(topic)
+                .subscriptionName("sub1")
+                .readCompacted(true)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe()) {
+            int received = 0;
+            while (true) {
+                Message<Integer> m = consumer.receive(2, TimeUnit.SECONDS);
+                if (m == null) {
+                    break;
+                }
+                MessageIdAdv messageId = (MessageIdAdv) m.getMessageId();
+                if (received < messages - 1) {
+                    assertEquals(messageId.getBatchSize(), 2);
+                } else {
+                    assertEquals(messageId.getBatchSize(), 0);
+                }
+                received++;
+            }
+            assertEquals(received, messages);
+        }
+
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactorTest.java
@@ -33,7 +33,7 @@ public class StrategicCompactorTest extends CompactorTest {
     @Override
     public void setup() throws Exception {
         super.setup();
-        compactor = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler, 1);
+        compactor = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler);
         strategy = new TopicCompactionStrategyTest.DummyTopicCompactionStrategy();
     }
 


### PR DESCRIPTION
(cherry picked from commit e59c850753f2a1d08e4df63bf8862c7cb5db4e71)

### Motivation

Currently, the `ServiceUnitStateChannelImpl` will send batch messages to `loadbalancer-service-unit-state` topic,
and the `StrategicTwoPhaseCompactor` will consume the message and rebatch the message to a new batch.

However, the `StrategicTwoPhaseCompactor` may write messages from the same batch into different entries, which will result in skipping some messages when reading compacted entries.

For example, we have a batch: `[(3:0:-1:0, k1), (3:0:-1:1, k2)]`, after compact, the batch maybe `[3:0:-1:0, k1]` and `[3:0:-1:0, k2]` , then if we only read one entry, the `readPosition` will be updated to `3:1` , so the `[3:0:-1:0, k2]` will be skipped.

### Modifications

* Check the add message `entryId` and `ledgerId` before adding a message to `RawBatchMessageContainerImpl`.
* Remove size limit for `RawBatchMessageContainerImpl` to let input batch decide.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

