### PR TITLE
[improve][ci] Improve thread leak detection by ignoring more Testcontainers threads

### DIFF
--- a/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
@@ -64,7 +64,8 @@ public class ThreadLeakDetectorListener extends BetweenTestClassesListenerAdapte
             targetField = Thread.class.getDeclaredField("target");
             targetField.setAccessible(true);
         } catch (NoSuchFieldException e) {
-            LOG.warn("Cannot find target field in Thread.class", e);
+            // ignore this error. on Java 21, the field is not present
+            // TODO: add support for extracting the Runnable target on Java 21
         }
         THREAD_TARGET_FIELD = targetField;
     }
@@ -230,6 +231,9 @@ public class ThreadLeakDetectorListener extends BetweenTestClassesListenerAdapte
     }
 
     private static Runnable extractRunnableTarget(Thread thread) {
+        if (THREAD_TARGET_FIELD == null) {
+            return null;
+        }
         Runnable target = null;
         try {
             target = (Runnable) THREAD_TARGET_FIELD.get(thread);

--- a/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
@@ -230,6 +230,8 @@ public class ThreadLeakDetectorListener extends BetweenTestClassesListenerAdapte
         return false;
     }
 
+    // use reflection to extract the Runnable target from a thread so that we can detect threads created by
+    // Testcontainers based on the Runnable's class name.
     private static Runnable extractRunnableTarget(Thread thread) {
         if (THREAD_TARGET_FIELD == null) {
             return null;

--- a/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
@@ -201,6 +201,10 @@ public class ThreadLeakDetectorListener extends BetweenTestClassesListenerAdapte
             if (threadName.equals("Grizzly-HttpSession-Expirer")) {
                 return true;
             }
+            // Testcontainers AbstractWaitStrategy.EXECUTOR
+            if (threadName.startsWith("testcontainers-wait-")) {
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
### Motivation

The thread leak detection added in #21450 reports some Testcontainer threads as leaks. These threads can be safely ignored since they will be terminated eventually.

### Modifications

- detect threads where the Runnable class is under "org.testcontainers" package. Some threads don't have an unique name and the only way to detect them is to check the Runnable's class name.
- ignore threads where the name starts "testcontainers-wait-"

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->