### PR TITLE
[fix][build] Fix Stage Docker images fail on M1 Mac

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@ flexible messaging model and an intuitive client API.</description>
     <reflections.version>0.10.2</reflections.version>
     <swagger.version>1.6.2</swagger.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
-    <docker-maven.version>0.42.1</docker-maven.version>
+    <docker-maven.version>0.43.3</docker-maven.version>
     <docker.verbose>true</docker.verbose>
     <typetools.version>0.5.0</typetools.version>
     <protobuf3.version>3.19.6</protobuf3.version>


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/21658

### Motivation

Fixes https://github.com/apache/pulsar/issues/21658

We could find the similar issue from here : https://github.com/IQSS/dataverse/issues/9771 .  And we could fix this issuse by  
updating the `fabric8` to `0.43.3`

### Modifications

bump io.fabric8 docker-maven-plugin to `0.43.3`

### Verifying this change

- [x] Make sure that the change passes the CI checks.



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

