### PR TITLE
[improve][ci] Upgrade Gradle Enterprise Maven extension

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -24,11 +24,11 @@
   <extension>
     <groupId>com.gradle</groupId>
     <artifactId>gradle-enterprise-maven-extension</artifactId>
-    <version>1.17.1</version>
+    <version>1.19.3</version>
   </extension>
   <extension>
     <groupId>com.gradle</groupId>
     <artifactId>common-custom-user-data-maven-extension</artifactId>
-    <version>1.11.1</version>
+    <version>1.12.4</version>
   </extension>
 </extensions>


### PR DESCRIPTION
### Motivation

- currently used version fails with exception about "Unsupported class file major version 65" in Gradle Enterprise Maven extension's `gradle-enterprise-custom-user-data.groovy` evaluation.

### Modifications

- prepare for Java 21 compatibility by upgrading Gradle Enterprise Maven extension libraries

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->