### PR TITLE
[fix][test] Fix thread leaks related to unclosed WebSocketService

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyEncryptionPublishConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyEncryptionPublishConsumeTest.java
@@ -73,7 +73,7 @@ public class ProxyEncryptionPublishConsumeTest extends ProducerConsumerBase {
         config.setClusterName("test");
         config.setConfigurationMetadataStoreUrl(GLOBAL_DUMMY_VALUE);
         config.setCryptoKeyReaderFactoryClassName(CryptoKeyReaderFactoryImpl.class.getName());
-        WebSocketService service = spy(new WebSocketService(config));
+        service = spy(new WebSocketService(config));
         doReturn(new ZKMetadataStore(mockZooKeeperGlobal)).when(service)
                 .createConfigMetadataStore(anyString(), anyInt(), anyBoolean());
         proxyServer = new ProxyServer(config);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeClientSideEncryptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeClientSideEncryptionTest.java
@@ -77,7 +77,7 @@ public class ProxyPublishConsumeClientSideEncryptionTest extends ProducerConsume
         config.setWebServicePort(Optional.of(0));
         config.setClusterName("test");
         config.setConfigurationMetadataStoreUrl(GLOBAL_DUMMY_VALUE);
-        WebSocketService service = spy(new WebSocketService(config));
+        service = spy(new WebSocketService(config));
         doReturn(new ZKMetadataStore(mockZooKeeperGlobal)).when(service)
                 .createConfigMetadataStore(anyString(), anyInt(), anyBoolean());
         proxyServer = new ProxyServer(config);

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/AbstractWebSocketHandlerTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/AbstractWebSocketHandlerTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import lombok.Cleanup;
 import lombok.Getter;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.client.api.CompressionType;
@@ -388,10 +389,11 @@ public class AbstractWebSocketHandlerTest {
     }
 
     @Test
-    public void testPingFuture() {
+    public void testPingFuture() throws IOException {
         WebSocketProxyConfiguration webSocketProxyConfiguration = new WebSocketProxyConfiguration();
         webSocketProxyConfiguration.setWebSocketPingDurationSeconds(5);
 
+        @Cleanup
         WebSocketService webSocketService = new WebSocketService(webSocketProxyConfiguration);
 
         HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/WebSocketHttpServletRequestWrapperTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/WebSocketHttpServletRequestWrapperTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.websocket;
 
+import lombok.Cleanup;
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
 import org.apache.pulsar.websocket.service.WebSocketProxyConfiguration;
 import org.eclipse.jetty.websocket.servlet.UpgradeHttpServletRequest;
@@ -70,6 +71,7 @@ public class WebSocketHttpServletRequestWrapperTest {
                 WebSocketProxyConfiguration.class);
         String publicKeyPath = "file://" + this.getClass().getClassLoader().getResource("my-public.key").getFile();
         config.getProperties().setProperty("tokenPublicKey", publicKeyPath);
+        @Cleanup
         WebSocketService service = new WebSocketService(config);
         service.start();
 


### PR DESCRIPTION
### Motivation

There are a few tests where threads are leaked since WebSocketService isn't closed.

### Additional context

This type of issues can now be detected with #21450 improvements to CI. 

### Modifications

Close WebSocketService properly in tests.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->