### PR TITLE
[feat] [broker] PIP-188 Fix cluster migration state store into local metadatastore 

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/PulsarResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/PulsarResources.java
@@ -61,7 +61,8 @@ public class PulsarResources {
             int operationTimeoutSec) {
         if (configurationMetadataStore != null) {
             tenantResources = new TenantResources(configurationMetadataStore, operationTimeoutSec);
-            clusterResources = new ClusterResources(configurationMetadataStore, operationTimeoutSec);
+            clusterResources = new ClusterResources(localMetadataStore, configurationMetadataStore,
+                    operationTimeoutSec);
             namespaceResources = new NamespaceResources(configurationMetadataStore, operationTimeoutSec);
             resourcegroupResources = new ResourceGroupResources(configurationMetadataStore, operationTimeoutSec);
         } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -65,7 +65,7 @@ import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
-import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.DelayedDeliveryPolicies;
 import org.apache.pulsar.common.policies.data.EntryFilters;
 import org.apache.pulsar.common.policies.data.HierarchyTopicPolicies;
@@ -1358,8 +1358,9 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
     }
 
     public static CompletableFuture<Optional<ClusterUrl>> getMigratedClusterUrlAsync(PulsarService pulsar,
-                                                                                     String topic) {
-        return pulsar.getPulsarResources().getClusterResources().getClusterAsync(pulsar.getConfig().getClusterName())
+            String topic) {
+        return pulsar.getPulsarResources().getClusterResources().getClusterPoliciesResources()
+                .getClusterPoliciesAsync(pulsar.getConfig().getClusterName())
                 .thenCombine(isNamespaceMigrationEnabledAsync(pulsar, topic),
                         ((clusterData, isNamespaceMigrationEnabled)
                                 -> ((clusterData.isPresent() && clusterData.get().isMigrated())

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -56,7 +56,7 @@ import org.apache.pulsar.common.api.proto.KeyLongValue;
 import org.apache.pulsar.common.api.proto.KeySharedMeta;
 import org.apache.pulsar.common.api.proto.MessageIdData;
 import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.TopicOperation;
 import org.apache.pulsar.common.policies.data.stats.ConsumerStatsImpl;
 import org.apache.pulsar.common.protocol.Commands;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -50,7 +50,7 @@ import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.api.proto.ProducerAccessMode;
 import org.apache.pulsar.common.api.proto.ServerError;
 import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.TopicOperation;
 import org.apache.pulsar.common.policies.data.stats.NonPersistentPublisherStatsImpl;
 import org.apache.pulsar.common.policies.data.stats.PublisherStatsImpl;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -152,7 +152,7 @@ import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
-import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.NamespaceOperation;
 import org.apache.pulsar.common.policies.data.TopicOperation;
 import org.apache.pulsar.common.policies.data.stats.ConsumerStatsImpl;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -73,7 +73,7 @@ import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.KeySharedMeta;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
-import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.CursorStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.Policies;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -147,7 +147,7 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
 import org.apache.pulsar.common.policies.data.ClusterData;
-import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.CursorStats;
 import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.LedgerInfo;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ClusterMigrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ClusterMigrationTest.java
@@ -502,7 +502,7 @@ public class ClusterMigrationTest {
         // verify that the producer1 is now is now connected to migrated cluster "r2" since backlog is cleared.
         retryStrategically((test) -> topic2.getProducers().size()==2, 10, 500);
         assertEquals(topic2.getProducers().size(), 2);
-        
+
         client1.close();
         client2.close();
         client3.close();
@@ -618,7 +618,7 @@ public class ClusterMigrationTest {
             }
         }, 10, 500);
         assertFalse(pulsar2Topic.getSubscription("s1").getConsumers().isEmpty());
-        
+
         client1.close();
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ClusterMigrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ClusterMigrationTest.java
@@ -45,7 +45,7 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.policies.data.ClusterData;
-import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.slf4j.Logger;
@@ -86,36 +86,12 @@ public class ClusterMigrationTest {
     PulsarService pulsar4;
     PulsarAdmin admin4;
 
-    @DataProvider(name = "TopicsubscriptionTypes")
-    public Object[][] subscriptionTypes() {
-        return new Object[][] {
-                {true, SubscriptionType.Shared},
-                {true, SubscriptionType.Key_Shared},
-                {true, SubscriptionType.Shared},
-                {true, SubscriptionType.Key_Shared},
-
-                {false, SubscriptionType.Shared},
-                {false, SubscriptionType.Key_Shared},
-                {false, SubscriptionType.Shared},
-                {false, SubscriptionType.Key_Shared},
-        };
-    }
-
     @DataProvider(name="NamespaceMigrationTopicSubscriptionTypes")
     public Object[][] namespaceMigrationSubscriptionTypes() {
         return new Object[][] {
-                {true, SubscriptionType.Shared, true, false},
-                {true, SubscriptionType.Key_Shared, true, false},
-                {true, SubscriptionType.Shared, false, true},
-                {true, SubscriptionType.Key_Shared, false, true},
-                {true, SubscriptionType.Shared, true, true},
-                {true, SubscriptionType.Key_Shared, true, true},
-                {false, SubscriptionType.Shared, true, false},
-                {false, SubscriptionType.Key_Shared, true, false},
-                {false, SubscriptionType.Shared, false, true},
-                {false, SubscriptionType.Key_Shared,false, true},
-                {false, SubscriptionType.Shared, true, true},
-                {false, SubscriptionType.Key_Shared,true, true},
+            {SubscriptionType.Shared, true, false},
+            {SubscriptionType.Shared, false, true},
+            {SubscriptionType.Shared, true, true},
         };
     }
 
@@ -227,14 +203,14 @@ public class ClusterMigrationTest {
     @AfterMethod(alwaysRun = true, timeOut = 300000)
     protected void cleanup() throws Exception {
         log.info("--- Shutting down ---");
-        broker1.cleanup();
         admin1.close();
-        broker2.cleanup();
         admin2.close();
-        broker3.cleanup();
         admin3.close();
-        broker4.cleanup();
         admin4.close();
+        broker1.cleanup();
+        broker2.cleanup();
+        broker3.cleanup();
+        broker4.cleanup();
     }
 
     @BeforeMethod(alwaysRun = true)
@@ -259,11 +235,11 @@ public class ClusterMigrationTest {
      * (11) Restart Broker-1 and connect producer/consumer on cluster-1
      * @throws Exception
      */
-    @Test(dataProvider = "TopicsubscriptionTypes")
-    public void testClusterMigration(boolean persistent, SubscriptionType subType) throws Exception {
+    @Test
+    public void testClusterMigration() throws Exception {
         log.info("--- Starting ReplicatorTest::testClusterMigration ---");
         final String topicName = BrokerTestUtil
-                .newUniqueName((persistent ? "persistent" : "non-persistent") + "://" + namespace + "/migrationTopic");
+                .newUniqueName("persistent://" + namespace + "/migrationTopic");
 
         @Cleanup
         PulsarClient client1 = PulsarClient.builder().serviceUrl(url1.toString()).statsInterval(0, TimeUnit.SECONDS)
@@ -271,7 +247,7 @@ public class ClusterMigrationTest {
         // cluster-1 producer/consumer
         Producer<byte[]> producer1 = client1.newProducer().topic(topicName).enableBatching(false)
                 .producerName("cluster1-1").messageRoutingMode(MessageRoutingMode.SinglePartition).create();
-        Consumer<byte[]> consumer1 = client1.newConsumer().topic(topicName).subscriptionType(subType)
+        Consumer<byte[]> consumer1 = client1.newConsumer().topic(topicName).subscriptionType(SubscriptionType.Shared)
                 .subscriptionName("s1").subscribe();
         AbstractTopic topic1 = (AbstractTopic) pulsar1.getBrokerService().getTopic(topicName, false).getNow(null).get();
         retryStrategically((test) -> !topic1.getProducers().isEmpty(), 5, 500);
@@ -298,6 +274,7 @@ public class ClusterMigrationTest {
         ClusterUrl migratedUrl = new ClusterUrl(pulsar2.getWebServiceAddress(), pulsar2.getWebServiceAddressTls(),
                 pulsar2.getBrokerServiceUrl(), pulsar2.getBrokerServiceUrlTls());
         admin1.clusters().updateClusterMigration("r1", true, migratedUrl);
+        assertEquals(admin1.clusters().getClusterMigration("r1").getMigratedClusterUrl(), migratedUrl);
 
         retryStrategically((test) -> {
             try {
@@ -330,12 +307,10 @@ public class ClusterMigrationTest {
 
         // try to consume backlog messages from cluster-1
         consumer1 = client1.newConsumer().topic(topicName).subscriptionName("s1").subscribe();
-        if (persistent) {
-            for (int i = 0; i < n; i++) {
-                Message<byte[]> msg = consumer1.receive();
-                assertEquals(msg.getData(), "test1".getBytes());
-                consumer1.acknowledge(msg);
-            }
+        for (int i = 0; i < n; i++) {
+            Message<byte[]> msg = consumer1.receive();
+            assertEquals(msg.getData(), "test1".getBytes());
+            consumer1.acknowledge(msg);
         }
         // after consuming all messages, consumer should have disconnected
         // from cluster-1 and reconnect with cluster-2
@@ -351,13 +326,13 @@ public class ClusterMigrationTest {
         assertTrue(topic1.getSubscriptions().isEmpty());
 
         // not also create a new consumer which should also reconnect to cluster-2
-        Consumer<byte[]> consumer2 = client1.newConsumer().topic(topicName).subscriptionType(subType)
+        Consumer<byte[]> consumer2 = client1.newConsumer().topic(topicName).subscriptionType(SubscriptionType.Shared)
                 .subscriptionName("s2").subscribe();
         retryStrategically((test) -> topic2.getSubscription("s2") != null, 10, 500);
         assertFalse(topic2.getSubscription("s2").getConsumers().isEmpty());
 
         // new sub on migration topic must be redirected immediately
-        Consumer<byte[]> consumerM = client1.newConsumer().topic(topicName).subscriptionType(subType)
+        Consumer<byte[]> consumerM = client1.newConsumer().topic(topicName).subscriptionType(SubscriptionType.Shared)
                 .subscriptionName("sM").subscribe();
         assertFalse(pulsar2.getBrokerService().getTopicReference(topicName).get().getSubscription("sM").getConsumers()
                 .isEmpty());
@@ -365,7 +340,7 @@ public class ClusterMigrationTest {
 
         // migrate topic after creating subscription
         String newTopicName = topicName + "-new";
-        consumerM = client1.newConsumer().topic(newTopicName).subscriptionType(subType)
+        consumerM = client1.newConsumer().topic(newTopicName).subscriptionType(SubscriptionType.Shared)
                 .subscriptionName("sM").subscribe();
         retryStrategically((t) -> pulsar2.getBrokerService().getTopicReference(newTopicName).isPresent(), 5, 100);
         pulsar2.getBrokerService().getTopicReference(newTopicName).get().checkClusterMigration().get();
@@ -392,8 +367,8 @@ public class ClusterMigrationTest {
 
         // create non-migrated topic which should connect to cluster-1
         String diffTopic = BrokerTestUtil
-                .newUniqueName((persistent ? "persistent" : "non-persistent") + "://" + namespace + "/migrationTopic");
-        Consumer<byte[]> consumerDiff = client1.newConsumer().topic(diffTopic).subscriptionType(subType)
+                .newUniqueName("persistent://" + namespace + "/migrationTopic");
+        Consumer<byte[]> consumerDiff = client1.newConsumer().topic(diffTopic).subscriptionType(SubscriptionType.Shared)
                 .subscriptionName("s1-d").subscribe();
         Producer<byte[]> producerDiff = client1.newProducer().topic(diffTopic).enableBatching(false)
                 .producerName("cluster1-d").messageRoutingMode(MessageRoutingMode.SinglePartition).create();
@@ -408,7 +383,7 @@ public class ClusterMigrationTest {
         broker1.restart();
         Producer<byte[]> producer4 = client1.newProducer().topic(topicName).enableBatching(false)
                 .producerName("cluster1-4").messageRoutingMode(MessageRoutingMode.SinglePartition).create();
-        Consumer<byte[]> consumer3 = client1.newConsumer().topic(topicName).subscriptionType(subType)
+        Consumer<byte[]> consumer3 = client1.newConsumer().topic(topicName).subscriptionType(SubscriptionType.Shared)
                 .subscriptionName("s3").subscribe();
         retryStrategically((test) -> topic2.getProducers().size() == 4, 10, 500);
         assertTrue(topic2.getProducers().size() == 4);
@@ -421,15 +396,16 @@ public class ClusterMigrationTest {
             assertEquals(consumer3.receive(2, TimeUnit.SECONDS).getData(), "test3".getBytes());
         }
 
+        client1.close();
+        client2.close();
         log.info("Successfully consumed messages by migrated consumers");
     }
 
-    @Test(dataProvider = "TopicsubscriptionTypes")
-    public void testClusterMigrationWithReplicationBacklog(boolean persistent, SubscriptionType subType) throws Exception {
+    @Test
+    public void testClusterMigrationWithReplicationBacklog() throws Exception {
         log.info("--- Starting ReplicatorTest::testClusterMigrationWithReplicationBacklog ---");
-        persistent = true;
         final String topicName = BrokerTestUtil
-                .newUniqueName((persistent ? "persistent" : "non-persistent") + "://" + namespace + "/migrationTopic");
+                .newUniqueName("persistent://" + namespace + "/migrationTopic");
 
         @Cleanup
         PulsarClient client1 = PulsarClient.builder().serviceUrl(url1.toString()).statsInterval(0, TimeUnit.SECONDS)
@@ -440,11 +416,11 @@ public class ClusterMigrationTest {
         // cluster-1 producer/consumer
         Producer<byte[]> producer1 = client1.newProducer().topic(topicName).enableBatching(false)
                 .producerName("cluster1-1").messageRoutingMode(MessageRoutingMode.SinglePartition).create();
-        Consumer<byte[]> consumer1 = client1.newConsumer().topic(topicName).subscriptionType(subType)
+        Consumer<byte[]> consumer1 = client1.newConsumer().topic(topicName).subscriptionType(SubscriptionType.Shared)
                 .subscriptionName("s1").subscribe();
 
         // cluster-3 consumer
-        Consumer<byte[]> consumer3 = client3.newConsumer().topic(topicName).subscriptionType(subType)
+        Consumer<byte[]> consumer3 = client3.newConsumer().topic(topicName).subscriptionType(SubscriptionType.Shared)
                 .subscriptionName("s1").subscribe();
         AbstractTopic topic1 = (AbstractTopic) pulsar1.getBrokerService().getTopic(topicName, false).getNow(null).get();
         retryStrategically((test) -> !topic1.getProducers().isEmpty(), 5, 500);
@@ -526,6 +502,10 @@ public class ClusterMigrationTest {
         // verify that the producer1 is now is now connected to migrated cluster "r2" since backlog is cleared.
         retryStrategically((test) -> topic2.getProducers().size()==2, 10, 500);
         assertEquals(topic2.getProducers().size(), 2);
+        
+        client1.close();
+        client2.close();
+        client3.close();
     }
 
     /**
@@ -638,17 +618,19 @@ public class ClusterMigrationTest {
             }
         }, 10, 500);
         assertFalse(pulsar2Topic.getSubscription("s1").getConsumers().isEmpty());
+        
+        client1.close();
     }
 
     @Test(dataProvider = "NamespaceMigrationTopicSubscriptionTypes")
-    public void testNamespaceMigration(boolean persistent, SubscriptionType subType, boolean isClusterMigrate, boolean isNamespaceMigrate) throws Exception {
+    public void testNamespaceMigration(SubscriptionType subType, boolean isClusterMigrate, boolean isNamespaceMigrate) throws Exception {
         log.info("--- Starting Test::testNamespaceMigration ---");
         // topic for the namespace1 (to be migrated)
         final String topicName = BrokerTestUtil
-                .newUniqueName((persistent ? "persistent" : "non-persistent") + "://" + namespace + "/migrationTopic");
+                .newUniqueName("persistent://" + namespace + "/migrationTopic");
         // topic for namespace2 (not to be migrated)
         final String topicName2 = BrokerTestUtil
-                .newUniqueName((persistent ? "persistent" : "non-persistent") + "://" + namespaceNotToMigrate + "/migrationTopic");
+                .newUniqueName("persistent://" + namespaceNotToMigrate + "/migrationTopic");
 
         @Cleanup
         PulsarClient client1 = PulsarClient.builder().serviceUrl(url1.toString()).statsInterval(0, TimeUnit.SECONDS)
@@ -764,16 +746,14 @@ public class ClusterMigrationTest {
         // try to consume backlog messages from cluster-1
         blueConsumerNs1_1 = client1.newConsumer().topic(topicName).subscriptionName("s1").subscribe();
         blueConsumerNs2_1 = client1.newConsumer().topic(topicName2).subscriptionName("s1").subscribe();
-        if (persistent) {
-            for (int i = 0; i < n; i++) {
-                Message<byte[]> msg = blueConsumerNs1_1.receive();
-                assertEquals(msg.getData(), "test1".getBytes());
-                blueConsumerNs1_1.acknowledge(msg);
+        for (int i = 0; i < n; i++) {
+            Message<byte[]> msg = blueConsumerNs1_1.receive();
+            assertEquals(msg.getData(), "test1".getBytes());
+            blueConsumerNs1_1.acknowledge(msg);
 
-                Message<byte[]> msg2 = blueConsumerNs2_1.receive();
-                assertEquals(msg2.getData(), "test1".getBytes());
-                blueConsumerNs2_1.acknowledge(msg2);
-            }
+            Message<byte[]> msg2 = blueConsumerNs2_1.receive();
+            assertEquals(msg2.getData(), "test1".getBytes());
+            blueConsumerNs2_1.acknowledge(msg2);
         }
         // after consuming all messages, consumer should have disconnected
         // from blue and reconnect with green
@@ -862,7 +842,7 @@ public class ClusterMigrationTest {
 
         // create non-migrated topic which should connect to blue
         String diffTopic = BrokerTestUtil
-                .newUniqueName((persistent ? "persistent" : "non-persistent") + "://" + namespace + "/migrationTopic");
+                .newUniqueName("persistent://" + namespace + "/migrationTopic");
         Consumer<byte[]> consumerDiff = client1.newConsumer().topic(diffTopic).subscriptionType(subType)
                 .subscriptionName("s1-d").subscribe();
         Producer<byte[]> producerDiff = client1.newProducer().topic(diffTopic).enableBatching(false)
@@ -902,18 +882,19 @@ public class ClusterMigrationTest {
         blueProducerNs2_1.close();
         greenProducerNs1_1.close();
         greenProducerNs2_1.close();
+        client1.close();
+        client2.close();
     }
 
     @Test(dataProvider = "NamespaceMigrationTopicSubscriptionTypes")
-    public void testNamespaceMigrationWithReplicationBacklog(boolean persistent, SubscriptionType subType, boolean isClusterMigrate, boolean isNamespaceMigrate) throws Exception {
+    public void testNamespaceMigrationWithReplicationBacklog(SubscriptionType subType, boolean isClusterMigrate, boolean isNamespaceMigrate) throws Exception {
         log.info("--- Starting ReplicatorTest::testNamespaceMigrationWithReplicationBacklog ---");
-        persistent = true;
         // topic for namespace1 (to be migrated)
         final String topicName = BrokerTestUtil
-                .newUniqueName((persistent ? "persistent" : "non-persistent") + "://" + namespace + "/migrationTopic");
+                .newUniqueName("persistent://" + namespace + "/migrationTopic");
         // topic for namespace2 (not to be migrated)
         final String topicName2 = BrokerTestUtil
-                .newUniqueName((persistent ? "persistent" : "non-persistent") + "://" + namespaceNotToMigrate + "/migrationTopic");
+                .newUniqueName("persistent://" + namespaceNotToMigrate + "/migrationTopic");
 
         @Cleanup
         PulsarClient client1 = PulsarClient.builder().serviceUrl(url1.toString()).statsInterval(0, TimeUnit.SECONDS)
@@ -1069,6 +1050,9 @@ public class ClusterMigrationTest {
         blueConsumerNs2_1.close();
         greenProducerNs1_1.close();
         greenProducerNs2_1.close();
+        client1.close();
+        client2.close();
+        client3.close();
     }
 
     static class TestBroker extends MockedPulsarServiceBaseTest {

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Clusters.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Clusters.java
@@ -29,7 +29,8 @@ import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
 import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationData;
 import org.apache.pulsar.common.policies.data.ClusterData;
-import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
+import org.apache.pulsar.common.policies.data.ClusterPolicies;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.FailureDomain;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationData;
 
@@ -208,6 +209,46 @@ public interface Clusters {
      *
      */
     CompletableFuture<Void> updatePeerClusterNamesAsync(String cluster, LinkedHashSet<String> peerClusterNames);
+
+    /**
+     * Get the cluster migration configuration data for the specified cluster.
+     * <p/>
+     * Response Example:
+     *
+     * <pre>
+     * <code>{ serviceUrl : "http://my-broker.example.com:8080/" }</code>
+     * </pre>
+     *
+     * @param cluster
+     *            Cluster name
+     *
+     * @return the cluster configuration
+     *
+     * @throws NotAuthorizedException
+     *             You don't have admin permission to get the configuration of the cluster
+     * @throws NotFoundException
+     *             Cluster doesn't exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    ClusterPolicies getClusterMigration(String cluster) throws PulsarAdminException;
+
+    /**
+     * Get the cluster migration configuration data for the specified cluster asynchronously.
+     * <p/>
+     * Response Example:
+     *
+     * <pre>
+     * <code>{ serviceUrl : "http://my-broker.example.com:8080/" }</code>
+     * </pre>
+     *
+     * @param cluster
+     *            Cluster name
+     *
+     * @return the cluster configuration
+     *
+     */
+    CompletableFuture<ClusterPolicies> getClusterMigrationAsync(String cluster);
 
     /**
      * Update the configuration for a cluster migration.

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
@@ -19,9 +19,6 @@
 package org.apache.pulsar.common.policies.data;
 
 import java.util.LinkedHashSet;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.apache.pulsar.client.admin.utils.ReflectionUtils;
 import org.apache.pulsar.client.api.ProxyProtocol;
 
@@ -70,10 +67,6 @@ public interface ClusterData {
 
     String getListenerName();
 
-    boolean isMigrated();
-
-    ClusterUrl getMigratedClusterUrl();
-
     interface Builder {
         Builder serviceUrl(String serviceUrl);
 
@@ -119,10 +112,6 @@ public interface ClusterData {
 
         Builder listenerName(String listenerName);
 
-        Builder migrated(boolean migrated);
-
-        Builder migratedClusterUrl(ClusterUrl migratedClusterUrl);
-
         ClusterData build();
     }
 
@@ -130,20 +119,5 @@ public interface ClusterData {
 
     static Builder builder() {
         return ReflectionUtils.newBuilder("org.apache.pulsar.common.policies.data.ClusterDataImpl");
-    }
-
-    @Data
-    @NoArgsConstructor
-    @AllArgsConstructor
-    class ClusterUrl {
-        String serviceUrl;
-        String serviceUrlTls;
-        String brokerServiceUrl;
-        String brokerServiceUrlTls;
-
-        public boolean isEmpty() {
-            return serviceUrl != null && serviceUrlTls != null && brokerServiceUrl == null
-                    && brokerServiceUrlTls == null;
-        }
     }
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ClusterPolicies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ClusterPolicies.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.apache.pulsar.client.admin.utils.ReflectionUtils;
+
+public interface ClusterPolicies {
+    boolean isMigrated();
+
+    ClusterUrl getMigratedClusterUrl();
+
+    interface Builder {
+        Builder migrated(boolean migrated);
+
+        Builder migratedClusterUrl(ClusterUrl migratedClusterUrl);
+
+        ClusterPolicies build();
+    }
+
+    Builder clone();
+
+    static Builder builder() {
+        return ReflectionUtils.newBuilder("org.apache.pulsar.common.policies.data.ClusterPoliciesImpl");
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @EqualsAndHashCode
+    class ClusterUrl {
+        String serviceUrl;
+        String serviceUrlTls;
+        String brokerServiceUrl;
+        String brokerServiceUrlTls;
+
+        public boolean isEmpty() {
+            return serviceUrl != null && serviceUrlTls != null && brokerServiceUrl == null
+                    && brokerServiceUrlTls == null;
+        }
+    }
+}

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ClustersImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ClustersImpl.java
@@ -34,8 +34,10 @@ import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationData;
 import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationDataImpl;
 import org.apache.pulsar.common.policies.data.ClusterData;
-import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
 import org.apache.pulsar.common.policies.data.ClusterDataImpl;
+import org.apache.pulsar.common.policies.data.ClusterPolicies;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
+import org.apache.pulsar.common.policies.data.ClusterPoliciesImpl;
 import org.apache.pulsar.common.policies.data.FailureDomain;
 import org.apache.pulsar.common.policies.data.FailureDomainImpl;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationData;
@@ -105,6 +107,18 @@ public class ClustersImpl extends BaseResource implements Clusters {
     public CompletableFuture<Void> updatePeerClusterNamesAsync(String cluster, LinkedHashSet<String> peerClusterNames) {
         WebTarget path = adminClusters.path(cluster).path("peers");
         return asyncPostRequest(path, Entity.entity(peerClusterNames, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public ClusterPolicies getClusterMigration(String cluster) throws PulsarAdminException {
+        return sync(() -> getClusterMigrationAsync(cluster));
+    }
+
+    @Override
+    public CompletableFuture<ClusterPolicies> getClusterMigrationAsync(String cluster) {
+        WebTarget path = adminClusters.path(cluster).path("migrate");
+        return asyncGetRequest(path, new FutureCallback<ClusterPoliciesImpl>() {
+        }).thenApply(policies -> policies);
     }
 
     @Override

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
@@ -32,8 +32,8 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.ProxyProtocol;
 import org.apache.pulsar.common.policies.data.ClusterData;
-import org.apache.pulsar.common.policies.data.ClusterData.ClusterUrl;
 import org.apache.pulsar.common.policies.data.ClusterDataImpl;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.FailureDomain;
 import org.apache.pulsar.common.policies.data.FailureDomainImpl;
 
@@ -151,6 +151,17 @@ public class CmdClusters extends CmdBase {
             java.util.LinkedHashSet<String> clusters = StringUtils.isBlank(peerClusterNames) ? null
                     : Sets.newLinkedHashSet(Arrays.asList(peerClusterNames.split(",")));
             getAdmin().clusters().updatePeerClusterNames(cluster, clusters);
+        }
+    }
+
+    @Parameters(commandDescription = "Get the cluster migration configuration data for the specified cluster")
+    private class GetClusterMigration extends CliCommand {
+        @Parameter(description = "cluster-name", required = true)
+        private java.util.List<String> params;
+
+        void run() throws PulsarAdminException {
+            String cluster = getOneArgument(params);
+            print(getAdmin().clusters().getClusterMigration(cluster));
         }
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
@@ -176,17 +176,6 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
             example = ""
     )
     private String listenerName;
-    @ApiModelProperty(
-            name = "migrated",
-            value = "flag to check if cluster is migrated to different cluster",
-            example = "true/false"
-    )
-    private boolean migrated;
-    @ApiModelProperty(
-            name = "migratedClusterUrl",
-            value = "url of cluster where current cluster is migrated"
-    )
-    private ClusterUrl migratedClusterUrl;
 
     public static ClusterDataImplBuilder builder() {
         return new ClusterDataImplBuilder();
@@ -216,9 +205,7 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
                 .brokerClientTrustCertsFilePath(brokerClientTrustCertsFilePath)
                 .brokerClientCertificateFilePath(brokerClientCertificateFilePath)
                 .brokerClientKeyFilePath(brokerClientKeyFilePath)
-                .listenerName(listenerName)
-                .migrated(migrated)
-                .migratedClusterUrl(migratedClusterUrl);
+                .listenerName(listenerName);
     }
 
     @Data
@@ -245,8 +232,6 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
         private String brokerClientKeyFilePath;
         private String brokerClientTrustCertsFilePath;
         private String listenerName;
-        private boolean migrated;
-        private ClusterUrl migratedClusterUrl;
 
         ClusterDataImplBuilder() {
         }
@@ -367,16 +352,6 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
             return this;
         }
 
-        public ClusterDataImplBuilder migrated(boolean migrated) {
-            this.migrated = migrated;
-            return this;
-        }
-
-        public ClusterDataImplBuilder migratedClusterUrl(ClusterUrl migratedClusterUrl) {
-            this.migratedClusterUrl = migratedClusterUrl;
-            return this;
-        }
-
         public ClusterDataImpl build() {
             return new ClusterDataImpl(
                     serviceUrl,
@@ -400,9 +375,7 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
                     brokerClientTrustCertsFilePath,
                     brokerClientKeyFilePath,
                     brokerClientCertificateFilePath,
-                    listenerName,
-                    migrated,
-                    migratedClusterUrl);
+                    listenerName);
         }
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterPoliciesImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterPoliciesImpl.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * The configuration data for a cluster.
+ */
+@ApiModel(
+        value = "ClusterPolicies",
+        description = "The local cluster policies for a cluster"
+)
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public final class ClusterPoliciesImpl implements  ClusterPolicies, Cloneable {
+    @ApiModelProperty(
+            name = "migrated",
+            value = "flag to check if cluster is migrated to different cluster",
+            example = "true/false"
+    )
+    private boolean migrated;
+    @ApiModelProperty(
+            name = "migratedClusterUrl",
+            value = "url of cluster where current cluster is migrated"
+    )
+    private ClusterUrl migratedClusterUrl;
+
+    public static ClusterPoliciesImplBuilder builder() {
+        return new ClusterPoliciesImplBuilder();
+    }
+
+    @Override
+    public ClusterPoliciesImplBuilder clone() {
+        return builder()
+                .migrated(migrated)
+                .migratedClusterUrl(migratedClusterUrl);
+    }
+
+    @Data
+    public static class ClusterPoliciesImplBuilder implements ClusterPolicies.Builder {
+        private boolean migrated;
+        private ClusterUrl migratedClusterUrl;
+
+        ClusterPoliciesImplBuilder() {
+        }
+
+        public ClusterPoliciesImplBuilder migrated(boolean migrated) {
+            this.migrated = migrated;
+            return this;
+        }
+
+        public ClusterPoliciesImplBuilder migratedClusterUrl(ClusterUrl migratedClusterUrl) {
+            this.migratedClusterUrl = migratedClusterUrl;
+            return this;
+        }
+
+        public ClusterPoliciesImpl build() {
+            return new ClusterPoliciesImpl(
+                    migrated,
+                    migratedClusterUrl);
+        }
+    }
+}

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataImplTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ClusterDataImplTest.java
@@ -53,9 +53,6 @@ public class ClusterDataImplTest {
                 .brokerClientKeyFilePath("/my/key/file")
                 .brokerClientCertificateFilePath("/my/cert/file")
                 .listenerName("a-listener")
-                .migrated(true)
-                .migratedClusterUrl(new ClusterData.ClusterUrl("http://remote", "https://remote", "pulsar://remote",
-                        "pulsar+ssl://remote"))
                 .build();
 
         ClusterDataImpl clone = originalData.clone().build();


### PR DESCRIPTION
### Motivation

Right now, when blue and green cluster shares the same global-zookeeper/configuration-metadata store to persist cluster metadata and migration metadata then cluster migration state also impact green cluster incorrectly as they both the same metadata because of that it also makes green cluster to start migration. Therefore, store cluster migration metadata to local metadata-store with name cluster policies.

### Modifications

Add cluster policies into local metadatastore and avoid cyclic cluster migration for green cluster. 
It depends on #21354

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
