### PR TITLE
[improve][sec] Align the default mechanism for server to request certificates

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/security/tls/MockedPulsarStandalone.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/security/tls/MockedPulsarStandalone.java
@@ -87,7 +87,6 @@ public abstract class MockedPulsarStandalone implements AutoCloseable {
         serviceConfiguration.setTlsKeyStorePassword(TLS_EC_KS_SERVER_PASS);
         serviceConfiguration.setTlsTrustStore(TLS_EC_KS_TRUSTED_STORE);
         serviceConfiguration.setTlsTrustStorePassword(TLS_EC_KS_TRUSTED_STORE_PASS);
-        serviceConfiguration.setTlsRequireTrustedClientCertOnConnect(true);
         serviceConfiguration.setBrokerClientTlsEnabled(true);
         serviceConfiguration.setBrokerClientTlsEnabledWithKeyStore(true);
         serviceConfiguration.setBrokerClientTlsKeyStore(TLS_EC_KS_BROKER_CLIENT_STORE);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/keystoretls/KeyStoreSSLContext.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/keystoretls/KeyStoreSSLContext.java
@@ -201,7 +201,11 @@ public class KeyStoreSSLContext {
         }
 
         if (this.mode == Mode.SERVER) {
-            sslEngine.setNeedClientAuth(this.needClientAuth);
+            if (needClientAuth) {
+                sslEngine.setNeedClientAuth(true);
+            } else {
+                sslEngine.setWantClientAuth(true);
+            }
             sslEngine.setUseClientMode(false);
         } else {
             sslEngine.setUseClientMode(true);


### PR DESCRIPTION
### Motivation

The current default behavior of Netty and Jetty's SSLContext implementation is that the server will request the client certificate, and the client can optionally pass it on.

[Netty SSL Context](https://github.com/apache/pulsar/blob/e1d06b5f54f08c09debab7a9a513b7c173c1779b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java#L575) 

[Jetty SSL Context](https://github.com/apache/pulsar/blob/e1d06b5f54f08c09debab7a9a513b7c173c1779b/pulsar-broker-common/src/main/java/org/apache/pulsar/jetty/tls/JettySslContextFactory.java#L106)

But the implementation of keystore is inconsistent. It will lead the server not to request the client certificate and can not do authentication without `tlsRequireTrustedClientCertOnConnect` configuration.

### Modifications

- set `sslEngine.setWantClientAuth` when `tlsRequireTrustedClientCertOnConnect ` is disabled.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->

