### PR TITLE
[improve][broker] Avoid potential inconsistent topic policy

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -1237,7 +1237,11 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
     /**
      * Get {@link TopicPolicies} for this topic.
      * @return TopicPolicies, if they exist. Otherwise, the value will not be present.
+     * @throws RuntimeException Undefined exception
+     * @deprecated This API deprecated by undefined exception and blocking call.
      */
+
+    @Deprecated
     public Optional<TopicPolicies> getTopicPolicies() {
         return brokerService.getTopicPolicies(TopicName.get(topic));
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -3414,19 +3414,25 @@ public class BrokerService implements Closeable {
     public @Nonnull CompletionStage<Boolean> isAllowAutoSubscriptionCreationAsync(@Nonnull TopicName tpName) {
         requireNonNull(tpName);
         // topic level policies
-        final var topicPolicies = getTopicPolicies(tpName);
-        if (topicPolicies.isPresent() && topicPolicies.get().getAutoSubscriptionCreationOverride() != null) {
-            return CompletableFuture.completedFuture(topicPolicies.get().getAutoSubscriptionCreationOverride()
-                    .isAllowAutoSubscriptionCreation());
-        }
-        // namespace level policies
-        return pulsar.getPulsarResources().getNamespaceResources().getPoliciesAsync(tpName.getNamespaceObject())
-                .thenApply(policies -> {
-                    if (policies.isPresent() && policies.get().autoSubscriptionCreationOverride != null) {
-                        return policies.get().autoSubscriptionCreationOverride.isAllowAutoSubscriptionCreation();
+        return pulsar.getTopicPoliciesService()
+                .getTopicPoliciesAsyncWithRetry(tpName, null, executor(), false)
+                .thenCompose(topicPoliciesOptional -> {
+                    if (topicPoliciesOptional .isPresent() &&
+                        topicPoliciesOptional .get().getAutoSubscriptionCreationOverride() != null) {
+                        return CompletableFuture.completedFuture(topicPoliciesOptional
+                                .get().getAutoSubscriptionCreationOverride().isAllowAutoSubscriptionCreation());
                     }
-                    // broker level policies
-                    return pulsar.getConfiguration().isAllowAutoSubscriptionCreation();
+                    // namespace level policies
+                    return pulsar.getPulsarResources().getNamespaceResources()
+                            .getPoliciesAsync(tpName.getNamespaceObject())
+                            .thenApply(policies -> {
+                                if (policies.isPresent() && policies.get().autoSubscriptionCreationOverride != null) {
+                                    return policies.get()
+                                            .autoSubscriptionCreationOverride.isAllowAutoSubscriptionCreation();
+                                }
+                                // broker level policies
+                                return pulsar.getConfiguration().isAllowAutoSubscriptionCreation();
+                            });
                 });
     }
 
@@ -3443,13 +3449,20 @@ public class BrokerService implements Closeable {
      * Get {@link TopicPolicies} for the parameterized topic.
      * @param topicName
      * @return TopicPolicies, if they exist. Otherwise, the value will not be present.
+     * @deprecated This API deprecated by undefined exception and blocking call.
      */
+    @Deprecated
     public Optional<TopicPolicies> getTopicPolicies(TopicName topicName) {
         if (!pulsar().getConfig().isTopicLevelPoliciesEnabled()) {
             return Optional.empty();
         }
-        return Optional.ofNullable(pulsar.getTopicPoliciesService()
-                .getTopicPoliciesIfExists(topicName));
+        try {
+            return pulsar.getTopicPoliciesService()
+                    .getTopicPoliciesAsyncWithRetry(topicName, null, executor(), false)
+                    .get(pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
+        } catch (Throwable ex) {
+            throw new RuntimeException(ex);
+        }
     }
 
     public CompletableFuture<Void> deleteTopicPolicies(TopicName topicName) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -501,7 +501,6 @@ public class TransactionTest extends TransactionTestBase {
                     log.error("Failed to getTopicPolicies of :" + originPersistentTopic);
                     Assert.fail();
                 }
-                TopicPolicies topicPolicies = originPersistentTopic.getTopicPolicies().get();
                 Assert.assertEquals(retentionSizeInMbSetTopic, retentionSize);
                 MLPendingAckStoreProvider mlPendingAckStoreProvider = new MLPendingAckStoreProvider();
                 CompletableFuture<PendingAckStore> future = mlPendingAckStoreProvider.newPendingAckStore(subscription);


### PR DESCRIPTION
### Motivation

Follow up #21231, avoid getting policy directly by cache in broker service.

### Modifications

- Avoid getting topic policy directly in the broker service. It will leave potential bugs by inconsistent topic policies.
- Deprecate some methods by undefined exceptions and blocking calls.
   - AbstractTopic#getTopicPolicies();
   - BrokerService#getTopicPolicies(TopicName topicName);
- Let BrokerService#isAllowAutoSubscriptionCreationAsync use async method to get topic policies.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
