### PR TITLE
[fix][test] Fix resource leak in TransactionCoordinatorClientTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionMetaStoreTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionMetaStoreTestBase.java
@@ -120,6 +120,9 @@ public abstract class TransactionMetaStoreTestBase extends TestRetrySupport {
 
     @Override
     protected void cleanup() throws Exception {
+        if (transactionCoordinatorClient != null) {
+            transactionCoordinatorClient.close();
+        }
         for (PulsarAdmin admin : pulsarAdmins) {
             if (admin != null) {
                 admin.close();
@@ -132,6 +135,9 @@ public abstract class TransactionMetaStoreTestBase extends TestRetrySupport {
             if (service != null) {
                 service.close();
             }
+        }
+        if (bkEnsemble != null) {
+            bkEnsemble.stop();
         }
         Mockito.reset();
     }


### PR DESCRIPTION
### Motivation

TransactionCoordinatorClientTest doesn't properly close all resources.

### Modifications

Close transactionCoordinatorClient and stop bkEnsemble

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->