### PR TITLE
[improve][txn][PIP-298] Consumer supports specifying consumption isolation level

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -124,6 +124,7 @@ import org.apache.pulsar.common.api.proto.CommandSeek;
 import org.apache.pulsar.common.api.proto.CommandSend;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
+import org.apache.pulsar.common.api.proto.CommandSubscribe.IsolationLevel;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.CommandTcClientConnectRequest;
 import org.apache.pulsar.common.api.proto.CommandTopicMigrated.ResourceType;
@@ -1145,6 +1146,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
               ? new KeySharedMeta().copyFrom(subscribe.getKeySharedMeta())
               : emptyKeySharedMeta;
         final long consumerEpoch = subscribe.hasConsumerEpoch() ? subscribe.getConsumerEpoch() : DEFAULT_CONSUMER_EPOCH;
+        final IsolationLevel isolationLevel = subscribe.getIsolationLevel();
         final Optional<Map<String, String>> subscriptionProperties = SubscriptionOption.getPropertiesMap(
                 subscribe.getSubscriptionPropertiesList());
 
@@ -1251,6 +1253,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                                 .subscriptionProperties(subscriptionProperties)
                                                 .consumerEpoch(consumerEpoch)
                                                 .schemaType(schema == null ? null : schema.getType())
+                                                .isolationLevel(isolationLevel)
                                                 .build();
                                         if (schema != null && schema.getType() != SchemaType.AUTO_CONSUME) {
                                             return topic.addSchemaIfIdleOrCheckCompatible(schema)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
@@ -27,6 +27,7 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import org.apache.pulsar.common.api.proto.CommandAck.AckType;
+import org.apache.pulsar.common.api.proto.CommandSubscribe.IsolationLevel;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.ReplicatedSubscriptionsSnapshot;
 
@@ -95,6 +96,8 @@ public interface Subscription extends MessageExpirer {
     SubType getType();
 
     String getTypeString();
+
+    IsolationLevel getIsolationLevel();
 
     void addUnAckedMessages(int unAckMessages);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SubscriptionOption.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SubscriptionOption.java
@@ -45,6 +45,7 @@ public class SubscriptionOption {
     private Map<String, String> metadata;
     private boolean readCompacted;
     private CommandSubscribe.InitialPosition initialPosition;
+    private CommandSubscribe.IsolationLevel isolationLevel;
     private long startMessageRollbackDurationSec;
     private boolean replicatedSubscriptionStateArg;
     private KeySharedMeta keySharedMeta;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -33,6 +33,7 @@ import org.apache.pulsar.broker.stats.NamespaceStats;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
+import org.apache.pulsar.common.api.proto.CommandSubscribe.IsolationLevel;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.KeySharedMeta;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
@@ -170,7 +171,8 @@ public interface Topic {
                                           Map<String, String> metadata, boolean readCompacted,
                                           InitialPosition initialPosition,
                                           long startMessageRollbackDurationSec, boolean replicateSubscriptionState,
-                                          KeySharedMeta keySharedMeta);
+                                          KeySharedMeta keySharedMeta,
+                                          IsolationLevel isolationLevel);
 
     /**
      * Subscribe a topic.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -41,6 +41,7 @@ import org.apache.pulsar.broker.service.Dispatcher;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.common.api.proto.CommandAck.AckType;
+import org.apache.pulsar.common.api.proto.CommandSubscribe.IsolationLevel;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.KeySharedMeta;
 import org.apache.pulsar.common.api.proto.KeySharedMode;
@@ -70,6 +71,8 @@ public class NonPersistentSubscription extends AbstractSubscription implements S
 
     private KeySharedMode keySharedMode = null;
 
+    private final IsolationLevel isolationLevel;
+
     public NonPersistentSubscription(NonPersistentTopic topic, String subscriptionName,
                                      Map<String, String> properties) {
         this.topic = topic;
@@ -79,6 +82,7 @@ public class NonPersistentSubscription extends AbstractSubscription implements S
         IS_FENCED_UPDATER.set(this, FALSE);
         this.subscriptionProperties = properties != null
                 ? Collections.unmodifiableMap(properties) : Collections.emptyMap();
+        this.isolationLevel = fetchIsolationLevelFromProperties(properties);
     }
 
     @Override
@@ -234,6 +238,11 @@ public class NonPersistentSubscription extends AbstractSubscription implements S
         }
 
         return "Null";
+    }
+
+    @Override
+    public IsolationLevel getIsolationLevel() {
+        return this.isolationLevel;
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -472,6 +472,7 @@ public class NonPersistentSubscription extends AbstractSubscription implements S
 
         subStats.type = getTypeString();
         subStats.msgDropRate = dispatcher.getMessageDropRate().getValueRate();
+        subStats.subscriptionIsolationLevel = this.isolationLevel.toString();
 
         KeySharedMode keySharedMode = this.keySharedMode;
         if (getType() == SubType.Key_Shared && keySharedMode != null) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -358,7 +358,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
 
     private PositionImpl getMaxReadPosition() {
         return subscription.getIsolationLevel() == IsolationLevel.READ_COMMITTED ?
-                topic.getMaxReadPosition() : PositionImpl.LATEST;
+                topic.getMaxReadPosition() : (PositionImpl) topic.getManagedLedger().getLastConfirmedEntry();
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -52,6 +52,7 @@ import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter.Type;
 import org.apache.pulsar.broker.transaction.exception.buffer.TransactionBufferException;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.impl.Backoff;
+import org.apache.pulsar.common.api.proto.CommandSubscribe.IsolationLevel;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.compaction.CompactedTopicUtils;
@@ -356,7 +357,7 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
                     ReadEntriesCtx readEntriesCtx =
                             ReadEntriesCtx.create(consumer, consumer.getConsumerEpoch());
                     cursor.asyncReadEntriesOrWait(messagesToRead,
-                            bytesToRead, this, readEntriesCtx, topic.getMaxReadPosition());
+                            bytesToRead, this, readEntriesCtx, getMaxReadPosition());
                 }
             }
         } else {
@@ -364,6 +365,11 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
                 log.debug("[{}-{}] Consumer buffer is full, pause reading", name, consumer);
             }
         }
+    }
+
+    private PositionImpl getMaxReadPosition() {
+        return subscription.getIsolationLevel() == IsolationLevel.READ_COMMITTED ?
+                topic.getMaxReadPosition() : PositionImpl.LATEST;
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -369,7 +369,7 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
 
     private PositionImpl getMaxReadPosition() {
         return subscription.getIsolationLevel() == IsolationLevel.READ_COMMITTED ?
-                topic.getMaxReadPosition() : PositionImpl.LATEST;
+                topic.getMaxReadPosition() : (PositionImpl) topic.getManagedLedger().getLastConfirmedEntry();
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -77,6 +77,7 @@ import org.apache.pulsar.broker.transaction.pendingack.impl.PendingAckHandleImpl
 import org.apache.pulsar.client.api.Range;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.api.proto.CommandAck.AckType;
+import org.apache.pulsar.common.api.proto.CommandSubscribe.IsolationLevel;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.KeySharedMeta;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
@@ -127,6 +128,7 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
     private volatile ReplicatedSubscriptionSnapshotCache replicatedSubscriptionSnapshotCache;
     private final PendingAckHandle pendingAckHandle;
     private volatile Map<String, String> subscriptionProperties;
+    private final IsolationLevel subscriptionIsolationLevel;
     private volatile CompletableFuture<Void> fenceFuture;
 
     static Map<String, Long> getBaseCursorProperties(boolean isReplicated) {
@@ -160,6 +162,7 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
             this.pendingAckHandle = new PendingAckHandleDisabled();
         }
         IS_FENCED_UPDATER.set(this, FALSE);
+        this.subscriptionIsolationLevel = fetchIsolationLevelFromProperties(subscriptionProperties);
     }
 
     public void updateLastMarkDeleteAdvancedTimestamp() {
@@ -504,6 +507,11 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
         }
 
         return "Null";
+    }
+
+    @Override
+    public IsolationLevel getIsolationLevel() {
+        return subscriptionIsolationLevel;
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -128,7 +128,7 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
     private volatile ReplicatedSubscriptionSnapshotCache replicatedSubscriptionSnapshotCache;
     private final PendingAckHandle pendingAckHandle;
     private volatile Map<String, String> subscriptionProperties;
-    private final IsolationLevel subscriptionIsolationLevel;
+    private final IsolationLevel isolationLevel;
     private volatile CompletableFuture<Void> fenceFuture;
 
     static Map<String, Long> getBaseCursorProperties(boolean isReplicated) {
@@ -162,7 +162,7 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
             this.pendingAckHandle = new PendingAckHandleDisabled();
         }
         IS_FENCED_UPDATER.set(this, FALSE);
-        this.subscriptionIsolationLevel = fetchIsolationLevelFromProperties(subscriptionProperties);
+        this.isolationLevel = fetchIsolationLevelFromProperties(subscriptionProperties);
     }
 
     public void updateLastMarkDeleteAdvancedTimestamp() {
@@ -511,7 +511,7 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
 
     @Override
     public IsolationLevel getIsolationLevel() {
-        return subscriptionIsolationLevel;
+        return isolationLevel;
     }
 
     @Override
@@ -1195,6 +1195,7 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
         subStats.isReplicated = isReplicated();
         subStats.subscriptionProperties = subscriptionProperties;
         subStats.isDurable = cursor.isDurable();
+        subStats.subscriptionIsolationLevel = this.isolationLevel.toString();
         if (getType() == SubType.Key_Shared && dispatcher instanceof PersistentStickyKeyDispatcherMultipleConsumers) {
             PersistentStickyKeyDispatcherMultipleConsumers keySharedDispatcher =
                     (PersistentStickyKeyDispatcherMultipleConsumers) dispatcher;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractSubscriptionTest.java
@@ -22,7 +22,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import org.apache.pulsar.common.api.proto.CommandSubscribe.IsolationLevel;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -53,5 +59,14 @@ public class AbstractSubscriptionTest {
         subscription.bytesOutFromRemovedConsumers.add(1L);
         when(consumer.getBytesOutCounter()).thenReturn(2L);
         assertEquals(subscription.getBytesOutCounter(), 3L);
+    }
+
+    @Test
+    public void testWrapAndFetchIsolationLevelInProperties() {
+        Map<String, String> properties = new HashMap<>(1);
+        AbstractSubscription.wrapIsolationLevelToProperties(properties, IsolationLevel.READ_UNCOMMITTED);
+        assertTrue(properties.containsKey(AbstractSubscription.SUBSCRIPTION_ISOLATION_LEVEL_PROPERTY));
+        assertEquals(Integer.valueOf(properties.get(AbstractSubscription.SUBSCRIPTION_ISOLATION_LEVEL_PROPERTY)),
+                IsolationLevel.READ_UNCOMMITTED.getValue());
     }
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
@@ -136,4 +136,7 @@ public interface SubscriptionStats {
     long getFilterRescheduledMsgCount();
 
     long getDelayedMessageIndexSizeInBytes();
+
+    /** The subscription isolationLevel as defined by {@link org.apache.pulsar.client.api.SubscriptionIsolationLevel}. */
+    String getSubscriptionIsolationLevel();
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -832,6 +832,16 @@ public interface ConsumerBuilder<T> extends Cloneable {
     ConsumerBuilder<T> autoScaledReceiverQueueSizeEnabled(boolean enabled);
 
     /**
+     * Sets the {@link SubscriptionIsolationLevel} for the consumer.
+     *
+     * @param subscriptionIsolationLevel If READ_COMMITTED is selected, the Consumer can only consume all transactional messages which have been committed,
+     *                                   else if READ_UNCOMMITTED is selected, the Consumer can consume all messages, even transactional messages which have been aborted.
+     *                                   Note that this is a subscription dimension configuration, and all consumers under the same subscription need to be configured with the same IsolationLevel.
+     * @return the consumer builder instance
+     */
+    ConsumerBuilder<T> subscriptionIsolationLevel(SubscriptionIsolationLevel subscriptionIsolationLevel);
+
+    /**
      * Configure topic specific options to override those set at the {@link ConsumerBuilder} level.
      *
      * @param topicName a topic name

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/SubscriptionIsolationLevel.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/SubscriptionIsolationLevel.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import org.apache.pulsar.common.classification.InterfaceAudience;
+import org.apache.pulsar.common.classification.InterfaceStability;
+
+/**
+ * When creating a consumer, if the subscription does not exist, a new subscription will be created.
+ * The default isolation level for Subscription is 'READ_COMMITTED'.
+ * See {@link #subscriptionIsolationLevel(SubscriptionIsolationLevel)} to configure the isolation level behavior.
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Stable
+public enum SubscriptionIsolationLevel {
+    // Consumer can only consume all transactional messages which have been committed.
+    READ_COMMITTED(0),
+
+    // Consumer can consume all messages, even transactional messages which have been aborted.
+    READ_UNCOMMITTED(1);
+
+    private final int value;
+
+    SubscriptionIsolationLevel(int value) {
+        this.value = value;
+    }
+
+    public final int getValue() {
+        return value;
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -50,6 +50,7 @@ import org.apache.pulsar.client.api.RedeliveryBackoff;
 import org.apache.pulsar.client.api.RegexSubscriptionMode;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionIsolationLevel;
 import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.TopicConsumerBuilder;
@@ -536,6 +537,12 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     @Override
     public ConsumerBuilder<T> autoScaledReceiverQueueSizeEnabled(boolean enabled) {
         conf.setAutoScaledReceiverQueueSizeEnabled(enabled);
+        return this;
+    }
+
+    @Override
+    public ConsumerBuilder<T> subscriptionIsolationLevel(SubscriptionIsolationLevel subscriptionIsolationLevel) {
+        conf.setSubscriptionIsolationLevel(subscriptionIsolationLevel);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -49,6 +49,7 @@ import org.apache.pulsar.client.api.RegexSubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.SubscriptionIsolationLevel;
 
 @Data
 @NoArgsConstructor
@@ -397,6 +398,14 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
     private boolean startPaused = false;
 
     private boolean autoScaledReceiverQueueSizeEnabled = false;
+
+    @ApiModelProperty(
+            name = "IsolationLevel",
+            value = "Consumer can specify subscription IsolationLevel.\n" +
+                    "If READ_COMMITTED is selected, the Consumer can only consume all transactional messages which have been committed.\n" +
+                    "If READ_UNCOMMITTED is selected, the Consumer can consume all messages, even transactional messages which have been aborted."
+    )
+    private SubscriptionIsolationLevel subscriptionIsolationLevel = SubscriptionIsolationLevel.READ_COMMITTED;
 
     private List<TopicConsumerConfigurationData> topicConfigurations = new ArrayList<>();
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerBuilderImplTest.java
@@ -52,6 +52,7 @@ import org.apache.pulsar.client.api.RedeliveryBackoff;
 import org.apache.pulsar.client.api.RegexSubscriptionMode;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionIsolationLevel;
 import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
@@ -441,7 +442,8 @@ public class ConsumerBuilderImplTest {
             + "    'ackReceiptEnabled' : true,\n"
             + "    'poolMessages' : true,\n"
             + "    'startPaused' : true,\n"
-            + "    'autoScaledReceiverQueueSizeEnabled' : true\n"
+            + "    'autoScaledReceiverQueueSizeEnabled' : true,\n"
+            + "    'subscriptionIsolationLevel' : 'READ_UNCOMMITTED'\n"
             + "  }").replace("'", "\"");
 
         Map<String, Object> conf = new ObjectMapper().readValue(jsonConf, new TypeReference<HashMap<String,Object>>() {});
@@ -498,6 +500,7 @@ public class ConsumerBuilderImplTest {
         assertEquals(configurationData.getDeadLetterPolicy().getRetryLetterTopic(), "new-retry");
         assertEquals(configurationData.getDeadLetterPolicy().getInitialSubscriptionName(), "new-dlq-sub");
         assertEquals(configurationData.getDeadLetterPolicy().getMaxRedeliverCount(), 2);
+        assertEquals(configurationData.getSubscriptionIsolationLevel(), SubscriptionIsolationLevel.READ_UNCOMMITTED);
         assertTrue(configurationData.isRetryEnable());
         assertFalse(configurationData.isAutoUpdatePartitions());
         assertEquals(configurationData.getAutoUpdatePartitionsIntervalSeconds(), 2);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
@@ -149,6 +149,11 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
 
     public long filterRescheduledMsgCount;
 
+    /**
+     * The subscription isolationLevel as defined by {@link org.apache.pulsar.client.api.SubscriptionIsolationLevel}.
+     */
+    public String subscriptionIsolationLevel;
+
     public SubscriptionStatsImpl() {
         this.consumers = new ArrayList<>();
         this.consumersAfterMarkDeletePosition = new LinkedHashMap<>();
@@ -185,6 +190,7 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
         filterRejectedMsgCount = 0;
         filterRescheduledMsgCount = 0;
         bucketDelayedIndexStats.clear();
+        subscriptionIsolationLevel = null;
     }
 
     // if the stats are added for the 1st time, we will need to make a copy of these stats and add it to the current
@@ -239,6 +245,7 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
         this.filterAcceptedMsgCount += stats.filterAcceptedMsgCount;
         this.filterRejectedMsgCount += stats.filterRejectedMsgCount;
         this.filterRescheduledMsgCount += stats.filterRescheduledMsgCount;
+        this.subscriptionIsolationLevel = stats.subscriptionIsolationLevel;
         stats.bucketDelayedIndexStats.forEach((k, v) -> {
             TopicMetricBean topicMetricBean =
                     this.bucketDelayedIndexStats.computeIfAbsent(k, __ -> new TopicMetricBean());

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -84,6 +84,7 @@ import org.apache.pulsar.common.api.proto.CommandSeek;
 import org.apache.pulsar.common.api.proto.CommandSend;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
+import org.apache.pulsar.common.api.proto.CommandSubscribe.IsolationLevel;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.CommandTcClientConnectResponse;
 import org.apache.pulsar.common.api.proto.CommandTopicMigrated.ResourceType;
@@ -573,18 +574,18 @@ public class Commands {
         return newSubscribe(topic, subscription, consumerId, requestId, subType, priorityLevel, consumerName,
                 true /* isDurable */, null /* startMessageId */, Collections.emptyMap(), false,
                 false /* isReplicated */, InitialPosition.Earliest, resetStartMessageBackInSeconds, null,
-                true /* createTopicIfDoesNotExist */);
+                true /* createTopicIfDoesNotExist */, IsolationLevel.READ_COMMITTED);
     }
 
     public static ByteBuf newSubscribe(String topic, String subscription, long consumerId, long requestId,
             SubType subType, int priorityLevel, String consumerName, boolean isDurable, MessageIdData startMessageId,
             Map<String, String> metadata, boolean readCompacted, boolean isReplicated,
             InitialPosition subscriptionInitialPosition, long startMessageRollbackDurationInSec, SchemaInfo schemaInfo,
-            boolean createTopicIfDoesNotExist) {
+            boolean createTopicIfDoesNotExist, IsolationLevel isolationLevel) {
         return newSubscribe(topic, subscription, consumerId, requestId, subType, priorityLevel, consumerName,
                 isDurable, startMessageId, metadata, readCompacted, isReplicated, subscriptionInitialPosition,
                 startMessageRollbackDurationInSec, schemaInfo, createTopicIfDoesNotExist, null,
-                Collections.emptyMap(), DEFAULT_CONSUMER_EPOCH);
+                Collections.emptyMap(), DEFAULT_CONSUMER_EPOCH, isolationLevel);
     }
 
     public static ByteBuf newSubscribe(String topic, String subscription, long consumerId, long requestId,
@@ -592,7 +593,7 @@ public class Commands {
                Map<String, String> metadata, boolean readCompacted, boolean isReplicated,
                InitialPosition subscriptionInitialPosition, long startMessageRollbackDurationInSec,
                SchemaInfo schemaInfo, boolean createTopicIfDoesNotExist, KeySharedPolicy keySharedPolicy,
-               Map<String, String> subscriptionProperties, long consumerEpoch) {
+               Map<String, String> subscriptionProperties, long consumerEpoch, IsolationLevel isolationLevel) {
         BaseCommand cmd = localCmd(Type.SUBSCRIBE);
         CommandSubscribe subscribe = cmd.setSubscribe()
                 .setTopic(topic)
@@ -607,7 +608,8 @@ public class Commands {
                 .setInitialPosition(subscriptionInitialPosition)
                 .setReplicateSubscriptionState(isReplicated)
                 .setForceTopicCreation(createTopicIfDoesNotExist)
-                .setConsumerEpoch(consumerEpoch);
+                .setConsumerEpoch(consumerEpoch)
+                .setIsolationLevel(isolationLevel);
 
         if (subscriptionProperties != null && !subscriptionProperties.isEmpty()) {
             List<KeyValue> keyValues = new ArrayList<>();

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -570,7 +570,7 @@ public class Commands {
     }
 
     public static ByteBuf newSubscribe(String topic, String subscription, long consumerId, long requestId,
-            SubType subType, int priorityLevel, String consumerName, long resetStartMessageBackInSeconds) {
+                                       SubType subType, int priorityLevel, String consumerName, long resetStartMessageBackInSeconds) {
         return newSubscribe(topic, subscription, consumerId, requestId, subType, priorityLevel, consumerName,
                 true /* isDurable */, null /* startMessageId */, Collections.emptyMap(), false,
                 false /* isReplicated */, InitialPosition.Earliest, resetStartMessageBackInSeconds, null,
@@ -578,10 +578,19 @@ public class Commands {
     }
 
     public static ByteBuf newSubscribe(String topic, String subscription, long consumerId, long requestId,
-            SubType subType, int priorityLevel, String consumerName, boolean isDurable, MessageIdData startMessageId,
-            Map<String, String> metadata, boolean readCompacted, boolean isReplicated,
-            InitialPosition subscriptionInitialPosition, long startMessageRollbackDurationInSec, SchemaInfo schemaInfo,
-            boolean createTopicIfDoesNotExist, IsolationLevel isolationLevel) {
+                                       SubType subType, int priorityLevel, String consumerName, long resetStartMessageBackInSeconds,
+                                       IsolationLevel isolationLevel) {
+        return newSubscribe(topic, subscription, consumerId, requestId, subType, priorityLevel, consumerName,
+                true /* isDurable */, null /* startMessageId */, Collections.emptyMap(), false,
+                false /* isReplicated */, InitialPosition.Earliest, resetStartMessageBackInSeconds, null,
+                true /* createTopicIfDoesNotExist */, isolationLevel);
+    }
+
+    public static ByteBuf newSubscribe(String topic, String subscription, long consumerId, long requestId,
+                                       SubType subType, int priorityLevel, String consumerName, boolean isDurable, MessageIdData startMessageId,
+                                       Map<String, String> metadata, boolean readCompacted, boolean isReplicated,
+                                       InitialPosition subscriptionInitialPosition, long startMessageRollbackDurationInSec, SchemaInfo schemaInfo,
+                                       boolean createTopicIfDoesNotExist, IsolationLevel isolationLevel) {
         return newSubscribe(topic, subscription, consumerId, requestId, subType, priorityLevel, consumerName,
                 isDurable, startMessageId, metadata, readCompacted, isReplicated, subscriptionInitialPosition,
                 startMessageRollbackDurationInSec, schemaInfo, createTopicIfDoesNotExist, null,

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -399,6 +399,14 @@ message CommandSubscribe {
 
     // The consumer epoch, when exclusive and failover consumer redeliver unack message will increase the epoch
     optional uint64 consumer_epoch = 19;
+
+    enum IsolationLevel {
+        READ_COMMITTED = 0;
+        READ_UNCOMMITTED = 1;
+    }
+    // If READ_COMMITTED is selected, the Consumer can only consume all transactional messages which have been committed.
+    // If READ_UNCOMMITTED is selected, the Consumer can consume all messages, even transactional messages which have been aborted.
+    optional IsolationLevel isolation_level = 20 [default = READ_COMMITTED];
 }
 
 message CommandPartitionedTopicMetadata {


### PR DESCRIPTION

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #21114 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

Consumer supports specifying consumption isolation level #21114 

### Modifications

Add a configuration 'SubscriptionIsolationLevel' in consumer builder:
```
PulsarClient client = PulsarClient.builder().serviceUrl("pulsar://localhost:6650").build();
Consumer<String> consumer = client.newConsumer(Schema.STRING)
        .topic("persistent://my-tenant/my-namespace/my-topic")
        .subscriptionName("my-subscription")
        .subscriptionType(SubscriptionType.Shared)
        .subscriptionIsolationLevel(IsolationLevel.READ_COMMITTED) // Adding the isolation level configuration
        .subscribe();
```

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
