### PR TITLE
[fix][test] Fix resource leak in PulsarServiceTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceTest.java
@@ -188,7 +188,7 @@ public class PulsarServiceTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
-    public void testBacklogAndRetentionCheck() {
+    public void testBacklogAndRetentionCheck() throws PulsarServerException {
         ServiceConfiguration config = new ServiceConfiguration();
         config.setClusterName("test");
         config.setMetadataStoreUrl("memory:local");
@@ -200,6 +200,8 @@ public class PulsarServiceTest extends MockedPulsarServiceBaseTest {
             pulsarService.start();
         } catch (Exception e) {
             assertFalse(e.getCause() instanceof IllegalArgumentException);
+        } finally {
+            pulsarService.close();
         }
 
         // Only set retention
@@ -212,6 +214,8 @@ public class PulsarServiceTest extends MockedPulsarServiceBaseTest {
             pulsarService.start();
         } catch (Exception e) {
             assertFalse(e.getCause() instanceof IllegalArgumentException);
+        } finally {
+            pulsarService.close();
         }
 
         // Set both retention and backlog quota
@@ -224,6 +228,8 @@ public class PulsarServiceTest extends MockedPulsarServiceBaseTest {
             pulsarService.start();
         } catch (Exception e) {
             assertFalse(e.getCause() instanceof IllegalArgumentException);
+        } finally {
+            pulsarService.close();
         }
 
         // Set invalidated retention and backlog quota
@@ -235,6 +241,8 @@ public class PulsarServiceTest extends MockedPulsarServiceBaseTest {
             pulsarService.start();
         } catch (Exception e) {
             assertTrue(e.getCause() instanceof IllegalArgumentException);
+        } finally {
+            pulsarService.close();
         }
 
         config.setBacklogQuotaDefaultLimitBytes(4 * 1024 * 1024);
@@ -246,6 +254,8 @@ public class PulsarServiceTest extends MockedPulsarServiceBaseTest {
             pulsarService.start();
         } catch (Exception e) {
             assertTrue(e.getCause() instanceof IllegalArgumentException);
+        } finally {
+            pulsarService.close();
         }
 
         // Only set backlog quota
@@ -258,6 +268,8 @@ public class PulsarServiceTest extends MockedPulsarServiceBaseTest {
             pulsarService.start();
         } catch (Exception e) {
             assertFalse(e.getCause() instanceof IllegalArgumentException);
+        } finally {
+            pulsarService.close();
         }
     }
 }


### PR DESCRIPTION
### Motivation

PulsarServiceTest leaks 141 threads currently.

### Modifications

Properly close resources in the test.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->