### PR TITLE
[fix][broker]Create v1/namespace with Policies

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -2656,4 +2656,15 @@ public abstract class NamespacesBase extends AdminResource {
             throw new RestException(e);
         }
     }
+
+    protected Policies getDefaultPolicesIfNull(Policies policies) {
+        if (policies == null) {
+            policies = new Policies();
+        }
+        int defaultNumberOfBundles = config().getDefaultNumberOfNamespaceBundles();
+        if (policies.bundles == null) {
+            policies.bundles = getBundles(defaultNumberOfBundles);
+        }
+        return policies;
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -1722,5 +1722,25 @@ public class Namespaces extends NamespacesBase {
         internalEnableMigration(migrated);
     }
 
+    @PUT
+    @Path("/{property}/{cluster}/{namespace}/policy")
+    @ApiOperation(value = "Creates a new namespace with the specified policies")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Property or cluster or namespace doesn't exist"),
+            @ApiResponse(code = 409, message = "Namespace already exists"),
+            @ApiResponse(code = 412, message = "Namespace name is not valid") })
+    public void createNamespace(@PathParam("property") String property, @PathParam("cluster") String cluster,
+                                @PathParam("namespace") String namespace,
+                                @ApiParam(value = "Policies for the namespace") Policies policies) {
+        validateNamespaceName(property, cluster, namespace);
+        if (!namespaceName.isGlobal()) {
+            // If the namespace is non global, make sure property has the access on the cluster. For global namespace,
+            // same check is made at the time of setting replication.
+            validateClusterForTenant(namespaceName.getTenant(), namespaceName.getCluster());
+        }
+        policies = getDefaultPolicesIfNull(policies);
+        internalCreateNamespace(policies);
+    }
+
     private static final Logger log = LoggerFactory.getLogger(Namespaces.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.admin.v2;
 
-import static org.apache.pulsar.common.policies.data.PoliciesUtil.getBundles;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -1964,20 +1963,6 @@ public class Namespaces extends NamespacesBase {
     public List<String> getAntiAffinityNamespaces(@PathParam("cluster") String cluster,
             @PathParam("group") String antiAffinityGroup, @QueryParam("tenant") String tenant) {
         return internalGetAntiAffinityNamespaces(cluster, antiAffinityGroup, tenant);
-    }
-
-    private Policies getDefaultPolicesIfNull(Policies policies) {
-        if (policies == null) {
-            policies = new Policies();
-        }
-
-        int defaultNumberOfBundles = config().getDefaultNumberOfNamespaceBundles();
-
-        if (policies.bundles == null) {
-            policies.bundles = getBundles(defaultNumberOfBundles);
-        }
-
-        return policies;
     }
 
     @GET

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -2110,38 +2110,42 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
     @Test
     public void testCreateNamespacesWithPolicy() throws Exception {
         try {
-            namespaces.createNamespace(this.testTenant, "other-colo", "my-namespace",
-                    new Policies());
+            asyncRequests(response -> namespaces.createNamespace(response, this.testTenant, "other-colo", "my-namespace",
+                    new Policies()));
             fail("should have failed");
         } catch (RestException e) {
             // Ok, cluster doesn't exist
+            assertEquals(e.getResponse().getStatus(), Status.FORBIDDEN.getStatusCode());
         }
 
         List<NamespaceName> nsnames = new ArrayList<>();
         nsnames.add(NamespaceName.get(this.testTenant, "use", "create-namespace-1"));
         nsnames.add(NamespaceName.get(this.testTenant, "use", "create-namespace-2"));
         nsnames.add(NamespaceName.get(this.testTenant, "usc", "create-other-namespace-1"));
-        createTestNamespaces(nsnames, new Policies());
+        createTestNamespaces(nsnames, BundlesData.builder().build());
 
         try {
-            namespaces.createNamespace(this.testTenant, "use", "create-namespace-1",
-                    new Policies());
+            asyncRequests(response -> namespaces.createNamespace(response, this.testTenant, "use", "create-namespace-1",
+                    new Policies()));
             fail("should have failed");
         } catch (RestException e) {
             // Ok, namespace already exists
+            assertEquals(e.getResponse().getStatus(), Status.CONFLICT.getStatusCode());
+
         }
 
         try {
-            namespaces.createNamespace("non-existing-tenant", "use", "create-namespace-1",
-                    new Policies());
+            asyncRequests(response -> namespaces.createNamespace(response,"non-existing-tenant", "use", "create-namespace-1",
+                    new Policies()));
             fail("should have failed");
         } catch (RestException e) {
             // Ok, tenant doesn't exist
+            assertEquals(e.getResponse().getStatus(), Status.NOT_FOUND.getStatusCode());
         }
 
         try {
-            namespaces.createNamespace(this.testTenant, "use", "create-namespace-#",
-                    new Policies());
+            asyncRequests(response -> namespaces.createNamespace(response, this.testTenant, "use", "create-namespace-#",
+                    new Policies()));
             fail("should have failed");
         } catch (RestException e) {
             // Ok, invalid namespace name
@@ -2153,16 +2157,17 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
                     && path.equals("/admin/policies/my-tenant/use/my-namespace-3");
         });
         try {
-            namespaces.createNamespace(this.testTenant, "use", "my-namespace-3", new Policies());
+            asyncRequests(response -> namespaces.createNamespace(response, this.testTenant, "use", "my-namespace-3", new Policies()));
             fail("should have failed");
         } catch (RestException e) {
             // Ok
+            assertEquals(e.getResponse().getStatus(), Status.INTERNAL_SERVER_ERROR.getStatusCode());
         }
     }
 
     private void createTestNamespaces(List<NamespaceName> nsnames, Policies policies) throws Exception {
         for (NamespaceName nsName : nsnames) {
-            namespaces.createNamespace(nsName.getTenant(), nsName.getCluster(), nsName.getLocalName(), policies);
+            asyncRequests(ctx -> namespaces.createNamespace(ctx, nsName.getTenant(), nsName.getCluster(), nsName.getLocalName(), policies));
         }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -2106,4 +2106,63 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
                 .getTopicPoliciesBypassCacheAsync(TopicName.get(systemTopic)).get(5, TimeUnit.SECONDS);
         assertNull(topicPolicies);
     }
+
+    @Test
+    public void testCreateNamespacesWithPolicy() throws Exception {
+        try {
+            namespaces.createNamespace(this.testTenant, "other-colo", "my-namespace",
+                    new Policies());
+            fail("should have failed");
+        } catch (RestException e) {
+            // Ok, cluster doesn't exist
+        }
+
+        List<NamespaceName> nsnames = new ArrayList<>();
+        nsnames.add(NamespaceName.get(this.testTenant, "use", "create-namespace-1"));
+        nsnames.add(NamespaceName.get(this.testTenant, "use", "create-namespace-2"));
+        nsnames.add(NamespaceName.get(this.testTenant, "usc", "create-other-namespace-1"));
+        createTestNamespaces(nsnames, new Policies());
+
+        try {
+            namespaces.createNamespace(this.testTenant, "use", "create-namespace-1",
+                    new Policies());
+            fail("should have failed");
+        } catch (RestException e) {
+            // Ok, namespace already exists
+        }
+
+        try {
+            namespaces.createNamespace("non-existing-tenant", "use", "create-namespace-1",
+                    new Policies());
+            fail("should have failed");
+        } catch (RestException e) {
+            // Ok, tenant doesn't exist
+        }
+
+        try {
+            namespaces.createNamespace(this.testTenant, "use", "create-namespace-#",
+                    new Policies());
+            fail("should have failed");
+        } catch (RestException e) {
+            // Ok, invalid namespace name
+            assertEquals(e.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
+        }
+
+        mockZooKeeperGlobal.failConditional(Code.SESSIONEXPIRED, (op, path) -> {
+            return op == MockZooKeeper.Op.CREATE
+                    && path.equals("/admin/policies/my-tenant/use/my-namespace-3");
+        });
+        try {
+            namespaces.createNamespace(this.testTenant, "use", "my-namespace-3", new Policies());
+            fail("should have failed");
+        } catch (RestException e) {
+            // Ok
+        }
+    }
+
+    private void createTestNamespaces(List<NamespaceName> nsnames, Policies policies) throws Exception {
+        for (NamespaceName nsName : nsnames) {
+            namespaces.createNamespace(nsName.getTenant(), nsName.getCluster(), nsName.getLocalName(), policies);
+        }
+    }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.client.admin.internal;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -182,9 +181,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     @Override
     public CompletableFuture<Void> createNamespaceAsync(String namespace, Policies policies) {
         NamespaceName ns = NamespaceName.get(namespace);
-        checkArgument(ns.isV2(), "Create namespace with policies is only supported on newer namespaces");
-        WebTarget path = namespacePath(ns);
-        // For V2 API we pass full Policy class instance
+        WebTarget path = ns.isV2() ? namespacePath(ns) : namespacePath(ns, "policy");
         return asyncPutRequest(path, Entity.entity(policies, MediaType.APPLICATION_JSON));
     }
 


### PR DESCRIPTION
### Motivation

Right now, there is no way to create v1/namespace with policies. Added support to create v1/namespace with policies.

### Modifications

Added a new endpoint /{property}/{cluster}/{namespace}/policy  to  support creation of v1/namespace with policies

### Verifying this change

- Added tests to create v1/namespace with policies

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [x] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
