### PR TITLE
[fix][ci] Use correct annotation to prevent resource leaks in Elastic integration tests

### DIFF
--- a/pulsar-io/elastic-search/pom.xml
+++ b/pulsar-io/elastic-search/pom.xml
@@ -29,10 +29,6 @@
   <name>Pulsar IO :: ElasticSearch</name>
 
   <properties>
-    <!--
-     Work-around for "Container exited with code 137" (OOM)
-    -->
-    <testReuseFork>false</testReuseFork>
     <testForkCount>1</testForkCount>
   </properties>
 

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchAuthTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchAuthTests.java
@@ -18,6 +18,13 @@
  */
 package org.apache.pulsar.io.elasticsearch;
 
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
@@ -25,33 +32,20 @@ import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.SinkContext;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import java.io.IOException;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.expectThrows;
 
 @Slf4j
 public abstract class ElasticSearchAuthTests extends ElasticSearchTestBase {
     public static final String ELASTICPWD = "elastic";
 
-    static ElasticsearchContainer container;
+    private ElasticsearchContainer container;
     public ElasticSearchAuthTests(String elasticImageName) {
         super(elasticImageName);
     }
 
-    @BeforeMethod(alwaysRun = true)
-    public void initBeforeClass() throws IOException {
-        if (container != null) {
-            return;
-        }
+    @BeforeClass(alwaysRun = true)
+    public void initBeforeClass() {
         container = createElasticsearchContainer()
                 .withEnv("xpack.security.enabled", "true")
                 .withEnv("xpack.security.authc.token.enabled", "true")
@@ -62,7 +56,7 @@ public abstract class ElasticSearchAuthTests extends ElasticSearchTestBase {
     }
 
     @AfterClass(alwaysRun = true)
-    public static void closeAfterClass() {
+    public void closeAfterClass() {
         if (container != null) {
             container.close();
         }

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchClientTests.java
@@ -49,32 +49,29 @@ import org.awaitility.Awaitility;
 import org.testcontainers.containers.Network;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Slf4j
 public abstract class ElasticSearchClientTests extends ElasticSearchTestBase {
     public final static String INDEX = "myindex";
 
-    static ElasticsearchContainer container;
-    static Network network;
+    private ElasticsearchContainer container;
+    private Network network;
 
     public ElasticSearchClientTests(String elasticImageName) {
         super(elasticImageName);
     }
 
-    @BeforeMethod(alwaysRun = true)
+    @BeforeClass(alwaysRun = true)
     public void initBeforeClass() throws IOException {
-        if (container != null) {
-            return;
-        }
         network = Network.newNetwork();
         container = createElasticsearchContainer().withNetwork(network);
         container.start();
     }
 
     @AfterClass(alwaysRun = true)
-    public static void closeAfterClass() {
+    public void closeAfterClass() {
         container.close();
         container = null;
         network.close();

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkRawDataTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkRawDataTests.java
@@ -18,6 +18,15 @@
  */
 package org.apache.pulsar.io.elasticsearch;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.fail;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.pulsar.client.api.Message;
@@ -31,24 +40,14 @@ import org.mockito.stubbing.Answer;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.testng.Assert.fail;
-
 public abstract class ElasticSearchSinkRawDataTests extends ElasticSearchTestBase {
 
-    private static ElasticsearchContainer container;
+    private ElasticsearchContainer container;
 
     public ElasticSearchSinkRawDataTests(String elasticImageName) {
         super(elasticImageName);
@@ -67,18 +66,15 @@ public abstract class ElasticSearchSinkRawDataTests extends ElasticSearchTestBas
 
     static Schema<byte[]> schema;
 
-    @BeforeMethod(alwaysRun = true)
+    @BeforeClass(alwaysRun = true)
     public final void initBeforeClass() {
-        if (container != null) {
-            return;
-        }
         container = createElasticsearchContainer();
         container.start();
         schema = Schema.BYTES;
     }
 
     @AfterClass(alwaysRun = true)
-    public static void closeAfterClass() {
+    public void closeAfterClass() {
         container.close();
         container = null;
     }


### PR DESCRIPTION
### Motivation

pulsar-io/elastic-search tests leak containers since the method initBeforeClass has the `@BeforeMethod` annotation when it should be `@BeforeClass`.

### Modifications

- rename `@BeforeMethod` -> `@BeforeClass` for the `initBeforeClass` methods
- remove the `testReuseFork=false` workaround
- add `testcontainers-ryuk` to ignored threads in `ThreadLeakDetectorListener`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->