### PR TITLE
[improve][broker] Improve managed ledger factory async delete method parametres.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
@@ -29,6 +29,9 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenLedgerCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenReadOnlyCursorCallback;
 import org.apache.bookkeeper.mledger.impl.cache.EntryCacheManager;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * A factory to open/create managed ledgers and delete them.
  *
@@ -183,8 +186,13 @@ public interface ManagedLedgerFactory {
      * @throws InterruptedException
      * @throws ManagedLedgerException
      */
+    @Deprecated
     void asyncDelete(String name, CompletableFuture<ManagedLedgerConfig> mlConfigFuture,
                              DeleteLedgerCallback callback, Object ctx);
+
+
+    void asyncDelete(@Nonnull String name, @Nonnull ManagedLedgerConfig managedLedgerConfig,
+                     @Nonnull DeleteLedgerCallback callback, @Nullable Object ctx);
 
     /**
      * Releases all the resources maintained by the ManagedLedgerFactory.

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
@@ -21,6 +21,8 @@ package org.apache.bookkeeper.mledger;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteLedgerCallback;
@@ -28,9 +30,6 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.ManagedLedgerInfoCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenLedgerCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenReadOnlyCursorCallback;
 import org.apache.bookkeeper.mledger.impl.cache.EntryCacheManager;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * A factory to open/create managed ledgers and delete them.

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
@@ -191,6 +191,16 @@ public interface ManagedLedgerFactory {
                              DeleteLedgerCallback callback, Object ctx);
 
 
+    /**
+     * Delete a managed ledger asynchronous. If it's not open, it's metadata will get regardless deleted.
+     *
+     * @param name                      Managed ledger name
+     * @param managedLedgerConfig       Managed ledger configuration
+     * @param callback                  Async Callback
+     * @param ctx                       Async Context
+     * @throws NullPointerException   When pass Null value to nonnull parameter
+     * @throws ManagedLedgerException Refer to get more information. #{@link ManagedLedgerException}
+     */
     void asyncDelete(@Nonnull String name, @Nonnull ManagedLedgerConfig managedLedgerConfig,
                      @Nonnull DeleteLedgerCallback callback, @Nullable Object ctx);
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -25,12 +25,7 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.Maps;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -829,6 +824,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
     }
 
     @Override
+    @Deprecated
     public void asyncDelete(String name, CompletableFuture<ManagedLedgerConfig> mlConfigFuture,
                             DeleteLedgerCallback callback, Object ctx) {
         mlConfigFuture.thenAccept(managedLedgerConfig -> {
@@ -853,6 +849,10 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
     @Override
     public void asyncDelete(@Nonnull String name, @Nonnull ManagedLedgerConfig managedLedgerConfig,
                             @Nonnull DeleteLedgerCallback callback, @Nullable Object ctx) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(managedLedgerConfig);
+        Objects.requireNonNull(callback);
+
         final CompletableFuture<ManagedLedgerImpl> future = ledgers.get(name);
         if (future == null) {
             // Managed ledger does not exist and we're not currently trying to open it


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/17915 added a new public API for the managed ledger factory interface. it's not a good approach to let the user pass a future instead of the managed configuration.

### Modifications

Improve the method parameters and keep the compatibility.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
