### PR TITLE
[fix][broker] Fix create topic with different auto creation strategies causes race condition

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1076,8 +1076,7 @@ public class BrokerService implements Closeable {
                                                     properties, topicPolicies);
                                         }
                                         final String errorMsg =
-                                                String.format("Creating a topic encountered an illegal partition name."
-                                                                + " topic_name=%s metadata_partition_number=%s",
+                                                String.format("Illegal topic partition name %s with max allowed %d partitions",
                                                         topicName, metadata.partitions);
                                         log.warn(errorMsg);
                                         return FutureUtil

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1086,8 +1086,7 @@ public class BrokerService implements Closeable {
                         return loadOrCreatePersistentTopic(tpName, createIfMissing, properties, topicPolicies);
                     }).thenCompose(optionalTopic -> {
                         if (!optionalTopic.isPresent() && createIfMissing) {
-                            log.warn("Different topic automatic creation strategies lead to race conditions. "
-                                    + "Try again to try to recover. topic_name={}", topicName);
+                            log.warn("[{}] Try to recreate the topic with createIfMissing=true but the returned topic is empty", topicName);
                             return getTopic(topicName, createIfMissing, properties);
                         }
                         return CompletableFuture.completedFuture(optionalTopic);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1080,7 +1080,7 @@ public class BrokerService implements Closeable {
                                                                 + " topic_name=%s metadata_partition_number=%s",
                                                         topicName, metadata.partitions);
                                         log.warn(info);
-                                        return CompletableFuture
+                                        return FutureUtil
                                                 .failedFuture(new BrokerServiceException.NotAllowedException(info));
                                     });
                         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1081,7 +1081,7 @@ public class BrokerService implements Closeable {
                                                         topicName, metadata.partitions);
                                         log.warn(info);
                                         return CompletableFuture
-                                                .failedFuture(new BrokerServiceException.TopicNotFoundException(info));
+                                                .failedFuture(new BrokerServiceException.NotAllowedException(info));
                                     });
                         }
                         return loadOrCreatePersistentTopic(tpName, createIfMissing, properties, topicPolicies);
@@ -1089,7 +1089,7 @@ public class BrokerService implements Closeable {
                         if (!optionalTopic.isPresent() && createIfMissing) {
                             log.warn("Different topic automatic creation strategies lead to race conditions. "
                                     + "Try again to try to recover. topic_name={}", topicName);
-                            return getTopic(topicName, true, properties);
+                            return getTopic(topicName, createIfMissing, properties);
                         }
                         return CompletableFuture.completedFuture(optionalTopic);
                     });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1081,7 +1081,7 @@ public class BrokerService implements Closeable {
                                                         topicName, metadata.partitions);
                                         log.warn(info);
                                         return CompletableFuture
-                                                .failedFuture(new BrokerServiceException.NamingException(info));
+                                                .failedFuture(new BrokerServiceException.TopicNotFoundException(info));
                                     });
                         }
                         return loadOrCreatePersistentTopic(tpName, createIfMissing, properties, topicPolicies);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1076,8 +1076,8 @@ public class BrokerService implements Closeable {
                                                     properties, topicPolicies);
                                         }
                                         final String errorMsg =
-                                                String.format("Illegal topic partition name %s with max allowed %d partitions",
-                                                        topicName, metadata.partitions);
+                                                String.format("Illegal topic partition name %s with max allowed "
+                                                        + "%d partitions", topicName, metadata.partitions);
                                         log.warn(errorMsg);
                                         return FutureUtil
                                                 .failedFuture(new BrokerServiceException.NotAllowedException(errorMsg));
@@ -1086,7 +1086,8 @@ public class BrokerService implements Closeable {
                         return loadOrCreatePersistentTopic(tpName, createIfMissing, properties, topicPolicies);
                     }).thenCompose(optionalTopic -> {
                         if (!optionalTopic.isPresent() && createIfMissing) {
-                            log.warn("[{}] Try to recreate the topic with createIfMissing=true but the returned topic is empty", topicName);
+                            log.warn("[{}] Try to recreate the topic with createIfMissing=true "
+                                    + "but the returned topic is empty", topicName);
                             return getTopic(topicName, createIfMissing, properties);
                         }
                         return CompletableFuture.completedFuture(optionalTopic);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1075,13 +1075,13 @@ public class BrokerService implements Closeable {
                                             return loadOrCreatePersistentTopic(tpName, createIfMissing,
                                                     properties, topicPolicies);
                                         }
-                                        final String info =
+                                        final String errorMsg =
                                                 String.format("Creating a topic encountered an illegal partition name."
                                                                 + " topic_name=%s metadata_partition_number=%s",
                                                         topicName, metadata.partitions);
-                                        log.warn(info);
+                                        log.warn(errorMsg);
                                         return FutureUtil
-                                                .failedFuture(new BrokerServiceException.NotAllowedException(info));
+                                                .failedFuture(new BrokerServiceException.NotAllowedException(errorMsg));
                                     });
                         }
                         return loadOrCreatePersistentTopic(tpName, createIfMissing, properties, topicPolicies);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -3193,7 +3193,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
             admin.topics().createSubscription(partitionedTopicName + "-partition-" + startPartitions, subName1,
                     MessageId.earliest);
             fail("Unexpected behaviour");
-        } catch (PulsarAdminException.PreconditionFailedException ex) {
+        } catch (PulsarAdminException.ConflictException ex) {
             // OK
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAutoCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAutoCreationTest.java
@@ -193,7 +193,7 @@ public class TopicAutoCreationTest extends ProducerConsumerBase {
     }
 
     @Test
-    public void testAutoCreationGotNotFoundException() throws PulsarAdminException, PulsarClientException {
+    public void testClientWithAutoCreationGotNotFoundException() throws PulsarAdminException, PulsarClientException {
         final String namespace = "public/test_1";
         final String topicName = "persistent://public/test_1/test_auto_creation_got_not_found"
                 + System.currentTimeMillis();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAutoCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAutoCreationTest.java
@@ -233,7 +233,7 @@ public class TopicAutoCreationTest extends ProducerConsumerBase {
             try {
                 adminListSub.join();
             } catch (Throwable ex) {
-                System.out.println(ex);
+                // we don't care the exception.
             }
 
             consumerSub.join().close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -56,7 +56,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import net.bytebuddy.implementation.bytecode.Throw;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -56,6 +56,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import net.bytebuddy.implementation.bytecode.Throw;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;
@@ -457,8 +458,7 @@ public class PersistentTopicTest extends BrokerTestBase {
                     .topic(partition.toString())
                     .create();
             fail("unexpected behaviour");
-        } catch (PulsarClientException.TopicDoesNotExistException ignored) {
-
+        } catch (PulsarClientException.NotAllowedException ex) {
         }
         Assert.assertEquals(admin.topics().getPartitionedTopicMetadata(topicName).partitions, 4);
     }


### PR DESCRIPTION
### Motivation

Fix create a topic with different auto creation strategies causes race conditions.

the problem happened steps are as follows:
(1) Two clients
- consumer
- admin

(2) Admin call `getSubscritpions` and then call broker internal `getTopicIfExists` method.
(3) `getTopicIfExists` method will put a future to `topics` map and then try to open the managed ledger.
(4) Consumer subscription requests get this future from the `topics` map and then wait for the future result.
(5) The topic does not exist. so, it will complete the future with an empty optional object and then trigger the callback.
(6) Callback to admin requests to return a 404 HTTP code.
(7) Callback to consumer subscription requests to return a topic does not exist exception.

But this broker has an auto-creation configuration, so, it doesn't make any sense for the user to receive a topicDoesNotExistException. it should be created automatically.



### Modifications

- Retry when requests get an empty topic optional object with createIfMissing=true.
- Make invalid partition topic name return `NotAllowedException`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

