### PR TITLE
[fix][client] Fix typos in AuthenticationDataProvider interface

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
@@ -152,7 +152,7 @@ public class AsyncHttpConnector implements Connector {
                                 ? SecurityUtility.createAutoRefreshSslContextForClient(
                                 sslProvider,
                                 conf.isTlsAllowInsecureConnection(),
-                                conf.getTlsTrustCertsFilePath(), authData.getTlsCerificateFilePath(),
+                                conf.getTlsTrustCertsFilePath(), authData.getTlsCertificateFilePath(),
                                 authData.getTlsPrivateKeyFilePath(), null, autoCertRefreshTimeSeconds, delayer)
                                 : SecurityUtility.createNettySslContextForClient(
                                 sslProvider,

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/AuthenticationDataProvider.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/AuthenticationDataProvider.java
@@ -62,7 +62,7 @@ public interface AuthenticationDataProvider extends Serializable {
     /**
      * @return a client certificate file path
      */
-    default String getTlsCerificateFilePath() {
+    default String getTlsCertificateFilePath() {
         return null;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationDataTls.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationDataTls.java
@@ -143,7 +143,7 @@ public class AuthenticationDataTls implements AuthenticationDataProvider {
     }
 
     @Override
-    public String getTlsCerificateFilePath() {
+    public String getTlsCertificateFilePath() {
         return certFile != null ? certFile.getFileName() : null;
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/NettyClientSslContextRefresher.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/NettyClientSslContextRefresher.java
@@ -55,7 +55,7 @@ public class NettyClientSslContextRefresher extends SslContextAutoRefreshBuilder
         this.tlsTrustCertsFilePath = new FileModifiedTimeUpdater(trustCertsFilePath);
         this.authData = authData;
         this.tlsCertsFilePath = new FileModifiedTimeUpdater(
-                authData != null ? authData.getTlsCerificateFilePath() : null);
+                authData != null ? authData.getTlsCertificateFilePath() : null);
         this.tlsPrivateKeyFilePath = new FileModifiedTimeUpdater(
                 authData != null ? authData.getTlsPrivateKeyFilePath() : null);
         this.sslProvider = sslProvider;

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/FileModifiedTimeUpdaterTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/FileModifiedTimeUpdaterTest.java
@@ -60,7 +60,7 @@ public class FileModifiedTimeUpdaterTest {
             return true;
         }
 
-        public String getTlsCerificateFilePath() {
+        public String getTlsCertificateFilePath() {
             return certFilePath;
         }
 


### PR DESCRIPTION
### Motivation

Fix typos in AuthenticationDataProvider interface


### Modifications

Modify the interface name from `getTlsCerificateFilePath` to `getTlsCertificateFilePath`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

