### PR TITLE
[fix][broker] Fixed reset for AggregatedNamespaceStats

### DIFF
--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -19,14 +19,14 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.2.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
+    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-broker</artifactId>
@@ -157,7 +157,6 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
-
 
     <!-- zookeeper server -->
     <dependency>
@@ -755,7 +754,7 @@
                     <version>v2</version>
                     <description>This provides the REST API for admin operations</description>
                     <license>
-                      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
                       <name>Apache 2.0</name>
                     </license>
                   </info>
@@ -774,7 +773,7 @@
                     <version>v2</version>
                     <description>This provides the REST API for lookup operations</description>
                     <license>
-                      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
                       <name>Apache 2.0</name>
                     </license>
                   </info>
@@ -793,7 +792,7 @@
                     <version>v3</version>
                     <description>This provides the REST API for Pulsar Functions operations</description>
                     <license>
-                      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
                       <name>Apache 2.0</name>
                     </license>
                   </info>
@@ -812,7 +811,7 @@
                     <version>v3</version>
                     <description>This provides the REST API for Pulsar Transactions operations</description>
                     <license>
-                      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
                       <name>Apache 2.0</name>
                     </license>
                   </info>
@@ -831,7 +830,7 @@
                     <version>v3</version>
                     <description>This provides the REST API for Pulsar Source operations</description>
                     <license>
-                      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
                       <name>Apache 2.0</name>
                     </license>
                   </info>
@@ -850,7 +849,7 @@
                     <version>v3</version>
                     <description>This provides the REST API for Pulsar Sink operations</description>
                     <license>
-                      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
                       <name>Apache 2.0</name>
                     </license>
                   </info>
@@ -869,7 +868,7 @@
                     <version>v3</version>
                     <description>This provides the REST API for Pulsar Packages operations</description>
                     <license>
-                      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
                       <name>Apache 2.0</name>
                     </license>
                   </info>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -19,14 +19,14 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.2.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>pulsar-broker</artifactId>
@@ -157,6 +157,7 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
+
 
     <!-- zookeeper server -->
     <dependency>
@@ -582,6 +583,7 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>${protobuf-maven-plugin.version}</version>
         <configuration>
+          <!--suppress UnresolvedMavenProperty -->
           <protocArtifact>com.google.protobuf:protoc:${protoc3.version}:exe:${os.detected.classifier}</protocArtifact>
           <checkStaleness>true</checkStaleness>
           <excludes>
@@ -753,7 +755,7 @@
                     <version>v2</version>
                     <description>This provides the REST API for admin operations</description>
                     <license>
-                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
                       <name>Apache 2.0</name>
                     </license>
                   </info>
@@ -772,7 +774,7 @@
                     <version>v2</version>
                     <description>This provides the REST API for lookup operations</description>
                     <license>
-                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
                       <name>Apache 2.0</name>
                     </license>
                   </info>
@@ -791,7 +793,7 @@
                     <version>v3</version>
                     <description>This provides the REST API for Pulsar Functions operations</description>
                     <license>
-                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
                       <name>Apache 2.0</name>
                     </license>
                   </info>
@@ -810,7 +812,7 @@
                     <version>v3</version>
                     <description>This provides the REST API for Pulsar Transactions operations</description>
                     <license>
-                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
                       <name>Apache 2.0</name>
                     </license>
                   </info>
@@ -829,7 +831,7 @@
                     <version>v3</version>
                     <description>This provides the REST API for Pulsar Source operations</description>
                     <license>
-                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
                       <name>Apache 2.0</name>
                     </license>
                   </info>
@@ -848,7 +850,7 @@
                     <version>v3</version>
                     <description>This provides the REST API for Pulsar Sink operations</description>
                     <license>
-                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
                       <name>Apache 2.0</name>
                     </license>
                   </info>
@@ -867,7 +869,7 @@
                     <version>v3</version>
                     <description>This provides the REST API for Pulsar Packages operations</description>
                     <license>
-                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
                       <name>Apache 2.0</name>
                     </license>
                   </info>

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedNamespaceStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedNamespaceStats.java
@@ -34,7 +34,7 @@ public class AggregatedNamespaceStats {
     public double throughputIn;
     public double throughputOut;
 
-    public long messageAckRate;
+    public double messageAckRate;
     public long bytesInCounter;
     public long msgInCounter;
     public long bytesOutCounter;
@@ -64,7 +64,7 @@ public class AggregatedNamespaceStats {
     long compactionCompactedEntriesCount;
     long compactionCompactedEntriesSize;
     StatsBuckets compactionLatencyBuckets = new StatsBuckets(CompactionRecord.WRITE_LATENCY_BUCKETS_USEC);
-    int delayedMessageIndexSizeInBytes;
+    long delayedMessageIndexSizeInBytes;
 
     Map<String, TopicMetricBean> bucketDelayedIndexStats = new HashMap<>();
 
@@ -182,14 +182,34 @@ public class AggregatedNamespaceStats {
         rateOut = 0;
         throughputIn = 0;
         throughputOut = 0;
+        messageAckRate = 0;
+        bytesInCounter = 0;
+        msgInCounter = 0;
+
+        bytesOutCounter = 0;
+        msgOutCounter = 0;
 
         msgBacklog = 0;
         msgDelayed = 0;
+        ongoingTxnCount = 0;
+        abortedTxnCount = 0;
+        committedTxnCount = 0;
+
         backlogQuotaLimit = 0;
         backlogQuotaLimitTime = -1;
 
         replicationStats.clear();
         subscriptionStats.clear();
+
+        compactionRemovedEventCount = 0;
+        compactionSucceedCount = 0;
+        compactionFailedCount = 0;
+        compactionDurationTimeInMills = 0;
+        compactionReadThroughput = 0;
+        compactionWriteThroughput = 0;
+        compactionCompactedEntriesCount = 0;
+        compactionCompactedEntriesSize = 0;
+
         delayedMessageIndexSizeInBytes = 0;
         bucketDelayedIndexStats.clear();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/AggregatedNamespaceStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/AggregatedNamespaceStatsTest.java
@@ -20,10 +20,12 @@ package org.apache.pulsar.broker.stats.prometheus;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-
+import java.util.HashMap;
+import org.apache.bookkeeper.mledger.util.StatsBuckets;
+import org.apache.pulsar.common.policies.data.stats.TopicMetricBean;
 import org.testng.annotations.Test;
 
-@Test(groups = "broker")
+@Test(groups = {"broker"})
 public class AggregatedNamespaceStatsTest {
 
     @Test
@@ -155,6 +157,103 @@ public class AggregatedNamespaceStatsTest {
         assertEquals(nsSubStats.msgBacklogNoDelayed, 50);
         assertEquals(nsSubStats.msgRateRedeliver, 2.2);
         assertEquals(nsSubStats.unackedMessages, 2);
+    }
+
+
+    @Test
+    public void testReset() {
+        AggregatedNamespaceStats stats = new AggregatedNamespaceStats();
+        stats.topicsCount = 8;
+        stats.subscriptionsCount = 3;
+        stats.producersCount = 1;
+        stats.consumersCount = 8;
+        stats.rateIn = 1.3;
+        stats.rateOut = 3.5;
+        stats.throughputIn = 3.2;
+        stats.throughputOut = 5.8;
+        stats.messageAckRate = 12;
+        stats.bytesInCounter = 1234;
+        stats.msgInCounter = 3889;
+        stats.bytesOutCounter = 89775;
+        stats.msgOutCounter = 28983;
+        stats.msgBacklog = 39;
+        stats.msgDelayed = 31;
+
+        stats.ongoingTxnCount = 87;
+        stats.abortedTxnCount = 74;
+        stats.committedTxnCount = 34;
+
+        stats.backlogQuotaLimit = 387;
+        stats.backlogQuotaLimitTime = 8771;
+
+        stats.replicationStats = new HashMap<>();
+        stats.replicationStats.put("r", new AggregatedReplicationStats());
+
+        stats.subscriptionStats = new HashMap<>();
+        stats.subscriptionStats.put("r", new AggregatedSubscriptionStats());
+
+        stats.compactionRemovedEventCount = 124;
+        stats.compactionSucceedCount = 487;
+        stats.compactionFailedCount = 84857;
+        stats.compactionDurationTimeInMills = 2384;
+        stats.compactionReadThroughput = 355423;
+        stats.compactionWriteThroughput = 23299;
+        stats.compactionCompactedEntriesCount = 37522;
+        stats.compactionCompactedEntriesSize = 8475;
+
+        stats.compactionLatencyBuckets = new StatsBuckets(5);
+        stats.compactionLatencyBuckets.addValue(3);
+
+        stats.delayedMessageIndexSizeInBytes = 45223;
+
+        stats.bucketDelayedIndexStats = new HashMap<>();
+        stats.bucketDelayedIndexStats.put("t", new TopicMetricBean());
+
+        stats.reset();
+
+        assertEquals(stats.bytesOutCounter, 0);
+        assertEquals(stats.topicsCount, 0);
+        assertEquals(stats.subscriptionsCount, 0);
+        assertEquals(stats.producersCount, 0);
+        assertEquals(stats.consumersCount, 0);
+        assertEquals(stats.rateIn, 0);
+        assertEquals(stats.rateOut, 0);
+        assertEquals(stats.throughputIn, 0);
+        assertEquals(stats.throughputOut, 0);
+        assertEquals(stats.messageAckRate, 0);
+        assertEquals(stats.bytesInCounter, 0);
+        assertEquals(stats.msgInCounter, 0);
+        assertEquals(stats.bytesOutCounter, 0);
+        assertEquals(stats.msgOutCounter, 0);
+
+        assertEquals(stats.managedLedgerStats.storageSize, 0);
+
+        assertEquals(stats.msgBacklog, 0);
+        assertEquals(stats.msgDelayed, 0);
+
+        assertEquals(stats.ongoingTxnCount, 0);
+        assertEquals(stats.abortedTxnCount, 0);
+        assertEquals(stats.committedTxnCount, 0);
+
+        assertEquals(stats.backlogQuotaLimit, 0);
+        assertEquals(stats.backlogQuotaLimitTime, -1);
+
+        assertEquals(stats.replicationStats.size(), 0);
+        assertEquals(stats.subscriptionStats.size(), 0);
+
+        assertEquals(stats.compactionRemovedEventCount, 0);
+        assertEquals(stats.compactionSucceedCount, 0);
+        assertEquals(stats.compactionFailedCount, 0);
+        assertEquals(stats.compactionDurationTimeInMills, 0);
+        assertEquals(stats.compactionReadThroughput, 0);
+        assertEquals(stats.compactionWriteThroughput, 0);
+        assertEquals(stats.compactionCompactedEntriesCount, 0);
+        assertEquals(stats.compactionCompactedEntriesSize, 0);
+
+        assertEquals(stats.compactionLatencyBuckets.getSum(), 0);
+
+        assertEquals(stats.delayedMessageIndexSizeInBytes, 0);
+        assertEquals(stats.bucketDelayedIndexStats.size(), 0);
     }
 
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

AggregatedNamespaceStats is the object used when topic-level metrics are aggregated into namespace level, specifically when `exposeTopicLevelMetricsInPrometheus=false`.
There is a loop which runs over all namespaces, and for each one, the same object is used, by first resetting it and then adding each topic metrics to it. 
The existing `reset()` method lacks all fields hence some fields were accumulating over round of metrics reporting to prometheus metrics servlet, good example for it would be `pulsar_out_bytes_total`.

### Modifications

I've fixed AggregatedNamespaceStats.reset() by including all the fields that were missing from it.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added tests and can be verified as follows:
* Added `testReset()` method. I may add in subsequent PR a more generic way to validate we never forget to reset an added field.
* 
### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/asafm/pulsar/pull/3

