### PR TITLE
[fix][client] Exit when no msg to consume if time reaches the limit

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -247,13 +247,6 @@ public class PerformanceConsumer {
         Semaphore messageReceiveLimiter = new Semaphore(arguments.numMessagesPerTransaction);
         Thread thread = Thread.currentThread();
         MessageListener<ByteBuffer> listener = (consumer, msg) -> {
-                if (arguments.testTime > 0) {
-                    if (System.nanoTime() > testEndTime) {
-                        log.info("------------------- DONE -----------------------");
-                        PerfClientUtils.exit(0);
-                        thread.interrupt();
-                    }
-                }
                 if (arguments.totalNumTxn > 0) {
                     if (totalEndTxnOpFailNum.sum() + totalEndTxnOpSuccessNum.sum() >= arguments.totalNumTxn) {
                         log.info("------------------- DONE -----------------------");
@@ -505,6 +498,14 @@ public class PerformanceConsumer {
 
             reportHistogram.reset();
             oldTime = now;
+
+            if (arguments.testTime > 0) {
+                if (now > testEndTime) {
+                    log.info("------------------- DONE -----------------------");
+                    PerfClientUtils.exit(0);
+                    thread.interrupt();
+                }
+            }
         }
 
         pulsarClient.close();

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -251,7 +251,6 @@ public class PerformanceConsumer {
                     if (System.nanoTime() > testEndTime) {
                         log.info("------------------- DONE -----------------------");
                         PerfClientUtils.exit(0);
-                        thread.interrupt();
                     }
                 }
 
@@ -259,7 +258,6 @@ public class PerformanceConsumer {
                     if (totalEndTxnOpFailNum.sum() + totalEndTxnOpSuccessNum.sum() >= arguments.totalNumTxn) {
                         log.info("------------------- DONE -----------------------");
                         PerfClientUtils.exit(0);
-                        thread.interrupt();
                     }
                 }
                 if (qRecorder != null) {
@@ -274,7 +272,6 @@ public class PerformanceConsumer {
                 if (arguments.numMessages > 0 && totalMessagesReceived.sum() >= arguments.numMessages) {
                     log.info("------------------- DONE -----------------------");
                     PerfClientUtils.exit(0);
-                    thread.interrupt();
                 }
 
                 if (limiter != null) {
@@ -511,7 +508,6 @@ public class PerformanceConsumer {
                 if (now > testEndTime) {
                     log.info("------------------- DONE -----------------------");
                     PerfClientUtils.exit(0);
-                    thread.interrupt();
                 }
             }
         }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -247,7 +247,15 @@ public class PerformanceConsumer {
         Semaphore messageReceiveLimiter = new Semaphore(arguments.numMessagesPerTransaction);
         Thread thread = Thread.currentThread();
         MessageListener<ByteBuffer> listener = (consumer, msg) -> {
-                if (arguments.totalNumTxn > 0) {
+            if (arguments.testTime > 0) {
+                if (System.nanoTime() > testEndTime) {
+                    log.info("------------------- DONE -----------------------");
+                    PerfClientUtils.exit(0);
+                    thread.interrupt();
+                }
+            }
+
+            if (arguments.totalNumTxn > 0) {
                     if (totalEndTxnOpFailNum.sum() + totalEndTxnOpSuccessNum.sum() >= arguments.totalNumTxn) {
                         log.info("------------------- DONE -----------------------");
                         PerfClientUtils.exit(0);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -251,6 +251,7 @@ public class PerformanceConsumer {
                     if (System.nanoTime() > testEndTime) {
                         log.info("------------------- DONE -----------------------");
                         PerfClientUtils.exit(0);
+                        thread.interrupt();
                     }
                 }
 
@@ -258,6 +259,7 @@ public class PerformanceConsumer {
                     if (totalEndTxnOpFailNum.sum() + totalEndTxnOpSuccessNum.sum() >= arguments.totalNumTxn) {
                         log.info("------------------- DONE -----------------------");
                         PerfClientUtils.exit(0);
+                        thread.interrupt();
                     }
                 }
                 if (qRecorder != null) {
@@ -272,6 +274,7 @@ public class PerformanceConsumer {
                 if (arguments.numMessages > 0 && totalMessagesReceived.sum() >= arguments.numMessages) {
                     log.info("------------------- DONE -----------------------");
                     PerfClientUtils.exit(0);
+                    thread.interrupt();
                 }
 
                 if (limiter != null) {
@@ -508,6 +511,7 @@ public class PerformanceConsumer {
                 if (now > testEndTime) {
                     log.info("------------------- DONE -----------------------");
                     PerfClientUtils.exit(0);
+                    thread.interrupt();
                 }
             }
         }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -254,7 +254,6 @@ public class PerformanceConsumer {
                         thread.interrupt();
                     }
                 }
-
                 if (arguments.totalNumTxn > 0) {
                     if (totalEndTxnOpFailNum.sum() + totalEndTxnOpSuccessNum.sum() >= arguments.totalNumTxn) {
                         log.info("------------------- DONE -----------------------");

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -247,15 +247,15 @@ public class PerformanceConsumer {
         Semaphore messageReceiveLimiter = new Semaphore(arguments.numMessagesPerTransaction);
         Thread thread = Thread.currentThread();
         MessageListener<ByteBuffer> listener = (consumer, msg) -> {
-            if (arguments.testTime > 0) {
-                if (System.nanoTime() > testEndTime) {
-                    log.info("------------------- DONE -----------------------");
-                    PerfClientUtils.exit(0);
-                    thread.interrupt();
+                if (arguments.testTime > 0) {
+                    if (System.nanoTime() > testEndTime) {
+                        log.info("------------------- DONE -----------------------");
+                        PerfClientUtils.exit(0);
+                        thread.interrupt();
+                    }
                 }
-            }
 
-            if (arguments.totalNumTxn > 0) {
+                if (arguments.totalNumTxn > 0) {
                     if (totalEndTxnOpFailNum.sum() + totalEndTxnOpSuccessNum.sum() >= arguments.totalNumTxn) {
                         log.info("------------------- DONE -----------------------");
                         PerfClientUtils.exit(0);


### PR DESCRIPTION

### Motivation

If there's no message to consume, the listener won't be invoked, so the main thread will still run in the loop even if time reaches the limit. 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/yaalsn/pulsar/pull/4
