### PR TITLE
[fix][sec] Upgrade rabbitmq client to address CVE-2023-46120

### DIFF
--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -155,6 +155,12 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>amqp-client</artifactId>
+          <groupId>com.rabbitmq</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -499,8 +499,6 @@ The Apache Software License, Version 2.0
     - com.github.seancfoley-ipaddress-5.3.3.jar
   * RxJava
     - io.reactivex.rxjava3-rxjava-3.0.1.jar
-  * RabbitMQ Java Client
-    - com.rabbitmq-amqp-client-5.18.0.jar
   * RoaringBitmap
     - org.roaringbitmap-RoaringBitmap-0.9.44.jar
 

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -500,7 +500,7 @@ The Apache Software License, Version 2.0
   * RxJava
     - io.reactivex.rxjava3-rxjava-3.0.1.jar
   * RabbitMQ Java Client
-    - com.rabbitmq-amqp-client-5.5.3.jar
+    - com.rabbitmq-amqp-client-5.18.0.jar
   * RoaringBitmap
     - org.roaringbitmap-RoaringBitmap-0.9.44.jar
 

--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -47,6 +47,12 @@
       <groupId>org.apache.bookkeeper.stats</groupId>
       <artifactId>codahale-metrics-provider</artifactId>
       <version>${bookkeeper.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>amqp-client</artifactId>
+          <groupId>com.rabbitmq</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@ flexible messaging model and an intuitive client API.</description>
     <cassandra.version>3.11.2</cassandra.version>
     <aerospike-client.version>4.4.20</aerospike-client.version>
     <kafka-client.version>3.4.0</kafka-client.version>
-    <rabbitmq-client.version>5.5.3</rabbitmq-client.version>
+    <rabbitmq-client.version>5.18.0</rabbitmq-client.version>
     <aws-sdk.version>1.12.262</aws-sdk.version>
     <avro.version>1.11.3</avro.version>
     <joda.version>2.10.10</joda.version>

--- a/pom.xml
+++ b/pom.xml
@@ -401,6 +401,12 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-graphite</artifactId>
         <version>${dropwizardmetrics.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.rabbitmq</groupId>
+            <artifactId>amqp-client</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -479,7 +479,7 @@ The Apache Software License, Version 2.0
   * Perfmark
     - perfmark-api-0.26.0.jar
   * RabbitMQ Java Client
-    - amqp-client-5.5.3.jar
+    - amqp-client-5.18.0.jar
   * Stream Lib
     - stream-2.9.5.jar
   * High Performance Primitive Collections for Java

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -478,8 +478,6 @@ The Apache Software License, Version 2.0
     - audience-annotations-0.12.0.jar
   * Perfmark
     - perfmark-api-0.26.0.jar
-  * RabbitMQ Java Client
-    - amqp-client-5.18.0.jar
   * Stream Lib
     - stream-2.9.5.jar
   * High Performance Primitive Collections for Java


### PR DESCRIPTION
### Motivation
owasp-dependency-check failed due to [CVE-2023-46120](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-46120).
All the releases between 5.5.3 and 5.18.0 are maintenance releases with usability improvement, bug fixes, and dependency upgrades. All users are encouraged to upgrade.

Release notes: 
https://github.com/rabbitmq/rabbitmq-java-client/releases?page=3

### Modifications
Upgrade rabbitmq client to 5.18.0.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
