### PR TITLE
[fix][broker] Remove getMessageIdData from PublishContext

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -376,7 +376,6 @@ public class Producer {
         private long sequenceId;
         private long ledgerId;
         private long entryId;
-        private MessageIdData messageIdData;
         private ByteBuf headerAndPayload;
         private Rate rateIn;
         private int msgSize;
@@ -569,7 +568,6 @@ public class Producer {
             callback.startTimeNs = startTimeNs;
             callback.isMarker = isMarker;
             callback.headerAndPayload = headersAndPayload;
-            callback.messageIdData = messageIdData;
             callback.ledgerId = messageIdData == null ? -1 : messageIdData.getLedgerId();
             callback.entryId = messageIdData == null ? -1 : messageIdData.getEntryId();
             if (callback.propertyMap != null) {
@@ -594,7 +592,6 @@ public class Producer {
             callback.chunked = chunked;
             callback.isMarker = isMarker;
             callback.headerAndPayload = headersAndPayload;
-            callback.messageIdData = messageIdData;
             callback.ledgerId = messageIdData == null ? -1 : messageIdData.getLedgerId();
             callback.entryId = messageIdData == null ? -1 : messageIdData.getEntryId();
             if (callback.propertyMap != null) {
@@ -616,11 +613,6 @@ public class Producer {
         @Override
         public boolean isMarkerMessage() {
             return isMarker;
-        }
-
-        @Override
-        public MessageIdData getMessageIdData() {
-            return messageIdData;
         }
 
         @Override
@@ -654,7 +646,6 @@ public class Producer {
             startTimeNs = -1L;
             chunked = false;
             isMarker = false;
-            messageIdData = null;
             headerAndPayload = null;
             if (propertyMap != null) {
                 propertyMap.clear();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -35,7 +35,6 @@ import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.KeySharedMeta;
-import org.apache.pulsar.common.api.proto.MessageIdData;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
 import org.apache.pulsar.common.policies.data.EntryFilters;
@@ -127,10 +126,6 @@ public interface Topic {
 
         default void setEntryTimestamp(long entryTimestamp) {
 
-        }
-
-        default MessageIdData getMessageIdData() {
-            return null;
         }
 
         default ByteBuf getHeaderAndPayload() {


### PR DESCRIPTION
### Motivation

`PublishContext#getMessageIdData` introduced in #21245, but this value is only used for shadow replicator, it is unless.

### Modifications

- Remove `PublishContext#getMessageIdData` method

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

