### PR TITLE
[cleanup][monitor] Remove metric `topic_load_times`

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
@@ -33,7 +33,6 @@ public class BrokerOperabilityMetrics {
     private static final Counter TOPIC_LOAD_FAILED = Counter.build("topic_load_failed", "-").register();
     private final List<Metrics> metricsList;
     private final String localCluster;
-    private final DimensionStats oldTopicLoadStats;
     private final DimensionStats topicLoadStats;
     private final String brokerName;
     private final LongAdder connectionTotalCreatedCount;
@@ -45,7 +44,6 @@ public class BrokerOperabilityMetrics {
     public BrokerOperabilityMetrics(String localCluster, String brokerName) {
         this.metricsList = new ArrayList<>();
         this.localCluster = localCluster;
-        this.oldTopicLoadStats = new DimensionStats("topic_load_times", 60);
         this.topicLoadStats = new DimensionStats("pulsar_topic_load_times", 60);
         this.brokerName = brokerName;
         this.connectionTotalCreatedCount = new LongAdder();
@@ -61,7 +59,6 @@ public class BrokerOperabilityMetrics {
     }
 
     private void generate() {
-        metricsList.add(getOldTopicLoadMetrics());
         metricsList.add(getTopicLoadMetrics());
         metricsList.add(getConnectionMetrics());
     }
@@ -88,11 +85,6 @@ public class BrokerOperabilityMetrics {
         return dimensionMap;
     }
 
-    Metrics getOldTopicLoadMetrics() {
-        Metrics metrics = getDimensionMetrics("topic_load_times", "topic_load", oldTopicLoadStats);
-        return metrics;
-    }
-
     Metrics getTopicLoadMetrics() {
         Metrics metrics = getDimensionMetrics("pulsar_topic_load_times", "topic_load", topicLoadStats);
         metrics.put("brk_topic_load_failed_count", TOPIC_LOAD_FAILED.get());
@@ -117,12 +109,10 @@ public class BrokerOperabilityMetrics {
 
     public void reset() {
         metricsList.clear();
-        oldTopicLoadStats.reset();
         topicLoadStats.reset();
     }
 
     public void recordTopicLoadTimeValue(long topicLoadLatencyMs) {
-        oldTopicLoadStats.recordDimensionTimeValue(topicLoadLatencyMs, TimeUnit.MILLISECONDS);
         topicLoadStats.recordDimensionTimeValue(topicLoadLatencyMs, TimeUnit.MILLISECONDS);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -247,10 +247,6 @@ public class PrometheusMetricsTest extends BrokerTestBase {
                 assertEquals(item.value, 3.0);
             }
         });
-        Collection<Metric> topicLoadTimesMetrics = metrics.get("topic_load_times");
-        Collection<Metric> topicLoadTimesCountMetrics = metrics.get("topic_load_times_count");
-        assertEquals(topicLoadTimesMetrics.size(), 6);
-        assertEquals(topicLoadTimesCountMetrics.size(), 1);
         Collection<Metric> pulsarTopicLoadTimesMetrics = metrics.get("pulsar_topic_load_times");
         Collection<Metric> pulsarTopicLoadTimesCountMetrics = metrics.get("pulsar_topic_load_times_count");
         assertEquals(pulsarTopicLoadTimesMetrics.size(), 6);
@@ -338,7 +334,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         assertEquals(cm.get(1).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic1");
         assertEquals(cm.get(1).tags.get("namespace"), "my-property/use/my-ns");
 
-        cm = (List<Metric>) metrics.get("topic_load_times_count");
+        cm = (List<Metric>) metrics.get("pulsar_topic_load_times_count");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).tags.get("cluster"), "test");
 


### PR DESCRIPTION
### Motivation

As talked in [PIP-276](https://github.com/apache/pulsar/pull/20518),  we will remove `topic_load_times` after release 3.1.0 



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

