### PR TITLE
[improve][client] pip-302 Add new API readAllExistingMessages for TableView

### DIFF
--- a/pip/pip-302.md
+++ b/pip/pip-302.md
@@ -1,0 +1,89 @@
+# Background Knowledge
+
+The TableView interface provides a convenient way to access data in a compacted topic by offering a continuously updated key-value map view. It operates on messages with keys and ignores those without keys.
+
+By utilizing the TableView, Pulsar clients can retrieve all message updates from a specific topic and create a map that contains the latest values for each key. This map can be used to establish a local cache of data. Additionally, clients can register consumers with the TableView and specify a listener to scan the map and receive notifications whenever new messages are received. This functionality enables event-driven applications and message monitoring.
+
+For more detailed information about the TableView, please refer to the [Pulsar documentation](https://pulsar.apache.org/docs/next/concepts-clients/#tableview).
+
+# Motivation
+
+In the context of utilizing the TableView component, there are instances where we aspire to consistently retrieve the most up-to-date value associated with a given key. To accomplish this, we can employ an API that allows us to wait until all data has been fully retrieved before accessing the value corresponding to the desired key.
+# Goals
+
+## In Scope
+
+The proposed changes aim to add a new API that triggers the reading of all existing messages, updates the TableView, and waits for the read operation to complete. This will be achieved by introducing the `readAllExistingMessages()` method.
+
+## Out of Scope
+
+No out-of-scope items have been identified at this time.
+
+# High-Level Design
+
+The high-level design involves the addition of a new API method called `readAllExistingMessages()`. This method will be responsible for initiating the process of reading all existing messages, updating the TableView, and waiting for the read operation to complete.
+
+# Detailed Design
+
+## Design & Implementation Details
+
+The `readAllExistingMessages()` method will be implemented as follows:
+
+```java
+@Override
+public CompletableFuture<Void> readAllExistingMessages() {
+        return reader.thenCompose(this::readAllExistingMessages);
+}
+```
+
+# Public-Facing Changes
+
+## Public API
+
+The following changes will be made to the public API:
+
+### `readAllExistingMessages()`
+
+This new API method triggers the reading of all existing messages, updates the TableView, and waits for the read operation to complete.
+```java
+/**
+ * Triggers the reading of all existing messages, updates the TableView, and waits for the read operation to complete.
+ * @return a CompletableFuture that completes when all existing messages have been read
+ * and the TableView has been updated
+ */
+CompletableFuture<Void> readAllExistingMessages();
+```
+
+# Monitoring
+
+The proposed changes do not introduce any specific monitoring considerations at this time.
+
+# Security Considerations
+
+No specific security considerations have been identified for this proposal.
+
+# Backward & Forward Compatibility
+
+## Revert
+
+No specific revert instructions are required for this proposal.
+
+## Upgrade
+
+No specific upgrade instructions are required for this proposal.
+
+# Alternatives
+
+No alternative approaches were considered for this proposal.
+
+# General Notes
+
+No additional general notes have been provided.
+
+# Links
+
+<!--
+Updated afterwards
+-->
+* Mailing List discussion thread:
+* Mailing List voting thread:


### PR DESCRIPTION
### Motivation
In the context of utilizing the TableView component, there are instances where we aspire to consistently retrieve the most up-to-date value associated with a given key. To accomplish this, we can employ an API that allows us to wait until all data has been fully retrieved before accessing the value corresponding to the desired key. 
### Modification
Introduce a new API method called `readAllExistingMessages()`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
