### PR TITLE
[fix][test] Fix flaky test ManagedLedgerTest#testManagedLedgerRollOverIfFull

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3456,7 +3456,6 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setRetentionTime(1, TimeUnit.SECONDS);
         config.setMaxEntriesPerLedger(2);
-        config.setMinimumRolloverTime(1, TimeUnit.MILLISECONDS);
         config.setMaximumRolloverTime(500, TimeUnit.MILLISECONDS);
 
         ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("test_managedLedger_rollOver", config);


### PR DESCRIPTION
Main Issue: #21603 

### Motivation
The root cause is `timeSinceLedgerCreationMs` > `minimumRolloverTimeMs` and the ledger is not rollover
see:
https://github.com/apache/pulsar/blob/d1b7d0b7d86a7a8883407d3dc054bb8e21f96d60/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L3809-L3836
log:
```
2023-11-22T15:53:43,503 - INFO  - [test-OrderedScheduler-0-0:ManagedLedgerImpl@1574] - [test_managedLedger_rollOver] Created new ledger 4
2023-11-22T15:53:43,510 - INFO  - [test-OrderedScheduler-0-0:ManagedLedgerImpl@3826] - Diff: 1, threshold: 1 -- switch: false
2023-11-22T15:53:43,512 - INFO  - [test-OrderedScheduler-0-0:ManagedLedgerImpl@3826] - Diff: 3, threshold: 1 -- switch: true
2023-11-22T15:53:43,514 - INFO  - [test-OrderedScheduler-0-0:OpAddEntry@245] - [test_managedLedger_rollOver] Closing ledger 4 for being full
2023-11-22T15:53:43,514 - INFO  - [test-OrderedScheduler-0-0:ManagedLedgerImpl@835] - [test_managedLedger_rollOver] Creating a new ledger
2023-11-22T15:53:43,514 - INFO  - [test-OrderedScheduler-0-0:PulsarMockBookKeeper@123] - Creating ledger 5
2023-11-22T15:53:43,514 - INFO  - [test-OrderedScheduler-0-0:ManagedLedgerImpl@1574] - [test_managedLedger_rollOver] Created new ledger 5
2023-11-22T15:53:43,517 - INFO  - [test-OrderedScheduler-0-0:ManagedLedgerImpl@3826] - Diff: 1, threshold: 1 -- switch: false
2023-11-22T15:53:43,519 - INFO  - [test-OrderedScheduler-0-0:ManagedLedgerImpl@3826] - Diff: 3, threshold: 1 -- switch: true
2023-11-22T15:53:43,520 - INFO  - [test-OrderedScheduler-0-0:OpAddEntry@245] - [test_managedLedger_rollOver] Closing ledger 5 for being full
2023-11-22T15:53:43,521 - INFO  - [test-OrderedScheduler-0-0:ManagedLedgerImpl@835] - [test_managedLedger_rollOver] Creating a new ledger
2023-11-22T15:53:43,521 - INFO  - [test-OrderedScheduler-0-0:PulsarMockBookKeeper@123] - Creating ledger 6
2023-11-22T15:53:43,521 - INFO  - [test-OrderedScheduler-0-0:ManagedLedgerImpl@1574] - [test_managedLedger_rollOver] Created new ledger 6
2023-11-22T15:53:43,523 - INFO  - [test-OrderedScheduler-0-0:ManagedLedgerImpl@3826] - Diff: 2, threshold: 1 -- switch: true
2023-11-22T15:53:43,524 - INFO  - [test-OrderedScheduler-0-0:OpAddEntry@245] - [test_managedLedger_rollOver] Closing ledger 6 for being full
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


