### PR TITLE
[improve][broker]filter-out non traffic bundles when shedding in UniformLoadShedder

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedderTest.java
@@ -153,13 +153,15 @@ public class UniformLoadShedderTest {
 
 
         for (int brokerId = 0; brokerId < numBrokers; brokerId++) {
+            // set LocalBrokerData first
+            localBrokerDatas[brokerId].setMsgRateIn(brokerMsgRates[brokerId]);
+            localBrokerDatas[brokerId].setMsgThroughputIn(brokerMsgThroughputs[brokerId]);
+            // then set bundle data
             double msgRate = brokerMsgRates[brokerId] / numBundles;
             double throughput = brokerMsgThroughputs[brokerId] / numBundles;
             for (int i = 0; i < numBundles; ++i) {
                 String bundleName = "broker-" + brokerId + "-bundle-" + i;
                 localBrokerDatas[brokerId].getBundles().add(bundleName);
-                localBrokerDatas[brokerId].setMsgRateIn(brokerMsgRates[brokerId]);
-                localBrokerDatas[brokerId].setMsgThroughputIn(brokerMsgThroughputs[brokerId]);
                 BundleData bundle = new BundleData();
 
                 TimeAverageMessageData timeAverageMessageData = new TimeAverageMessageData();
@@ -168,7 +170,7 @@ public class UniformLoadShedderTest {
                 bundle.setShortTermData(timeAverageMessageData);
                 loadData.getBundleData().put(bundleName, bundle);
             }
-           loadData.getBrokerData().put(brokerNames[brokerId], new BrokerData(localBrokerDatas[brokerId]));
+            loadData.getBrokerData().put(brokerNames[brokerId], new BrokerData(localBrokerDatas[brokerId]));
         }
 
         // disable throughput based load shedding, enable rate based load shedding only
@@ -195,6 +197,91 @@ public class UniformLoadShedderTest {
         bundlesToUnload = uniformLoadShedder.findBundlesForUnloading(loadData, conf);
         assertEquals(bundlesToUnload.size(), 1);
         assertTrue(bundlesToUnload.containsKey("broker2"));
+    }
+
+    @Test
+    public void testFilterOutNonTrafficBundlesForUnloading() {
+        conf.setMaxUnloadBundleNumPerShedding(5);
+        conf.setMaxUnloadPercentage(0.5);
+        LoadData loadData = new LoadData();
+
+        String[] brokerNames = new String[]{"broker0", "broker1"};
+
+        double[] brokerMsgRates = new double[]{
+                10_000, // broker0
+                100_000};// broker1
+
+        double[] brokerMsgThroughputs = new double[]{
+                10 * 1024 * 1024, // broker0  10MB
+                100 * 1024 * 1024};// broker1 100MB
+
+        LocalBrokerData brokerData0 = new LocalBrokerData();
+        LocalBrokerData brokerData1 = new LocalBrokerData();
+
+        // set broker data
+        brokerData0.setMsgRateIn(brokerMsgRates[0]);
+        brokerData0.setMsgThroughputIn(brokerMsgThroughputs[0]);
+        brokerData1.setMsgRateIn(brokerMsgRates[1]);
+        brokerData1.setMsgThroughputIn(brokerMsgThroughputs[1]);
+
+        // broker0 bundle data
+        String bundleName = "broker-0-bundle-0";
+        brokerData0.getBundles().add(bundleName);
+        double bundleMsgRate = brokerMsgRates[0];
+        double bundleMsgThroughput = brokerMsgThroughputs[0];
+        TimeAverageMessageData timeAverageMessageData = new TimeAverageMessageData();
+        timeAverageMessageData.setMsgRateIn(bundleMsgRate);
+        timeAverageMessageData.setMsgThroughputIn(bundleMsgThroughput);
+        BundleData bundle = new BundleData();
+        bundle.setShortTermData(timeAverageMessageData);
+        loadData.getBundleData().put(bundleName, bundle);
+
+        // broker1 bundle data, 5 bundles and some of them are non traffic bundles
+        // details are:
+        // bundleName   msgRate   msgThroughput
+        // bundle-0     60_000     60 MB
+        // bundle-1     20_000     60 MB
+        // bundle-2     20_000     60 MB
+        // bundle-3     0           0 MB
+        // bundle-4     0           0 MB
+        double[] broker1BundleMsgRates = new double[]{
+                60_000, 20_000, 20_000, 0, 0};
+        double[] broker1BundleMsgThroughputs = new double[]{
+                60 * 1024 * 1024, 20 * 1024 * 1024, 20 * 1024 * 1024, 0, 0};
+        for (int i = 0 ; i < 5; i++) {
+            bundleName = "broker-1-bundle-" + i;
+            brokerData1.getBundles().add(bundleName);
+            bundleMsgRate = broker1BundleMsgRates[i];
+            bundleMsgThroughput = broker1BundleMsgThroughputs[i];
+            timeAverageMessageData = new TimeAverageMessageData();
+            timeAverageMessageData.setMsgRateIn(bundleMsgRate);
+            timeAverageMessageData.setMsgThroughputIn(bundleMsgThroughput);
+            bundle = new BundleData();
+            bundle.setShortTermData(timeAverageMessageData);
+            loadData.getBundleData().put(bundleName, bundle);
+        }
+
+        loadData.getBrokerData().put(brokerNames[0], new BrokerData(brokerData0));
+        loadData.getBrokerData().put(brokerNames[1], new BrokerData(brokerData1));
+
+        // disable throughput based load shedding, enable rate based load shedding only
+        conf.setLoadBalancerMsgRateDifferenceShedderThreshold(50);
+        conf.setLoadBalancerMsgThroughputMultiplierDifferenceShedderThreshold(0);
+
+        Multimap<String, String> bundlesToUnload = uniformLoadShedder.findBundlesForUnloading(loadData, conf);
+        assertEquals(bundlesToUnload.size(), 2);
+        assertTrue(bundlesToUnload.containsValue("broker-1-bundle-1"));
+        assertTrue(bundlesToUnload.containsValue("broker-1-bundle-2"));
+
+
+        // disable rate based load shedding, enable throughput based load shedding only
+        conf.setLoadBalancerMsgRateDifferenceShedderThreshold(0);
+        conf.setLoadBalancerMsgThroughputMultiplierDifferenceShedderThreshold(2);
+
+        bundlesToUnload = uniformLoadShedder.findBundlesForUnloading(loadData, conf);
+        assertEquals(bundlesToUnload.size(), 2);
+        assertTrue(bundlesToUnload.containsValue("broker-1-bundle-1"));
+        assertTrue(bundlesToUnload.containsValue("broker-1-bundle-2"));
     }
 
 }


### PR DESCRIPTION
### Motivation

UniformLoadShedder may select some non-traffic bundles to unload now like 
```shell
18:55:26.784 [pulsar-load-manager-1-1] INFO  org.apache.pulsar.broker.loadbalance.impl.UniformLoadShedder - Found bundle to unload with msgRate 15048.115011923204
18:55:26.784 [pulsar-load-manager-1-1] INFO  org.apache.pulsar.broker.loadbalance.impl.UniformLoadShedder - Found bundle to unload with msgRate 0.0
18:55:26.784 [pulsar-load-manager-1-1] INFO  org.apache.pulsar.broker.loadbalance.impl.UniformLoadShedder - Found bundle to unload with msgRate 0.0
18:55:26.784 [pulsar-load-manager-1-1] INFO  org.apache.pulsar.broker.loadbalance.impl.UniformLoadShedder - Found bundle to unload with msgRate 0.0
18:55:26.784 [pulsar-load-manager-1-1] INFO  org.apache.pulsar.broker.loadbalance.impl.UniformLoadShedder - Found bundle to unload with msgRate 0.0
18:57:26.894 [pulsar-load-manager-1-1] INFO  org.apache.pulsar.broker.loadbalance.impl.UniformLoadShedder - Found bundle to unload with msgRate 17720.31788204035
18:57:26.894 [pulsar-load-manager-1-1] INFO  org.apache.pulsar.broker.loadbalance.impl.UniformLoadShedder - Found bundle to unload with msgRate 0.0
18:59:26.924 [pulsar-load-manager-1-1] INFO  org.apache.pulsar.broker.loadbalance.impl.UniformLoadShedder - Found bundle to unload with msgRate 17704.503414568837
18:59:26.924 [pulsar-load-manager-1-1] INFO  org.apache.pulsar.broker.loadbalance.impl.UniformLoadShedder - Found bundle to unload with msgRate 0.0
19:01:26.954 [pulsar-load-manager-1-1] INFO  org.apache.pulsar.broker.loadbalance.impl.UniformLoadShedder - Found bundle to unload with msgRate 18242.125261353547
19:01:26.954 [pulsar-load-manager-1-1] INFO  org.apache.pulsar.broker.loadbalance.impl.UniformLoadShedder - Found bundle to unload with msgRate 15923.1548577726
19:01:26.954 [pulsar-load-manager-1-1] INFO  org.apache.pulsar.broker.loadbalance.impl.UniformLoadShedder - Found bundle to unload with msgRate 0.0
19:01:26.954 [pulsar-load-manager-1-1] INFO  org.apache.pulsar.broker.loadbalance.impl.UniformLoadShedder - Found bundle to unload with msgRate 0.0
19:01:26.954 [pulsar-load-manager-1-1] INFO  org.apache.pulsar.broker.loadbalance.impl.UniformLoadShedder - Found bundle to unload with msgRate 0.0
```
This is unnecessary, the leader broker should filter out bundles without traffic when unloading.

### Modifications
1. filter-out bundles without traffic when unloading
2. add a test to cover this modification
3. add some logs and fix typo

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/aloyszhang/pulsar/pull/21
