### PR TITLE
[fix][test] Fix resource leak when PulsarTestClient is closed or shutdown

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PulsarTestClient.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PulsarTestClient.java
@@ -24,9 +24,11 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -50,6 +52,7 @@ import org.awaitility.Awaitility;
  *   called after the message to send out has been added to the pending messages in the client.
  *
  */
+@Slf4j
 public class PulsarTestClient extends PulsarClientImpl {
     private volatile int overrideRemoteEndpointProtocolVersion;
     private volatile boolean rejectNewConnections;
@@ -73,7 +76,7 @@ public class PulsarTestClient extends PulsarClientImpl {
         // method.
         EventLoopGroup eventLoopGroup = EventLoopUtil.newEventLoopGroup(clientConfigurationData.getNumIoThreads(),
                 false,
-                new DefaultThreadFactory("pulsar-client-io", Thread.currentThread().isDaemon()));
+                new DefaultThreadFactory("pulsar-test-client-io", Thread.currentThread().isDaemon()));
 
         AtomicReference<Supplier<ClientCnx>> clientCnxSupplierReference = new AtomicReference<>();
         ConnectionPool connectionPool = new ConnectionPool(clientConfigurationData, eventLoopGroup,
@@ -216,5 +219,32 @@ public class PulsarTestClient extends PulsarClientImpl {
      */
     public void dropOpSendMessages() {
         this.dropOpSendMessages = true;
+    }
+
+    @Override
+    public CompletableFuture<Void> closeAsync() {
+        return super.closeAsync().handle((__, t) -> {
+            shutdownCnxPoolAndEventLoopGroup();
+            return null;
+        });
+    }
+
+    @Override
+    public void shutdown() throws PulsarClientException {
+        super.shutdown();
+        shutdownCnxPoolAndEventLoopGroup();
+    }
+
+    private void shutdownCnxPoolAndEventLoopGroup() {
+        try {
+            getCnxPool().close();
+        } catch (Exception e) {
+            log.warn("Error closing connection pool", e);
+        }
+        try {
+            eventLoopGroup.shutdownGracefully().get(5, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.warn("Error closing event loop group", e);
+        }
     }
 }


### PR DESCRIPTION
### Motivation

PulsarTestClient used in tests leaks resources.

### Modifications

- close the resources when the client is closed or shutdown

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->