### PR TITLE
[fix][client] Avert extensive time consumption during table view construction

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import com.google.common.collect.Sets;
@@ -473,10 +474,12 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
         when(mockReader.readNextAsync()).thenAnswer(invocation -> {
             Message<byte[]> message = spy(Message.class);
             int localIndex = index.decrementAndGet();
-            when(message.getTopicName()).thenReturn(lastMessageIds.get(localIndex).getOwnerTopic());
-            when(message.getMessageId()).thenReturn(lastMessageIds.get(localIndex));
-            when(message.hasKey()).thenReturn(false);
-            doNothing().when(message).release();
+            if (localIndex >= 0) {
+                when(message.getTopicName()).thenReturn(lastMessageIds.get(localIndex).getOwnerTopic());
+                when(message.getMessageId()).thenReturn(lastMessageIds.get(localIndex));
+                when(message.hasKey()).thenReturn(false);
+                doNothing().when(message).release();
+            }
             return CompletableFuture.completedFuture(message);
         });
         @Cleanup
@@ -493,6 +496,6 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
 
         // The future will complete after receive all the messages from lastMessageIds.
         future.get(3, TimeUnit.SECONDS);
-        assertEquals(index.get(), 0);
+        assertTrue(index.get() <= 0);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
 import com.google.common.collect.Sets;
@@ -33,8 +32,6 @@ import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
@@ -440,24 +437,5 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
             assertEquals(tv.size(), msgCnt);
         });
         verify(consumer, times(msgCnt)).receiveAsync();
-    }
-
-    @Test
-    public void testBuildTableViewWithMessageSendingBriskly() throws Exception {
-        String topic = "persistent://public/default/testBuildTableViewWithMessageSendingBriskly";
-        admin.topics().createPartitionedTopic(topic, 5);
-        int msgCnt = 2000000000;
-        int threadCount = 100;
-        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-        executorService.submit(() -> {
-            for (int i = 0; i < threadCount - 1; i++) {
-                executorService.submit(() -> this.publishMessages(topic, msgCnt, false, false));
-            }
-        });
-        CompletableFuture<TableView<byte[]>> tvFuture = pulsarClient.newTableView(Schema.BYTES)
-                .topic(topic)
-                .autoUpdatePartitionsInterval(60, TimeUnit.SECONDS)
-                .createAsync();
-        TableView<byte[]> tableView = tvFuture.get(5, TimeUnit.SECONDS);
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -246,6 +246,7 @@ public class TableViewImpl<T> implements TableView<T> {
             future.completeExceptionally(ex);
             return null;
         });
+        future.thenAccept(__ -> readTailMessages(reader));
         return future;
     }
 
@@ -266,7 +267,6 @@ public class TableViewImpl<T> implements TableView<T> {
                                   handleMessage(msg);
                                   if (maxMessageIds.isEmpty()) {
                                       future.complete(reader);
-                                      readTailMessages(reader);
                                   } else {
                                       readAllExistingMessages(reader, future, startTime, messagesRead, maxMessageIds);
                                   }
@@ -290,7 +290,6 @@ public class TableViewImpl<T> implements TableView<T> {
                                messagesRead,
                                durationMillis / 1000.0);
                        future.complete(reader);
-                       readTailMessages(reader);
                    }
                 });
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -258,13 +258,13 @@ public class TableViewImpl<T> implements TableView<T> {
                        reader.readNextAsync()
                                .thenAccept(msg -> {
                                   messagesRead.incrementAndGet();
-                                  handleMessage(msg);
-                                  // The message is read one by one in a single thread,
-                                  // so it's fine that uses a hashmap to store last message ID.
+                                  // We need remove the partition form the maxMessageIds map
+                                  // once the partition has been read completely.
                                   TopicMessageId maxMessageId = maxMessageIds.get(msg.getTopicName());
                                   if (maxMessageId != null && msg.getMessageId().compareTo(maxMessageId) >= 0) {
                                       maxMessageIds.remove(msg.getTopicName());
                                   }
+                                   handleMessage(msg);
                                   if (maxMessageIds.isEmpty()) {
                                       future.complete(reader);
                                   } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -22,7 +22,6 @@ import static org.apache.pulsar.common.topics.TopicCompactionStrategy.TABLE_VIEW
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -258,13 +258,13 @@ public class TableViewImpl<T> implements TableView<T> {
                        reader.readNextAsync()
                                .thenAccept(msg -> {
                                   messagesRead.incrementAndGet();
-                                  // We need remove the partition form the maxMessageIds map
+                                  // We need remove the partition from the maxMessageIds map
                                   // once the partition has been read completely.
                                   TopicMessageId maxMessageId = maxMessageIds.get(msg.getTopicName());
                                   if (maxMessageId != null && msg.getMessageId().compareTo(maxMessageId) >= 0) {
                                       maxMessageIds.remove(msg.getTopicName());
                                   }
-                                   handleMessage(msg);
+                                  handleMessage(msg);
                                   if (maxMessageIds.isEmpty()) {
                                       future.complete(reader);
                                   } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -266,6 +266,7 @@ public class TableViewImpl<T> implements TableView<T> {
                                   handleMessage(msg);
                                   if (maxMessageIds.isEmpty()) {
                                       future.complete(reader);
+                                      readTailMessages(reader);
                                   } else {
                                       readAllExistingMessages(reader, future, startTime, messagesRead, maxMessageIds);
                                   }


### PR DESCRIPTION
Reopen https://github.com/apache/pulsar/pull/21170
### Motivation
If a topic persistently experiences a substantial quantity of data inputs,  the act of reading all the messages present in this topic to build a TableView can take an excessive amount of time.
### Modification
In the process of constructing the TableView, initially, the last message ID of the current topic is procured. Consequently, once this last message ID has been reached, the creation ensues to its completion.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
