### PR TITLE
[fix][test] Fix flaky OneWayReplicatorTest.testReplicatorProducerStatInTopic

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.policies.data.TopicStats;
@@ -55,11 +54,6 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         final String topicName = BrokerTestUtil.newUniqueName("persistent://" + defaultNamespace + "/tp_");
         final String subscribeName = "subscribe_1";
         final byte[] msgValue = "test".getBytes();
-
-        admin1.topics().createNonPartitionedTopic(topicName);
-        admin2.topics().createNonPartitionedTopic(topicName);
-        admin1.topics().createSubscription(topicName, subscribeName, MessageId.earliest);
-        admin2.topics().createSubscription(topicName, subscribeName, MessageId.earliest);
 
         // Verify replicator works.
         Producer<byte[]> producer1 = client1.newProducer().topic(topicName).create();


### PR DESCRIPTION
Fixes #21331

### Motivation

OneWayReplicatorTest.testReplicatorProducerStatInTopic is flaky

### Modifications

Remove the explicit creation of topics and subscriptions since it's not relevant for this test.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->