### PR TITLE
[fix][build] Fix Dockerfile's apt configuration so that retries would work

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -59,7 +59,7 @@ ARG JDK_MAJOR_VERSION=17
 # Install some utilities
 RUN sed -i -e "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-mirror://mirrors.ubuntu.com/mirrors.txt}|g" \
      -e "s|http://security\.ubuntu\.com/ubuntu/|${UBUNTU_SECURITY_MIRROR:-http://security.ubuntu.com/ubuntu/}|g" /etc/apt/sources.list \
-     && echo 'Acquire::http::Timeout "30";\nAcquire::ftp::Timeout "30";\nAcquire::Retries "3";' > /etc/apt/apt.conf.d/99timeout_and_retries \
+     && echo -e 'Acquire::http::Timeout "30";\nAcquire::ftp::Timeout "30";\nAcquire::Retries "3";' > /etc/apt/apt.conf.d/99timeout_and_retries \
      && apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install --no-install-recommends netcat dnsutils less procps iputils-ping \


### PR DESCRIPTION
### Motivation

Building the docker file fails often with this kind of error:
```
[INFO] DOCKER> Err:5 https://packages.adoptium.net/artifactory/deb jammy/main amd64 temurin-17-jdk amd64 17.0.9.0.0+9
  Error reading from server. Remote end closed connection [IP: 146.75.31.42 443]
[INFO] DOCKER> [91mE: Failed to fetch https://packages.adoptium.net/artifactory/deb/pool/main/t/temurin-17/temurin-17-jdk_17.0.9.0.0%2b9_amd64.deb  Error reading from server. Remote end closed connection [IP: 146.75.31.42 443]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

### Modifications

It appears that the apt configuration is invalid. the `echo` command is missing the `-e` flag. Add this flag so that the apt custom config becomes correct. The assumption is that timeouts or retries are currently invalid when the apt config file is invalid. This change will fix that issue and hopefully address the package download issue.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->