### PR TITLE
[fix][client] Fix print error log 'Auto getting partitions failed' when expend partition.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -436,7 +436,7 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
                                 });
                         // call interceptor with the metadata change
                         onPartitionsChange(topic, currentPartitionNumber);
-                        return null;
+                        return future;
                     }
                 } else {
                     log.error("[{}] not support shrink topic partitions. old: {}, new: {}",


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/21484

### Motivation

We will encounter an error log 'Auto getting partitions failed' when expend partition.


### Modifications

When null is returned in method `thenCompose` we will encounter an NPE exception. Because the returned value will be applied to the next stage.

We use `future` instead of `null` as the return value.



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

