### PR TITLE
[fix][test] Fix resource leaks in LoadBalancerTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -34,10 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.SneakyThrows;
@@ -87,8 +84,6 @@ import org.testng.annotations.Test;
 @Test(groups = "broker")
 public class LoadBalancerTest {
     LocalBookkeeperEnsemble bkEnsemble;
-
-    ExecutorService executor = new ThreadPoolExecutor(5, 20, 30, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
 
     private static final Logger log = LoggerFactory.getLogger(LoadBalancerTest.class);
 
@@ -150,13 +145,10 @@ public class LoadBalancerTest {
     @AfterMethod(alwaysRun = true)
     void shutdown() throws Exception {
         log.info("--- Shutting down ---");
-        executor.shutdownNow();
 
         for (int i = 0; i < BROKER_COUNT; i++) {
             pulsarAdmins[i].close();
-            if (pulsarServices[i] != null) {
-                pulsarServices[i].close();
-            }
+            pulsarServices[i].close();
         }
 
         bkEnsemble.stop();
@@ -670,27 +662,21 @@ public class LoadBalancerTest {
      */
     @Test
     public void testLeaderElection() throws Exception {
-        // this.pulsarServices is the reference to all of the PulsarServices
-        // it is used in order to clean up the resources
-        PulsarService[] allServices = new PulsarService[pulsarServices.length];
-        System.arraycopy(pulsarServices, 0, allServices, 0, pulsarServices.length);
         for (int i = 0; i < BROKER_COUNT - 1; i++) {
             List<PulsarService> activePulsar = new ArrayList<>();
             List<PulsarService> followerPulsar = new ArrayList<>();
             LeaderBroker oldLeader = null;
             PulsarService leaderPulsar = null;
             for (int j = 0; j < BROKER_COUNT; j++) {
-                if (allServices[j].getState() != PulsarService.State.Closed) {
-                    activePulsar.add(allServices[j]);
-                    LeaderElectionService les = allServices[j].getLeaderElectionService();
+                PulsarService pulsarService = pulsarServices[j];
+                if (pulsarService.getState() != PulsarService.State.Closed) {
+                    activePulsar.add(pulsarService);
+                    LeaderElectionService les = pulsarService.getLeaderElectionService();
                     if (les.isLeader()) {
                         oldLeader = les.getCurrentLeader().get();
-                        leaderPulsar = allServices[j];
-                        // set the refence to null in the main array,
-                        // in order to prevent closing this PulsarService twice
-                        pulsarServices[i] = null;
+                        leaderPulsar = pulsarService;
                     } else {
-                        followerPulsar.add(allServices[j]);
+                        followerPulsar.add(pulsarService);
                     }
                 }
             }


### PR DESCRIPTION
### Motivation

LoadBalancerTest leaks some threads. 

### Modifications

- remove the unused thread pool
- while debugging, it revealed that testLeaderElection method caused some thread leaks. 
  - the logic to prevent duplicate calls to `PulsarService.close()` isn't needed anymore. 
  - removing this logic fixed the issue although it doesn't seem to be obvious from the code since it looks like cleanup was happening properly also before making these changes.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->