### PR TITLE
[improve][broker] heartbeat namespace not create event topic 

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -220,6 +220,9 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
     @Override
     public TopicPolicies getTopicPolicies(TopicName topicName,
                                           boolean isGlobal) throws TopicPoliciesCacheNotInitException {
+        if (NamespaceService.isHeartbeatNamespace(topicName.getNamespaceObject())) {
+            return null;
+        }
         if (!policyCacheInitMap.containsKey(topicName.getNamespaceObject())) {
             NamespaceName namespace = topicName.getNamespaceObject();
             prepareInitPoliciesCacheAsync(namespace);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
@@ -215,6 +215,22 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
     }
 
     @Test
+    public void testHeartbeatTopicBeDeleted() throws Exception {
+        admin.brokers().healthcheck(TopicVersion.V2);
+        NamespaceName namespaceName = NamespaceService.getHeartbeatNamespaceV2(pulsar.getLookupServiceAddress(),
+                pulsar.getConfig());
+        TopicName heartbeatTopicName = TopicName.get("persistent", namespaceName, BrokersBase.HEALTH_CHECK_TOPIC_SUFFIX);
+
+        List<String> topics = getPulsar().getNamespaceService().getListOfPersistentTopics(namespaceName).join();
+        Assert.assertEquals(topics.size(), 1);
+        Assert.assertEquals(topics.get(0), heartbeatTopicName.toString());
+
+        admin.topics().delete(heartbeatTopicName.toString(), true);
+        topics = getPulsar().getNamespaceService().getListOfPersistentTopics(namespaceName).join();
+        Assert.assertEquals(topics.size(), 0);
+    }
+
+    @Test
     public void testSetBacklogCausedCreatingProducerFailure() throws Exception {
         final String ns = "prop/ns-test";
         final String topic = ns + "/topic-1";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
@@ -190,6 +190,13 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
         Optional<Topic> optionalTopic = pulsar.getBrokerService()
                 .getTopic(topicName.getPartition(1).toString(), false).join();
         Assert.assertTrue(optionalTopic.isEmpty());
+
+        TopicName heartbeatTopicName = TopicName.get("persistent",
+                namespaceName, BrokersBase.HEALTH_CHECK_TOPIC_SUFFIX);
+        admin.topics().getRetention(heartbeatTopicName.toString());
+        optionalTopic = pulsar.getBrokerService()
+                .getTopic(topicName.getPartition(1).toString(), false).join();
+        Assert.assertTrue(optionalTopic.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Heartbeat namespace should not create __change_events topics. But if we call admin.topics.getRetention(persistent://pulsar/localhost:65213/healthcheck) , or other admin topic api, event topic still be created. 

we'd better avoid this case, although in most time we would not call admin api for healthcheck topic.


```
2023-10-12T11:52:59,499+0800 [pulsar-io-8-3] INFO  org.eclipse.jetty.server.RequestLog - 127.0.0.1 - - [12/10月/2023:11:52:59 +0800] "GET /admin/v2/brokers/health?topicVersion=V2 HTTP/1.1" 200 2 "-" "Pulsar-Java-v3.2.0-SNAPSHOT" 426
2023-10-12T11:52:59,508+0800 [bookkeeper-ml-scheduler-OrderedScheduler-6-0] INFO  org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl - Opening managed ledger pulsar/localhost:54480/persistent/__change_events-partition-1
2023-10-12T11:52:59,513+0800 [bookkeeper-ml-scheduler-OrderedScheduler-6-0] INFO  org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl - [pulsar/localhost:54480/persistent/__change_events-partition-1] Closing managed ledger
2023-10-12T11:52:59,531+0800 [pulsar-7-4] INFO  org.apache.pulsar.broker.systopic.NamespaceEventsSystemTopicFactory - Create topic policies system topic client persistent://pulsar/localhost:54480/__change_events
2023-10-12T11:52:59,533+0800 [pulsar-7-4] WARN  org.apache.pulsar.client.util.RetryUtil - Execution with retry fail, because of Topic policies cache have not init., will retry in 500 ms
2023-10-12T11:52:59,561+0800 [configuration-metadata-store-4-1] INFO  org.apache.pulsar.broker.service.BrokerService - partitioned metadata successfully created for persistent://pulsar/localhost:54480/__change_events
2023-10-12T11:52:59,574+0800 [pulsar-io-8-3] INFO  org.apache.pulsar.client.impl.ConsumerImpl - [persistent://pulsar/localhost:54480/__change_events-partition-0][multiTopicsReader-12e15916e3] Subscribing to topic on cnx [id: 0x3d7925a7, L:/127.0.0.1:54525 - R:localhost/127.0.0.1:54440], consumerId 1
2023-10-12T11:52:59,575+0800 [pulsar-io-8-3] INFO  org.apache.pulsar.client.impl.ConsumerImpl - [persistent://pulsar/localhost:54480/__change_events-partition-1][multiTopicsReader-12e15916e3] Subscribing to topic on cnx [id: 0x3d7925a7, L:/127.0.0.1:54525 - R:localhost/127.0.0.1:54440], consumerId 2
2023-10-12T11:52:59,575+0800 [pulsar-io-8-3] INFO  org.apache.pulsar.client.impl.ConsumerImpl - [persistent://pulsar/localhost:54480/__change_events-partition-2][multiTopicsReader-12e15916e3] Subscribing to topic on cnx [id: 0x3d7925a7, L:/127.0.0.1:54525 - R:localhost/127.0.0.1:54440], consumerId 3
2023-10-12T11:52:59,575+0800 [pulsar-io-8-3] INFO  org.apache.pulsar.client.impl.ConsumerImpl - [persistent://pulsar/localhost:54480/__change_events-partition-3][multiTopicsReader-12e15916e3] Subscribing to topic on cnx [id: 0x3d7925a7, L:/127.0.0.1:54525 - R:localhost/127.0.0.1:54440], consumerId 4
2023-10-12T11:52:59,575+0800 [pulsar-io-8-3] INFO  org.apache.pulsar.client.impl.ConsumerImpl - [persistent://pulsar/localhost:54480/__change_events-partition-4][multiTopicsReader-12e15916e3] Subscribing to topic on cnx [id: 0x3d7925a7, L:/127.0.0.1:54525 - R:localhost/127.0.0.1:54440], consumerId 5
```

### Modifications

return null topicPolicy if topic belongs to heartbeat namespace.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->
- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/TakaHiR07/pulsar/pull/16

