### PR TITLE
[fix] [build] Fix license animal-sniffer-annotations-1.21.jar

### DIFF
--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -521,7 +521,7 @@ MIT License
  * Checker Qual
    - checker-qual-3.33.0.jar
  * Annotations
-   - animal-sniffer-annotations-1.19.jar
+   - animal-sniffer-annotations-1.21.jar
    - annotations-4.1.1.4.jar
  * ScribeJava
    - scribejava-apis-6.9.0.jar


### PR DESCRIPTION
### Motivation

The dependency's version of `animal-sniffer-annotations` is `1.21` now, but the license of presto(trino) is still `1.19`

see: https://github.com/apache/pulsar/actions/runs/6627474211/job/18019187456?pr=21435
```
Run src/check-binary-license.sh ./distribution/server/target/apache-pulsar-*-bin.tar.gz && src/check-binary-license.sh ./distribution/shell/target/apache-pulsar-shell-*-bin.tar.gz
  src/check-binary-license.sh ./distribution/server/target/apache-pulsar-*-bin.tar.gz && src/check-binary-license.sh ./distribution/shell/target/apache-pulsar-shell-*-bin.tar.gz
  shell: /usr/bin/bash -e {0}
  env:
    MAVEN_OPTS: -Xss1500k -Xmx1024m -Daether.connector.http.reuseConnections=false -Daether.connector.requestTimeout=60000 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.http.serviceUnavailableRetryStrategy.class=standard -Dmaven.wagon.rto=60000
    ARTIFACT_RETENTION_DAYS: 3
    GRADLE_ENTERPRISE_ACCESS_KEY: 
    JAVA_HOME: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.8-1/x64
    JAVA_HOME_17_X64: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.8-1/x64
    ACTIONS_RUNTIME_TOKEN: ***
    ACTIONS_RUNTIME_URL: https://pipelinesghubeus21.actions.githubusercontent.com/EXIZfX8ixSbQEfqDA00dMJrEtloTMSwjlUs9NqJqrTcJfd7NaR/
    UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
    UBUNTU_SECURITY_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
src/check-binary-license.sh: line 69: echo: write error: Broken pipe
src/check-binary-license.sh: line 69: echo: write error: Broken pipe
animal-sniffer-annotations-1.21.jar unaccounted for in trino/LICENSE
animal-sniffer-annotations-1.19.jar mentioned in trino/LICENSE, but not bundled

It looks like there are issues with the LICENSE/NOTICE.
Error: Process completed with exit code 2.
```

The master branch removed this dependency by the PR https://github.com/apache/pulsar/pull/20339

### Modifications

Correct the license file


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x