### PR TITLE
[fix][broker] Fix MultiRoles token provider NPE when using anonymous clients

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataSubscription.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataSubscription.java
@@ -71,4 +71,8 @@ public class AuthenticationDataSubscription implements AuthenticationDataSource 
     public String getSubscription() {
         return subscription;
     }
+
+    public AuthenticationDataSource getAuthData() {
+        return authData;
+    }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProvider.java
@@ -35,6 +35,7 @@ import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSubscription;
 import org.apache.pulsar.broker.resources.PulsarResources;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
@@ -144,7 +145,8 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
     }
 
     private Set<String> getRoles(String role, AuthenticationDataSource authData) {
-        if (authData == null) {
+        if (authData == null || (authData instanceof AuthenticationDataSubscription
+                && ((AuthenticationDataSubscription) authData).getAuthData() == null)) {
             return Collections.singleton(role);
         }
 

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProviderTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProviderTest.java
@@ -28,6 +28,7 @@ import java.util.function.Function;
 import lombok.Cleanup;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSubscription;
 import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
 import org.apache.pulsar.broker.resources.PulsarResources;
 import org.testng.annotations.Test;
@@ -150,6 +151,7 @@ public class MultiRolesTokenAuthorizationProviderTest {
         };
         assertTrue(provider.authorize("test-role", null, authorizeFunc).get());
         assertFalse(provider.authorize("test-role-x", null, authorizeFunc).get());
+        assertTrue(provider.authorize("test-role", new AuthenticationDataSubscription(null, "test-sub"), authorizeFunc).get());
     }
 
     @Test


### PR DESCRIPTION
### Motivation
```
2023-10-24T01:39:33,477+0000 [pulsar-io-4-2] WARN  org.apache.pulsar.broker.service.ServerCnx - [/10.90.12.95:39414] Got exception java.lang.NullPointerException: Cannot invoke "org.apache.pulsar.broker.authentication.AuthenticationDataSource.hasDataFromCommand()" because "this.authData" is null
        at org.apache.pulsar.broker.authentication.AuthenticationDataSubscription.hasDataFromCommand(AuthenticationDataSubscription.java:37)
        at org.apache.pulsar.broker.authorization.MultiRolesTokenAuthorizationProvider.getRoles(MultiRolesTokenAuthorizationProvider.java:153)
        at org.apache.pulsar.broker.authorization.MultiRolesTokenAuthorizationProvider.authorize(MultiRolesTokenAuthorizationProvider.java:201)
```


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


