### PR TITLE
[fix][broker] Fix heartbeat namespace create transaction internal topic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -310,7 +310,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         TopicName topicName = TopicName.get(topic);
         if (brokerService.getPulsar().getConfiguration().isTransactionCoordinatorEnabled()
-                && !isEventSystemTopic(topicName)) {
+                && !isEventSystemTopic(topicName)
+                && !NamespaceService.isHeartbeatNamespace(topicName.getNamespaceObject())) {
             this.transactionBuffer = brokerService.getPulsar()
                     .getTransactionBufferProvider().newTransactionBuffer(this);
         } else {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
@@ -81,6 +81,7 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
         conf.setDefaultNumPartitions(PARTITIONS);
         conf.setManagedLedgerMaxEntriesPerLedger(1);
         conf.setBrokerDeleteInactiveTopicsEnabled(false);
+        conf.setTransactionCoordinatorEnabled(true);
 
         super.baseSetup();
     }
@@ -205,6 +206,24 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
         Assert.assertThrows(PulsarAdminException.ConflictException.class, () -> {
             admin.topicPolicies().setMaxConsumers(topicName.toString(), 2);
         });
+    }
+
+    @Test
+    public void testHeartbeatNamespaceNotCreateTransactionInternalTopic() throws Exception {
+        admin.brokers().healthcheck(TopicVersion.V2);
+        NamespaceName namespaceName = NamespaceService.getHeartbeatNamespaceV2(pulsar.getLookupServiceAddress(),
+                pulsar.getConfig());
+        TopicName topicName = TopicName.get("persistent",
+                namespaceName, SystemTopicNames.TRANSACTION_BUFFER_SNAPSHOT);
+        Optional<Topic> optionalTopic = pulsar.getBrokerService()
+                .getTopic(topicName.getPartition(1).toString(), false).join();
+        Assert.assertTrue(optionalTopic.isEmpty());
+
+        List<String> topics = getPulsar().getNamespaceService().getListOfPersistentTopics(namespaceName).join();
+        Assert.assertEquals(topics.size(), 1);
+        TopicName heartbeatTopicName = TopicName.get("persistent",
+                namespaceName, BrokersBase.HEALTH_CHECK_TOPIC_SUFFIX);
+        Assert.assertEquals(topics.get(0), heartbeatTopicName.toString());
     }
 
     @Test


### PR DESCRIPTION
### Motivation

If we set transactionCoordinatorEnabled=true, heartbeat namespace create __transaction_buffer_snapshot topic. 

Actually heartbeat namespace should not create transaction internal topic.

```
2023-10-12T11:24:44,738+0800 [bookkeeper-ml-scheduler-OrderedScheduler-2-0] INFO  org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl - [pulsar/localhost:59381/persistent/healthcheck] Successfully initialize managed ledger
2023-10-12T11:24:44,809+0800 [bookkeeper-ml-scheduler-OrderedScheduler-2-0] INFO  org.apache.pulsar.broker.systopic.NamespaceEventsSystemTopicFactory - Create transaction buffer snapshot client, topicName : persistent://pulsar/localhost:59381/__transaction_buffer_snapshot
2023-10-12T11:24:44,839+0800 [broker-topic-workers-OrderedExecutor-7-0] INFO  org.apache.pulsar.broker.service.BrokerService - Created topic persistent://pulsar/localhost:59381/healthcheck - dedup is disabled
2023-10-12T11:24:44,843+0800 [pulsar-io-16-3] INFO  org.apache.pulsar.client.impl.ConnectionPool - [[id: 0x50bf7bc3, L:/127.0.0.1:59501 - R:localhost/127.0.0.1:59338]] Connected to server
2023-10-12T11:24:44,870+0800 [pulsar-io-16-4] INFO  org.apache.pulsar.broker.service.ServerCnx - [/127.0.0.1:59501] connected with clientVersion=Pulsar-Java-v3.2.0-SNAPSHOT, clientProtocolVersion=21, proxyVersion=null
2023-10-12T11:24:44,899+0800 [configuration-metadata-store-4-1] INFO  org.apache.pulsar.broker.service.BrokerService - partitioned metadata successfully created for persistent://pulsar/localhost:59381/__transaction_buffer_snapshot
2023-10-12T11:24:44,965+0800 [pulsar-io-16-3] INFO  org.apache.pulsar.client.impl.ProducerImpl - [persistent://pulsar/localhost:59381/healthcheck] [null] Creating producer on cnx [id: 0x50bf7bc3, L:/127.0.0.1:59501 - R:localhost/127.0.0.1:59338]
2023-10-12T11:24:44,971+0800 [pulsar-io-16-3] INFO  org.apache.pulsar.client.impl.ProducerImpl - [persistent://pulsar/localhost:59381/__transaction_buffer_snapshot-partition-0] [null] Creating producer on cnx [id: 0x50bf7bc3, L:/127.0.0.1:59501 - R:localhost/127.0.0.1:59338]
2023-10-12T11:24:44,972+0800 [pulsar-io-16-3] INFO  org.apache.pulsar.client.impl.ConsumerImpl - [persistent://pulsar/localhost:59381/__transaction_buffer_snapshot-partition-0][multiTopicsReader-0fc4fb7bcc] Subscribing to topic on cnx [id: 0x50bf7bc3, L:/127.0.0.1:59501 - R:localhost/127.0.0.1:59338], consumerId 0
2023-10-12T11:24:44,975+0800 [pulsar-io-16-3] INFO  org.apache.pulsar.client.impl.ConsumerImpl - [persistent://pulsar/localhost:59381/__transaction_buffer_snapshot-partition-1][multiTopicsReader-0fc4fb7bcc] Subscribing to topic on cnx [id: 0x50bf7bc3, L:/127.0.0.1:59501 - R:localhost/127.0.0.1:59338], consumerId 1
2023-10-12T11:24:44,976+0800 [pulsar-io-16-3] INFO  org.apache.pulsar.client.impl.ConsumerImpl - [persistent://pulsar/localhost:59381/__transaction_buffer_snapshot-partition-2][multiTopicsReader-0fc4fb7bcc] Subscribing to topic on cnx [id: 0x50bf7bc3, L:/127.0.0.1:59501 - R:localhost/127.0.0.1:59338], consumerId 2
2023-10-12T11:24:44,976+0800 [pulsar-io-16-3] INFO  org.apache.pulsar.client.impl.ConsumerImpl - [persistent://pulsar/localhost:59381/__transaction_buffer_snapshot-partition-3][multiTopicsReader-0fc4fb7bcc] Subscribing to topic on cnx [id: 0x50bf7bc3, L:/127.0.0.1:59501 - R:localhost/127.0.0.1:59338], consumerId 3
2023-10-12T11:24:44,977+0800 [pulsar-io-16-3] INFO  org.apache.pulsar.client.impl.ConsumerImpl - [persistent://pulsar/localhost:59381/__transaction_buffer_snapshot-partition-4][multiTopicsReader-0fc4fb7bcc] Subscribing to topic on cnx [id: 0x50bf7bc3, L:/127.0.0.1:59501 - R:localhost/127.0.0.1:59338], consumerId 4
2023-10-12T11:24:44,991+0800 [pulsar-io-16-4] INFO  org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl - Opening managed ledger pulsar/localhost:59381/persistent/__transaction_buffer_snapshot-partition-0
```

### Modifications

do not construct TransactionBuffer if topic belongs to heartbeat namespace


### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/TakaHiR07/pulsar/pull/15

