### PR TITLE
[improve][ci] Disable Gradle Enterprise unless GRADLE_ENTERPRISE_ACCESS_KEY is set

### DIFF
--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -22,6 +22,7 @@
 <gradleEnterprise
         xmlns="https://www.gradle.com/gradle-enterprise-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="https://www.gradle.com/gradle-enterprise-maven https://www.gradle.com/schema/gradle-enterprise-maven.xsd">
+  <enabled>#{env['GRADLE_ENTERPRISE_ACCESS_KEY']?.trim() > ''}</enabled>
   <server>
     <url>https://ge.apache.org</url>
     <allowUntrusted>false</allowUntrusted>


### PR DESCRIPTION
### Motivation

The Gradle Enterprise Maven extension is active even when it's not needed. 
Some PR builds failed with this kind of exception.
```
  Error: [ERROR] Internal error in Gradle Enterprise Maven extension: Failed to capture test events
  com.gradle.maven.common.logging.GradleEnterpriseException: Internal error in Gradle Enterprise Maven extension: Failed to capture test events
      at com.gradle.maven.common.logging.GradleEnterpriseException.a (SourceFile:19)
      at com.gradle.maven.scan.extension.internal.capture.r.i.a (SourceFile:189)
      at com.gradle.maven.cache.extension.d.h.a (SourceFile:31)
      at com.gradle.maven.cache.extension.d.m.a (SourceFile:27)
      at com.gradle.maven.cache.extension.d.a.c (SourceFile:115)
      at com.gradle.maven.cache.extension.d.a.a (SourceFile:61)
      at com.gradle.maven.cache.extension.d.e.a (SourceFile:27)
      at com.gradle.maven.cache.extension.d.l.a (SourceFile:17)
      at com.gradle.maven.cache.extension.d.d.a (SourceFile:42)
      at com.gradle.maven.cache.extension.d.b.a (SourceFile:26)
      at com.gradle.maven.cache.extension.d.f$1.run (SourceFile:35)
      at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute (SourceFile:29)
      at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute (SourceFile:26)
      at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute (SourceFile:66)
      at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute (SourceFile:59)
      at org.gradle.internal.operations.DefaultBuildOperationRunner.execute (SourceFile:157)
      at org.gradle.internal.operations.DefaultBuildOperationRunner.execute (SourceFile:59)
      at org.gradle.internal.operations.DefaultBuildOperationRunner.run (SourceFile:47)
      at com.gradle.maven.cache.extension.d.f.a (SourceFile:31)
      at com.gradle.maven.cache.extension.d.k.a (SourceFile:67)
      at com.gradle.maven.cache.extension.h.b.lambda$createProxy$0 (SourceFile:79)
      at jdk.proxy29.$Proxy119.execute (Unknown Source)
      at com.gradle.maven.scan.extension.internal.d.a.executeMojo (SourceFile:114)
      at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:370)
      at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:351)
      at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
      at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
      at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
      at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
      at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
      at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
      at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
      at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:299)
      at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:193)
      at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:106)
      at org.apache.maven.cli.MavenCli.execute (MavenCli.java:963)
      at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:296)
      at org.apache.maven.cli.MavenCli.main (MavenCli.java:199)
      at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
      at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
      at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
      at java.lang.reflect.Method.invoke (Method.java:568)
      at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
      at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
      at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
      at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
  Caused by: org.apache.maven.surefire.booter.SurefireBooterForkException: There was an error in the forked process
  Unexpected failure while capturing test events for Gradle Enterprise
      at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork (ForkStarter.java:628)
      at org.apache.maven.plugin.surefire.booterclient.ForkStarter.lambda$null$3 (ForkStarter.java:350)
      at java.util.concurrent.FutureTask.run (FutureTask.java:264)
      at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1136)
      at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:635)
      at java.lang.Thread.run (Thread.java:833)
```

### Modifications

Disable Gradle Enterprise maven extension unless GRADLE_ENTERPRISE_ACCESS_KEY is set.


### Additional context

Gradle Enterprise Maven Extension [documentation for `gradle-enterprise.xml`](https://docs.gradle.com/enterprise/maven-extension/#gradle_enterprise_xml).

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->