### PR TITLE
[improve][txn] Only read snapshot once at the same broker

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -867,7 +867,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 MLTransactionMetadataStoreProvider.initBufferedWriterMetrics(getAdvertisedAddress());
                 MLPendingAckStoreProvider.initBufferedWriterMetrics(getAdvertisedAddress());
 
-                this.transactionBufferSnapshotServiceFactory = new TransactionBufferSnapshotServiceFactory(getClient());
+                this.transactionBufferSnapshotServiceFactory = new TransactionBufferSnapshotServiceFactory(getClient(),
+                        transactionTimer);
 
                 this.transactionTimer =
                         new HashedWheelTimer(new DefaultThreadFactory("pulsar-transaction-timer"));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicTxnBufferSnapshotService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicTxnBufferSnapshotService.java
@@ -18,16 +18,20 @@
  */
 package org.apache.pulsar.broker.service;
 
-import java.util.HashMap;
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.Timeout;
+import io.netty.util.Timer;
+import io.netty.util.TimerTask;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.systopic.NamespaceEventsSystemTopicFactory;
 import org.apache.pulsar.broker.systopic.SystemTopicClient;
 import org.apache.pulsar.broker.systopic.SystemTopicClientBase;
-import org.apache.pulsar.broker.transaction.buffer.metadata.TransactionBufferSnapshot;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.TableView;
@@ -36,7 +40,7 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 
 @Slf4j
-public class SystemTopicTxnBufferSnapshotService<T> {
+public class SystemTopicTxnBufferSnapshotService<T> implements TimerTask {
 
     protected final ConcurrentHashMap<NamespaceName, SystemTopicClient<T>> clients;
     protected final NamespaceEventsSystemTopicFactory namespaceEventsSystemTopicFactory;
@@ -45,6 +49,13 @@ public class SystemTopicTxnBufferSnapshotService<T> {
     protected final EventType systemTopicType;
     protected final Map<NamespaceName, CompletableFuture<TableView<T>>> tableViewMap =
             new ConcurrentHashMap<>();
+    // The duration for which a TableView will be maintained in memory, post-cessation of its utilization.
+    // The default setting denotes a length of one hour.
+    private final long tableViewRetentionPeriodInMilliseconds = 60 * 60 * 1000;
+    // The predefined interval intended for the execution of a TableView's cleanup process. The default configuration represents a span of ten minutes.
+    private final long tableViewCleanupInterval = 30 * 60 * 1000;
+    private final Map<NamespaceName, Long> tableViewLastUsedMap = new ConcurrentHashMap<>();
+    private final Timer timer;
     private final ConcurrentHashMap<NamespaceName, ReferenceCountedWriter<T>> refCountedWriterMap;
 
     // The class ReferenceCountedWriter will maintain the reference count,
@@ -100,29 +111,39 @@ public class SystemTopicTxnBufferSnapshotService<T> {
     }
 
     public SystemTopicTxnBufferSnapshotService(PulsarClient client, EventType systemTopicType,
-                                               Class<T> schemaType) {
+                                               Class<T> schemaType, Timer timer) {
         this.namespaceEventsSystemTopicFactory = new NamespaceEventsSystemTopicFactory(client);
         this.systemTopicType = systemTopicType;
         this.schemaType = schemaType;
         this.clients = new ConcurrentHashMap<>();
         this.refCountedWriterMap = new ConcurrentHashMap<>();
+        this.timer = Objects.requireNonNullElseGet(timer, HashedWheelTimer::new);
+        timer.newTimeout(this, tableViewCleanupInterval, TimeUnit.MILLISECONDS);
     }
 
     public CompletableFuture<SystemTopicClient.Reader<T>> createReader(TopicName topicName) {
         return getTransactionBufferSystemTopicClient(topicName.getNamespaceObject()).newReaderAsync();
     }
 
-    public CompletableFuture<TableView<T>> getTableView(TopicName topicName) {
+    @Override
+    public synchronized void run(Timeout timeout) {
+        long currentTime = System.currentTimeMillis();
+        tableViewMap.forEach((namespaceName, tableViewCompletableFuture) -> {
+            if (tableViewLastUsedMap.get(namespaceName) + tableViewRetentionPeriodInMilliseconds < currentTime) {
+                tableViewLastUsedMap.remove(namespaceName);
+                tableViewMap.remove(namespaceName);
+            }
+        });
+        timer.newTimeout(this, tableViewCleanupInterval, TimeUnit.MILLISECONDS);
+    }
+
+    public synchronized CompletableFuture<TableView<T>> getTableView(TopicName topicName) {
+        tableViewLastUsedMap.put(topicName.getNamespaceObject(), System.currentTimeMillis());
         if (tableViewMap.containsKey(topicName.getNamespaceObject())) {
             return tableViewMap.get(topicName.getNamespaceObject());
         } else {
-            synchronized (tableViewMap) {
-                if (tableViewMap.containsKey(topicName.getNamespaceObject())) {
-                    return tableViewMap.get(topicName.getNamespaceObject());
-                } else {
-                    return getTransactionBufferSystemTopicClient(topicName.getNamespaceObject()).getTableView();
-                }
-            }
+            return tableViewMap.put(topicName.getNamespaceObject(),
+                    getTransactionBufferSystemTopicClient(topicName.getNamespaceObject()).getTableView());
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicTxnBufferSnapshotService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicTxnBufferSnapshotService.java
@@ -44,7 +44,7 @@ public class SystemTopicTxnBufferSnapshotService<T> {
     protected final Class<T> schemaType;
     protected final EventType systemTopicType;
     protected final Map<NamespaceName, CompletableFuture<TableView<T>>> tableViewMap =
-            new HashMap<>();
+            new ConcurrentHashMap<>();
     private final ConcurrentHashMap<NamespaceName, ReferenceCountedWriter<T>> refCountedWriterMap;
 
     // The class ReferenceCountedWriter will maintain the reference count,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TransactionBufferSnapshotServiceFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TransactionBufferSnapshotServiceFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service;
 
+import io.netty.util.Timer;
 import org.apache.pulsar.broker.transaction.buffer.metadata.TransactionBufferSnapshot;
 import org.apache.pulsar.broker.transaction.buffer.metadata.v2.TransactionBufferSnapshotIndexes;
 import org.apache.pulsar.broker.transaction.buffer.metadata.v2.TransactionBufferSnapshotSegment;
@@ -34,13 +35,17 @@ public class TransactionBufferSnapshotServiceFactory {
     private SystemTopicTxnBufferSnapshotService<TransactionBufferSnapshotIndexes> txnBufferSnapshotIndexService;
 
     public TransactionBufferSnapshotServiceFactory(PulsarClient pulsarClient) {
+        this(pulsarClient, null);
+    }
+
+    public TransactionBufferSnapshotServiceFactory(PulsarClient pulsarClient, Timer timer) {
         this.txnBufferSnapshotSegmentService = new SystemTopicTxnBufferSnapshotService<>(pulsarClient,
                 EventType.TRANSACTION_BUFFER_SNAPSHOT_SEGMENTS,
-                TransactionBufferSnapshotSegment.class);
+                TransactionBufferSnapshotSegment.class, timer);
         this.txnBufferSnapshotIndexService = new SystemTopicTxnBufferSnapshotService<>(pulsarClient,
-                EventType.TRANSACTION_BUFFER_SNAPSHOT_INDEXES, TransactionBufferSnapshotIndexes.class);
+                EventType.TRANSACTION_BUFFER_SNAPSHOT_INDEXES, TransactionBufferSnapshotIndexes.class, timer);
         this.txnBufferSnapshotService = new SystemTopicTxnBufferSnapshotService<>(pulsarClient,
-                EventType.TRANSACTION_BUFFER_SNAPSHOT, TransactionBufferSnapshot.class);
+                EventType.TRANSACTION_BUFFER_SNAPSHOT, TransactionBufferSnapshot.class, timer);
     }
 
     public SystemTopicTxnBufferSnapshotService<TransactionBufferSnapshotIndexes> getTxnBufferSnapshotIndexService() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.TableView;
 import org.apache.pulsar.common.naming.TopicName;
 
 /**
@@ -82,6 +83,8 @@ public interface SystemTopicClient<T> {
      * @return {@link java.util.Set} the set of readers
      */
     List<Reader<T>> getReaders();
+
+    CompletableFuture<TableView<T>> getTableView();
 
     /**
      * Writer for system topic.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/TopicPoliciesSystemTopicClient.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/TopicPoliciesSystemTopicClient.java
@@ -29,6 +29,7 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.TableView;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.apache.pulsar.common.events.ActionType;
 import org.apache.pulsar.common.events.PulsarEvent;
@@ -72,6 +73,11 @@ public class TopicPoliciesSystemTopicClient extends SystemTopicClientBase<Pulsar
                     }
                     return new TopicPolicyReader(reader, TopicPoliciesSystemTopicClient.this);
                 });
+    }
+
+    @Override
+    public CompletableFuture<TableView<PulsarEvent>> getTableView() {
+        return client.newTableView(Schema.AVRO(PulsarEvent.class)).topic(topicName.toString()).createAsync();
     }
 
     private static class TopicPolicyWriter implements Writer<PulsarEvent> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/TransactionBufferSnapshotBaseSystemTopicClient.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/TransactionBufferSnapshotBaseSystemTopicClient.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.systopic;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.service.SystemTopicTxnBufferSnapshotService;
@@ -28,6 +29,7 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.TableView;
 import org.apache.pulsar.common.naming.TopicName;
 
 @Slf4j
@@ -54,6 +56,11 @@ public class  TransactionBufferSnapshotBaseSystemTopicClient<T> extends SystemTo
     protected void removeReader(Reader<T> reader) {
         readers.remove(reader);
         this.systemTopicTxnBufferSnapshotService.removeClient(topicName, this);
+    }
+
+    @Override
+    public CompletableFuture<TableView<T>> getTableView() {
+        return client.newTableView(Schema.AVRO(schemaType)).topic(topicName.toString()).createAsync();
     }
 
     protected static class TransactionBufferSnapshotWriter<T> implements Writer<T> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
@@ -99,38 +99,23 @@ public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcesso
     public CompletableFuture<PositionImpl> recoverFromSnapshot() {
         return topic.getBrokerService().getPulsar().getTransactionBufferSnapshotServiceFactory()
                 .getTxnBufferSnapshotService()
-                .createReader(TopicName.get(topic.getName())).thenComposeAsync(reader -> {
-                    try {
-                    PositionImpl startReadCursorPosition = null;
-                        while (reader.hasMoreEvents()) {
-                            Message<TransactionBufferSnapshot> message = reader.readNextAsync()
-                                    .get(getSystemClientOperationTimeoutMs(), TimeUnit.MILLISECONDS);
-                            if (topic.getName().equals(message.getKey())) {
-                                TransactionBufferSnapshot transactionBufferSnapshot = message.getValue();
-                                if (transactionBufferSnapshot != null) {
-                                    handleSnapshot(transactionBufferSnapshot);
+                .getTableView(TopicName.get(topic.getName()))
+                .thenComposeAsync(transactionBufferSnapshotTableView -> {
+                    return transactionBufferSnapshotTableView.readAllExistingMessages()
+                            .thenApply(__ -> {
+                                TransactionBufferSnapshot snapshot = transactionBufferSnapshotTableView
+                                        .get(topic.getName());
+                                PositionImpl startReadCursorPosition = null;
+                                if (snapshot != null) {
+                                    handleSnapshot(snapshot);
                                     startReadCursorPosition = PositionImpl.get(
-                                            transactionBufferSnapshot.getMaxReadPositionLedgerId(),
-                                            transactionBufferSnapshot.getMaxReadPositionEntryId());
+                                            snapshot.getMaxReadPositionLedgerId(),
+                                            snapshot.getMaxReadPositionEntryId());
                                 }
-                            }
-                        }
-                        return CompletableFuture.completedFuture(startReadCursorPosition);
-                    } catch (TimeoutException ex) {
-                        Throwable t = FutureUtil.unwrapCompletionException(ex);
-                        String errorMessage = String.format("[%s] Transaction buffer recover fail by read "
-                                + "transactionBufferSnapshot timeout!", topic.getName());
-                        log.error(errorMessage, t);
-                        return FutureUtil.failedFuture(
-                                new BrokerServiceException.ServiceUnitNotReadyException(errorMessage, t));
-                    } catch (Exception ex) {
-                        log.error("[{}] Transaction buffer recover fail when read "
-                                + "transactionBufferSnapshot!", topic.getName(), ex);
-                        return FutureUtil.failedFuture(ex);
-                    } finally {
-                        closeReader(reader);
-                    }
-                },  topic.getBrokerService().getPulsar().getTransactionExecutorProvider()
+                                return startReadCursorPosition;
+                            });
+                    },
+                        topic.getBrokerService().getPulsar().getTransactionExecutorProvider()
                         .getExecutor(this));
     }
 

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TableView.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TableView.java
@@ -110,4 +110,6 @@ public interface TableView<T> extends Closeable {
      * @return a future that can used to track when the table view has been closed.
      */
     CompletableFuture<Void> closeAsync();
+
+    CompletableFuture<Reader<T>> readAllExistingMessages();
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -230,6 +230,11 @@ public class TableViewImpl<T> implements TableView<T> {
         }
     }
 
+    @Override
+    public CompletableFuture<Reader<T>> readAllExistingMessages() {
+        return reader.thenCompose(this::readAllExistingMessages);
+    }
+
     private CompletableFuture<Reader<T>> readAllExistingMessages(Reader<T> reader) {
         long startTime = System.nanoTime();
         AtomicLong messagesRead = new AtomicLong();


### PR DESCRIPTION
## Motivation
Every topic within a namespace has a common system topic that stores the transaction buffer snapshot. Whenever a topic is loaded and transactions are enabled, it reads the snapshot system topic from the earliest position once.

In scenarios where there are numerous topics within a namespace, repeated reads on the system topic occur frequently. This results in a large number of connections to bookies.

## Modifications
To address this issue, we propose optimizing the TableView API and implementing it within the SnapshotService. This optimization would ensure that the snapshot system topic is read only once, from the beginning to the end, eliminating any unnecessary repeated reads.
The process of accessing the system topic in the new approach can be illustrated by referring to the following diagram:
<img width="891" alt="image" src="https://github.com/apache/pulsar/assets/55571188/abec59aa-87c6-42e7-8e33-4dc6b1e5d558">


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
