### PR TITLE
[fix][broker] Fix memory leak during topic compaction

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TwoPhaseCompactor.java
@@ -253,6 +253,7 @@ public class TwoPhaseCompactor extends Compactor {
             }
 
             if (m.getMessageId().compareTo(lastCompactedMessageId) <= 0) {
+                m.close();
                 phaseTwoLoop(reader, to, latestForKey, lh, outstanding, promise, lastCompactedMessageId);
                 return;
             }


### PR DESCRIPTION
### Motivation

Found the following error log in  `CompactionTest.testCompactionDuplicate`:
```java
2023-11-30T12:48:53,002 - ERROR - [pulsar-client-io-692-4:ResourceLeakDetector@337] - LEAK: ByteBuf.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
Recent access records: 
#1:
	io.netty.buffer.AdvancedLeakAwareByteBuf.readByte(AdvancedLeakAwareByteBuf.java:401)
	org.apache.pulsar.common.api.proto.LightProtoCodec.readVarInt(LightProtoCodec.java:140)
	org.apache.pulsar.common.api.proto.MessageMetadata.parseFrom(MessageMetadata.java:1315)
	org.apache.pulsar.common.protocol.Commands.parseMessageMetadata(Commands.java:459)
	org.apache.pulsar.common.protocol.Commands.parseMessageMetadata(Commands.java:446)
	org.apache.pulsar.client.impl.RawReaderImpl$RawConsumerImpl.tryCompletePending(RawReaderImpl.java:148)
	org.apache.pulsar.client.impl.RawReaderImpl$RawConsumerImpl.receiveRawAsync(RawReaderImpl.java:197)
	org.apache.pulsar.client.impl.RawReaderImpl.readNextAsync(RawReaderImpl.java:85)
	org.apache.pulsar.compaction.TwoPhaseCompactor.phaseTwoLoop(TwoPhaseCompactor.java:249)
	org.apache.pulsar.compaction.TwoPhaseCompactor.lambda$phaseTwoLoop$16(TwoPhaseCompactor.java:256)
	java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:718)
	java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482)
	java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	java.base/java.lang.Thread.run(Thread.java:833)
```

Fix memory leak after RawReader reconnects when topic compaction, this issue introduced from https://github.com/apache/pulsar/pull/21081.

### Modifications

Close RawMessage if `messageId <= lastCompactedMessageId`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
