### PR TITLE
[fix][ml] Fix unfinished callback when deleting managed ledger

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -839,7 +839,8 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
             }).exceptionally(ex -> {
                 // If it fails to get open, it will be cleaned by managed ledger opening error handling.
                 // then retry will go to `future=null` branch.
-                callback.deleteLedgerFailed(getManagedLedgerException(ex), ctx);
+                final Throwable rc = FutureUtil.unwrapCompletionException(ex);
+                callback.deleteLedgerFailed(getManagedLedgerException(rc), ctx);
                 return null;
             });
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -837,7 +837,9 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                 // If it's open, delete in the normal way
                 ml.asyncDelete(callback, ctx);
             }).exceptionally(ex -> {
-                // If it's failing to get open, just delete from metadata
+                // If it fails to get open, it will be cleaned by managed ledger opening error handling.
+                // then retry will go to `future=null` branch.
+                callback.deleteLedgerFailed(getManagedLedgerException(ex), ctx);
                 return null;
             });
         }


### PR DESCRIPTION
### Motivation

#7131 introduced an unfinished callback.

### Modifications


- Complete the callback with an exception to let the user retry.

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->


### Verifying this change

- [x] Make sure that the change passes the CI checks.