### PR TITLE
[fix][build] Fix apt download issue in building the docker image

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -62,9 +62,9 @@ RUN sed -i -e "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-mirror://m
      && echo 'Acquire::http::Timeout "30";\nAcquire::ftp::Timeout "30";\nAcquire::Retries "3";' > /etc/apt/apt.conf.d/99timeout_and_retries \
      && apt-get update \
      && apt-get -y dist-upgrade \
-     && apt-get -y install --no-install-recommends netcat dnsutils less procps iputils-ping \
-                 python3 python3-kazoo python3-pip \
-                 curl ca-certificates wget apt-transport-https
+     && apt-get -y install netcat dnsutils less procps iputils-ping \
+                 curl ca-certificates wget apt-transport-https \
+     && apt-get -y install --no-install-recommends python3 python3-kazoo python3-pip
 
 # Install Eclipse Temurin Package
 RUN mkdir -p /etc/apt/keyrings \


### PR DESCRIPTION
### Motivation

Building the docker file fails often with this kind of error:
```
[INFO] DOCKER> Err:5 https://packages.adoptium.net/artifactory/deb jammy/main amd64 temurin-17-jdk amd64 17.0.9.0.0+9
  Error reading from server. Remote end closed connection [IP: 146.75.31.42 443]
[INFO] DOCKER> [91mE: Failed to fetch https://packages.adoptium.net/artifactory/deb/pool/main/t/temurin-17/temurin-17-jdk_17.0.9.0.0%2b9_amd64.deb  Error reading from server. Remote end closed connection [IP: 146.75.31.42 443]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

### Modifications

`ca-certificates` package should be installed without `--no-install-recommends`. Rearrange the apt-get commands to achieve the desired result.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->