### PR TITLE
[improve][ci] Schedule daily Pulsar CI build with Java 21

### DIFF
--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -23,7 +23,11 @@ on:
     branches:
       - master
   schedule:
+    # scheduled job with JDK 17
     - cron: '0 12 * * *'
+    # scheduled job with JDK 21
+    # if cron expression is changed, make sure to update the expression in jdk_major_version step in preconditions job
+    - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       collect_coverage:
@@ -42,7 +46,7 @@ on:
 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdk_major_version || '' }}
   cancel-in-progress: true
 
 env:
@@ -64,9 +68,23 @@ jobs:
       jdk_major_version: ${{ steps.jdk_major_version.outputs.jdk_major_version }}
 
     steps:
+      - name: Cancel scheduled jobs in forks by default
+        if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'schedule' }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            await github.rest.actions.cancelWorkflowRun({owner: context.repo.owner, repo: context.repo.repo, run_id: context.runId});
+            process.exit(1);
+
       - name: Select JDK major version
         id: jdk_major_version
         run: |
+          # use JDK 21 for the scheduled build with cron expression '0 6 * * *'
+          if [[ "${{ github.event_name == 'schedule' && github.event.schedule == '0 6 * * *' && 'true' || 'false' }}" == "true" ]]; then
+            echo "jdk_major_version=21" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          # use JDK 17 for build unless overridden with workflow_dispatch input
           echo "jdk_major_version=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdk_major_version || '17'}}" >> $GITHUB_OUTPUT
 
       - name: checkout

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -23,7 +23,11 @@ on:
     branches:
       - master
   schedule:
+    # scheduled job with JDK 17
     - cron: '0 12 * * *'
+    # scheduled job with JDK 21
+    # if cron expression is changed, make sure to update the expression in jdk_major_version step in preconditions job
+    - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       collect_coverage:
@@ -41,7 +45,7 @@ on:
         default: '17'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdk_major_version || '' }}
   cancel-in-progress: true
 
 env:
@@ -63,9 +67,23 @@ jobs:
       jdk_major_version: ${{ steps.jdk_major_version.outputs.jdk_major_version }}
 
     steps:
+      - name: Cancel scheduled jobs in forks by default
+        if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'schedule' }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            await github.rest.actions.cancelWorkflowRun({owner: context.repo.owner, repo: context.repo.repo, run_id: context.runId});
+            process.exit(1);
+
       - name: Select JDK major version
         id: jdk_major_version
         run: |
+          # use JDK 21 for the scheduled build with cron expression '0 6 * * *'
+          if [[ "${{ github.event_name == 'schedule' && github.event.schedule == '0 6 * * *' && 'true' || 'false' }}" == "true" ]]; then
+            echo "jdk_major_version=21" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          # use JDK 17 for build unless overridden with workflow_dispatch input
           echo "jdk_major_version=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdk_major_version || '17'}}" >> $GITHUB_OUTPUT
 
       - name: checkout


### PR DESCRIPTION
### Motivation

Run a scheduled daily Java 21 CI build to ensure that Java 21 support doesn't break in master branch. 
apache/pulsar master branch currently supports compiling and running all tests with Java 21. A scheduled build with Java 21 will help prevent possible regressions. 

### Modifications

- add new scheduled build to pulsar-ci.yaml and pulsar-ci-flaky.yaml which will use Java 21
- cancel scheduled builds in forks by default so that forks don't waste resources on scheduled Pulsar CI builds

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->