### PR TITLE
[fix][broker] Miss headersAndPayload and messageIdData in MessagePubl…

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1752,17 +1752,15 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             return;
         }
 
-        // This position is only used for shadow replicator
-        Position position = send.hasMessageId()
-                ? PositionImpl.get(send.getMessageId().getLedgerId(), send.getMessageId().getEntryId()) : null;
+        MessageIdData messageIdData = send.hasMessageId() ? send.getMessageId() : null;
 
         // Persist the message
         if (send.hasHighestSequenceId() && send.getSequenceId() <= send.getHighestSequenceId()) {
             producer.publishMessage(send.getProducerId(), send.getSequenceId(), send.getHighestSequenceId(),
-                    headersAndPayload, send.getNumMessages(), send.isIsChunk(), send.isMarker(), position);
+                    headersAndPayload, send.getNumMessages(), send.isIsChunk(), send.isMarker(), messageIdData);
         } else {
             producer.publishMessage(send.getProducerId(), send.getSequenceId(), headersAndPayload,
-                    send.getNumMessages(), send.isIsChunk(), send.isMarker(), position);
+                    send.getNumMessages(), send.isIsChunk(), send.isMarker(), messageIdData);
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -35,6 +35,7 @@ import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.KeySharedMeta;
+import org.apache.pulsar.common.api.proto.MessageIdData;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
 import org.apache.pulsar.common.policies.data.EntryFilters;
@@ -126,6 +127,14 @@ public interface Topic {
 
         default void setEntryTimestamp(long entryTimestamp) {
 
+        }
+
+        default MessageIdData getMessageIdData() {
+            return null;
+        }
+
+        default ByteBuf getHeaderAndPayload() {
+            return null;
         }
     }
 


### PR DESCRIPTION
### Motivation

We have a scenario that uses the `org.apache.pulsar.broker.intercept.BrokerInterceptor#messageProduced`, and need to obtain the complete message id and metadata, but the `org.apache.pulsar.broker.service.Topic.PublishContext` doesn't include these data.

### Modifications

- Add  `getMessageIdData()` to `org.apache.pulsar.broker.service.Topic.PublishContext` to obtain the complete message id
- Add  `getHeaderAndPayload()` to `org.apache.pulsar.broker.service.Topic.PublishContext` to obtain the message metadata

### Verifying this change


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
