### PR TITLE
[fix][broker] Avoid pass null role in MultiRolesTokenAuthorizationProvider

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProvider.java
@@ -181,7 +181,14 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
 
         Jwt<?, Claims> jwt = parser.parseClaimsJwt(unsignedToken);
         try {
-            return new HashSet<>(Collections.singletonList(jwt.getBody().get(roleClaim, String.class)));
+            final String jwtRole = jwt.getBody().get(roleClaim, String.class);
+            if (jwtRole == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Do not have corresponding claim in jwt token. claim={}", roleClaim);
+                }
+                return Collections.emptySet();
+            }
+            return new HashSet<>(Collections.singletonList(jwtRole));
         } catch (RequiredTypeException requiredTypeException) {
             try {
                 List list = jwt.getBody().get(roleClaim, List.class);

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProviderTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProviderTest.java
@@ -164,10 +164,7 @@ public class MultiRolesTokenAuthorizationProviderTest {
             if (role == null) {
                 throw new IllegalStateException("We should avoid pass null to sub providers");
             }
-            if (role.equals(testRole)) {
-                return CompletableFuture.completedFuture(true);
-            }
-            return CompletableFuture.completedFuture(false);
+            return CompletableFuture.completedFuture(role.equals(testRole));
         }).get());
     }
 

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProviderTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProviderTest.java
@@ -143,7 +143,9 @@ public class MultiRolesTokenAuthorizationProviderTest {
         // broker will use "sub" as the claim by default.
         final String token = Jwts.builder()
                 .claim("whatever", testRole).signWith(secretKey).compact();
+        ServiceConfiguration conf = new ServiceConfiguration();
         final MultiRolesTokenAuthorizationProvider provider = new MultiRolesTokenAuthorizationProvider();
+        provider.initialize(conf, mock(PulsarResources.class));
         final AuthenticationDataSource ads = new AuthenticationDataSource() {
             @Override
             public boolean hasDataFromHttp() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiRolesTokenAuthorizationProviderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiRolesTokenAuthorizationProviderTest.java
@@ -53,6 +53,7 @@ public class MultiRolesTokenAuthorizationProviderTest extends MockedPulsarServic
     private final String superUserToken;
     private final String normalUserToken;
 
+
     public MultiRolesTokenAuthorizationProviderTest() {
         Map<String, Object> claims = new HashMap<>();
         Set<String> roles = new HashSet<>();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiRolesTokenAuthorizationProviderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiRolesTokenAuthorizationProviderTest.java
@@ -53,7 +53,6 @@ public class MultiRolesTokenAuthorizationProviderTest extends MockedPulsarServic
     private final String superUserToken;
     private final String normalUserToken;
 
-
     public MultiRolesTokenAuthorizationProviderTest() {
         Map<String, Object> claims = new HashMap<>();
         Set<String> roles = new HashSet<>();


### PR DESCRIPTION
### Motivation

Avoid passing the `null` role in `MultiRolesTokenAuthorizationProvider` when the JWT token does not have a corresponding claim.

```
2023-10-31T06:24:46,838+0000 [pulsar-io-4-1] DEBUG org.apache.pulsar.broker.service.ServerCnx - [/10.xx.xx.xx:52096] Authenticate role : admin
2023-10-31T06:24:46,839+0000 [pulsar-io-4-1] DEBUG org.apache.pulsar.broker.service.ServerCnx - [/10.xx.xx.xx:52096] Authenticate original role : d8a70f89-062f-4d9e-9ca5-024d8c5342ec
2023-10-31T06:24:46,839+0000 [pulsar-io-4-1] DEBUG org.apache.pulsar.broker.service.ServerCnx - Authenticate using original auth state : false, role = null
2023-10-31T06:24:46,839+0000 [pulsar-io-4-1] WARN  org.apache.pulsar.broker.authorization.AuthorizationService - [/10.xx.xx.xx:52096] Non-proxy role [admin] passed originalPrincipal [d8a70f89-062f-4d9e-9ca5-024d8c5342ec]. This behavior will not
be allowed in a future release. A proxy's role must be in the broker's proxyRoles configuration.
2023-10-31T06:24:46,839+0000 [pulsar-io-4-1] DEBUG org.apache.pulsar.broker.service.ServerCnx - [/10.xx.xx.xx:52096] connect state change to : [Connected]
2023-10-31T06:24:46,839+0000 [pulsar-io-4-1] DEBUG org.apache.pulsar.broker.service.ServerCnx - [/10.xx.xx.xx:52096] Client successfully authenticated with token role admin and originalPrincipal d8a70f89-062f-4d9e-9ca5-024d8c5342ec
2023-10-31T06:24:46,844+0000 [pulsar-io-4-1] DEBUG org.apache.pulsar.common.protocol.PulsarDecoder - [/10.xx.xx.xx:52096] Received cmd PARTITIONED_METADATA
2023-10-31T06:24:46,844+0000 [pulsar-io-4-1] DEBUG org.apache.pulsar.broker.service.ServerCnx - [persistent://public/default/testabcd] Received PartitionMetadataLookup from /10.xx.xx.xx:52096 for 2833399182903941192
2023-10-31T06:24:46,844+0000 [pulsar-io-4-1] DEBUG org.apache.pulsar.broker.authorization.AuthorizationService - Check if role d8a70f89-062f-4d9e-9ca5-024d8c5342ec is allowed to execute topic operation LOOKUP on topic persistent://public/default/testabcd
2023-10-31T06:24:46,844+0000 [pulsar-io-4-1] DEBUG org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider - Check allowTopicOperationAsync [LOOKUP] on [persistent://public/default/testabcd].
2023-10-31T06:24:46,844+0000 [pulsar-io-4-1] DEBUG org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider - Verify if role null is allowed to LOOKUP to topic persistent://public/default/testabcd: isSuperUserOrAdmin=false
2023-10-31T06:24:46,844+0000 [pulsar-io-4-1] DEBUG org.apache.pulsar.broker.authorization.AuthorizationService - Topic operation LOOKUP on topic persistent://public/default/testabcd is NOT allowed: role = d8a70f89-062f-4d9e-9ca5-024d8c5342ec
2023-10-31T06:24:46,844+0000 [pulsar-io-4-1] DEBUG org.apache.pulsar.broker.authorization.AuthorizationService - Check if role admin is allowed to execute topic operation LOOKUP on topic persistent://public/default/testabcd
2023-10-31T06:24:46,844+0000 [pulsar-io-4-1] DEBUG org.apache.pulsar.broker.authorization.AuthorizationService - Topic operation LOOKUP on topic persistent://public/default/testabcd is allowed: role = admin
2023-10-31T06:24:46,844+0000 [pulsar-io-4-1] WARN  org.apache.pulsar.broker.service.ServerCnx - OriginalRole d8a70f89-062f-4d9e-9ca5-024d8c5342ec is not authorized to perform operation LOOKUP on topic persistent://public/default/testabcd
2023-10-31T06:24:46,844+0000 [pulsar-io-4-1] WARN  org.apache.pulsar.broker.service.ServerCnx - [/10.xx.xx.xx:52096] Client is not authorized to Get Partition Metadata with role d8a70f89-062f-4d9e-9ca5-024d8c5342ec on topic persistent://public/d
```

### Modifications

- Add Null check.
- Add debugging log.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->