### PR TITLE
[improve][client] Add a way to configure which DNS use

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.api;
 import java.io.Serializable;
 import java.net.InetSocketAddress;
 import java.time.Clock;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -594,6 +595,13 @@ public interface ClientBuilder extends Serializable, Cloneable {
      * @return
      */
     ClientBuilder dnsLookupBind(String address, int port);
+
+    /**
+     * Set dns lookup server addresses.
+     * @param addresses dnsServerAddresses
+     * @return
+     */
+    ClientBuilder dnsServerAddresses(List<InetSocketAddress> addresses);
 
     /**
      *  Set socks5 proxy address.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.impl;
 import static com.google.common.base.Preconditions.checkArgument;
 import java.net.InetSocketAddress;
 import java.time.Clock;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -36,6 +37,7 @@ import org.apache.pulsar.client.api.ServiceUrlProvider;
 import org.apache.pulsar.client.api.SizeUnit;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ConfigurationDataUtils;
+import org.apache.pulsar.common.tls.InetAddressUtils;
 
 public class ClientBuilderImpl implements ClientBuilder {
     ClientConfigurationData conf;
@@ -390,6 +392,17 @@ public class ClientBuilderImpl implements ClientBuilder {
         checkArgument(port >= 0 && port <= 65535, "DnsLookBindPort need to be within the range of 0 and 65535");
         conf.setDnsLookupBindAddress(address);
         conf.setDnsLookupBindPort(port);
+        return this;
+    }
+
+    @Override
+    public ClientBuilder dnsServerAddresses(List<InetSocketAddress> addresses) {
+        for (InetSocketAddress address : addresses) {
+            String ip = address.getHostString();
+            checkArgument(InetAddressUtils.isIPv4Address(ip) || InetAddressUtils.isIPv6Address(ip),
+                    "DnsServerAddresses need to be valid IPv4 or IPv6 addresses");
+        }
+        conf.setDnsServerAddresses(addresses);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
@@ -29,6 +29,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.resolver.AddressResolver;
 import io.netty.resolver.dns.DnsAddressResolverGroup;
 import io.netty.resolver.dns.DnsNameResolverBuilder;
+import io.netty.resolver.dns.SequentialDnsServerAddressStreamProvider;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ScheduledFuture;
 import java.net.InetSocketAddress;
@@ -155,6 +156,10 @@ public class ConnectionPool implements AutoCloseable {
             InetSocketAddress addr = new InetSocketAddress(conf.getDnsLookupBindAddress(),
                     conf.getDnsLookupBindPort());
             dnsNameResolverBuilder.localAddress(addr);
+        }
+        List<InetSocketAddress> serverAddresses = conf.getDnsServerAddresses();
+        if (serverAddresses != null && !serverAddresses.isEmpty()) {
+            dnsNameResolverBuilder.nameServerProvider(new SequentialDnsServerAddressStreamProvider(serverAddresses));
         }
         DnsResolverUtil.applyJdkDnsCacheSettings(dnsNameResolverBuilder);
         // use DnsAddressResolverGroup to create the AddressResolver since it contains a solution

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -19,11 +19,14 @@
 package org.apache.pulsar.client.impl.conf;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.Serializable;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.time.Clock;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -358,6 +361,13 @@ public class ClientConfigurationData implements Serializable, Cloneable {
                     + " default value is 0."
     )
     private int dnsLookupBindPort = 0;
+
+    @ApiModelProperty(
+            name = "dnsServerAddresses",
+            value = "The Pulsar client dns lookup server address"
+    )
+    @SuppressFBWarnings({"EI_EXPOSE_REP2", "EI_EXPOSE_REP"})
+    private List<InetSocketAddress> dnsServerAddresses = new ArrayList<>();
 
     // socks5
     @ApiModelProperty(

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientBuilderImplTest.java
@@ -23,6 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -99,6 +101,17 @@ public class ClientBuilderImplTest {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testClientBuilderWithIllegalLargePort() throws PulsarClientException {
         PulsarClient.builder().dnsLookupBind("localhost", 65536).build();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testClientBuilderWithIllegalDNSServerHostname() throws PulsarClientException {
+        PulsarClient.builder().dnsServerAddresses(
+                Arrays.asList(new InetSocketAddress("1.2.3.4", 53), new InetSocketAddress("localhost",53))).build();
+    }
+
+    public void testClientBuilderWithDNSServerIP() throws PulsarClientException {
+        PulsarClient.builder().dnsServerAddresses(
+                Arrays.asList(new InetSocketAddress("1.2.3.4", 53))).build();
     }
 
     @Test

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientBuilderImplTest.java
@@ -109,6 +109,7 @@ public class ClientBuilderImplTest {
                 Arrays.asList(new InetSocketAddress("1.2.3.4", 53), new InetSocketAddress("localhost",53))).build();
     }
 
+    @Test()
     public void testClientBuilderWithDNSServerIP() throws PulsarClientException {
         PulsarClient.builder().dnsServerAddresses(
                 Arrays.asList(new InetSocketAddress("1.2.3.4", 53))).build();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientBuilderImplTest.java
@@ -106,13 +106,13 @@ public class ClientBuilderImplTest {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testClientBuilderWithIllegalDNSServerHostname() throws PulsarClientException {
         PulsarClient.builder().dnsServerAddresses(
-                Arrays.asList(new InetSocketAddress("1.2.3.4", 53), new InetSocketAddress("localhost",53))).build();
+                Arrays.asList(new InetSocketAddress("1.2.3.4", 53), new InetSocketAddress("localhost",53)));
     }
 
     @Test()
     public void testClientBuilderWithDNSServerIP() throws PulsarClientException {
         PulsarClient.builder().dnsServerAddresses(
-                Arrays.asList(new InetSocketAddress("1.2.3.4", 53))).build();
+                Arrays.asList(new InetSocketAddress("1.2.3.4", 53)));
     }
 
     @Test

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
@@ -37,6 +37,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoopGroup;
+import io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.lang.reflect.Field;
@@ -187,6 +188,16 @@ public class PulsarClientImplTest {
 
         client.shutdown();
         client.timer().stop();
+    }
+
+    @Test
+    public void testInitializeWithDNSServerAddresses() throws Exception {
+        ClientConfigurationData conf = new ClientConfigurationData();
+        conf.setDnsServerAddresses(DefaultDnsServerAddressStreamProvider.defaultAddressList());
+        conf.setServiceUrl("pulsar://localhost:6650");
+        initializeEventLoopGroup(conf);
+        PulsarClientImpl client = new PulsarClientImpl(conf, eventLoopGroup);
+        client.shutdown();
     }
 
     @Test

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
@@ -29,6 +29,8 @@ import static org.testng.Assert.fail;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -61,8 +63,10 @@ public class ConfigurationDataUtilsTest {
         config.put("authParams", "testAuthParams");
         config.put("authParamMap", authParamMap);
         config.put("dnsLookupBindAddress", "0.0.0.0");
-        config.put("dnsLookupBindPort", 0);
-
+        List<InetSocketAddress> dnsServerAddresses = Arrays.asList(new InetSocketAddress[] {
+                new InetSocketAddress("1.1.1.1", 53), new InetSocketAddress("2.2.2.2",100)
+        });
+        config.put("dnsServerAddresses", dnsServerAddresses);
         confData = ConfigurationDataUtils.loadData(config, confData, ClientConfigurationData.class);
         assertEquals("pulsar://localhost:6650", confData.getServiceUrl());
         assertEquals(70000, confData.getMaxLookupRequest());
@@ -73,6 +77,7 @@ public class ConfigurationDataUtilsTest {
         assertEquals("v2", confData.getAuthParamMap().get("k2"));
         assertEquals("0.0.0.0", confData.getDnsLookupBindAddress());
         assertEquals(0, confData.getDnsLookupBindPort());
+        assertEquals(dnsServerAddresses, confData.getDnsServerAddresses());
     }
 
     @Test

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
@@ -63,6 +63,7 @@ public class ConfigurationDataUtilsTest {
         config.put("authParams", "testAuthParams");
         config.put("authParamMap", authParamMap);
         config.put("dnsLookupBindAddress", "0.0.0.0");
+        config.put("dnsLookupBindPort", 0);
         List<InetSocketAddress> dnsServerAddresses = Arrays.asList(new InetSocketAddress[] {
                 new InetSocketAddress("1.1.1.1", 53), new InetSocketAddress("2.2.2.2",100)
         });


### PR DESCRIPTION
This closes #21226


### Motivation

Currently is not possibile to configure one or more dns servers that will be used by the client to resolve hostnames.

### Modifications

Added an optional configuration ClientConfigurationData.dnsServerAddresses to allow to configure custom DNSs. It not provided or empty will default to the existing behaviour.
Handled the new conf in ConnectionPool.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change added tests and can be verified as follows:
  - *Added unit test on ClientBuilderImplTest with configuration of both good or wrong dns servers*
  - *Added integration test on PulsarClientImplTest with a custom configured dns servers list*
  - *Added unit test on ConfigurationDataUtilsTest about the new configuration loading*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
