### PR TITLE
[fix][test] Fix flaky test SimpleProducerConsumerStatTest#testPartitionTopicStats

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
@@ -46,6 +46,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -495,9 +496,10 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
             msg = consumer.receive(5, TimeUnit.SECONDS);
             String receivedMessage = new String(msg.getData());
             log.info("Received message: [{}]", receivedMessage);
-            String expectedMessage = "my-message-" + i;
-            testMessageOrderAndDuplicates(messageSet, receivedMessage, expectedMessage);
+            Assert.assertTrue(messageSet.add(receivedMessage), "Received duplicate message " + receivedMessage);
         }
+        Assert.assertEquals(messageSet.size(), numMessages);
+
         // Acknowledge the consumption of all messages at once
         consumer.acknowledgeCumulative(msg);
 


### PR DESCRIPTION
Fixes #21614 

### Motivation

The root cause is that we can't keep the order of the msgs from the partitioned topic. We just keep the order of the msg in single partition.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


