### PR TITLE
[improve][broker][PIP-286] Make the TopicCompactionService to support find entry based on publishTime or index

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/PulsarTopicCompactionService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/PulsarTopicCompactionService.java
@@ -22,18 +22,23 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.pulsar.compaction.CompactedTopicImpl.COMPACT_LEDGER_EMPTY;
 import static org.apache.pulsar.compaction.CompactedTopicImpl.NEWER_THAN_COMPACTED;
 import static org.apache.pulsar.compaction.CompactedTopicImpl.findStartPoint;
+import static org.apache.pulsar.compaction.CompactedTopicImpl.readEntries;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.pulsar.common.api.proto.BrokerEntryMetadata;
+import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.util.FutureUtil;
 
 
@@ -104,6 +109,78 @@ public class PulsarTopicCompactionService implements TopicCompactionService {
     @Override
     public CompletableFuture<Position> getLastCompactedPosition() {
         return CompletableFuture.completedFuture(compactedTopic.getCompactionHorizon().orElse(null));
+    }
+
+    @Override
+    public CompletableFuture<Entry> findEntryByPublishTime(long publishTime) {
+        final Predicate<Entry> predicate = entry -> {
+            try {
+                return Commands.parseMessageMetadata(entry.getDataBuffer()).getPublishTime() >= publishTime;
+            } finally {
+                entry.release();
+            }
+        };
+        return findFirstMatchEntry(predicate);
+    }
+
+    @Override
+    public CompletableFuture<Entry> findEntryByEntryIndex(long entryIndex) {
+        final Predicate<Entry> predicate = entry -> {
+            try {
+                BrokerEntryMetadata brokerEntryMetadata =
+                        Commands.parseBrokerEntryMetadataIfExist(entry.getDataBuffer());
+                if (brokerEntryMetadata == null || !brokerEntryMetadata.hasIndex()) {
+                    return false;
+                }
+                return brokerEntryMetadata.getIndex() >= entryIndex;
+            } finally {
+                entry.release();
+            }
+        };
+        return findFirstMatchEntry(predicate);
+    }
+
+    private CompletableFuture<Entry> findFirstMatchEntry(final Predicate<Entry> predicate) {
+        var compactedTopicContextFuture = compactedTopic.getCompactedTopicContextFuture();
+
+        if (compactedTopicContextFuture == null) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return compactedTopicContextFuture.thenCompose(compactedTopicContext -> {
+            LedgerHandle lh = compactedTopicContext.getLedger();
+            CompletableFuture<Long> promise = new CompletableFuture<>();
+            findFirstMatchIndexLoop(predicate, 0L, lh.getLastAddConfirmed(), promise, null, lh);
+            return promise.thenCompose(index -> {
+                if (index == null) {
+                    return CompletableFuture.completedFuture(null);
+                }
+                return readEntries(lh, index, index).thenApply(entries -> entries.get(0));
+            });
+        });
+    }
+
+    private static void findFirstMatchIndexLoop(final Predicate<Entry> predicate,
+                                           final long start, final long end,
+                                           final CompletableFuture<Long> promise,
+                                           final Long lastMatchIndex,
+                                           final LedgerHandle lh) {
+        if (start > end) {
+            promise.complete(lastMatchIndex);
+            return;
+        }
+
+        long mid = (start + end) / 2;
+        CompactedTopicImpl.readEntries(lh, mid, mid).thenAccept(entries -> {
+            Entry entry = entries.get(0);
+            if (predicate.test(entry)) {
+                findFirstMatchIndexLoop(predicate, start, mid - 1, promise, mid, lh);
+            } else {
+                findFirstMatchIndexLoop(predicate, mid + 1, end, promise, lastMatchIndex, lh);
+            }
+        }).exceptionally(ex -> {
+            promise.completeExceptionally(ex);
+            return null;
+        });
     }
 
     public CompactedTopicImpl getCompactedTopic() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TopicCompactionService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TopicCompactionService.java
@@ -60,4 +60,20 @@ public interface TopicCompactionService extends AutoCloseable {
      * @return a future that will be completed with the last compacted position, this position can be null.
      */
     CompletableFuture<Position> getLastCompactedPosition();
+
+    /**
+    * Find the first entry that greater or equal to target publishTime.
+    *
+    * @param publishTime  the publish time of entry.
+    * @return the first entry metadata that greater or equal to target publishTime, this entry can be null.
+    */
+    CompletableFuture<Entry> findEntryByPublishTime(long publishTime);
+
+    /**
+    * Find the first entry that greater or equal to target entryIndex.
+    *
+    * @param entryIndex  the index of entry.
+    * @return the first entry that greater or equal to target entryIndex, this entry can be null.
+    */
+    CompletableFuture<Entry> findEntryByEntryIndex(long entryIndex);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TopicCompactionService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TopicCompactionService.java
@@ -70,7 +70,8 @@ public interface TopicCompactionService extends AutoCloseable {
     CompletableFuture<Entry> findEntryByPublishTime(long publishTime);
 
     /**
-    * Find the first entry that greater or equal to target entryIndex.
+    * Find the first entry that greater or equal to target entryIndex,
+    * if an entry that broker entry metadata is missed, then it will be skipped and find the next match entry.
     *
     * @param entryIndex  the index of entry.
     * @return the first entry that greater or equal to target entryIndex, this entry can be null.


### PR DESCRIPTION
PIP: #20867 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

#20867 

### Modifications

Add `findEntryByPublishTime` and `findEntryByEntryIndex`  in the TopicCompactionService API.

Implement them in the PulsarTopicCompactionService using binary search.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
