### PR TITLE
[improve][pip] PIP-320: OpenTelemetry Scaffolding

### DIFF
--- a/pip/pip-320.md
+++ b/pip/pip-320.md
@@ -6,7 +6,8 @@
 [PIP-264](https://github.com/apache/pulsar/pull/21080), which can also be viewed [here](pip-264.md), describes in high 
 level a plan to greatly enhance Pulsar metric system by replacing it with [OpenTelemetry](https://opentelemetry.io/).
 You can read in the PIP the numerous existing problems PIP-264 solves. Among them are:
-- Control which metrics to export per topic/group/namespace via the introduction of a metric filter configuration
+- Control which metrics to export per topic/group/namespace via the introduction of a metric filter configuration.
+  This configuration is planned to be dynamic as outline in the [PIP-264](pip-264.md).
 - Reduce the immense metrics cardinality due to high topic count (One of Pulsar great features), by introducing
 the concept of Metric Group - a group of topics for metric purposes. Metric reporting will also be done to a 
 group granularity. 100k topics can be downsized to 1k groups. The dynamic metric filter configuration would allow 
@@ -50,7 +51,7 @@ The basic premise is that you will be able to enable or disable OTel metrics, al
 metric exporting.
 
 ## Why OTel in Pulsar will be marked experimental and not GA
-As specified in [PIP-264]((pip-264.md), OpenTelemetry Java SDK has several fixes the Pulsar community must 
+As specified in [PIP-264](pip-264.md), OpenTelemetry Java SDK has several fixes the Pulsar community must 
 complete before it can be used in production. They are [documented](pip-264.md#what-we-need-to-fix-in-opentelemetry)
 in PIP-264. The most important one is reducing memory allocations to be negligible. OTel SDK is built upon immutability, 
 hence allocated memory in O(`#topics`) which is a performance killer for low latency application like Pulsar. 
@@ -85,7 +86,7 @@ OTel form. It means the same metrics will co-exist in the codebase and also in r
 ## Out of Scope
 - Ability to add metrics using OpenTelemetry as Pulsar Function author.
 - Only authenticated sessions can access OTel Prometheus endpoint, using Pulsar authentication 
-
+- Metrics in Pulsar clients (as defined in [PIP-264](pip-264.md#out-of-scope)))
 
 # High Level Design
 
@@ -135,6 +136,20 @@ no-op mode. This means, instruments do get built, but the instrument builders re
 no-op instrument, which does nothing on record-values method (e.g. `add(number)`, `record(number)`). The no-op
 `MeterProvider` has no registered `MetricReader` hence no metric collection will be made. The memory impact
 is almost 0 and the same goes for CPU impact.
+
+The current metric system doesn't have a toggle which causes all existing data structures to stop collecting
+data. Inserting will need changing in so many places since we don't have a single place which through
+all metric instrument are created (one of the motivations for PIP-264). 
+The current system do have a toggle: `exposeTopicLevelMetricsInPrometheus`. It enables toggling off
+topic-level metrics, which means the highest cardinality metrics will be namespace level.
+Once that toggle is `false`, the amount of data structures accounting memory would in the range of 
+a few thousands which shouldn't post a burden memory wise. If the user refrain from calling 
+`/metrics` it will also reduce the CPU and memory cost associated with collecting metrics.
+
+When the user enables OTel it means there will be a memory increase, but if the user disabled topic-level 
+metrics in existing system, as specified above, the majority of the memory increase will be due to topic level
+metrics in OTel, at the expense of not having them in the existing metric system.
+
 
 
 ## Cluster attribute name
@@ -188,7 +203,7 @@ It's customary to use reverse domain name for meter names. Hence, we'll use:
 OTel meter name is converted to the attribute name `otel_scope_name` and added to each unique time series
 attributes by Prometheus exporter.
 
-We won't specify a meter version, as it is used solely to signify the version of the instrumentation and 
+We won't specify a meter version, as it is used solely to signify the version of the instrumentation, and 
 currently we are the first version, hence not use it.
 
 
@@ -230,7 +245,7 @@ currently we are the first version, hence not use it.
 * OTel configurations are used
 
 # Security Considerations
-* OTel currently does not support setting a custom Authenicator for Prometheus exporter.  
+* OTel currently does not support setting a custom Authenticator for Prometheus exporter.  
 An issue has been raised [here](https://github.com/open-telemetry/opentelemetry-java/issues/6013).  
    * Once it do we can secure the Prometheus exporter metrics endpoint using `AuthenticationProvider` 
 * Any user can access metrics, and they are not protected per tenant. Like today's implementation

--- a/pip/pip-320.md
+++ b/pip/pip-320.md
@@ -133,7 +133,7 @@ using the mechanism described [above](#setting-sensible-defaults-for-pulsar):
 With OTel disabled, the user remains with the existing metrics system. OTel in a disabled state operates in a 
 no-op mode. This means, instruments do get built, but the instrument builders return the same instance of a
 no-op instrument, which does nothing on record-values method (e.g. `add(number)`, `record(number)`). The no-op
-`MeterProvider` has no registered `MetricReader` hence when no metric collection will be made. The memory impact
+`MeterProvider` has no registered `MetricReader` hence no metric collection will be made. The memory impact
 is almost 0 and the same goes for CPU impact.
 
 

--- a/pip/pip-320.md
+++ b/pip/pip-320.md
@@ -130,7 +130,12 @@ using the mechanism described [above](#setting-sensible-defaults-for-pulsar):
 * `otel.sdk.disabled` - value: true
   This property value disables OpenTelemetry.
 
-With OTel disabled, the user remains with the existing metrics system.
+With OTel disabled, the user remains with the existing metrics system. OTel in a disabled state operates in a 
+no-op mode. This means, instruments do gets built, but the instrument builders return the same instance of a
+no-op instrument, which do nothing on record-values method (e.g. `add(number)`, `record(number)`). The no-op
+`MeterProvider` has no registered `MetricReader` hence when no metric collection will be made. The memory impact
+is almost 0 and same goes for CPU impact.
+
 
 ## Cluster attribute name
 A broker is part of a cluster. It is configured in the Pulsar configuration key `clusterName`. When the broker is part

--- a/pip/pip-320.md
+++ b/pip/pip-320.md
@@ -1,4 +1,4 @@
-# PIP-XXX OpenTelemetry Scaffolding 
+# PIP-320 OpenTelemetry Scaffolding 
 
 # Background knowledge
 

--- a/pip/pip-320.md
+++ b/pip/pip-320.md
@@ -252,5 +252,5 @@ An issue has been raised [here](https://github.com/open-telemetry/opentelemetry-
 
 # Links
 
-* Mailing List discussion thread:
-* Mailing List voting thread:
+* Mailing List discussion thread: https://lists.apache.org/thread/xcn9rm551tyf4vxrpb0th0wj0kktnrr2
+* Mailing List voting thread: https://lists.apache.org/thread/zp6vl9z9dhwbvwbplm60no13t8fvlqs2

--- a/pip/pip-320.md
+++ b/pip/pip-320.md
@@ -131,10 +131,10 @@ using the mechanism described [above](#setting-sensible-defaults-for-pulsar):
   This property value disables OpenTelemetry.
 
 With OTel disabled, the user remains with the existing metrics system. OTel in a disabled state operates in a 
-no-op mode. This means, instruments do gets built, but the instrument builders return the same instance of a
-no-op instrument, which do nothing on record-values method (e.g. `add(number)`, `record(number)`). The no-op
+no-op mode. This means, instruments do get built, but the instrument builders return the same instance of a
+no-op instrument, which does nothing on record-values method (e.g. `add(number)`, `record(number)`). The no-op
 `MeterProvider` has no registered `MetricReader` hence when no metric collection will be made. The memory impact
-is almost 0 and same goes for CPU impact.
+is almost 0 and the same goes for CPU impact.
 
 
 ## Cluster attribute name

--- a/pip/pip-xxx.md
+++ b/pip/pip-xxx.md
@@ -1,0 +1,182 @@
+# PIP-XXX OpenTelemetry Scaffolding 
+
+# Background knowledge
+
+## PIP-264 - parent PIP titled "Enhanced OTel-based metric system"
+[PIP-264](https://github.com/apache/pulsar/pull/21080), which can also be viewed [here](pip-264.md), describes in high 
+level a plan to greatly enhance Pulsar metric system by replacing it with [OpenTelemetry](https://opentelemetry.io/).
+You can read in the PIP the numerous existing problems PIP-264 solves. Among them are:
+- Control which metrics to export per topic/group/namespace via the introduction of a metric filter configuration
+- Reduce the immense metrics cardinality due to high topic count (One of Pulsar great features), by introducing
+the concept of Metric Group - a group of topics for metric purposes. Metric reporting will also be done to a 
+group granularity. 100k topics can be downsized to 1k groups. The dynamic metric filter configuration would allow 
+the user to control which metric group to un-filter. 
+- Proper histogram exporting
+- Clean-up codebase clutter, by relying on a single industry standard API, SDK and metrics protocol (OTLP) instead of 
+existing mix of home-brew libraries and hard coded Prometheus exporter.
+- any many more
+
+You can [here](pip-264.md#why-opentelemetry) why OpenTelemetry was chosen.
+
+## OpenTelemetry
+Since OpenTelemetry (a.k.a. OTel) is an emerging industry standard, there are plenty of good articles, videos and
+documentation about it. In this very short paragraph I'll describe what you need to know about OTel from this PIP
+perspective.
+
+OpenTelemetry is a project aimed to standardize the way we instrument, collect and ship metrics from applications
+to telemetry backends, be it databases (e.g. Prometheus, Cortex, Thanos) or vendors (e.g. Datadog, Logz.io).
+It is divided into API, SDK and Collector:
+- API: interfaces to use to instrument: define a counter, record values to a histogram, etc.
+- SDK: a library, available in many languages, implementing the API, and other important features such as
+reading the metrics and exporting it out to a telemetry backend or OTel Collector. 
+- Collector: a lightweight process (application) which can receive or retrieve telemetry, transform it (e.g.
+filter, drop, aggregate)  and export it (e.g. send it to various backends). The SDK supports out-of-the-box 
+exporting metrics as Prometheus HTTP endpoint or sending them out using OTLP protocol. Many times companies choose to
+ship to the Collector and there ship to their preferred vendors, since each vendor already published their exporter
+plugin to OTel Collector. This makes the SDK exporters very light-weight as they don't need to support any 
+vendor. It's also easier for the DevOps team as they can make OTel Collector their responsibility, and have
+application developers only focus on shipping metrics to that collector.
+
+Just to have some context: Pulsar codebase will use the OTel API to create counters / histograms and records values to 
+them. So will the Pulsar plugins and Pulsar Function authors. Pulsar itself will be the one creating the SDK
+and using that to hand over an implementation of the API where ever needed in Pulsar. Collector is up to the choice
+of the user, as OTel provides a way to expose the metrics as `/metrics` endpoint on a configured port, so Prometheus
+compatible scrapers can grab it from it directly. They can also send it via OTLP to OTel collector.
+
+
+# Motivation
+
+
+
+<!--
+Describe the problem this proposal is trying to solve.
+
+* Explain what is the problem you're trying to solve - current situation.
+* This section is the "Why" of your proposal.
+-->
+
+# Goals
+
+## In Scope
+
+<!--
+What this PIP intend to achieve once It's integrated into Pulsar.
+Why does it benefit Pulsar.
+-->
+
+## Out of Scope
+
+<!--
+Describe what you have decided to keep out of scope, perhaps left for a different PIP/s.
+-->
+
+
+# High Level Design
+
+<!--
+Describe the design of your solution in *high level*.
+Describe the solution end to end, from a birds-eye view.
+Don't go into implementation details in this section.
+
+I should be able to finish reading from beginning of the PIP to here (including) and understand the feature and 
+how you intend to solve it, end to end.
+
+DON'T
+* Avoid code snippets, unless it's essential to explain your intent.
+-->
+
+# Detailed Design
+
+## Design & Implementation Details
+
+<!--
+This is the section where you dive into the details. It can be:
+* Concrete class names and their roles and responsibility, including methods.
+* Code snippets of existing code.
+* Interface names and its methods.
+* ...
+-->
+
+## Public-facing Changes
+
+<!--
+Describe the additions you plan to make for each public facing component. 
+Remove the sections you are not changing.
+Clearly mark any changes which are BREAKING backward compatability.
+-->
+
+### Public API
+<!--
+When adding a new endpoint to the REST API, please make sure to document the following:
+
+* path
+* query parameters
+* HTTP body parameters, usually as JSON.
+* Response codes, and for each what they mean.
+  For each response code, please include a detailed description of the response body JSON, specifying each field and what it means.
+  This is the place to document the errors.
+-->
+
+### Binary protocol
+
+### Configuration
+
+### CLI
+
+### Metrics
+
+<!--
+For each metric provide:
+* Full name
+* Description
+* Attributes (labels)
+* Unit
+-->
+
+
+# Monitoring
+
+<!-- 
+Describe how the changes you make in this proposal should be monitored. 
+Don't describe the detailed metrics - they should be at "Public-facing Changes" / "Metrics" section.
+Describe how the user will use the metrics to monitor the feature: Which alerts they should set up, which thresholds, ...
+-->
+
+# Security Considerations
+<!--
+A detailed description of the security details that ought to be considered for the PIP. This is most relevant for any new HTTP endpoints, new Pulsar Protocol Commands, and new security features. The goal is to describe details like which role will have permission to perform an action.
+
+An important aspect to consider is also multi-tenancy: Does the feature I'm adding have the permissions / roles set in such a way that prevent one tenant accessing another tenant's data/configuration? For example, the Admin API to read a specific message for a topic only allows a client to read messages for the target topic. However, that was not always the case. CVE-2021-41571 (https://github.com/apache/pulsar/wiki/CVE-2021-41571) resulted because the API was incorrectly written and did not properly prevent a client from reading another topic's messages even though authorization was in place. The problem was missing input validation that verified the requested message was actually a message for that topic. The fix to CVE-2021-41571 was input validation. 
+
+If there is uncertainty for this section, please submit the PIP and request for feedback on the mailing list.
+-->
+
+# Backward & Forward Compatibility
+
+## Revert
+
+<!--
+Describe a cookbook detailing the steps required to revert pulsar to previous version *without* this feature.
+-->
+
+## Upgrade
+
+<!--
+Specify the list of instructions, if there are such, needed to perform before/after upgrading to Pulsar version containing this feature.
+-->
+
+# Alternatives
+
+<!--
+If there are alternatives that were already considered by the authors or, after the discussion, by the community, and were rejected, please list them here along with the reason why they were rejected.
+-->
+
+# General Notes
+
+# Links
+
+<!--
+Updated afterwards
+-->
+* Mailing List discussion thread:
+* Mailing List voting thread:

--- a/pip/pip-xxx.md
+++ b/pip/pip-xxx.md
@@ -43,32 +43,41 @@ and using that to hand over an implementation of the API where ever needed in Pu
 of the user, as OTel provides a way to expose the metrics as `/metrics` endpoint on a configured port, so Prometheus
 compatible scrapers can grab it from it directly. They can also send it via OTLP to OTel collector.
 
+## Telemetry layers
+PIP-264 clearly outlined there will be two layers of metrics, collected and exported, side by side: OpenTelemetry 
+and the existing metric system - currently exporting in Prometheus. This PIP will explain in detail how it will work. 
+The basic premise is that you will be able to enable or disable OTel metrics, alongside the existing Prometheus 
+metric exporting.
+
+## Why OTel in Pulsar will be marked experimental and not GA
+As specified in [PIP-264]((pip-264.md), OpenTelemetry Java SDK has several fixes the Pulsar community must 
+complete before it can be used in production. They are [documented](pip-264.md#what-we-need-to-fix-in-opentelemetry)
+in PIP-264. The most important one is reducing memory allocations to be negligible. OTel SDK is built upon immutability, 
+hence allocated memory in O(`#topics`) which is a performance killer for low latency application like Pulsar. 
+
+You can track the proposal and progress the Pulsar and OTel communities are making in 
+[this issue](https://github.com/open-telemetry/opentelemetry-java/issues/5105).
 
 # Motivation
 
-
-
-<!--
-Describe the problem this proposal is trying to solve.
-
-* Explain what is the problem you're trying to solve - current situation.
-* This section is the "Why" of your proposal.
--->
+Implementing PIP-264 consists of a long list of steps, which are detailed in 
+[this issue](https://github.com/apache/pulsar/issues/21121). The first step is add all the bare-bones infrastructure
+to use OpenTelemetry in Pulsar, such that next PRs can use it to start translating existing metrics to their 
+OTel form. It means the same metrics will co-exist in the codebase and also in runtime, if OTel was enabled.
 
 # Goals
 
 ## In Scope
+- Ability to add metrics using OpenTelemetry to Pulsar components: Broker, Function Worker and Proxy.
+- User can disable or enable OpenTelemetry metrics, which by default will be disabled
+- OpenTelemetry metrics will be configured via its native OTel Java SDK configuration options
+- All the necessary information to use OTel with Pulsar will be documented in Pulsar documentation site
+- OpenTelemetry metrics layer defined as experimental, and *not* GA
 
-<!--
-What this PIP intend to achieve once It's integrated into Pulsar.
-Why does it benefit Pulsar.
--->
 
 ## Out of Scope
-
-<!--
-Describe what you have decided to keep out of scope, perhaps left for a different PIP/s.
--->
+- Ability to add metrics using OpenTelemetry as Pulsar Function author.
+- Only authenticated sessions can access OTel Prometheus endpoint, using Pulsar authentication 
 
 
 # High Level Design
@@ -84,6 +93,8 @@ how you intend to solve it, end to end.
 DON'T
 * Avoid code snippets, unless it's essential to explain your intent.
 -->
+
+
 
 # Detailed Design
 


### PR DESCRIPTION
### Motivation

Adding PIP-320, which a sub-PIP of PIP-264 (Implementation tracked at #21121).
This PIP is about adding the infrastructure to use OpenTelemetry in Pulsar broker, proxy and function worker.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

