### PR TITLE
[fix][sec] Upgrade Jetty to 9.4.53 to address CVE-2023-44487

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -383,25 +383,25 @@ The Apache Software License, Version 2.0
     - org.asynchttpclient-async-http-client-2.12.1.jar
     - org.asynchttpclient-async-http-client-netty-utils-2.12.1.jar
  * Jetty
-    - org.eclipse.jetty-jetty-client-9.4.52.v20230823.jar
-    - org.eclipse.jetty-jetty-continuation-9.4.52.v20230823.jar
-    - org.eclipse.jetty-jetty-http-9.4.52.v20230823.jar
-    - org.eclipse.jetty-jetty-io-9.4.52.v20230823.jar
-    - org.eclipse.jetty-jetty-proxy-9.4.52.v20230823.jar
-    - org.eclipse.jetty-jetty-security-9.4.52.v20230823.jar
-    - org.eclipse.jetty-jetty-server-9.4.52.v20230823.jar
-    - org.eclipse.jetty-jetty-servlet-9.4.52.v20230823.jar
-    - org.eclipse.jetty-jetty-servlets-9.4.52.v20230823.jar
-    - org.eclipse.jetty-jetty-util-9.4.52.v20230823.jar
-    - org.eclipse.jetty-jetty-util-ajax-9.4.52.v20230823.jar
-    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.52.v20230823.jar
-    - org.eclipse.jetty.websocket-websocket-api-9.4.52.v20230823.jar
-    - org.eclipse.jetty.websocket-websocket-client-9.4.52.v20230823.jar
-    - org.eclipse.jetty.websocket-websocket-common-9.4.52.v20230823.jar
-    - org.eclipse.jetty.websocket-websocket-server-9.4.52.v20230823.jar
-    - org.eclipse.jetty.websocket-websocket-servlet-9.4.52.v20230823.jar
-    - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.52.v20230823.jar
-    - org.eclipse.jetty-jetty-alpn-server-9.4.52.v20230823.jar
+    - org.eclipse.jetty-jetty-client-9.4.53.v20231009.jar
+    - org.eclipse.jetty-jetty-continuation-9.4.53.v20231009.jar
+    - org.eclipse.jetty-jetty-http-9.4.53.v20231009.jar
+    - org.eclipse.jetty-jetty-io-9.4.53.v20231009.jar
+    - org.eclipse.jetty-jetty-proxy-9.4.53.v20231009.jar
+    - org.eclipse.jetty-jetty-security-9.4.53.v20231009.jar
+    - org.eclipse.jetty-jetty-server-9.4.53.v20231009.jar
+    - org.eclipse.jetty-jetty-servlet-9.4.53.v20231009.jar
+    - org.eclipse.jetty-jetty-servlets-9.4.53.v20231009.jar
+    - org.eclipse.jetty-jetty-util-9.4.53.v20231009.jar
+    - org.eclipse.jetty-jetty-util-ajax-9.4.53.v20231009.jar
+    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.53.v20231009.jar
+    - org.eclipse.jetty.websocket-websocket-api-9.4.53.v20231009.jar
+    - org.eclipse.jetty.websocket-websocket-client-9.4.53.v20231009.jar
+    - org.eclipse.jetty.websocket-websocket-common-9.4.53.v20231009.jar
+    - org.eclipse.jetty.websocket-websocket-server-9.4.53.v20231009.jar
+    - org.eclipse.jetty.websocket-websocket-servlet-9.4.53.v20231009.jar
+    - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.53.v20231009.jar
+    - org.eclipse.jetty-jetty-alpn-server-9.4.53.v20231009.jar
  * SnakeYaml -- org.yaml-snakeyaml-2.0.jar
  * RocksDB - org.rocksdb-rocksdbjni-7.9.2.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.5.1.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -395,14 +395,14 @@ The Apache Software License, Version 2.0
     - async-http-client-2.12.1.jar
     - async-http-client-netty-utils-2.12.1.jar
  * Jetty
-    - jetty-client-9.4.52.v20230823.jar
-    - jetty-http-9.4.52.v20230823.jar
-    - jetty-io-9.4.52.v20230823.jar
-    - jetty-util-9.4.52.v20230823.jar
-    - javax-websocket-client-impl-9.4.52.v20230823.jar
-    - websocket-api-9.4.52.v20230823.jar
-    - websocket-client-9.4.52.v20230823.jar
-    - websocket-common-9.4.52.v20230823.jar
+    - jetty-client-9.4.53.v20231009.jar
+    - jetty-http-9.4.53.v20231009.jar
+    - jetty-io-9.4.53.v20231009.jar
+    - jetty-util-9.4.53.v20231009.jar
+    - javax-websocket-client-impl-9.4.53.v20231009.jar
+    - websocket-api-9.4.53.v20231009.jar
+    - websocket-client-9.4.53.v20231009.jar
+    - websocket-common-9.4.53.v20231009.jar
  * SnakeYaml -- snakeyaml-2.0.jar
  * Google Error Prone Annotations - error_prone_annotations-2.5.1.jar
  * Javassist -- javassist-3.25.0-GA.jar

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@ flexible messaging model and an intuitive client API.</description>
     <curator.version>5.1.0</curator.version>
     <netty.version>4.1.99.Final</netty.version>
     <netty-iouring.version>0.0.21.Final</netty-iouring.version>
-    <jetty.version>9.4.52.v20230823</jetty.version>
+    <jetty.version>9.4.53.v20231009</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.34</jersey.version>
     <athenz.version>1.10.50</athenz.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -283,22 +283,22 @@ The Apache Software License, Version 2.0
     - joda-time-2.10.10.jar
     - failsafe-2.4.4.jar
   * Jetty
-    - http2-client-9.4.52.v20230823.jar
-    - http2-common-9.4.52.v20230823.jar
-    - http2-hpack-9.4.52.v20230823.jar
-    - http2-http-client-transport-9.4.52.v20230823.jar
-    - jetty-alpn-client-9.4.52.v20230823.jar
-    - http2-server-9.4.52.v20230823.jar
-    - jetty-alpn-java-client-9.4.52.v20230823.jar
-    - jetty-client-9.4.52.v20230823.jar
-    - jetty-http-9.4.52.v20230823.jar
-    - jetty-io-9.4.52.v20230823.jar
-    - jetty-jmx-9.4.52.v20230823.jar
-    - jetty-security-9.4.52.v20230823.jar
-    - jetty-server-9.4.52.v20230823.jar
-    - jetty-servlet-9.4.52.v20230823.jar
-    - jetty-util-9.4.52.v20230823.jar
-    - jetty-util-ajax-9.4.52.v20230823.jar
+    - http2-client-9.4.53.v20231009.jar
+    - http2-common-9.4.53.v20231009.jar
+    - http2-hpack-9.4.53.v20231009.jar
+    - http2-http-client-transport-9.4.53.v20231009.jar
+    - jetty-alpn-client-9.4.53.v20231009.jar
+    - http2-server-9.4.53.v20231009.jar
+    - jetty-alpn-java-client-9.4.53.v20231009.jar
+    - jetty-client-9.4.53.v20231009.jar
+    - jetty-http-9.4.53.v20231009.jar
+    - jetty-io-9.4.53.v20231009.jar
+    - jetty-jmx-9.4.53.v20231009.jar
+    - jetty-security-9.4.53.v20231009.jar
+    - jetty-server-9.4.53.v20231009.jar
+    - jetty-servlet-9.4.53.v20231009.jar
+    - jetty-util-9.4.53.v20231009.jar
+    - jetty-util-ajax-9.4.53.v20231009.jar
   * Byte Buddy
     - byte-buddy-1.14.8.jar
   * Apache BVal


### PR DESCRIPTION
### Motivation

OWASP dependency check reports CVE-2023-44487 for Jetty (and also Netty).

### Modifications

Upgrade Jetty to 9.4.53.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->