### PR TITLE
[draft] [fix] [client] Could not consume messages after one partition deleted

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicGCTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicGCTest.java
@@ -18,23 +18,29 @@
  */
 package org.apache.pulsar.broker.service;
 
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.TopicMessageId;
 import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.awaitility.Awaitility;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Slf4j
@@ -62,9 +68,32 @@ public class TopicGCTest extends ProducerConsumerBase {
         this.conf.setBrokerDeleteInactiveTopicsFrequencySeconds(10);
     }
 
-    @Test
-    public void testCreateConsumerAfterOnePartDeleted() throws Exception {
+    private enum SubscribeTopicType {
+        MULTI_PARTITIONED_TOPIC,
+        REGEX_TOPIC;
+    }
+
+    @DataProvider(name = "subscribeTopicTypes")
+    public Object[][] subTopicTypes() {
+        return new Object[][]{
+            {SubscribeTopicType.MULTI_PARTITIONED_TOPIC},
+            {SubscribeTopicType.REGEX_TOPIC}
+        };
+    }
+
+    private void setSubscribeTopic(ConsumerBuilder consumerBuilder, SubscribeTopicType subscribeTopicType,
+                                   String topicName, String topicPattern) {
+        if (subscribeTopicType.equals(SubscribeTopicType.MULTI_PARTITIONED_TOPIC)) {
+            consumerBuilder.topic(topicName);
+        } else {
+            consumerBuilder.topicsPattern(Pattern.compile(topicPattern));
+        }
+    }
+
+    @Test(dataProvider = "subscribeTopicTypes")
+    public void testConsumerAfterOnePartDeleted(SubscribeTopicType subscribeTopicType) throws Exception {
         final String topic = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
+        final String topicPattern = "persistent://public/default/tp.*";
         final String partition0 = topic + "-partition-0";
         final String partition1 = topic + "-partition-1";
         final String subscription = "s1";
@@ -76,18 +105,23 @@ public class TopicGCTest extends ProducerConsumerBase {
                 .enableBatching(false).create();
         Producer<String> producer1 = pulsarClient.newProducer(Schema.STRING).topic(partition1)
                 .enableBatching(false).create();
-        org.apache.pulsar.client.api.Consumer<String> consumer1 = pulsarClient.newConsumer(Schema.STRING).topic(topic)
-                .subscriptionName(subscription).isAckReceiptEnabled(true).subscribe();
+        ConsumerBuilder<String> consumerBuilder1 = pulsarClient.newConsumer(Schema.STRING)
+                .subscriptionName(subscription)
+                .isAckReceiptEnabled(true)
+                .subscriptionType(SubscriptionType.Shared);
+        setSubscribeTopic(consumerBuilder1, subscribeTopicType, topic, topicPattern);
+        Consumer<String> consumer1 = consumerBuilder1.subscribe();
 
         // Make consume all messages for one topic, do not consume any messages for another one.
-        producer0.send("1");
-        producer1.send("2");
+        producer0.send("partition-0-1");
+        producer1.send("partition-1-1");
+        producer1.send("partition-1-2");
+        producer1.send("partition-1-4");
         admin.topics().skipAllMessages(partition0, subscription);
 
         // Wait for topic GC.
         // Partition 0 will be deleted about 20s later, left 2min to avoid flaky.
         producer0.close();
-        consumer1.close();
         Awaitility.await().atMost(2, TimeUnit.MINUTES).untilAsserted(() -> {
             CompletableFuture<Optional<Topic>> tp1 = pulsar.getBrokerService().getTopic(partition0, false);
             CompletableFuture<Optional<Topic>> tp2 = pulsar.getBrokerService().getTopic(partition1, false);
@@ -95,16 +129,33 @@ public class TopicGCTest extends ProducerConsumerBase {
             assertTrue(tp2 != null && tp2.get().isPresent());
         });
 
+        // Verify that the messages under "partition-1" still can be ack.
+        for (int i = 0; i < 2; i++) {
+            Message msg = consumer1.receive(2, TimeUnit.SECONDS);
+            assertNotNull(msg, "Expected at least received 3 messages.");
+            TopicMessageId messageId = (TopicMessageId) msg.getMessageId();
+            if (messageId.getOwnerTopic().equals(partition1)) {
+                consumer1.acknowledge(msg);
+            }
+
+        }
+        consumer1.close();
+
         // Verify that the consumer subscribed with partitioned topic can be created successful.
-        Consumer<String> consumerAllPartition = pulsarClient.newConsumer(Schema.STRING).topic(topic)
-                .subscriptionName(subscription).isAckReceiptEnabled(true).subscribe();
-        Message<String> msg = consumerAllPartition.receive(2, TimeUnit.SECONDS);
+        ConsumerBuilder<String> consumerBuilder2 = pulsarClient.newConsumer(Schema.STRING)
+                .subscriptionName(subscription)
+                .isAckReceiptEnabled(true)
+                .subscriptionType(SubscriptionType.Shared);
+        setSubscribeTopic(consumerBuilder2, subscribeTopicType, topic, topicPattern);
+        Consumer<String> consumer2 = consumerBuilder2.subscribe();
+        producer1.send("partition-1-5");
+        Message<String> msg = consumer2.receive(2, TimeUnit.SECONDS);
         String receivedMsgValue = msg.getValue();
         log.info("received msg: {}", receivedMsgValue);
-        consumerAllPartition.acknowledge(msg);
+        consumer2.acknowledge(msg);
 
         // cleanup.
-        consumerAllPartition.close();
+        consumer2.close();
         producer0.close();
         producer1.close();
         admin.topics().deletePartitionedTopic(topic);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -532,14 +532,15 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
                 .topic(topicName)
                 .subscriptionName("subscriptionName")
                 .subscribe();
-        ((MultiTopicsConsumerImpl) consumer).subscribeAsync("ns-abc/testTopicNameValid", 5).handle((res, exception) -> {
+        ((MultiTopicsConsumerImpl) consumer).subscribeAsync("ns-abc/testTopicNameValid").handle((res, exception) -> {
             assertTrue(exception instanceof PulsarClientException.AlreadyClosedException);
             assertEquals(((PulsarClientException.AlreadyClosedException) exception).getMessage(), "Topic name not valid");
             return null;
         }).get();
-        ((MultiTopicsConsumerImpl) consumer).subscribeAsync(topicName, 3).handle((res, exception) -> {
-            assertTrue(exception instanceof PulsarClientException.AlreadyClosedException);
-            assertEquals(((PulsarClientException.AlreadyClosedException) exception).getMessage(), "Already subscribed to " + topicName);
+        ((MultiTopicsConsumerImpl) consumer).subscribeAsync(topicName).handle((res, exception) -> {
+            Throwable pulsarClientEx = PulsarClientException.extractPulsarClientEx((Throwable) exception);
+            assertTrue(pulsarClientEx instanceof PulsarClientException.ConsumerBusyException);
+            assertTrue(pulsarClientEx.getMessage().contains("is already connected"));
             return null;
         }).get();
     }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -948,7 +948,22 @@ public class PulsarClientException extends IOException {
     }
 
     // wrap an exception to enriching more info messages.
-    public static Throwable wrap(Throwable t, String msg) {
+    public static Throwable extractPulsarClientEx(Throwable t) {
+        if (t.getCause() == null || t.getCause() == t) {
+            return t;
+        }
+        if (t instanceof PulsarClientException) {
+            return t;
+        }
+        if (t instanceof ExecutionException || t instanceof CompletionException) {
+            return extractPulsarClientEx(t.getCause());
+        }
+        return t;
+    }
+
+    // wrap an exception to enriching more info messages.
+    public static Throwable wrap(Throwable originalThrowable, String msg) {
+        Throwable t = extractPulsarClientEx(originalThrowable);
         msg += "\n" + t.getMessage();
         // wrap an exception with new message info
         if (t instanceof TimeoutException) {

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -40,6 +40,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+      <version>${commons.collections4.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-common</artifactId>
       <version>${project.parent.version}</version>

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/LookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/LookupService.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace.Mode;
-import org.apache.pulsar.common.lookup.GetTopicsResult;
+import org.apache.pulsar.common.lookup.CollatedGetTopicsResult;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
@@ -103,6 +103,6 @@ public interface LookupService extends AutoCloseable {
      * @param namespace : namespace-name
      * @return
      */
-    CompletableFuture<GetTopicsResult> getTopicsUnderNamespace(NamespaceName namespace, Mode mode,
-                                                               String topicPattern, String topicsHash);
+    CompletableFuture<CollatedGetTopicsResult> getTopicsUnderNamespace(NamespaceName namespace, Mode mode,
+                                                                       String topicPattern, String topicsHash);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -75,9 +76,10 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                                           CompletableFuture<Consumer<T>> subscribeFuture,
                                           Schema<T> schema,
                                           Mode subscriptionMode,
-                                          ConsumerInterceptors<T> interceptors) {
+                                          ConsumerInterceptors<T> interceptors,
+                                          Map<String, List<Integer>> partitions) {
         super(client, conf, executorProvider, subscribeFuture, schema, interceptors,
-                false /* createTopicIfDoesNotExist */);
+                false /* createTopicIfDoesNotExist */, partitions);
         this.topicsPattern = topicsPattern;
         this.topicsHash = topicsHash;
         this.subscriptionMode = subscriptionMode;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -593,7 +593,7 @@ public class PulsarClientImpl implements PulsarClient {
                         conf,
                         externalExecutorProvider,
                         consumerSubscribedFuture,
-                        schema, subscriptionMode, interceptors);
+                        schema, subscriptionMode, interceptors, getTopicsResult.getPartitions());
 
                 consumers.add(consumer);
             })

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
@@ -56,7 +56,7 @@ import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.client.util.ExecutorProvider;
 import org.apache.pulsar.client.util.ScheduledExecutorProvider;
 import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace;
-import org.apache.pulsar.common.lookup.GetTopicsResult;
+import org.apache.pulsar.common.lookup.CollatedGetTopicsResult;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
@@ -105,7 +105,8 @@ public class PulsarClientImplTest {
                 nullable(String.class),
                 nullable(String.class)))
                 .thenReturn(CompletableFuture.completedFuture(
-                        new GetTopicsResult(Collections.emptyList(), null, false, true)));
+                        new CollatedGetTopicsResult(Collections.emptyList(),
+                                null, false, true, Collections.emptyMap())));
         when(lookup.getPartitionedTopicMetadata(any(TopicName.class)))
                 .thenReturn(CompletableFuture.completedFuture(new PartitionedTopicMetadata()));
         when(lookup.getBroker(any()))

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/lookup/CollatedGetTopicsResult.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/lookup/CollatedGetTopicsResult.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.lookup;
+
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class CollatedGetTopicsResult extends GetTopicsResult{
+
+    /** Key: partitioned topic name; Value: existed partitions. **/
+    private Map<String, List<Integer>> partitions;
+
+    public CollatedGetTopicsResult(List<String> topics, String topicsHash, boolean filtered, boolean changed,
+                                   Map<String, List<Integer>> partitions) {
+        super(topics, topicsHash, filtered, changed);
+        this.partitions = partitions;
+    }
+}


### PR DESCRIPTION
### Motivation

**Background**:
- For the client side, there is a regular task that monitors topic creation and deletion when registering a regex consumer
  - Stop subscribing after a topic has been deleted.
  - Start a new subscriber after a new topic has been created.
- https://github.com/apache/pulsar/pull/5230 stopped to recreate partitions under the partitioned topic to avoid a partition being created after it was deleted. This led to a part of the partitions being deleted.

**Issue**:
- `Regexp Topic & Partitioned Topics`: The Pulsar client stopped subscriptions of all partitions when one partition has been deleted, even if other partitions are still there. It causes the messages in other partitions not to be fully consumed.
- `Regexp Topic`: The Pulsar client tries to create subscriptions for all partitions when the consumer starts, even if some partitions have been deleted. It causes the consumer not to start and throws an error "topic not found"( the issue of the current ticket )

You can reproduce the issue by the test `testConsumerAfterOnePartDeleted`.

### Modifications
- Instead of stopping all partitions when a partition has been deleted, just stop the partitions which have been deleted.
- Split `GetTopicsResult` into two classes:
  - `GetTopicsResult`: the field `topics` are the collection of the topic names that contains partition name. It is only used by `ClientCnx.GET_TOPICS_OF_NAMESPACE`.
  - `CollatedGetTopicsResult`: merge the topic names that are under the same `Partitioned Topic`, It is only used in the client internal.

**TODO:** Since this PR has changed a lot, the following things will be done in the subsequent PR:
- [ ] The same test for the Reader API.
- [ ] Collate methods for the class `MultiTopicsConsumerImpl` and `PatternMultiTopicsConsumerImpl`
- [ ] Recheck the behavior of `TopicListWatcher`.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
