### PR TITLE
[improve] [auto-recovery] Make AutoRecovery enable stickyReadS as default.

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -769,3 +769,8 @@ dbStorage_rocksDB_bloomFilterBitsPerKey=10
 dbStorage_rocksDB_numLevels=-1
 dbStorage_rocksDB_numFilesInLevel0=4
 dbStorage_rocksDB_maxSizeInLevel1MB=256
+
+# Enable/disable having read operations for a ledger to be sticky to a single bookie.
+# This configuration is targeted towards the AutoRecovery, it will read data from bookie,
+# then replicate the data to other bookie.
+stickyReadSEnabled=true


### PR DESCRIPTION
### Motivation
The AutoRecovery would move the data to another alive bookie to ensure the data replicas. So it will read data from the alive bookie at the ensemble, then write the data to the new bookie.

When reading data, it will choose the bookie in the ensemble randomly, so it may choose the bookie that may be already shut down, and then print many warm logs.

If we make `stickyReadSEnabled=true`, it will read the data from the alive bookie continually, and won't print any warm log, and the stickyReadS can improve hit rate of the bookie server read cache, speed the read operation.



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
