### PR TITLE
[fix][broker] Duplicate LedgerOffloader creation when namespace/topic…

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPoliciesImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPoliciesImpl.java
@@ -30,6 +30,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -86,6 +87,7 @@ public class OffloadPoliciesImpl implements Serializable, OffloadPolicies {
     public static final Long DEFAULT_OFFLOAD_THRESHOLD_IN_BYTES = null;
     public static final Long DEFAULT_OFFLOAD_THRESHOLD_IN_SECONDS = null;
     public static final Long DEFAULT_OFFLOAD_DELETION_LAG_IN_MILLIS = null;
+    public static final String EXTRA_CONFIG_PREFIX = "managedLedgerOffloadExtraConfig";
 
     public static final String OFFLOAD_THRESHOLD_NAME_IN_CONF_FILE =
             "managedLedgerOffloadAutoTriggerSizeThresholdBytes";
@@ -121,8 +123,7 @@ public class OffloadPoliciesImpl implements Serializable, OffloadPolicies {
     private OffloadedReadPriority managedLedgerOffloadedReadPriority = DEFAULT_OFFLOADED_READ_PRIORITY;
     @Configuration
     @JsonProperty(access = JsonProperty.Access.READ_WRITE)
-    private Map<String, String> managedLedgerExtraConfigurations = null;
-
+    private Map<String, String> managedLedgerExtraConfigurations = new HashMap<>();
     // s3 config, set by service configuration or cli
     @Configuration
     @JsonProperty(access = JsonProperty.Access.READ_WRITE)
@@ -248,8 +249,7 @@ public class OffloadPoliciesImpl implements Serializable, OffloadPolicies {
 
     public static OffloadPoliciesImpl create(Properties properties) {
         OffloadPoliciesImpl data = new OffloadPoliciesImpl();
-        Field[] fields = OffloadPoliciesImpl.class.getDeclaredFields();
-        Arrays.stream(fields).forEach(f -> {
+        for (Field f : CONFIGURATION_FIELDS) {
             if (properties.containsKey(f.getName())) {
                 try {
                     f.setAccessible(true);
@@ -260,14 +260,15 @@ public class OffloadPoliciesImpl implements Serializable, OffloadPolicies {
                                     f.getName(), properties.get(f.getName())), e);
                 }
             }
-        });
-        Map<String, String> extraConfigurations = properties.entrySet().stream()
-            .filter(entry -> entry.getKey().toString().startsWith("managedLedgerOffloadExtraConfig"))
-            .collect(Collectors.toMap(
-                entry -> entry.getKey().toString().replaceFirst("managedLedgerOffloadExtraConfig", ""),
-                entry -> entry.getValue().toString()));
+        }
 
-        data.setManagedLedgerExtraConfigurations(extraConfigurations);
+        Map<String, String> extraConfigurations = properties.entrySet().stream()
+                .filter(entry -> entry.getKey().toString().startsWith(EXTRA_CONFIG_PREFIX))
+                .collect(Collectors.toMap(
+                        entry -> entry.getKey().toString().replaceFirst(EXTRA_CONFIG_PREFIX, ""),
+                        entry -> entry.getValue().toString()));
+
+        data.getManagedLedgerExtraConfigurations().putAll(extraConfigurations);
 
         data.compatibleWithBrokerConfigFile(properties);
         return data;
@@ -346,66 +347,21 @@ public class OffloadPoliciesImpl implements Serializable, OffloadPolicies {
 
     public Properties toProperties() {
         Properties properties = new Properties();
-        setProperty(properties, "managedLedgerOffloadedReadPriority", this.getManagedLedgerOffloadedReadPriority());
-        setProperty(properties, "offloadersDirectory", this.getOffloadersDirectory());
-        setProperty(properties, "managedLedgerOffloadDriver", this.getManagedLedgerOffloadDriver());
-        setProperty(properties, "managedLedgerOffloadMaxThreads",
-                this.getManagedLedgerOffloadMaxThreads());
-        setProperty(properties, "managedLedgerOffloadPrefetchRounds",
-                this.getManagedLedgerOffloadPrefetchRounds());
-        setProperty(properties, "managedLedgerOffloadThresholdInBytes",
-                this.getManagedLedgerOffloadThresholdInBytes());
-        setProperty(properties, "managedLedgerOffloadThresholdInSeconds",
-                this.getManagedLedgerOffloadThresholdInSeconds());
-        setProperty(properties, "managedLedgerOffloadDeletionLagInMillis",
-                this.getManagedLedgerOffloadDeletionLagInMillis());
-        setProperty(properties, "managedLedgerOffloadExtraConfigurations",
-                this.getManagedLedgerExtraConfigurations());
-
-        if (this.isS3Driver()) {
-            setProperty(properties, "s3ManagedLedgerOffloadRegion",
-                    this.getS3ManagedLedgerOffloadRegion());
-            setProperty(properties, "s3ManagedLedgerOffloadBucket",
-                    this.getS3ManagedLedgerOffloadBucket());
-            setProperty(properties, "s3ManagedLedgerOffloadServiceEndpoint",
-                    this.getS3ManagedLedgerOffloadServiceEndpoint());
-            setProperty(properties, "s3ManagedLedgerOffloadMaxBlockSizeInBytes",
-                    this.getS3ManagedLedgerOffloadMaxBlockSizeInBytes());
-            setProperty(properties, "s3ManagedLedgerOffloadCredentialId",
-                    this.getS3ManagedLedgerOffloadCredentialId());
-            setProperty(properties, "s3ManagedLedgerOffloadCredentialSecret",
-                    this.getS3ManagedLedgerOffloadCredentialSecret());
-            setProperty(properties, "s3ManagedLedgerOffloadRole",
-                    this.getS3ManagedLedgerOffloadRole());
-            setProperty(properties, "s3ManagedLedgerOffloadRoleSessionName",
-                    this.getS3ManagedLedgerOffloadRoleSessionName());
-            setProperty(properties, "s3ManagedLedgerOffloadReadBufferSizeInBytes",
-                    this.getS3ManagedLedgerOffloadReadBufferSizeInBytes());
-        } else if (this.isGcsDriver()) {
-            setProperty(properties, "gcsManagedLedgerOffloadRegion",
-                    this.getGcsManagedLedgerOffloadRegion());
-            setProperty(properties, "gcsManagedLedgerOffloadBucket",
-                    this.getGcsManagedLedgerOffloadBucket());
-            setProperty(properties, "gcsManagedLedgerOffloadMaxBlockSizeInBytes",
-                    this.getGcsManagedLedgerOffloadMaxBlockSizeInBytes());
-            setProperty(properties, "gcsManagedLedgerOffloadReadBufferSizeInBytes",
-                    this.getGcsManagedLedgerOffloadReadBufferSizeInBytes());
-            setProperty(properties, "gcsManagedLedgerOffloadServiceAccountKeyFile",
-                    this.getGcsManagedLedgerOffloadServiceAccountKeyFile());
-        } else if (this.isFileSystemDriver()) {
-            setProperty(properties, "fileSystemProfilePath", this.getFileSystemProfilePath());
-            setProperty(properties, "fileSystemURI", this.getFileSystemURI());
+        for (Field f : CONFIGURATION_FIELDS) {
+            try {
+                f.setAccessible(true);
+                if (f.getName() == "managedLedgerExtraConfigurations") {
+                    Map<String, String> extraConfig = (Map<String, String>) f.get(this);
+                    extraConfig.forEach((key, value) -> {
+                        setProperty(properties, EXTRA_CONFIG_PREFIX + key, value);
+                    });
+                } else {
+                    setProperty(properties, f.getName(), f.get(this));
+                }
+            } catch (Exception e) {
+                throw new IllegalArgumentException("An error occurred while processing the field: " + f.getName(), e);
+            }
         }
-
-        setProperty(properties, "managedLedgerOffloadBucket", this.getManagedLedgerOffloadBucket());
-        setProperty(properties, "managedLedgerOffloadRegion", this.getManagedLedgerOffloadRegion());
-        setProperty(properties, "managedLedgerOffloadServiceEndpoint",
-                this.getManagedLedgerOffloadServiceEndpoint());
-        setProperty(properties, "managedLedgerOffloadMaxBlockSizeInBytes",
-                this.getManagedLedgerOffloadMaxBlockSizeInBytes());
-        setProperty(properties, "managedLedgerOffloadReadBufferSizeInBytes",
-                this.getManagedLedgerOffloadReadBufferSizeInBytes());
-
         return properties;
     }
 


### PR DESCRIPTION
### Motivation
#21590 

When namespace/topic policies are updated, will call this method to try to apply new policies of offload.

https://github.com/apache/pulsar/blob/eebd821e00aaabb15e0ddfa9516f854c9bfacdec/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java#L1373-L1392

But, in this case(#21590), Never hit 1380 lines. `offloader.getOffloadPolicies()` and  `offloadPolicies` are always unequal.


**Reason:**

1. In #21590 reproduce step, set a useless config: `fileSystemProfilePath`, because it has been set to `managedLedgerOffloadDriver=aws-s3`.
2. This configuration is then ignored when [converted to properties](https://github.com/apache/pulsar/blob/v3.1.1/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPoliciesImpl.java#L395-L398), then `offloader.getOffloadPolicies()` result not be included `fileSystemProfilePath`
3. `offloadPolicies` is built from the broker configuration, which contains this configuration.
4. So, the two are not equal

**Note:**
In v3.1 after. This pr: #20804 introduces a `managedLedgerExtraConfigurations` variable, which is also always unequal if the user does not set the value. (`null` vs `empty map`)

So after v3.1, In this case(#21590), this issue will appear regardless of whether you have `fileSystemProfilePath` set.


### Modifications
- Changed `toProperties` method:  Regardless of the user's configuration, we should all convert.
- The `toProperties` and `create(Properties properties)` methods should be complementary.
- Fix `managedLedgerExtraConfigurations` conversion issue. 


### Verifying this change


### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

