### PR TITLE
[fix][test] Fix resource leaks in pulsar-metadata bookkeeper.replication tests

### DIFF
--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -29,6 +29,11 @@
     <relativePath>..</relativePath>
   </parent>
 
+  <properties>
+    <!-- workaround for OOM error 134 in CI -->
+    <testForkCount>2</testForkCount>
+  </properties>
+
   <artifactId>pulsar-metadata</artifactId>
   <name>Pulsar Metadata</name>
   <dependencies>
@@ -149,7 +154,7 @@
           </execution>
         </executions>
       </plugin>
-      
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorCheckAllLedgersTaskTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorCheckAllLedgersTaskTest.java
@@ -65,15 +65,15 @@ public class AuditorCheckAllLedgersTaskTest extends BookKeeperClusterTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        final BookKeeper bookKeeper = new BookKeeper(baseClientConf);
+        final BookKeeper bookKeeper = registerCloseable(new BookKeeper(baseClientConf));
         admin = new BookKeeperAdmin(bookKeeper, NullStatsLogger.INSTANCE, new ClientConfiguration(baseClientConf));
 
         String ledgersRoot = "/ledgers";
         String storeUri = metadataServiceUri.replaceAll("zk://", "").replaceAll("/ledgers", "");
-        MetadataStoreExtended store = MetadataStoreExtended.create(storeUri,
-                MetadataStoreConfig.builder().fsyncEnable(false).build());
+        MetadataStoreExtended store = registerCloseable(MetadataStoreExtended.create(storeUri,
+                MetadataStoreConfig.builder().fsyncEnable(false).build()));
         LayoutManager layoutManager = new PulsarLayoutManager(store, ledgersRoot);
-        PulsarLedgerManagerFactory ledgerManagerFactory = new PulsarLedgerManagerFactory();
+        PulsarLedgerManagerFactory ledgerManagerFactory = registerCloseable(new PulsarLedgerManagerFactory());
 
         ClientConfiguration conf = new ClientConfiguration();
         conf.setZkLedgersRootPath(ledgersRoot);
@@ -86,7 +86,7 @@ public class AuditorCheckAllLedgersTaskTest extends BookKeeperClusterTestCase {
                 acquireConcurrentOpenLedgerOperationsTimeoutMSec);
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @Override
     public void tearDown() throws Exception {
         if (ledgerManager != null) {

--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
@@ -136,14 +136,14 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
 
         String ledgersRoot = "/ledgers";
         String storeUri = metadataServiceUri.replaceAll("zk://", "").replaceAll("/ledgers", "");
-        MetadataStoreExtended store = MetadataStoreExtended.create(storeUri,
-                MetadataStoreConfig.builder().fsyncEnable(false).build());
+        MetadataStoreExtended store = registerCloseable(MetadataStoreExtended.create(storeUri,
+                MetadataStoreConfig.builder().fsyncEnable(false).build()));
         LayoutManager layoutManager = new PulsarLayoutManager(store, ledgersRoot);
-        PulsarLedgerManagerFactory ledgerManagerFactory = new PulsarLedgerManagerFactory();
+        PulsarLedgerManagerFactory ledgerManagerFactory = registerCloseable(new PulsarLedgerManagerFactory());
         ClientConfiguration conf = new ClientConfiguration();
         conf.setZkLedgersRootPath(ledgersRoot);
         ledgerManagerFactory.initialize(conf, layoutManager, 1);
-        urLedgerMgr = ledgerManagerFactory.newLedgerUnderreplicationManager();
+        urLedgerMgr = registerCloseable(ledgerManagerFactory.newLedgerUnderreplicationManager());
         urLedgerMgr.setCheckAllLedgersCTime(System.currentTimeMillis());
 
         baseClientConf.setMetadataServiceUri(

--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorPlacementPolicyCheckTaskTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorPlacementPolicyCheckTaskTest.java
@@ -63,16 +63,19 @@ public class AuditorPlacementPolicyCheckTaskTest extends BookKeeperClusterTestCa
         super.setUp();
         baseClientConf.setMetadataServiceUri(
                 metadataServiceUri.replaceAll("zk://", "metadata-store:").replaceAll("/ledgers", ""));
-        final BookKeeper bookKeeper = new BookKeeper(baseClientConf);
+        final BookKeeper bookKeeper = registerCloseable(new BookKeeper(baseClientConf));
         admin = new BookKeeperAdmin(bookKeeper, NullStatsLogger.INSTANCE, new ClientConfiguration(baseClientConf));
-        LedgerManagerFactory ledgerManagerFactory = bookKeeper.getLedgerManagerFactory();
+        LedgerManagerFactory ledgerManagerFactory = registerCloseable(bookKeeper.getLedgerManagerFactory());
         ledgerManager = ledgerManagerFactory.newLedgerManager();
         ledgerUnderreplicationManager = ledgerManagerFactory.newLedgerUnderreplicationManager();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @Override
     public void tearDown() throws Exception {
+        if (admin != null) {
+            admin.close();
+        }
         if (ledgerManager != null) {
             ledgerManager.close();
         }

--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorReplicasCheckTaskTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorReplicasCheckTaskTest.java
@@ -63,14 +63,14 @@ public class AuditorReplicasCheckTaskTest extends BookKeeperClusterTestCase {
         super.setUp();
         baseClientConf.setMetadataServiceUri(
                 metadataServiceUri.replaceAll("zk://", "metadata-store:").replaceAll("/ledgers", ""));
-        final BookKeeper bookKeeper = new BookKeeper(baseClientConf);
+        final BookKeeper bookKeeper = registerCloseable(new BookKeeper(baseClientConf));
         admin = new BookKeeperAdmin(bookKeeper, NullStatsLogger.INSTANCE, new ClientConfiguration(baseClientConf));
-        LedgerManagerFactory ledgerManagerFactory = bookKeeper.getLedgerManagerFactory();
+        LedgerManagerFactory ledgerManagerFactory = registerCloseable(bookKeeper.getLedgerManagerFactory());
         ledgerManager = ledgerManagerFactory.newLedgerManager();
         ledgerUnderreplicationManager = ledgerManagerFactory.newLedgerUnderreplicationManager();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     @Override
     public void tearDown() throws Exception {
         if (ledgerManager != null) {

--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/BookieLedgerIndexTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/BookieLedgerIndexTest.java
@@ -91,8 +91,8 @@ public class BookieLedgerIndexTest extends BookKeeperClusterTestCase {
 
         String ledgersRoot = "/ledgers";
         String storeUri = metadataServiceUri.replaceAll("zk://", "").replaceAll("/ledgers", "");
-        MetadataStoreExtended store = MetadataStoreExtended.create(storeUri,
-                MetadataStoreConfig.builder().fsyncEnable(false).build());
+        MetadataStoreExtended store = registerCloseable(MetadataStoreExtended.create(storeUri,
+                MetadataStoreConfig.builder().fsyncEnable(false).build()));
         LayoutManager layoutManager = new PulsarLayoutManager(store, ledgersRoot);
         newLedgerManagerFactory = new PulsarLedgerManagerFactory();
 


### PR DESCRIPTION
### Motivation

There are multiple resource leaks in pulsar-metadata bookkeeper.replication tests.

### Modifications

- Introduce the `registerCloseable` solution to `BookKeeperClusterTestCase` to conveniently handle closing of resources in the tearDown method.
  - Use this in the tests to close resources properly.
- also change testForkCount to 2 since there's a sporadical error the pulsar-metadata tests fail with OOM error code 134.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->