### PR TITLE
[fix][test] Fix flaky test NarUnpackerTest

### DIFF
--- a/pulsar-common/src/test/java/org/apache/pulsar/common/nar/NarUnpackerTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/nar/NarUnpackerTest.java
@@ -38,7 +38,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 @Slf4j
-@Test(groups = "flaky")
+@Test
 public class NarUnpackerTest {
     File sampleZipFile;
     File extractDirectory;
@@ -47,7 +47,7 @@ public class NarUnpackerTest {
     public void createSampleZipFile() throws IOException {
         sampleZipFile = Files.createTempFile("sample", ".zip").toFile();
         try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(sampleZipFile))) {
-            for (int i = 0; i < 10000; i++) {
+            for (int i = 0; i < 5000; i++) {
                 ZipEntry e = new ZipEntry("hello" + i + ".txt");
                 out.putNextEntry(e);
                 byte[] msg = "hello world!".getBytes(StandardCharsets.UTF_8);
@@ -59,12 +59,20 @@ public class NarUnpackerTest {
     }
 
     @AfterMethod(alwaysRun = true)
-    void deleteSampleZipFile() throws IOException {
-        if (sampleZipFile != null) {
-            sampleZipFile.delete();
+    void deleteSampleZipFile() {
+        if (sampleZipFile != null && sampleZipFile.exists()) {
+            try {
+                sampleZipFile.delete();
+            } catch (Exception e) {
+                log.warn("Failed to delete file {}", sampleZipFile, e);
+            }
         }
-        if (extractDirectory != null) {
-            FileUtils.deleteFile(extractDirectory, true);
+        if (extractDirectory != null && extractDirectory.exists()) {
+            try {
+                FileUtils.deleteFile(extractDirectory, true);
+            } catch (IOException e) {
+                log.warn("Failed to delete directory {}", extractDirectory, e);
+            }
         }
     }
 
@@ -112,7 +120,7 @@ public class NarUnpackerTest {
 
     @Test
     void shouldExtractFilesOnceInDifferentProcess() throws InterruptedException {
-        int processes = 10;
+        int processes = 5;
         String javaExePath = findJavaExe().getAbsolutePath();
         CountDownLatch countDownLatch = new CountDownLatch(processes);
         AtomicInteger exceptionCounter = new AtomicInteger();
@@ -123,7 +131,9 @@ public class NarUnpackerTest {
                     // fork a new process with the same classpath
                     Process process = new ProcessBuilder()
                             .command(javaExePath,
-                                    "-Xmx64m",
+                                    "-Xmx96m",
+                                    "-XX:TieredStopAtLevel=1",
+                                    "-Dlog4j2.disable.jmx=true",
                                     "-cp",
                                     System.getProperty("java.class.path"),
                                     // use NarUnpackerWorker as the main class
@@ -131,6 +141,7 @@ public class NarUnpackerTest {
                                     // pass arguments to use for testing
                                     sampleZipFile.getAbsolutePath(),
                                     extractDirectory.getAbsolutePath())
+                            .redirectErrorStream(true)
                             .start();
                     String output = IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8);
                     int retval = process.waitFor();
@@ -148,7 +159,7 @@ public class NarUnpackerTest {
                 }
             }).start();
         }
-        assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
+        assertTrue(countDownLatch.await(30, TimeUnit.SECONDS), "All processes should finish before timeout");
         assertEquals(exceptionCounter.get(), 0);
         assertEquals(extractCounter.get(), 1);
     }


### PR DESCRIPTION
Fixes #21291
Fixes #21285

### Motivation

NarUnpackerTest is really flaky. See the above isues that this PR fixes. 
When investigating the problem, I was able to reproduce the issue by running the test within Docker with constrained resources. There's a 30 second timeout in the shouldExtractFilesOnceInDifferentProcess test for the 10 different processes to complete. This takes much longer since each process uses significant amount of CPU. The fix is to reduce the CPU consumption by reducing the test data size, reducing the number of processes and tuning the JVM parameters for the forked processes.

### Modifications

- reduce number of processes from 10 to 5
- reduce the number of files in the sample zip from 10000 to 5000
- make the test use less CPU resources so that it will run in CI with constrained resources
  - make JIT compiler stop at C1
  - disable JMX registration in Log4j2 which showed up in profiling
  - increase max heap size from 64MB to 96MB to give more head room for GC

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->