### PR TITLE
[improve][cli]Introduce Regex and File Input Parameters for Enhanced Topic Deletion Command

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -751,7 +751,11 @@ public class CmdTopics extends CmdBase {
                 String path = checkArgument(params);
                 List<String> topicsFromFile = Files.readAllLines(Path.of(path));
                 for (String t : topicsFromFile) {
-                    getTopics().delete(t, force);
+                    try {
+                        getTopics().delete(t, force);
+                    } catch (Exception e) {
+                        print("Failed to delete topic: " + t + ". Exception: " + e);
+                    }
                 }
             } else {
                 String topic = validateTopicName(params);
@@ -760,10 +764,18 @@ public class CmdTopics extends CmdBase {
                     List<String> topics = getTopics().getList(namespace);
                     topics = topics.stream().filter(s -> s.matches(topic)).toList();
                     for (String t : topics) {
-                        getTopics().delete(t, force);
+                        try {
+                            getTopics().delete(t, force);
+                        } catch (Exception e) {
+                            print("Failed to delete topic: " + t + ". Exception: " + e);
+                        }
                     }
                 } else {
-                    getTopics().delete(topic, force);
+                    try {
+                        getTopics().delete(topic, force);
+                    } catch (Exception e) {
+                        print("Failed to delete topic: " + topic + ". Exception: " + e);
+                    }
                 }
             }
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -32,6 +32,9 @@ import com.google.gson.JsonParser;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -93,10 +96,12 @@ import org.apache.pulsar.common.util.ObjectMapperFactory;
 @Parameters(commandDescription = "Operations on persistent topics")
 public class CmdTopics extends CmdBase {
     private final CmdTopics.PartitionedLookup partitionedLookup;
+    private final CmdTopics.DeleteCmd deleteCmd;
 
     public CmdTopics(Supplier<PulsarAdmin> admin) {
         super("topics", admin);
         partitionedLookup = new PartitionedLookup();
+        deleteCmd = new DeleteCmd();
         jcommander.addCommand("list", new ListCmd());
         jcommander.addCommand("list-partitioned-topics", new PartitionedTopicListCmd());
         jcommander.addCommand("permissions", new Permissions());
@@ -105,7 +110,7 @@ public class CmdTopics extends CmdBase {
         jcommander.addCommand("lookup", new Lookup());
         jcommander.addCommand("partitioned-lookup", partitionedLookup);
         jcommander.addCommand("bundle-range", new GetBundleRange());
-        jcommander.addCommand("delete", new DeleteCmd());
+        jcommander.addCommand("delete", deleteCmd);
         jcommander.addCommand("truncate", new TruncateCmd());
         jcommander.addCommand("unload", new UnloadCmd());
         jcommander.addCommand("subscriptions", new ListSubscriptions());
@@ -714,9 +719,12 @@ public class CmdTopics extends CmdBase {
             + "And the application is not able to connect to the topic(delete then re-create with same name) again "
             + "if the schema auto uploading is disabled. Besides, users should to use the truncate cmd to clean up "
             + "data of the topic instead of delete cmd if users continue to use this topic later.")
-    private class DeleteCmd extends CliCommand {
-        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
-        private java.util.List<String> params;
+    protected class DeleteCmd extends CliCommand {
+        @Parameter(description = "Provide either a single topic in the format 'persistent://tenant/namespace/topic', "
+                + "or a path to a file containing a list of topics, e.g., 'path://resources/topics.txt'. "
+                + "This parameter is required.",
+                required = true)
+        java.util.List<String> params;
 
         @Parameter(names = { "-f",
                 "--force" }, description = "Close all producer/consumer/replicator and delete topic forcefully")
@@ -726,10 +734,38 @@ public class CmdTopics extends CmdBase {
                 + "but the parameter is invalid and the schema is always deleted", hidden = true)
         private boolean deleteSchema = false;
 
+        @Parameter(names = {"-r", "regex"},
+                description = "Use a regex expression to match multiple topics for deletion.")
+        boolean regex = false;
+
+        @Parameter(names = {"--from-file"}, description = "Read a list of topics from a file for deletion.")
+        boolean readFromFile;
+
+
         @Override
-        void run() throws PulsarAdminException {
-            String topic = validateTopicName(params);
-            getTopics().delete(topic, force);
+        void run() throws PulsarAdminException, IOException {
+            if (readFromFile && regex) {
+                throw new ParameterException("Could not apply regex when read topics from file.");
+            }
+            if (readFromFile) {
+                String path = checkArgument(params);
+                List<String> topicsFromFile = Files.readAllLines(Path.of(path));
+                for (String t : topicsFromFile) {
+                    getTopics().delete(t);
+                }
+            } else {
+                String topic = validateTopicName(params);
+                if (regex) {
+                    String namespace = TopicName.get(topic).getNamespace();
+                    List<String> topics = getTopics().getList(namespace);
+                    topics = topics.stream().filter(s -> s.matches(topic)).toList();
+                    for (String t : topics) {
+                        getTopics().delete(t);
+                    }
+                } else {
+                    getTopics().delete(topic, force);
+                }
+            }
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -751,7 +751,7 @@ public class CmdTopics extends CmdBase {
                 String path = checkArgument(params);
                 List<String> topicsFromFile = Files.readAllLines(Path.of(path));
                 for (String t : topicsFromFile) {
-                    getTopics().delete(t);
+                    getTopics().delete(t, force);
                 }
             } else {
                 String topic = validateTopicName(params);
@@ -760,7 +760,7 @@ public class CmdTopics extends CmdBase {
                     List<String> topics = getTopics().getList(namespace);
                     topics = topics.stream().filter(s -> s.matches(topic)).toList();
                     for (String t : topics) {
-                        getTopics().delete(t);
+                        getTopics().delete(t, force);
                     }
                 } else {
                     getTopics().delete(topic, force);

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdTopics.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdTopics.java
@@ -197,8 +197,9 @@ public class TestCmdTopics {
         deleteCmd.run();
 
         // Assert: Verify that the delete method was called once for each of the matching topics
-        verify(mockTopics, times(1)).delete("persistent://tenant/namespace/topic1");
-        verify(mockTopics, times(1)).delete("persistent://tenant/namespace/topic2");
+        verify(mockTopics, times(1)).getList("tenant/namespace");
+        verify(mockTopics, times(1)).delete("persistent://tenant/namespace/topic1", false);
+        verify(mockTopics, times(1)).delete("persistent://tenant/namespace/topic2", false);
     }
 
     @Test
@@ -219,7 +220,7 @@ public class TestCmdTopics {
 
         // Assert: Verify that the delete method was called once for each topic in the file
         for (String topic : topics) {
-            verify(mockTopics, times(1)).delete(topic);
+            verify(mockTopics, times(1)).delete(topic, false);
         }
 
         // Cleanup: Delete the temporary file
@@ -254,8 +255,9 @@ public class TestCmdTopics {
             verify(mockTopics, times(1)).delete(topic, false);
         }
 
-        // Cleanup: Delete the temporary file
+        // Cleanup: Delete the temporary file and recreate the mockTopics.
         Files.delete(tempFile);
+        mockTopics = mock(Topics.class);
     }
 
 }


### PR DESCRIPTION
PIP: https://github.com/apache/pulsar/issues/20225
### Motivation

The current implementation of the `DeleteCmd` class in the Pulsar CLI does not provide the flexibility to delete multiple topics at once using a regex or a file containing a list of topics. This can be inconvenient and time-consuming in environments where there are many topics that need to be deleted. 

### Modifications

To address this, we have added three new parameters to the `DeleteCmd` class:

1. `-r` or `regex`: This parameter allows the user to specify a regex to match multiple topics for deletion.
2. `--from-file`: This parameter allows the user to read a list of topics from a file for deletion.

Additionally, we have written unit tests to ensure the correct behavior of these new features. These tests cover the deletion of a single topic, multiple topics via regex, and multiple topics from a file.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
