### PR TITLE
[fix][sec] Add OWASP Dependency Check suppressions

### DIFF
--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -457,4 +457,16 @@
        ]]></notes>
         <cve>CVE-2023-35116</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   This is a false positive in avro-protobuf. The vulnerability is in Hamba avro golang library.
+   ]]></notes>
+        <cve>CVE-2023-37475</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+    This CVE can be suppressed since it is covered in Pulsar by hostname verification changes made in https://github.com/apache/pulsar/pull/15824.
+   ]]></notes>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### Motivation

OWASP dependency check report ([example](https://github.com/apache/pulsar/actions/runs/6345669507/job/17238038834)) has some CVEs that can be suppressed.

### Modifications

- add 2 suppressions
  - CVE-2023-37475 is a false positive
  - CVE-2023-4586 is about Netty hostname verification and that is already covered in Pulsar code base with https://github.com/apache/pulsar/pull/15824 changes.
    - Please notice that hostname verification is not enabled by default in Pulsar. Please see PIP-273 to change the default. #20453 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->