### PR TITLE
[fix][build] Fix potential insufficient protostuff-related configs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1875,6 +1875,31 @@ flexible messaging model and an intuitive client API.</description>
             </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <goals>
+              <goal>set-system-properties</goal>
+            </goals>
+            <configuration>
+              <properties combine.children="append">
+                <!-- for lightproto (protostuff) -->
+                <property>
+                  <name>proto_path</name>
+                  <value>${pulsar.basedir}</value>
+                </property>
+                <property>
+                  <name>proto_search_strategy</name>
+                  <value>2</value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
     <pluginManagement>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -614,30 +614,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>initialize</phase>
-            <goals>
-              <goal>set-system-properties</goal>
-            </goals>
-            <configuration>
-              <properties>
-                <property>
-                  <name>proto_path</name>
-                  <value>${project.parent.basedir}</value>
-                </property>
-                <property>
-                  <name>proto_search_strategy</name>
-                  <value>2</value>
-                </property>
-              </properties>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>com.github.splunk.lightproto</groupId>
         <artifactId>lightproto-maven-plugin</artifactId>
         <version>${lightproto-maven-plugin.version}</version>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -269,6 +269,30 @@
       </plugin>
 
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <goals>
+              <goal>set-system-properties</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <property>
+                  <name>proto_path</name>
+                  <value>${project.parent.basedir}</value>
+                </property>
+                <property>
+                  <name>proto_search_strategy</name>
+                  <value>2</value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>com.github.splunk.lightproto</groupId>
         <artifactId>lightproto-maven-plugin</artifactId>
         <version>${lightproto-maven-plugin.version}</version>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -269,30 +269,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>initialize</phase>
-            <goals>
-              <goal>set-system-properties</goal>
-            </goals>
-            <configuration>
-              <properties>
-                <property>
-                  <name>proto_path</name>
-                  <value>${project.parent.basedir}</value>
-                </property>
-                <property>
-                  <name>proto_search_strategy</name>
-                  <value>2</value>
-                </property>
-              </properties>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>com.github.splunk.lightproto</groupId>
         <artifactId>lightproto-maven-plugin</artifactId>
         <version>${lightproto-maven-plugin.version}</version>

--- a/pulsar-transaction/coordinator/pom.xml
+++ b/pulsar-transaction/coordinator/pom.xml
@@ -82,30 +82,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>properties-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>set-system-properties</goal>
-                        </goals>
-                        <configuration>
-                            <properties>
-                                <property>
-                                    <name>proto_path</name>
-                                    <value>${project.parent.parent.basedir}</value>
-                                </property>
-                                <property>
-                                    <name>proto_search_strategy</name>
-                                    <value>2</value>
-                                </property>
-                            </properties>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>com.github.splunk.lightproto</groupId>
                 <artifactId>lightproto-maven-plugin</artifactId>
                 <version>${lightproto-maven-plugin.version}</version>


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

Currently, protobuf messages are built by lightproto. Lightproto uses protostuff in build. Protostuff can be configured using system property as follows:
https://github.com/apache/pulsar/blob/e1d06b5f54f08c09debab7a9a513b7c173c1779b/pulsar-broker/pom.xml#L610-L633
https://github.com/apache/pulsar/blob/e1d06b5f54f08c09debab7a9a513b7c173c1779b/pulsar-transaction/coordinator/pom.xml#L84-L107

These configs are held as a static field, so it is impossible to separate each module's settings in a single build phase.
https://github.com/protostuff/protostuff/blob/protostuff-1.7.2/protostuff-parser/src/main/java/io/protostuff/parser/DefaultProtoLoader.java#L38-L39
https://github.com/protostuff/protostuff/blob/protostuff-1.7.2/protostuff-parser/src/main/java/io/protostuff/parser/DefaultProtoLoader.java#L49

For example, if we build as follows, [pulsar-transaction/coordinator-specific configs](https://github.com/apache/pulsar/blob/e1d06b5f54f08c09debab7a9a513b7c173c1779b/pulsar-transaction/coordinator/pom.xml#L84-L107) are not used because maven builds pulsar-common first.
```
$ mvn package -pl pulsar-common,pulsar-transaction/coordinator -am -DskipTests=true
```

In the first place, there is no need to separate protostuff-related configs for each module, at least at present.

### Modifications

<!-- Describe the modifications you've done. -->

* Add protostuff-related configs to the pulsar parent

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/equanz/pulsar/pull/4

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
