### PR TITLE
[improve][misc] Disable rebase and merge to prevent unsquashed PRs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -37,7 +37,7 @@ github:
   enabled_merge_buttons:
     squash:  true
     merge:   false
-    rebase:  true
+    rebase:  false
   protected_branches:
     master:
       required_status_checks:


### PR DESCRIPTION
Discussion: https://lists.apache.org/thread/6hsv4lsrx00ztd7cw6b00xjr1w6tgcjg.

The Pulsar repo needs to prevent accidental unsquashed PR merges. As discussed, we could reenable this `rebase and merge` option if there is strong demand(currently this merge option is rarely used)


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
