### PR TITLE
[fix][offload] Fix NPE issue when read offload data

### DIFF
--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamImpl.java
@@ -19,6 +19,7 @@
 package org.apache.bookkeeper.mledger.offload.jcloud.impl;
 
 import io.netty.buffer.ByteBuf;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
@@ -120,6 +121,9 @@ public class BlobStoreBackedInputStreamImpl extends BackedInputStream {
             } catch (Throwable e) {
                 if (null != this.offloaderStats) {
                     this.offloaderStats.recordReadOffloadError(this.topicName);
+                }
+                if (!blobStore.blobExists(bucket, key)) {
+                    throw new FileNotFoundException("The file in the blobstore does not exist!");
                 }
                 throw new IOException("Error reading from BlobStore", e);
             }

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
@@ -147,6 +147,7 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
                     if (dataStream.available() < 12) {
                         promise.completeExceptionally(new ManagedLedgerException
                                 .NonRecoverableLedgerException("There is no complete data in the ledger: " + ledgerId));
+                        return;
                     }
                 }
 

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
@@ -22,6 +22,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import io.netty.buffer.ByteBuf;
 import java.io.DataInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -144,11 +145,6 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
                     log.warn("There hasn't enough data to read, current available data has {} bytes,"
                         + " seek to the first entry {} to avoid EOF exception", inputStream.available(), firstEntry);
                     seekToEntry(firstEntry);
-                    if (dataStream.available() < 12) {
-                        promise.completeExceptionally(new ManagedLedgerException
-                                .NonRecoverableLedgerException("There is no complete data in the ledger: " + ledgerId));
-                        return;
-                    }
                 }
 
                 while (entriesToRead > 0) {
@@ -200,7 +196,12 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
             } catch (Throwable t) {
                 log.error("Failed to read entries {} - {} from the offloader in ledger {}",
                     firstEntry, lastEntry, ledgerId, t);
-                promise.completeExceptionally(t);
+                if (t instanceof FileNotFoundException) {
+                    promise.completeExceptionally(new ManagedLedgerException
+                            .NonRecoverableLedgerException("The blobstore file does not exist for ledger:" + ledgerId));
+                } else {
+                    promise.completeExceptionally(t);
+                }
                 entries.forEach(LedgerEntry::close);
             }
         });
@@ -283,8 +284,11 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
             try (InputStream payLoadStream = blob.getPayload().openStream()) {
                 index = (OffloadIndexBlock) indexBuilder.fromStream(payLoadStream);
             } catch (IOException e) {
+                if (!blobStore.blobExists(bucket, indexKey)) {
+                    throw new FileNotFoundException("The index file in the blob store does not exist!");
+                }
                 // retry to avoid the network issue caused read failure
-                log.warn("Failed to get index block from the offoaded index file {}, still have {} times to retry",
+                log.warn("Failed to get index block from the offloaded index file {}, still have {} times to retry",
                     indexKey, retryCount, e);
                 lastException = e;
                 continue;

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
@@ -144,6 +144,10 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
                     log.warn("There hasn't enough data to read, current available data has {} bytes,"
                         + " seek to the first entry {} to avoid EOF exception", inputStream.available(), firstEntry);
                     seekToEntry(firstEntry);
+                    if (dataStream.available() < 12) {
+                        promise.completeExceptionally(new ManagedLedgerException
+                                .NonRecoverableLedgerException("There is no complete data in the ledger: " + ledgerId));
+                    }
                 }
 
                 while (entriesToRead > 0) {

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplV2.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplV2.java
@@ -247,7 +247,8 @@ public class BlobStoreBackedReadHandleImplV2 implements ReadHandle {
 
         if (groupedReaders.size() == 0) {
             throw new ManagedLedgerException.NonRecoverableLedgerException(
-                    String.format("There is no data for ledger %d, from entry %d to %d", ledgerId, firstEntry, lastEntry));
+                    String.format("There is no data for ledger %d, from entry %d to %d",
+                            ledgerId, firstEntry, lastEntry));
         }
 
         checkArgument(firstEntry > lastEntry);

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplV2.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplV2.java
@@ -235,10 +235,19 @@ public class BlobStoreBackedReadHandleImplV2 implements ReadHandle {
                 log.debug("entries are in earlier indices, skip this segment ledger id: {}, begin entry id: {}",
                         ledgerId, startEntryId);
             } else {
-                groupedReaders.add(new GroupedReader(ledgerId, startEntryId, lastEntry, index, inputStreams.get(i),
-                        dataStreams.get(i)));
-                lastEntry = startEntryId - 1;
+                if (dataStreams.get(i).available() < 12) {
+                    log.warn("The blob store offload segment is not enough data for ledger {}", ledgerId);
+                } else {
+                    groupedReaders.add(new GroupedReader(ledgerId, startEntryId, lastEntry, index, inputStreams.get(i),
+                            dataStreams.get(i)));
+                    lastEntry = startEntryId - 1;
+                }
             }
+        }
+
+        if (groupedReaders.size() == 0) {
+            throw new ManagedLedgerException.NonRecoverableLedgerException(
+                    String.format("There is no data for ledger %d, from entry %d to %d", ledgerId, firstEntry, lastEntry));
         }
 
         checkArgument(firstEntry > lastEntry);

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplV2.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplV2.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.mledger.offload.jcloud.impl;
 import static com.google.common.base.Preconditions.checkArgument;
 import io.netty.buffer.ByteBuf;
 import java.io.DataInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -216,7 +217,13 @@ public class BlobStoreBackedReadHandleImplV2 implements ReadHandle {
                         }
                     }
                 } catch (Throwable t) {
-                    promise.completeExceptionally(t);
+                    if (t instanceof FileNotFoundException) {
+                        promise.completeExceptionally(new ManagedLedgerException
+                                .NonRecoverableLedgerException(
+                                        "The blobstore file does not exist for ledger:" + ledgerId));
+                    } else {
+                        promise.completeExceptionally(t);
+                    }
                     entries.forEach(LedgerEntry::close);
                 }
 
@@ -235,20 +242,10 @@ public class BlobStoreBackedReadHandleImplV2 implements ReadHandle {
                 log.debug("entries are in earlier indices, skip this segment ledger id: {}, begin entry id: {}",
                         ledgerId, startEntryId);
             } else {
-                if (dataStreams.get(i).available() < 12) {
-                    log.warn("The blob store offload segment is not enough data for ledger {}", ledgerId);
-                } else {
-                    groupedReaders.add(new GroupedReader(ledgerId, startEntryId, lastEntry, index, inputStreams.get(i),
-                            dataStreams.get(i)));
-                    lastEntry = startEntryId - 1;
-                }
+                groupedReaders.add(new GroupedReader(ledgerId, startEntryId, lastEntry, index, inputStreams.get(i),
+                        dataStreams.get(i)));
+                lastEntry = startEntryId - 1;
             }
-        }
-
-        if (groupedReaders.size() == 0) {
-            throw new ManagedLedgerException.NonRecoverableLedgerException(
-                    String.format("There is no data for ledger %d, from entry %d to %d",
-                            ledgerId, firstEntry, lastEntry));
         }
 
         checkArgument(firstEntry > lastEntry);
@@ -320,9 +317,22 @@ public class BlobStoreBackedReadHandleImplV2 implements ReadHandle {
             log.debug("indexKey blob: {} {}", indexKey, blob);
             versionCheck.check(indexKey, blob);
             OffloadIndexBlockV2Builder indexBuilder = OffloadIndexBlockV2Builder.create();
-            OffloadIndexBlockV2 index;
-            try (InputStream payloadStream = blob.getPayload().openStream()) {
-                index = indexBuilder.fromStream(payloadStream);
+            OffloadIndexBlockV2 index = null;
+            int retryCount = 3;
+            while (retryCount > 0) {
+                try (InputStream payloadStream = blob.getPayload().openStream()) {
+                    index = indexBuilder.fromStream(payloadStream);
+                } catch (IOException e) {
+                    if (!blobStore.blobExists(bucket, indexKey)) {
+                        throw new FileNotFoundException("The index file in the blob store does not exist!");
+                    }
+                    // retry to avoid the network issue caused read failure
+                    log.warn("Failed to get index block from the offloaded index file {}, still have {} times to retry",
+                            indexKey, retryCount, e);
+                    if (--retryCount == 0) {
+                        throw e;
+                    }
+                }
             }
 
             BackedInputStream inputStream = new BlobStoreBackedInputStreamImpl(blobStore, bucket, key,

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTest.java
@@ -18,15 +18,19 @@
  */
 package org.apache.bookkeeper.mledger.offload.jcloud.impl;
 
+import static org.apache.bookkeeper.mledger.offload.jcloud.impl.OffloadIndexTest.createLedgerMetadata;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,16 +41,21 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerEntry;
+import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
 import org.apache.bookkeeper.mledger.LedgerOffloaderStats;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.impl.LedgerOffloaderStatsImpl;
 import org.apache.bookkeeper.mledger.OffloadedLedgerMetadata;
+import org.apache.bookkeeper.mledger.offload.jcloud.BackedInputStream;
+import org.apache.bookkeeper.mledger.offload.jcloud.OffloadIndexBlock;
+import org.apache.bookkeeper.mledger.offload.jcloud.OffloadIndexBlockBuilder;
 import org.apache.bookkeeper.mledger.offload.jcloud.provider.JCloudBlobStoreProvider;
 import org.apache.bookkeeper.mledger.offload.jcloud.provider.TieredStorageConfiguration;
 import org.apache.pulsar.common.naming.TopicName;
@@ -444,6 +453,32 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
             Assert.fail("Shouldn't have been able to offload");
         } catch (ExecutionException e) {
             assertEquals(e.getCause().getClass(), IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    public void testThrowNonRecoverableLedgerExceptionAvoidEOFAndNPE() throws Exception {
+        BackedInputStream mockInputStream =  spy(BackedInputStream.class);
+        OffloadIndexBlockBuilder indexBuilder = OffloadIndexBlockBuilder.create();
+        LedgerMetadata metadata = createLedgerMetadata(1);
+        indexBuilder.withLedgerMetadata(metadata).withDataObjectLength(1).withDataBlockHeaderLength(23455);
+
+        indexBuilder.addBlock(0, 2, 64 * 1024 * 1024);
+        indexBuilder.addBlock(1000, 3, 64 * 1024 * 1024);
+        indexBuilder.addBlock(2000, 4, 64 * 1024 * 1024);
+        Constructor<BlobStoreBackedReadHandleImpl> constructMethod = BlobStoreBackedReadHandleImpl.class
+                .getDeclaredConstructor(long.class, OffloadIndexBlock.class,
+                BackedInputStream.class, ExecutorService.class);
+        constructMethod.setAccessible(true);
+        BlobStoreBackedReadHandleImpl readHandle = constructMethod.newInstance(1,
+                indexBuilder.build(),
+                mockInputStream, Executors.newSingleThreadExecutor());
+
+        try {
+            readHandle.read(1, 3);
+            fail();
+        } catch (Exception e) {
+            assertTrue(e.getCause() instanceof ManagedLedgerException.NonRecoverableLedgerException);
         }
     }
 

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTest.java
@@ -461,7 +461,8 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
         BackedInputStream mockInputStream =  spy(BackedInputStream.class);
         OffloadIndexBlockBuilder indexBuilder = OffloadIndexBlockBuilder.create();
         LedgerMetadata metadata = createLedgerMetadata(1);
-        indexBuilder.withLedgerMetadata(metadata).withDataObjectLength(1).withDataBlockHeaderLength(23455);
+        indexBuilder.withLedgerMetadata(metadata).withDataObjectLength(1)
+                .withDataBlockHeaderLength(23455);
 
         indexBuilder.addBlock(0, 2, 64 * 1024 * 1024);
         indexBuilder.addBlock(1000, 3, 64 * 1024 * 1024);


### PR DESCRIPTION
## Motivation
The metadata of the ledger still exists, but the offloaded metadata is lost or damaged.
```log
2023-08-28T02:35:23,512+0000 [offloader-OrderedScheduler-1-0] WARN  org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedReadHandleImpl - There hasn't enough data to read        , current available data has 0 bytes, seek to the first entry 0 to avoid EOF exception
     89 2023-08-28T02:35:23,541+0000 [offloader-OrderedScheduler-0-0] ERROR org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedReadHandleImpl - Failed to read entries 0 - 0 fro        m the offloader in ledger 1358058
     90 java.io.IOException: Error reading from BlobStore
     91         at org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedInputStreamImpl.refillBufferIfNeeded(BlobStoreBackedInputStreamImpl.java:91) ~[?:?]
     92         at org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedInputStreamImpl.read(BlobStoreBackedInputStreamImpl.java:99) ~[?:?]
     93         at java.io.DataInputStream.readInt(DataInputStream.java:392) ~[?:?]
     94         at org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedReadHandleImpl.lambda$readAsync$1(BlobStoreBackedReadHandleImpl.java:136) ~[?:?]
     95         at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
     96         at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
     97         at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]
     98         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
     99         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
    100         at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.87.Final.jar:4.1.87.Final]
    101         at java.lang.Thread.run(Thread.java:829) ~[?:?]
    102 Caused by: java.lang.NullPointerException
    103 2023-08-28T02:35:23,542+0000 [offloader-OrderedScheduler-0-0] ERROR org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl - Unknown exception for ManagedLedgerException.
    104 java.io.IOException: Error reading from BlobStore
    105         at org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedInputStreamImpl.refillBufferIfNeeded(BlobStoreBackedInputStreamImpl.java:91) ~[?:?]
    106         at org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedInputStreamImpl.read(BlobStoreBackedInputStreamImpl.java:99) ~[?:?]
    107         at java.io.DataInputStream.readInt(DataInputStream.java:392) ~[?:?]
    108         at org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedReadHandleImpl.lambda$readAsync$1(BlobStoreBackedReadHandleImpl.java:136) ~[?:?]
    109         at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
    110         at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
    111         at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]
    112         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
    113         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
    114         at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.87.Final.jar:4.1.87.Final]
    115         at java.lang.Thread.run(Thread.java:829) ~[?:?]
    116 Caused by: java.lang.NullPointerException
    117 2023-08-28T02:35:23,544+0000 [offloader-OrderedScheduler-0-0] WARN  org.apache.bookkeeper.mledger.impl.OpReadEntry - [test/test/persistent/test-partition-1][test-consume] read failed from ledger at position:1358058:0
    118 org.apache.bookkeeper.mledger.ManagedLedgerException: Other exception
    119 Caused by: java.io.IOException: Error reading from BlobStore
    120         at org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedInputStreamImpl.refillBufferIfNeeded(BlobStoreBackedInputStreamImpl.java:91) ~[?:?]
    121         at org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedInputStreamImpl.read(BlobStoreBackedInputStreamImpl.java:99) ~[?:?]
    122         at java.io.DataInputStream.readInt(DataInputStream.java:392) ~[?:?]
    123         at org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedReadHandleImpl.lambda$readAsync$1(BlobStoreBackedReadHandleImpl.java:136) ~[?:?]
    124         at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
    125         at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
    126         at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]
    127         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
    128         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
    129         at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.87.Final.jar:4.1.87.Final]
    130         at java.lang.Thread.run(Thread.java:829) ~[?:?]
    131 Caused by: java.lang.NullPointerException
    132 2023-08-28T02:35:23,545+0000 [broker-topic-workers-OrderedExecutor-5-0] ERROR org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer - [persistent://test/test/test-partition-1 / test-consume -Consumer{subscription=PersistentSubscription{topic=persistent://test/test/test-partition-1, name=test-consume}, consumerId=1, consumerName=07da3, address=/127.0.0.1:39850}] Error reading entries at 1358058:0 : Other exception - Retrying         to read in 27.426 seconds
    133 2023-08-28T02:35:25,999+0000 [offloader-OrderedScheduler-0-0] ERROR org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedReadHandleImpl - Failed to read entries 0 - 0 fro        m the offloader in ledger 1358058
    134 java.io.IOException: Error reading from BlobStore
```

## Modification
Throw a NonRecoverableLedgerException to avoid null pointer. If the user has configured autoSkipNonRecoverableData=true, the caller will skip this ledger. https://github.com/apache/pulsar/blob/66271e3bf3cf0699789c759d852c24e6f00f90cd/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java#L114-L140


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
