### PR TITLE
[improve] [broker] disable balancing based on DirectMemory.

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1372,7 +1372,9 @@ loadBalancerCPUResourceWeight=1.0
 
 # The direct memory usage weight when calculating new resource usage.
 # It only takes effect in the ThresholdShedder strategy.
-loadBalancerDirectMemoryResourceWeight=1.0
+# Direct memory usage cannot accurately reflect the machine's load,
+# and it is not recommended to use it to score the machine's load.
+loadBalancerDirectMemoryResourceWeight=0
 
 # Bundle unload minimum throughput threshold (MB), avoiding bundle unload frequently.
 # It only takes effect in the ThresholdShedder strategy.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2419,9 +2419,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
             dynamic = true,
             category = CATEGORY_LOAD_BALANCER,
-            doc = "Direct Memory Resource Usage Weight"
+            doc = "Direct Memory Resource Usage Weight. Direct memory usage cannot accurately reflect the " +
+                    "machine's load, and it is not recommended to use it to score the machine's load."
     )
-    private double loadBalancerDirectMemoryResourceWeight = 1.0;
+    private double loadBalancerDirectMemoryResourceWeight = 0;
 
     @FieldContext(
             dynamic = true,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2419,8 +2419,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
             dynamic = true,
             category = CATEGORY_LOAD_BALANCER,
-            doc = "Direct Memory Resource Usage Weight. Direct memory usage cannot accurately reflect the " +
-                    "machine's load, and it is not recommended to use it to score the machine's load."
+            doc = "Direct Memory Resource Usage Weight. Direct memory usage cannot accurately reflect the "
+                    + "machine's load, and it is not recommended to use it to score the machine's load."
     )
     private double loadBalancerDirectMemoryResourceWeight = 0;
 


### PR DESCRIPTION
### Motivation
As shown in the following figure, the throughput in/out, message in/out, bandwidht in/out usage and CPU usage go up and down periodically as time goes by, while the memory usage and direct memory usage has nothing to do with the actual load.
![image](https://github.com/apache/pulsar/assets/52550727/a018b79e-22c4-4b9a-a077-296f7e0456d3)
![image](https://github.com/apache/pulsar/assets/52550727/65e2a415-7b60-48c2-b27b-843e83975320)
![image](https://github.com/apache/pulsar/assets/52550727/0d322f6c-5621-4c92-a526-72b8e7083154)
![image](https://github.com/apache/pulsar/assets/52550727/bbfc5452-3be5-42d9-8c74-0b65e54be017)

Using memory usage and direct memory usage to score the broker load will result into wrong result.

### Modifications

~~Removing memory usage and direct memory usage for scoring.
As [PR#19559 ](https://github.com/apache/pulsar/pull/19559) has removed memory usage, i will remove direct memory usage for scoring.~~
Change the default value of `loadBalancerDirectMemoryResourceWeight`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/30