### PR TITLE
[fix][client] Use byte schema for DLQ topic to avoid client side schema validation

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2195,7 +2195,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                     String originMessageIdStr = message.getMessageId().toString();
                     String originTopicNameStr = getOriginTopicNameStr(message);
                     TypedMessageBuilder<byte[]> typedMessageBuilderNew =
-                            producerDLQ.newMessage(Schema.AUTO_PRODUCE_BYTES(message.getReaderSchema().get()))
+                            producerDLQ.newMessage(Schema.BYTES)
                             .value(message.getData())
                             .properties(getPropertiesMap(message, originMessageIdStr, originTopicNameStr));
                     if (message.hasKey()) {
@@ -2246,7 +2246,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             try {
                 if (deadLetterProducer == null) {
                     deadLetterProducer =
-                            ((ProducerBuilderImpl<byte[]>) client.newProducer(Schema.AUTO_PRODUCE_BYTES(schema)))
+                            ((ProducerBuilderImpl<byte[]>) client.newProducer(Schema.BYTES))
                                     .initialSubscriptionName(this.deadLetterPolicy.getInitialSubscriptionName())
                                     .topic(this.deadLetterPolicy.getDeadLetterTopic())
                                     .producerName(String.format("%s-%s-%s-DLQ", this.topicName, this.subscription,


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

Fixes #20635

### Motivation

When broker side schema validation is disabled and consumer receives an Avro message that has an incompatible schema then sending messages to DLQ fails due to a client side schema validation. This causes a fast loop that starts creating producers for DLQ topic, consumer gets stuck and explodes the number of producer metrics exposed from broker. [Example implementation of this issue](https://github.com/tonisojandu/pulsar-dlq-schema-issue-example). 

### Modifications

By not inferring the DLQ producer schema from the consumer schema and just producing them as byte schema, this issue is fixed. 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already mostly covered by existing tests, such as `org.apache.pulsar.client.impl.ConsumerImplTest`. 

However, to cover this specific verification edge case `org.apache.pulsar.client.impl.ConsumerImpl` would need to refactored to expose `possibleSendToDeadLetterTopicMessages` for stubbing. Alternatively, a more complicated component test would be needed that would cover the complete `ConsumerImpl.messageReceived(CommandMessage cmdMessage, ByteBuf headersAndPayload, ClientCnx cnx)`. This would need to deal with encryption and compression. Did not find an example to base this potential test, so I am not sure what approach to take here.

Manually checked that the problem was solved in the constructed [example](https://github.com/tonisojandu/pulsar-dlq-schema-issue-example).

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [x] The schema
- [x] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/tonisojandu/pulsar

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
