### PR TITLE
[improve][txn] Add command to abort transaction

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TransactionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TransactionsBase.java
@@ -562,9 +562,9 @@ public abstract class TransactionsBase extends AdminResource {
 
     protected CompletableFuture<Void> internalAbortTransaction(boolean authoritative, long mostSigBits,
                                                                long leastSigBits) {
-        validateTopicOwnership(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN.getPartition((int) mostSigBits),
-                authoritative);
-        return validateSuperUserAccessAsync()
+        return validateTopicOwnershipAsync(
+                SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN.getPartition((int) mostSigBits), authoritative)
+                .thenCompose(__ -> validateSuperUserAccessAsync())
                 .thenCompose(__ -> pulsar().getTransactionMetadataStoreService()
                         .endTransaction(new TxnID(mostSigBits, leastSigBits), TxnAction.ABORT_VALUE, false));
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TransactionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TransactionsBase.java
@@ -44,6 +44,7 @@ import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.Transactions;
 import org.apache.pulsar.client.api.transaction.TxnID;
+import org.apache.pulsar.common.api.proto.TxnAction;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.naming.TopicDomain;
@@ -557,5 +558,14 @@ public abstract class TransactionsBase extends AdminResource {
                     return null;
         });
         return completableFuture;
+    }
+
+    protected CompletableFuture<Void> internalAbortTransaction(boolean authoritative, long mostSigBits,
+                                                               long leastSigBits) {
+        validateTopicOwnership(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN.getPartition((int) mostSigBits),
+                authoritative);
+        return validateSuperUserAccessAsync()
+                .thenCompose(__ -> pulsar().getTransactionMetadataStoreService()
+                        .endTransaction(new TxnID(mostSigBits, leastSigBits), TxnAction.ABORT_VALUE, false));
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
@@ -439,4 +439,33 @@ public class Transactions extends TransactionsBase {
         }
     }
 
+    @POST
+    @Path("/abortTransaction/{mostSigBits}/{leastSigBits}")
+    @ApiOperation(value = "Abort transaction")
+    @ApiResponses(value = {
+            @ApiResponse(code = 404, message = "Tenant or cluster or namespace or topic "
+                    + "or coordinator or transaction doesn't exist"),
+            @ApiResponse(code = 503, message = "This Broker is not configured "
+                    + "with transactionCoordinatorEnabled=true."),
+            @ApiResponse(code = 307, message = "Topic is not owned by this broker!"),
+            @ApiResponse(code = 400, message = "Topic is not a persistent topic!"),
+            @ApiResponse(code = 409, message = "Concurrent modification"),
+            @ApiResponse(code = 401, message = "This operation requires super-user access")})
+    public void abortTransaction(@Suspended final AsyncResponse asyncResponse,
+                                 @QueryParam("authoritative")
+                                 @DefaultValue("false") boolean authoritative,
+                                 @PathParam("mostSigBits") String mostSigBits,
+                                 @PathParam("leastSigBits") String leastSigBits) {
+        try {
+            checkTransactionCoordinatorEnabled();
+            internalAbortTransaction(authoritative, Long.parseLong(mostSigBits), Long.parseLong(leastSigBits))
+                    .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
+                    .exceptionally(ex -> {
+                        resumeAsyncResponseExceptionally(asyncResponse, ex);
+                        return null;
+                    });
+        } catch (Exception e) {
+            resumeAsyncResponseExceptionally(asyncResponse, e);
+        }
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -911,6 +911,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         admin.transactions().abortTransaction(transaction.getTxnID());
         try {
             pulsar.getTransactionMetadataStoreService().getTxnMeta(transaction.getTxnID()).get();
+            fail();
         } catch (ExecutionException e) {
             assertTrue(e.getCause() instanceof CoordinatorException.TransactionNotFoundException);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -75,7 +75,10 @@ import org.apache.pulsar.common.policies.data.TransactionPendingAckInternalStats
 import org.apache.pulsar.common.policies.data.TransactionPendingAckStats;
 import org.apache.pulsar.common.stats.PositionInPendingAckStats;
 import org.apache.pulsar.packages.management.core.MockedPackagesStorageProvider;
+import org.apache.pulsar.transaction.coordinator.TxnMeta;
+import org.apache.pulsar.transaction.coordinator.exceptions.CoordinatorException;
 import org.apache.pulsar.transaction.coordinator.impl.MLTransactionLogImpl;
+import org.apache.pulsar.transaction.coordinator.proto.TxnStatus;
 import org.awaitility.Awaitility;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -892,6 +895,25 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
                         messageId.getLedgerId(), messageId.getEntryId(), 10);
         assertEquals(positionStatsInPendingAckStats.state, PositionInPendingAckStats.State.InvalidPosition);
 
+    }
+
+    @Test
+    public void testAbortTransaction() throws Exception {
+        initTransaction(1);
+
+        Transaction transaction = pulsarClient.newTransaction()
+                .withTransactionTimeout(5, TimeUnit.MINUTES).build().get();
+
+        TxnMeta txnMeta = pulsar.getTransactionMetadataStoreService().getTxnMeta(transaction.getTxnID()).get();
+        assertEquals(txnMeta.status(), TxnStatus.OPEN);
+
+        // abort
+        admin.transactions().abortTransaction(transaction.getTxnID());
+        try {
+            pulsar.getTransactionMetadataStoreService().getTxnMeta(transaction.getTxnID()).get();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof CoordinatorException.TransactionNotFoundException);
+        }
     }
 
     private static void verifyCoordinatorStats(String state,

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Transactions.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Transactions.java
@@ -400,4 +400,18 @@ public interface Transactions {
     CompletableFuture<PositionInPendingAckStats> getPositionStatsInPendingAckAsync(String topic, String subName,
                                                                                    Long ledgerId, Long entryId,
                                                                                    Integer batchIndex);
+
+    /**
+     * Abort a transaction.
+     *
+     * @param txnID the txnId
+     */
+    void abortTransaction(TxnID txnID) throws PulsarAdminException;
+
+    /**
+     * Asynchronously Abort a transaction.
+     *
+     * @param txnID the txnId
+     */
+    CompletableFuture<Void> abortTransactionAsync(TxnID txnID);
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Transactions.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Transactions.java
@@ -409,7 +409,7 @@ public interface Transactions {
     void abortTransaction(TxnID txnID) throws PulsarAdminException;
 
     /**
-     * Asynchronously Abort a transaction.
+     * Asynchronously abort a transaction.
      *
      * @param txnID the txnId
      */

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TransactionsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TransactionsImpl.java
@@ -283,4 +283,17 @@ public class TransactionsImpl extends BaseResource implements Transactions {
             throws PulsarAdminException {
         return sync(() -> getPositionStatsInPendingAckAsync(topic, subName, ledgerId, entryId, batchIndex));
     }
+
+    @Override
+    public CompletableFuture<Void> abortTransactionAsync(TxnID txnID)  {
+        WebTarget path = adminV3Transactions.path("abortTransaction");
+        path = path.path(String.valueOf(txnID.getMostSigBits()));
+        path = path.path(String.valueOf(txnID.getLeastSigBits()));
+        return asyncPostRequest(path, Entity.entity("", MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void abortTransaction(TxnID txnID) throws PulsarAdminException {
+        sync(() -> abortTransactionAsync(txnID));
+    }
 }

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -2406,6 +2406,10 @@ public class PulsarAdminToolTest {
         cmdTransactions = new CmdTransactions(() -> admin);
         cmdTransactions.run(split("coordinators-list"));
         verify(transactions).listTransactionCoordinators();
+
+        cmdTransactions = new CmdTransactions(() -> admin);
+        cmdTransactions.run(split("abort-transaction -m 1 -l 2"));
+        verify(transactions).abortTransaction(new TxnID(1, 2));
     }
 
     @Test

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTransactions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTransactions.java
@@ -250,6 +250,19 @@ public class CmdTransactions extends CmdBase {
         }
     }
 
+    @Parameters(commandDescription = "Abort transaction")
+    private class AbortTransaction extends CliCommand {
+        @Parameter(names = {"-m", "--most-sig-bits"}, description = "The most sig bits", required = true)
+        private int mostSigBits;
+
+        @Parameter(names = {"-l", "--least-sig-bits"}, description = "The least sig bits", required = true)
+        private long leastSigBits;
+
+        @Override
+        void run() throws Exception {
+            getAdmin().transactions().abortTransaction(new TxnID(mostSigBits, leastSigBits));
+        }
+    }
 
     public CmdTransactions(Supplier<PulsarAdmin> admin) {
         super("transactions", admin);
@@ -266,6 +279,7 @@ public class CmdTransactions extends CmdBase {
         jcommander.addCommand("scale-transactionCoordinators", new ScaleTransactionCoordinators());
         jcommander.addCommand("position-stats-in-pending-ack", new GetPositionStatsInPendingAck());
         jcommander.addCommand("coordinators-list", new ListTransactionCoordinators());
+        jcommander.addCommand("abort-transaction", new AbortTransaction());
 
     }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTransactions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTransactions.java
@@ -253,7 +253,7 @@ public class CmdTransactions extends CmdBase {
     @Parameters(commandDescription = "Abort transaction")
     private class AbortTransaction extends CliCommand {
         @Parameter(names = {"-m", "--most-sig-bits"}, description = "The most sig bits", required = true)
-        private int mostSigBits;
+        private long mostSigBits;
 
         @Parameter(names = {"-l", "--least-sig-bits"}, description = "The least sig bits", required = true)
         private long leastSigBits;


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
In the implementation of Pulsar  transaction, if we have a stuck transaction, then the transactions after this one cannot be consumed by the consumer even if they have been committed. The consumer will be stuck until the stuck transaction is aborted due to timeout, and then it will continue to consume messages. Therefore, we need to provide an admin command to proactively abort the transaction in such situations.
### Modifications

<!-- Describe the modifications you've done. -->
Introduce a new API for aborting transaction.
### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

- Added test in `org.apache.pulsar.broker.admin.v3.AdminApiTransactionTest#testAbortTransaction`
- Extended integration test `org.apache.pulsar.admin.cli.PulsarAdminToolTest#transactions`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [x] The REST endpoints
- [x] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/hrzzzz/pulsar/pull/3

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
