### PR TITLE
[fix][test] Cleanup test resources in pulsar-client module

### DIFF
--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
@@ -48,6 +49,7 @@ public class AutoClusterFailoverTest {
         long failoverDelay = 30;
         long switchBackDelay = 60;
         long checkInterval = 1_000;
+        @Cleanup
         ServiceUrlProvider provider = AutoClusterFailover.builder()
                 .primary(primary)
                 .secondary(Collections.singletonList(secondary))
@@ -86,6 +88,7 @@ public class AutoClusterFailoverTest {
         Map<String, Authentication> secondaryAuthentications = new HashMap<>();
         secondaryAuthentications.put(secondary, secondaryAuthentication);
 
+        @Cleanup
         ServiceUrlProvider provider1 = AutoClusterFailover.builder()
                 .primary(primary)
                 .secondary(Collections.singletonList(secondary))
@@ -112,6 +115,7 @@ public class AutoClusterFailoverTest {
 
         ClientConfigurationData configurationData = new ClientConfigurationData();
 
+        @Cleanup
         ServiceUrlProvider provider = AutoClusterFailover.builder()
                 .primary(primary)
                 .secondary(Collections.singletonList(secondary))
@@ -156,6 +160,7 @@ public class AutoClusterFailoverTest {
 
         ClientConfigurationData configurationData = new ClientConfigurationData();
 
+        @Cleanup
         ServiceUrlProvider provider = AutoClusterFailover.builder()
                 .primary(primary)
                 .secondary(Collections.singletonList(secondary))
@@ -210,6 +215,7 @@ public class AutoClusterFailoverTest {
         configurationData.setTlsTrustCertsFilePath(primaryTlsTrustCertsFilePath);
         configurationData.setAuthentication(primaryAuthentication);
 
+        @Cleanup
         ServiceUrlProvider provider = AutoClusterFailover.builder()
                 .primary(primary)
                 .secondary(Collections.singletonList(secondary))
@@ -265,6 +271,7 @@ public class AutoClusterFailoverTest {
         configurationData.setTlsTrustStorePath(primaryTlsTrustStorePath);
         configurationData.setTlsTrustStorePassword(primaryTlsTrustStorePassword);
 
+        @Cleanup
         ServiceUrlProvider provider = AutoClusterFailover.builder()
                 .primary(primary)
                 .secondary(Collections.singletonList(secondary))

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientTestFixtures.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientTestFixtures.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoop;
 import io.netty.util.Timer;
@@ -38,7 +39,12 @@ import org.apache.pulsar.client.util.ExecutorProvider;
 import org.mockito.Mockito;
 
 class ClientTestFixtures {
-    public static ScheduledExecutorService SCHEDULER = Executors.newSingleThreadScheduledExecutor();
+    public static ScheduledExecutorService SCHEDULER =
+            Executors.newSingleThreadScheduledExecutor(
+                    new ThreadFactoryBuilder()
+                            .setNameFormat("ClientTestFixtures-SCHEDULER-%d")
+                            .setDaemon(true)
+                            .build());
 
 //    static <T> PulsarClientImpl createPulsarClientMock() {
 //        return createPulsarClientMock(mock(ExecutorService.class));

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ControlledClusterFailoverTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ControlledClusterFailoverTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.ServiceUrlProvider;
 import org.asynchttpclient.Request;
@@ -47,6 +48,7 @@ public class ControlledClusterFailoverTest {
         Map<String, String> header = new HashMap<>();
         header.put(keyA, valueA);
         header.put(keyB, valueB);
+        @Cleanup
         ServiceUrlProvider provider = ControlledClusterFailover.builder()
             .defaultServiceUrl(defaultServiceUrl)
             .urlProvider(urlProvider)
@@ -81,6 +83,7 @@ public class ControlledClusterFailoverTest {
         controlledConfiguration.setAuthPluginClassName(authPluginClassName);
         controlledConfiguration.setAuthParamsString(authParamsString);
 
+        @Cleanup
         ServiceUrlProvider provider = ControlledClusterFailover.builder()
             .defaultServiceUrl(defaultServiceUrl)
             .urlProvider(urlProvider)

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
@@ -29,10 +29,10 @@ import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+import com.google.api.client.util.Lists;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.Timer;
 import io.netty.util.concurrent.DefaultThreadFactory;
-import com.google.api.client.util.Lists;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -40,6 +40,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadFactory;
+import lombok.Cleanup;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageRouter;
 import org.apache.pulsar.client.api.MessageRoutingMode;
@@ -188,8 +189,10 @@ public class PartitionedProducerImplTest {
         conf.setStatsIntervalSeconds(100);
 
         ThreadFactory threadFactory = new DefaultThreadFactory("client-test-stats", Thread.currentThread().isDaemon());
+        @Cleanup("shutdownGracefully")
         EventLoopGroup eventLoopGroup = EventLoopUtil.newEventLoopGroup(conf.getNumIoThreads(), false, threadFactory);
 
+        @Cleanup
         PulsarClientImpl clientImpl = new PulsarClientImpl(conf, eventLoopGroup);
 
         ProducerConfigurationData producerConfData = new ProducerConfigurationData();
@@ -214,9 +217,11 @@ public class PartitionedProducerImplTest {
 
         ThreadFactory threadFactory =
                 new DefaultThreadFactory("client-test-stats", Thread.currentThread().isDaemon());
+        @Cleanup("shutdownGracefully")
         EventLoopGroup eventLoopGroup = EventLoopUtil
                 .newEventLoopGroup(conf.getNumIoThreads(), false, threadFactory);
 
+        @Cleanup
         PulsarClientImpl clientImpl = new PulsarClientImpl(conf, eventLoopGroup);
 
         ProducerConfigurationData producerConfData = new ProducerConfigurationData();
@@ -246,8 +251,10 @@ public class PartitionedProducerImplTest {
         conf.setStatsIntervalSeconds(100);
 
         ThreadFactory threadFactory = new DefaultThreadFactory("client-test-stats", Thread.currentThread().isDaemon());
+        @Cleanup("shutdownGracefully")
         EventLoopGroup eventLoopGroup = EventLoopUtil.newEventLoopGroup(conf.getNumIoThreads(), false, threadFactory);
 
+        @Cleanup
         PulsarClientImpl clientImpl = new PulsarClientImpl(conf, eventLoopGroup);
 
         ProducerConfigurationData producerConfData = new ProducerConfigurationData();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImplTest.java
@@ -26,6 +26,7 @@ import static org.testng.Assert.assertTrue;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
 import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.testng.annotations.Test;
@@ -43,6 +44,7 @@ public class ProducerStatsRecorderImplTest {
         ConnectionPool connectionPool = mock(ConnectionPool.class);
         when(client.getCnxPool()).thenReturn(connectionPool);
         when(client.getConfiguration()).thenReturn(conf);
+        @Cleanup("stop")
         Timer timer = new HashedWheelTimer();
         when(client.timer()).thenReturn(timer);
         ProducerImpl<?> producer = mock(ProducerImpl.class);
@@ -55,6 +57,7 @@ public class ProducerStatsRecorderImplTest {
         recorder.incrementNumAcksReceived(latencyNs);
         Thread.sleep(1200);
         assertEquals(1000.0, recorder.getSendLatencyMillisMax(), 0.5);
+        recorder.cancelStatsTimeout();
     }
 
     @Test
@@ -65,6 +68,7 @@ public class ProducerStatsRecorderImplTest {
         ConnectionPool connectionPool = mock(ConnectionPool.class);
         when(client.getCnxPool()).thenReturn(connectionPool);
         when(client.getConfiguration()).thenReturn(conf);
+        @Cleanup("stop")
         Timer timer = new HashedWheelTimer();
         when(client.timer()).thenReturn(timer);
         ProducerImpl<?> producer = mock(ProducerImpl.class);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
@@ -178,6 +178,7 @@ public class PulsarClientImplTest {
     @Test
     public void testInitializeWithTimer() throws PulsarClientException {
         ClientConfigurationData conf = new ClientConfigurationData();
+        @Cleanup("shutdownGracefully")
         EventLoopGroup eventLoop = EventLoopUtil.newEventLoopGroup(1, false, new DefaultThreadFactory("test"));
         ConnectionPool pool = Mockito.spy(new ConnectionPool(conf, eventLoop));
         conf.setServiceUrl("pulsar://localhost:6650");

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/AuthenticationTokenTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/AuthenticationTokenTest.java
@@ -28,6 +28,7 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
 
+import lombok.Cleanup;
 import org.apache.commons.io.FileUtils;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
@@ -68,6 +69,7 @@ public class AuthenticationTokenTest {
         clientConfig.setAuthentication(AuthenticationFactory.create(
                 AuthenticationToken.class.getName(), "token-xyz"));
 
+        @Cleanup
         PulsarClientImpl pulsarClient = new PulsarClientImpl(clientConfig);
 
         Authentication authToken = pulsarClient.getConfiguration().getAuthentication();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.impl.conf;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
+import lombok.Cleanup;
 import org.testng.Assert;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -148,6 +149,7 @@ public class ConfigurationDataUtilsTest {
         clientConfig.setServiceUrl("pulsar://unknown:6650");
         clientConfig.setStatsIntervalSeconds(80);
 
+        @Cleanup
         PulsarClientImpl pulsarClient = new PulsarClientImpl(clientConfig);
         assertNotNull(pulsarClient, "Pulsar client built using config should not be null");
 
@@ -213,6 +215,7 @@ public class ConfigurationDataUtilsTest {
         clientConfig.setSocks5ProxyUsername("test");
         clientConfig.setSocks5ProxyPassword("test123");
 
+        @Cleanup
         PulsarClientImpl pulsarClient = new PulsarClientImpl(clientConfig);
         assertEquals(pulsarClient.getConfiguration().getSocks5ProxyAddress(), new InetSocketAddress("localhost", 11080));
         assertEquals(pulsarClient.getConfiguration().getSocks5ProxyUsername(), "test");


### PR DESCRIPTION
### Motivation

Tests should properly cleanup and close test resources. 

### Modifications

Cleanup and close test resources in the tests that are in the pulsar-client module.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->