### PR TITLE
[fix][test] Fix LocalBookkeeperEnsemble resource leak in tests

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -52,7 +52,6 @@ import org.apache.bookkeeper.clients.config.StorageClientSettings;
 import org.apache.bookkeeper.clients.exceptions.NamespaceExistsException;
 import org.apache.bookkeeper.clients.exceptions.NamespaceNotFoundException;
 import org.apache.bookkeeper.common.allocator.PoolingPolicy;
-import org.apache.bookkeeper.common.component.ComponentStarter;
 import org.apache.bookkeeper.common.component.LifecycleComponent;
 import org.apache.bookkeeper.common.component.LifecycleComponentStack;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
@@ -132,7 +131,7 @@ public class LocalBookkeeperEnsemble {
                                    boolean clearOldData,
                                    String advertisedAddress) {
         this(numberOfBookies, zkPort, streamStoragePort, zkDataDirName, bkDataDirName, clearOldData, advertisedAddress,
-                new BasePortManager(bkBasePort));
+                bkBasePort != 0 ? new BasePortManager(bkBasePort) : () -> 0);
     }
 
     public LocalBookkeeperEnsemble(int numberOfBookies,
@@ -311,6 +310,7 @@ public class LocalBookkeeperEnsemble {
             bsConfs[i] = new ServerConfiguration(baseConf);
             // override settings
             bsConfs[i].setBookiePort(bookiePort);
+            bsConfs[i].setBookieId("bk" + i + "test");
             String zkServers = "127.0.0.1:" + zkPort;
             String metadataServiceUriStr = "zk://" + zkServers + "/ledgers";
 
@@ -455,8 +455,10 @@ public class LocalBookkeeperEnsemble {
         try {
             bookieComponents[i] = org.apache.bookkeeper.server.Main
                     .buildBookieServer(new BookieConfiguration(bsConfs[i]));
-            ComponentStarter.startComponent(bookieComponents[i]);
+            bookieComponents[i].start();
         } catch (BookieException.InvalidCookieException ice) {
+            LOG.warn("Invalid cookie found for bookie {}", i, ice);
+
             // InvalidCookieException can happen if the machine IP has changed
             // Since we are running here a local bookie that is always accessed
             // from localhost, we can ignore the error
@@ -473,7 +475,7 @@ public class LocalBookkeeperEnsemble {
 
             bookieComponents[i] = org.apache.bookkeeper.server.Main
                     .buildBookieServer(new BookieConfiguration(bsConfs[i]));
-            ComponentStarter.startComponent(bookieComponents[i]);
+            bookieComponents[i].start();
         }
 
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsembleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsembleTest.java
@@ -21,10 +21,6 @@ package org.apache.pulsar.zookeeper;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
-
-import java.util.Collections;
-import java.util.List;
-
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -37,22 +33,6 @@ public class LocalBookkeeperEnsembleTest {
 
     @AfterMethod(alwaysRun = true)
     void teardown() throws Exception {
-    }
-
-    @Test
-    public void testAdvertisedAddress() throws Exception {
-        final int numBk = 1;
-
-        LocalBookkeeperEnsemble ensemble = new LocalBookkeeperEnsemble(
-            numBk, 0, 0, null, null, true, "127.0.0.2");
-        ensemble.startStandalone();
-
-        List<String> bookies = ensemble.getZkClient().getChildren("/ledgers/available", false);
-        Collections.sort(bookies);
-        assertEquals(bookies.size(), 2);
-        assertTrue(bookies.get(0).startsWith("127.0.0.2:"));
-
-        ensemble.stop();
     }
 
     @Test


### PR DESCRIPTION
### Motivation

LocalBookkeeperEnsemble leaks threads and memory.
The way it leaks threads is when `portManager` is set to `() -> 0`, the metadata in Zookeeper will conflict and the bookies that start after the first bookie will first throw InvalidCookieException. When the InvalidCookieException is thrown, threads are leaked since the embedded bookie server doesn't close the Zookeeper client in that case.

Another problem is the memory leak that happens via shutdown hooks when Bookkeeper's `ComponentStarter` class is used to start each bookie. That registers a shutdown hook which essentially causes a memory leak.

### Modifications

To fix the issue with the invalid cookie, set a unique bookie id for each bookie.

 The solution to the memory leak via the shutdown hook is to start the component directly without the `ComponentStarter`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->