### PR TITLE
[improve][pip] PIP-302 Introduce refreshAsync API for TableView

### DIFF
--- a/pip/pip-302.md
+++ b/pip/pip-302.md
@@ -1,120 +1,99 @@
-# Background
+# Background Knowledge
 
-The TableView interface provides a convenient way to access data in a compacted topic by providing a continuously updated view of a key-value mapping. It operates on messages with keys and ignores those without keys.
+The TableView interface provides a convenient way to access data in a compacted topic by offering a continuously updated key-value map view. It operates on messages with keys and ignores those without keys.
 
-Using TableView, a Pulsar client can retrieve all message updates from a specific topic and create a mapping with the latest value for each key. This mapping can be used to establish a local data cache. Additionally, the client can register consumers with TableView and specify a listener to scan the mapping and receive notifications when new messages are received. This functionality enables event-driven applications and message monitoring.
+By utilizing the TableView, Pulsar clients can retrieve all message updates from a specific topic and create a map that contains the latest values for each key. This map can be used to establish a local cache of data. Additionally, clients can register consumers with the TableView and specify a listener to scan the map and receive notifications whenever new messages are received. This functionality enables event-driven applications and message monitoring.
 
-For more detailed information about TableView, please refer to the [Pulsar documentation](https://pulsar.apache.org/docs/next/concepts-clients/#tableview).
+For more detailed information about the TableView, please refer to the [Pulsar documentation](https://pulsar.apache.org/docs/next/concepts-clients/#tableview).
 
 # Motivation
 
-In the context of using the TableView component, we sometimes want to always be able to retrieve the latest value associated with a given key. To accomplish this, we can modify the TableView's builder to include a configuration option that refreshes the key each time it's read, retrieving the latest value.
-
-# Goal
+In the context of utilizing the TableView component, there are instances where we aspire to consistently retrieve the most up-to-date value associated with a given key. To accomplish this, we can employ an API that allows us to wait until all data has been fully retrieved before accessing the value corresponding to the desired key.
+# Goals
 
 ## In Scope
 
-The proposed changes aim to modify the TableView's builder to include a configuration option that refreshes the key each time it's read, retrieving the latest value.
+The proposed changes aim to add a new API that triggers the reading of all existing messages, updates the TableView, and waits for the read operation to complete. This will be achieved by introducing the `readAllExistingMessages()` method.
 
 ## Out of Scope
 
-No out of scope items have been determined at this time.
+No out-of-scope items have been identified at this time.
 
 # High-Level Design
 
-The high-level design involves modifying the TableView's builder to include a configuration option that refreshes the key each time it's read, retrieving the latest value.
+The high-level design involves the addition of a new API method called `readAllExistingMessages()`. This method will be responsible for initiating the process of reading all existing messages, updating the TableView, and waiting for the read operation to complete.
 
 # Detailed Design
 
-## Design and Implementation Details
+## Design & Implementation Details
 
-The TableView's builder will be modified to include a new configuration option that will determine whether to refresh each time a key is read, retrieving the latest value. A possible Java code implementation might look like this:
+The `readAllExistingMessages()` method will be implemented as follows:
 
 ```java
-public class TableViewConfigurationData {
-    private boolean alwaysRefresh = false;
-
-    public void setAlwaysRefresh(boolean alwaysRefresh) {
-        this.alwaysRefresh = alwaysRefresh;
-    }
-
-    public boolean isAlwaysRefresh() {
-        return alwaysRefresh;
-    }
-}
-
-public class TableViewBuilderImpl<T> implements TableViewBuilder<T> {
-    private TableViewConfigurationData conf;
-
-    @Override
-    public TableViewBuilder<T> alwaysRefresh(boolean alwaysRefresh) {
-        conf.setAlwaysRefresh(alwaysRefresh);
-        return this;
-    }
-
-    // ...
+@Override
+public CompletableFuture<Void> refresh() {
+        return reader.thenCompose(this::readAllExistingMessages);
 }
 ```
 
-In this modification, we added a new field `alwaysRefresh` in the `TableViewConfigurationData` class and provided corresponding getter and setter. Then, in the `TableViewBuilderImpl` class, we added a new method `alwaysRefresh(boolean alwaysRefresh)` that updates the `TableViewConfigurationData` instance with the new configuration option.
-
-# Public Changes
+# Public-Facing Changes
 
 ## Public API
 
-Here are the changes to the public API:
+The following changes will be made to the public API:
 
-### `alwaysRefresh(boolean alwaysRefresh)`
+### `readAllExistingMessages()`
 
-This is a new TableView config that allows users to set whether to refresh each time a key is read, retrieving the latest value.
-
+This new API method triggers the reading of all existing messages, updates the TableView, and waits for the read operation to complete.
 ```java
 /**
- * Sets whether to refresh each time a key is read, retrieving the latest value.
- *
- * @param alwaysRefresh If true, refresh each time a key is read, retrieving the latest value; otherwise, retrieve the latest value only at the first build.
- * @return Returns an instance of TableViewBuilder for chain calling.
- *
+ * Triggers the reading of all existing messages from the topics, updates the TableView and waits for the read operation to complete.
+ * This method fetches the last message of the topics at the point of invocation and updates the TableView with all messages up to and including this last message.
+ * After the update is complete, users can use the TableView to obtain the latest value for any key. 
  * Note that the 'latest' value refers to the value at the point of calling refresh, not necessarily the current latest if more messages have been produced in the meantime.
  *
- * Usage example:
- * TableViewBuilder<String> builder = new TableViewBuilderImpl<>();
- * builder.alwaysRefresh(true).build();
+ * @return a CompletableFuture that completes when all existing messages up to the point of invocation have been read, and the TableView has been updated.
+ *
+ * Example usage:
+ * table.refresh().whenComplete((__, ex) -> {
+ *     if (ex == null) {
+ *         table.get(key);
+ *     }
+ * });
  */
-@Override
-public TableViewBuilder<T> alwaysRefresh(boolean alwaysRefresh);
+CompletableFuture<Void> refresh();
 ```
 
 # Monitoring
 
-The proposed changes have not introduced any specific monitoring considerations at this time.
+The proposed changes do not introduce any specific monitoring considerations at this time.
 
 # Security Considerations
 
-No specific security considerations have been determined for this proposal.
+No specific security considerations have been identified for this proposal.
 
-# Backward and Forward Compatibility
+# Backward & Forward Compatibility
 
-## Rollback
+## Revert
 
-This proposal does not require specific rollback guidelines.
+No specific revert instructions are required for this proposal.
 
 ## Upgrade
 
-This proposal does not require specific upgrade guidelines.
+No specific upgrade instructions are required for this proposal.
 
 # Alternatives
 
-No other alternatives have been considered for this proposal.
+No alternative approaches were considered for this proposal.
 
-# General Remarks
+# General Notes
 
-No additional general remarks have been provided.
+No additional general notes have been provided.
 
 # Links
 
 <!--
-Update after submission
+Updated afterwards
 -->
-* Email list discussion thread:
-* Email list voting thread:
+* Mailing List discussion thread:
+* Mailing List voting thread:

--- a/pip/pip-302.md
+++ b/pip/pip-302.md
@@ -31,7 +31,7 @@ The `readAllExistingMessages()` method will be implemented as follows:
 
 ```java
 @Override
-public CompletableFuture<Void> refresh() {
+public CompletableFuture<Void> refreshAsync() {
         return reader.thenCompose(this::readAllExistingMessages);
 }
 ```
@@ -55,13 +55,13 @@ This new API method triggers the reading of all existing messages, updates the T
  * @return a CompletableFuture that completes when all existing messages up to the point of invocation have been read, and the TableView has been updated.
  *
  * Example usage:
- * table.refresh().whenComplete((__, ex) -> {
+ * table.refreshAsync().whenComplete((__, ex) -> {
  *     if (ex == null) {
  *         table.get(key);
  *     }
  * });
  */
-CompletableFuture<Void> refresh();
+CompletableFuture<Void> refreshAsync();
 ```
 
 # Monitoring

--- a/pip/pip-302.md
+++ b/pip/pip-302.md
@@ -1,0 +1,89 @@
+# Background Knowledge
+
+The TableView interface provides a convenient way to access data in a compacted topic by offering a continuously updated key-value map view. It operates on messages with keys and ignores those without keys.
+
+By utilizing the TableView, Pulsar clients can retrieve all message updates from a specific topic and create a map that contains the latest values for each key. This map can be used to establish a local cache of data. Additionally, clients can register consumers with the TableView and specify a listener to scan the map and receive notifications whenever new messages are received. This functionality enables event-driven applications and message monitoring.
+
+For more detailed information about the TableView, please refer to the [Pulsar documentation](https://pulsar.apache.org/docs/next/concepts-clients/#tableview).
+
+# Motivation
+
+In the context of utilizing the TableView component, there are instances where we aspire to consistently retrieve the most up-to-date value associated with a given key. To accomplish this, we can employ an API that allows us to wait until all data has been fully retrieved before accessing the value corresponding to the desired key.
+# Goals
+
+## In Scope
+
+The proposed changes aim to add a new API that triggers the reading of all existing messages, updates the TableView, and waits for the read operation to complete. This will be achieved by introducing the `readAllExistingMessages()` method.
+
+## Out of Scope
+
+No out-of-scope items have been identified at this time.
+
+# High-Level Design
+
+The high-level design involves the addition of a new API method called `readAllExistingMessages()`. This method will be responsible for initiating the process of reading all existing messages, updating the TableView, and waiting for the read operation to complete.
+
+# Detailed Design
+
+## Design & Implementation Details
+
+The `readAllExistingMessages()` method will be implemented as follows:
+
+```java
+@Override
+public CompletableFuture<Void> readAllExistingMessages() {
+        return reader.thenCompose(this::readAllExistingMessages);
+}
+```
+
+# Public-Facing Changes
+
+## Public API
+
+The following changes will be made to the public API:
+
+### `readAllExistingMessages()`
+
+This new API method triggers the reading of all existing messages, updates the TableView, and waits for the read operation to complete.
+```java
+/**
+ * Triggers the reading of all existing messages, updates the TableView, and waits for the read operation to complete.
+ * @return a CompletableFuture that completes when all existing messages have been read
+ * and the TableView has been updated
+ */
+CompletableFuture<Void> readAllExistingMessages();
+```
+
+# Monitoring
+
+The proposed changes do not introduce any specific monitoring considerations at this time.
+
+# Security Considerations
+
+No specific security considerations have been identified for this proposal.
+
+# Backward & Forward Compatibility
+
+## Revert
+
+No specific revert instructions are required for this proposal.
+
+## Upgrade
+
+No specific upgrade instructions are required for this proposal.
+
+# Alternatives
+
+No alternative approaches were considered for this proposal.
+
+# General Notes
+
+No additional general notes have been provided.
+
+# Links
+
+<!--
+Updated afterwards
+-->
+* Mailing List discussion thread:
+* Mailing List voting thread:

--- a/pip/pip-302.md
+++ b/pip/pip-302.md
@@ -8,12 +8,15 @@ For more detailed information about the TableView, please refer to the [Pulsar d
 
 # Motivation
 
-In the context of utilizing the TableView component, there are instances where we aspire to consistently retrieve the most up-to-date value associated with a given key. To accomplish this, we can employ an API that allows us to wait until all data has been fully retrieved before accessing the value corresponding to the desired key.
+In the context of utilizing the TableView component, there are instances where we aspire to consistently retrieve the most up-to-date value associated with a given key. 
+When read and write operations for a certain key do not occur simultaneously, we can refresh the TableView before reading the key to obtain the latest value for this key.
+To accomplish this, we can employ an API `refreshAsync` that allows us to refresh the TableView before accessing the value corresponding to the desired key.
 # Goals
 
 ## In Scope
 
-The proposed changes aim to add a new API that triggers the reading of all existing messages, updates the TableView, and waits for the read operation to complete. This will be achieved by introducing the `readAllExistingMessages()` method.
+The proposed changes aim to add a new API that triggers the reading of all existing messages that before the trigger time, 
+updates the TableView, and waits for the read operation to complete. This will be achieved by introducing the `refreshAsync()` method.
 
 ## Out of Scope
 
@@ -21,13 +24,15 @@ No out-of-scope items have been identified at this time.
 
 # High-Level Design
 
-The high-level design involves the addition of a new API method called `readAllExistingMessages()`. This method will be responsible for initiating the process of reading all existing messages, updating the TableView, and waiting for the read operation to complete.
+The high-level design involves the addition of a new API method called `refreshAsync()`. 
+This method will be responsible for initiating the process of reading all existing messages that before the trigger time,
+updating the TableView, and returning a future to wait for the read operation to complete.
 
 # Detailed Design
 
 ## Design & Implementation Details
 
-The `readAllExistingMessages()` method will be implemented as follows:
+The `refreshAsync()` method will be implemented as follows:
 
 ```java
 @Override
@@ -42,7 +47,7 @@ public CompletableFuture<Void> refreshAsync() {
 
 The following changes will be made to the public API:
 
-### `readAllExistingMessages()`
+### `refreshAsync()`
 
 This new API method triggers the reading of all existing messages, updates the TableView, and waits for the read operation to complete.
 ```java

--- a/pip/pip-302.md
+++ b/pip/pip-302.md
@@ -1,72 +1,91 @@
 # Background Knowledge
 
-The TableView interface provides a convenient way to access data in a compacted topic by offering a continuously updated key-value map view. It operates on messages with keys and ignores those without keys.
+The TableView interface provides a convenient way to access the streaming updatable dataset in a topic by offering a continuously updated key-value map view.  The TableView retains the last value of the key which provides you with an almost up-to-date dataset but cannot guarantee you always get the latest data (with the latest written message).
 
-By utilizing the TableView, Pulsar clients can retrieve all message updates from a specific topic and create a map that contains the latest values for each key. This map can be used to establish a local cache of data. Additionally, clients can register consumers with the TableView and specify a listener to scan the map and receive notifications whenever new messages are received. This functionality enables event-driven applications and message monitoring.
+The TableView can be used to establish a local cache of data. Additionally, clients can register consumers with TableView and specify a listener to scan the map and receive notifications whenever new messages are received. This functionality enables event-driven applications and message monitoring.
 
 For more detailed information about the TableView, please refer to the [Pulsar documentation](https://pulsar.apache.org/docs/next/concepts-clients/#tableview).
 
 # Motivation
 
-In the context of utilizing the TableView component, there are instances where we aspire to consistently retrieve the most up-to-date value associated with a given key. 
-When read and write operations for a certain key do not occur simultaneously, we can refresh the TableView before reading the key to obtain the latest value for this key.
-To accomplish this, we can employ an API `refreshAsync` that allows us to refresh the TableView before accessing the value corresponding to the desired key.
+When a TableView is created, it retrieves the position of the latest written message and reads all messages from the beginning up to that fetched position. This ensures that the TableView will include any messages written prior to its creation. However, it does not guarantee that the TableView will include any newly added messages during its creation.
+Therefore, the value you read from a TableView instance may not be the most recent value, but you will not read an older value once a new value becomes available. It's important to note that this guarantee is not maintained across multiple TableView instances on the same topic. This means that you may receive a newer value from one instance first, and then receive an older value from another instance later.
+In addition, we have several other components, such as the transaction buffer snapshot and the topic policies service, that employ a similar mechanism to the TableView. This is because the TableView is not available at that time. However, we cannot replace these implementations with a TableView because they involve multiple TableView instances across brokers within the same system topic, and the data read from these TableViews is not guaranteed to be up-to-date. As a result, subsequent writes may occur based on outdated versions of the data.
+For example, in the transaction buffer snapshot, when a broker owns topics within a namespace, it maintains a TableView containing all the transaction buffer snapshots for those topics. It is crucial to ensure that the owner can read the most recently written transaction buffer snapshot when loading a topic (where the topic name serves as the key for the transaction buffer snapshot message). However, the current capabilities provided by TableView do not guarantee this, especially when ownership of the topic is transferred and the TableView of transaction buffer snapshots in the new owner broker is not up-to-date.
+
+Regarding both the transaction buffer snapshot and topic policies service, updates to a key are only performed by a single writer at a given time until the topic's owner is changed. As a result, it is crucial to ensure that the last written value of this key is read prior to any subsequent writing. By guaranteeing this, all subsequent writes will consistently be based on the most up-to-date value.
+
+The proposal will introduce a new API to refresh the table view with the latest written data on the topic, ensuring that all subsequent reads are based on the refreshed data.
+
+```java
+tableView.refresh();
+tableView.get(“key”);
+```
+
+After the refresh, it is ensured that all messages written prior to the refresh will be available to be read. However, it should be noted that the inclusion of newly added messages during or after the refresh is not guaranteed.
+
 # Goals
 
 ## In Scope
 
-The proposed changes aim to add a new API that triggers the reading of all existing messages that before the trigger time, 
-updates the TableView, and waits for the read operation to complete. This will be achieved by introducing the `refreshAsync()` method.
+Providing the capability to refresh the TableView to the last written message of the topic and all the subsequent reads to be conducted using either the refreshed dataset or a dataset that is even more up-to-date than the refreshed one.
 
 ## Out of Scope
 
-No out-of-scope items have been identified at this time.
+
+A static perspective of a TableView at a given moment in time
+Read consistency across multiple TableViews on the same topic
 
 # High-Level Design
 
-The high-level design involves the addition of a new API method called `refreshAsync()`. 
-This method will be responsible for initiating the process of reading all existing messages that before the trigger time,
-updating the TableView, and returning a future to wait for the read operation to complete.
-
-# Detailed Design
+Provide a new API for TableView to support refreshing the dataset of the TableView to the last written message.
 
 ## Design & Implementation Details
-
-The `refreshAsync()` method will be implemented as follows:
-
-```java
-@Override
-public CompletableFuture<Void> refreshAsync() {
-        return reader.thenCompose(this::readAllExistingMessages);
-}
-```
 
 # Public-Facing Changes
 
 ## Public API
 
-The following changes will be made to the public API:
+The following changes will be added to the public API of TableView:
 
 ### `refreshAsync()`
 
-This new API method triggers the reading of all existing messages, updates the TableView, and waits for the read operation to complete.
+This new API retrieves the position of the latest written message and reads all messages from the beginning up to that fetched position. This ensures that the TableView will include any messages written prior to its refresh.
+
 ```java
 /**
- * Triggers the reading of all existing messages from the topics, updates the TableView and waits for the read operation to complete.
- * This method fetches the last message of the topics at the point of invocation and updates the TableView with all messages up to and including this last message.
- * After the update is complete, users can use the TableView to obtain the latest value for any key. 
- * Note that the 'latest' value refers to the value at the point of calling refresh, not necessarily the current latest if more messages have been produced in the meantime.
- *
- * @return a CompletableFuture that completes when all existing messages up to the point of invocation have been read, and the TableView has been updated.
- *
- * Example usage:
- * table.refreshAsync().whenComplete((__, ex) -> {
- *     if (ex == null) {
- *         table.get(key);
- *     }
- * });
- */
+*
+* Refresh the table view with the latest data in the topic, ensuring that all subsequent reads are based on the refreshed data.
+*
+* Example usage:
+*
+* table.refreshAsync().thenApply(__ -> table.get(key));
+*
+* This function retrieves the last written message in the topic and refreshes the table view accordingly.
+* Once the refresh is complete, all subsequent reads will be performed on the refreshed data or a combination of the refreshed
+* data and newly published data. The table view remains synchronized with any newly published data after the refresh.
+*
+* |x:0|->|y:0|->|z:0|->|x:1|->|z:1|->|x:2|->|y:1|->|y:2|
+*
+* If a read occurs after the refresh (at the last published message |y:2|), it ensures that outdated data like x=1 is not obtained.
+* However, it does not guarantee that the values will always be x=2, y=2, z=1, as the table view may receive updates with newly
+* published data.
+*
+* |x:0|->|y:0|->|z:0|->|x:1|->|z:1|->|x:2|->|y:1|->|y:2| -> |y:3|
+*
+* Both y=2 or y=3 are possible. Therefore, different readers may receive different values, but all values will be equal to or newer
+* than the data refreshed from the last call to the refresh method.
+*/
 CompletableFuture<Void> refreshAsync();
+
+/**
+* Refresh the table view with the latest data in the topic, ensuring that all subsequent reads are based on the refreshed data.
+*
+* @throws PulsarClientException if there is any error refreshing the table view.
+*/
+void refresh() throws PulsarClientException;
+
+
 ```
 
 # Monitoring
@@ -89,7 +108,24 @@ No specific upgrade instructions are required for this proposal.
 
 # Alternatives
 
-No alternative approaches were considered for this proposal.
+## Add consistency model policy to TableView
+Add new option configuration `STRONG_CONSISTENCY_MODEL` and `EVENTUAL_CONSISTENCY_MODEL` in TableViewConfigurationData.
+• `STRONG_CONSISTENCY_MODEL`: any method will be blocked until the latest value is retrieved.
+• `EVENTUAL_CONSISTENCY_MODEL`: all methods are non-blocking, but the value retrieved might not be the latest at the time point.
+
+However, there might be some drawbacks to this approach:
+1. As read and write operations might happen simultaneously, we cannot guarantee consistency. If we provide a configuration about consistency, it might confuse users.
+2. This operation will block each get operation. We need to add more asynchronous methods.
+3. Less flexibility if users don’t want to refresh the TableView for any reads.
+
+## New method for combining the refresh and get
+
+Another option is to add new methods for the existing methods to combine the refresh and reads. For example
+
+CompletableFuture<T> refreshGet(String key);
+
+It will refresh the dataset of the TableView and perform the get operation based on the refreshed dataset. But we need to add 11 new methods to the public APIs of the TableView.
+
 
 # General Notes
 

--- a/pip/pip-302.md
+++ b/pip/pip-302.md
@@ -1,99 +1,120 @@
-# Background Knowledge
+# Background
 
-The TableView interface provides a convenient way to access data in a compacted topic by offering a continuously updated key-value map view. It operates on messages with keys and ignores those without keys.
+The TableView interface provides a convenient way to access data in a compacted topic by providing a continuously updated view of a key-value mapping. It operates on messages with keys and ignores those without keys.
 
-By utilizing the TableView, Pulsar clients can retrieve all message updates from a specific topic and create a map that contains the latest values for each key. This map can be used to establish a local cache of data. Additionally, clients can register consumers with the TableView and specify a listener to scan the map and receive notifications whenever new messages are received. This functionality enables event-driven applications and message monitoring.
+Using TableView, a Pulsar client can retrieve all message updates from a specific topic and create a mapping with the latest value for each key. This mapping can be used to establish a local data cache. Additionally, the client can register consumers with TableView and specify a listener to scan the mapping and receive notifications when new messages are received. This functionality enables event-driven applications and message monitoring.
 
-For more detailed information about the TableView, please refer to the [Pulsar documentation](https://pulsar.apache.org/docs/next/concepts-clients/#tableview).
+For more detailed information about TableView, please refer to the [Pulsar documentation](https://pulsar.apache.org/docs/next/concepts-clients/#tableview).
 
 # Motivation
 
-In the context of utilizing the TableView component, there are instances where we aspire to consistently retrieve the most up-to-date value associated with a given key. To accomplish this, we can employ an API that allows us to wait until all data has been fully retrieved before accessing the value corresponding to the desired key.
-# Goals
+In the context of using the TableView component, we sometimes want to always be able to retrieve the latest value associated with a given key. To accomplish this, we can modify the TableView's builder to include a configuration option that refreshes the key each time it's read, retrieving the latest value.
+
+# Goal
 
 ## In Scope
 
-The proposed changes aim to add a new API that triggers the reading of all existing messages, updates the TableView, and waits for the read operation to complete. This will be achieved by introducing the `readAllExistingMessages()` method.
+The proposed changes aim to modify the TableView's builder to include a configuration option that refreshes the key each time it's read, retrieving the latest value.
 
 ## Out of Scope
 
-No out-of-scope items have been identified at this time.
+No out of scope items have been determined at this time.
 
 # High-Level Design
 
-The high-level design involves the addition of a new API method called `readAllExistingMessages()`. This method will be responsible for initiating the process of reading all existing messages, updating the TableView, and waiting for the read operation to complete.
+The high-level design involves modifying the TableView's builder to include a configuration option that refreshes the key each time it's read, retrieving the latest value.
 
 # Detailed Design
 
-## Design & Implementation Details
+## Design and Implementation Details
 
-The `readAllExistingMessages()` method will be implemented as follows:
+The TableView's builder will be modified to include a new configuration option that will determine whether to refresh each time a key is read, retrieving the latest value. A possible Java code implementation might look like this:
 
 ```java
-@Override
-public CompletableFuture<Void> refresh() {
-        return reader.thenCompose(this::readAllExistingMessages);
+public class TableViewConfigurationData {
+    private boolean alwaysRefresh = false;
+
+    public void setAlwaysRefresh(boolean alwaysRefresh) {
+        this.alwaysRefresh = alwaysRefresh;
+    }
+
+    public boolean isAlwaysRefresh() {
+        return alwaysRefresh;
+    }
+}
+
+public class TableViewBuilderImpl<T> implements TableViewBuilder<T> {
+    private TableViewConfigurationData conf;
+
+    @Override
+    public TableViewBuilder<T> alwaysRefresh(boolean alwaysRefresh) {
+        conf.setAlwaysRefresh(alwaysRefresh);
+        return this;
+    }
+
+    // ...
 }
 ```
 
-# Public-Facing Changes
+In this modification, we added a new field `alwaysRefresh` in the `TableViewConfigurationData` class and provided corresponding getter and setter. Then, in the `TableViewBuilderImpl` class, we added a new method `alwaysRefresh(boolean alwaysRefresh)` that updates the `TableViewConfigurationData` instance with the new configuration option.
+
+# Public Changes
 
 ## Public API
 
-The following changes will be made to the public API:
+Here are the changes to the public API:
 
-### `readAllExistingMessages()`
+### `alwaysRefresh(boolean alwaysRefresh)`
 
-This new API method triggers the reading of all existing messages, updates the TableView, and waits for the read operation to complete.
+This is a new TableView config that allows users to set whether to refresh each time a key is read, retrieving the latest value.
+
 ```java
 /**
- * Triggers the reading of all existing messages from the topics, updates the TableView and waits for the read operation to complete.
- * This method fetches the last message of the topics at the point of invocation and updates the TableView with all messages up to and including this last message.
- * After the update is complete, users can use the TableView to obtain the latest value for any key. 
+ * Sets whether to refresh each time a key is read, retrieving the latest value.
+ *
+ * @param alwaysRefresh If true, refresh each time a key is read, retrieving the latest value; otherwise, retrieve the latest value only at the first build.
+ * @return Returns an instance of TableViewBuilder for chain calling.
+ *
  * Note that the 'latest' value refers to the value at the point of calling refresh, not necessarily the current latest if more messages have been produced in the meantime.
  *
- * @return a CompletableFuture that completes when all existing messages up to the point of invocation have been read, and the TableView has been updated.
- *
- * Example usage:
- * table.refresh().whenComplete((__, ex) -> {
- *     if (ex == null) {
- *         table.get(key);
- *     }
- * });
+ * Usage example:
+ * TableViewBuilder<String> builder = new TableViewBuilderImpl<>();
+ * builder.alwaysRefresh(true).build();
  */
-CompletableFuture<Void> refresh();
+@Override
+public TableViewBuilder<T> alwaysRefresh(boolean alwaysRefresh);
 ```
 
 # Monitoring
 
-The proposed changes do not introduce any specific monitoring considerations at this time.
+The proposed changes have not introduced any specific monitoring considerations at this time.
 
 # Security Considerations
 
-No specific security considerations have been identified for this proposal.
+No specific security considerations have been determined for this proposal.
 
-# Backward & Forward Compatibility
+# Backward and Forward Compatibility
 
-## Revert
+## Rollback
 
-No specific revert instructions are required for this proposal.
+This proposal does not require specific rollback guidelines.
 
 ## Upgrade
 
-No specific upgrade instructions are required for this proposal.
+This proposal does not require specific upgrade guidelines.
 
 # Alternatives
 
-No alternative approaches were considered for this proposal.
+No other alternatives have been considered for this proposal.
 
-# General Notes
+# General Remarks
 
-No additional general notes have been provided.
+No additional general remarks have been provided.
 
 # Links
 
 <!--
-Updated afterwards
+Update after submission
 -->
-* Mailing List discussion thread:
-* Mailing List voting thread:
+* Email list discussion thread:
+* Email list voting thread:

--- a/pip/pip-302.md
+++ b/pip/pip-302.md
@@ -31,7 +31,7 @@ The `readAllExistingMessages()` method will be implemented as follows:
 
 ```java
 @Override
-public CompletableFuture<Void> readAllExistingMessages() {
+public CompletableFuture<Void> refresh() {
         return reader.thenCompose(this::readAllExistingMessages);
 }
 ```
@@ -47,11 +47,21 @@ The following changes will be made to the public API:
 This new API method triggers the reading of all existing messages, updates the TableView, and waits for the read operation to complete.
 ```java
 /**
- * Triggers the reading of all existing messages, updates the TableView, and waits for the read operation to complete.
- * @return a CompletableFuture that completes when all existing messages have been read
- * and the TableView has been updated
+ * Triggers the reading of all existing messages from the topics, updates the TableView and waits for the read operation to complete.
+ * This method fetches the last message of the topics at the point of invocation and updates the TableView with all messages up to and including this last message.
+ * After the update is complete, users can use the TableView to obtain the latest value for any key. 
+ * Note that the 'latest' value refers to the value at the point of calling refresh, not necessarily the current latest if more messages have been produced in the meantime.
+ *
+ * @return a CompletableFuture that completes when all existing messages up to the point of invocation have been read, and the TableView has been updated.
+ *
+ * Example usage:
+ * table.refresh().whenComplete((__, ex) -> {
+ *     if (ex == null) {
+ *         table.get(key);
+ *     }
+ * });
  */
-CompletableFuture<Void> readAllExistingMessages();
+CompletableFuture<Void> refresh();
 ```
 
 # Monitoring


### PR DESCRIPTION
Reopen https://github.com/apache/pulsar/pull/21166
## Motivation
**Prerequisite:** Since messages are constantly being written into the Topic and there is no read-write lock guarantee, we cannot assure the retrieval of the most up-to-date value.
**Implementation Goal:** Record a checkpoint before reading and ensure the retrieval of the latest value of the key up to this checkpoint.
**Use Case:** When read and write operations for a certain key do not occur simultaneously, we can refresh the TableView before reading the key to obtain the latest value for this key.

## Modification
Introduce a new API `refreshAsync`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
