### PR TITLE
[fix][sec] Upgrade Jetty to address CVEs

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -383,25 +383,25 @@ The Apache Software License, Version 2.0
     - org.asynchttpclient-async-http-client-2.12.1.jar
     - org.asynchttpclient-async-http-client-netty-utils-2.12.1.jar
  * Jetty
-    - org.eclipse.jetty-jetty-client-9.4.51.v20230217.jar
-    - org.eclipse.jetty-jetty-continuation-9.4.51.v20230217.jar
-    - org.eclipse.jetty-jetty-http-9.4.51.v20230217.jar
-    - org.eclipse.jetty-jetty-io-9.4.51.v20230217.jar
-    - org.eclipse.jetty-jetty-proxy-9.4.51.v20230217.jar
-    - org.eclipse.jetty-jetty-security-9.4.51.v20230217.jar
-    - org.eclipse.jetty-jetty-server-9.4.51.v20230217.jar
-    - org.eclipse.jetty-jetty-servlet-9.4.51.v20230217.jar
-    - org.eclipse.jetty-jetty-servlets-9.4.51.v20230217.jar
-    - org.eclipse.jetty-jetty-util-9.4.51.v20230217.jar
-    - org.eclipse.jetty-jetty-util-ajax-9.4.51.v20230217.jar
-    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.51.v20230217.jar
-    - org.eclipse.jetty.websocket-websocket-api-9.4.51.v20230217.jar
-    - org.eclipse.jetty.websocket-websocket-client-9.4.51.v20230217.jar
-    - org.eclipse.jetty.websocket-websocket-common-9.4.51.v20230217.jar
-    - org.eclipse.jetty.websocket-websocket-server-9.4.51.v20230217.jar
-    - org.eclipse.jetty.websocket-websocket-servlet-9.4.51.v20230217.jar
-    - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.51.v20230217.jar
-    - org.eclipse.jetty-jetty-alpn-server-9.4.51.v20230217.jar
+    - org.eclipse.jetty-jetty-client-9.4.52.v20230823.jar
+    - org.eclipse.jetty-jetty-continuation-9.4.52.v20230823.jar
+    - org.eclipse.jetty-jetty-http-9.4.52.v20230823.jar
+    - org.eclipse.jetty-jetty-io-9.4.52.v20230823.jar
+    - org.eclipse.jetty-jetty-proxy-9.4.52.v20230823.jar
+    - org.eclipse.jetty-jetty-security-9.4.52.v20230823.jar
+    - org.eclipse.jetty-jetty-server-9.4.52.v20230823.jar
+    - org.eclipse.jetty-jetty-servlet-9.4.52.v20230823.jar
+    - org.eclipse.jetty-jetty-servlets-9.4.52.v20230823.jar
+    - org.eclipse.jetty-jetty-util-9.4.52.v20230823.jar
+    - org.eclipse.jetty-jetty-util-ajax-9.4.52.v20230823.jar
+    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.52.v20230823.jar
+    - org.eclipse.jetty.websocket-websocket-api-9.4.52.v20230823.jar
+    - org.eclipse.jetty.websocket-websocket-client-9.4.52.v20230823.jar
+    - org.eclipse.jetty.websocket-websocket-common-9.4.52.v20230823.jar
+    - org.eclipse.jetty.websocket-websocket-server-9.4.52.v20230823.jar
+    - org.eclipse.jetty.websocket-websocket-servlet-9.4.52.v20230823.jar
+    - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.52.v20230823.jar
+    - org.eclipse.jetty-jetty-alpn-server-9.4.52.v20230823.jar
  * SnakeYaml -- org.yaml-snakeyaml-2.0.jar
  * RocksDB - org.rocksdb-rocksdbjni-7.9.2.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -395,14 +395,14 @@ The Apache Software License, Version 2.0
     - async-http-client-2.12.1.jar
     - async-http-client-netty-utils-2.12.1.jar
  * Jetty
-    - jetty-client-9.4.51.v20230217.jar
-    - jetty-http-9.4.51.v20230217.jar
-    - jetty-io-9.4.51.v20230217.jar
-    - jetty-util-9.4.51.v20230217.jar
-    - javax-websocket-client-impl-9.4.51.v20230217.jar
-    - websocket-api-9.4.51.v20230217.jar
-    - websocket-client-9.4.51.v20230217.jar
-    - websocket-common-9.4.51.v20230217.jar
+    - jetty-client-9.4.52.v20230823.jar
+    - jetty-http-9.4.52.v20230823.jar
+    - jetty-io-9.4.52.v20230823.jar
+    - jetty-util-9.4.52.v20230823.jar
+    - javax-websocket-client-impl-9.4.52.v20230823.jar
+    - websocket-api-9.4.52.v20230823.jar
+    - websocket-client-9.4.52.v20230823.jar
+    - websocket-common-9.4.52.v20230823.jar
  * SnakeYaml -- snakeyaml-2.0.jar
  * Google Error Prone Annotations - error_prone_annotations-2.5.1.jar
  * Javassist -- javassist-3.25.0-GA.jar

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@ flexible messaging model and an intuitive client API.</description>
     <curator.version>5.1.0</curator.version>
     <netty.version>4.1.94.Final</netty.version>
     <netty-iouring.version>0.0.21.Final</netty-iouring.version>
-    <jetty.version>9.4.51.v20230217</jetty.version>
+    <jetty.version>9.4.52.v20230823</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.34</jersey.version>
     <athenz.version>1.10.50</athenz.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -283,22 +283,22 @@ The Apache Software License, Version 2.0
     - joda-time-2.10.10.jar
     - failsafe-2.4.4.jar
   * Jetty
-    - http2-client-9.4.51.v20230217.jar
-    - http2-common-9.4.51.v20230217.jar
-    - http2-hpack-9.4.51.v20230217.jar
-    - http2-http-client-transport-9.4.51.v20230217.jar
-    - jetty-alpn-client-9.4.51.v20230217.jar
-    - http2-server-9.4.51.v20230217.jar
-    - jetty-alpn-java-client-9.4.51.v20230217.jar
-    - jetty-client-9.4.51.v20230217.jar
-    - jetty-http-9.4.51.v20230217.jar
-    - jetty-io-9.4.51.v20230217.jar
-    - jetty-jmx-9.4.51.v20230217.jar
-    - jetty-security-9.4.51.v20230217.jar
-    - jetty-server-9.4.51.v20230217.jar
-    - jetty-servlet-9.4.51.v20230217.jar
-    - jetty-util-9.4.51.v20230217.jar
-    - jetty-util-ajax-9.4.51.v20230217.jar
+    - http2-client-9.4.52.v20230823.jar
+    - http2-common-9.4.52.v20230823.jar
+    - http2-hpack-9.4.52.v20230823.jar
+    - http2-http-client-transport-9.4.52.v20230823.jar
+    - jetty-alpn-client-9.4.52.v20230823.jar
+    - http2-server-9.4.52.v20230823.jar
+    - jetty-alpn-java-client-9.4.52.v20230823.jar
+    - jetty-client-9.4.52.v20230823.jar
+    - jetty-http-9.4.52.v20230823.jar
+    - jetty-io-9.4.52.v20230823.jar
+    - jetty-jmx-9.4.52.v20230823.jar
+    - jetty-security-9.4.52.v20230823.jar
+    - jetty-server-9.4.52.v20230823.jar
+    - jetty-servlet-9.4.52.v20230823.jar
+    - jetty-util-9.4.52.v20230823.jar
+    - jetty-util-ajax-9.4.52.v20230823.jar
   * Byte Buddy
     - byte-buddy-1.11.13.jar
   * Apache BVal


### PR DESCRIPTION
### Motivation

Jetty 9.4.51 has CVE-2023-36479(4.3), CVE-2023-40167(5.3), CVE-2023-41900(4.3). These don't seem to be severe for Pulsar, but it's better to upgrade when there's a possibility to use dependencies which don't have reported CVEs. 

### Modifications

Upgrade Jetty to 9.4.52

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->