### PR TITLE
[fix][sec] Upgrade Zookeeper to 3.8.3 to address CVE-2023-44981

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -480,9 +480,9 @@ The Apache Software License, Version 2.0
     - io.vertx-vertx-web-common-4.3.8.jar
     - io.vertx-vertx-grpc-4.3.5.jar
   * Apache ZooKeeper
-    - org.apache.zookeeper-zookeeper-3.8.1.jar
-    - org.apache.zookeeper-zookeeper-jute-3.8.1.jar
-    - org.apache.zookeeper-zookeeper-prometheus-metrics-3.8.1.jar
+    - org.apache.zookeeper-zookeeper-3.8.3.jar
+    - org.apache.zookeeper-zookeeper-jute-3.8.3.jar
+    - org.apache.zookeeper-zookeeper-prometheus-metrics-3.8.3.jar
   * Snappy Java
     - org.xerial.snappy-snappy-java-1.1.10.5.jar
   * Google HTTP Client

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@ flexible messaging model and an intuitive client API.</description>
     <commons-compress.version>1.21</commons-compress.version>
 
     <bookkeeper.version>4.16.3</bookkeeper.version>
-    <zookeeper.version>3.8.1</zookeeper.version>
+    <zookeeper.version>3.8.3</zookeeper.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <commons-text.version>1.10.0</commons-text.version>
     <snappy.version>1.1.10.5</snappy.version> <!-- ZooKeeper server -->

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -472,8 +472,8 @@ The Apache Software License, Version 2.0
     - memory-0.8.3.jar
     - sketches-core-0.8.3.jar
   * Apache Zookeeper
-    - zookeeper-3.8.1.jar
-    - zookeeper-jute-3.8.1.jar
+    - zookeeper-3.8.3.jar
+    - zookeeper-jute-3.8.3.jar
   * Apache Yetus Audience Annotations
     - audience-annotations-0.12.0.jar
   * Perfmark


### PR DESCRIPTION
### Motivation

OWASP dependency check reports CVE-2023-44981 for Zookeeper.

### Modifications

Upgrade Zookeeper to 3.8.3.
Release notes: https://zookeeper.apache.org/doc/r3.8.3/releasenotes.html

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->