### PR TITLE
[fix] [build] Unified the version of the library org.checkerframework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,6 +300,7 @@ flexible messaging model and an intuitive client API.</description>
     <roaringbitmap.version>0.9.44</roaringbitmap.version>
     <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
     <oshi.version>6.4.0</oshi.version>
+    <checkerframework.version>3.33.0</checkerframework.version>
 
     <!-- Used to configure rename.netty.native. Libs -->
     <rename.netty.native.libs>rename-netty-native-libs.sh</rename.netty.native.libs>
@@ -1410,6 +1411,11 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>com.github.oshi</groupId>
         <artifactId>oshi-core-java11</artifactId>
         <version>${oshi.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.checkerframework</groupId>
+        <artifactId>checker-qual</artifactId>
+        <version>${checkerframework.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
### Motivation

Pulsar depends on multi-version `org.checkerframework:checker-qual`

<img width="569" alt="Screenshot 2023-11-02 at 11 06 35" src="https://github.com/apache/pulsar/assets/25195800/b8cebd99-9d96-4564-a0ed-ba9d15413c3e">


### Modifications

Unified the version of the library `org.checkerframework:checker-qual`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x