### PR TITLE
[fix][broker] Replicator failed to create remote producer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
@@ -89,7 +89,7 @@ public abstract class AbstractReplicator {
                         localTopicName + "-->" + remoteTopicName,
                 StringUtils.equals(localCluster, remoteCluster) ? localCluster : localCluster + "-->" + remoteCluster
         );
-        this.producerBuilder = replicationClient.newProducer(Schema.AUTO_PRODUCE_BYTES()) //
+        this.producerBuilder = replicationClient.newProducer(Schema.BYTES) //
                 .topic(remoteTopicName)
                 .messageRoutingMode(MessageRoutingMode.SinglePartition)
                 .enableBatching(false)


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/21242

### Motivation

We will encounter an error if remote topic has a schema definition by `Schema.JSON(String.class)`  when start geo-replication.
For details: https://github.com/apache/pulsar/issues/21242


### Modifications

When creating the replicator producer, we use ` Schema.BYTES` instead of `Schema.AUTO_PRODUCE_BYTES()`.

There are two intentions here:
1. Use Schema.BYTES can avoid the above problems.
2. Whether schema is `Schema.BYTES` or `Schema.AUTO_PRODUCE_BYTES()`, it does not affect the replicate schemas across multiple.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

