### PR TITLE
[fix][ci] Fix docker image building by releasing more disk space before building

### DIFF
--- a/.github/actions/clean-disk/action.yml
+++ b/.github/actions/clean-disk/action.yml
@@ -31,7 +31,7 @@ runs:
           directories=(/usr/local/lib/android /opt/ghc)
           if [[ "${{ inputs.mode }}" == "full" ]]; then
             # remove these directories only when mode is 'full'
-            directories+=(/usr/share/dotnet)
+            directories+=(/usr/share/dotnet /opt/hostedtoolcache/CodeQL)
           fi
           emptydir=/tmp/empty$$/
           mkdir $emptydir

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -876,7 +876,7 @@ jobs:
         uses: ./.github/actions/tune-runner-vm
 
       - name: Clean Disk when needed
-        if: ${{ matrix.clean_disk == 'true' }}
+        if: ${{ matrix.clean_disk }}
         uses: ./.github/actions/clean-disk
 
       - name: Setup ssh access to build runner VM
@@ -1089,7 +1089,7 @@ jobs:
         uses: ./.github/actions/tune-runner-vm
 
       - name: Clean Disk when needed
-        if: ${{ matrix.clean_disk == 'true' }}
+        if: ${{ matrix.clean_disk }}
         uses: ./.github/actions/clean-disk
 
       - name: Setup ssh access to build runner VM

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -746,6 +746,8 @@ jobs:
 
       - name: Clean Disk
         uses: ./.github/actions/clean-disk
+        with:
+          mode: full
 
       - name: Cache local Maven repository
         uses: actions/cache@v3

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -863,6 +863,7 @@ jobs:
 
           - name: Pulsar IO
             group: PULSAR_IO
+            clean_disk: true
 
           - name: Sql
             group: SQL
@@ -873,6 +874,10 @@ jobs:
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
+
+      - name: Clean Disk when needed
+        if: ${{ matrix.clean_disk == 'true' }}
+        uses: ./.github/actions/clean-disk
 
       - name: Setup ssh access to build runner VM
         # ssh access is enabled for builds in own forks
@@ -1074,6 +1079,7 @@ jobs:
 
           - name: Pulsar IO - Oracle
             group: PULSAR_IO_ORA
+            clean_disk: true
 
     steps:
       - name: checkout
@@ -1081,6 +1087,10 @@ jobs:
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
+
+      - name: Clean Disk when needed
+        if: ${{ matrix.clean_disk == 'true' }}
+        uses: ./.github/actions/clean-disk
 
       - name: Setup ssh access to build runner VM
         # ssh access is enabled for builds in own forks


### PR DESCRIPTION
### Motivation

The docker image building in Pulsar CI started failing recently with an error that can be seen in the summary view
`Unhandled exception. System.IO.IOException: No space left on device : '/home/runner/runners/2.309.0/_diag/Worker_20231013-122508-utc.log'`

The reason seems to be that there's less disk space available for the build. 
There used to be [32717 MB of free disk space before starting the build](https://github.com/apache/pulsar/actions/runs/6469034273/job/17562750174#step:5:140). In that case, the docker image building would complete. There's now [32001 MB of free disk space](https://github.com/apache/pulsar/actions/runs/6508004785/job/17677042855#step:5:137) and in that case, the disk space runs out.

### Modifications

Pass `mode: full` parameter to the [clean-disk action so that it also deletes `/usr/share/dotnet` directory](https://github.com/apache/pulsar/blob/master/.github/actions/clean-disk/action.yml#L32-L35) before running the build to have more disk space available.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->