### PR TITLE
[fix][test] Move NarUnpackerTest to flaky group

### DIFF
--- a/pulsar-common/src/test/java/org/apache/pulsar/common/nar/NarUnpackerTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/nar/NarUnpackerTest.java
@@ -38,6 +38,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 @Slf4j
+@Test(groups = "flaky")
 public class NarUnpackerTest {
     File sampleZipFile;
     File extractDirectory;


### PR DESCRIPTION
### Motivation

Temporarily move to the flaky group to avoid the CI being blocked.

See https://github.com/apache/pulsar/issues/21291

### Modifications

- Move NarUnpackerTest to flaky group

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->