### PR TITLE
[improve] [broker] Not close the socket if lookup failed caused by bundle unloading or metadata ex

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/ServiceUnitUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/ServiceUnitUtils.java
@@ -36,7 +36,7 @@ public final class ServiceUnitUtils {
      */
     private static final String OWNER_INFO_ROOT = "/namespace";
 
-    static String path(NamespaceBundle suname) {
+    public static String path(NamespaceBundle suname) {
         // The ephemeral node path for new namespaces should always have bundle name appended
         return OWNER_INFO_ROOT + "/" + suname.toString();
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -530,6 +530,7 @@ public abstract class PulsarWebResource {
         pulsar.getPulsarResources().getClusterResources().getClusterAsync(cluster)
                 .whenComplete((clusterDataResult, ex) -> {
                     if (ex != null) {
+                        log.warn("[{}] Load cluster data failed: requested={}", clientAppId, cluster);
                         clusterDataFuture.completeExceptionally(FutureUtil.unwrapCompletionException(ex));
                         return;
                     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LeaderElectionServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LeaderElectionServiceTest.java
@@ -129,10 +129,10 @@ public class LeaderElectionServiceTest {
                     .topic("persistent://" + tenant + "/" + namespace + "/1p")
                     .create();
         } catch (PulsarClientException t) {
-            Assert.assertTrue(t instanceof PulsarClientException.LookupException);
+            Assert.assertTrue(t instanceof PulsarClientException.BrokerMetadataException
+                    || t instanceof PulsarClientException.LookupException);
             Assert.assertTrue(
-                    t.getMessage().contains(
-                            "java.lang.IllegalStateException: The leader election has not yet been completed!"));
+                    t.getMessage().contains("The leader election has not yet been completed"));
         }
     }
 


### PR DESCRIPTION
### Motivation

**Background**: The Pulsar client will close the socket if it receives a ServiceNotReady error when doing a lookup. 
see https://github.com/apache/pulsar/blob/af20a8a8623055bab665e566b3f54f6f884d121d/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java#L1193-L1200

Closing the socket causes the other consumer or producer to reconnect and does not make the lookup more efficient.

There are two cases that should be improved:
- If the broker gets a metadata read/write error, the broker responds with a `ServiceNotReady` error, but it should respond with a `MetadataError`
- If the topic is unloading, the broker responds with a `ServiceNotReady` error.

### Modifications
- Respond to the client with a `MetadataError` if the broker gets a metadata read/write error.
- Respond to the client with a `MetadataError` if the topic is unloading

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x