### PR TITLE
[improve][ci] Add new CI unit test group "Broker Group 4" with cluster migration tests

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -189,6 +189,8 @@ jobs:
             group: BROKER_GROUP_2
           - name: Brokers - Broker Group 3
             group: BROKER_GROUP_3
+          - name: Brokers - Broker Group 4
+            group: BROKER_GROUP_4
           - name: Brokers - Client Api
             group: BROKER_CLIENT_API
           - name: Brokers - Client Impl

--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -87,6 +87,10 @@ function test_group_broker_group_3() {
   mvn_test -pl pulsar-broker -Dgroups='broker-admin'
 }
 
+function test_group_broker_group_4() {
+  mvn_test -pl pulsar-broker -Dgroups='cluster-migration'
+}
+
 function test_group_broker_client_api() {
   mvn_test -pl pulsar-broker -Dgroups='broker-api'
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ClusterMigrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ClusterMigrationTest.java
@@ -55,7 +55,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-@Test(groups = "broker")
+@Test(groups = "cluster-migration")
 public class ClusterMigrationTest {
 
     private static final Logger log = LoggerFactory.getLogger(ClusterMigrationTest.class);


### PR DESCRIPTION
### Motivation

There are too many tests in the "broker" TestNG test group which gets executed in the "Broker Group 1" CI job.
The tests could take over 60 minutes to run and that is currently the timeout.

### Modifications

Add a new "Broker Group 4" unit test group and build job.
Move one of the slowest tests "ClusterMigrationTest" to "cluster-migration" TestNG test group. Assign "cluster-migration" to "Broker Group 4".

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->