### PR TITLE
[fix][broker] Key-shared subscription must follow consumer redelivery as per shared sub semantic

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
@@ -862,4 +862,11 @@ public interface ManagedCursor {
      * @return whether this cursor is closed.
      */
     boolean isClosed();
+
+    /**
+     * Checks if position is already deleted.
+     * @param position
+     * @return whether position is deleted.
+     */
+    boolean isMessageDeleted(Position position);
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3400,6 +3400,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         return individualDeletedMessages;
     }
 
+    @Override
     public boolean isMessageDeleted(Position position) {
         checkArgument(position instanceof PositionImpl);
         return ((PositionImpl) position).compareTo(markDeletePosition) <= 0

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -418,6 +418,12 @@ public class ManagedCursorContainerTest {
         public boolean isClosed() {
             return false;
         }
+
+        @Override
+        public boolean isMessageDeleted(Position position) {
+            // TODO Auto-generated method stub
+            return false;
+        }
     }
 
     @Test

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -421,7 +421,6 @@ public class ManagedCursorContainerTest {
 
         @Override
         public boolean isMessageDeleted(Position position) {
-            // TODO Auto-generated method stub
             return false;
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -1014,6 +1014,10 @@ public class Consumer {
         return pendingAcks;
     }
 
+    public boolean isPendingAck(long ledgerId, long entryId) {
+        return pendingAcks.containsKey(ledgerId, entryId);
+    }
+
     public int getPriorityLevel() {
         return priorityLevel;
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/MockManagedCursor.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/MockManagedCursor.java
@@ -418,7 +418,6 @@ public class MockManagedCursor implements ManagedCursor {
 
     @Override
     public boolean isMessageDeleted(Position position) {
-        // TODO Auto-generated method stub
         return false;
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/MockManagedCursor.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/MockManagedCursor.java
@@ -415,4 +415,10 @@ public class MockManagedCursor implements ManagedCursor {
     public boolean isClosed() {
         return false;
     }
+
+    @Override
+    public boolean isMessageDeleted(Position position) {
+        // TODO Auto-generated method stub
+        return false;
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -896,6 +896,9 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
 
         checkMessageOrdering(consumer3, totalMessages);
 
+        // drain consumer 1
+        checkMessageOrdering(consumer1, totalMessages);
+
         Optional<Topic> topicRef = pulsar.getBrokerService().getTopic(topic, false).get();
         assertTrue(topicRef.isPresent());
         Thread.sleep((defaultTTLSec - 1) * 1000);
@@ -909,9 +912,12 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                     .send();
         }
 
+        boolean consumed = 
+                consumer1.receive(1, TimeUnit.SECONDS) != null ||
+                consumer2.receive(1, TimeUnit.SECONDS) != null ||
+                consumer3.receive(1, TimeUnit.SECONDS) != null;
         // Wait broker dispatch messages.
-        Assert.assertNotNull(consumer2.receive(1, TimeUnit.SECONDS));
-        Assert.assertNotNull(consumer3.receive(1, TimeUnit.SECONDS));
+        Assert.assertTrue(consumed);
     }
 
     @Test(dataProvider = "partitioned")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -1631,8 +1631,14 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         Assert.assertEquals(sum, delayedMessages + messages);
     }
 
+    /**
+     * This test validates key-shared subscription should not get stuck and if one of the consumer dies then broker
+     * should redeliver those messages to the new consumer instead stop dispatching messages to all consumers.
+     * 
+     * @throws Exception
+     */
     @Test
-    public void test()
+    public void testKeySharedMessageRedeliveryWithoutStuck()
             throws Exception {
         String topic = "persistent://public/default/key_shared-" + UUID.randomUUID();
         boolean enableBatch = false;
@@ -1645,7 +1651,6 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         Producer<Integer> producer = createProducer(topic, enableBatch);
         int count = 0;
         for (int i = 0; i < 10; i++) {
-            // Send the same key twice so that we'll have a batch message
             String key = String.valueOf(random.nextInt(NUMBER_OF_KEYS));
             producer.newMessage().key(key).value(count++).send();
         }
@@ -1654,7 +1659,6 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         Consumer<Integer> consumer2 = createConsumer(topic);
 
         for (int i = 0; i < 10; i++) {
-            // Send the same key twice so that we'll have a batch message
             String key = String.valueOf(random.nextInt(NUMBER_OF_KEYS));
             producer.newMessage().key(key).value(count++).send();
         }
@@ -1665,7 +1669,6 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         consumer2.redeliverUnacknowledgedMessages();
 
         for (int i = 0; i < 10; i++) {
-            // Send the same key twice so that we'll have a batch message
             String key = String.valueOf(random.nextInt(NUMBER_OF_KEYS));
             producer.newMessage().key(key).value(count++).send();
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -709,13 +709,6 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                 .consumerName("c2")
                 .subscribe();
 
-        /*for (int i = 10; i < 20; i++) {
-            producer.newMessage()
-                    .key(String.valueOf(random.nextInt(NUMBER_OF_KEYS)))
-                    .value(i)
-                    .send();
-        }*/
-
         // C2 will not be able to receive any messages until C1 is done processing whatever he got prefetched
         assertNull(c2.receive(100, TimeUnit.MILLISECONDS));
 


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/21656

<!-- or this PR is one task of an issue -->





### Motivation

SHARED or key-SHARED subscription must dispatch redelivered messages in any scenario. every shared subscription should dispatch already delivered unack messages. You can follow strict ordering for new messages which broker is reading first time by advancing readPosition of the cursor but broker can dispatch already delivered unack messages when its required without restricting any scenario.

However, key-shared subscription is incorrectly handling redelivered messages by keep reading redelivered messages , discarding them and not dispatching any single messages to the consumer by incorrectly changing the semantics of consumer delivery ordering. broker doesn't dispatch redelivery message if that message id is smaller than consumer's assigned offset-message-id when it joined. broker assigns cursor's current read position as consumer's min-message-id offset to manage ordering but delivered messageId can be smaller than that position and redelivery should not be restricted by ordering as we already discussed semantics of shared subscription earlier. But as broker handles it incorrectly in key-shared because of that key-shared subscription topics which have connected consumers with positive permits are not able to receive any messages and dispatching is stuck also broker is keep performing same cold reads across those stuck topics and wasting storage and CPU resources by discarding read messages. which impacts application, broker and bookies and such buggy handling is semantically and practically invalid.

Right now, such multiple topics with key-shared subscription and redelivery messages can significantly impact broker and bookies by keep reading large number of messages without dispatching them and client application are not able to consume any messages which also impacts application significantly.

### Modifications

Allow dispatching of redelivered messages, avoid reading and discarding duplicate messages, and fix broken stuck dispatcher on unack messages.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
