### PR TITLE
[feat] [broker] PIP-188 Add support to auto create topic resources into green cluster before migration [part-3]

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1593,6 +1593,10 @@ aggregatePublisherStatsByProducerName=false
 # if cluster is marked migrated. Disable with value 0. (Default disabled).
 clusterMigrationCheckDurationSeconds=0
 
+# Flag to start cluster migration for topic only after creating all topic's resources
+# such as tenant, namespaces, subscriptions at new green cluster. (Default disabled).
+clusterMigrationAutoResourceCreation=false
+
 ### --- Schema storage --- ###
 # The schema storage implementation used by this broker
 schemaRegistryStorageClassName=org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorageFactory

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -999,6 +999,14 @@ splitTopicAndPartitionLabelInPrometheus=false
 # Otherwise, aggregate it by list index.
 aggregatePublisherStatsByProducerName=false
 
+# Interval between checks to see if cluster is migrated and marks topic migrated
+# if cluster is marked migrated. Disable with value 0. (Default disabled).
+clusterMigrationCheckDurationSeconds=0
+
+# Flag to start cluster migration for topic only after creating all topic's resources
+# such as tenant, namespaces, subscriptions at new green cluster. (Default disabled).
+clusterMigrationAutoResourceCreation=false
+
 ### --- Schema storage --- ###
 # The schema storage implementation used by this broker.
 schemaRegistryStorageClassName=org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorageFactory

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2779,6 +2779,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int clusterMigrationCheckDurationSeconds = 0;
 
     @FieldContext(
+        category = CATEGORY_SERVER,
+        doc = "Flag to start cluster migration for topic only after creating all topic's resources"
+                + " such as tenant, namespaces, subscriptions at new green cluster. (Default disabled)."
+    )
+    private boolean clusterMigrationAutoResourceCreation = false;
+
+    @FieldContext(
         category = CATEGORY_SCHEMA,
         doc = "Enforce schema validation on following cases:\n\n"
             + " - if a producer without a schema attempts to produce to a topic with schema, the producer will be\n"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -77,6 +77,7 @@ import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.mledger.impl.ShadowManagedLedgerImpl;
+import org.apache.bookkeeper.mledger.util.Futures;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -103,6 +104,7 @@ import org.apache.pulsar.broker.service.BrokerServiceException.TopicBacklogQuota
 import org.apache.pulsar.broker.service.BrokerServiceException.TopicBusyException;
 import org.apache.pulsar.broker.service.BrokerServiceException.TopicClosedException;
 import org.apache.pulsar.broker.service.BrokerServiceException.TopicFencedException;
+import org.apache.pulsar.broker.service.BrokerServiceException.TopicMigratedException;
 import org.apache.pulsar.broker.service.BrokerServiceException.TopicTerminatedException;
 import org.apache.pulsar.broker.service.BrokerServiceException.UnsupportedSubscriptionException;
 import org.apache.pulsar.broker.service.BrokerServiceException.UnsupportedVersionException;
@@ -125,6 +127,8 @@ import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferDisable
 import org.apache.pulsar.broker.transaction.pendingack.impl.MLPendingAckStore;
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
 import org.apache.pulsar.client.admin.OffloadProcessStatus;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException.ConflictException;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
@@ -137,10 +141,12 @@ import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.KeySharedMeta;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.api.proto.TxnAction;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
+import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
 import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.CursorStats;
@@ -205,6 +211,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     private static final double MESSAGE_EXPIRY_THRESHOLD = 1.5;
 
     private static final long POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS = 60;
+
+    private static final String MIGRATION_CLUSTER_NAME = "migration-cluster";
+    private volatile boolean migrationSubsCreated = false;
 
     // topic has every published chunked message since topic is loaded
     public boolean msgChunkPublished;
@@ -2582,16 +2591,110 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         if (!clusterUrl.isPresent()) {
             return CompletableFuture.completedFuture(null);
         }
-        CompletableFuture<?> migrated = !isMigrated() ? ledger.asyncMigrate() :
-                CompletableFuture.completedFuture(null);
-        return migrated.thenApply(__ -> {
-            subscriptions.forEach((name, sub) -> {
-                if (sub.isSubsciptionMigrated()) {
-                    sub.getConsumers().forEach(Consumer::checkAndApplyTopicMigration);
-                }
-            });
-            return null;
-        }).thenCompose(__ -> checkAndDisconnectReplicators()).thenCompose(__ -> checkAndUnsubscribeSubscriptions());
+        return initMigration().thenCompose(subCreated -> {
+            migrationSubsCreated = true;
+            CompletableFuture<?> migrated = !isMigrated() ? ledger.asyncMigrate()
+                    : CompletableFuture.completedFuture(null);
+            return migrated.thenApply(__ -> {
+                subscriptions.forEach((name, sub) -> {
+                    if (sub.isSubsciptionMigrated()) {
+                        sub.getConsumers().forEach(Consumer::checkAndApplyTopicMigration);
+                    }
+                });
+                return null;
+            }).thenCompose(__ -> checkAndDisconnectReplicators()).thenCompose(__ -> checkAndUnsubscribeSubscriptions());
+        });
+    }
+
+    /**
+     * Initialize migration for a topic by creating topic's resources at migration cluster.
+     */
+    private CompletableFuture<Void> initMigration() {
+        if (migrationSubsCreated) {
+            return CompletableFuture.completedFuture(null);
+        }
+        log.info("{} initializing subscription created at migration cluster", topic);
+        return getMigratedClusterUrlAsync(getBrokerService().getPulsar()).thenCompose(clusterUrl -> {
+            if (!brokerService.getPulsar().getConfig().isClusterMigrationAutoResourceCreation()) {
+                return CompletableFuture.completedFuture(null);
+            }
+            if (!clusterUrl.isPresent()) {
+                return FutureUtil
+                        .failedFuture(new TopicMigratedException("cluster migration service-url is not configired"));
+            }
+            ClusterUrl url = clusterUrl.get();
+            ClusterData clusterData = ClusterData.builder().serviceUrl(url.getServiceUrl())
+                    .serviceUrlTls(url.getServiceUrlTls()).brokerServiceUrl(url.getBrokerServiceUrl())
+                    .brokerServiceUrlTls(url.getBrokerServiceUrlTls()).build();
+            PulsarAdmin admin = getBrokerService().getClusterPulsarAdmin(MIGRATION_CLUSTER_NAME,
+                    Optional.of(clusterData));
+
+            // namespace creation
+            final String tenant = TopicName.get(topic).getTenant();
+            final NamespaceName ns = TopicName.get(topic).getNamespaceObject();
+            List<CompletableFuture<Void>> subResults = new ArrayList<>();
+
+            return brokerService.getPulsar().getPulsarResources().getTenantResources().getTenantAsync(tenant)
+                    .thenCompose(tenantInfo -> {
+                        if (!tenantInfo.isPresent()) {
+                            return CompletableFuture.completedFuture(null);
+                        }
+                        CompletableFuture<Void> ts = new CompletableFuture<>();
+                        admin.tenants().createTenantAsync(tenant, tenantInfo.get()).handle((__, ex) -> {
+                            if (ex == null || ex instanceof ConflictException) {
+                                log.info("[{}] successfully created tenant {} for migration", topic, tenant);
+                                ts.complete(null);
+                                return null;
+                            }
+                            log.warn("[{}] Failed to create tenant {} on migration cluster {}", topic, tenant,
+                                    ex.getCause().getMessage());
+                            ts.completeExceptionally(ex.getCause());
+                            return null;
+                        });
+                        return ts;
+                    }).thenCompose(t -> {
+                        return brokerService.getPulsar().getPulsarResources().getNamespaceResources()
+                                .getPoliciesAsync(ns).thenCompose(policies -> {
+                                    if (!policies.isPresent()) {
+                                        return CompletableFuture.completedFuture(null);
+                                    }
+                                    CompletableFuture<Void> nsFuture = new CompletableFuture<>();
+                                    admin.namespaces().createNamespaceAsync(ns.toString(), policies.get())
+                                            .handle((__, ex) -> {
+                                                if (ex == null || ex instanceof ConflictException) {
+                                                    log.info("[{}] successfully created namespace {} for migration",
+                                                            topic, ns);
+                                                    nsFuture.complete(null);
+                                                    return null;
+                                                }
+                                                log.warn("[{}] Failed to create namespace {} on migration cluster {}",
+                                                        topic, ns, ex.getCause().getMessage());
+                                                nsFuture.completeExceptionally(ex.getCause());
+                                                return null;
+                                            });
+                                    return nsFuture;
+                                }).thenCompose(p -> {
+                                    subscriptions.forEach((subName, sub) -> {
+                                        CompletableFuture<Void> subResult = new CompletableFuture<>();
+                                        subResults.add(subResult);
+                                        admin.topics().createSubscriptionAsync(topic, subName, MessageId.earliest)
+                                                .handle((__, ex) -> {
+                                                    if (ex == null || ex instanceof ConflictException) {
+                                                        log.info("[{}] successfully created sub {} for migration",
+                                                                topic, subName);
+                                                        subResult.complete(null);
+                                                        return null;
+                                                    }
+                                                    log.warn("[{}] Failed to create sub {} on migration cluster, {}",
+                                                            topic, subName, ex.getCause().getMessage());
+                                                    subResult.completeExceptionally(ex.getCause());
+                                                    return null;
+                                                });
+                                    });
+                                    return Futures.waitForAll(subResults);
+                                });
+                    });
+        });
     }
 
     private CompletableFuture<Void> checkAndUnsubscribeSubscriptions() {

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
@@ -136,11 +136,14 @@ public interface ClusterData {
     @NoArgsConstructor
     @AllArgsConstructor
     class ClusterUrl {
+        String serviceUrl;
+        String serviceUrlTls;
         String brokerServiceUrl;
         String brokerServiceUrlTls;
 
         public boolean isEmpty() {
-            return brokerServiceUrl == null && brokerServiceUrlTls == null;
+            return serviceUrl != null && serviceUrlTls != null && brokerServiceUrl == null
+                    && brokerServiceUrlTls == null;
         }
     }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
@@ -162,6 +162,13 @@ public class CmdClusters extends CmdBase {
         @Parameter(names = "--migrated", description = "Is cluster migrated", required = true)
         private boolean migrated;
 
+        @Parameter(names = "--service-url", description = "New migrated cluster service url", required = false)
+        private String serviceUrl;
+
+        @Parameter(names = "--service-url-secure",
+                description = "New migrated cluster service url secure", required = false)
+        private String serviceUrlTls;
+
         @Parameter(names = "--broker-url", description = "New migrated cluster broker service url", required = false)
         private String brokerServiceUrl;
 
@@ -171,7 +178,7 @@ public class CmdClusters extends CmdBase {
 
         void run() throws PulsarAdminException {
             String cluster = getOneArgument(params);
-            ClusterUrl clusterUrl = new ClusterUrl(brokerServiceUrl, brokerServiceUrlTls);
+            ClusterUrl clusterUrl = new ClusterUrl(serviceUrl, serviceUrlTls, brokerServiceUrl, brokerServiceUrlTls);
             getAdmin().clusters().updateClusterMigration(cluster, migrated, clusterUrl);
         }
     }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataImplTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataImplTest.java
@@ -54,7 +54,8 @@ public class ClusterDataImplTest {
                 .brokerClientCertificateFilePath("/my/cert/file")
                 .listenerName("a-listener")
                 .migrated(true)
-                .migratedClusterUrl(new ClusterData.ClusterUrl("pulsar://remote", "pulsar+ssl://remote"))
+                .migratedClusterUrl(new ClusterData.ClusterUrl("http://remote", "https://remote", "pulsar://remote",
+                        "pulsar+ssl://remote"))
                 .build();
 
         ClusterDataImpl clone = originalData.clone().build();


### PR DESCRIPTION
### Motivation

Right now, topic migration requires pre-req manual steps for admin to create migrated topic's resources into green cluster such as tenant, namespaces, namespace policies, and subscriptions. This PR allows admin to automate this process and perform migration without any manual intervention.

### Modifications

- add config to control auto resource creation for topic migration
- perform topic resource creation at migrated green cluster before starting topic migration

```
./bin/pulsar-admin clusters update-cluster-migration $blueClusterName \
--service-url ${greenClusterServiceURL} \
--broker-url ${greenClusterURL} \
--broker-url-secure ${greenClusterURL} \
 --migrated
```

### Result

Broker manages topic resource creation at new migrated/green cluster and then perform topic migration without losing data.


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
