### PR TITLE
[fix][broker] Fix resource_quota_zpath

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -106,7 +106,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
     public static final int NUM_SHORT_SAMPLES = 10;
 
     // Path to ZNode whose children contain ResourceQuota jsons.
-    public static final String RESOURCE_QUOTA_ZPATH = "/loadbalance/resource-quota/namespace";
+    public static final String RESOURCE_QUOTA_ZPATH = "/loadbalance/resource-quota";
 
     // Set of broker candidates to reuse so that object creation is avoided.
     private final Set<String> brokerCandidateCache;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
@@ -77,8 +77,10 @@ import org.apache.pulsar.common.naming.NamespaceBundles;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.ServiceUnitId;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationDataImpl;
+import org.apache.pulsar.common.policies.data.ResourceQuota;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.metadata.api.MetadataCache;
@@ -783,6 +785,49 @@ public class ModularLoadManagerImplTest {
 
         Awaitility.await().untilAsserted(() -> assertTrue(pulsar1.getLeaderElectionService().isLeader()));
         assertEquals(data.size(), 1);
+    }
+
+    @Test
+    public void testBundleDataDefaultValue() throws Exception {
+        final String tenant = "test";
+        final String cluster = "test";
+        String namespace = tenant + "/" + cluster + "/" + "test";
+        admin1.clusters().createCluster(cluster, ClusterData.builder().serviceUrl("http://" + pulsar1.getAdvertisedAddress()).build());
+        admin1.tenants().createTenant(tenant,
+                new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet(cluster)));
+        admin1.namespaces().createNamespace(namespace, 16);
+
+        // set resourceQuota to the first bundle range.
+        BundlesData bundlesData = admin1.namespaces().getBundles(namespace);
+        NamespaceBundle namespaceBundle = nsFactory.getBundle(NamespaceName.get(tenant, cluster, "test"),
+                Range.range(Long.decode(bundlesData.getBoundaries().get(0)), BoundType.CLOSED, Long.decode(bundlesData.getBoundaries().get(1)),
+                        BoundType.OPEN));
+        ResourceQuota quota = new ResourceQuota();
+        quota.setMsgRateIn(1024.1);
+        quota.setMsgRateOut(1024.2);
+        quota.setBandwidthIn(1024.3);
+        quota.setBandwidthOut(1024.4);
+        quota.setMemory(1024.0);
+        admin1.resourceQuotas().setNamespaceBundleResourceQuota(namespace, namespaceBundle.getBundleRange(), quota);
+
+        ModularLoadManagerWrapper loadManagerWrapper = (ModularLoadManagerWrapper) pulsar1.getLoadManager().get();
+        ModularLoadManagerImpl lm = (ModularLoadManagerImpl) loadManagerWrapper.getLoadManager();
+
+        // get the bundleData of the first bundle range.
+        // The default value of the bundleData be the same as resourceQuota because the resourceQuota is present.
+        BundleData defaultBundleData = lm.getBundleDataOrDefault(namespaceBundle.toString());
+
+        TimeAverageMessageData shortTermData = defaultBundleData.getShortTermData();
+        TimeAverageMessageData longTermData = defaultBundleData.getLongTermData();
+        assertEquals(shortTermData.getMsgRateIn(), 1024.1);
+        assertEquals(shortTermData.getMsgRateOut(), 1024.2);
+        assertEquals(shortTermData.getMsgThroughputIn(), 1024.3);
+        assertEquals(shortTermData.getMsgThroughputOut(), 1024.4);
+
+        assertEquals(longTermData.getMsgRateIn(), 1024.1);
+        assertEquals(longTermData.getMsgRateOut(), 1024.2);
+        assertEquals(longTermData.getMsgThroughputIn(), 1024.3);
+        assertEquals(longTermData.getMsgThroughputOut(), 1024.4);
     }
 
 

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationController.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationController.java
@@ -61,7 +61,7 @@ import org.slf4j.LoggerFactory;
  */
 public class LoadSimulationController {
     private static final Logger log = LoggerFactory.getLogger(LoadSimulationController.class);
-    private static final String QUOTA_ROOT = "/loadbalance/resource-quota/namespace";
+    private static final String QUOTA_ROOT = "/loadbalance/resource-quota";
 
     // Input streams for each client to send commands through.
     private final DataInputStream[] inputStreams;


### PR DESCRIPTION
### Motivation

Fix the `resource_quota_zpath` in `LoadSimulationController` and `ModularLoadManagerImpl`.

As we can see from the `BundlesQuotas`(line30) that the `resource_quota_zpath` should be `/loadbalance/resource-quota`, not `/loadbalance/resource-quota/namespace`. so here we fix it.


https://github.com/apache/pulsar/blob/e55de39e358e18a72b4156c7cd4ac4831a573864/pulsar-broker/src/main/java/org/apache/pulsar/broker/cache/BundlesQuotas.java#L30-L32



### Modifications

Fix resource_quota_zpath

### Verifying this change

- [x] Make sure that the change passes the CI checks.



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository
https://github.com/AnonHxy/pulsar/pull/47

