### PR TITLE
[improve][broker] Don't need to individual acknowledge filtered message with Exclusive/Failover subscription mode

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -271,8 +271,10 @@ public abstract class AbstractBaseDispatcher extends EntryFilterSupport implemen
             }
         }
         if (CollectionUtils.isNotEmpty(entriesToFiltered)) {
-            subscription.acknowledgeMessage(entriesToFiltered, AckType.Individual,
+            if (Subscription.isIndividualAckMode(subscription.getType())) {
+                subscription.acknowledgeMessage(entriesToFiltered, AckType.Individual,
                     Collections.emptyMap());
+            }
 
             int filtered = entriesToFiltered.size();
             Topic topic = subscription.getTopic();


### PR DESCRIPTION
### Motivation

Don't need to acknowledge filtered messages by EntryFilter with Exclusive/Failover subscription mode, since individual acknowledge is not supported in Exclusive/Failover subscription mode. 

### Modifications

Skip acknowledge if the subscription mode doesn't support individual acknowledge.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
