### PR TITLE
[improve][build] Upgrade Jacoco version to 0.8.11 to support Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@ flexible messaging model and an intuitive client API.</description>
     <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
     <wagon-ssh-external.version>3.5.3</wagon-ssh-external.version>
     <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
-    <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
     <spotbugs-maven-plugin.version>4.7.3.0</spotbugs-maven-plugin.version>
     <spotbugs.version>4.7.3</spotbugs.version>
     <errorprone.version>2.5.1</errorprone.version>


### PR DESCRIPTION
### Motivation

As a preparation for future Java 21 support, it's useful to upgrade library versions to such that support Java 21 for building and running tests. Jacoco version should be upgraded to 0.8.11 to support Java 21.
Jacoco 0.8.11 release notes: https://github.com/jacoco/jacoco/releases/tag/v0.8.11

### Modifications

Upgrade Jacoco to 0.8.11 version

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->