### PR TITLE
[improve][pip] PIP-318: Don't retain null-key messages during topic compaction

### DIFF
--- a/pip/pip-318.md
+++ b/pip/pip-318.md
@@ -23,24 +23,24 @@ If the configuration is true, we will retain null-key messages during topic comp
 
 ### Configuration
 
-Add config to broker.conf
+Add config to broker.conf/standalone.conf
 ```properties
-compactionRemainNullKey=false
+topicCompactionRemainNullKey=false
 ```
 
 # Backward & Forward Compatibility
 
-- Make `compactionRemainNullKey=false` default  in the 3.2.0.
-- Cherry-pick it to a branch less than 3.2.0 make `compactionRemainNullKey=true` default.
-- Delete the configuration `compactionRemainNullKey` in 3.3.0 and don't supply an option to retain null-keys.
+- Make `topicCompactionRemainNullKey=false` default  in the 3.2.0.
+- Cherry-pick it to a branch less than 3.2.0 make `topicCompactionRemainNullKey=true` default.
+- Delete the configuration `topicCompactionRemainNullKey` in 3.3.0 and don't supply an option to retain null-keys.
 
 ## Revert
 
-Make `compactionRemainNullKey=true` in broker.conf.
+Make `topicCompactionRemainNullKey=true` in broker.conf/standalone.conf.
 
 ## Upgrade
 
-Make `compactionRemainNullKey=false` in broker.conf.
+Make `topicCompactionRemainNullKey=false` in broker.conf/standalone.conf.
 
 
 # Links

--- a/pip/pip-318.md
+++ b/pip/pip-318.md
@@ -46,4 +46,4 @@ Make `compactionRemainNullKey=false` in broker.conf.
 # Links
 
 * Mailing List discussion thread: https://lists.apache.org/thread/68k6vrghfp3np601lrfx5mbfmghbbrjh
-* Mailing List voting thread: 
+* Mailing List voting thread: https://lists.apache.org/thread/36rfmvz5rchgnvqb2wcq4wb64k6st90p

--- a/pip/pip-318.md
+++ b/pip/pip-318.md
@@ -1,0 +1,49 @@
+# PIP-318: Don't retain null-key messages during topic compaction
+
+# Background knowledge
+
+Apache Pulsar is supported [Topic Compaction](https://pulsar.apache.org/docs/en/concepts-topic-compaction/) which is a key-based data retention mechanism. 
+
+# Motivation
+
+Currently, we retain all null-key messages during topic compaction, which I don't think is necessary because when you use topic compaction, it means that you want to retain the value according to the key, so retaining null-key messages is meaningless.
+
+Additionally, retaining all null-key messages will double the storage cost, and we'll never be able to clean them up since the compacted topic has not supported the retention policy yet.
+
+In summary, I don't think we should retain null-key messages during topic compaction.
+
+# Goals
+
+# High Level Design
+
+In order to avoid introducing break changes to release version, we need to add a configuration to control whether to retain null-key messages during topic compaction.
+If the configuration is true, we will retain null-key messages during topic compaction, otherwise, we will not retain null-key messages during topic compaction.
+
+## Public-facing Changes
+
+### Configuration
+
+Add config to broker.conf
+```properties
+compactionRemainNullKey=false
+```
+
+# Backward & Forward Compatibility
+
+- Make `compactionRemainNullKey=false` default  in the 3.2.0.
+- Cherry-pick it to a branch less than 3.2.0 make `compactionRemainNullKey=true` default.
+- Delete the configuration `compactionRemainNullKey` in 3.3.0 and don't supply an option to retain null-keys.
+
+## Revert
+
+Make `compactionRemainNullKey=true` in broker.conf.
+
+## Upgrade
+
+Make `compactionRemainNullKey=false` in broker.conf.
+
+
+# Links
+
+* Mailing List discussion thread: https://lists.apache.org/thread/68k6vrghfp3np601lrfx5mbfmghbbrjh
+* Mailing List voting thread: 


### PR DESCRIPTION
Motivation & Modifications
Start a PIP: Don't retain null-key messages during topic compaction

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
