### PR TITLE
[fix][broker] Ignore individual acknowledgment for CompactorSubscription when an entry has been filtered.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PulsarCompactorSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PulsarCompactorSubscription.java
@@ -58,11 +58,7 @@ public class PulsarCompactorSubscription extends PersistentSubscription {
 
     @Override
     public void acknowledgeMessage(List<Position> positions, AckType ackType, Map<String, Long> properties) {
-        if (ackType == AckType.Individual) {
-            // Ignore individual ack
-            return;
-        }
-
+        checkArgument(ackType == AckType.Cumulative);
         checkArgument(positions.size() == 1);
         checkArgument(properties.containsKey(Compactor.COMPACTED_TOPIC_LEDGER_PROPERTY));
         long compactedLedgerId = properties.get(Compactor.COMPACTED_TOPIC_LEDGER_PROPERTY);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PulsarCompactorSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PulsarCompactorSubscription.java
@@ -58,7 +58,11 @@ public class PulsarCompactorSubscription extends PersistentSubscription {
 
     @Override
     public void acknowledgeMessage(List<Position> positions, AckType ackType, Map<String, Long> properties) {
-        checkArgument(ackType == AckType.Cumulative);
+        if (ackType == AckType.Individual) {
+            // Ignore individual ack
+            return;
+        }
+
         checkArgument(positions.size() == 1);
         checkArgument(properties.containsKey(Compactor.COMPACTED_TOPIC_LEDGER_PROPERTY));
         long compactedLedgerId = properties.get(Compactor.COMPACTED_TOPIC_LEDGER_PROPERTY);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/plugin/FilterEntryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/plugin/FilterEntryTest.java
@@ -22,6 +22,7 @@ import static org.apache.pulsar.broker.BrokerTestUtil.spyWithClassAndConstructor
 import static org.apache.pulsar.broker.BrokerTestUtil.spyWithClassAndConstructorArgsRecordingInvocations;
 import static org.apache.pulsar.client.api.SubscriptionInitialPosition.Earliest;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -30,8 +31,9 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
-
+import io.netty.buffer.ByteBuf;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +41,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-
 import lombok.Cleanup;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -58,11 +59,15 @@ import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.RawMessage;
+import org.apache.pulsar.client.api.RawReader;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.nar.NarClassLoader;
+import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.stats.AnalyzeSubscriptionBacklogResult;
+import org.apache.pulsar.compaction.Compactor;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -148,6 +153,58 @@ public class FilterEntryTest extends BrokerTestBase {
         assertEquals(10, counter1);
         conf.setAllowOverrideEntryFilters(false);
         consumer.close();
+    }
+
+    @Test
+    public void testEntryFilterWithCompactor() throws Exception {
+        conf.setAllowOverrideEntryFilters(true);
+        String topic = "persistent://prop/ns-abc/topic" + UUID.randomUUID();
+
+        List<String> messages = new ArrayList<>();
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .enableBatching(false).topic(topic).create();
+        producer.newMessage().key("K1").value("V1").send();
+        producer.newMessage().key("K2").value("V2").send();
+        producer.newMessage().key("K3").value("V3").send();
+        producer.newMessage().key("K4").value("V4").send();
+        messages.add("V2");
+        messages.add("V4");
+
+        PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic).get();
+
+        // set topic level entry filters
+        EntryFilter mockFilter = mock(EntryFilter.class);
+        doAnswer(invocationOnMock -> {
+            FilterContext filterContext = invocationOnMock.getArgument(1);
+            String partitionKey = filterContext.getMsgMetadata().getPartitionKey();
+            if (partitionKey.equals("K1") || partitionKey.equals("K3")) {
+                return EntryFilter.FilterResult.REJECT;
+            } else {
+                return EntryFilter.FilterResult.ACCEPT;
+            }
+        }).when(mockFilter).filterEntry(any(Entry.class), any(FilterContext.class));
+        setMockFilterToTopic(topicRef, List.of(mockFilter));
+
+        List<String> results = new ArrayList<>();
+        RawReader rawReader = RawReader.create(pulsarClient, topic, Compactor.COMPACTION_SUBSCRIPTION).get();
+        while (true) {
+            boolean hasMsg = rawReader.hasMessageAvailableAsync().get();
+            if (hasMsg) {
+                try (RawMessage m = rawReader.readNextAsync().get()) {
+                    ByteBuf headersAndPayload = m.getHeadersAndPayload();
+                    Commands.skipMessageMetadata(headersAndPayload);
+                    byte[] bytes = new byte[headersAndPayload.readableBytes()];
+                    headersAndPayload.readBytes(bytes);
+
+                    results.add(new String(bytes));
+                }
+            } else {
+                break;
+            }
+        }
+        rawReader.closeAsync().get();
+
+        Assert.assertEquals(messages, results);
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Motivation

When we use custom compactor works with EntryFilter, we will get an NPE if an entry has been filtered, the root cause is we used individual acknowledges for CompactorSubscription, we should ignore individual acknowledges for CompactorSubscription.

Exception stack:
```
java.lang.IllegalArgumentException: null
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:129) ~[guava-32.1.2-jre.jar:?]
	at org.apache.pulsar.broker.service.persistent.PulsarCompactorSubscription.acknowledgeMessage(PulsarCompactorSubscription.java:61) ~[classes/:?]
	at org.apache.pulsar.broker.service.AbstractBaseDispatcher.filterEntriesForConsumer(AbstractBaseDispatcher.java:273) ~[classes/:?]
	at org.apache.pulsar.broker.service.AbstractBaseDispatcher.filterEntriesForConsumer(AbstractBaseDispatcher.java:100) ~[classes/:?]
	at org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer.internalReadEntriesComplete(PersistentDispatcherSingleActiveConsumer.java:212) ~[classes/:?]
	at org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer.lambda$readEntriesComplete$1(PersistentDispatcherSingleActiveConsumer.java:153) ~[classes/:?]
	at org.apache.bookkeeper.common.util.SingleThreadExecutor.safeRunTask(SingleThreadExecutor.java:137) ~[bookkeeper-common-4.16.3.jar:4.16.3]
	at org.apache.bookkeeper.common.util.SingleThreadExecutor.run(SingleThreadExecutor.java:113) ~[bookkeeper-common-4.16.3.jar:4.16.3]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.100.Final.jar:4.1.100.Final]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

### Modifications

Ignore individual acknowledgment for CompactorSubscription when an entry has been filtered.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
