### PR TITLE
[fix] [ml] Fix orphan scheduled task for ledger create timeout check

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -4068,7 +4068,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
 
         ScheduledFuture timeoutChecker = scheduledExecutor.schedule(() -> {
-            if (ledgerFutureHook.completeExceptionally(new TimeoutException(name + " Create ledger timeout"))) {
+            if (!ledgerFutureHook.isDone()
+                    && ledgerFutureHook.completeExceptionally(new TimeoutException(name + " Create ledger timeout"))) {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Timeout creating ledger", name);
                 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -4081,9 +4081,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }, config.getMetadataOperationsTimeoutSeconds(), TimeUnit.SECONDS);
 
         ledgerFutureHook.whenComplete((ignore, ex) -> {
-            if (!timeoutChecker.isDone()) {
-                timeoutChecker.cancel(false);
-            }
+            timeoutChecker.cancel(false);
         });
     }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -4106,6 +4106,10 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         assertNotNull(ml.newNonDurableCursor(Position));
     }
 
+    /***
+     * When a ML tries to create a ledger, it will create a delay task to check if the ledger create request is timeout.
+     * But we should guarantee that the delay task should be canceled after the ledger create request responded.
+     */
     @Test
     public void testNoOrphanScheduledTasksAfterCloseML() throws Exception {
         String mlName = UUID.randomUUID().toString();


### PR DESCRIPTION
### Motivation

When an ML tries to create a new ledger, it will create a delay task to check if the ledger create request is timeout<sup>[1]</sup>.

However, we should cancel this delay task after the request to create new ledgers is finished. Otherwise, these tasks will cost unnecessary CPU resources<sup>[2]</sup>.

**[1]**: https://github.com/apache/pulsar/blob/master/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L4070-L4082


```java
bookKeeper.asyncCreateLedger(config.getEnsembleSize(), config.getWriteQuorumSize(), config.getAckQuorumSize(), digestType, config.getPassword(), cb, ledgerCreated, finalMetadata);

scheduledExecutor.schedule(() -> {
    if (!ledgerCreated.get()) {
        cb.createComplete(BKException.Code.TimeoutException, null, ledgerCreated);
    }
}, config.getMetadataOperationsTimeoutSeconds(), TimeUnit.SECONDS);

```

**[2]**: Thousands delay tasks in memory 

<img width="1450" alt="for_pr_1" src="https://github.com/apache/pulsar/assets/25195800/bd287044-6b02-4128-b9ac-2f0548b0a7cd">
<img width="1447" alt="for_pr_2" src="https://github.com/apache/pulsar/assets/25195800/812c7071-ccce-4869-ba30-934d65997cc2">



### Modifications

Cancel the scheduled task after the create ledger request is finished


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
