### PR TITLE
[improve][test] Use BrokerInterceptors to load CounterBrokerInterceptor

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorTest.java
@@ -91,7 +91,20 @@ public class BrokerInterceptorTest extends ProducerConsumerBase {
 
     @Override
     protected void customizeMainPulsarTestContextBuilder(PulsarTestContext.Builder pulsarTestContextBuilder) {
-        pulsarTestContextBuilder.brokerInterceptor(new CounterBrokerInterceptor());
+        HashMap<String, BrokerInterceptorWithClassLoader> brokerInterceptorWithClassLoaderHashMap = new HashMap<>();
+        NarClassLoader narClassLoader = mock(NarClassLoader.class);
+        BrokerInterceptorWithClassLoader counterBrokerInterceptor
+                = new BrokerInterceptorWithClassLoader(new CounterBrokerInterceptor(), narClassLoader);
+        brokerInterceptorWithClassLoaderHashMap.put(CounterBrokerInterceptor.NAME, counterBrokerInterceptor);
+        BrokerInterceptors brokerInterceptors = new BrokerInterceptors(brokerInterceptorWithClassLoaderHashMap);
+        pulsarTestContextBuilder.brokerInterceptor(brokerInterceptors);
+    }
+
+    private CounterBrokerInterceptor getCounterBrokerInterceptor() {
+        BrokerInterceptor brokerInterceptor = pulsar.getBrokerInterceptor();
+        BrokerInterceptorWithClassLoader brokerInterceptorWithClassLoader =
+                ((BrokerInterceptors) brokerInterceptor).getInterceptors().get(CounterBrokerInterceptor.NAME);
+        return (CounterBrokerInterceptor) brokerInterceptorWithClassLoader.getInterceptor();
     }
 
     @Override
@@ -119,93 +132,83 @@ public class BrokerInterceptorTest extends ProducerConsumerBase {
 
     @Test
     public void testWebserviceRequest() throws PulsarAdminException {
-        BrokerInterceptor listener = pulsar.getBrokerInterceptor();
-        Assert.assertTrue(listener instanceof CounterBrokerInterceptor);
         admin.namespaces().createNamespace("public/test", 4);
-        Awaitility.await().until(() -> ((CounterBrokerInterceptor) listener).getCount() >= 1);
+        Awaitility.await().until(() -> getCounterBrokerInterceptor().getCount() >= 1);
     }
 
     @Test
     public void testPulsarCommand() throws PulsarClientException {
-        BrokerInterceptor listener = pulsar.getBrokerInterceptor();
-        Assert.assertTrue(listener instanceof CounterBrokerInterceptor);
         pulsarClient.newProducer(Schema.BOOL).topic("test").create();
         // CONNECT and PRODUCER
-        Awaitility.await().until(() -> ((CounterBrokerInterceptor) listener).getCount() >= 2);
+        Awaitility.await().until(() -> getCounterBrokerInterceptor().getCount() >= 2);
     }
 
     @Test
     public void testConnectionCreation() throws PulsarClientException {
-        BrokerInterceptor listener = pulsar.getBrokerInterceptor();
-        Assert.assertTrue(listener instanceof CounterBrokerInterceptor);
         pulsarClient.newProducer(Schema.BOOL).topic("test").create();
         pulsarClient.newConsumer(Schema.STRING).topic("test1").subscriptionName("test-sub").subscribe();
         // single connection for both producer and consumer
-        Awaitility.await().until(() -> ((CounterBrokerInterceptor) listener).getConnectionCreationCount() == 1);
+        Awaitility.await().until(() -> getCounterBrokerInterceptor().getConnectionCreationCount() == 1);
     }
 
     @Test
     public void testProducerCreation() throws PulsarClientException {
-        BrokerInterceptor listener = pulsar.getBrokerInterceptor();
-        Assert.assertTrue(listener instanceof CounterBrokerInterceptor);
-        assertEquals(((CounterBrokerInterceptor) listener).getProducerCount(), 0);
+        CounterBrokerInterceptor counterBrokerInterceptor = getCounterBrokerInterceptor();
+        assertEquals(counterBrokerInterceptor.getProducerCount(), 0);
         pulsarClient.newProducer(Schema.BOOL).topic("test").create();
-        Awaitility.await().until(() -> ((CounterBrokerInterceptor) listener).getProducerCount() == 1);
+        Awaitility.await().until(() -> counterBrokerInterceptor.getProducerCount() == 1);
     }
 
     @Test
     public void testProducerClose() throws PulsarClientException {
-        BrokerInterceptor listener = pulsar.getBrokerInterceptor();
-        Assert.assertTrue(listener instanceof CounterBrokerInterceptor);
-        assertEquals(((CounterBrokerInterceptor) listener).getProducerCount(), 0);
+        CounterBrokerInterceptor counterBrokerInterceptor = getCounterBrokerInterceptor();
+        assertEquals(counterBrokerInterceptor.getProducerCount(), 0);
         Producer<Boolean> producer = pulsarClient.newProducer(Schema.BOOL).topic("test").create();
-        Awaitility.await().until(() -> ((CounterBrokerInterceptor) listener).getProducerCount() == 1);
+        Awaitility.await().until(() -> counterBrokerInterceptor.getProducerCount() == 1);
         producer.close();
-        Awaitility.await().until(() -> ((CounterBrokerInterceptor) listener).getProducerCount() == 0);
+        Awaitility.await().until(() -> counterBrokerInterceptor.getProducerCount() == 0);
     }
 
     @Test
     public void testConsumerCreation() throws PulsarClientException {
-        BrokerInterceptor listener = pulsar.getBrokerInterceptor();
-        Assert.assertTrue(listener instanceof CounterBrokerInterceptor);
-        assertEquals(((CounterBrokerInterceptor) listener).getConsumerCount(), 0);
+        CounterBrokerInterceptor counterBrokerInterceptor = getCounterBrokerInterceptor();
+        assertEquals(counterBrokerInterceptor.getConsumerCount(), 0);
         pulsarClient.newConsumer(Schema.STRING).topic("test1").subscriptionName("test-sub").subscribe();
-        Awaitility.await().until(() -> ((CounterBrokerInterceptor) listener).getConsumerCount() == 1);
+        Awaitility.await().until(() -> counterBrokerInterceptor.getConsumerCount() == 1);
     }
 
     @Test
     public void testConsumerClose() throws PulsarClientException {
-        BrokerInterceptor listener = pulsar.getBrokerInterceptor();
-        Assert.assertTrue(listener instanceof CounterBrokerInterceptor);
-        assertEquals(((CounterBrokerInterceptor) listener).getConsumerCount(), 0);
+        CounterBrokerInterceptor counterBrokerInterceptor = getCounterBrokerInterceptor();
+        assertEquals(counterBrokerInterceptor.getConsumerCount(), 0);
         Consumer<String> consumer = pulsarClient
                 .newConsumer(Schema.STRING).topic("test1").subscriptionName("test-sub").subscribe();
-        Awaitility.await().until(() -> ((CounterBrokerInterceptor) listener).getConsumerCount() == 1);
+        Awaitility.await().until(() -> counterBrokerInterceptor.getConsumerCount() == 1);
         consumer.close();
-        Awaitility.await().until(() -> ((CounterBrokerInterceptor) listener).getConsumerCount() == 0);
+        Awaitility.await().until(() -> counterBrokerInterceptor.getConsumerCount() == 0);
     }
 
     @Test
     public void testMessagePublishAndProduced() throws PulsarClientException {
-        BrokerInterceptor listener = pulsar.getBrokerInterceptor();
-        Assert.assertTrue(listener instanceof CounterBrokerInterceptor);
+        CounterBrokerInterceptor counterBrokerInterceptor = getCounterBrokerInterceptor();
 
         @Cleanup
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
                 .topic("test-before-send-message")
                 .create();
 
-        assertEquals(((CounterBrokerInterceptor)listener).getMessagePublishCount(),0);
-        assertEquals(((CounterBrokerInterceptor)listener).getMessageProducedCount(),0);
+        assertEquals(counterBrokerInterceptor.getMessagePublishCount(), 0);
+        assertEquals(counterBrokerInterceptor.getMessageProducedCount(), 0);
         producer.send("hello world");
-        assertEquals(((CounterBrokerInterceptor)listener).getMessagePublishCount(),1);
-        assertEquals(((CounterBrokerInterceptor)listener).getMessageProducedCount(),1);
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(counterBrokerInterceptor.getMessagePublishCount(), 1);
+            assertEquals(counterBrokerInterceptor.getMessageProducedCount(), 1);
+        });
     }
 
     @Test
     public void testBeforeSendMessage() throws PulsarClientException {
-        BrokerInterceptor listener = pulsar.getBrokerInterceptor();
-        Assert.assertTrue(listener instanceof CounterBrokerInterceptor);
+        CounterBrokerInterceptor counterBrokerInterceptor = getCounterBrokerInterceptor();
 
         @Cleanup
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
@@ -217,26 +220,22 @@ public class BrokerInterceptorTest extends ProducerConsumerBase {
             .subscriptionName("test")
             .subscribe();
 
-        assertEquals(((CounterBrokerInterceptor)listener).getMessageProducedCount(),0);
-        assertEquals(((CounterBrokerInterceptor)listener).getMessageDispatchCount(),0);
+        assertEquals(counterBrokerInterceptor.getMessageProducedCount(), 0);
+        assertEquals(counterBrokerInterceptor.getMessageDispatchCount(), 0);
         producer.send("hello world");
-        assertEquals(((CounterBrokerInterceptor)listener).getMessageProducedCount(),1);
-
+        Awaitility.await().until(() -> counterBrokerInterceptor.getMessageProducedCount() == 1);
         Message<String> msg = consumer.receive();
 
         assertEquals(msg.getValue(), "hello world");
 
-        Awaitility.await().until(() -> ((CounterBrokerInterceptor) listener).getBeforeSendCount() == 1);
-        Awaitility.await().until(() -> ((CounterBrokerInterceptor) listener).getBeforeSendCountAtConsumerLevel() == 1);
-        Awaitility.await().until(() -> ((CounterBrokerInterceptor) listener).getMessageDispatchCount() == 1);
+        Awaitility.await().until(() -> counterBrokerInterceptor.getBeforeSendCount() == 1);
+        Awaitility.await().until(() -> counterBrokerInterceptor.getBeforeSendCountAtConsumerLevel() == 1);
+        Awaitility.await().until(() -> counterBrokerInterceptor.getMessageDispatchCount() == 1);
     }
 
     @Test
     public void testInterceptAck() throws Exception {
         final String topic = "test-intercept-ack" + UUID.randomUUID();
-        BrokerInterceptor interceptor = pulsar.getBrokerInterceptor();
-        Assert.assertTrue(interceptor instanceof CounterBrokerInterceptor);
-
         try (Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
              Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING).topic(topic)
                      .subscriptionName("test-sub").subscribe()) {
@@ -244,13 +243,12 @@ public class BrokerInterceptorTest extends ProducerConsumerBase {
             Message<String> message = consumer.receive();
             consumer.acknowledge(message);
         }
-        Awaitility.await().until(() -> ((CounterBrokerInterceptor) interceptor).getHandleAckCount() == 1);
+        Awaitility.await().until(() -> getCounterBrokerInterceptor().getHandleAckCount() == 1);
     }
 
     @Test
     public void asyncResponseFilterTest() throws Exception {
-        Assert.assertTrue(pulsar.getBrokerInterceptor() instanceof CounterBrokerInterceptor);
-        CounterBrokerInterceptor interceptor = (CounterBrokerInterceptor) pulsar.getBrokerInterceptor();
+        CounterBrokerInterceptor interceptor = getCounterBrokerInterceptor();
         interceptor.clearResponseList();
 
         OkHttpClient client = new OkHttpClient();
@@ -309,9 +307,6 @@ public class BrokerInterceptorTest extends ProducerConsumerBase {
 
     @Test
     public void testInterceptNack() throws Exception {
-        BrokerInterceptor interceptor = pulsar.getBrokerInterceptor();
-        Assert.assertTrue(interceptor instanceof CounterBrokerInterceptor);
-
         final String topic = "test-intercept-nack" + UUID.randomUUID();
         @Cleanup
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
@@ -323,6 +318,6 @@ public class BrokerInterceptorTest extends ProducerConsumerBase {
         producer.send("test intercept nack message");
         Message<String> message = consumer.receive();
         consumer.negativeAcknowledge(message);
-        Awaitility.await().until(() -> ((CounterBrokerInterceptor) interceptor).getHandleNackCount().get() == 1);
+        Awaitility.await().until(() -> getCounterBrokerInterceptor().getHandleNackCount().get() == 1);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/CounterBrokerInterceptor.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/CounterBrokerInterceptor.java
@@ -68,6 +68,7 @@ public class CounterBrokerInterceptor implements BrokerInterceptor {
     private final AtomicInteger txnCount = new AtomicInteger();
     private final AtomicInteger committedTxnCount = new AtomicInteger();
     private final AtomicInteger abortedTxnCount = new AtomicInteger();
+    public static final String NAME = "COUNTER-BROKER-INTERCEPTOR";
 
     public void reset() {
         beforeSendCount.set(0);


### PR DESCRIPTION
### Motivation

In `BrokerInterceptorTest.java`, we directly set `CounterBrokerInterceptor` as the broker interceptor, which is different from the loading mechanism of the production broker. The production broker uses the `BrokerInterceptors` to load multiple broker interceptors. When we didn't override the intercept method in `BrokerInterceptors`, this test case still passed.

The following is the process of the broker calls a custom interceptor:

`BrokerInterceptors` -> `BrokerInterceptorWithClassLoader` -> `MyBrokerInterceptor`

### Modifications

- Use `BrokerInterceptors` to load `CounterBrokerInterceptor` in `BrokerInterceptorTest.java`
- Fix Assertions in `testMessagePublishAndProduced`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->