### PR TITLE
[improve][pip] PIP-308: Support share Retry and DLQ topic producers for `MultiTopicConsumer` instance.

### DIFF
--- a/pip/pip-308.md
+++ b/pip/pip-308.md
@@ -1,0 +1,172 @@
+# PIP 308: Support share Retry and DLQ topic producers for `MultiTopicConsumer` instance.
+
+<!--
+RULES
+* Never place a link to an external site like Google Doc. The proposal should be in this issue entirely.
+* Use a spelling and grammar checker tools if available for you (there are plenty of free ones).
+
+PROPOSAL HEALTH CHECK
+I can read the design document and understand the problem statement and what you plan to change *without* resorting to a couple of hours of code reading just to start having a high level understanding of the change.
+
+IMAGES
+If you need diagrams, avoid attaching large files. You can use [MermaidJS]([url](https://mermaid.js.org/)) as a simple language to describe many types of diagrams.
+
+THIS COMMENTS
+Please remove them when done.
+-->
+
+# Background knowledge
+
+[PIP-48](https://github.com/apache/pulsar/wiki/PIP-58-%3A-Support-Consumers--Set-Custom-Retry-Delay)
+add support for retry and dlq topic for message processing. 
+
+User can set retry topic and dlq topic in `DeadLetterPolicy` when subscribe and start processing.
+
+When reconsumeLater api called the message will be send back to retry topic using producer.
+When message reach max-consume times the message will be send back to dlq topic using producer too.
+
+And Pulsar support user subscribe partitioned topic, and also the retry and dlq topic can also be partitioned.
+
+When user subscribe to one partitioned topic. The api will create each partition one consumer.
+And for each topic partition consumer, a retry producer and dlq producer will be created.
+
+<!--
+Describes all the knowledge you need to know in order to understand all the other sections in this PIP
+
+* Give a high level explanation on all concepts you will be using throughout this document. For example, if you want to talk about Persistent Subscriptions, explain briefly (1 paragraph) what this is. If you're going to talk about Transaction Buffer, explain briefly what this is. 
+  If you're going to change something specific, then go into more detail about it and how it works. 
+* Provide links where possible if a person wants to dig deeper into the background information. 
+
+DON'T
+* Do not include links *instead* explanation. Do provide links for further explanation.
+
+EXAMPLES
+* See [PIP-248](https://github.com/apache/pulsar/issues/19601), Background section to get an understanding on how you add the background knowledge needed.
+  (They also included the motivation there, but ignore it as we place that in Motivation section explicitly).
+-->
+
+# Motivation
+
+When consumer subscribe large partition topic. the retry and dlq topic producer can be reused to reduce resources.
+
+---
+Suppose that user topic has 16 partitions, retry topic and dlq topic has 8 partition (maybe auto created).
+So for this consumer each partitions of user topic will create one retry topic producer and dlq topic producer. (which each is also partitioned producer with 8 inner producer inside)
+
+When user scale the message processing program to 16 instances.
+the retry and dlq producer will be huge.
+
+
+
+<!--
+Describe the problem this proposal is trying to solve.
+
+* Explain what is the problem you're trying to solve - current situation.
+* This section is the "Why" of your proposal.
+-->
+
+# Goals
+
+## In Scope
+
+Share retry and dlq producer within partitioned consumer to reduce resource usage both client and server side.
+
+
+# Detailed Design
+
+## Design & Implementation Details
+
+1. Add field in `DeadLetterPolicy` for user to enable producer sharing.
+
+```java
+public class DeadLetterPolicy {
+    ...
+
+    /**
+     * If shared deadLetterPolicy producers for retry and dlq topic producer.
+     * If this field set to true. When consumer subscribe to multi-partition topic,
+     * only one instance of retry and dlq topic producer for this consumer instance
+     * which can reduce connection pressure on broker side and reduce resource for client.
+     */
+    private boolean shareDeadLetterPolicyProducers;
+}
+
+```
+
+
+2. Provide `DeadLetterPolicyTopicProducerProvider` to create prodcuers.
+    we can have two implementations. The default `DefaultDeadLetterPolicyProducerProvider` will just create and return the producer to the caller. The shared version `SharedDeadLetterPolicyProducerProvider` will try to cache the producer and return the same instance to the caller.
+
+```java
+public interface DeadLetterPolicyTopicProducerProvider {
+    Producer<byte[]> getRetryTopicProducer(DeadLetterPolicy policy, Schema<?> schema) throws PulsarClientException;
+
+    CompletableFuture<Producer<byte[]>> getDLQTopicProducer(DeadLetterPolicy policy, Schema<?> schema);
+
+    /**
+     * Indicate if the ConsumerImpl is the producer owner.
+     * if yes, the ConsumerImpl should close the created producer.
+     */
+    boolean isProducerOwner();
+
+    CompletableFuture<Void> closeAsync();
+}
+```
+
+3. Change the current `ConsumerImpl` to use the `DeadLetterPolicyTopicProducerProvider` when try to get the producer the logic will be handled by this interface.
+
+
+4. Provide a way to pass `DeadLetterPolicyTopicProducerProvider` to `ConsumerImpl` 
+when use subscribe to multi topics the `MultiTopicsConsumerImpl` will create all the topic partition consumers. So for these consumers they should shared one instance of `DeadLetterPolicyTopicProducerProvider`. The `ConsumerConfigurationData` is used for pass the `DefaultDeadLetterPolicyProducerProvider` instance.
+
+
+5. Cleanup, when the `MultiTopicsConsumerImpl` is closed the shared producers should be handled by this instance, but not by the inner `ConsumerImpl`. When user only subscribe to one non-partitioned topic the `ConsumerImpl` should handle the close.
+
+## Public-facing Changes
+
+<!--
+Describe the additions you plan to make for each public facing component. 
+Remove the sections you are not changing.
+Clearly mark any changes which are BREAKING backward compatability.
+-->
+
+### Public API
+
+User can enable `shareDeadLetterPolicyProducers` in `DeadLetterPolicy`
+
+```java
+Consumer<byte[]> consumer = client.newConsumer()
+        .topic("persistent://public/test/test-reuse-producer")
+        .enableRetry(true)
+        .deadLetterPolicy(
+        DeadLetterPolicy.builder()
+            .deadLetterTopic("persistent://public/test/test-reuse-producer-DLQ")
+            .retryLetterTopic("persistent://public/test/test-reuse-producer-RETRY")
+            .shareDeadLetterPolicyProducers(true)
+            .maxRedeliverCount(3).build())
+        .subscriptionName("sub")
+        .subscriptionType(SubscriptionType.Shared)
+        .subscribe();
+
+```
+
+
+# Backward & Forward Compatibility
+
+## Revert
+The option is default false which will create `DefaultDeadLetterPolicyProducerProvider` which will not cache producers at all. So the user won't be affected.
+
+## Upgrade
+
+User set the option to `true` the feature is then enabled.
+
+# Alternatives
+
+none
+
+# General Notes
+
+# Links
+
+* Mailing List discussion thread:
+* Mailing List voting thread:


### PR DESCRIPTION
### Motivation
Reuse the retry and dlq topic producers within multi-partition subscribe consumers to reduce resource usage

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->