### PR TITLE
[fix][broker] Intercept REDELIVER_UNACKNOWLEDGED_MESSAGES command

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -306,4 +307,22 @@ public class BrokerInterceptorTest extends ProducerConsumerBase {
         }
     }
 
+    @Test
+    public void testInterceptNack() throws Exception {
+        BrokerInterceptor interceptor = pulsar.getBrokerInterceptor();
+        Assert.assertTrue(interceptor instanceof CounterBrokerInterceptor);
+
+        final String topic = "test-intercept-nack" + UUID.randomUUID();
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
+        @Cleanup
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .negativeAckRedeliveryDelay(1, TimeUnit.SECONDS)
+                .topic(topic)
+                .subscriptionName("test-sub").subscribe();
+        producer.send("test intercept nack message");
+        Message<String> message = consumer.receive();
+        consumer.negativeAcknowledge(message);
+        Awaitility.await().until(() -> ((CounterBrokerInterceptor) interceptor).getHandleNackCount().get() == 1);
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/CounterBrokerInterceptor.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/CounterBrokerInterceptor.java
@@ -31,6 +31,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.http.HttpStatus;
@@ -62,6 +63,8 @@ public class CounterBrokerInterceptor implements BrokerInterceptor {
     private final AtomicInteger messageDispatchCount = new AtomicInteger();
     private final AtomicInteger messageAckCount = new AtomicInteger();
     private final AtomicInteger handleAckCount = new AtomicInteger();
+    @Getter
+    private final AtomicInteger handleNackCount = new AtomicInteger();
     private final AtomicInteger txnCount = new AtomicInteger();
     private final AtomicInteger committedTxnCount = new AtomicInteger();
     private final AtomicInteger abortedTxnCount = new AtomicInteger();
@@ -79,6 +82,7 @@ public class CounterBrokerInterceptor implements BrokerInterceptor {
         txnCount.set(0);
         committedTxnCount.set(0);
         abortedTxnCount.set(0);
+        handleNackCount.set(0);
     }
 
     private final List<ResponseEvent> responseList = new CopyOnWriteArrayList<>();
@@ -208,6 +212,9 @@ public class CounterBrokerInterceptor implements BrokerInterceptor {
         }
         if (command.getType().equals(BaseCommand.Type.ACK)) {
             handleAckCount.incrementAndGet();
+        }
+        if(command.getType().equals(BaseCommand.Type.REDELIVER_UNACKNOWLEDGED_MESSAGES)) {
+            handleNackCount.incrementAndGet();
         }
         count.incrementAndGet();
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
@@ -291,6 +291,7 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
 
             case REDELIVER_UNACKNOWLEDGED_MESSAGES:
                 checkArgument(cmd.hasRedeliverUnacknowledgedMessages());
+                safeInterceptCommand(cmd);
                 handleRedeliverUnacknowledged(cmd.getRedeliverUnacknowledgedMessages());
                 break;
 


### PR DESCRIPTION
### Motivation

The broker misses intercept the `REDELIVER_UNACKNOWLEDGED_MESSAGES` command.

### Modifications

- Call `safeInterceptCommand()` to intercept the `REDELIVER_UNACKNOWLEDGED_MESSAGES` command

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->