### PR TITLE
[improve][pip] PIP-304: Make PublishContext provide the message metadata

### DIFF
--- a/pip/pip-304.md
+++ b/pip/pip-304.md
@@ -1,0 +1,85 @@
+# Motivation
+
+We have a scenario that uses the `org.apache.pulsar.broker.intercept.BrokerInterceptor#messageProduced`, and need to
+obtain the `org.apache.pulsar.common.api.proto.MessageMetadata`, but the `org.apache.pulsar.broker.service.Topic.PublishContext` doesn't provide this data.
+
+I will obtain the following data from the `org.apache.pulsar.common.api.proto.MessageMetadata`:
+
+- getPublishTime
+- getEventTime
+- getDeliverAtTime
+- getPartitionKey
+
+# Goals
+
+## In Scope
+
+Make `org.apache.pulsar.broker.service.Topic.PublishContext` to provide the `org.apache.pulsar.common.api.proto.MessageMetadata`.
+
+# Detailed Design
+
+## Design & Implementation Details
+
+1. Add `getMessageMetadata()` to `org.apache.pulsar.broker.service.Topic.PublishContext` to obtain the message metadata:
+
+```java
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+
+public interface Topic {
+    interface PublishContext {
+        default MessageMetadata getMessageMetadata() {
+            return null;
+        }
+    }
+}
+```
+
+2. Override `getMessageMetadata()` in `org.apache.pulsar.broker.service.Producer.MessagePublishContext`:
+
+```java
+
+private static final class MessagePublishContext implements PublishContext, Runnable, Position {
+    private ByteBuf headerAndPayload; // From org.apache.pulsar.broker.service.ServerCnx.handleSend 
+
+    @Override
+    public MessageMetadata getMessageMetadata() {
+        MessageMetadata md;
+        headerAndPayload.markReaderIndex();
+        try {
+            md = Commands.parseMessageMetadata(headersAndPayload);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid headersAndPayload");
+        } finally {
+            headerAndPayload.resetReaderIndex();
+        }
+
+        return md;
+    }
+}
+```
+
+# Backward & Forward Compatibility
+
+## Revert
+
+This should be considered a bug, so cherry-pick is needed.
+
+- branch-2.10
+- branch-2.11
+- branch-3.0
+- branch-3.1
+
+## Upgrade
+
+None.
+
+# Alternatives
+
+None.
+
+# General Notes
+
+# Links
+
+* Mailing List discussion thread:
+* Mailing List voting thread:

--- a/pip/pip-304.md
+++ b/pip/pip-304.md
@@ -81,5 +81,5 @@ None.
 
 # Links
 
-* Mailing List discussion thread:
+* Mailing List discussion thread: https://lists.apache.org/thread/72szlzc0rw1hbn4v0w54qgq93cn9k4px
 * Mailing List voting thread:


### PR DESCRIPTION
### Motivation

A PIP for making PublishContext provide the message metadata.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->