### PR TITLE
[fix][broker] Fix issue with GetMessageIdByTimestamp can't find match messageId from compacted ledger

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -22,7 +22,6 @@ import static org.apache.pulsar.common.naming.SystemTopicNames.isSystemTopic;
 import static org.apache.pulsar.common.naming.SystemTopicNames.isTransactionCoordinatorAssign;
 import static org.apache.pulsar.common.naming.SystemTopicNames.isTransactionInternalName;
 import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.github.zafarkhaja.semver.Version;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.compaction;
 
 import static org.apache.pulsar.common.protocol.Commands.DEFAULT_CONSUMER_EPOCH;
-
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
@@ -53,7 +52,6 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.RawMessage;
 import org.apache.pulsar.client.impl.RawMessageImpl;
 import org.apache.pulsar.common.api.proto.MessageIdData;
-import org.apache.pulsar.common.protocol.Commands;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -323,12 +321,6 @@ public class CompactedTopicImpl implements CompactedTopic {
         });
     }
 
-    public CompletableFuture<Entry> findEntryByPublishTime(long publishTime) {
-        final Predicate<Entry> predicate = entry -> {
-            return Commands.parseMessageMetadata(entry.getDataBuffer()).getPublishTime() >= publishTime;
-        };
-        return findFirstMatchEntry(predicate);
-    }
     CompletableFuture<Entry> findFirstMatchEntry(final Predicate<Entry> predicate) {
         var compactedTopicContextFuture = this.getCompactedTopicContextFuture();
 
@@ -348,10 +340,10 @@ public class CompactedTopicImpl implements CompactedTopic {
         });
     }
     private static void findFirstMatchIndexLoop(final Predicate<Entry> predicate,
-                                           final long start, final long end,
-                                           final CompletableFuture<Long> promise,
-                                           final Long lastMatchIndex,
-                                           final LedgerHandle lh) {
+                                                final long start, final long end,
+                                                final CompletableFuture<Long> promise,
+                                                final Long lastMatchIndex,
+                                                final LedgerHandle lh) {
         if (start > end) {
             promise.complete(lastMatchIndex);
             return;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/PulsarTopicCompactionService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/PulsarTopicCompactionService.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.pulsar.compaction.CompactedTopicImpl.COMPACT_LEDGER_EMPTY;
 import static org.apache.pulsar.compaction.CompactedTopicImpl.NEWER_THAN_COMPACTED;
 import static org.apache.pulsar.compaction.CompactedTopicImpl.findStartPoint;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/PulsarTopicCompactionService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/PulsarTopicCompactionService.java
@@ -22,7 +22,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.pulsar.compaction.CompactedTopicImpl.COMPACT_LEDGER_EMPTY;
 import static org.apache.pulsar.compaction.CompactedTopicImpl.NEWER_THAN_COMPACTED;
 import static org.apache.pulsar.compaction.CompactedTopicImpl.findStartPoint;
-import static org.apache.pulsar.compaction.CompactedTopicImpl.readEntries;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -33,7 +33,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import org.apache.bookkeeper.client.BookKeeper;
-import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
@@ -116,7 +115,7 @@ public class PulsarTopicCompactionService implements TopicCompactionService {
         final Predicate<Entry> predicate = entry -> {
             return Commands.parseMessageMetadata(entry.getDataBuffer()).getPublishTime() >= publishTime;
         };
-        return findFirstMatchEntry(predicate);
+        return compactedTopic.findFirstMatchEntry(predicate);
     }
 
     @Override
@@ -128,57 +127,7 @@ public class PulsarTopicCompactionService implements TopicCompactionService {
             }
             return brokerEntryMetadata.getIndex() >= entryIndex;
         };
-        return findFirstMatchEntry(predicate);
-    }
-
-    private CompletableFuture<Entry> findFirstMatchEntry(final Predicate<Entry> predicate) {
-        var compactedTopicContextFuture = compactedTopic.getCompactedTopicContextFuture();
-
-        if (compactedTopicContextFuture == null) {
-            return CompletableFuture.completedFuture(null);
-        }
-        return compactedTopicContextFuture.thenCompose(compactedTopicContext -> {
-            LedgerHandle lh = compactedTopicContext.getLedger();
-            CompletableFuture<Long> promise = new CompletableFuture<>();
-            findFirstMatchIndexLoop(predicate, 0L, lh.getLastAddConfirmed(), promise, null, lh);
-            return promise.thenCompose(index -> {
-                if (index == null) {
-                    return CompletableFuture.completedFuture(null);
-                }
-                return readEntries(lh, index, index).thenApply(entries -> entries.get(0));
-            });
-        });
-    }
-
-    private static void findFirstMatchIndexLoop(final Predicate<Entry> predicate,
-                                           final long start, final long end,
-                                           final CompletableFuture<Long> promise,
-                                           final Long lastMatchIndex,
-                                           final LedgerHandle lh) {
-        if (start > end) {
-            promise.complete(lastMatchIndex);
-            return;
-        }
-
-        long mid = (start + end) / 2;
-        readEntries(lh, mid, mid).thenAccept(entries -> {
-            Entry entry = entries.get(0);
-            final boolean isMatch;
-            try {
-                isMatch = predicate.test(entry);
-            } finally {
-                entry.release();
-            }
-
-            if (isMatch) {
-                findFirstMatchIndexLoop(predicate, start, mid - 1, promise, mid, lh);
-            } else {
-                findFirstMatchIndexLoop(predicate, mid + 1, end, promise, lastMatchIndex, lh);
-            }
-        }).exceptionally(ex -> {
-            promise.completeExceptionally(ex);
-            return null;
-        });
+        return compactedTopic.findFirstMatchEntry(predicate);
     }
 
     public CompactedTopicImpl getCompactedTopic() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -1468,7 +1468,6 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("test"));
         admin.tenants().createTenant("tenant-xyz", tenantInfo);
         admin.namespaces().createNamespace("tenant-xyz/ns-abc", Set.of("test"));
-        admin.namespaces().setCompactionThreshold("tenant-xyz/ns-abc", 100*1024*1024L);
         final String topicName = "persistent://tenant-xyz/ns-abc/testGetMessageIdByTimestampWithCompaction";
         admin.topics().createNonPartitionedTopic(topicName);
 


### PR DESCRIPTION
<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

Currently, if topic compaction is enabled and the original ledger is trimmed, we won't be able to get the correct messageID by `publishTime`, we should first try to find messageID from the compacted ledger. Since we introduced the findEntryByPublishTime method in [PIP-286](https://github.com/apache/pulsar/pull/20867), we can easily implement it.

### Modifications

* Try to find messageID from the compacted ledger when getting messageID by publishTime.
* Move `findFirstMatchEntry` and `findFirstMatchIndexLoop` methods to `CompactedTopicImpl` to cherry-pick this change into branches before 3.1.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
