### PR TITLE
[improve][client] add custom probes for cluster auto failover

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/AutoClusterFailoverBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/AutoClusterFailoverBuilder.java
@@ -46,12 +46,27 @@ public interface AutoClusterFailoverBuilder {
     AutoClusterFailoverBuilder primary(String primary);
 
     /**
+     * Set the primary service url with customer probes.
+     *
+     * @param primary
+     * @return
+     */
+    AutoClusterFailoverBuilder primaryWithCustomProbe(String primary, AutoClusterFailoverCustomProbe probe);
+    /**
      * Set the secondary service url.
      *
      * @param secondary
      * @return
      */
     AutoClusterFailoverBuilder secondary(List<String> secondary);
+
+    /**
+     * Set the secondary service url with customer probes.
+     *
+     * @param custom
+     * @return
+     */
+    AutoClusterFailoverBuilder secondaryWithCustomProbes(Map<String, AutoClusterFailoverCustomProbe> custom);
 
     /**
      * Set secondary choose policy. The default secondary choose policy is `ORDER`.

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/AutoClusterFailoverCustomProbe.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/AutoClusterFailoverCustomProbe.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import org.apache.pulsar.common.classification.InterfaceAudience;
+import org.apache.pulsar.common.classification.InterfaceStability;
+
+/**
+ * {@link AutoClusterFailoverCustomProbe} allows for custom probes.
+ *
+ * @since 2.10.0
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public interface AutoClusterFailoverCustomProbe {
+
+    /**
+     * Probe a cluster using custom logic and conditions.
+     *
+     * @return
+     */
+    boolean execute();
+}

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
@@ -32,6 +32,7 @@ import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.client.api.AutoClusterFailoverCustomProbe;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.ServiceUrlProvider;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
@@ -42,6 +43,7 @@ import org.testng.annotations.Test;
 @Test(groups = "broker-impl")
 @Slf4j
 public class AutoClusterFailoverTest {
+    
     @Test
     public void testBuildAutoClusterFailoverInstance() throws PulsarClientException {
         String primary = "pulsar://localhost:6650";
@@ -128,8 +130,14 @@ public class AutoClusterFailoverTest {
         PulsarClientImpl pulsarClient = mock(PulsarClientImpl.class);
         ConnectionPool connectionPool = mock(ConnectionPool.class);
         when(pulsarClient.getCnxPool()).thenReturn(connectionPool);
-        Mockito.doReturn(false).when(autoClusterFailover).probeAvailable(primary);
-        Mockito.doReturn(true).when(autoClusterFailover).probeAvailable(secondary);
+        
+        AutoClusterFailoverCustomProbe primaryProbe = mock(AutoClusterFailoverCustomProbe.class);
+        autoClusterFailover.getProbes().put(primary, primaryProbe);
+        AutoClusterFailoverCustomProbe secondaryProbe = mock(AutoClusterFailoverCustomProbe.class);
+        autoClusterFailover.getProbes().put(secondary, secondaryProbe);
+
+        Mockito.doReturn(false).when(primaryProbe).execute(); 
+        Mockito.doReturn(true).when(secondaryProbe).execute(); 
         Mockito.doReturn(configurationData).when(pulsarClient).getConfiguration();
 
         autoClusterFailover.initialize(pulsarClient);
@@ -140,13 +148,13 @@ public class AutoClusterFailoverTest {
             assertEquals(autoClusterFailover.getFailedTimestamp(), -1);
 
             // primary cluster came back
-            Mockito.doReturn(true).when(autoClusterFailover).probeAvailable(primary);
+            Mockito.doReturn(true).when(primaryProbe).execute();
             Awaitility.await().untilAsserted(() ->
                     assertEquals(autoClusterFailover.getServiceUrl(), primary));
             assertEquals(autoClusterFailover.getRecoverTimestamp(), -1);
             assertEquals(autoClusterFailover.getFailedTimestamp(), -1);
 
-            Mockito.doReturn(false).when(autoClusterFailover).probeAvailable(primary);
+            Mockito.doReturn(false).when(primaryProbe).execute();
         }
     }
 
@@ -173,8 +181,14 @@ public class AutoClusterFailoverTest {
         PulsarClientImpl pulsarClient = mock(PulsarClientImpl.class);
         ConnectionPool connectionPool = mock(ConnectionPool.class);
         when(pulsarClient.getCnxPool()).thenReturn(connectionPool);
-        Mockito.doReturn(false).when(autoClusterFailover).probeAvailable(primary);
-        Mockito.doReturn(true).when(autoClusterFailover).probeAvailable(secondary);
+        
+        AutoClusterFailoverCustomProbe primaryProbe = mock(AutoClusterFailoverCustomProbe.class);
+        autoClusterFailover.getProbes().put(primary, primaryProbe);
+        AutoClusterFailoverCustomProbe secondaryProbe = mock(AutoClusterFailoverCustomProbe.class);
+        autoClusterFailover.getProbes().put(secondary, secondaryProbe);
+        
+        Mockito.doReturn(false).when(primaryProbe).execute(); 
+        Mockito.doReturn(true).when(secondaryProbe).execute(); 
         Mockito.doReturn(configurationData).when(pulsarClient).getConfiguration();
 
         autoClusterFailover.initialize(pulsarClient);
@@ -182,7 +196,8 @@ public class AutoClusterFailoverTest {
         Awaitility.await().untilAsserted(() -> assertEquals(autoClusterFailover.getServiceUrl(), secondary));
 
         // primary cluster came back
-        Mockito.doReturn(true).when(autoClusterFailover).probeAvailable(primary);
+        Mockito.doReturn(true).when(primaryProbe).execute();
+//        Mockito.doReturn(true).when(autoClusterFailover).probeAvailable(primary);
         Awaitility.await().untilAsserted(() -> assertEquals(autoClusterFailover.getServiceUrl(), primary));
     }
 
@@ -230,8 +245,13 @@ public class AutoClusterFailoverTest {
         PulsarClientImpl pulsarClient = mock(PulsarClientImpl.class);
         ConnectionPool connectionPool = mock(ConnectionPool.class);
         when(pulsarClient.getCnxPool()).thenReturn(connectionPool);
-        Mockito.doReturn(false).when(autoClusterFailover).probeAvailable(primary);
-        Mockito.doReturn(true).when(autoClusterFailover).probeAvailable(secondary);
+        AutoClusterFailoverCustomProbe primaryProbe = mock(AutoClusterFailoverCustomProbe.class);
+        autoClusterFailover.getProbes().put(primary, primaryProbe);
+        AutoClusterFailoverCustomProbe secondaryProbe = mock(AutoClusterFailoverCustomProbe.class);
+        autoClusterFailover.getProbes().put(secondary, secondaryProbe);
+        
+        Mockito.doReturn(false).when(primaryProbe).execute();
+        Mockito.doReturn(true).when(secondaryProbe).execute();
         Mockito.doReturn(configurationData).when(pulsarClient).getConfiguration();
 
         autoClusterFailover.initialize(pulsarClient);
@@ -242,12 +262,11 @@ public class AutoClusterFailoverTest {
         Mockito.verify(pulsarClient, Mockito.atLeastOnce()).updateAuthentication(secondaryAuthentication);
 
         // primary cluster came back
-        Mockito.doReturn(true).when(autoClusterFailover).probeAvailable(primary);
+        Mockito.doReturn(true).when(primaryProbe).execute();
         Awaitility.await().untilAsserted(() -> assertEquals(autoClusterFailover.getServiceUrl(), primary));
         Mockito.verify(pulsarClient, Mockito.atLeastOnce()).reloadLookUp();
         Mockito.verify(pulsarClient, Mockito.atLeastOnce()).updateTlsTrustCertsFilePath(primaryTlsTrustCertsFilePath);
         Mockito.verify(pulsarClient, Mockito.atLeastOnce()).updateAuthentication(primaryAuthentication);
-
     }
 
     @Test
@@ -286,8 +305,14 @@ public class AutoClusterFailoverTest {
         PulsarClientImpl pulsarClient = mock(PulsarClientImpl.class);
         ConnectionPool connectionPool = mock(ConnectionPool.class);
         when(pulsarClient.getCnxPool()).thenReturn(connectionPool);
-        Mockito.doReturn(false).when(autoClusterFailover).probeAvailable(primary);
-        Mockito.doReturn(true).when(autoClusterFailover).probeAvailable(secondary);
+        
+        AutoClusterFailoverCustomProbe primaryProbe = mock(AutoClusterFailoverCustomProbe.class);
+        autoClusterFailover.getProbes().put(primary, primaryProbe);
+        AutoClusterFailoverCustomProbe secondaryProbe = mock(AutoClusterFailoverCustomProbe.class);
+        autoClusterFailover.getProbes().put(secondary, secondaryProbe);
+        
+        Mockito.doReturn(false).when(primaryProbe).execute();
+        Mockito.doReturn(true).when(secondaryProbe).execute();
         Mockito.doReturn(configurationData).when(pulsarClient).getConfiguration();
 
         autoClusterFailover.initialize(pulsarClient);
@@ -297,10 +322,9 @@ public class AutoClusterFailoverTest {
                 .updateTlsTrustStorePathAndPassword(secondaryTlsTrustStorePath, secondaryTlsTrustStorePassword);
 
         // primary cluster came back
-        Mockito.doReturn(true).when(autoClusterFailover).probeAvailable(primary);
+        Mockito.doReturn(true).when(primaryProbe).execute();
         Awaitility.await().untilAsserted(() -> assertEquals(autoClusterFailover.getServiceUrl(), primary));
         Mockito.verify(pulsarClient, Mockito.atLeastOnce())
                 .updateTlsTrustStorePathAndPassword(primaryTlsTrustStorePath, primaryTlsTrustStorePassword);
-
     }
 }


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->

Improve the default cluster auto-failvoer probe to allow for custom logic.

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: n/a

### Motivation

The default mechanism used to guage whether a cluster is up or not relies on resolving the DNS of a given cluster. This is the only option for clients which have only one entry point to pulsar, however in my scenario most of my microservices are deployed next to Pulsar and can
utilise other ways of checking if the clusters are indeed alive.

### Modifications

Kept the existing DNS resolution as the default when the client does not specify its own probe.  The default is applied to both the primary and all secondary cluster URLs.
Two new methods allow a client to attached their own probes to the URL for their clusters.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as the AutoClusterFailover which tests whether a fail over will occur based on the results of probes.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

* note: This PR adds two new methods to the client API.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/wojtekkedzior/pulsar/pull/1

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.