### PR TITLE
[improve][broker] PIP-307 Expose inflight state waiting time and service channel monitor interval configs. Handle AddEntry failure during topic transfer

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2661,6 +2661,27 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private boolean loadBalancerSheddingBundlesWithPoliciesEnabled = false;
 
+    @FieldContext(
+            category = CATEGORY_LOAD_BALANCER,
+            doc = "Time to wait before fixing any stuck in-flight service unit states. "
+                    + "The leader monitor fixes any in-flight service unit(bundle) states "
+                    + "by reassigning the ownerships if stuck too long, longer than this period."
+                    + "(only used in load balancer extension logics)"
+    )
+    private long loadBalancerInFlightServiceUnitStateWaitingTimeInMillis = 30 * 1000;
+
+    @FieldContext(
+            category = CATEGORY_LOAD_BALANCER,
+            doc = "Interval between service unit state monitor checks. "
+                    + "The service unit(bundle) state channel is periodically monitored"
+                    + " by the leader broker at this interval"
+                    + " to fix any orphan bundle ownerships, stuck in-flight states, and other cleanup jobs."
+                    + "`loadBalancerServiceUnitStateTombstoneDelayTimeInSeconds` * 1000 must be bigger than "
+                    + "`loadBalancerInFlightServiceUnitStateWaitingTimeInMillis`."
+                    + "(only used in load balancer extension logics)"
+    )
+    private long loadBalancerServiceUnitStateMonitorIntervalInSeconds = 60;
+
     /**** --- Replication. --- ****/
     @FieldContext(
         category = CATEGORY_REPLICATION,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -353,7 +353,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
                             }
                         });
                     });
-            this.serviceUnitStateChannel = ServiceUnitStateChannelImpl.newInstance(pulsar);
+            this.serviceUnitStateChannel = new ServiceUnitStateChannelImpl(pulsar);
             this.brokerRegistry.start();
             this.splitManager = new SplitManager(splitCounter);
             this.unloadManager = new UnloadManager(unloadCounter);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -111,13 +111,10 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             "loadbalancer-service-unit-state").toString();
 
     public static final CompressionType MSG_COMPRESSION_TYPE = CompressionType.ZSTD;
-    private static final long MAX_IN_FLIGHT_STATE_WAITING_TIME_IN_MILLIS = 30 * 1000; // 30sec
-
     private static final int OWNERSHIP_CLEAN_UP_MAX_WAIT_TIME_IN_MILLIS = 5000;
     private static final int OWNERSHIP_CLEAN_UP_WAIT_RETRY_DELAY_IN_MILLIS = 100;
     private static final int OWNERSHIP_CLEAN_UP_CONVERGENCE_DELAY_IN_MILLIS = 3000;
     public static final long VERSION_ID_INIT = 1; // initial versionId
-    private static final long OWNERSHIP_MONITOR_DELAY_TIME_IN_SECS = 60;
     public static final long MAX_CLEAN_UP_DELAY_TIME_IN_SECS = 3 * 60; // 3 mins
     private static final long MIN_CLEAN_UP_DELAY_TIME_IN_SECS = 0; // 0 secs to clean immediately
     private static final long MAX_CHANNEL_OWNER_ELECTION_WAITING_TIME_IN_SECS = 10;
@@ -141,7 +138,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
     private long inFlightStateWaitingTimeInMillis;
 
     private long ownershipMonitorDelayTimeInSecs;
-    private long semiTerminalStateWaitingTimeInMillis;
+    private long stateTombstoneDelayTimeInSeconds;
     private long maxCleanupDelayTimeInSecs;
     private long minCleanupDelayTimeInSecs;
     // cleanup metrics
@@ -200,18 +197,8 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         Unstable
     }
 
-    public static ServiceUnitStateChannelImpl newInstance(PulsarService pulsar) {
-        return new ServiceUnitStateChannelImpl(pulsar);
-    }
-
-    public ServiceUnitStateChannelImpl(PulsarService pulsar) {
-        this(pulsar, MAX_IN_FLIGHT_STATE_WAITING_TIME_IN_MILLIS, OWNERSHIP_MONITOR_DELAY_TIME_IN_SECS);
-    }
-
     @VisibleForTesting
-    public ServiceUnitStateChannelImpl(PulsarService pulsar,
-                                       long inFlightStateWaitingTimeInMillis,
-                                       long ownershipMonitorDelayTimeInSecs) {
+    public ServiceUnitStateChannelImpl(PulsarService pulsar) {
         this.pulsar = pulsar;
         this.config = pulsar.getConfig();
         this.lookupServiceAddress = pulsar.getLookupServiceAddress();
@@ -219,14 +206,16 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         this.getOwnerRequests = new ConcurrentHashMap<>();
         this.cleanupJobs = new ConcurrentHashMap<>();
         this.stateChangeListeners = new StateChangeListeners();
-        this.semiTerminalStateWaitingTimeInMillis = config.getLoadBalancerServiceUnitStateTombstoneDelayTimeInSeconds()
+        this.stateTombstoneDelayTimeInSeconds = config.getLoadBalancerServiceUnitStateTombstoneDelayTimeInSeconds()
                 * 1000;
-        this.inFlightStateWaitingTimeInMillis = inFlightStateWaitingTimeInMillis;
-        this.ownershipMonitorDelayTimeInSecs = ownershipMonitorDelayTimeInSecs;
-        if (semiTerminalStateWaitingTimeInMillis < inFlightStateWaitingTimeInMillis) {
+        this.inFlightStateWaitingTimeInMillis = config.getLoadBalancerInFlightServiceUnitStateWaitingTimeInMillis();
+        this.ownershipMonitorDelayTimeInSecs = config.getLoadBalancerServiceUnitStateMonitorIntervalInSeconds();
+        if (stateTombstoneDelayTimeInSeconds < inFlightStateWaitingTimeInMillis) {
             throw new IllegalArgumentException(
-                    "Invalid Config: loadBalancerServiceUnitStateCleanUpDelayTimeInSeconds < "
-                            + (MAX_IN_FLIGHT_STATE_WAITING_TIME_IN_MILLIS / 1000) + " secs");
+                    "Invalid Config: loadBalancerServiceUnitStateTombstoneDelayTimeInSeconds"
+                            + stateTombstoneDelayTimeInSeconds + " secs"
+                            + "< loadBalancerInFlightServiceUnitStateWaitingTimeInMillis"
+                            + inFlightStateWaitingTimeInMillis + " millis");
         }
         this.maxCleanupDelayTimeInSecs = MAX_CLEAN_UP_DELAY_TIME_IN_SECS;
         this.minCleanupDelayTimeInSecs = MIN_CLEAN_UP_DELAY_TIME_IN_SECS;
@@ -1457,7 +1446,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                 continue;
             }
 
-            if (now - stateData.timestamp() > semiTerminalStateWaitingTimeInMillis) {
+            if (now - stateData.timestamp() > stateTombstoneDelayTimeInSeconds) {
                 log.info("Found semi-terminal states to tombstone"
                         + " serviceUnit:{}, stateData:{}", serviceUnit, stateData);
                 tombstoneAsync(serviceUnit).whenComplete((__, e) -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -138,7 +138,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
     private long inFlightStateWaitingTimeInMillis;
 
     private long ownershipMonitorDelayTimeInSecs;
-    private long stateTombstoneDelayTimeInSeconds;
+    private long stateTombstoneDelayTimeInMillis;
     private long maxCleanupDelayTimeInSecs;
     private long minCleanupDelayTimeInSecs;
     // cleanup metrics
@@ -206,14 +206,14 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         this.getOwnerRequests = new ConcurrentHashMap<>();
         this.cleanupJobs = new ConcurrentHashMap<>();
         this.stateChangeListeners = new StateChangeListeners();
-        this.stateTombstoneDelayTimeInSeconds = config.getLoadBalancerServiceUnitStateTombstoneDelayTimeInSeconds()
+        this.stateTombstoneDelayTimeInMillis = config.getLoadBalancerServiceUnitStateTombstoneDelayTimeInSeconds()
                 * 1000;
         this.inFlightStateWaitingTimeInMillis = config.getLoadBalancerInFlightServiceUnitStateWaitingTimeInMillis();
         this.ownershipMonitorDelayTimeInSecs = config.getLoadBalancerServiceUnitStateMonitorIntervalInSeconds();
-        if (stateTombstoneDelayTimeInSeconds < inFlightStateWaitingTimeInMillis) {
+        if (stateTombstoneDelayTimeInMillis < inFlightStateWaitingTimeInMillis) {
             throw new IllegalArgumentException(
                     "Invalid Config: loadBalancerServiceUnitStateTombstoneDelayTimeInSeconds"
-                            + stateTombstoneDelayTimeInSeconds + " secs"
+                            + stateTombstoneDelayTimeInMillis / 1000 + " secs"
                             + "< loadBalancerInFlightServiceUnitStateWaitingTimeInMillis"
                             + inFlightStateWaitingTimeInMillis + " millis");
         }
@@ -1446,7 +1446,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                 continue;
             }
 
-            if (now - stateData.timestamp() > stateTombstoneDelayTimeInSeconds) {
+            if (now - stateData.timestamp() > stateTombstoneDelayTimeInMillis) {
                 log.info("Found semi-terminal states to tombstone"
                         + " serviceUnit:{}, stateData:{}", serviceUnit, stateData);
                 tombstoneAsync(serviceUnit).whenComplete((__, e) -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -157,6 +157,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
     protected final LongAdder msgOutFromRemovedSubscriptions = new LongAdder();
     protected final LongAdder bytesOutFromRemovedSubscriptions = new LongAdder();
     protected volatile Pair<String, List<EntryFilter>> entryFilters;
+    protected volatile boolean transferring = false;
 
     public AbstractTopic(String topic, BrokerService brokerService) {
         this.topic = topic;
@@ -956,11 +957,6 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
         }
     }
 
-    @Override
-    public boolean isFenced() {
-        return isFenced;
-    }
-
     protected CompletableFuture<Void> internalAddProducer(Producer producer) {
         if (isProducersExceeded(producer)) {
             log.warn("[{}] Attempting to add producer to topic which reached max producers limit", topic);
@@ -1248,6 +1244,10 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
     protected abstract boolean isTerminated();
 
     protected abstract boolean isMigrated();
+
+    public boolean isTransferring() {
+        return transferring;
+    }
 
     private static final Logger log = LoggerFactory.getLogger(AbstractTopic.class);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -485,6 +485,14 @@ public class Producer {
         @Override
         public void completed(Exception exception, long ledgerId, long entryId) {
             if (exception != null) {
+                // if the topic is transferring, we don't send error code to the clients.
+                if (producer.getTopic().isTransferring()) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] Received producer exception: {} while transferring.",
+                                producer.getTopic().getName(), exception.getMessage(), exception);
+                    }
+                    return;
+                }
                 final ServerError serverError = getServerError(exception);
 
                 producer.cnx.execute(() -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -485,18 +485,16 @@ public class Producer {
         @Override
         public void completed(Exception exception, long ledgerId, long entryId) {
             if (exception != null) {
-                // if the topic is transferring, we don't send error code to the clients.
-                if (producer.getTopic().isTransferring()) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Received producer exception: {} while transferring.",
-                                producer.getTopic().getName(), exception.getMessage(), exception);
-                    }
-                    return;
-                }
                 final ServerError serverError = getServerError(exception);
 
                 producer.cnx.execute(() -> {
-                    if (!(exception instanceof TopicClosedException)) {
+                    // if the topic is transferring, we don't send error code to the clients.
+                    if (producer.getTopic().isTransferring()) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("[{}] Received producer exception: {} while transferring.",
+                                    producer.getTopic().getName(), exception.getMessage(), exception);
+                        }
+                    } else if (!(exception instanceof TopicClosedException)) {
                         // For TopicClosed exception there's no need to send explicit error, since the client was
                         // already notified
                         long callBackSequenceId = Math.max(highestSequenceId, sequenceId);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1763,12 +1763,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         }
 
         PulsarService pulsar = getBrokerService().pulsar();
-        if (producer.getTopic().isFenced()
-                && ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(pulsar)) {
+        // if the topic is transferring, we ignore send msg.
+        if (producer.getTopic().isTransferring()) {
             long ignoredMsgCount = ExtensibleLoadManagerImpl.get(pulsar)
                     .getIgnoredSendMsgCounter().incrementAndGet();
             if (log.isDebugEnabled()) {
-                log.debug("Ignored send msg from:{}:{} to fenced topic:{} during unloading."
+                log.debug("Ignored send msg from:{}:{} to fenced topic:{} while transferring."
                                 + " Ignored message count:{}.",
                         remoteAddress, send.getProducerId(), producer.getTopic().getName(), ignoredMsgCount);
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -338,7 +338,7 @@ public interface Topic {
 
     boolean isPersistent();
 
-    boolean isFenced();
+    boolean isTransferring();
 
     /* ------ Transaction related ------ */
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -507,6 +507,9 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
 
         lock.writeLock().lock();
         try {
+            if (!disconnectClients) {
+                transferring = true;
+            }
             if (!isFenced || closeWithoutWaitingClientDisconnect) {
                 isFenced = true;
             } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -651,21 +651,20 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     @Override
     public synchronized void addFailed(ManagedLedgerException exception, Object ctx) {
-        PublishContext callback = (PublishContext) ctx;
-
         /* If the topic is being transferred(in the Releasing bundle state),
          we don't want to forcefully close topic here.
          Instead, we will rely on the service unit state channel's bundle(topic) transfer protocol.
          At the end of the transfer protocol, at Owned state, the source broker should close the topic properly.
          */
-        if (isClosingOrDeleting
-                && ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(getBrokerService().pulsar())) {
+        if (transferring) {
             if (log.isDebugEnabled()) {
-                log.debug("[{}] Failed to persist msg in store: {} while closing or deleting.",
+                log.debug("[{}] Failed to persist msg in store: {} while transferring.",
                         topic, exception.getMessage(), exception);
             }
             return;
         }
+
+        PublishContext callback = (PublishContext) ctx;
         if (exception instanceof ManagedLedgerFencedException) {
             // If the managed ledger has been fenced, we cannot continue using it. We need to close and reopen
             close();
@@ -1487,6 +1486,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         lock.writeLock().lock();
         try {
+            if (!disconnectClients) {
+                transferring = true;
+            }
             // closing managed-ledger waits until all producers/consumers/replicators get closed. Sometimes, broker
             // forcefully wants to close managed-ledger without waiting all resources to be closed.
             if (!isClosingOrDeleting || closeWithoutWaitingClientDisconnect) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -460,10 +460,8 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
             }
         });
 
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
-            assertTrue(producer.isConnected());
-            verify(lookup, times(lookupCountBeforeUnload)).getBroker(topicName);
-        });
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(producer::isConnected);
+        verify(lookup, times(lookupCountBeforeUnload)).getBroker(topicName);
         producer.close();
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -38,11 +38,9 @@ import static org.apache.pulsar.broker.loadbalance.extensions.models.UnloadDecis
 import static org.apache.pulsar.broker.namespace.NamespaceService.getHeartbeatNamespace;
 import static org.apache.pulsar.broker.namespace.NamespaceService.getHeartbeatNamespaceV2;
 import static org.apache.pulsar.broker.namespace.NamespaceService.getSLAMonitorNamespace;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -120,7 +118,6 @@ import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.policies.data.loadbalancer.ResourceUsage;
 import org.apache.pulsar.policies.data.loadbalancer.SystemResourceUsage;
 import org.awaitility.Awaitility;
-import org.mockito.MockedStatic;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -154,53 +151,47 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
     @BeforeClass
     @Override
     public void setup() throws Exception {
-        try (MockedStatic<ServiceUnitStateChannelImpl> channelMockedStatic =
-                     mockStatic(ServiceUnitStateChannelImpl.class)) {
-            channelMockedStatic.when(() -> ServiceUnitStateChannelImpl.newInstance(isA(PulsarService.class)))
-                    .thenAnswer(invocation -> {
-                        PulsarService pulsarService = invocation.getArgument(0);
-                        // Set the inflight state waiting time and ownership monitor delay time to 5 seconds to avoid
-                        // stuck when doing unload.
-                        return new ServiceUnitStateChannelImpl(pulsarService, 5 * 1000, 1);
-                    });
-            conf.setForceDeleteNamespaceAllowed(true);
-            conf.setAllowAutoTopicCreationType(TopicType.NON_PARTITIONED);
-            conf.setAllowAutoTopicCreation(true);
-            conf.setLoadManagerClassName(ExtensibleLoadManagerImpl.class.getName());
-            conf.setLoadBalancerLoadSheddingStrategy(TransferShedder.class.getName());
-            conf.setLoadBalancerSheddingEnabled(false);
-            conf.setLoadBalancerDebugModeEnabled(true);
-            conf.setTopicLevelPoliciesEnabled(true);
-            super.internalSetup(conf);
-            pulsar1 = pulsar;
-            ServiceConfiguration defaultConf = getDefaultConf();
-            defaultConf.setAllowAutoTopicCreation(true);
-            defaultConf.setForceDeleteNamespaceAllowed(true);
-            defaultConf.setLoadManagerClassName(ExtensibleLoadManagerImpl.class.getName());
-            defaultConf.setLoadBalancerLoadSheddingStrategy(TransferShedder.class.getName());
-            defaultConf.setLoadBalancerSheddingEnabled(false);
-            defaultConf.setTopicLevelPoliciesEnabled(true);
-            additionalPulsarTestContext = createAdditionalPulsarTestContext(defaultConf);
-            pulsar2 = additionalPulsarTestContext.getPulsarService();
+        // Set the inflight state waiting time and ownership monitor delay time to 5 seconds to avoid
+        // stuck when doing unload.
+        conf.setLoadBalancerInFlightServiceUnitStateWaitingTimeInMillis(5 * 1000);
+        conf.setLoadBalancerServiceUnitStateMonitorIntervalInSeconds(1);
+        conf.setForceDeleteNamespaceAllowed(true);
+        conf.setAllowAutoTopicCreationType(TopicType.NON_PARTITIONED);
+        conf.setAllowAutoTopicCreation(true);
+        conf.setLoadManagerClassName(ExtensibleLoadManagerImpl.class.getName());
+        conf.setLoadBalancerLoadSheddingStrategy(TransferShedder.class.getName());
+        conf.setLoadBalancerSheddingEnabled(false);
+        conf.setLoadBalancerDebugModeEnabled(true);
+        conf.setTopicLevelPoliciesEnabled(true);
+        super.internalSetup(conf);
+        pulsar1 = pulsar;
+        ServiceConfiguration defaultConf = getDefaultConf();
+        defaultConf.setAllowAutoTopicCreation(true);
+        defaultConf.setForceDeleteNamespaceAllowed(true);
+        defaultConf.setLoadManagerClassName(ExtensibleLoadManagerImpl.class.getName());
+        defaultConf.setLoadBalancerLoadSheddingStrategy(TransferShedder.class.getName());
+        defaultConf.setLoadBalancerSheddingEnabled(false);
+        defaultConf.setTopicLevelPoliciesEnabled(true);
+        additionalPulsarTestContext = createAdditionalPulsarTestContext(defaultConf);
+        pulsar2 = additionalPulsarTestContext.getPulsarService();
 
-            setPrimaryLoadManager();
+        setPrimaryLoadManager();
 
-            setSecondaryLoadManager();
+        setSecondaryLoadManager();
 
-            admin.clusters().createCluster(this.conf.getClusterName(),
-                    ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
-            admin.tenants().createTenant("public",
-                    new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"),
-                            Sets.newHashSet(this.conf.getClusterName())));
-            admin.namespaces().createNamespace("public/default");
-            admin.namespaces().setNamespaceReplicationClusters("public/default",
-                    Sets.newHashSet(this.conf.getClusterName()));
+        admin.clusters().createCluster(this.conf.getClusterName(),
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.tenants().createTenant("public",
+                new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"),
+                        Sets.newHashSet(this.conf.getClusterName())));
+        admin.namespaces().createNamespace("public/default");
+        admin.namespaces().setNamespaceReplicationClusters("public/default",
+                Sets.newHashSet(this.conf.getClusterName()));
 
-            admin.namespaces().createNamespace(defaultTestNamespace, 128);
-            admin.namespaces().setNamespaceReplicationClusters(defaultTestNamespace,
-                    Sets.newHashSet(this.conf.getClusterName()));
-            lookupService = (LookupService) FieldUtils.readDeclaredField(pulsarClient, "lookup", true);
-        }
+        admin.namespaces().createNamespace(defaultTestNamespace, 128);
+        admin.namespaces().setNamespaceReplicationClusters(defaultTestNamespace,
+                Sets.newHashSet(this.conf.getClusterName()));
+        lookupService = (LookupService) FieldUtils.readDeclaredField(pulsarClient, "lookup", true);
     }
 
     @Override
@@ -468,8 +459,11 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
                 throw new RuntimeException(e);
             }
         });
-        assertTrue(producer.isConnected());
-        verify(lookup, times(lookupCountBeforeUnload)).getBroker(topicName);
+
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertTrue(producer.isConnected());
+            verify(lookup, times(lookupCountBeforeUnload)).getBroker(topicName);
+        });
         producer.close();
     }
 
@@ -568,15 +562,21 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
 
         admin.namespaces().splitNamespaceBundle(namespace, firstBundle, true, null);
 
-        BundlesData bundlesData = admin.namespaces().getBundles(namespace);
-        assertEquals(bundlesData.getNumBundles(), numBundles + 1);
-        String lowBundle = String.format("0x%08x", bundleRanges.get(0));
-        String midBundle = String.format("0x%08x", mid);
-        String highBundle = String.format("0x%08x", bundleRanges.get(1));
-        assertTrue(bundlesData.getBoundaries().contains(lowBundle));
-        assertTrue(bundlesData.getBoundaries().contains(midBundle));
-        assertTrue(bundlesData.getBoundaries().contains(highBundle));
-        assertEquals(splitCount.get(), 1);
+
+        Awaitility.await()
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    BundlesData bundlesData = admin.namespaces().getBundles(namespace);
+                    assertEquals(bundlesData.getNumBundles(), numBundles + 1);
+                    String lowBundle = String.format("0x%08x", bundleRanges.get(0));
+                    String midBundle = String.format("0x%08x", mid);
+                    String highBundle = String.format("0x%08x", bundleRanges.get(1));
+                    assertTrue(bundlesData.getBoundaries().contains(lowBundle));
+                    assertTrue(bundlesData.getBoundaries().contains(midBundle));
+                    assertTrue(bundlesData.getBoundaries().contains(highBundle));
+                    assertEquals(splitCount.get(), 1);
+                });
+
 
         // Test split bundle with invalid bundle range.
         try {
@@ -619,15 +619,24 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
         final String namespace = "public/testDeleteNamespaceBundle";
         admin.namespaces().createNamespace(namespace, 3);
         TopicName topicName = TopicName.get(namespace + "/test-delete-namespace-bundle");
-        NamespaceBundle bundle = getBundleAsync(pulsar1, topicName).get();
 
-        String broker = admin.lookups().lookupTopic(topicName.toString());
-        log.info("Assign the bundle {} to {}", bundle, broker);
 
-        checkOwnershipState(broker, bundle);
 
-        admin.namespaces().deleteNamespaceBundle(topicName.getNamespace(), bundle.getBundleRange());
-        assertFalse(primaryLoadManager.checkOwnershipAsync(Optional.empty(), bundle).get());
+        Awaitility.await()
+                .atMost(30, TimeUnit.SECONDS)
+                .ignoreExceptions()
+                .untilAsserted(() -> {
+                    NamespaceBundle bundle = getBundleAsync(pulsar1, topicName).get();
+                    String broker = admin.lookups().lookupTopic(topicName.toString());
+                    log.info("Assign the bundle {} to {}", bundle, broker);
+                    checkOwnershipState(broker, bundle);
+                    admin.namespaces().deleteNamespaceBundle(topicName.getNamespace(), bundle.getBundleRange(), true);
+                    // this could fail if the system topic lookup asynchronously happens before this.
+                    // we will retry if it fails.
+                    assertFalse(primaryLoadManager.checkOwnershipAsync(Optional.empty(), bundle).get());
+                });
+
+        admin.namespaces().deleteNamespace(namespace, true);
     }
 
     @Test(timeOut = 30 * 1000)
@@ -704,15 +713,6 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testDeployAndRollbackLoadManager() throws Exception {
-        try (MockedStatic<ServiceUnitStateChannelImpl> channelMockedStatic =
-                     mockStatic(ServiceUnitStateChannelImpl.class)) {
-            channelMockedStatic.when(() -> ServiceUnitStateChannelImpl.newInstance(isA(PulsarService.class)))
-                    .thenAnswer(invocation -> {
-                        PulsarService pulsarService = invocation.getArgument(0);
-                        // Set the inflight state waiting time and ownership monitor delay time to 5 seconds to avoid
-                        // stuck when doing unload.
-                        return new ServiceUnitStateChannelImpl(pulsarService, 5 * 1000, 1);
-                    });
             // Test rollback to modular load manager.
             ServiceConfiguration defaultConf = getDefaultConf();
             defaultConf.setAllowAutoTopicCreation(true);
@@ -833,8 +833,6 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
                     }
                 }
             }
-        }
-
     }
 
     private void assertLookupHeartbeatOwner(PulsarService pulsar,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
@@ -622,12 +622,12 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         FieldUtils.writeDeclaredField(channel1,
                 "inFlightStateWaitingTimeInMillis", 1 , true);
         FieldUtils.writeDeclaredField(channel1,
-                "semiTerminalStateWaitingTimeInMillis", 1, true);
+                "stateTombstoneDelayTimeInSeconds", 1, true);
 
         FieldUtils.writeDeclaredField(channel2,
                 "inFlightStateWaitingTimeInMillis", 1 , true);
         FieldUtils.writeDeclaredField(channel2,
-                "semiTerminalStateWaitingTimeInMillis", 1, true);
+                "stateTombstoneDelayTimeInSeconds", 1, true);
 
         ((ServiceUnitStateChannelImpl) channel1).monitorOwnerships(
                 List.of(lookupServiceAddress1, lookupServiceAddress2));
@@ -654,12 +654,12 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         FieldUtils.writeDeclaredField(channel1,
                 "inFlightStateWaitingTimeInMillis", 30 * 1000, true);
         FieldUtils.writeDeclaredField(channel1,
-                "semiTerminalStateWaitingTimeInMillis", 300 * 1000, true);
+                "stateTombstoneDelayTimeInSeconds", 300 * 1000, true);
 
         FieldUtils.writeDeclaredField(channel2,
                 "inFlightStateWaitingTimeInMillis", 30 * 1000, true);
         FieldUtils.writeDeclaredField(channel2,
-                "semiTerminalStateWaitingTimeInMillis", 300 * 1000, true);
+                "stateTombstoneDelayTimeInSeconds", 300 * 1000, true);
     }
 
     @Test(priority = 7)
@@ -1066,12 +1066,12 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         FieldUtils.writeDeclaredField(channel1,
                 "inFlightStateWaitingTimeInMillis", 1 , true);
         FieldUtils.writeDeclaredField(channel1,
-                "semiTerminalStateWaitingTimeInMillis", 1, true);
+                "stateTombstoneDelayTimeInSeconds", 1, true);
 
         FieldUtils.writeDeclaredField(channel2,
                 "inFlightStateWaitingTimeInMillis", 1 , true);
         FieldUtils.writeDeclaredField(channel2,
-                "semiTerminalStateWaitingTimeInMillis", 1, true);
+                "stateTombstoneDelayTimeInSeconds", 1, true);
 
         ((ServiceUnitStateChannelImpl) channel1).monitorOwnerships(
                 List.of(lookupServiceAddress1, lookupServiceAddress2));
@@ -1094,12 +1094,12 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         FieldUtils.writeDeclaredField(channel1,
                 "inFlightStateWaitingTimeInMillis", 30 * 1000, true);
         FieldUtils.writeDeclaredField(channel1,
-                "semiTerminalStateWaitingTimeInMillis", 30 * 1000, true);
+                "stateTombstoneDelayTimeInSeconds", 30 * 1000, true);
 
         FieldUtils.writeDeclaredField(channel2,
                 "inFlightStateWaitingTimeInMillis", 300 * 1000, true);
         FieldUtils.writeDeclaredField(channel2,
-                "semiTerminalStateWaitingTimeInMillis", 300 * 1000, true);
+                "stateTombstoneDelayTimeInSeconds", 300 * 1000, true);
     }
 
     @Test(priority = 13)
@@ -1396,9 +1396,9 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         // try the monitor and check the monitor moves `Deleted` -> `Init`
 
         FieldUtils.writeDeclaredField(channel1,
-                "semiTerminalStateWaitingTimeInMillis", 1, true);
+                "stateTombstoneDelayTimeInSeconds", 1, true);
         FieldUtils.writeDeclaredField(channel2,
-                "semiTerminalStateWaitingTimeInMillis", 1, true);
+                "stateTombstoneDelayTimeInSeconds", 1, true);
 
         ((ServiceUnitStateChannelImpl) channel1).monitorOwnerships(
                 List.of(lookupServiceAddress1, lookupServiceAddress2));
@@ -1422,12 +1422,12 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         FieldUtils.writeDeclaredField(channel1,
                 "inFlightStateWaitingTimeInMillis", 30 * 1000, true);
         FieldUtils.writeDeclaredField(channel1,
-                "semiTerminalStateWaitingTimeInMillis", 300 * 1000, true);
+                "stateTombstoneDelayTimeInSeconds", 300 * 1000, true);
 
         FieldUtils.writeDeclaredField(channel2,
                 "inFlightStateWaitingTimeInMillis", 30 * 1000, true);
         FieldUtils.writeDeclaredField(channel2,
-                "semiTerminalStateWaitingTimeInMillis", 300 * 1000, true);
+                "stateTombstoneDelayTimeInSeconds", 300 * 1000, true);
     }
 
     @Test(priority = 17)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
@@ -622,12 +622,12 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         FieldUtils.writeDeclaredField(channel1,
                 "inFlightStateWaitingTimeInMillis", 1 , true);
         FieldUtils.writeDeclaredField(channel1,
-                "stateTombstoneDelayTimeInSeconds", 1, true);
+                "stateTombstoneDelayTimeInMillis", 1, true);
 
         FieldUtils.writeDeclaredField(channel2,
                 "inFlightStateWaitingTimeInMillis", 1 , true);
         FieldUtils.writeDeclaredField(channel2,
-                "stateTombstoneDelayTimeInSeconds", 1, true);
+                "stateTombstoneDelayTimeInMillis", 1, true);
 
         ((ServiceUnitStateChannelImpl) channel1).monitorOwnerships(
                 List.of(lookupServiceAddress1, lookupServiceAddress2));
@@ -654,12 +654,12 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         FieldUtils.writeDeclaredField(channel1,
                 "inFlightStateWaitingTimeInMillis", 30 * 1000, true);
         FieldUtils.writeDeclaredField(channel1,
-                "stateTombstoneDelayTimeInSeconds", 300 * 1000, true);
+                "stateTombstoneDelayTimeInMillis", 300 * 1000, true);
 
         FieldUtils.writeDeclaredField(channel2,
                 "inFlightStateWaitingTimeInMillis", 30 * 1000, true);
         FieldUtils.writeDeclaredField(channel2,
-                "stateTombstoneDelayTimeInSeconds", 300 * 1000, true);
+                "stateTombstoneDelayTimeInMillis", 300 * 1000, true);
     }
 
     @Test(priority = 7)
@@ -1066,12 +1066,12 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         FieldUtils.writeDeclaredField(channel1,
                 "inFlightStateWaitingTimeInMillis", 1 , true);
         FieldUtils.writeDeclaredField(channel1,
-                "stateTombstoneDelayTimeInSeconds", 1, true);
+                "stateTombstoneDelayTimeInMillis", 1, true);
 
         FieldUtils.writeDeclaredField(channel2,
                 "inFlightStateWaitingTimeInMillis", 1 , true);
         FieldUtils.writeDeclaredField(channel2,
-                "stateTombstoneDelayTimeInSeconds", 1, true);
+                "stateTombstoneDelayTimeInMillis", 1, true);
 
         ((ServiceUnitStateChannelImpl) channel1).monitorOwnerships(
                 List.of(lookupServiceAddress1, lookupServiceAddress2));
@@ -1094,12 +1094,12 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         FieldUtils.writeDeclaredField(channel1,
                 "inFlightStateWaitingTimeInMillis", 30 * 1000, true);
         FieldUtils.writeDeclaredField(channel1,
-                "stateTombstoneDelayTimeInSeconds", 30 * 1000, true);
+                "stateTombstoneDelayTimeInMillis", 30 * 1000, true);
 
         FieldUtils.writeDeclaredField(channel2,
                 "inFlightStateWaitingTimeInMillis", 300 * 1000, true);
         FieldUtils.writeDeclaredField(channel2,
-                "stateTombstoneDelayTimeInSeconds", 300 * 1000, true);
+                "stateTombstoneDelayTimeInMillis", 300 * 1000, true);
     }
 
     @Test(priority = 13)
@@ -1396,9 +1396,9 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         // try the monitor and check the monitor moves `Deleted` -> `Init`
 
         FieldUtils.writeDeclaredField(channel1,
-                "stateTombstoneDelayTimeInSeconds", 1, true);
+                "stateTombstoneDelayTimeInMillis", 1, true);
         FieldUtils.writeDeclaredField(channel2,
-                "stateTombstoneDelayTimeInSeconds", 1, true);
+                "stateTombstoneDelayTimeInMillis", 1, true);
 
         ((ServiceUnitStateChannelImpl) channel1).monitorOwnerships(
                 List.of(lookupServiceAddress1, lookupServiceAddress2));
@@ -1422,12 +1422,12 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         FieldUtils.writeDeclaredField(channel1,
                 "inFlightStateWaitingTimeInMillis", 30 * 1000, true);
         FieldUtils.writeDeclaredField(channel1,
-                "stateTombstoneDelayTimeInSeconds", 300 * 1000, true);
+                "stateTombstoneDelayTimeInMillis", 300 * 1000, true);
 
         FieldUtils.writeDeclaredField(channel2,
                 "inFlightStateWaitingTimeInMillis", 30 * 1000, true);
         FieldUtils.writeDeclaredField(channel2,
-                "stateTombstoneDelayTimeInSeconds", 300 * 1000, true);
+                "stateTombstoneDelayTimeInMillis", 300 * 1000, true);
     }
 
     @Test(priority = 17)


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes: https://github.com/apache/pulsar/issues/21654 

PIP: [#307 ](https://github.com/apache/pulsar/pull/20748)

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

- We want to expose the in-flight state waiting time and service channel monitor interval configs to further control the Extensible Load Balancer behavior. We don't expose these vars in the broker.conf in this PR, as their tuning is rare.

- Improve the flakiness of the ExtensibleLoadBalancerImplTest by removing static mock.

- Add AddEntry failure handler logic for the PIP-307 to cover the edge-case.



### Modifications

<!-- Describe the modifications you've done. -->

- Expose the in-flight state waiting time and service channel monitor interval configs in ServiceConfiguration.

- Removed static mock in the ExtensibleLoadBalancerImplTest

- Added retries in ExtensibleLoadBalancerImplTest test cases.

- Add AddEntry failure handler logic for the PIP-307 to cover the edgecase. (added transferring state in AbstracTopic)


### Verifying this change

- [x] Make sure that the change passes the CI checks.

- `Add AddEntry failure handler logic for the PIP-307 to cover the edgecase.` logic is covered by `testTransferClientReconnectionWithoutLookup` (this test was flaky because of the AddEntry failure while the ledger is fenced by the unloading)

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/heesung-sn/pulsar/pull/54

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
