### PR TITLE
[fix] [test] [branch-2.11] fix testEscapeLabelValue failed

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -1752,7 +1752,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
                 false, statsOut);
         String metricsStr = statsOut.toString();
         final List<String> subCountLines = metricsStr.lines()
-                .filter(line -> line.startsWith("pulsar_subscriptions_count"))
+                .filter(line -> line.startsWith("pulsar_subscriptions_count{cluster=\"test\",namespace=\"prop/ns-abc1\""))
                 .collect(Collectors.toList());
         System.out.println(subCountLines);
         assertEquals(subCountLines.size(), 1);


### PR DESCRIPTION
### Motivation
At the branch master, the test can be passed, 
At branch-2.11, the `NamespaceStatsAggregator#printDefaultBrokerStats` will append the `pulsar_subscriptions_count`. This logic has been removed at the master branch.
https://github.com/apache/pulsar/blob/2a3b96a39c6595d7ac978e22284ac315784f25d8/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java#L309C30-L309C56

At the topic level, it will also print `pulsar_subscriptions_count`. So the test will be failed.

The failed test:
```
Error:  testEscapeLabelValue(org.apache.pulsar.broker.stats.PrometheusMetricsTest)  Time elapsed: 0.146 s  <<< FAILURE!
  java.lang.AssertionError: expected [1] but found [2]
  	at org.testng.Assert.fail(Assert.java:99)
  	at org.testng.Assert.failNotEquals(Assert.java:1037)
  	at org.testng.Assert.assertEqualsImpl(Assert.java:140)
  	at org.testng.Assert.assertEquals(Assert.java:122)
  	at org.testng.Assert.assertEquals(Assert.java:907)
  	at org.testng.Assert.assertEquals(Assert.java:917)
  	at org.apache.pulsar.broker.stats.PrometheusMetricsTest.testEscapeLabelValue(PrometheusMetricsTest.java:1758)
  	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
  	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
  	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
  	at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:45)
  	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:73)
  	at org.testng.internal.InvokeMethodRunnable.call(InvokeMethodRunnable.java:11)
  	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
  	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
  	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
  	at java.base/java.lang.Thread.run(Thread.java:833)
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

