### PR TITLE
[fix][broker] Fix setReplicatedSubscriptionStatus incorrect behavior

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -199,7 +199,12 @@ public class PersistentSubscription extends AbstractSubscription implements Subs
 
         if (this.cursor != null) {
             if (replicated) {
-                return this.cursor.putProperty(REPLICATED_SUBSCRIPTION_PROPERTY, 1L);
+                if (!config.isEnableReplicatedSubscriptions()) {
+                    log.warn("[{}][{}] Failed set replicated subscription status to {}, please enable the "
+                            + "configuration enableReplicatedSubscriptions", topicName, subName, replicated);
+                } else {
+                    return this.cursor.putProperty(REPLICATED_SUBSCRIPTION_PROPERTY, 1L);
+                }
             } else {
                 return this.cursor.removeProperty(REPLICATED_SUBSCRIPTION_PROPERTY);
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorSubscriptionTest.java
@@ -41,6 +41,7 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.service.persistent.ReplicatedSubscriptionsController;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
@@ -50,11 +51,13 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.policies.data.PartitionedTopicStats;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -619,6 +622,27 @@ public class ReplicatorSubscriptionTest extends ReplicatorTestBase {
                 String.format("numReceivedMessages1 (%d) should be less than %d", numReceivedMessages1, numMessages));
         assertTrue(numReceivedMessages2 < numMessages,
                 String.format("numReceivedMessages2 (%d) should be less than %d", numReceivedMessages2, numMessages));
+    }
+
+    @Test(timeOut = 30000)
+    public void testReplicatedSubscriptionRestApi3() throws Exception {
+        final String namespace = BrokerTestUtil.newUniqueName("geo/replicatedsubscription");
+        final String topicName = "persistent://" + namespace + "/topic-rest-api3";
+        final String subName = "sub";
+        admin4.tenants().createTenant("geo",
+                new TenantInfoImpl(Sets.newHashSet("appid1", "appid4"), Sets.newHashSet(cluster1, cluster4)));
+        admin4.namespaces().createNamespace(namespace);
+        admin4.namespaces().setNamespaceReplicationClusters(namespace, Sets.newHashSet(cluster1, cluster4));
+        admin4.topics().createPartitionedTopic(topicName, 2);
+
+        @Cleanup
+        final PulsarClient client4 = PulsarClient.builder().serviceUrl(url4.toString())
+                .statsInterval(0, TimeUnit.SECONDS).build();
+
+        Consumer<byte[]> consumer4 = client4.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
+        Assert.expectThrows(PulsarAdminException.class, () ->
+                admin4.topics().setReplicatedSubscriptionStatus(topicName, subName, true));
+        consumer4.close();
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
@@ -82,6 +82,13 @@ public abstract class ReplicatorTestBase extends TestRetrySupport {
     PulsarAdmin admin3;
     LocalBookkeeperEnsemble bkEnsemble3;
 
+    URL url4;
+    URL urlTls4;
+    ServiceConfiguration config4 = new ServiceConfiguration();
+    PulsarService pulsar4;
+    PulsarAdmin admin4;
+    LocalBookkeeperEnsemble bkEnsemble4;
+
     ZookeeperServerTest globalZkS;
 
     ExecutorService executor;
@@ -111,6 +118,7 @@ public abstract class ReplicatorTestBase extends TestRetrySupport {
     protected final String cluster1 = "r1";
     protected final String cluster2 = "r2";
     protected final String cluster3 = "r3";
+    protected final String cluster4 = "r4";
 
     // Default frequency
     public int getBrokerServicePurgeInactiveFrequency() {
@@ -178,6 +186,21 @@ public abstract class ReplicatorTestBase extends TestRetrySupport {
         urlTls3 = new URL(pulsar3.getWebServiceAddressTls());
         admin3 = PulsarAdmin.builder().serviceHttpUrl(url3.toString()).build();
 
+        // Start region 4
+
+        // Start zk & bks
+        bkEnsemble4 = new LocalBookkeeperEnsemble(3, 0, () -> 0);
+        bkEnsemble4.start();
+
+        setConfig4DefaultValue();
+        pulsar4 = new PulsarService(config4);
+        pulsar4.start();
+
+        url4 = new URL(pulsar4.getWebServiceAddress());
+        urlTls4 = new URL(pulsar4.getWebServiceAddressTls());
+        admin4 = PulsarAdmin.builder().serviceHttpUrl(url4.toString()).build();
+
+
         // Provision the global namespace
         admin1.clusters().createCluster(cluster1, ClusterData.builder()
                 .serviceUrl(url1.toString())
@@ -230,6 +253,23 @@ public abstract class ReplicatorTestBase extends TestRetrySupport {
                 .brokerClientTlsTrustStorePassword(keyStorePassword)
                 .brokerClientTlsTrustStoreType(keyStoreType)
                 .build());
+        admin4.clusters().createCluster(cluster4, ClusterData.builder()
+                .serviceUrl(url4.toString())
+                .serviceUrlTls(urlTls4.toString())
+                .brokerServiceUrl(pulsar4.getBrokerServiceUrl())
+                .brokerServiceUrlTls(pulsar4.getBrokerServiceUrlTls())
+                .brokerClientTlsEnabled(true)
+                .brokerClientCertificateFilePath(clientCertFilePath)
+                .brokerClientKeyFilePath(clientKeyFilePath)
+                .brokerClientTrustCertsFilePath(caCertFilePath)
+                .brokerClientTlsEnabledWithKeyStore(tlsWithKeyStore)
+                .brokerClientTlsKeyStore(clientKeyStorePath)
+                .brokerClientTlsKeyStorePassword(keyStorePassword)
+                .brokerClientTlsKeyStoreType(keyStoreType)
+                .brokerClientTlsTrustStore(clientTrustStorePath)
+                .brokerClientTlsTrustStorePassword(keyStorePassword)
+                .brokerClientTlsTrustStoreType(keyStoreType)
+                .build());
 
         admin1.tenants().createTenant("pulsar",
                 new TenantInfoImpl(Sets.newHashSet("appid1", "appid2", "appid3"), Sets.newHashSet("r1", "r2", "r3")));
@@ -257,7 +297,7 @@ public abstract class ReplicatorTestBase extends TestRetrySupport {
     }
 
     public void setConfig3DefaultValue() {
-        setConfigDefaults(config3, "r3", bkEnsemble3);
+        setConfigDefaults(config3, cluster3, bkEnsemble3);
         config3.setTlsEnabled(true);
     }
 
@@ -267,6 +307,11 @@ public abstract class ReplicatorTestBase extends TestRetrySupport {
 
     public void setConfig2DefaultValue() {
         setConfigDefaults(config2, cluster2, bkEnsemble2);
+    }
+
+    public void setConfig4DefaultValue() {
+        setConfigDefaults(config4, cluster4, bkEnsemble4);
+        config4.setEnableReplicatedSubscriptions(false);
     }
 
     private void setConfigDefaults(ServiceConfiguration config, String clusterName,
@@ -316,6 +361,11 @@ public abstract class ReplicatorTestBase extends TestRetrySupport {
         setConfig3DefaultValue();
     }
 
+    public void resetConfig4() {
+        config4 = new ServiceConfiguration();
+        setConfig4DefaultValue();
+    }
+
     private int inSec(int time, TimeUnit unit) {
         return (int) TimeUnit.SECONDS.convert(time, unit);
     }
@@ -332,7 +382,11 @@ public abstract class ReplicatorTestBase extends TestRetrySupport {
         admin1.close();
         admin2.close();
         admin3.close();
+        admin4.close();
 
+        if (pulsar4 != null) {
+            pulsar4.close();
+        }
         if (pulsar3 != null) {
             pulsar3.close();
         }
@@ -346,11 +400,13 @@ public abstract class ReplicatorTestBase extends TestRetrySupport {
         bkEnsemble1.stop();
         bkEnsemble2.stop();
         bkEnsemble3.stop();
+        bkEnsemble4.stop();
         globalZkS.stop();
 
         resetConfig1();
         resetConfig2();
         resetConfig3();
+        resetConfig4();
     }
 
     static class MessageProducer implements AutoCloseable {


### PR DESCRIPTION

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #21506

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

fix  setReplicatedSubscriptionStatus Incorrect behavior, when unenable enableReplicatedSubscriptions.

### Modifications

when unenable enableReplicatedSubscriptions, set replicatedSubscription status  to ture, should throw an exception.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
