### PR TITLE
[fix][fn] fix functions_log4j2.xml delete strategy config

### DIFF
--- a/conf/functions_log4j2.xml
+++ b/conf/functions_log4j2.xml
@@ -68,7 +68,7 @@
                     <basePath>${sys:pulsar.function.log.dir}</basePath>
                     <maxDepth>2</maxDepth>
                     <IfFileName>
-                        <glob>*/${sys:pulsar.function.log.file}*log.gz</glob>
+                        <glob>${sys:pulsar.function.log.file}*log.gz</glob>
                     </IfFileName>
                     <IfLastModified>
                         <age>30d</age>
@@ -101,7 +101,7 @@
                     <basePath>${sys:pulsar.function.log.dir}</basePath>
                     <maxDepth>2</maxDepth>
                     <IfFileName>
-                        <glob>*/${sys:pulsar.function.log.file}.bk*log.gz</glob>
+                        <glob>${sys:pulsar.function.log.file}.bk*log.gz</glob>
                     </IfFileName>
                     <IfLastModified>
                         <age>30d</age>


### PR DESCRIPTION
### Motivation

In the current function_log4j2.xml deletion policy, the matching rules for log files are incorrect. This will cause log cleaning to fail.

The previous PR [https://github.com/apache/pulsar/pull/19495] fixed the broker’s log cleaning configuration. But the function’s log configuration file is still wrong.


### Modifications

remove "*/" of IfFileName in function_log4j2.xml 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->