### PR TITLE
[improve][client] Ignore InterruptedException when pulsar-perf finishing

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -581,7 +581,11 @@ public class PerformanceProducer {
                             log.info("------------- DONE (reached the maximum duration: [{} seconds] of production) "
                                     + "--------------", arguments.testTime);
                             doneLatch.countDown();
-                            Thread.sleep(5000);
+                            try {
+                                Thread.sleep(5000);
+                            } catch (InterruptedException e) {
+                                // ignore this
+                            }
                             produceEnough = true;
                             break;
                         }
@@ -592,7 +596,11 @@ public class PerformanceProducer {
                             log.info("------------- DONE (reached the maximum number: {} of production) --------------"
                                     , numMessages);
                             doneLatch.countDown();
-                            Thread.sleep(5000);
+                            try {
+                                Thread.sleep(5000);
+                            } catch (InterruptedException e) {
+                                // ignore this
+                            }
                             produceEnough = true;
                             break;
                         }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -581,11 +581,6 @@ public class PerformanceProducer {
                             log.info("------------- DONE (reached the maximum duration: [{} seconds] of production) "
                                     + "--------------", arguments.testTime);
                             doneLatch.countDown();
-                            try {
-                                Thread.sleep(5000);
-                            } catch (InterruptedException e) {
-                                // ignore this
-                            }
                             produceEnough = true;
                             break;
                         }
@@ -596,11 +591,6 @@ public class PerformanceProducer {
                             log.info("------------- DONE (reached the maximum number: {} of production) --------------"
                                     , numMessages);
                             doneLatch.countDown();
-                            try {
-                                Thread.sleep(5000);
-                            } catch (InterruptedException e) {
-                                // ignore this
-                            }
                             produceEnough = true;
                             break;
                         }


### PR DESCRIPTION
### Motivation

If I run the command `bin/pulsar-perf produce my-topic -time 5`, it returns a `java.lang.InterruptedException` before it exits.

<img width="1561" alt="image" src="https://github.com/apache/pulsar/assets/10069311/d889d2b8-79cd-4453-85d2-036cefda07f0">

The reason is that `doneLatch`  will be zero before `sleep(5000)`, and the main thread exits 0 when `doneLatch<=0`, so the `pulsar-perf-producer-exec` thread pool will be terminated and has a chance to throw an `InterruptedException` if it starts to run `sleep(5000)`.

https://github.com/apache/pulsar/blob/d1b7d0b7d86a7a8883407d3dc054bb8e21f96d60/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java#L583-L584


https://github.com/apache/pulsar/blob/d1b7d0b7d86a7a8883407d3dc054bb8e21f96d60/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java#L381-L390
https://github.com/apache/pulsar/blob/d1b7d0b7d86a7a8883407d3dc054bb8e21f96d60/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java#L435-L436

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

https://github.com/yaalsn/pulsar/pull/3
