### PR TITLE
[improve][build] Disable stale bot

### DIFF
--- a/.github/workflows/ci-stale-issue-pr.yaml
+++ b/.github/workflows/ci-stale-issue-pr.yaml
@@ -1,7 +1,9 @@
 name: 'Stale issues and PRs'
-on:
-  schedule:
-    - cron: '30 1 * * *'
+
+# Disabled since we have discovered stale bot normally generate more noise than good
+# on:
+#  schedule:
+#    - cron: '30 1 * * *'
 
 jobs:
   stale:


### PR DESCRIPTION
### Motivation

Stale bot generates more noise than attributing any value to maintaining PR and issues.
There was a [discussion](https://lists.apache.org/thread/0woo9h53t109qsmtxsfqlcxzr16n5mn0) on this hence it's time to make the first step.

### Modifications

Disable the GitHub workflow which triggers the stale check

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

