### PR TITLE
[improve][pip] PIP-310: Support custom publish rate limiters

### DIFF
--- a/pip/pip-310.md
+++ b/pip/pip-310.md
@@ -117,5 +117,5 @@ In case user was using precise rate limiter, i.e., they had `preciseTopicPublish
 <!--
 Updated afterwards
 -->
-* Mailing List discussion thread:
+* Mailing List discussion thread: https://lists.apache.org/thread/13ncst2nc311vxok1s75thl2gtnk7w1t
 * Mailing List voting thread:

--- a/pip/pip-310.md
+++ b/pip/pip-310.md
@@ -1,0 +1,121 @@
+# PIP-310 Support custom publish rate limiters
+
+# Background knowledge
+
+Pulsar uses rate limiters to control produce and consume rates. At core, this utility is provided by the RateLimiter.java class.
+There are many places where a rate limiter is used today. Mainly:
+* Produce path:
+  * ResourceGroupPublishLimiter - resource group's produce qps and MBps checks
+  * PrecisePublishLimiter - the topic quota rate limiter in case when `preciseTopicPublishRateLimiterEnable` broker config is `true`
+  * PublishRateLimiterImpl - the topic quota rate limiter in case when `preciseTopicPublishRateLimiterEnable` broker
+  config is `false`
+  * BrokerService - manage total publish rate of the broker
+* Consume path:
+  * DispatchRateLimiter - dispatch rate limiter
+  * BrokerService - manage total dispatch rate of the broker 
+* Misc:
+  * BrokerService - concurrent unloader rate limiter
+  * (Function|Sink|Source)StatsManager
+
+RateLimiter.java has two ways of implementing the rate limit check - precise and poller based. The poller based accumulates allowed permit and check for breach at a regular, configurable, frequency within each second. The precise one checks for breach before handing out permits each time.
+
+The DispatchRateLimiter hard codes RateLimiter to use precise rate limiter, but in the produce path , users can configure which one to choose for their brokers.
+
+# Motivation
+
+<!--
+Describe the problem this proposal is trying to solve.
+
+* Explain what is the problem you're trying to solve - current situation.
+* This section is the "Why" of your proposal.
+-->
+
+We have used both the poller based and precise publish rate limiters and there are challenges with both the approaches:
+
+* Poller based doesn't really do any throttling, all pending requests due to limit breach in the first second pass through in the first interval of the subsequent second.
+  * Effectively, there is no rate limiting.
+  * This also leads to noisy neighbour issues where topics hosted on the same broker/bookie face latency spikes.
+* Precise rate limiter fixes the above two issues, but introduces another challenge - the rate limiting is too strict.
+  * This leads potential for data loss in case there are sudden spikes in produce and client side produce queue breaches.
+  * The produce latencies increase exponentially in case produce breaches the set throughput even for small windows.
+
+Thus, there is a need for a rate limiter which is in between the above two implementations. As such, the handling of produce spikes
+and bursts may way from use-case to use-case, so it's not ideal to implement and add another rate limiter logic inside of Pulsar codebase
+as it will never be able to meet all possible requirements.
+
+# Goals
+
+I propose a configurable rate limiter implementation support, just like how AuthorizationProvider and
+AuthenticationProvider allow for.
+
+## In Scope
+
+For this PIP, the scope is the produce path only. It covers both the topic and the resource group level rate limiter.
+
+## Out of Scope
+
+Dispatch rate limiter is out of scope of this PIP. Generally speaking, the dispatch rate can smoothen out over time even if there are high produce spikes.
+
+# High Level Design
+
+* Add a new `initialize(PublishRate, ServiceConfigurations)` method in the interface `PublishRateLimiter.java` replacing direct constructor call.
+* Add 2 new optional properties in broker config: 
+  * `topicPublishRateLimiterProvider: <classpath>`
+  * `resourceGroupPublishRateLimiterProvider: <classpath>`
+* Based on the config values, and historic property, `AbstractTopic.java` and `ResourceGroup.java` initialize the relevant class.
+  * Fallback to `PublishRateLimiterImpl.java` in case rate limiter is enabled but class doesn't load.
+
+# Detailed Design
+
+## Design & Implementation Details
+
+* In `AbstractTopic.java`, instead of if-else based constructor call to either `PublishRateLimiterImpl` or `
+  PrecisePublishLimiter`, we read the `topicPublishRateLimiterProvider` config and load that class instead.
+  * Similarly, in `ResourceGroup.java`, we load the class defined in `resourceGroupPublishRateLimiterProvider` config.
+* Replace constructor call for `ResourceGroupPublishLimiter`, `PrecisePublishLimiter` and `PublishRateLimiterImpl` to `.initialize` method call.
+* Add fallback & default logic to load `PublishRateLimiterImpl` and `ResourceGroupPublishLimiter` in case of ClassNotFoundException or exception in `initialize` call in `AbstractTopic.java` and `
+  ResourceGroup.java`
+* For cases where rate limiting is disabled, we continue to use `PublishRateLimiterDisable` like we do currently.
+* For backward compatibility (for 2 minor versions), in `AbstractTopic.java` we add following logic:
+  * In case users have the flag `preciseTopicPublishRateLimiterEnable` as true *and* the `
+    topicPublishRateLimiterProvider` is empty, we still load `PublishRateLimiterImpl`.
+  * In case `topicPublishRateLimiterProvider` is a valid class, we ignore the value of `
+    preciseTopicPublishRateLimiterEnable`
+  * We mark the config `preciseTopicPublishRateLimiterEnable` deprecated in the config file and ask users to use the provider config with the classpath.
+
+### Configuration
+
+* `topicPublishRateLimiterProvider: <classpath>`
+* `resourceGroupPublishRateLimiterProvider: <classpath>`
+
+# Backward & Forward Compatibility
+
+## Upgrade
+
+In detailed design, backward compatibility logic is explained. Upgrades would work without need of config change until
+we finally remove the logic to understand `preciseTopicPublishRateLimiterEnable`.
+
+As a best practice:
+
+* Users requiring precise rate limiter remove the config `preciseTopicPublishRateLimiterEnable` and
+  add `topicPublishRateLimiterProvider: org.apache.pulsar.broker.service.PrecisePublishLimiter`
+* Users requiring custom rate limiter ensure that their class is present in pulsar classpath and they set
+  the `topicPublishRateLimiterProvider` or `
+  resourceGroupPublishRateLimiterProvider` accordingly
+
+## Revert
+
+In case user was not using the precise rate limiter, simply deleting the two new configs should revert back to previous version.
+
+In case user was using precise rate limiter, i.e., they had `preciseTopicPublishRateLimiterEnable: true` and:
+* They removed that and switched to `topicPublishRateLimiterProvider: org.apache.pulsar.broker.service.PrecisePublishLimiter`
+  * To revert, they simply need to remove the config `topicPublishRateLimiterProvider` and put in `preciseTopicPublishRateLimiterEnable: true`
+* They did not change any of their configs, i.e. they did not specifically add and value in `topicPublishRateLimiterProvider`, then no change needed.
+
+# Links
+
+<!--
+Updated afterwards
+-->
+* Mailing List discussion thread:
+* Mailing List voting thread:


### PR DESCRIPTION

### Motivation

Support custom publish rate limiters to support produce use cases which do not fit well within either the poller or the precise rate limier.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
