### PR TITLE
[improve][broker] Unblock stuck Key_Shared subscription after consumer reconnect

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -32,7 +32,6 @@ import java.util.NavigableSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.Position;
@@ -269,7 +268,8 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             for (Entry entryWithTheSameKey : entriesWithSameKey) {
                 if (!entriesForC.contains(entryWithTheSameKey)) {
                     long stickyKeyHash = getStickyKeyHash(entryWithTheSameKey);
-                    addMessageToReplay(entryWithTheSameKey.getLedgerId(), entryWithTheSameKey.getEntryId(), stickyKeyHash);
+                    addMessageToReplay(entryWithTheSameKey.getLedgerId(), entryWithTheSameKey.getEntryId(),
+                            stickyKeyHash);
                     entryWithTheSameKey.release();
                 }
             }
@@ -278,7 +278,8 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
                 // remove positions first from replay list first : sendMessages recycles entries
                 if (readType == ReadType.Replay) {
                     for (Entry entryToRemoveFromRedelivery : entriesForC) {
-                        redeliveryMessages.remove(entryToRemoveFromRedelivery.getLedgerId(), entryToRemoveFromRedelivery.getEntryId());
+                        redeliveryMessages.remove(
+                                entryToRemoveFromRedelivery.getLedgerId(), entryToRemoveFromRedelivery.getEntryId());
                     }
                 }
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes https://github.com/apache/pulsar/issues/21199

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

There's strange behaviour while not acknowledging a message due to a processing error.

The setup is:

- 14 consumers listen to a non-partitioned key-shared topic A;
- in case any of them encounters a corrupted message, it restarts in some time. During some short time there is 13 consumers;
- also consumers are disconnected in similar fashion while performing rolling restart;
- batches are disabled on the producer and on the consumer (enableBatchIndexAcknowledgment = false).

The flow is:
1. producer sends a corrupted message to the topic with (message 1);
2. producer sends correct messages to the topic (message 2 and message 3);
3. consumer 1 fails to process the corrupted message (message 1);
4. the corrupted message 1 is recorded for replay (PersistentDispatcherMultipleConsumers#redeliveryMessages);
5. consumer 1 proceeds processing messages further for some time (e.g. the message 2 is processed successfully);
6. in some time consumer 1 stops;
7. consumer 2 picks up the corrupted message 1 from the replay set (PersistentDispatcherMultipleConsumers#readMoreEntries) and fails too;
8. consumer 1 spins up again and becomes a recently joined consumer (PersistentStickyKeyDispatcherMultipleConsumers#recentlyJoinedConsumers);
9. consumer 1 waits for message 1 to be acknowledged by anyone in order to be removed from recently joined consumers (PersistentStickyKeyDispatcherMultipleConsumers#removeConsumersFromRecentJoinedConsumers), so that it would be able to receive message 3;
10. steps 4-9 are repeated for all consumers until message 1 to be acknowledged, so none of the restarted consumers receives any messages.

As a result, not acknowledging message 1 for message 1, followed by restart of consumer 1 from the cluster, leads to full blocking of the topic.

I checked the code and I suppose it is implemented this way in order to prevent breaking the order.

### Modifications

I used `MessageRedeliveryController` in order to track if the not-acked message has not yet been sent to a consumer. Until it is not, I block sending other messages with the same key hash. After the not-acked message is sent, the other message are also allowed to be sent.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/ivans0773/pulsar/pull/1

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
