### PR TITLE
[fix][admin] Fix delete cluster not check resource in use.

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/ClusterResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/ClusterResources.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.broker.resources;
 
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -110,9 +110,9 @@ public class ClusterResources extends BaseResources<ClusterData> {
                                 .thenCombineAsync(
                                         currentClusterName.equalsIgnoreCase(clusterName)
                                                 ? getCache().getChildren(joinPath(BASE_POLICIES_PATH, tenant)) :
-                                        CompletableFuture.completedFuture(Lists.newArrayList()),
+                                        CompletableFuture.completedFuture(new ArrayList()),
                                     (v1, v2) -> {
-                                        List<Object> ret = Lists.newArrayList(v1);
+                                        List<Object> ret = new ArrayList<>(v1);
                                         ret.addAll(v2);
                                         return ret;
                                     })

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/ClusterResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/ClusterResources.java
@@ -102,14 +102,17 @@ public class ClusterResources extends BaseResources<ClusterData> {
         return deleteAsync(joinPath(BASE_CLUSTERS_PATH, clusterName));
     }
 
-    public CompletableFuture<Boolean> isClusterUsedAsync(String clusterName) {
+    public CompletableFuture<Boolean> isClusterUsedAsync(String currentClusterName, String clusterName) {
         return getCache().getChildren(BASE_POLICIES_PATH)
                 .thenCompose(tenants -> {
-                    List<CompletableFuture<List<String>>> futures = tenants.stream()
+                    List<CompletableFuture<List<Object>>> futures = tenants.stream()
                             .map(tenant -> getCache().getChildren(joinPath(BASE_POLICIES_PATH, tenant, clusterName))
-                                .thenCombineAsync(getCache().getChildren(joinPath(BASE_POLICIES_PATH, tenant)),
+                                .thenCombineAsync(
+                                        currentClusterName.equalsIgnoreCase(clusterName)
+                                                ? getCache().getChildren(joinPath(BASE_POLICIES_PATH, tenant)) :
+                                        CompletableFuture.completedFuture(Lists.newArrayList()),
                                     (v1, v2) -> {
-                                        List<String> ret = Lists.newArrayList(v1);
+                                        List<Object> ret = Lists.newArrayList(v1);
                                         ret.addAll(v2);
                                         return ret;
                                     })

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
@@ -482,7 +482,8 @@ public class ClustersBase extends AdminResource {
 
     private CompletableFuture<Void> internalDeleteClusterAsync(String cluster) {
         // Check that the cluster is not used by any tenant (eg: no namespaces provisioned there)
-        return pulsar().getPulsarResources().getClusterResources().isClusterUsedAsync(cluster)
+        return pulsar().getPulsarResources().getClusterResources().isClusterUsedAsync(
+                    pulsar().getConfig().getClusterName(), cluster)
                 .thenCompose(isClusterUsed -> {
                     if (isClusterUsed) {
                         throw new RestException(PRECONDITION_FAILED, "Cluster not empty");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -290,6 +290,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void clusters() throws Exception {
+        admin.namespaces().deleteNamespace("prop-xyz/ns1");
         admin.clusters().createCluster("usw",
                 ClusterData.builder().serviceUrl("http://broker.messaging.use.example.com:8080").build());
         // "test" cluster is part of config-default cluster and it's znode gets created when PulsarService creates


### PR DESCRIPTION
### Motivation
When v2 topic is introduced, delete cluster should check path not contain `clusterName`


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


