### PR TITLE
[fix] [broker] Delete topic timeout due to NPE

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -690,7 +690,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             position = ledger.getLastPosition();
         }
         log.info("[{}] Cursor {} recovered to position {}", ledger.getName(), name, position);
-        this.cursorProperties = cursorProperties;
+        this.cursorProperties = cursorProperties == null ? Collections.emptyMap(): cursorProperties;
         messagesConsumedCounter = -getNumberOfEntries(Range.openClosed(position, ledger.getLastPosition()));
         markDeletePosition = position;
         persistentMarkDeletePosition = position;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -690,7 +690,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             position = ledger.getLastPosition();
         }
         log.info("[{}] Cursor {} recovered to position {}", ledger.getName(), name, position);
-        this.cursorProperties = cursorProperties == null ? Collections.emptyMap(): cursorProperties;
+        this.cursorProperties = cursorProperties == null ? Collections.emptyMap() : cursorProperties;
         messagesConsumedCounter = -getNumberOfEntries(Range.openClosed(position, ledger.getLastPosition()));
         markDeletePosition = position;
         persistentMarkDeletePosition = position;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/BucketDelayedDeliveryTrackerFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/BucketDelayedDeliveryTrackerFactory.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.delayed.bucket.BookkeeperBucketSnapshotStorage;
@@ -87,7 +88,7 @@ public class BucketDelayedDeliveryTrackerFactory implements DelayedDeliveryTrack
      */
     public CompletableFuture<Void> cleanResidualSnapshots(ManagedCursor cursor) {
         Map<String, String> cursorProperties = cursor.getCursorProperties();
-        if (cursorProperties == null) {
+        if (MapUtils.isEmpty(cursorProperties)) {
             return CompletableFuture.completedFuture(null);
         }
         List<CompletableFuture<Void>> futures = new ArrayList<>();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/BucketDelayedDeliveryTrackerFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/BucketDelayedDeliveryTrackerFactory.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.pulsar.broker.PulsarService;
@@ -37,7 +36,6 @@ import org.apache.pulsar.broker.delayed.bucket.BucketSnapshotStorage;
 import org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers;
 import org.apache.pulsar.common.util.FutureUtil;
 
-@Slf4j
 public class BucketDelayedDeliveryTrackerFactory implements DelayedDeliveryTrackerFactory {
 
     BucketSnapshotStorage bucketSnapshotStorage;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/BucketDelayedDeliveryTrackerFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/BucketDelayedDeliveryTrackerFactory.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -35,6 +36,7 @@ import org.apache.pulsar.broker.delayed.bucket.BucketSnapshotStorage;
 import org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers;
 import org.apache.pulsar.common.util.FutureUtil;
 
+@Slf4j
 public class BucketDelayedDeliveryTrackerFactory implements DelayedDeliveryTrackerFactory {
 
     BucketSnapshotStorage bucketSnapshotStorage;
@@ -85,6 +87,9 @@ public class BucketDelayedDeliveryTrackerFactory implements DelayedDeliveryTrack
      */
     public CompletableFuture<Void> cleanResidualSnapshots(ManagedCursor cursor) {
         Map<String, String> cursorProperties = cursor.getCursorProperties();
+        if (cursorProperties == null) {
+            return CompletableFuture.completedFuture(null);
+        }
         List<CompletableFuture<Void>> futures = new ArrayList<>();
         FutureUtil.Sequencer<Void> sequencer = FutureUtil.Sequencer.create();
         cursorProperties.forEach((k, v) -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
@@ -50,6 +50,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.mutable.MutableLong;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.delayed.AbstractDelayedDeliveryTracker;
@@ -137,9 +138,13 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
     private synchronized long recoverBucketSnapshot() throws RuntimeException {
         ManagedCursor cursor = this.lastMutableBucket.getCursor();
+        Map<String, String> cursorProperties = cursor.getCursorProperties();
+        if (MapUtils.isEmpty(cursorProperties)) {
+            return 0;
+        }
         FutureUtil.Sequencer<Void> sequencer = this.lastMutableBucket.getSequencer();
         Map<Range<Long>, ImmutableBucket> toBeDeletedBucketMap = new HashMap<>();
-        cursor.getCursorProperties().keySet().forEach(key -> {
+        cursorProperties.keySet().forEach(key -> {
             if (key.startsWith(DELAYED_BUCKET_KEY_PREFIX)) {
                 String[] keys = key.split(DELIMITER);
                 checkArgument(keys.length == 3);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/BucketDelayedDeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/BucketDelayedDeliveryTest.java
@@ -52,6 +52,7 @@ import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker")
@@ -359,18 +360,29 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
         }
     }
 
+    @DataProvider(name = "subscriptionTypes")
+    public Object[][] subscriptionTypes() {
+        return new Object[][]{
+                {SubscriptionType.Shared},
+                {SubscriptionType.Key_Shared},
+                {SubscriptionType.Failover},
+                {SubscriptionType.Exclusive},
+        };
+    }
+
     /**
      * see: https://github.com/apache/pulsar/pull/21595.
      */
-    @Test
-    public void testDeleteTopicIfCursorPropsEmpty() throws Exception {
+    @Test(dataProvider = "subscriptionTypes")
+    public void testDeleteTopicIfCursorPropsEmpty(SubscriptionType subscriptionType) throws Exception {
         final String topic = BrokerTestUtil.newUniqueName("persistent://my-property/my-ns/tp_");
         final String subscriptionName = "s1";
         // create a topic.
         admin.topics().createNonPartitionedTopic(topic);
         // create a subscription without props.
         admin.topics().createSubscription(topic, subscriptionName, MessageId.earliest);
-        pulsarClient.newConsumer().topic(topic).subscriptionName(subscriptionName).subscribe().close();
+        pulsarClient.newConsumer().topic(topic).subscriptionName(subscriptionName)
+                .subscriptionType(subscriptionType).subscribe().close();
         ManagedCursorImpl cursor = findCursor(topic, subscriptionName);
         assertNotNull(cursor);
         assertTrue(cursor.getCursorProperties() == null || cursor.getCursorProperties().isEmpty());
@@ -381,14 +393,16 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
     /**
      * see: https://github.com/apache/pulsar/pull/21595.
      */
-    @Test
-    public void testDeletePartitionedTopicIfCursorPropsEmpty() throws Exception {
+    @Test(dataProvider = "subscriptionTypes")
+    public void testDeletePartitionedTopicIfCursorPropsEmpty(SubscriptionType subscriptionType) throws Exception {
         final String topic = BrokerTestUtil.newUniqueName("persistent://my-property/my-ns/tp_");
         final String subscriptionName = "s1";
         // create a topic.
         admin.topics().createPartitionedTopic(topic, 2);
         // create a subscription without props.
         admin.topics().createSubscription(topic, subscriptionName, MessageId.earliest);
+        pulsarClient.newConsumer().topic(topic).subscriptionName(subscriptionName)
+                .subscriptionType(subscriptionType).subscribe().close();
         ManagedCursorImpl cursor = findCursor(topic + "-partition-0", subscriptionName);
         assertNotNull(cursor);
         assertTrue(cursor.getCursorProperties() == null || cursor.getCursorProperties().isEmpty());
@@ -399,14 +413,16 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
     /**
      * see: https://github.com/apache/pulsar/pull/21595.
      */
-    @Test
-    public void testDeleteTopicIfCursorPropsNotEmpty() throws Exception {
+    @Test(dataProvider = "subscriptionTypes")
+    public void testDeleteTopicIfCursorPropsNotEmpty(SubscriptionType subscriptionType) throws Exception {
         final String topic = BrokerTestUtil.newUniqueName("persistent://my-property/my-ns/tp_");
         final String subscriptionName = "s1";
         // create a topic.
         admin.topics().createNonPartitionedTopic(topic);
         // create a subscription without props.
         admin.topics().createSubscription(topic, subscriptionName, MessageId.earliest);
+        pulsarClient.newConsumer().topic(topic).subscriptionName(subscriptionName)
+                .subscriptionType(subscriptionType).subscribe().close();
         ManagedCursorImpl cursor = findCursor(topic, subscriptionName);
         assertNotNull(cursor);
         assertTrue(cursor.getCursorProperties() == null || cursor.getCursorProperties().isEmpty());
@@ -422,8 +438,8 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
     /**
      * see: https://github.com/apache/pulsar/pull/21595.
      */
-    @Test
-    public void testDeletePartitionedTopicIfCursorPropsNotEmpty() throws Exception {
+    @Test(dataProvider = "subscriptionTypes")
+    public void testDeletePartitionedTopicIfCursorPropsNotEmpty(SubscriptionType subscriptionType) throws Exception {
         final String topic = BrokerTestUtil.newUniqueName("persistent://my-property/my-ns/tp_");
         final String subscriptionName = "s1";
         // create a topic.
@@ -431,7 +447,8 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
         pulsarClient.newProducer().topic(topic).create().close();
         // create a subscription without props.
         admin.topics().createSubscription(topic, subscriptionName, MessageId.earliest);
-        pulsarClient.newConsumer().topic(topic).subscriptionName(subscriptionName).subscribe().close();
+        pulsarClient.newConsumer().topic(topic).subscriptionName(subscriptionName)
+                .subscriptionType(subscriptionType).subscribe().close();
 
         ManagedCursorImpl cursor = findCursor(topic + "-partition-0", subscriptionName);
         assertNotNull(cursor);


### PR DESCRIPTION
### Motivation

**Background:**
- `BucketDelayedDeliveryTrackerFactory` was added with [PIP-195: New bucket based delayed message tracker](https://github.com/apache/pulsar/issues/16763)
  -  `BucketDelayedDeliveryTrackerFactory` will be initialized if setting config `setDelayedDeliveryTrackerFactoryClassName` to `BucketDelayedDeliveryTrackerFactory`
  - Pulsar will delete the delay message indexes bucket when a subscription is unsubscribing.

**Issue:**
There is an NPE that causes the Future of Delay message indexes bucket deletion to be no longer complete, which leads to the topic deletion timeout. You can reproduce this issue by the test `testDeletePartitionedTopicIfCursorPropsEmpty` and `testDeleteTopicIfCursorPropsEmpty`


**Issue logs:**

```
2023-11-16T17:53:00,154+0000 [delayer-53-1] WARN  org.apache.pulsar.client.admin.internal.BaseResource - [http://xxx:8080/admin/v2/persistent/public/default/tp1-partition-0?force=true&deleteSchema=true] Failed to perform http delete request: java.util.concurrent.CompletionException: org.apache.pulsar.common.util.FutureUtil$LowOverheadTimeoutException: Read timeout
2023-11-16T17:53:00,154+0000 [delayer-53-1] ERROR org.apache.pulsar.broker.admin.impl.PersistentTopicsBase - [11c16270-bb0f-42bf-9e53-f4a94c6e98c3] Failed to delete partition persistent://public/default/tp1-partition-0
org.apache.pulsar.client.admin.PulsarAdminException: java.util.concurrent.CompletionException: org.apache.pulsar.common.util.FutureUtil$LowOverheadTimeoutException: Read timeout
	at org.apache.pulsar.client.admin.internal.BaseResource.getApiException(BaseResource.java:300) ~[org.apache.pulsar-pulsar-client-admin-original-3.0.1.jar:3.0.1]
	at org.apache.pulsar.client.admin.internal.BaseResource$4.failed(BaseResource.java:237) ~[org.apache.pulsar-pulsar-client-admin-original-3.0.1.jar:3.0.1]
	at org.glassfish.jersey.client.JerseyInvocation$1.failed(JerseyInvocation.java:882) ~[org.glassfish.jersey.core-jersey-client-2.34.jar:?]
	at org.glassfish.jersey.client.ClientRuntime.processFailure(ClientRuntime.java:247) ~[org.glassfish.jersey.core-jersey-client-2.34.jar:?]
	at org.glassfish.jersey.client.ClientRuntime.processFailure(ClientRuntime.java:242) ~[org.glassfish.jersey.core-jersey-client-2.34.jar:?]
	at org.glassfish.jersey.client.ClientRuntime.access$100(ClientRuntime.java:62) ~[org.glassfish.jersey.core-jersey-client-2.34.jar:?]
	at org.glassfish.jersey.client.ClientRuntime$2.lambda$failure$1(ClientRuntime.java:178) ~[org.glassfish.jersey.core-jersey-client-2.34.jar:?]
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248) ~[org.glassfish.jersey.core-jersey-common-2.34.jar:?]
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244) ~[org.glassfish.jersey.core-jersey-common-2.34.jar:?]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292) ~[org.glassfish.jersey.core-jersey-common-2.34.jar:?]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274) ~[org.glassfish.jersey.core-jersey-common-2.34.jar:?]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:244) ~[org.glassfish.jersey.core-jersey-common-2.34.jar:?]
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:288) ~[org.glassfish.jersey.core-jersey-common-2.34.jar:?]
	at org.glassfish.jersey.client.ClientRuntime$2.failure(ClientRuntime.java:178) ~[org.glassfish.jersey.core-jersey-client-2.34.jar:?]
	at org.apache.pulsar.client.admin.internal.http.AsyncHttpConnector.lambda$apply$1(AsyncHttpConnector.java:227) ~[org.apache.pulsar-pulsar-client-admin-original-3.0.1.jar:3.0.1]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2162) ~[?:?]
	at org.apache.pulsar.common.util.FutureUtil.lambda$addTimeoutHandling$9(FutureUtil.java:236) ~[org.apache.pulsar-pulsar-common-3.0.1.jar:3.0.1]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: java.util.concurrent.CompletionException: org.apache.pulsar.common.util.FutureUtil$LowOverheadTimeoutException: Read timeout
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:332) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:347) ~[?:?]
	at java.util.concurrent.CompletableFuture$OrApply.tryFire(CompletableFuture.java:1576) ~[?:?]
	at java.util.concurrent.CompletableFuture$CoCompletion.tryFire(CompletableFuture.java:1219) ~[?:?]
	... 10 more
Caused by: org.apache.pulsar.common.util.FutureUtil$LowOverheadTimeoutException: Read timeout
	at org.apache.pulsar.client.admin.internal.http.AsyncHttpConnector.retryOrTimeout(...)(Unknown Source) ~[org.apache.pulsar-pulsar-client-admin-original-3.0.1.jar:3.0.1]
2023-11-16T17:53:00,160+0000 [configuration-metadata-store-13-1] INFO  org.eclipse.jetty.server.RequestLog - 172.16.167.53 - - [16/Nov/2023:17:52:29 +0000] "DELETE /admin/v2/persistent/public/default/tp1/partitions?force=true HTTP/1.1" 500 2 "-" "PostmanRuntime/7.34.0" 30256
```

<img width="1255" alt="Screenshot 2023-11-20 at 19 14 44" src="https://github.com/apache/pulsar/assets/25195800/bb021bb8-367e-4b63-8d40-17a748ee4ade">


### Modifications

Fix the NPE.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x