### PR TITLE
[improve][pip] PIP-305: Customize DNS servers to use for Pulsar Client

### DIFF
--- a/pip/pip-305.md
+++ b/pip/pip-305.md
@@ -4,15 +4,15 @@ Pulsar client use Netty DNS to resolve hostnames.
 
 # Motivation
 
-Currently Pulsar client levereage on JVM detected DNSes or on Google DNSes if nothing was found (as per Netty default). You cannot change which DNSes use to resolve hostnames but you are forced to use local server one (like DNSes configured through resolv.conf or similar ways) or leverage on some Netty "black magic" system properties.
+Currently Pulsar client levereage on JVM detected DNS servers or on Google DNS servers if nothing was found (as per Netty default). You cannot change which DNS use to resolve hostnames but you are forced to use local server one (like DNS servers configured through resolv.conf or similar ways) or leverage on some Netty "black magic" system properties.
 
-The ability to directly configure which DNSes use is strictly necessary in environment with "specialized" DNSes.
+The ability to directly configure which DNS use is strictly necessary in environment with "specialized" DNS servers.
 
 # Goals
 
 ## In Scope
 
-Add a new configuration on Pulsar client to explicitly set which DNSes use.
+Add a new configuration on Pulsar client to explicitly set which DNS use.
 
 ## Out of Scope
 
@@ -21,7 +21,7 @@ Fully configure DNS layer, properties, timeouts etcetera.
 
 # High Level Design
 
-A new client configuration will be added to list wich DNSes use. Such configuration will be checked when creating Pulsar clients to instantiate the DNS resolver.
+A new client configuration will be added to list wich DNS server use. Such configuration will be checked when creating Pulsar clients to instantiate the DNS resolver.
 If no configuration is provided the client must use current defaults.
 
 
@@ -63,7 +63,7 @@ NA
 
 # Security Considerations
 
-The client will have the ability to use a different seto of DNSes. It is possible to alter hostnames resolutions however it is expected that this does not pose any security risks.
+The client will have the ability to use a different set of DNS servers. It is possible to alter hostnames resolutions however it is expected that this does not pose any security risks.
 
 # Backward & Forward Compatibility
 

--- a/pip/pip-305.md
+++ b/pip/pip-305.md
@@ -83,5 +83,5 @@ Expose an interface builder to fully configure the DNS layer. It has much more i
 
 # Links
 
-* Mailing List discussion thread:
+* Mailing List discussion thread: https://lists.apache.org/thread/p0870y7o6brv5y1ghn5tz9hvs24bl1k4
 * Mailing List voting thread:

--- a/pip/pip-305.md
+++ b/pip/pip-305.md
@@ -1,0 +1,87 @@
+# Background knowledge
+
+Pulsar client use Netty DNS to resolve hostnames.
+
+# Motivation
+
+Currently Pulsar client levereage on JVM detected DNSes or on Google DNSes if nothing was found (as per Netty default). You cannot change which DNSes use to resolve hostnames but you are forced to use local server one (like DNSes configured through resolv.conf or similar ways) or leverage on some Netty "black magic" system properties.
+
+The ability to directly configure which DNSes use is strictly necessary in environment with "specialized" DNSes.
+
+# Goals
+
+## In Scope
+
+Add a new configuration on Pulsar client to explicitly set which DNSes use.
+
+## Out of Scope
+
+Fully configure DNS layer, properties, timeouts etcetera.
+
+
+# High Level Design
+
+A new client configuration will be added to list wich DNSes use. Such configuration will be checked when creating Pulsar clients to instantiate the DNS resolver.
+If no configuration is provided the client must use current defaults.
+
+
+# Detailed Design
+
+## Design & Implementation Details
+
+The new configuration will be read from org.apache.pulsar.client.impl.ConnectionPool to configure a DnsNameResolverBuilder
+
+## Public-facing Changes
+Add new dnsServerAddresses method on org.apache.pulsar.client.api.ClientBuilder.
+
+There are no breaking changes, if dnsServerAddresses is not configuret Pulsar will continue to behave like now.
+
+
+### Public API
+
+NA
+
+### Binary protocol
+
+NA
+
+### Configuration
+
+Add new dnsServerAddresses property on org.apache.pulsar.client.impl.conf.ClientConfigurationData.
+
+### CLI
+
+NA
+
+### Metrics
+
+NA
+
+# Monitoring
+
+NA
+
+# Security Considerations
+
+The client will have the ability to use a different seto of DNSes. It is possible to alter hostnames resolutions however it is expected that this does not pose any security risks.
+
+# Backward & Forward Compatibility
+
+## Revert
+
+Just remove dnsServerAddresses configuration
+
+## Upgrade
+
+Configure a dnsServerAddresses server list. The configuration is not mandatory, Pulsar can run without it just like before.
+
+# Alternatives
+
+Expose an interface builder to fully configure the DNS layer. It has much more impact and conflict with existing configuration properties dnsLookupBindAddress and dnsLookupBindPort.
+
+# General Notes
+
+# Links
+
+* Mailing List discussion thread:
+* Mailing List voting thread:

--- a/pip/pip-305.md
+++ b/pip/pip-305.md
@@ -84,4 +84,4 @@ Expose an interface builder to fully configure the DNS layer. It has much more i
 # Links
 
 * Mailing List discussion thread: https://lists.apache.org/thread/p0870y7o6brv5y1ghn5tz9hvs24bl1k4
-* Mailing List voting thread:
+* Mailing List voting thread: https://lists.apache.org/thread/7dd0htk0qqkrjxztj445lj3qskxr2dky


### PR DESCRIPTION
### Motivation

A PIP for making Pulsar Client used DNS servers configurable.

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/apache/pulsar/pull/21227