### PR TITLE
[fix][sec] Upgrade snappy-java to 1.1.10.5

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -484,7 +484,7 @@ The Apache Software License, Version 2.0
     - org.apache.zookeeper-zookeeper-jute-3.8.1.jar
     - org.apache.zookeeper-zookeeper-prometheus-metrics-3.8.1.jar
   * Snappy Java
-    - org.xerial.snappy-snappy-java-1.1.10.1.jar
+    - org.xerial.snappy-snappy-java-1.1.10.5.jar
   * Google HTTP Client
     - com.google.http-client-google-http-client-gson-1.41.0.jar
     - com.google.http-client-google-http-client-1.41.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@ flexible messaging model and an intuitive client API.</description>
     <zookeeper.version>3.8.1</zookeeper.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <commons-text.version>1.10.0</commons-text.version>
-    <snappy.version>1.1.10.1</snappy.version> <!-- ZooKeeper server -->
+    <snappy.version>1.1.10.5</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
     <netty.version>4.1.94.Final</netty.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -458,7 +458,7 @@ The Apache Software License, Version 2.0
   * JSON Simple
     - json-simple-1.1.1.jar
   * Snappy
-    - snappy-java-1.1.10.1.jar
+    - snappy-java-1.1.10.5.jar
   * Jackson
     - jackson-module-parameter-names-2.14.2.jar
   * Java Assist


### PR DESCRIPTION
### Motivation

snappy-java 1.1.10.1 contains CVE-2023-43642 . Upgrade the dependency to 1.1.10.5 to get rid of the CVE.

### Modifications

Upgrade the dependency to 1.1.10.5 to get rid of the CVE.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
