### PR TITLE
[fix][test] Fix the bug caused by unload topic and compaction task failure after task is triggered

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -1970,10 +1970,10 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
         // Unload topic make reader of compaction reconnect
         admin.topics().unload(topic);
 
+        Optional<Topic> topicRef = pulsar.getBrokerService().getTopicIfExists(topic).get();
+        Assert.assertTrue(topicRef.isPresent());
+        PersistentTopic persistentTopic = (PersistentTopic) topicRef.get();
         Awaitility.await().untilAsserted(() -> {
-            Optional<Topic> topicReference = pulsar.getBrokerService().getTopicReference(topic);
-            Assert.assertTrue(topicReference.isPresent());
-            PersistentTopic persistentTopic = (PersistentTopic) topicReference.get();
             PulsarTopicCompactionService topicCompactionService =
                     (PulsarTopicCompactionService) persistentTopic.getTopicCompactionService();
             Optional<CompactedTopicContext> compactedTopicContext = topicCompactionService.getCompactedTopic()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -1971,8 +1971,9 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
         admin.topics().unload(topic);
 
         Awaitility.await().untilAsserted(() -> {
-            PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic).get();
-            Assert.assertNotNull(persistentTopic);
+            Optional<Topic> topicReference = pulsar.getBrokerService().getTopicReference(topic);
+            Assert.assertTrue(topicReference.isPresent());
+            PersistentTopic persistentTopic = (PersistentTopic) topicReference.get();
             PulsarTopicCompactionService topicCompactionService =
                     (PulsarTopicCompactionService) persistentTopic.getTopicCompactionService();
             Optional<CompactedTopicContext> compactedTopicContext = topicCompactionService.getCompactedTopic()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -1967,6 +1967,15 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
         // Wait for phase one to complete
         Thread.sleep(500);
 
+        Awaitility.await().untilAsserted(() -> {
+            PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic).get();
+            PulsarTopicCompactionService topicCompactionService =
+                    (PulsarTopicCompactionService) persistentTopic.getTopicCompactionService();
+            Optional<CompactedTopicContext> compactedTopicContext = topicCompactionService.getCompactedTopic()
+                    .getCompactedTopicContext();
+            Assert.assertTrue(compactedTopicContext.isPresent());
+        });
+
         // Unload topic make reader of compaction reconnect
         admin.topics().unload(topic);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -1988,11 +1988,6 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
                 // trigger compaction again
                 admin.topics().triggerCompaction(topic);
                 Assert.assertEquals(currentLongRunningProcessStatus.status, LongRunningProcessStatus.Status.SUCCESS);
-            } else if (previousLongRunningProcessStatus.status == LongRunningProcessStatus.Status.RUNNING
-                    || previousLongRunningProcessStatus.status == LongRunningProcessStatus.Status.SUCCESS) {
-                Assert.assertEquals(previousLongRunningProcessStatus.status, LongRunningProcessStatus.Status.SUCCESS);
-            } else {
-                Assert.assertEquals(currentLongRunningProcessStatus.status, LongRunningProcessStatus.Status.SUCCESS);
             }
         });
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -1966,6 +1966,8 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
 
         // Wait for phase one to complete
         Thread.sleep(500);
+        // Unload topic make reader of compaction reconnect
+        admin.topics().unload(topic);
 
         Awaitility.await().untilAsserted(() -> {
             PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic).get();
@@ -1975,9 +1977,6 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
                     .getCompactedTopicContext();
             Assert.assertTrue(compactedTopicContext.isPresent());
         });
-
-        // Unload topic make reader of compaction reconnect
-        admin.topics().unload(topic);
 
         Awaitility.await().untilAsserted(() -> {
             PersistentTopicInternalStats internalStats = admin.topics().getInternalStats(topic, false);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -1966,6 +1966,7 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
 
         // Wait for phase one to complete
         Thread.sleep(500);
+
         // Unload topic make reader of compaction reconnect
         admin.topics().unload(topic);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -1972,6 +1972,7 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
 
         Awaitility.await().untilAsserted(() -> {
             PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic).get();
+            Assert.assertNotNull(persistentTopic);
             PulsarTopicCompactionService topicCompactionService =
                     (PulsarTopicCompactionService) persistentTopic.getTopicCompactionService();
             Optional<CompactedTopicContext> compactedTopicContext = topicCompactionService.getCompactedTopic()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -1988,6 +1988,8 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
                 // trigger compaction again
                 admin.topics().triggerCompaction(topic);
                 Assert.assertEquals(currentLongRunningProcessStatus.status, LongRunningProcessStatus.Status.SUCCESS);
+            } else if (previousLongRunningProcessStatus.status == LongRunningProcessStatus.Status.RUNNING) {
+                Assert.assertEquals(previousLongRunningProcessStatus.status, LongRunningProcessStatus.Status.SUCCESS);
             }
         });
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionTest.java
@@ -30,6 +30,9 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.CryptoKeyReader;
@@ -45,11 +48,13 @@ import org.apache.pulsar.client.api.TableView;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.topics.TopicCompactionStrategy;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 @Test(groups = "flaky")
+@Slf4j
 public class StrategicCompactionTest extends CompactionTest {
     private TopicCompactionStrategy strategy;
     private StrategicTwoPhaseCompactor compactor;
@@ -212,5 +217,68 @@ public class StrategicCompactionTest extends CompactionTest {
             assertEquals(received, messages);
         }
 
+    }
+
+    @Test
+    public void testCompactionDuplicateWithStrategicCompaction() throws Exception {
+        String topic = "persistent://my-property/use/my-ns/testCompactionDuplicateWithStrategicCompaction";
+        final int numMessages = 1000;
+        final int maxKeys = 800;
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topic)
+                .enableBatching(false)
+                .messageRoutingMode(MessageRoutingMode.SinglePartition)
+                .create();
+
+        // trigger compaction
+        StrategicTwoPhaseCompactor compactor
+                = new StrategicTwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler);
+        compactor.compact(topic, strategy).get();
+
+        Map<String, byte[]> expected = new HashMap<>();
+        Random r = new Random(0);
+
+        pulsarClient.newConsumer().topic(topic).subscriptionName("sub1").readCompacted(true).subscribe().close();
+
+        for (int j = 0; j < numMessages; j++) {
+            int keyIndex = r.nextInt(maxKeys);
+            String key = "key" + keyIndex;
+            byte[] data = ("my-message-" + key + "-" + j).getBytes();
+            producer.newMessage().key(key).value(data).send();
+            expected.put(key, data);
+        }
+
+        producer.flush();
+
+        // trigger compaction
+        compactor.compact(topic, strategy).get();
+
+        // Wait for phase one to complete
+        Thread.sleep(500);
+
+        // Unload topic make reader of compaction reconnect
+        admin.topics().unload(topic);
+
+        Awaitility.await().untilAsserted(() -> {
+            PersistentTopicInternalStats internalStats = admin.topics().getInternalStats(topic, false);
+            // Compacted topic ledger should have same number of entry equals to number of unique key.
+            Assert.assertEquals(internalStats.compactedLedger.entries, expected.size());
+            Assert.assertTrue(internalStats.compactedLedger.ledgerId > -1);
+            Assert.assertFalse(internalStats.compactedLedger.offloaded);
+        });
+
+        // consumer with readCompacted enabled only get compacted entries
+        try (Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("sub1")
+                .readCompacted(true).subscribe()) {
+            while (true) {
+                Message<byte[]> m = consumer.receive(2, TimeUnit.SECONDS);
+                Assert.assertEquals(expected.remove(m.getKey()), m.getData());
+                if (expected.isEmpty()) {
+                    break;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #21537

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation
Because of https://github.com/apache/pulsar/issues/21536 . The consumer with the subscription name `__compaction` can not reconnect. Therefore, the compaction task triggered before the topic unload fails. In this case, a compaction task can be triggered again after unload.

![CleanShot 2023-11-30 at 9 41 32@2x](https://github.com/apache/pulsar/assets/54846009/9d86b83b-2216-4654-8627-b3f285cd9547)

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications
After unload the topic, make sure that the topic has been initialized correctly. Then trigger compaction again after previous task failed.

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/Denovo1998/pulsar/pull/5

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
