### PR TITLE
[improve][misc] Upgrade Netty to 4.1.99.Final

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -47,7 +47,7 @@
     <license-maven-plugin.version>4.1</license-maven-plugin.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-    <netty.version>4.1.94.Final</netty.version>
+    <netty.version>4.1.99.Final</netty.version>
     <guice.version>4.2.3</guice.version>
     <guava.version>32.1.2-jre</guava.version>
     <ant.version>1.10.12</ant.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -289,27 +289,27 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-lang3-3.11.jar
     - org.apache.commons-commons-text-1.10.0.jar
  * Netty
-    - io.netty-netty-buffer-4.1.94.Final.jar
-    - io.netty-netty-codec-4.1.94.Final.jar
-    - io.netty-netty-codec-dns-4.1.94.Final.jar
-    - io.netty-netty-codec-http-4.1.94.Final.jar
-    - io.netty-netty-codec-http2-4.1.94.Final.jar
-    - io.netty-netty-codec-socks-4.1.94.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.94.Final.jar
-    - io.netty-netty-common-4.1.94.Final.jar
-    - io.netty-netty-handler-4.1.94.Final.jar
-    - io.netty-netty-handler-proxy-4.1.94.Final.jar
-    - io.netty-netty-resolver-4.1.94.Final.jar
-    - io.netty-netty-resolver-dns-4.1.94.Final.jar
-    - io.netty-netty-resolver-dns-classes-macos-4.1.94.Final.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.94.Final-osx-aarch_64.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.94.Final-osx-x86_64.jar
-    - io.netty-netty-transport-4.1.94.Final.jar
-    - io.netty-netty-transport-classes-epoll-4.1.94.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.94.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.94.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.94.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.94.Final-linux-x86_64.jar
+    - io.netty-netty-buffer-4.1.99.Final.jar
+    - io.netty-netty-codec-4.1.99.Final.jar
+    - io.netty-netty-codec-dns-4.1.99.Final.jar
+    - io.netty-netty-codec-http-4.1.99.Final.jar
+    - io.netty-netty-codec-http2-4.1.99.Final.jar
+    - io.netty-netty-codec-socks-4.1.99.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.99.Final.jar
+    - io.netty-netty-common-4.1.99.Final.jar
+    - io.netty-netty-handler-4.1.99.Final.jar
+    - io.netty-netty-handler-proxy-4.1.99.Final.jar
+    - io.netty-netty-resolver-4.1.99.Final.jar
+    - io.netty-netty-resolver-dns-4.1.99.Final.jar
+    - io.netty-netty-resolver-dns-classes-macos-4.1.99.Final.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.99.Final-osx-aarch_64.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.99.Final-osx-x86_64.jar
+    - io.netty-netty-transport-4.1.99.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.99.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.99.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.99.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.99.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.99.Final-linux-x86_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -344,22 +344,22 @@ The Apache Software License, Version 2.0
     - commons-text-1.10.0.jar
     - commons-compress-1.21.jar
  * Netty
-    - netty-buffer-4.1.94.Final.jar
-    - netty-codec-4.1.94.Final.jar
-    - netty-codec-dns-4.1.94.Final.jar
-    - netty-codec-http-4.1.94.Final.jar
-    - netty-codec-socks-4.1.94.Final.jar
-    - netty-codec-haproxy-4.1.94.Final.jar
-    - netty-common-4.1.94.Final.jar
-    - netty-handler-4.1.94.Final.jar
-    - netty-handler-proxy-4.1.94.Final.jar
-    - netty-resolver-4.1.94.Final.jar
-    - netty-resolver-dns-4.1.94.Final.jar
-    - netty-transport-4.1.94.Final.jar
-    - netty-transport-classes-epoll-4.1.94.Final.jar
-    - netty-transport-native-epoll-4.1.94.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.94.Final.jar
-    - netty-transport-native-unix-common-4.1.94.Final-linux-x86_64.jar
+    - netty-buffer-4.1.99.Final.jar
+    - netty-codec-4.1.99.Final.jar
+    - netty-codec-dns-4.1.99.Final.jar
+    - netty-codec-http-4.1.99.Final.jar
+    - netty-codec-socks-4.1.99.Final.jar
+    - netty-codec-haproxy-4.1.99.Final.jar
+    - netty-common-4.1.99.Final.jar
+    - netty-handler-4.1.99.Final.jar
+    - netty-handler-proxy-4.1.99.Final.jar
+    - netty-resolver-4.1.99.Final.jar
+    - netty-resolver-dns-4.1.99.Final.jar
+    - netty-transport-4.1.99.Final.jar
+    - netty-transport-classes-epoll-4.1.99.Final.jar
+    - netty-transport-native-epoll-4.1.99.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.99.Final.jar
+    - netty-transport-native-unix-common-4.1.99.Final-linux-x86_64.jar
     - netty-tcnative-boringssl-static-2.0.61.Final.jar
     - netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar
     - netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar
@@ -370,9 +370,9 @@ The Apache Software License, Version 2.0
     - netty-incubator-transport-classes-io_uring-0.0.21.Final.jar
     - netty-incubator-transport-native-io_uring-0.0.21.Final-linux-aarch_64.jar
     - netty-incubator-transport-native-io_uring-0.0.21.Final-linux-x86_64.jar
-    - netty-resolver-dns-classes-macos-4.1.94.Final.jar
-    - netty-resolver-dns-native-macos-4.1.94.Final-osx-aarch_64.jar
-    - netty-resolver-dns-native-macos-4.1.94.Final-osx-x86_64.jar
+    - netty-resolver-dns-classes-macos-4.1.99.Final.jar
+    - netty-resolver-dns-native-macos-4.1.99.Final-osx-aarch_64.jar
+    - netty-resolver-dns-native-macos-4.1.99.Final-osx-x86_64.jar
  * Prometheus client
     - simpleclient-0.16.0.jar
     - simpleclient_log4j2-0.16.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.10.1</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
-    <netty.version>4.1.94.Final</netty.version>
+    <netty.version>4.1.99.Final</netty.version>
     <netty-iouring.version>0.0.21.Final</netty-iouring.version>
     <jetty.version>9.4.51.v20230217</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -231,21 +231,21 @@ The Apache Software License, Version 2.0
     - commons-compress-1.21.jar
     - commons-lang3-3.11.jar
  * Netty
-    - netty-buffer-4.1.94.Final.jar
-    - netty-codec-4.1.94.Final.jar
-    - netty-codec-dns-4.1.94.Final.jar
-    - netty-codec-http-4.1.94.Final.jar
-    - netty-codec-haproxy-4.1.94.Final.jar
-    - netty-codec-socks-4.1.94.Final.jar
-    - netty-handler-proxy-4.1.94.Final.jar
-    - netty-common-4.1.94.Final.jar
-    - netty-handler-4.1.94.Final.jar
+    - netty-buffer-4.1.99.Final.jar
+    - netty-codec-4.1.99.Final.jar
+    - netty-codec-dns-4.1.99.Final.jar
+    - netty-codec-http-4.1.99.Final.jar
+    - netty-codec-haproxy-4.1.99.Final.jar
+    - netty-codec-socks-4.1.99.Final.jar
+    - netty-handler-proxy-4.1.99.Final.jar
+    - netty-common-4.1.99.Final.jar
+    - netty-handler-4.1.99.Final.jar
     - netty-reactive-streams-2.0.6.jar
-    - netty-resolver-4.1.94.Final.jar
-    - netty-resolver-dns-4.1.94.Final.jar
-    - netty-resolver-dns-classes-macos-4.1.94.Final.jar
-    - netty-resolver-dns-native-macos-4.1.94.Final-osx-aarch_64.jar
-    - netty-resolver-dns-native-macos-4.1.94.Final-osx-x86_64.jar
+    - netty-resolver-4.1.99.Final.jar
+    - netty-resolver-dns-4.1.99.Final.jar
+    - netty-resolver-dns-classes-macos-4.1.99.Final.jar
+    - netty-resolver-dns-native-macos-4.1.99.Final-osx-aarch_64.jar
+    - netty-resolver-dns-native-macos-4.1.99.Final-osx-x86_64.jar
     - netty-tcnative-boringssl-static-2.0.61.Final.jar
     - netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar
     - netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar
@@ -253,12 +253,12 @@ The Apache Software License, Version 2.0
     - netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar
     - netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar
     - netty-tcnative-classes-2.0.61.Final.jar
-    - netty-transport-4.1.94.Final.jar
-    - netty-transport-classes-epoll-4.1.94.Final.jar
-    - netty-transport-native-epoll-4.1.94.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.94.Final.jar
-    - netty-transport-native-unix-common-4.1.94.Final-linux-x86_64.jar
-    - netty-codec-http2-4.1.94.Final.jar
+    - netty-transport-4.1.99.Final.jar
+    - netty-transport-classes-epoll-4.1.99.Final.jar
+    - netty-transport-native-epoll-4.1.99.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.99.Final.jar
+    - netty-transport-native-unix-common-4.1.99.Final-linux-x86_64.jar
+    - netty-codec-http2-4.1.99.Final.jar
     - netty-incubator-transport-classes-io_uring-0.0.21.Final.jar
     - netty-incubator-transport-native-io_uring-0.0.21.Final-linux-x86_64.jar
     - netty-incubator-transport-native-io_uring-0.0.21.Final-linux-aarch_64.jar


### PR DESCRIPTION
### Motivation

Keep Netty dependency up-to-date to get improvements. 

- release notes since 4.1.94: 
  - https://netty.io/news/2023/09/21/4-1-99-Final.html
  - https://netty.io/news/2023/09/21/4-1-98-Final.html
  - https://netty.io/news/2023/08/23/4-1-97-Final.html
  - https://netty.io/news/2023/07/27/4-1-96-Final.html
  - https://netty.io/news/2023/07/20/4-1-95-Final.html

The most relevant improvement seems to be the SSLHandler allocation improvements that came in [4.1.95](https://netty.io/news/2023/07/20/4-1-95-Final.html), https://github.com/netty/netty/pull/13472 .

### Modifications

Upgrade Netty to 4.1.99.Final (from 4.1.94.Final).

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->