### PR TITLE
[improve][pip] PIP-306: Introduce start index for AppendIndexMetadataInterceptor

### DIFF
--- a/pip/pip-306.md
+++ b/pip/pip-306.md
@@ -13,7 +13,7 @@ The list earliest offset maybe wrong in the following case:
 3. List earliest offset use Kafka client
 4. The earliest offset should be 10, since the topic is empty right now.
 
-However,  we can't use the interceptor's current index as the earliest offset because if a producer produces messages to the current `ManagedLedger`, the index might be changing.
+However, we can't use the interceptor's current index as the earliest offset because if a producer produces messages to the current `ManagedLedger`, the index might be changing.
 
 The root cause is we do not maintain the start index in the interceptor.
 

--- a/pip/pip-306.md
+++ b/pip/pip-306.md
@@ -1,0 +1,130 @@
+# Background knowledge
+
+Currently, the KoP(Kafka-on-Pulsar) protocol handler are using `AppendIndexMetadataInterceptor`
+
+to generator continuous offset, See: [#9038](https://github.com/apache/pulsar/issues/9038)
+
+The `AppendIndexMetadataInterceptor` has an `indexGenerator` to generate the index(offset) and store the index in `BrokerEntryMetadata`
+
+# Motivation
+
+The list earliest offset maybe wrong in the following case:
+
+1. Send several messages to a topic. For example, the last offset is 9
+2. The topic has been cleaned cross by retention, and now the topic is empty.
+3. List earliest offset use Kafka client
+4. The earliest offset should be 10, since the topic is empty right now.
+
+However,  we can't use the interceptor's current index as the earliest offset because if a producer produces messages to the current `ManagedLedger`, the index might be changing.
+
+The root cause is we do not maintain the start index in the interceptor.
+
+# Goals
+
+## In Scope
+
+Introduce start index for `AppendIndexMetadataInterceptor`
+
+## Out of Scope
+
+None.
+
+# High Level Design
+
+Introduce `startIndex` in `AppendIndexMetadataInterceptor` and update this `startIndex` before ledgers are deleted.
+
+For example, we have several entris(<ledgerId, entryId, index>) each entry has two messages:
+
+```text
+<3,0,1>, <3,1,3>, <4,0,5>, <4,1,7>, <5,0,9>, <5,1,11>, <6,0,13>, <6,1,15>, <7,0,17>, <7,1,19>
+```
+
+The start index should be the last deleted entry's `index + 1`, If delete from `<4,1,7>`, then the start index should be `7 + 1 = 8` , if all entry has been deleted, the start index should be `19 + 1 = 20`
+
+# Detailed Design
+
+## Design & Implementation Details
+
+This PIP proposes to add a new method `onTrimLedgers` and `hasAppendIndexMetadataInterceptor` to the `hasAppendIndexMetadataInterceptor`.
+
+The `onTrimLedgers` allows set the new start index to interceptor before ledgers are deleted.
+
+To get the last index of entry, we need to read the last entry from `ledgersToDelete` list and peek at the broker entry metadata from the entry data buffer. Then set index + 1 as the new start index.
+
+To avoid unnecessary entry read, we can skip the read by using the `hasAppendIndexMetadataInterceptor` method to check if the broker configured `AppendIndexMetadataInterceptor` .
+
+When initializing the managed ledger and the ledger is empty, we can set the start index as the `current index + 1` to avoid returning an unexpected start index after upgrading the broker.
+
+## Public-facing Changes
+
+### Public API
+
+Introduce `onTrimLedgers` and `hasAppendIndexMetadataInterceptor` method to the `ManagedLedgerInterceptor`:
+
+```Java
+/**
+ * Check if it has AppendIndexMetadataInterceptor.
+ *
+ * @return Has AppendIndexMetadataInterceptor or not.
+ */
+default boolean hasAppendIndexMetadataInterceptor() {
+    return false;
+}
+
+/**
+ * Intercept when trimming ledgers.
+ * @param newStartIndex
+ */
+default void onTrimLedgers(long newStartIndex) {
+
+}
+```
+
+### Binary protocol
+
+No changes for this part.
+
+### Configuration
+
+No changes for this part.
+
+### CLI
+
+No changes for this part.
+
+### Metrics
+
+No changes for this part.
+
+# Monitoring
+
+No changes for this part.
+
+# Security Considerations
+
+No security-related changes.
+
+# Backward & Forward Compatibility
+
+## Revert
+
+No operation required.
+
+## Upgrade
+
+No operation required.
+
+# Alternatives
+
+# General Notes
+
+# Links
+
+<!--  
+
+Updated afterwards  
+
+-->  
+
+- Mailing List discussion thread:
+- Mailing List voting thread:

--- a/pip/pip-306.md
+++ b/pip/pip-306.md
@@ -2,7 +2,7 @@
 
 Currently, the KoP(Kafka-on-Pulsar) protocol handler are using `AppendIndexMetadataInterceptor` to generator continuous offset, See: [#9038](https://github.com/apache/pulsar/issues/9038)
 
-The `AppendIndexMetadataInterceptor` has an `indexGenerator` to generate the index(offset) and store the index in `BrokerEntryMetadata`
+The `AppendIndexMetadataInterceptor` has an `indexGenerator` to generate the index(offset) and store the index in `BrokerEntryMetadata`.
 
 # Motivation
 
@@ -37,7 +37,7 @@ For example, we have several entris(<ledgerId, entryId, index>) each entry has t
 <3,0,1>, <3,1,3>, <4,0,5>, <4,1,7>, <5,0,9>, <5,1,11>, <6,0,13>, <6,1,15>, <7,0,17>, <7,1,19>
 ```
 
-The start index should be the last deleted entry's `index + 1`, If delete from `<4,1,7>`, then the start index should be `7 + 1 = 8` , if all entry has been deleted, the start index should be `19 + 1 = 20`
+The start index should be the last deleted entry's index + 1, If delete from `<4,1,7>`, then the start index should be `7 + 1 = 8` , if all entry has been deleted, the start index should be `19 + 1 = 20`
 
 # Detailed Design
 
@@ -45,11 +45,11 @@ The start index should be the last deleted entry's `index + 1`, If delete from `
 
 This PIP proposes to add a new method `onTrimLedgers` and `hasAppendIndexMetadataInterceptor` to the `hasAppendIndexMetadataInterceptor`.
 
-The `onTrimLedgers` allows set the new start index to interceptor before ledgers are deleted.
+The `onTrimLedgers` allows set the new start index to interceptor before ledgers are deleted. The new start index should be updated when the ledger gets trimmed, and the new start index should be the last index of deleted entry + 1.
 
-To get the last index of entry, we need to read the last entry from `ledgersToDelete` list and peek at the broker entry metadata from the entry data buffer. Then set index + 1 as the new start index.
+To get the last index of entry, we need to read the last entry from `ledgersToDelete` list and peek at the broker entry metadata from the entry data buffer. Then set index + 1 as the new start index. 
 
-To avoid unnecessary entry read, we can skip the read by using the `hasAppendIndexMetadataInterceptor` method to check if the broker configured `AppendIndexMetadataInterceptor` .
+To avoid unnecessary entry read, we can skip the read by using the `hasAppendIndexMetadataInterceptor` method to check if the broker configured `AppendIndexMetadataInterceptor`.
 
 When initializing the managed ledger and the ledger is empty, we can set the start index as the `current index + 1` to avoid returning an unexpected start index after upgrading the broker.
 

--- a/pip/pip-306.md
+++ b/pip/pip-306.md
@@ -1,8 +1,6 @@
 # Background knowledge
 
-Currently, the KoP(Kafka-on-Pulsar) protocol handler are using `AppendIndexMetadataInterceptor`
-
-to generator continuous offset, See: [#9038](https://github.com/apache/pulsar/issues/9038)
+Currently, the KoP(Kafka-on-Pulsar) protocol handler are using `AppendIndexMetadataInterceptor` to generator continuous offset, See: [#9038](https://github.com/apache/pulsar/issues/9038)
 
 The `AppendIndexMetadataInterceptor` has an `indexGenerator` to generate the index(offset) and store the index in `BrokerEntryMetadata`
 


### PR DESCRIPTION
### Motivation

Introduce start index for `AppendIndexMetadataInterceptor`


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->