### PR TITLE
[improve][build] Upgrade spotbugs maven plugin version for Java 21 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@ flexible messaging model and an intuitive client API.</description>
     <wagon-ssh-external.version>3.5.3</wagon-ssh-external.version>
     <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
-    <spotbugs-maven-plugin.version>4.7.3.0</spotbugs-maven-plugin.version>
+    <spotbugs-maven-plugin.version>4.7.3.6</spotbugs-maven-plugin.version>
     <spotbugs.version>4.7.3</spotbugs.version>
     <errorprone.version>2.5.1</errorprone.version>
     <errorprone.javac.version>9+181-r4173-1</errorprone.javac.version>

--- a/pulsar-client/src/main/resources/findbugsExclude.xml
+++ b/pulsar-client/src/main/resources/findbugsExclude.xml
@@ -339,6 +339,11 @@
     </Match>
     <Match>
         <Class name="org.apache.pulsar.client.impl.conf.ConsumerConfigurationData"/>
+        <Method name="getProperties"/>
+        <Bug pattern="EI_EXPOSE_REP"/>
+    </Match>
+    <Match>
+        <Class name="org.apache.pulsar.client.impl.conf.ConsumerConfigurationData"/>
         <Method name="&lt;init&gt;"/>
         <Bug pattern="EI_EXPOSE_REP2"/>
     </Match>
@@ -388,6 +393,11 @@
         <Bug pattern="EI_EXPOSE_REP2"/>
     </Match>
     <Match>
+        <Class name="org.apache.pulsar.client.impl.conf.ConsumerConfigurationData"/>
+        <Method name="setProperties"/>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
+    <Match>
         <Class name="org.apache.pulsar.client.impl.conf.DefaultCryptoKeyReaderConfigurationData"/>
         <Method name="getPrivateKeys"/>
         <Bug pattern="EI_EXPOSE_REP"/>
@@ -429,6 +439,11 @@
     </Match>
     <Match>
         <Class name="org.apache.pulsar.client.impl.conf.ProducerConfigurationData"/>
+        <Method name="getProperties"/>
+        <Bug pattern="EI_EXPOSE_REP"/>
+    </Match>
+    <Match>
+        <Class name="org.apache.pulsar.client.impl.conf.ProducerConfigurationData"/>
         <Method name="&lt;init&gt;"/>
         <Bug pattern="EI_EXPOSE_REP2"/>
     </Match>
@@ -445,6 +460,11 @@
     <Match>
         <Class name="org.apache.pulsar.client.impl.conf.ProducerConfigurationData"/>
         <Method name="setMessageCrypto"/>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
+    <Match>
+        <Class name="org.apache.pulsar.client.impl.conf.ProducerConfigurationData"/>
+        <Method name="setProperties"/>
         <Bug pattern="EI_EXPOSE_REP2"/>
     </Match>
     <Match>


### PR DESCRIPTION
### Motivation

When building with Java 21, it currently fails in spotbugs with  "Unsupported class file major version 65".

### Modifications

- upgrade spotbugs maven plugin version to 4.7.3.6 
- fix new spotbugs errors by adding excludes

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->