### PR TITLE
[fix][doc] Fix typos in doc for Validator class

### DIFF
--- a/pulsar-config-validation/src/main/java/org/apache/pulsar/config/validation/Validator.java
+++ b/pulsar-config-validation/src/main/java/org/apache/pulsar/config/validation/Validator.java
@@ -32,7 +32,7 @@ public abstract class Validator {
     }
 
     /**
-     * validate the field value o that belogs to the field which is named name
+     * validate the field value o that belongs to the field which is named name
      * This method should throw IllegalArgumentException in case o doesn't
      * validate per this validator's implementation.
      */


### PR DESCRIPTION
### Motivation

Fix typos in doc for Validator class


### Modifications

`belogs` => `belongs`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->