### PR TITLE
[fix][test] Detects whether an empty object is returned, prevent NPE exception

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -372,7 +372,7 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
     }
 
     // This listener is triggered when topics partitions are updated.
-    public class TopicsPartitionChangedListener implements PartitionsChangedListener {
+    private class TopicsPartitionChangedListener implements PartitionsChangedListener {
         // Check partitions changes of passed in topics, and add new topic partitions.
         @Override
         public CompletableFuture<Void> onTopicsExtended(Collection<String> topicsExtended) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -372,7 +372,7 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
     }
 
     // This listener is triggered when topics partitions are updated.
-    private class TopicsPartitionChangedListener implements PartitionsChangedListener {
+    public class TopicsPartitionChangedListener implements PartitionsChangedListener {
         // Check partitions changes of passed in topics, and add new topic partitions.
         @Override
         public CompletableFuture<Void> onTopicsExtended(Collection<String> topicsExtended) {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
@@ -30,27 +30,29 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.api.client.util.Lists;
+import com.google.common.collect.ImmutableList;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.Timer;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadFactory;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import lombok.Cleanup;
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageRouter;
-import org.apache.pulsar.client.api.MessageRoutingMode;
-import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.TopicMetadata;
+import org.apache.pulsar.client.api.*;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.client.impl.customroute.PartialRoundRobinMessageRouterImpl;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
 import org.assertj.core.util.Sets;
 import org.testng.annotations.BeforeMethod;
@@ -271,6 +273,35 @@ public class PartitionedProducerImplTest {
         ProducerImpl producerImpl = new ProducerImpl(clientImpl, nonPartitionedTopicName, producerConfDataNonPartitioned,
                 null, 0, null, null, Optional.empty());
         assertEquals(producerImpl.getNumOfPartitions(), 0);
+    }
+
+
+    @Test
+    public void testOnTopicsExtended() throws Exception {
+        String topicName = "test-on-topics-extended";
+        ClientConfigurationData conf = new ClientConfigurationData();
+        conf.setServiceUrl("pulsar://localhost:6650");
+        conf.setStatsIntervalSeconds(100);
+        ThreadFactory threadFactory = new DefaultThreadFactory("client-test-stats", Thread.currentThread().isDaemon());
+        @Cleanup("shutdownGracefully")
+        EventLoopGroup eventLoopGroup = EventLoopUtil.newEventLoopGroup(conf.getNumIoThreads(), false, threadFactory);
+
+        @Cleanup
+        PulsarClientImpl clientImpl = new PulsarClientImpl(conf, eventLoopGroup);
+
+        ProducerConfigurationData producerConfData = new ProducerConfigurationData();
+        producerConfData.setMessageRoutingMode(MessageRoutingMode.CustomPartition);
+        producerConfData.setCustomMessageRouter(new CustomMessageRouter());
+
+        PartitionedProducerImpl impl = new PartitionedProducerImpl(
+                clientImpl, topicName, producerConfData, 1, null, null, null);
+        // TopicsPartitionChangedListener
+        PartitionedProducerImpl.TopicsPartitionChangedListener listener = impl.new TopicsPartitionChangedListener();
+        CompletableFuture future = listener.onTopicsExtended(ImmutableList.of("topic"));
+        // When null is returned in method thenCompose we will encounter an NPE exception.
+        // Because the returned value will be applied to the next stage.
+        // We use future instead of null as the return value.
+        assertNotNull(future);
     }
 
 }


### PR DESCRIPTION
an NPE exception is generated when the method return null

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->
Add related test for #21485 
Fixes  #21559 

<!-- or this PR is one task of an issue -->



<!-- If the PR belongs to a PIP, please add the PIP link here -->



<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
Add a unit test to detect if an empty object is returned
### Modifications

The OnTopicsExtended method might return an empty object, which is not allowed,
Because the returned value will be applied to the next stage.

We use future instead of null as the return value.

The test shows that we are not returning an empty object


<!-- Describe the modifications you've done. -->




### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->




