### PR TITLE
[improve][ci] Move pulsar-metadata unit tests from OTHER to new METADATA group

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -261,6 +261,8 @@ jobs:
             group: PULSAR_IO_KAFKA_CONNECT
           - name: Pulsar Client
             group: CLIENT
+          - name: Pulsar Metadata
+            group: METADATA
 
     steps:
       - name: checkout

--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -103,6 +103,10 @@ function test_group_client() {
   mvn_test -pl pulsar-client
 }
 
+function test_group_metadata() {
+  mvn_test -pl pulsar-metadata
+}
+
 # prints summaries of failed tests to console
 # by using the targer/surefire-reports files
 # works only when testForkCount > 1 since that is when surefire will create reports for individual test classes

--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -199,4 +199,20 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>skipTestsForUnitGroupOther</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
### Motivation

The test JVM crashes frequently in pulsar-metadata tests due to #19307 . Since metadata unit tests are part of the OTHER group, there's a need to re-run all tests in that group. The OTHER group is already slow so this wastes resources and adds delay. 

### Modifications

- move pulsar-metadata unit tests from OTHER to new METADATA group

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->