### PR TITLE
[fix][broker] Allow broker deployment in heterogeneous hw config cluster without restricting nic speed detection

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -83,7 +83,6 @@ import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import org.apache.pulsar.broker.intercept.BrokerInterceptors;
 import org.apache.pulsar.broker.loadbalance.LeaderBroker;
 import org.apache.pulsar.broker.loadbalance.LeaderElectionService;
-import org.apache.pulsar.broker.loadbalance.LinuxInfoUtils;
 import org.apache.pulsar.broker.loadbalance.LoadManager;
 import org.apache.pulsar.broker.loadbalance.LoadReportUpdaterTask;
 import org.apache.pulsar.broker.loadbalance.LoadResourceQuotaUpdaterTask;
@@ -731,14 +730,6 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                                 + "the retention time duration is %d",
                         config.getBacklogQuotaDefaultLimitSecond(),
                         config.getDefaultRetentionTimeInMinutes() * 60));
-            }
-
-            if (config.getLoadBalancerOverrideBrokerNicSpeedGbps().isEmpty()
-                    && config.isLoadBalancerEnabled()
-                    && LinuxInfoUtils.isLinux()
-                    && !LinuxInfoUtils.checkHasNicSpeeds()) {
-                throw new IllegalStateException("Unable to read VM NIC speed. You must set "
-                        + "[loadBalancerOverrideBrokerNicSpeedGbps] to override it when load balancer is enabled.");
             }
 
             localMetadataSynchronizer = StringUtils.isNotBlank(config.getMetadataSyncEventTopic())

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -256,6 +256,14 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
         TopicName topicName = TopicName.get(defaultTestNamespace + "/test-check-ownership");
         NamespaceBundle bundle = getBundleAsync(pulsar1, topicName).get();
         // 1. The bundle is never assigned.
+        retryStrategically((test) -> {
+            try {
+                return !primaryLoadManager.checkOwnershipAsync(Optional.empty(), bundle).get()
+                        && !secondaryLoadManager.checkOwnershipAsync(Optional.empty(), bundle).get();
+            } catch (Exception e) {
+                return false;
+            }
+        }, 5, 200);
         assertFalse(primaryLoadManager.checkOwnershipAsync(Optional.empty(), bundle).get());
         assertFalse(secondaryLoadManager.checkOwnershipAsync(Optional.empty(), bundle).get());
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.tests.integration.loadbalance;
 
 import static org.apache.pulsar.tests.integration.containers.PulsarContainer.BROKER_HTTP_PORT;
+import static org.apache.pulsar.tests.integration.suites.PulsarTestSuite.retryStrategically;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -308,7 +309,7 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
     }
 
     @Test(timeOut = 40 * 1000)
-    public void testIsolationPolicy() throws PulsarAdminException {
+    public void testIsolationPolicy() throws Exception {
         final String namespaceIsolationPolicyName = "my-isolation-policy";
         final String isolationEnabledNameSpace = DEFAULT_TENANT + "/my-isolation-policy" + nsSuffix;
         Map<String, String> parameters1 = new HashMap<>();
@@ -346,6 +347,8 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
 
         broker = admin.lookups().lookupTopic(topic);
 
+        final String brokerName = broker;
+        retryStrategically((test) -> extractBrokerIndex(brokerName) == 1, 100, 200);
         assertEquals(extractBrokerIndex(broker), 1);
 
         for (BrokerContainer container : pulsarCluster.getBrokers()) {


### PR DESCRIPTION
### Motivation

This PR #14648 is incorrectly introduced, causing broker service unavailability while upgrading brokers in heterogeneous hardware config clusters. Sometime broker can’t find nic speed as it’s not defined into multiple types of VM which is very well know behavior and that’s why broker handles such usecase while managing load report by avoiding n/w bandwidth metrics.
This PR #14648 was introduced by completely ignoring heterogeneous hardware configuration cluster usecase because of that broker upgrade in that cluster has brought down all those VM brokers and can cause the outage. that PR also had test cases failing due to the same reason and it was addressed by another hack by configuring `loadBalancerOverrideBrokerNicSpeedGbps`. again `loadBalancerOverrideBrokerNicSpeedGbps` doesn’t work in heterogeneous h/w config cluster as we can not configure every different broker with different config file.
Right now, broker startup fails on every VM due to this error and we can't even configure `loadBalancerOverrideBrokerNicSpeedGbps` as there are different h/w config types of broker in a cluster and it's not easy to manage different config-base for each broker:
```
00:00:01.667 [main] ERROR org.apache.pulsar.broker.loadbalance.LinuxInfoUtils - [LinuxInfo] Failed to get total nic limit.
java.io.IOException: Invalid argument
        at sun.nio.ch.FileDispatcherImpl.read0(Native Method) ~[?:?]
        at sun.nio.ch.FileDispatcherImpl.read(FileDispatcherImpl.java:48) ~[?:?]
        at sun.nio.ch.IOUtil.readIntoNativeBuffer(IOUtil.java:276) ~[?:?]
        at sun.nio.ch.IOUtil.read(IOUtil.java:245) ~[?:?]
        at sun.nio.ch.FileChannelImpl.read(FileChannelImpl.java:223) ~[?:?]
        at sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:65) ~[?:?]
        at sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:107) ~[?:?]
        at sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:101) ~[?:?]
        at java.nio.file.Files.read(Files.java:3159) ~[?:?]
        at java.nio.file.Files.readAllBytes(Files.java:3213) ~[?:?]
        at org.apache.pulsar.broker.loadbalance.LinuxInfoUtils.readTrimStringFromFile(LinuxInfoUtils.java:303)
```
so, either broker can perform auto-detect nic speed, if not then there has to be an option to ignore n/w bandwidth calculation which was the existing behavior by considering different h/w config cluster which was completely ignored by this PR #14648  and that has to be removed. if anyone wants to add restriction then we can add a config but I don’t see any value in introducing another config just to avoid this warning message. so, this PR fixes this behavior which are causing service outage with this feature upgrade.

### Modifications

Remove incorrect restriction that makes Pulsar unusable for broker service deployed on heterogeneous hw configuration with VMs.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
