### PR TITLE
[fix][broker] Fix topic compaction is failed after compactedLedger's all quorum is being recover

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
@@ -238,7 +238,7 @@ public class CompactedTopicImpl implements CompactedTopic {
 
     private static CompletableFuture<CompactedTopicContext> openCompactedLedger(BookKeeper bk, long id) {
         CompletableFuture<LedgerHandle> promise = new CompletableFuture<>();
-        bk.asyncOpenLedger(id,
+        bk.asyncOpenLedgerNoRecovery(id,
                            Compactor.COMPACTED_TOPIC_LEDGER_DIGEST_TYPE,
                            Compactor.COMPACTED_TOPIC_LEDGER_PASSWORD,
                            (rc, ledger, ctx) -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicTest.java
@@ -855,7 +855,7 @@ public class CompactedTopicTest extends MockedPulsarServiceBaseTest {
             Thread.sleep(1500);
             invocation.callRealMethod();
             return null;
-        }).when(bk).asyncOpenLedger(Mockito.anyLong(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+        }).when(bk).asyncOpenLedgerNoRecovery(Mockito.anyLong(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
 
         LedgerHandle oldCompactedLedger = bk.createLedger(1, 1,
                 Compactor.COMPACTED_TOPIC_LEDGER_DIGEST_TYPE,


### PR DESCRIPTION
Fixes #21551

### Motivation

Fix topic compaction is failed after compactedLedger's all quorum is being recover, which is described in issue. 

### Modifications

When CompactedTopicImpl try to open compactedLedger, use asyncOpenLedgerNoRecovery instead of asyncOpenLedger. Then compactedLedger can watch the zk node change and update the ledger metadata in broker.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/TakaHiR07/pulsar/pull/19
