### PR TITLE
[fix][broker] Fix starting function worker with tls error

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1888,7 +1888,6 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         workerConfig.setTlsCertificateFilePath(brokerConfig.getTlsCertificateFilePath());
 
         // client in worker will use this config to authenticate with broker
-        // client in worker will use this config to authenticate with broker
         if (isNotBlank(brokerConfig.getBrokerClientAuthenticationPlugin())
                 && isNotBlank(brokerConfig.getBrokerClientAuthenticationParameters())) {
             workerConfig.setBrokerClientAuthenticationEnabled(true);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1766,18 +1766,32 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                                     AuthorizationService authorizationService)
             throws Exception {
         if (functionWorkerService.isPresent()) {
-            if (workerConfig.isUseTls() || brokerServiceUrl == null) {
+            if (isNotBlank(brokerServiceUrlTls)) {
                 workerConfig.setPulsarServiceUrl(brokerServiceUrlTls);
             } else {
                 workerConfig.setPulsarServiceUrl(brokerServiceUrl);
             }
-            if (workerConfig.isUseTls() || webServiceAddress == null) {
+            if (isNotBlank(webServiceAddressTls)) {
                 workerConfig.setPulsarWebServiceUrl(webServiceAddressTls);
                 workerConfig.setFunctionWebServiceUrl(webServiceAddressTls);
             } else {
                 workerConfig.setPulsarWebServiceUrl(webServiceAddress);
                 workerConfig.setFunctionWebServiceUrl(webServiceAddress);
             }
+            workerConfig.setTlsEnabled(config.isTlsEnabled());
+            workerConfig.setTlsAllowInsecureConnection(config.isTlsAllowInsecureConnection());
+            workerConfig.setTlsEnableHostnameVerification(config.isTlsHostnameVerificationEnabled());
+            workerConfig.setTlsTrustCertsFilePath(config.getTlsTrustCertsFilePath());
+            workerConfig.setTlsKeyFilePath(config.getTlsKeyFilePath());
+            workerConfig.setTlsCertificateFilePath(config.getTlsCertificateFilePath());
+            workerConfig.setBrokerClientTrustCertsFilePath(config.getBrokerClientTrustCertsFilePath());
+            if (isNotBlank(config.getBrokerClientAuthenticationPlugin())
+                    && isNotBlank(config.getBrokerClientAuthenticationParameters())) {
+                workerConfig.setBrokerClientAuthenticationEnabled(true);
+            }
+            // client in worker will use this config to authenticate with broker
+            workerConfig.setBrokerClientAuthenticationPlugin(config.getBrokerClientAuthenticationPlugin());
+            workerConfig.setBrokerClientAuthenticationParameters(config.getBrokerClientAuthenticationParameters());
 
             LOG.info("Starting function worker service: serviceUrl = {},"
                 + " webServiceUrl = {}, functionWebServiceUrl = {}",
@@ -1870,8 +1884,15 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         workerConfig.setTlsEnableHostnameVerification(brokerConfig.isTlsHostnameVerificationEnabled());
         workerConfig.setBrokerClientTrustCertsFilePath(brokerConfig.getBrokerClientTrustCertsFilePath());
         workerConfig.setTlsTrustCertsFilePath(brokerConfig.getTlsTrustCertsFilePath());
+        workerConfig.setTlsKeyFilePath(brokerConfig.getTlsKeyFilePath());
+        workerConfig.setTlsCertificateFilePath(brokerConfig.getTlsCertificateFilePath());
 
         // client in worker will use this config to authenticate with broker
+        // client in worker will use this config to authenticate with broker
+        if (isNotBlank(brokerConfig.getBrokerClientAuthenticationPlugin())
+                && isNotBlank(brokerConfig.getBrokerClientAuthenticationParameters())) {
+            workerConfig.setBrokerClientAuthenticationEnabled(true);
+        }
         workerConfig.setBrokerClientAuthenticationPlugin(brokerConfig.getBrokerClientAuthenticationPlugin());
         workerConfig.setBrokerClientAuthenticationParameters(brokerConfig.getBrokerClientAuthenticationParameters());
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerService.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerService.java
@@ -141,6 +141,8 @@ public class PulsarWorkerService implements WorkerService {
                         brokerClientAuthenticationPlugin,
                         brokerClientAuthenticationParameters,
                         workerConfig.getBrokerClientTrustCertsFilePath(),
+                        workerConfig.getTlsKeyFilePath(),
+                        workerConfig.getTlsCertificateFilePath(),
                         workerConfig.isTlsAllowInsecureConnection(),
                         workerConfig.isTlsEnableHostnameVerification(),
                         workerConfig);
@@ -164,6 +166,8 @@ public class PulsarWorkerService implements WorkerService {
                         brokerClientAuthenticationParameters,
                         workerConfig.isUseTls(),
                         workerConfig.getBrokerClientTrustCertsFilePath(),
+                        workerConfig.getTlsKeyFilePath(),
+                        workerConfig.getTlsCertificateFilePath(),
                         workerConfig.isTlsAllowInsecureConnection(),
                         workerConfig.isTlsEnableHostnameVerification(),
                         workerConfig);
@@ -428,10 +432,8 @@ public class PulsarWorkerService implements WorkerService {
                         .buildAdmin();
             }
 
-            final String functionWebServiceUrl = StringUtils.isNotBlank(workerConfig.getFunctionWebServiceUrl())
-                    ? workerConfig.getFunctionWebServiceUrl()
-                    : (workerConfig.getTlsEnabled()
-                        ? workerConfig.getWorkerWebAddressTls() : workerConfig.getWorkerWebAddress());
+            final String functionWebServiceUrl = workerConfig.getTlsEnabled()
+                        ? workerConfig.getWorkerWebAddressTls() : workerConfig.getWorkerWebAddress();
 
             this.brokerAdmin = clientCreator.newPulsarAdmin(workerConfig.getPulsarWebServiceUrl(), workerConfig);
             this.functionAdmin = clientCreator.newPulsarAdmin(functionWebServiceUrl, workerConfig);

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerService.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerService.java
@@ -35,7 +35,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.clients.StorageClientBuilder;
 import org.apache.bookkeeper.clients.admin.StorageAdminClient;
 import org.apache.bookkeeper.clients.config.StorageClientSettings;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.distributedlog.DistributedLogConfiguration;
 import org.apache.distributedlog.api.namespace.Namespace;
 import org.apache.distributedlog.api.namespace.NamespaceBuilder;

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
@@ -282,8 +282,8 @@ public final class WorkerUtils {
                                                String tlsCertificateFilePath,
                                                Boolean allowTlsInsecureConnection,
                                                Boolean enableTlsHostnameVerification) {
-        return getPulsarClient(pulsarServiceUrl, authPlugin, authParams, useTls, tlsTrustCertsFilePath,
-                tlsKeyFilePath, tlsCertificateFilePath, allowTlsInsecureConnection, enableTlsHostnameVerification, null);
+        return getPulsarClient(pulsarServiceUrl, authPlugin, authParams, useTls, tlsTrustCertsFilePath, tlsKeyFilePath,
+                tlsCertificateFilePath, allowTlsInsecureConnection, enableTlsHostnameVerification, null);
     }
 
     public static PulsarClient getPulsarClient(String pulsarServiceUrl, String authPlugin, String authParams,

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
@@ -229,12 +229,16 @@ public final class WorkerUtils {
     }
 
     public static PulsarAdmin getPulsarAdminClient(String pulsarWebServiceUrl, String authPlugin, String authParams,
-                                                   String tlsTrustCertsFilePath, Boolean allowTlsInsecureConnection,
+                                                   String tlsTrustCertsFilePath,
+                                                   String tlsKeyFilePath,
+                                                   String tlsCertificateFilePath,
+                                                   Boolean allowTlsInsecureConnection,
                                                    Boolean enableTlsHostnameVerification,
                                                    WorkerConfig workerConfig) {
-        log.info("Create Pulsar Admin to service url {}: "
+        log.info("Create Pulsar Admin to service url = {}, "
                         + "authPlugin = {}, authParams = {}, "
-                        + "tlsTrustCerts = {}, allowTlsInsecureConnection = {}, enableTlsHostnameVerification = {}",
+                        + "tlsTrustCerts = {}, tlsKeyFilePath = {}, tlsCertificateFilePath = {}, "
+                        + "allowTlsInsecureConnection = {}, enableTlsHostnameVerification = {}",
                 pulsarWebServiceUrl, authPlugin, authParams,
                 tlsTrustCertsFilePath, allowTlsInsecureConnection, enableTlsHostnameVerification);
         try {
@@ -252,6 +256,12 @@ public final class WorkerUtils {
             if (isNotBlank(tlsTrustCertsFilePath)) {
                 adminBuilder.tlsTrustCertsFilePath(tlsTrustCertsFilePath);
             }
+            if (isNotBlank(tlsKeyFilePath)) {
+                adminBuilder.tlsKeyFilePath(tlsKeyFilePath);
+            }
+            if (isNotBlank(tlsCertificateFilePath)) {
+                adminBuilder.tlsCertificateFilePath(tlsCertificateFilePath);
+            }
             if (allowTlsInsecureConnection != null) {
                 adminBuilder.allowTlsInsecureConnection(allowTlsInsecureConnection);
             }
@@ -268,16 +278,20 @@ public final class WorkerUtils {
 
     public static PulsarClient getPulsarClient(String pulsarServiceUrl, String authPlugin, String authParams,
                                                Boolean useTls, String tlsTrustCertsFilePath,
+                                               String tlsKeyFilePath,
+                                               String tlsCertificateFilePath,
                                                Boolean allowTlsInsecureConnection,
-                                               Boolean enableTlsHostnameVerificationEnable) {
+                                               Boolean enableTlsHostnameVerification) {
         return getPulsarClient(pulsarServiceUrl, authPlugin, authParams, useTls, tlsTrustCertsFilePath,
-                allowTlsInsecureConnection, enableTlsHostnameVerificationEnable, null);
+                tlsKeyFilePath, tlsCertificateFilePath, allowTlsInsecureConnection, enableTlsHostnameVerification, null);
     }
 
     public static PulsarClient getPulsarClient(String pulsarServiceUrl, String authPlugin, String authParams,
                                                Boolean useTls, String tlsTrustCertsFilePath,
+                                               String tlsKeyFilePath,
+                                               String tlsCertificateFilePath,
                                                Boolean allowTlsInsecureConnection,
-                                               Boolean enableTlsHostnameVerificationEnable,
+                                               Boolean enableTlsHostnameVerification,
                                                WorkerConfig workerConfig) {
 
         try {
@@ -305,8 +319,14 @@ public final class WorkerUtils {
             if (isNotBlank(tlsTrustCertsFilePath)) {
                 clientBuilder.tlsTrustCertsFilePath(tlsTrustCertsFilePath);
             }
-            if (enableTlsHostnameVerificationEnable != null) {
-                clientBuilder.enableTlsHostnameVerification(enableTlsHostnameVerificationEnable);
+            if (isNotBlank(tlsKeyFilePath)) {
+                clientBuilder.tlsKeyFilePath(tlsKeyFilePath);
+            }
+            if (isNotBlank(tlsCertificateFilePath)) {
+                clientBuilder.tlsCertificateFilePath(tlsCertificateFilePath);
+            }
+            if (enableTlsHostnameVerification != null) {
+                clientBuilder.enableTlsHostnameVerification(enableTlsHostnameVerification);
             }
             return clientBuilder.build();
         } catch (PulsarClientException e) {

--- a/tests/docker-images/latest-version-image/scripts/run-standalone.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-standalone.sh
@@ -18,4 +18,7 @@
 # under the License.
 #
 
+bin/apply-config-from-env.py conf/standalone.conf && \
+    bin/apply-config-from-env.py conf/pulsar_env.sh
+
 bin/pulsar standalone

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/StandaloneContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/StandaloneContainer.java
@@ -31,29 +31,30 @@ public class StandaloneContainer extends PulsarContainer<StandaloneContainer> {
     public static final String NAME = "standalone";
 
     public StandaloneContainer(String clusterName) {
-        super(clusterName,
-            NAME,
-            NAME + "-cluster",
-            "bin/pulsar",
-            BROKER_PORT,
-            BROKER_HTTP_PORT);
+        this(clusterName, DEFAULT_IMAGE_NAME, false);
     }
 
     public StandaloneContainer(String clusterName, String pulsarImageName) {
+        this(clusterName, pulsarImageName, false);
+    }
+
+    public StandaloneContainer(String clusterName, String pulsarImageName, boolean enableTls) {
         super(clusterName,
                 NAME,
                 NAME + "-cluster",
-                "bin/pulsar",
+                "bin/run-standalone.sh",
                 BROKER_PORT,
+                enableTls ? BROKER_PORT_TLS : 0,
                 BROKER_HTTP_PORT,
+                enableTls ? BROKER_HTTPS_PORT : 0,
                 "",
                 pulsarImageName);
+        tailContainerLog();
     }
 
     @Override
     protected void configure() {
         super.configure();
-        setCommand("standalone");
         addEnv("PULSAR_MEM", "-Xms128M -Xmx1g -XX:MaxDirectMemorySize=1g");
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/StandaloneContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/StandaloneContainer.java
@@ -31,7 +31,7 @@ public class StandaloneContainer extends PulsarContainer<StandaloneContainer> {
     public static final String NAME = "standalone";
 
     public StandaloneContainer(String clusterName) {
-        this(clusterName, DEFAULT_IMAGE_NAME, false);
+        this(clusterName, DEFAULT_IMAGE_NAME);
     }
 
     public StandaloneContainer(String clusterName, String pulsarImageName) {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/StandaloneContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/StandaloneContainer.java
@@ -42,19 +42,26 @@ public class StandaloneContainer extends PulsarContainer<StandaloneContainer> {
         super(clusterName,
                 NAME,
                 NAME + "-cluster",
-                "bin/run-standalone.sh",
+                pulsarImageName.endsWith("latest") ? "bin/run-standalone.sh" : "bin/pulsar",
                 BROKER_PORT,
                 enableTls ? BROKER_PORT_TLS : 0,
                 BROKER_HTTP_PORT,
                 enableTls ? BROKER_HTTPS_PORT : 0,
                 "",
                 pulsarImageName);
-        tailContainerLog();
+        if (pulsarImageName.endsWith("latest")) {
+            tailContainerLog();
+        }
     }
+
+
 
     @Override
     protected void configure() {
         super.configure();
+        if (!getDockerImageName().endsWith("latest")) {
+            setCommand("standalone");
+        }
         addEnv("PULSAR_MEM", "-Xms128M -Xmx1g -XX:MaxDirectMemorySize=1g");
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarStandaloneTestSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarStandaloneTestSuite.java
@@ -24,7 +24,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
 public abstract class PulsarStandaloneTestSuite extends PulsarStandaloneTestBase {
-    private final String imageName;
+    protected final String imageName;
 
     protected PulsarStandaloneTestSuite() {
         this(PulsarContainer.DEFAULT_IMAGE_NAME);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarStandaloneTestSuite.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/suites/PulsarStandaloneTestSuite.java
@@ -24,7 +24,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
 public abstract class PulsarStandaloneTestSuite extends PulsarStandaloneTestBase {
-    protected final String imageName;
+    private final String imageName;
 
     protected PulsarStandaloneTestSuite() {
         this(PulsarContainer.DEFAULT_IMAGE_NAME);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/tls/StandaloneWithFunctionTlsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/tls/StandaloneWithFunctionTlsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.tests.integration.tls;
+
+import lombok.Cleanup;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.tests.integration.suites.PulsarStandaloneTestSuite;
+import org.testng.annotations.Test;
+
+public class StandaloneWithFunctionTlsTest extends PulsarStandaloneTestSuite {
+
+    @Override
+    public void setUpCluster() throws Exception {
+        enableTls = true;
+        super.startCluster(imageName);
+    }
+
+    @Test
+    public void testFunctionTls() throws Exception {
+        @Cleanup PulsarAdmin admin = PulsarAdmin.builder()
+                .serviceHttpUrl(container.getHttpsServiceUrl())
+                .tlsTrustCertsFilePath(clientTlsTrustCertsFilePath)
+                .tlsKeyFilePath(clientTlsKeyFilePath)
+                .tlsCertificateFilePath(clientTlsCertificateFilePath)
+                .build();
+        admin.functions().getBuiltInFunctions();
+    }
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/tls/StandaloneWithFunctionTlsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/tls/StandaloneWithFunctionTlsTest.java
@@ -29,7 +29,7 @@ public class StandaloneWithFunctionTlsTest extends PulsarStandaloneTestSuite {
     @Override
     public void setUpCluster() throws Exception {
         enableTls = true;
-        super.startCluster(imageName);
+        super.setUpCluster();
     }
 
     @Test

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarStandaloneTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarStandaloneTestBase.java
@@ -18,8 +18,12 @@
  */
 package org.apache.pulsar.tests.integration.topologies;
 
+import static org.apache.pulsar.tests.integration.containers.PulsarContainer.BROKER_HTTPS_PORT;
+import static org.apache.pulsar.tests.integration.containers.PulsarContainer.BROKER_PORT_TLS;
 import static org.testng.Assert.assertEquals;
 import java.util.function.Supplier;
+
+import com.google.common.io.Resources;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.apache.pulsar.tests.integration.containers.StandaloneContainer;
@@ -37,6 +41,17 @@ import org.testng.annotations.DataProvider;
  */
 @Slf4j
 public abstract class PulsarStandaloneTestBase extends PulsarTestBase {
+
+    protected boolean enableTls = false;
+
+    protected final static String clientTlsTrustCertsFilePath = loadCertificateAuthorityFile("certs/ca.cert.pem");
+    protected final static String clientTlsKeyFilePath = loadCertificateAuthorityFile("client-keys/admin.key-pk8.pem");
+    protected final static String clientTlsCertificateFilePath = loadCertificateAuthorityFile("client-keys/admin.cert.pem");
+
+
+    private static String loadCertificateAuthorityFile(String name) {
+        return Resources.getResource("certificate-authority/" + name).getPath();
+    }
 
     @DataProvider(name = "StandaloneServiceUrlAndTopics")
     public Object[][] serviceUrlAndTopics() {
@@ -79,11 +94,27 @@ public abstract class PulsarStandaloneTestBase extends PulsarTestBase {
     protected void startCluster(final String pulsarImageName) throws Exception {
         network = Network.newNetwork();
         String clusterName = PulsarClusterTestBase.randomName(8);
-        container = new StandaloneContainer(clusterName, pulsarImageName)
+        container = new StandaloneContainer(clusterName, pulsarImageName, enableTls)
             .withNetwork(network)
             .withNetworkAliases(StandaloneContainer.NAME + "-" + clusterName)
             .withEnv("PF_stateStorageServiceUrl", "bk://localhost:4181")
             .withEnv("PULSAR_STANDALONE_USE_ZOOKEEPER", "true");
+        if (enableTls) {
+            container
+                .withEnv("webServicePortTls", String.valueOf(BROKER_HTTPS_PORT))
+                .withEnv("brokerServicePortTls", String.valueOf(BROKER_PORT_TLS))
+                .withEnv("tlsEnabled", "true")
+                .withEnv("tlsRequireTrustedClientCertOnConnect", "true")
+                .withEnv("tlsAllowInsecureConnection", "false")
+                .withEnv("tlsCertificateFilePath", "/pulsar/certificate-authority/server-keys/broker.cert.pem")
+                .withEnv("tlsKeyFilePath", "/pulsar/certificate-authority/server-keys/broker.key-pk8.pem")
+                .withEnv("tlsTrustCertsFilePath", "/pulsar/certificate-authority/certs/ca.cert.pem")
+                .withEnv("brokerClientAuthenticationEnabled", "true")
+                .withEnv("brokerClientAuthenticationPlugin", "org.apache.pulsar.client.impl.auth.AuthenticationTls")
+                .withEnv("brokerClientAuthenticationParameters",
+                        "{\"tlsCertFile\":\"/pulsar/certificate-authority/client-keys/admin.cert.pem\","
+                                + "\"tlsKeyFile\":\"/pulsar/certificate-authority/client-keys/admin.key-pk8.pem\"}");
+        }
         container.start();
         log.info("Pulsar cluster {} is up running:", clusterName);
         log.info("\tBinary Service Url : {}", container.getPlainTextServiceUrl());

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarStandaloneTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarStandaloneTestBase.java
@@ -22,7 +22,6 @@ import static org.apache.pulsar.tests.integration.containers.PulsarContainer.BRO
 import static org.apache.pulsar.tests.integration.containers.PulsarContainer.BROKER_PORT_TLS;
 import static org.testng.Assert.assertEquals;
 import java.util.function.Supplier;
-
 import com.google.common.io.Resources;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarStandaloneTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarStandaloneTestBase.java
@@ -100,15 +100,15 @@ public abstract class PulsarStandaloneTestBase extends PulsarTestBase {
             .withEnv("PULSAR_STANDALONE_USE_ZOOKEEPER", "true");
         if (enableTls) {
             container
-                .withEnv("webServicePortTls", String.valueOf(BROKER_HTTPS_PORT))
-                .withEnv("brokerServicePortTls", String.valueOf(BROKER_PORT_TLS))
+                .withEnv("PULSAR_PREFIX_webServicePortTls", String.valueOf(BROKER_HTTPS_PORT))
+                .withEnv("PULSAR_PREFIX_brokerServicePortTls", String.valueOf(BROKER_PORT_TLS))
                 .withEnv("tlsEnabled", "true")
                 .withEnv("tlsRequireTrustedClientCertOnConnect", "true")
                 .withEnv("tlsAllowInsecureConnection", "false")
                 .withEnv("tlsCertificateFilePath", "/pulsar/certificate-authority/server-keys/broker.cert.pem")
                 .withEnv("tlsKeyFilePath", "/pulsar/certificate-authority/server-keys/broker.key-pk8.pem")
                 .withEnv("tlsTrustCertsFilePath", "/pulsar/certificate-authority/certs/ca.cert.pem")
-                .withEnv("brokerClientAuthenticationEnabled", "true")
+                .withEnv("PULSAR_PREFIX_brokerClientAuthenticationEnabled", "true")
                 .withEnv("brokerClientAuthenticationPlugin", "org.apache.pulsar.client.impl.auth.AuthenticationTls")
                 .withEnv("brokerClientAuthenticationParameters",
                         "{\"tlsCertFile\":\"/pulsar/certificate-authority/client-keys/admin.cert.pem\","


### PR DESCRIPTION
### Motivation



```
2023-09-14T01:09:52,892+0000 [main] ERROR org.apache.pulsar.functions.worker.PulsarWorkerService - Error Starting up in worker
java.lang.NullPointerException: null
        at [java.io](http://java.io/).FileInputStream.<init>(FileInputStream.java:130) ~[?:1.8.0_382]
        at [java.io](http://java.io/).FileInputStream.<init>(FileInputStream.java:93) ~[?:1.8.0_382]
        at org.apache.pulsar.common.util.KeyManagerProxy.updateKeyManager(KeyManagerProxy.java:94) ~[org.apache.pulsar-pulsar-common-2.10.2.jar:2.10.2]
        at org.apache.pulsar.common.util.KeyManagerProxy.<init>(KeyManagerProxy.java:59) ~[org.apache.pulsar-pulsar-common-2.10.2.jar:2.10.2]
        at org.apache.pulsar.common.util.SecurityUtility.createAutoRefreshSslContextForClient(SecurityUtility.java:246) ~[org.apache.pulsar-pulsar-common-2.10.2.jar:2.10.2]
        at org.apache.pulsar.client.admin.internal.http.AsyncHttpConnector.<init>(AsyncHttpConnector.java:150) ~[org.apache.pulsar-pulsar-client-admin-original-2.10.2.jar:2.10.2]
        at org.apache.pulsar.client.admin.internal.http.AsyncHttpConnectorProvider.getConnector(AsyncHttpConnectorProvider.java:52) ~[org.apache.pulsar-pulsar-client-admin-original-2.10.2.jar:2.10.2]
        at org.apache.pulsar.client.admin.internal.PulsarAdminImpl.<init>(PulsarAdminImpl.java:202) ~[org.apache.pulsar-pulsar-client-admin-original-2.10.2.jar:2.10.2]
        at org.apache.pulsar.client.admin.internal.PulsarAdminBuilderImpl.build(PulsarAdminBuilderImpl.java:48) ~[org.apache.pulsar-pulsar-client-admin-original-2.10.2.jar:2.10.2]
        at org.apache.pulsar.functions.worker.WorkerUtils.getPulsarAdminClient(WorkerUtils.java:273) ~[org.apache.pulsar-pulsar-functions-worker-2.10.2.jar:2.10.2]
        at org.apache.pulsar.functions.worker.PulsarWorkerService$1.newPulsarAdmin(PulsarWorkerService.java:131) ~[org.apache.pulsar-pulsar-functions-worker-2.10.2.jar:2.10.2]
        at org.apache.pulsar.functions.worker.PulsarWorkerService.start(PulsarWorkerService.java:437) ~[org.apache.pulsar-pulsar-functions-worker-2.10.2.jar:2.10.2]
        at org.apache.pulsar.broker.PulsarService.startWorkerService(PulsarService.java:1608) ~[org.apache.pulsar-pulsar-broker-2.10.2.jar:2.10.2]
        at org.apache.pulsar.broker.PulsarService.start(PulsarService.java:795) ~[org.apache.pulsar-pulsar-broker-2.10.2.jar:2.10.2]
        at org.apache.pulsar.PulsarStandalone.start(PulsarStandalone.java:301) ~[org.apache.pulsar-pulsar-broker-2.10.2.jar:2.10.2]
        at org.apache.pulsar.PulsarStandaloneStarter.main(PulsarStandaloneStarter.java:143) ~[org.apache.pulsar-pulsar-broker-2.10.2.jar:2.10.2]
2023-09-14T01:09:52,893+0000 [main] ERROR org.apache.pulsar.broker.PulsarService - Failed to start Pulsar service: java.lang.NullPointerException
java.lang.RuntimeException: java.lang.NullPointerException
        at org.apache.pulsar.functions.worker.PulsarWorkerService.start(PulsarWorkerService.java:585) ~[org.apache.pulsar-pulsar-functions-worker-2.10.2.jar:2.10.2]
        at org.apache.pulsar.broker.PulsarService.startWorkerService(PulsarService.java:1608) ~[org.apache.pulsar-pulsar-broker-2.10.2.jar:2.10.2]
        at org.apache.pulsar.broker.PulsarService.start(PulsarService.java:795) ~[org.apache.pulsar-pulsar-broker-2.10.2.jar:2.10.2]
        at org.apache.pulsar.PulsarStandalone.start(PulsarStandalone.java:301) ~[org.apache.pulsar-pulsar-broker-2.10.2.jar:2.10.2]
        at org.apache.pulsar.PulsarStandaloneStarter.main(PulsarStandaloneStarter.java:143) ~[org.apache.pulsar-pulsar-broker-2.10.2.jar:2.10.2]
Caused by: java.lang.NullPointerException
```


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

