### PR TITLE
[improve][client] Support zero queue size consumer for multi-topics

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -349,9 +349,11 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * <ul>
      * <li>Decreases the throughput of the consumer by disabling pre-fetching of messages. This approach improves the
      * message distribution on shared subscriptions by pushing messages only to the consumers that are ready to process
-     * them. Neither {@link Consumer#receive(int, TimeUnit)} nor Partitioned Topics can be used if the consumer queue
-     * size is zero. {@link Consumer#receive()} function call should not be interrupted when the consumer queue size is
-     * zero.</li>
+     * them.
+     * <li>When a non-partitioned topic is subscribed, {@link Consumer#receive(int, TimeUnit)} cannot be used.
+     * {@link Consumer#receive()} function call should not be interrupted.</li>
+     * <li>When a partitioned topic or multiple topics are subscribed, both {@link Consumer#receive()} and
+     * {@link Consumer#receive(int, TimeUnit)} cannot be used.</li>
      * <li>Doesn't support Batch-Message. If a consumer receives a batch-message, it closes the consumer connection with
      * the broker and {@link Consumer#receive()} calls remain blocked while {@link Consumer#receiveAsync()} receives
      * exception in callback.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -74,6 +74,7 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageCrypto;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageIdAdv;
+import org.apache.pulsar.client.api.MessageListener;
 import org.apache.pulsar.client.api.Messages;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -214,14 +215,12 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                                                ConsumerConfigurationData<T> conf,
                                                ExecutorProvider executorProvider,
                                                int partitionIndex,
-                                               boolean hasParentConsumer,
                                                CompletableFuture<Consumer<T>> subscribeFuture,
-                                               MessageId startMessageId,
                                                Schema<T> schema,
-                                               ConsumerInterceptors<T> interceptors,
-                                               boolean createTopicIfDoesNotExist) {
-        return newConsumerImpl(client, topic, conf, executorProvider, partitionIndex, hasParentConsumer, false,
-                subscribeFuture, startMessageId, schema, interceptors, createTopicIfDoesNotExist, 0);
+                                               ConsumerInterceptors<T> interceptors) {
+        return newConsumerImpl(client, topic, conf, executorProvider, partitionIndex, false,
+                conf.getMessageListener(), subscribeFuture, null, schema, interceptors,
+                true, 0);
     }
 
     static <T> ConsumerImpl<T> newConsumerImpl(PulsarClientImpl client,
@@ -230,7 +229,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                                                ExecutorProvider executorProvider,
                                                int partitionIndex,
                                                boolean hasParentConsumer,
-                                               boolean parentConsumerHasListener,
+                                               MessageListener<T> listener,
                                                CompletableFuture<Consumer<T>> subscribeFuture,
                                                MessageId startMessageId,
                                                Schema<T> schema,
@@ -241,10 +240,10 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             return new ZeroQueueConsumerImpl<>(client, topic, conf, executorProvider, partitionIndex, hasParentConsumer,
                     subscribeFuture,
                     startMessageId, schema, interceptors,
-                    createTopicIfDoesNotExist);
+                    createTopicIfDoesNotExist, listener);
         } else {
             return new ConsumerImpl<>(client, topic, conf, executorProvider, partitionIndex, hasParentConsumer,
-                    parentConsumerHasListener,
+                    listener != null,
                     subscribeFuture, startMessageId,
                     startMessageRollbackDurationInSec /* rollback time in sec to start msgId */,
                     schema, interceptors, createTopicIfDoesNotExist);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -133,8 +133,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         super(client, singleTopic, conf, Math.max(2, conf.getReceiverQueueSize()), executorProvider, subscribeFuture,
                 schema, interceptors);
 
-        checkArgument(conf.getReceiverQueueSize() > 0,
-            "Receiver queue size needs to be greater than 0 for Topics Consumer");
+        checkArgument(conf.getMessageListener() == null && conf.getReceiverQueueSize() > 0,
+                "Receiver queue size needs to be greater than 0 for Topics Consumer when listener is null");
 
         this.partitionedTopics = new ConcurrentHashMap<>();
         this.consumers = new ConcurrentHashMap<>();
@@ -227,9 +227,13 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
         if (getState() == State.Ready) {
             newConsumers.forEach(consumer -> {
-                consumer.increaseAvailablePermits(consumer.getConnectionHandler().cnx(),
-                        consumer.getCurrentReceiverQueueSize());
-                internalPinnedExecutor.execute(() -> receiveMessageFromConsumer(consumer, true));
+                if (consumer instanceof ZeroQueueConsumerImpl) {
+                    consumer.increaseAvailablePermits(1);
+                } else {
+                    consumer.increaseAvailablePermits(consumer.getConnectionHandler().cnx(),
+                            consumer.getCurrentReceiverQueueSize());
+                    internalPinnedExecutor.execute(() -> receiveMessageFromConsumer(consumer, true));
+                }
             });
         }
     }
@@ -1126,7 +1130,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         configurationData = configurationData.clone();
         return ConsumerImpl.newConsumerImpl(client, partitionName,
                 configurationData, client.externalExecutorProvider(),
-                partitionIndex, true, listener != null, subFuture,
+                partitionIndex, true, listener, subFuture,
                 startMessageId, schema, interceptors,
                 createIfDoesNotExist, startMessageRollbackDurationInSec);
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -531,8 +531,8 @@ public class PulsarClientImpl implements PulsarClient {
             } else {
                 int partitionIndex = TopicName.getPartitionIndex(topic);
                 consumer = ConsumerImpl.newConsumerImpl(PulsarClientImpl.this, topic, conf, externalExecutorProvider,
-                        partitionIndex, false, consumerSubscribedFuture, null, schema, interceptors,
-                        true /* createTopicIfDoesNotExist */);
+                        partitionIndex, consumerSubscribedFuture, schema, interceptors
+                        /* createTopicIfDoesNotExist */);
             }
             consumers.add(consumer);
         }).exceptionally(ex -> {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
@@ -81,8 +81,8 @@ public class ConsumerImplTest {
 
         consumerConf.setSubscriptionName("test-sub");
         consumer = ConsumerImpl.newConsumerImpl(client, topic, consumerConf,
-                executorProvider, -1, false, subscribeFuture, null, null, null,
-                true);
+                executorProvider, -1, subscribeFuture, null, null
+        );
         consumer.setState(HandlerState.State.Ready);
     }
 
@@ -227,8 +227,8 @@ public class ConsumerImplTest {
         consumerConf.setStartPaused(true);
 
         consumer = ConsumerImpl.newConsumerImpl(client, topic, consumerConf,
-                executorProvider, -1, false, new CompletableFuture<>(), null, null, null,
-                true);
+                executorProvider, -1, new CompletableFuture<>(), null, null
+        );
 
         Assert.assertTrue(consumer.paused);
     }


### PR DESCRIPTION
### Motivation

The multi-topics consumer does not support configuring queue size with 0. It's counter-intuitive to have this limitation.

### Modifications

Change the config check in `MultiTopicsConsumerImpl`. It will fail only if the listener is not specified for zero queue size consumer for multi-topics.

In `startReceivingMessages`, send a FLOW request with 1 permit when the internal consumer has zero queue size. Pass the listener from `MultiTopicsConsumerImpl` to `ZeroQueueConsumerImpl`.

`testMultiTopics` and `testMultiTopicsWithoutListener` are added to `ZeroQueueSizeTest` to protect this change.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

The semantics of `ConsumerBuilder#receiverQueueSize` changed.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: