### PR TITLE
[fix][test] Close metadata stores in MultiBrokerTestZKBaseTests

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerTestZKBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerTestZKBaseTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.broker;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.metadata.TestZKServer;
@@ -32,6 +34,7 @@ import org.jetbrains.annotations.NotNull;
 @Slf4j
 public abstract class MultiBrokerTestZKBaseTest extends MultiBrokerBaseTest {
     TestZKServer testZKServer;
+    List<MetadataStoreExtended> storesToClose = new ArrayList<>();
 
     @Override
     protected void doInitConf() throws Exception {
@@ -42,6 +45,14 @@ public abstract class MultiBrokerTestZKBaseTest extends MultiBrokerBaseTest {
     @Override
     protected void onCleanup() {
         super.onCleanup();
+        for (MetadataStoreExtended store : storesToClose) {
+            try {
+                store.close();
+            } catch (Exception e) {
+                log.error("Error in closing metadata store", e);
+            }
+        }
+        storesToClose.clear();
         if (testZKServer != null) {
             try {
                 testZKServer.close();
@@ -61,8 +72,11 @@ public abstract class MultiBrokerTestZKBaseTest extends MultiBrokerBaseTest {
     @NotNull
     protected MetadataStoreExtended createMetadataStore(String metadataStoreName)  {
         try {
-            return MetadataStoreExtended.create(testZKServer.getConnectionString(),
-                    MetadataStoreConfig.builder().metadataStoreName(metadataStoreName).build());
+            MetadataStoreExtended store =
+                    MetadataStoreExtended.create(testZKServer.getConnectionString(),
+                            MetadataStoreConfig.builder().metadataStoreName(metadataStoreName).build());
+            storesToClose.add(store);
+            return store;
         } catch (MetadataStoreException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
### Motivation

MultiBrokerLeaderElectionExpirationTest and MultiBrokerLeaderElectionTest both leak over 70 threads. They use MultiBrokerTestZKBaseTests as the base class. There's an issue that the base test creates metadata store instances, but doesn't close them. 

### Modifications

Close metadata stores instances created in the test.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->