### PR TITLE
[improve][ci] Ignore Testcontainers background threads in ThreadLeakDetectorListener

### DIFF
--- a/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
@@ -164,7 +164,7 @@ public class ThreadLeakDetectorListener extends BetweenTestClassesListenerAdapte
             return true;
         }
         // skip Testcontainers threads
-        if (thread.getThreadGroup().getName().equals("testcontainers")) {
+        if (thread.getThreadGroup() != null && "testcontainers".equals(thread.getThreadGroup().getName())) {
             return true;
         }
         String threadName = thread.getName();

--- a/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
@@ -163,6 +163,10 @@ public class ThreadLeakDetectorListener extends BetweenTestClassesListenerAdapte
         if (thread instanceof ForkJoinWorkerThread) {
             return true;
         }
+        // skip Testcontainers threads
+        if (thread.getThreadGroup().getName().equals("testcontainers")) {
+            return true;
+        }
         String threadName = thread.getName();
         if (threadName != null) {
             // skip ClientTestFixtures.SCHEDULER threads
@@ -187,6 +191,10 @@ public class ThreadLeakDetectorListener extends BetweenTestClassesListenerAdapte
             }
             // skip OkHttp TaskRunner thread
             if (threadName.equals("OkHttp TaskRunner")) {
+                return true;
+            }
+            // skip JNA background thread
+            if (threadName.equals("JNA Cleaner")) {
                 return true;
             }
         }

--- a/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
@@ -197,6 +197,10 @@ public class ThreadLeakDetectorListener extends BetweenTestClassesListenerAdapte
             if (threadName.equals("JNA Cleaner")) {
                 return true;
             }
+            // skip org.glassfish.grizzly.http.server.DefaultSessionManager thread pool
+            if (threadName.equals("Grizzly-HttpSession-Expirer")) {
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
### Motivation

Testcontainers background threads get reported as leaked threads by ThreadLeakDetectorListener. These threads aren't actual leaks and should be ignored.

### Modifications

- Add rule to ignore Testcontainers background threads in ThreadLeakDetectorListener
- Also ignore "JNA Cleaner" which is unrelated to Testcontainers

### Other context

There might be more threads that need to be ignored, but let's see if those appear.
Examples from other OSS projects:
- https://github.com/apache/cassandra/blob/trunk/test/unit/org/apache/cassandra/tools/OfflineToolUtils.java
- https://github.com/apache/activemq-artemis/blob/main/artemis-unit-test-support/src/main/java/org/apache/activemq/artemis/utils/ThreadLeakCheckRule.java

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->