### PR TITLE
[improve][io] Make connectors load sensitive fields from secrets

### DIFF
--- a/pulsar-io/canal/pom.xml
+++ b/pulsar-io/canal/pom.xml
@@ -39,6 +39,11 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>pulsar-io-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>pulsar-io-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/pulsar-io/canal/src/main/java/org/apache/pulsar/io/canal/CanalAbstractSource.java
+++ b/pulsar-io/canal/src/main/java/org/apache/pulsar/io/canal/CanalAbstractSource.java
@@ -57,7 +57,7 @@ public abstract class CanalAbstractSource<V> extends PushSource<V> {
 
     @Override
     public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
-        canalSourceConfig = CanalSourceConfig.load(config);
+        canalSourceConfig = CanalSourceConfig.load(config, sourceContext);
         if (canalSourceConfig.getCluster()) {
             connector = CanalConnectors.newClusterConnector(canalSourceConfig.getZkServers(),
                     canalSourceConfig.getDestination(), canalSourceConfig.getUsername(),

--- a/pulsar-io/canal/src/main/java/org/apache/pulsar/io/canal/CanalSourceConfig.java
+++ b/pulsar-io/canal/src/main/java/org/apache/pulsar/io/canal/CanalSourceConfig.java
@@ -26,6 +26,8 @@ import java.io.Serializable;
 import java.util.Map;
 import lombok.Data;
 import lombok.experimental.Accessors;
+import org.apache.pulsar.io.common.IOConfigUtils;
+import org.apache.pulsar.io.core.SourceContext;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
 
 
@@ -86,8 +88,7 @@ public class CanalSourceConfig implements Serializable{
     }
 
 
-    public static CanalSourceConfig load(Map<String, Object> map) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(mapper.writeValueAsString(map), CanalSourceConfig.class);
+    public static CanalSourceConfig load(Map<String, Object> map, SourceContext sourceContext) throws IOException {
+        return IOConfigUtils.loadWithSecrets(map, CanalSourceConfig.class, sourceContext);
     }
 }

--- a/pulsar-io/common/src/main/java/org/apache/pulsar/io/common/IOConfigUtils.java
+++ b/pulsar-io/common/src/main/java/org/apache/pulsar/io/common/IOConfigUtils.java
@@ -77,12 +77,13 @@ public class IOConfigUtils {
                         }
                     }
                     configs.computeIfAbsent(field.getName(), key -> {
-                        if (fieldDoc.required()) {
-                            throw new IllegalArgumentException(field.getName() + " cannot be null");
-                        }
+                        // Use default value if it is not null before checking required
                         String value = fieldDoc.defaultValue();
                         if (value != null && !value.isEmpty()) {
                             return value;
+                        }
+                        if (fieldDoc.required()) {
+                            throw new IllegalArgumentException(field.getName() + " cannot be null");
                         }
                         return null;
                     });

--- a/pulsar-io/common/src/test/java/org/apache/pulsar/io/common/IOConfigUtilsTest.java
+++ b/pulsar-io/common/src/test/java/org/apache/pulsar/io/common/IOConfigUtilsTest.java
@@ -55,6 +55,14 @@ public class IOConfigUtilsTest {
         protected String testRequired;
 
         @FieldDoc(
+                required = true,
+                defaultValue = "defaultRequired",
+                sensitive = true,
+                help = "testRequired"
+        )
+        protected String testDefaultRequired;
+
+        @FieldDoc(
                 required = false,
                 defaultValue = "defaultStr",
                 sensitive = false,
@@ -304,6 +312,9 @@ public class IOConfigUtilsTest {
         configMap.put("testRequired", "test");
         TestDefaultConfig testDefaultConfig =
                 IOConfigUtils.loadWithSecrets(configMap, TestDefaultConfig.class, new TestSinkContext());
+        // if there is default value for a required field and no value provided when load config,
+        // it should not throw exception but use the default value.
+        Assert.assertEquals(testDefaultConfig.getTestDefaultRequired(), "defaultRequired");
         Assert.assertEquals(testDefaultConfig.getDefaultStr(), "defaultStr");
         Assert.assertEquals(testDefaultConfig.isDefaultBool(), true);
         Assert.assertEquals(testDefaultConfig.getDefaultInt(), 100);

--- a/pulsar-io/dynamodb/pom.xml
+++ b/pulsar-io/dynamodb/pom.xml
@@ -34,6 +34,12 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-io-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-io-core</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/pulsar-io/dynamodb/src/main/java/org/apache/pulsar/io/dynamodb/DynamoDBSource.java
+++ b/pulsar-io/dynamodb/src/main/java/org/apache/pulsar/io/dynamodb/DynamoDBSource.java
@@ -65,7 +65,7 @@ public class DynamoDBSource extends AbstractAwsConnector implements Source<byte[
 
     @Override
     public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
-        this.dynamodbSourceConfig = DynamoDBSourceConfig.load(config);
+        this.dynamodbSourceConfig = DynamoDBSourceConfig.load(config, sourceContext);
         checkArgument(isNotBlank(dynamodbSourceConfig.getAwsDynamodbStreamArn()),
                 "empty dynamo-stream arn");
         // Even if the endpoint is set, it seems to require a region to go with it

--- a/pulsar-io/dynamodb/src/main/java/org/apache/pulsar/io/dynamodb/DynamoDBSourceConfig.java
+++ b/pulsar-io/dynamodb/src/main/java/org/apache/pulsar/io/dynamodb/DynamoDBSourceConfig.java
@@ -35,6 +35,8 @@ import java.util.Date;
 import java.util.Map;
 import lombok.Data;
 import org.apache.pulsar.io.aws.AwsCredentialProviderPlugin;
+import org.apache.pulsar.io.common.IOConfigUtils;
+import org.apache.pulsar.io.core.SourceContext;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
 import software.amazon.awssdk.regions.Region;
 
@@ -77,6 +79,7 @@ public class DynamoDBSourceConfig implements Serializable {
     @FieldDoc(
             required = false,
             defaultValue = "",
+            sensitive = true,
             help = "json-parameters to initialize `AwsCredentialsProviderPlugin`")
     private String awsCredentialPluginParam = "";
 
@@ -170,9 +173,8 @@ public class DynamoDBSourceConfig implements Serializable {
         return mapper.readValue(new File(yamlFile), DynamoDBSourceConfig.class);
     }
 
-    public static DynamoDBSourceConfig load(Map<String, Object> map) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(mapper.writeValueAsString(map), DynamoDBSourceConfig.class);
+    public static DynamoDBSourceConfig load(Map<String, Object> map, SourceContext sourceContext) throws IOException {
+        return IOConfigUtils.loadWithSecrets(map, DynamoDBSourceConfig.class, sourceContext);
     }
 
     protected Region regionAsV2Region() {

--- a/pulsar-io/influxdb/pom.xml
+++ b/pulsar-io/influxdb/pom.xml
@@ -34,6 +34,11 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>pulsar-io-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>pulsar-io-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/InfluxDBGenericRecordSink.java
+++ b/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/InfluxDBGenericRecordSink.java
@@ -46,12 +46,12 @@ public class InfluxDBGenericRecordSink implements Sink<GenericRecord> {
     @Override
     public void open(Map<String, Object> map, SinkContext sinkContext) throws Exception {
         try {
-            val configV2 = InfluxDBSinkConfig.load(map);
+            val configV2 = InfluxDBSinkConfig.load(map, sinkContext);
             configV2.validate();
             sink = new InfluxDBSink();
         } catch (Exception e) {
             try {
-                val configV1 = org.apache.pulsar.io.influxdb.v1.InfluxDBSinkConfig.load(map);
+                val configV1 = org.apache.pulsar.io.influxdb.v1.InfluxDBSinkConfig.load(map, sinkContext);
                 configV1.validate();
                 sink = new org.apache.pulsar.io.influxdb.v1.InfluxDBGenericRecordSink();
             } catch (Exception e1) {

--- a/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/v1/InfluxDBAbstractSink.java
+++ b/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/v1/InfluxDBAbstractSink.java
@@ -43,7 +43,7 @@ public abstract class InfluxDBAbstractSink<T> extends BatchSink<Point, T> {
 
     @Override
     public void open(Map<String, Object> config, SinkContext sinkContext) throws Exception {
-        InfluxDBSinkConfig influxDBSinkConfig = InfluxDBSinkConfig.load(config);
+        InfluxDBSinkConfig influxDBSinkConfig = InfluxDBSinkConfig.load(config, sinkContext);
         influxDBSinkConfig.validate();
 
         super.init(influxDBSinkConfig.getBatchTimeMs(), influxDBSinkConfig.getBatchSize());

--- a/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/v1/InfluxDBSinkConfig.java
+++ b/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/v1/InfluxDBSinkConfig.java
@@ -117,8 +117,6 @@ public class InfluxDBSinkConfig implements Serializable {
     }
 
     public void validate() {
-        Preconditions.checkNotNull(influxdbUrl, "influxdbUrl property not set.");
-        Preconditions.checkNotNull(database, "database property not set.");
         Preconditions.checkArgument(batchSize > 0, "batchSize must be a positive integer.");
         Preconditions.checkArgument(batchTimeMs > 0, "batchTimeMs must be a positive long.");
     }

--- a/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/v1/InfluxDBSinkConfig.java
+++ b/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/v1/InfluxDBSinkConfig.java
@@ -96,7 +96,7 @@ public class InfluxDBSinkConfig implements Serializable {
 
     @FieldDoc(
         required = false,
-        defaultValue = "1000L",
+        defaultValue = "1000",
         help = "The InfluxDB operation time in milliseconds")
     private long batchTimeMs = 1000L;
 

--- a/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/v1/InfluxDBSinkConfig.java
+++ b/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/v1/InfluxDBSinkConfig.java
@@ -27,6 +27,8 @@ import java.io.Serializable;
 import java.util.Map;
 import lombok.Data;
 import lombok.experimental.Accessors;
+import org.apache.pulsar.io.common.IOConfigUtils;
+import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
 
 /**
@@ -110,9 +112,8 @@ public class InfluxDBSinkConfig implements Serializable {
         return mapper.readValue(new File(yamlFile), InfluxDBSinkConfig.class);
     }
 
-    public static InfluxDBSinkConfig load(Map<String, Object> map) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(mapper.writeValueAsString(map), InfluxDBSinkConfig.class);
+    public static InfluxDBSinkConfig load(Map<String, Object> map, SinkContext sinkContext) throws IOException {
+        return IOConfigUtils.loadWithSecrets(map, InfluxDBSinkConfig.class, sinkContext);
     }
 
     public void validate() {

--- a/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/v2/InfluxDBSink.java
+++ b/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/v2/InfluxDBSink.java
@@ -49,7 +49,7 @@ public class InfluxDBSink extends BatchSink<Point, GenericRecord> {
 
     @Override
     public void open(Map<String, Object> config, SinkContext sinkContext) throws Exception {
-        InfluxDBSinkConfig influxDBSinkConfig = InfluxDBSinkConfig.load(config);
+        InfluxDBSinkConfig influxDBSinkConfig = InfluxDBSinkConfig.load(config, sinkContext);
         influxDBSinkConfig.validate();
         super.init(influxDBSinkConfig.getBatchTimeMs(), influxDBSinkConfig.getBatchSize());
 

--- a/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/v2/InfluxDBSinkConfig.java
+++ b/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/v2/InfluxDBSinkConfig.java
@@ -27,6 +27,8 @@ import java.io.Serializable;
 import java.util.Map;
 import lombok.Data;
 import lombok.experimental.Accessors;
+import org.apache.pulsar.io.common.IOConfigUtils;
+import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
 
 /**
@@ -103,9 +105,8 @@ public class InfluxDBSinkConfig implements Serializable {
         return mapper.readValue(new File(yamlFile), InfluxDBSinkConfig.class);
     }
 
-    public static InfluxDBSinkConfig load(Map<String, Object> map) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(mapper.writeValueAsString(map), InfluxDBSinkConfig.class);
+    public static InfluxDBSinkConfig load(Map<String, Object> map, SinkContext sinkContext) throws IOException {
+        return IOConfigUtils.loadWithSecrets(map, InfluxDBSinkConfig.class, sinkContext);
     }
 
     public void validate() {

--- a/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/v2/InfluxDBSinkConfig.java
+++ b/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/v2/InfluxDBSinkConfig.java
@@ -110,11 +110,6 @@ public class InfluxDBSinkConfig implements Serializable {
     }
 
     public void validate() {
-        Preconditions.checkNotNull(influxdbUrl, "influxdbUrl property not set.");
-        Preconditions.checkNotNull(token, "token property not set.");
-        Preconditions.checkNotNull(organization, "organization property not set.");
-        Preconditions.checkNotNull(bucket, "bucket property not set.");
-
         Preconditions.checkArgument(batchSize > 0, "batchSize must be a positive integer.");
         Preconditions.checkArgument(batchTimeMs > 0, "batchTimeMs must be a positive long.");
     }

--- a/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/v2/InfluxDBSinkConfig.java
+++ b/pulsar-io/influxdb/src/main/java/org/apache/pulsar/io/influxdb/v2/InfluxDBSinkConfig.java
@@ -89,7 +89,7 @@ public class InfluxDBSinkConfig implements Serializable {
 
     @FieldDoc(
             required = false,
-            defaultValue = "1000L",
+            defaultValue = "1000",
             help = "The InfluxDB operation time in milliseconds")
     private long batchTimeMs = 1000;
 

--- a/pulsar-io/influxdb/src/test/java/org/apache/pulsar/io/influxdb/v1/InfluxDBSinkConfigTest.java
+++ b/pulsar-io/influxdb/src/test/java/org/apache/pulsar/io/influxdb/v1/InfluxDBSinkConfigTest.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pulsar.io.influxdb.v1;
 
+import org.apache.pulsar.io.core.SinkContext;
 import org.influxdb.InfluxDB;
+import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -60,8 +62,11 @@ public class InfluxDBSinkConfigTest {
         map.put("gzipEnable", "false");
         map.put("batchTimeMs", "1000");
         map.put("batchSize", "100");
+        map.put("username", "admin");
+        map.put("password", "admin");
 
-        InfluxDBSinkConfig config = InfluxDBSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        InfluxDBSinkConfig config = InfluxDBSinkConfig.load(map, sinkContext);
         assertNotNull(config);
         assertEquals("http://localhost:8086", config.getInfluxdbUrl());
         assertEquals("test_db", config.getDatabase());
@@ -71,6 +76,39 @@ public class InfluxDBSinkConfigTest {
         assertEquals(Boolean.parseBoolean("false"), config.isGzipEnable());
         assertEquals(Long.parseLong("1000"), config.getBatchTimeMs());
         assertEquals(Integer.parseInt("100"), config.getBatchSize());
+        assertEquals("admin", config.getUsername());
+        assertEquals("admin", config.getPassword());
+    }
+
+    @Test
+    public final void loadFromMapCredentialFromSecretTest() throws IOException {
+        Map<String, Object> map = new HashMap<>();
+        map.put("influxdbUrl", "http://localhost:8086");
+        map.put("database", "test_db");
+        map.put("consistencyLevel", "ONE");
+        map.put("logLevel", "NONE");
+        map.put("retentionPolicy", "autogen");
+        map.put("gzipEnable", "false");
+        map.put("batchTimeMs", "1000");
+        map.put("batchSize", "100");
+
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        Mockito.when(sinkContext.getSecret("username"))
+                .thenReturn("admin");
+        Mockito.when(sinkContext.getSecret("password"))
+                .thenReturn("admin");
+        InfluxDBSinkConfig config = InfluxDBSinkConfig.load(map, sinkContext);
+        assertNotNull(config);
+        assertEquals("http://localhost:8086", config.getInfluxdbUrl());
+        assertEquals("test_db", config.getDatabase());
+        assertEquals("ONE", config.getConsistencyLevel());
+        assertEquals("NONE", config.getLogLevel());
+        assertEquals("autogen", config.getRetentionPolicy());
+        assertEquals(Boolean.parseBoolean("false"), config.isGzipEnable());
+        assertEquals(Long.parseLong("1000"), config.getBatchTimeMs());
+        assertEquals(Integer.parseInt("100"), config.getBatchSize());
+        assertEquals("admin", config.getUsername());
+        assertEquals("admin", config.getPassword());
     }
 
     @Test
@@ -85,12 +123,13 @@ public class InfluxDBSinkConfigTest {
         map.put("batchTimeMs", "1000");
         map.put("batchSize", "100");
 
-        InfluxDBSinkConfig config = InfluxDBSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        InfluxDBSinkConfig config = InfluxDBSinkConfig.load(map, sinkContext);
         config.validate();
     }
 
-    @Test(expectedExceptions = NullPointerException.class,
-        expectedExceptionsMessageRegExp = "influxdbUrl property not set.")
+    @Test(expectedExceptions = IllegalArgumentException.class,
+        expectedExceptionsMessageRegExp = "influxdbUrl cannot be null")
     public final void missingInfluxdbUrlValidateTest() throws IOException {
         Map<String, Object> map = new HashMap<>();
         map.put("database", "test_db");
@@ -101,7 +140,8 @@ public class InfluxDBSinkConfigTest {
         map.put("batchTimeMs", "1000");
         map.put("batchSize", "100");
 
-        InfluxDBSinkConfig config = InfluxDBSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        InfluxDBSinkConfig config = InfluxDBSinkConfig.load(map, sinkContext);
         config.validate();
     }
 
@@ -118,7 +158,8 @@ public class InfluxDBSinkConfigTest {
         map.put("batchTimeMs", "1000");
         map.put("batchSize", "-100");
 
-        InfluxDBSinkConfig config = InfluxDBSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        InfluxDBSinkConfig config = InfluxDBSinkConfig.load(map, sinkContext);
         config.validate();
     }
 
@@ -135,7 +176,8 @@ public class InfluxDBSinkConfigTest {
         map.put("batchTimeMs", "1000");
         map.put("batchSize", "100");
 
-        InfluxDBSinkConfig config = InfluxDBSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        InfluxDBSinkConfig config = InfluxDBSinkConfig.load(map, sinkContext);
         config.validate();
 
         InfluxDB.ConsistencyLevel.valueOf(config.getConsistencyLevel().toUpperCase());

--- a/pulsar-io/jdbc/core/pom.xml
+++ b/pulsar-io/jdbc/core/pom.xml
@@ -34,6 +34,12 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-io-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-io-core</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcAbstractSink.java
+++ b/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcAbstractSink.java
@@ -76,7 +76,7 @@ public abstract class JdbcAbstractSink<T> implements Sink<T> {
 
     @Override
     public void open(Map<String, Object> config, SinkContext sinkContext) throws Exception {
-        jdbcSinkConfig = JdbcSinkConfig.load(config);
+        jdbcSinkConfig = JdbcSinkConfig.load(config, sinkContext);
         jdbcSinkConfig.validate();
 
         jdbcUrl = jdbcSinkConfig.getJdbcUrl();

--- a/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcSinkConfig.java
+++ b/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/JdbcSinkConfig.java
@@ -26,6 +26,8 @@ import java.io.Serializable;
 import java.util.Map;
 import lombok.Data;
 import lombok.experimental.Accessors;
+import org.apache.pulsar.io.common.IOConfigUtils;
+import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
 
 @Data
@@ -145,9 +147,8 @@ public class JdbcSinkConfig implements Serializable {
         return mapper.readValue(new File(yamlFile), JdbcSinkConfig.class);
     }
 
-    public static JdbcSinkConfig load(Map<String, Object> map) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(mapper.writeValueAsString(map), JdbcSinkConfig.class);
+    public static JdbcSinkConfig load(Map<String, Object> map, SinkContext sinkContext) throws IOException {
+        return IOConfigUtils.loadWithSecrets(map, JdbcSinkConfig.class, sinkContext);
     }
 
     public void validate() {

--- a/pulsar-io/kafka/pom.xml
+++ b/pulsar-io/kafka/pom.xml
@@ -46,6 +46,11 @@
   </dependencyManagement>
 
   <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-io-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSink.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSink.java
@@ -79,7 +79,7 @@ public abstract class KafkaAbstractSink<K, V> implements Sink<byte[]> {
 
     @Override
     public void open(Map<String, Object> config, SinkContext sinkContext) throws Exception {
-        kafkaSinkConfig = KafkaSinkConfig.load(config);
+        kafkaSinkConfig = KafkaSinkConfig.load(config, sinkContext);
         Objects.requireNonNull(kafkaSinkConfig.getTopic(), "Kafka topic is not set");
         Objects.requireNonNull(kafkaSinkConfig.getBootstrapServers(), "Kafka bootstrapServers is not set");
         Objects.requireNonNull(kafkaSinkConfig.getAcks(), "Kafka acks mode is not set");

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSink.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSink.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.io.kafka;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSink.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSink.java
@@ -80,9 +80,6 @@ public abstract class KafkaAbstractSink<K, V> implements Sink<byte[]> {
     @Override
     public void open(Map<String, Object> config, SinkContext sinkContext) throws Exception {
         kafkaSinkConfig = KafkaSinkConfig.load(config, sinkContext);
-        Objects.requireNonNull(kafkaSinkConfig.getTopic(), "Kafka topic is not set");
-        Objects.requireNonNull(kafkaSinkConfig.getBootstrapServers(), "Kafka bootstrapServers is not set");
-        Objects.requireNonNull(kafkaSinkConfig.getAcks(), "Kafka acks mode is not set");
         if (kafkaSinkConfig.getBatchSize() <= 0) {
             throw new IllegalArgumentException("Invalid Kafka Producer batchSize : "
                 + kafkaSinkConfig.getBatchSize());

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSource.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSource.java
@@ -66,7 +66,7 @@ public abstract class KafkaAbstractSource<V> extends PushSource<V> {
 
     @Override
     public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
-        kafkaSourceConfig = KafkaSourceConfig.load(config);
+        kafkaSourceConfig = KafkaSourceConfig.load(config, sourceContext);
         Objects.requireNonNull(kafkaSourceConfig.getTopic(), "Kafka topic is not set");
         Objects.requireNonNull(kafkaSourceConfig.getBootstrapServers(), "Kafka bootstrapServers is not set");
         Objects.requireNonNull(kafkaSourceConfig.getGroupId(), "Kafka consumer group id is not set");

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSinkConfig.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSinkConfig.java
@@ -87,12 +87,12 @@ public class KafkaSinkConfig implements Serializable {
                     + " before considering a request complete. This controls the durability of records that are sent.")
     private String acks;
     @FieldDoc(
-            defaultValue = "16384L",
+            defaultValue = "16384",
             help = "The batch size that Kafka producer will attempt to batch records together"
                     + " before sending them to brokers.")
     private long batchSize = 16384L;
     @FieldDoc(
-            defaultValue = "1048576L",
+            defaultValue = "1048576",
             help =
                     "The maximum size of a Kafka request in bytes.")
     private long maxRequestSize = 1048576L;

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSinkConfig.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSinkConfig.java
@@ -26,6 +26,8 @@ import java.io.Serializable;
 import java.util.Map;
 import lombok.Data;
 import lombok.experimental.Accessors;
+import org.apache.pulsar.io.common.IOConfigUtils;
+import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
 
 @Data
@@ -123,8 +125,7 @@ public class KafkaSinkConfig implements Serializable {
         return mapper.readValue(new File(yamlFile), KafkaSinkConfig.class);
     }
 
-    public static KafkaSinkConfig load(Map<String, Object> map) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(mapper.writeValueAsString(map), KafkaSinkConfig.class);
+    public static KafkaSinkConfig load(Map<String, Object> map, SinkContext sinkContext) throws IOException {
+        return IOConfigUtils.loadWithSecrets(map, KafkaSinkConfig.class, sinkContext);
     }
 }

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSourceConfig.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSourceConfig.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
 import java.util.Map;
 import lombok.Data;
 import lombok.experimental.Accessors;
+import org.apache.pulsar.io.core.SourceContext;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
 
 @Data
@@ -152,8 +153,13 @@ public class KafkaSourceConfig implements Serializable {
         return mapper.readValue(new File(yamlFile), KafkaSourceConfig.class);
     }
 
-    public static KafkaSourceConfig load(Map<String, Object> map) throws IOException {
+    public static KafkaSourceConfig load(Map<String, Object> map, SourceContext sourceContext) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
+        try {
+            map.put("sslTruststorePassword", sourceContext.getSecret("sslTruststorePassword"));
+        } catch (Exception e) {
+            // ignore
+        }
         mapper.enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
         return mapper.readValue(mapper.writeValueAsString(map), KafkaSourceConfig.class);
     }

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSourceConfig.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSourceConfig.java
@@ -155,7 +155,12 @@ public class KafkaSourceConfig implements Serializable {
 
     public static KafkaSourceConfig load(Map<String, Object> map, SourceContext sourceContext) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
-        map.put("sslTruststorePassword", sourceContext.getSecret("sslTruststorePassword"));
+        // since the KafkaSourceConfig requires the ACCEPT_EMPTY_STRING_AS_NULL_OBJECT feature
+        // We manually set the sensitive fields here instead of calling `IOConfigUtils.loadWithSecrets`
+        String sslTruststorePassword = sourceContext.getSecret("sslTruststorePassword");
+        if (sslTruststorePassword != null) {
+            map.put("sslTruststorePassword", sslTruststorePassword);
+        }
         mapper.enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
         return mapper.readValue(mapper.writeValueAsString(map), KafkaSourceConfig.class);
     }

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSourceConfig.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSourceConfig.java
@@ -155,11 +155,7 @@ public class KafkaSourceConfig implements Serializable {
 
     public static KafkaSourceConfig load(Map<String, Object> map, SourceContext sourceContext) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
-        try {
-            map.put("sslTruststorePassword", sourceContext.getSecret("sslTruststorePassword"));
-        } catch (Exception e) {
-            // ignore
-        }
+        map.put("sslTruststorePassword", sourceContext.getSecret("sslTruststorePassword"));
         mapper.enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
         return mapper.readValue(mapper.writeValueAsString(map), KafkaSourceConfig.class);
     }

--- a/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/sink/KafkaAbstractSinkTest.java
+++ b/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/sink/KafkaAbstractSinkTest.java
@@ -193,12 +193,12 @@ public class KafkaAbstractSinkTest {
                 sink.close();
             }
         };
-        expectThrows(NullPointerException.class, "Kafka topic is not set", openAndClose);
-        config.put("topic", "topic_2");
-        expectThrows(NullPointerException.class, "Kafka bootstrapServers is not set", openAndClose);
+        expectThrows(IllegalArgumentException.class, "bootstrapServers cannot be null", openAndClose);
         config.put("bootstrapServers", "localhost:6667");
-        expectThrows(NullPointerException.class, "Kafka acks mode is not set", openAndClose);
+        expectThrows(IllegalArgumentException.class, "acks cannot be null", openAndClose);
         config.put("acks", "1");
+        expectThrows(IllegalArgumentException.class, "topic cannot be null", openAndClose);
+        config.put("topic", "topic_2");
         config.put("batchSize", "-1");
         expectThrows(IllegalArgumentException.class, "Invalid Kafka Producer batchSize : -1", openAndClose);
         config.put("batchSize", "16384");

--- a/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/source/KafkaAbstractSourceTest.java
+++ b/pulsar-io/kafka/src/test/java/org/apache/pulsar/io/kafka/source/KafkaAbstractSourceTest.java
@@ -108,17 +108,37 @@ public class KafkaAbstractSourceTest {
     public void loadConsumerConfigPropertiesFromMapTest() throws Exception {
         Map<String, Object> config = new HashMap<>();
         config.put("consumerConfigProperties", "");
-        KafkaSourceConfig kafkaSourceConfig = KafkaSourceConfig.load(config);
+        config.put("bootstrapServers", "localhost:8080");
+        config.put("groupId", "test-group");
+        config.put("topic", "test-topic");
+        SourceContext sourceContext = Mockito.mock(SourceContext.class);
+        KafkaSourceConfig kafkaSourceConfig = KafkaSourceConfig.load(config, sourceContext);
         assertNotNull(kafkaSourceConfig);
         assertNull(kafkaSourceConfig.getConsumerConfigProperties());
 
         config.put("consumerConfigProperties", null);
-        kafkaSourceConfig = KafkaSourceConfig.load(config);
+        kafkaSourceConfig = KafkaSourceConfig.load(config, sourceContext);
         assertNull(kafkaSourceConfig.getConsumerConfigProperties());
 
         config.put("consumerConfigProperties", ImmutableMap.of("foo", "bar"));
-        kafkaSourceConfig = KafkaSourceConfig.load(config);
+        kafkaSourceConfig = KafkaSourceConfig.load(config, sourceContext);
         assertEquals(kafkaSourceConfig.getConsumerConfigProperties(), ImmutableMap.of("foo", "bar"));
+    }
+
+    @Test
+    public void loadSensitiveFieldsFromSecretTest() throws Exception {
+        Map<String, Object> config = new HashMap<>();
+        config.put("consumerConfigProperties", "");
+        config.put("bootstrapServers", "localhost:8080");
+        config.put("groupId", "test-group");
+        config.put("topic", "test-topic");
+        SourceContext sourceContext = Mockito.mock(SourceContext.class);
+        Mockito.when(sourceContext.getSecret("sslTruststorePassword"))
+                .thenReturn("xxxx");
+        KafkaSourceConfig kafkaSourceConfig = KafkaSourceConfig.load(config, sourceContext);
+        assertNotNull(kafkaSourceConfig);
+        assertNull(kafkaSourceConfig.getConsumerConfigProperties());
+        assertEquals("xxxx", kafkaSourceConfig.getSslTruststorePassword());
     }
 
     @Test

--- a/pulsar-io/mongo/pom.xml
+++ b/pulsar-io/mongo/pom.xml
@@ -38,6 +38,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-io-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>${project.parent.groupId}</groupId>
       <artifactId>pulsar-io-core</artifactId>
       <version>${project.parent.version}</version>

--- a/pulsar-io/mongo/src/main/java/org/apache/pulsar/io/mongodb/MongoAbstractConfig.java
+++ b/pulsar-io/mongo/src/main/java/org/apache/pulsar/io/mongodb/MongoAbstractConfig.java
@@ -42,6 +42,7 @@ public abstract class MongoAbstractConfig implements Serializable {
 
     @FieldDoc(
             required = true,
+            sensitive = true, // it may contain password
             defaultValue = "",
             help = "The URI of MongoDB that the connector connects to "
                     + "(see: https://docs.mongodb.com/manual/reference/connection-string/)"

--- a/pulsar-io/mongo/src/main/java/org/apache/pulsar/io/mongodb/MongoAbstractConfig.java
+++ b/pulsar-io/mongo/src/main/java/org/apache/pulsar/io/mongodb/MongoAbstractConfig.java
@@ -96,7 +96,6 @@ public abstract class MongoAbstractConfig implements Serializable {
     }
 
     public void validate() {
-        checkArgument(!StringUtils.isEmpty(getMongoUri()), "Required MongoDB URI is not set.");
         checkArgument(getBatchSize() > 0, "batchSize must be a positive integer.");
         checkArgument(getBatchTimeMs() > 0, "batchTimeMs must be a positive long.");
     }

--- a/pulsar-io/mongo/src/main/java/org/apache/pulsar/io/mongodb/MongoAbstractConfig.java
+++ b/pulsar-io/mongo/src/main/java/org/apache/pulsar/io/mongodb/MongoAbstractConfig.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import lombok.Data;
 import lombok.experimental.Accessors;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
 
 /**

--- a/pulsar-io/mongo/src/main/java/org/apache/pulsar/io/mongodb/MongoSink.java
+++ b/pulsar-io/mongo/src/main/java/org/apache/pulsar/io/mongodb/MongoSink.java
@@ -86,7 +86,7 @@ public class MongoSink implements Sink<byte[]> {
     public void open(Map<String, Object> config, SinkContext sinkContext) throws Exception {
         log.info("Open MongoDB Sink");
 
-        mongoSinkConfig = MongoSinkConfig.load(config);
+        mongoSinkConfig = MongoSinkConfig.load(config, sinkContext);
         mongoSinkConfig.validate();
 
         if (clientProvider != null) {

--- a/pulsar-io/mongo/src/main/java/org/apache/pulsar/io/mongodb/MongoSinkConfig.java
+++ b/pulsar-io/mongo/src/main/java/org/apache/pulsar/io/mongodb/MongoSinkConfig.java
@@ -30,6 +30,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.io.common.IOConfigUtils;
+import org.apache.pulsar.io.core.SinkContext;
 
 /**
  * Configuration class for the MongoDB Sink Connectors.
@@ -59,11 +61,8 @@ public class MongoSinkConfig extends MongoAbstractConfig {
         return cfg;
     }
 
-    public static MongoSinkConfig load(Map<String, Object> map) throws IOException {
-        final ObjectMapper mapper = new ObjectMapper();
-        final MongoSinkConfig cfg = mapper.readValue(mapper.writeValueAsString(map), MongoSinkConfig.class);
-
-        return cfg;
+    public static MongoSinkConfig load(Map<String, Object> map, SinkContext sinkContext) throws IOException {
+        return IOConfigUtils.loadWithSecrets(map, MongoSinkConfig.class, sinkContext);
     }
 
     @Override

--- a/pulsar-io/mongo/src/main/java/org/apache/pulsar/io/mongodb/MongoSource.java
+++ b/pulsar-io/mongo/src/main/java/org/apache/pulsar/io/mongodb/MongoSource.java
@@ -79,7 +79,7 @@ public class MongoSource extends PushSource<byte[]> {
     public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
         log.info("Open MongoDB Source");
 
-        mongoSourceConfig = MongoSourceConfig.load(config);
+        mongoSourceConfig = MongoSourceConfig.load(config, sourceContext);
         mongoSourceConfig.validate();
 
         if (clientProvider != null) {

--- a/pulsar-io/mongo/src/main/java/org/apache/pulsar/io/mongodb/MongoSourceConfig.java
+++ b/pulsar-io/mongo/src/main/java/org/apache/pulsar/io/mongodb/MongoSourceConfig.java
@@ -29,6 +29,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.io.common.IOConfigUtils;
+import org.apache.pulsar.io.core.SourceContext;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
 
 /**
@@ -75,12 +77,8 @@ public class MongoSourceConfig extends MongoAbstractConfig {
         return cfg;
     }
 
-    public static MongoSourceConfig load(Map<String, Object> map) throws IOException {
-        final ObjectMapper mapper = new ObjectMapper();
-        final MongoSourceConfig cfg =
-                mapper.readValue(mapper.writeValueAsString(map), MongoSourceConfig.class);
-
-        return cfg;
+    public static MongoSourceConfig load(Map<String, Object> map, SourceContext sourceContext) throws IOException {
+        return IOConfigUtils.loadWithSecrets(map, MongoSourceConfig.class, sourceContext);
     }
 
     /**

--- a/pulsar-io/mongo/src/test/java/org/apache/pulsar/io/mongodb/MongoSinkConfigTest.java
+++ b/pulsar-io/mongo/src/test/java/org/apache/pulsar/io/mongodb/MongoSinkConfigTest.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.io.mongodb;
 
 import java.util.Map;
+import org.apache.pulsar.io.core.SinkContext;
+import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -34,7 +36,27 @@ public class MongoSinkConfigTest {
         commonConfigMap.put("batchSize", TestHelper.BATCH_SIZE);
         commonConfigMap.put("batchTimeMs", TestHelper.BATCH_TIME);
 
-        final MongoSinkConfig cfg = MongoSinkConfig.load(commonConfigMap);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        final MongoSinkConfig cfg = MongoSinkConfig.load(commonConfigMap, sinkContext);
+
+        assertEquals(cfg.getMongoUri(), TestHelper.URI);
+        assertEquals(cfg.getDatabase(), TestHelper.DB);
+        assertEquals(cfg.getCollection(), TestHelper.COLL);
+        assertEquals(cfg.getBatchSize(), TestHelper.BATCH_SIZE);
+        assertEquals(cfg.getBatchTimeMs(), TestHelper.BATCH_TIME);
+    }
+
+    @Test
+    public void testLoadMapConfigUrlFromSecret() throws IOException {
+        final Map<String, Object> commonConfigMap = TestHelper.createCommonConfigMap();
+        commonConfigMap.put("batchSize", TestHelper.BATCH_SIZE);
+        commonConfigMap.put("batchTimeMs", TestHelper.BATCH_TIME);
+        commonConfigMap.remove("mongoUri");
+
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        Mockito.when(sinkContext.getSecret("mongoUri"))
+                .thenReturn(TestHelper.URI);
+        final MongoSinkConfig cfg = MongoSinkConfig.load(commonConfigMap, sinkContext);
 
         assertEquals(cfg.getMongoUri(), TestHelper.URI);
         assertEquals(cfg.getDatabase(), TestHelper.DB);
@@ -44,12 +66,13 @@ public class MongoSinkConfigTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class,
-            expectedExceptionsMessageRegExp = "Required MongoDB URI is not set.")
+            expectedExceptionsMessageRegExp = "mongoUri cannot be null")
     public void testBadMongoUri() throws IOException {
         final Map<String, Object> configMap = TestHelper.createCommonConfigMap();
         TestHelper.removeMongoUri(configMap);
 
-        final MongoSinkConfig cfg = MongoSinkConfig.load(configMap);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        final MongoSinkConfig cfg = MongoSinkConfig.load(configMap, sinkContext);
 
         cfg.validate();
     }
@@ -60,7 +83,8 @@ public class MongoSinkConfigTest {
         final Map<String, Object> configMap = TestHelper.createCommonConfigMap();
         TestHelper.removeDatabase(configMap);
 
-        final MongoSinkConfig cfg = MongoSinkConfig.load(configMap);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        final MongoSinkConfig cfg = MongoSinkConfig.load(configMap, sinkContext);
 
         cfg.validate();
     }
@@ -71,7 +95,8 @@ public class MongoSinkConfigTest {
         final Map<String, Object> configMap = TestHelper.createCommonConfigMap();
         TestHelper.removeCollection(configMap);
 
-        final MongoSinkConfig cfg = MongoSinkConfig.load(configMap);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        final MongoSinkConfig cfg = MongoSinkConfig.load(configMap, sinkContext);
 
         cfg.validate();
     }
@@ -82,7 +107,8 @@ public class MongoSinkConfigTest {
         final Map<String, Object> configMap = TestHelper.createCommonConfigMap();
         TestHelper.putBatchSize(configMap, 0);
 
-        final MongoSinkConfig cfg = MongoSinkConfig.load(configMap);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        final MongoSinkConfig cfg = MongoSinkConfig.load(configMap, sinkContext);
 
         cfg.validate();
     }
@@ -93,7 +119,8 @@ public class MongoSinkConfigTest {
         final Map<String, Object> configMap = TestHelper.createCommonConfigMap();
         TestHelper.putBatchTime(configMap, 0L);
 
-        final MongoSinkConfig cfg = MongoSinkConfig.load(configMap);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        final MongoSinkConfig cfg = MongoSinkConfig.load(configMap, sinkContext);
 
         cfg.validate();
     }

--- a/pulsar-io/rabbitmq/pom.xml
+++ b/pulsar-io/rabbitmq/pom.xml
@@ -34,6 +34,11 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-io-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-io-core</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSink.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSink.java
@@ -53,7 +53,7 @@ public class RabbitMQSink implements Sink<byte[]> {
 
     @Override
     public void open(Map<String, Object> config, SinkContext sinkContext) throws Exception {
-        rabbitMQSinkConfig = RabbitMQSinkConfig.load(config);
+        rabbitMQSinkConfig = RabbitMQSinkConfig.load(config, sinkContext);
         rabbitMQSinkConfig.validate();
 
         ConnectionFactory connectionFactory = rabbitMQSinkConfig.createConnectionFactory();

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSinkConfig.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSinkConfig.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
+import org.apache.pulsar.io.common.IOConfigUtils;
+import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
 
 @Data
@@ -60,9 +62,8 @@ public class RabbitMQSinkConfig extends RabbitMQAbstractConfig implements Serial
         return mapper.readValue(new File(yamlFile), RabbitMQSinkConfig.class);
     }
 
-    public static RabbitMQSinkConfig load(Map<String, Object> map) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(mapper.writeValueAsString(map), RabbitMQSinkConfig.class);
+    public static RabbitMQSinkConfig load(Map<String, Object> map, SinkContext sinkContext) throws IOException {
+        return IOConfigUtils.loadWithSecrets(map, RabbitMQSinkConfig.class, sinkContext);
     }
 
     @Override

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSinkConfig.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSinkConfig.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.io.rabbitmq;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSinkConfig.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSinkConfig.java
@@ -69,6 +69,5 @@ public class RabbitMQSinkConfig extends RabbitMQAbstractConfig implements Serial
     @Override
     public void validate() {
         super.validate();
-        Preconditions.checkNotNull(exchangeName, "exchangeName property not set.");
     }
 }

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
@@ -54,7 +54,7 @@ public class RabbitMQSource extends PushSource<byte[]> {
 
     @Override
     public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
-        rabbitMQSourceConfig = RabbitMQSourceConfig.load(config);
+        rabbitMQSourceConfig = RabbitMQSourceConfig.load(config, sourceContext);
         rabbitMQSourceConfig.validate();
 
         ConnectionFactory connectionFactory = rabbitMQSourceConfig.createConnectionFactory();

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSourceConfig.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSourceConfig.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
+import org.apache.pulsar.io.common.IOConfigUtils;
+import org.apache.pulsar.io.core.SourceContext;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
 
 @Data
@@ -66,9 +68,8 @@ public class RabbitMQSourceConfig extends RabbitMQAbstractConfig implements Seri
         return mapper.readValue(new File(yamlFile), RabbitMQSourceConfig.class);
     }
 
-    public static RabbitMQSourceConfig load(Map<String, Object> map) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(mapper.writeValueAsString(map), RabbitMQSourceConfig.class);
+    public static RabbitMQSourceConfig load(Map<String, Object> map, SourceContext sourceContext) throws IOException {
+        return IOConfigUtils.loadWithSecrets(map, RabbitMQSourceConfig.class, sourceContext);
     }
 
     @Override

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkConfigTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkConfigTest.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pulsar.io.rabbitmq.sink;
 
+import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.rabbitmq.RabbitMQSinkConfig;
+import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -71,7 +73,45 @@ public class RabbitMQSinkConfigTest {
         map.put("exchangeName", "test-exchange");
         map.put("exchangeType", "test-exchange-type");
 
-        RabbitMQSinkConfig config = RabbitMQSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        RabbitMQSinkConfig config = RabbitMQSinkConfig.load(map, sinkContext);
+        assertNotNull(config);
+        assertEquals(config.getHost(), "localhost");
+        assertEquals(config.getPort(), Integer.parseInt("5673"));
+        assertEquals(config.getVirtualHost(), "/");
+        assertEquals(config.getUsername(), "guest");
+        assertEquals(config.getPassword(), "guest");
+        assertEquals(config.getConnectionName(), "test-connection");
+        assertEquals(config.getRequestedChannelMax(), Integer.parseInt("0"));
+        assertEquals(config.getRequestedFrameMax(), Integer.parseInt("0"));
+        assertEquals(config.getConnectionTimeout(), Integer.parseInt("60000"));
+        assertEquals(config.getHandshakeTimeout(), Integer.parseInt("10000"));
+        assertEquals(config.getRequestedHeartbeat(), Integer.parseInt("60"));
+        assertEquals(config.getExchangeName(), "test-exchange");
+        assertEquals(config.getExchangeType(), "test-exchange-type");
+    }
+
+    @Test
+    public final void loadFromMapCredentialsFromSecretTest() throws IOException {
+        Map<String, Object> map = new HashMap<>();
+        map.put("host", "localhost");
+        map.put("port", "5673");
+        map.put("virtualHost", "/");
+        map.put("connectionName", "test-connection");
+        map.put("requestedChannelMax", "0");
+        map.put("requestedFrameMax", "0");
+        map.put("connectionTimeout", "60000");
+        map.put("handshakeTimeout", "10000");
+        map.put("requestedHeartbeat", "60");
+        map.put("exchangeName", "test-exchange");
+        map.put("exchangeType", "test-exchange-type");
+
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        Mockito.when(sinkContext.getSecret("username"))
+                .thenReturn("guest");
+        Mockito.when(sinkContext.getSecret("password"))
+                .thenReturn("guest");
+        RabbitMQSinkConfig config = RabbitMQSinkConfig.load(map, sinkContext);
         assertNotNull(config);
         assertEquals(config.getHost(), "localhost");
         assertEquals(config.getPort(), Integer.parseInt("5673"));
@@ -105,12 +145,13 @@ public class RabbitMQSinkConfigTest {
         map.put("exchangeName", "test-exchange");
         map.put("exchangeType", "test-exchange-type");
 
-        RabbitMQSinkConfig config = RabbitMQSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        RabbitMQSinkConfig config = RabbitMQSinkConfig.load(map, sinkContext);
         config.validate();
     }
 
-    @Test(expectedExceptions = NullPointerException.class,
-        expectedExceptionsMessageRegExp = "exchangeName property not set.")
+    @Test(expectedExceptions = IllegalArgumentException.class,
+        expectedExceptionsMessageRegExp = "exchangeName cannot be null")
     public final void missingExchangeValidateTest() throws IOException {
         Map<String, Object> map = new HashMap<>();
         map.put("host", "localhost");
@@ -126,7 +167,8 @@ public class RabbitMQSinkConfigTest {
         map.put("requestedHeartbeat", "60");
         map.put("exchangeType", "test-exchange-type");
 
-        RabbitMQSinkConfig config = RabbitMQSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        RabbitMQSinkConfig config = RabbitMQSinkConfig.load(map, sinkContext);
         config.validate();
     }
 

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceConfigTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceConfigTest.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pulsar.io.rabbitmq.source;
 
+import org.apache.pulsar.io.core.SourceContext;
 import org.apache.pulsar.io.rabbitmq.RabbitMQSourceConfig;
+import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -76,7 +78,50 @@ public class RabbitMQSourceConfigTest {
         map.put("prefetchGlobal", "false");
         map.put("passive", "true");
 
-        RabbitMQSourceConfig config = RabbitMQSourceConfig.load(map);
+        SourceContext sourceContext = Mockito.mock(SourceContext.class);
+        RabbitMQSourceConfig config = RabbitMQSourceConfig.load(map, sourceContext);
+        assertNotNull(config);
+        assertEquals("localhost", config.getHost());
+        assertEquals(Integer.parseInt("5672"), config.getPort());
+        assertEquals("/", config.getVirtualHost());
+        assertEquals("guest", config.getUsername());
+        assertEquals("guest", config.getPassword());
+        assertEquals("test-queue", config.getQueueName());
+        assertEquals("test-connection", config.getConnectionName());
+        assertEquals(Integer.parseInt("0"), config.getRequestedChannelMax());
+        assertEquals(Integer.parseInt("0"), config.getRequestedFrameMax());
+        assertEquals(Integer.parseInt("60000"), config.getConnectionTimeout());
+        assertEquals(Integer.parseInt("10000"), config.getHandshakeTimeout());
+        assertEquals(Integer.parseInt("60"), config.getRequestedHeartbeat());
+        assertEquals(Integer.parseInt("0"), config.getPrefetchCount());
+        assertEquals(false, config.isPrefetchGlobal());
+        assertEquals(false, config.isPrefetchGlobal());
+        assertEquals(true, config.isPassive());
+    }
+
+    @Test
+    public final void loadFromMapCredentialsFromSecretTest() throws IOException {
+        Map<String, Object> map = new HashMap<>();
+        map.put("host", "localhost");
+        map.put("port", "5672");
+        map.put("virtualHost", "/");
+        map.put("queueName", "test-queue");
+        map.put("connectionName", "test-connection");
+        map.put("requestedChannelMax", "0");
+        map.put("requestedFrameMax", "0");
+        map.put("connectionTimeout", "60000");
+        map.put("handshakeTimeout", "10000");
+        map.put("requestedHeartbeat", "60");
+        map.put("prefetchCount", "0");
+        map.put("prefetchGlobal", "false");
+        map.put("passive", "true");
+
+        SourceContext sourceContext = Mockito.mock(SourceContext.class);
+        Mockito.when(sourceContext.getSecret("username"))
+                .thenReturn("guest");
+        Mockito.when(sourceContext.getSecret("password"))
+                .thenReturn("guest");
+        RabbitMQSourceConfig config = RabbitMQSourceConfig.load(map, sourceContext);
         assertNotNull(config);
         assertEquals("localhost", config.getHost());
         assertEquals(Integer.parseInt("5672"), config.getPort());
@@ -115,12 +160,13 @@ public class RabbitMQSourceConfigTest {
         map.put("prefetchGlobal", "false");
         map.put("passive", "false");
 
-        RabbitMQSourceConfig config = RabbitMQSourceConfig.load(map);
+        SourceContext sourceContext = Mockito.mock(SourceContext.class);
+        RabbitMQSourceConfig config = RabbitMQSourceConfig.load(map, sourceContext);
         config.validate();
     }
 
-    @Test(expectedExceptions = NullPointerException.class,
-        expectedExceptionsMessageRegExp = "host property not set.")
+    @Test(expectedExceptions = IllegalArgumentException.class,
+        expectedExceptionsMessageRegExp = "host cannot be null")
     public final void missingHostValidateTest() throws IOException {
         Map<String, Object> map = new HashMap<>();
         map.put("port", "5672");
@@ -138,7 +184,8 @@ public class RabbitMQSourceConfigTest {
         map.put("prefetchGlobal", "false");
         map.put("passive", "false");
 
-        RabbitMQSourceConfig config = RabbitMQSourceConfig.load(map);
+        SourceContext sourceContext = Mockito.mock(SourceContext.class);
+        RabbitMQSourceConfig config = RabbitMQSourceConfig.load(map, sourceContext);
         config.validate();
     }
 
@@ -162,7 +209,8 @@ public class RabbitMQSourceConfigTest {
         map.put("prefetchGlobal", "false");
         map.put("passive", "false");
 
-        RabbitMQSourceConfig config = RabbitMQSourceConfig.load(map);
+        SourceContext sourceContext = Mockito.mock(SourceContext.class);
+        RabbitMQSourceConfig config = RabbitMQSourceConfig.load(map, sourceContext);
         config.validate();
     }
 

--- a/pulsar-io/redis/pom.xml
+++ b/pulsar-io/redis/pom.xml
@@ -34,6 +34,11 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>pulsar-io-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>pulsar-io-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/pulsar-io/redis/src/main/java/org/apache/pulsar/io/redis/RedisAbstractConfig.java
+++ b/pulsar-io/redis/src/main/java/org/apache/pulsar/io/redis/RedisAbstractConfig.java
@@ -88,7 +88,7 @@ public class RedisAbstractConfig implements Serializable {
 
     @FieldDoc(
         required = false,
-        defaultValue = "10000L",
+        defaultValue = "10000",
         help = "The amount of time in milliseconds to wait before timing out when connecting")
     private long connectTimeout = 10000L;
 

--- a/pulsar-io/redis/src/main/java/org/apache/pulsar/io/redis/RedisAbstractConfig.java
+++ b/pulsar-io/redis/src/main/java/org/apache/pulsar/io/redis/RedisAbstractConfig.java
@@ -93,8 +93,6 @@ public class RedisAbstractConfig implements Serializable {
     private long connectTimeout = 10000L;
 
     public void validate() {
-        Preconditions.checkNotNull(redisHosts, "redisHosts property not set.");
-        Preconditions.checkNotNull(redisDatabase, "redisDatabase property not set.");
         Preconditions.checkNotNull(clientMode, "clientMode property not set.");
     }
 
@@ -105,7 +103,6 @@ public class RedisAbstractConfig implements Serializable {
 
     public List<HostAndPort> getHostAndPorts() {
         List<HostAndPort> hostAndPorts = Lists.newArrayList();
-        Preconditions.checkNotNull(redisHosts, "redisHosts property not set.");
         String[] hosts = StringUtils.split(redisHosts, ",");
         for (String host : hosts) {
             HostAndPort hostAndPort = HostAndPort.fromString(host);

--- a/pulsar-io/redis/src/main/java/org/apache/pulsar/io/redis/sink/RedisSink.java
+++ b/pulsar-io/redis/src/main/java/org/apache/pulsar/io/redis/sink/RedisSink.java
@@ -68,7 +68,7 @@ public class RedisSink implements Sink<byte[]> {
     public void open(Map<String, Object> config, SinkContext sinkContext) throws Exception {
         log.info("Open Redis Sink");
 
-        redisSinkConfig = RedisSinkConfig.load(config);
+        redisSinkConfig = RedisSinkConfig.load(config, sinkContext);
         redisSinkConfig.validate();
 
         redisSession = RedisSession.create(redisSinkConfig);

--- a/pulsar-io/redis/src/main/java/org/apache/pulsar/io/redis/sink/RedisSinkConfig.java
+++ b/pulsar-io/redis/src/main/java/org/apache/pulsar/io/redis/sink/RedisSinkConfig.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
+import org.apache.pulsar.io.common.IOConfigUtils;
+import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
 import org.apache.pulsar.io.redis.RedisAbstractConfig;
 
@@ -62,9 +64,8 @@ public class RedisSinkConfig extends RedisAbstractConfig implements Serializable
         return mapper.readValue(new File(yamlFile), RedisSinkConfig.class);
     }
 
-    public static RedisSinkConfig load(Map<String, Object> map) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(mapper.writeValueAsString(map), RedisSinkConfig.class);
+    public static RedisSinkConfig load(Map<String, Object> map, SinkContext sinkContext) throws IOException {
+        return IOConfigUtils.loadWithSecrets(map, RedisSinkConfig.class, sinkContext);
     }
 
     @Override

--- a/pulsar-io/redis/src/main/java/org/apache/pulsar/io/redis/sink/RedisSinkConfig.java
+++ b/pulsar-io/redis/src/main/java/org/apache/pulsar/io/redis/sink/RedisSinkConfig.java
@@ -42,13 +42,13 @@ public class RedisSinkConfig extends RedisAbstractConfig implements Serializable
 
     @FieldDoc(
         required = false,
-        defaultValue = "10000L",
+        defaultValue = "10000",
         help = "The amount of time in milliseconds before an operation is marked as timed out")
     private long operationTimeout = 10000L;
 
     @FieldDoc(
         required = false,
-        defaultValue = "1000L",
+        defaultValue = "1000",
         help = "The Redis operation time in milliseconds")
     private long batchTimeMs = 1000L;
 

--- a/pulsar-io/redis/src/test/java/org/apache/pulsar/io/redis/sink/RedisSinkConfigTest.java
+++ b/pulsar-io/redis/src/test/java/org/apache/pulsar/io/redis/sink/RedisSinkConfigTest.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pulsar.io.redis.sink;
 
+import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.redis.RedisAbstractConfig;
+import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -62,7 +64,34 @@ public class RedisSinkConfigTest {
         map.put("batchTimeMs", "1000");
         map.put("connectTimeout", "3000");
 
-        RedisSinkConfig config = RedisSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        RedisSinkConfig config = RedisSinkConfig.load(map, sinkContext);
+        assertNotNull(config);
+        assertEquals(config.getRedisHosts(), "localhost:6379");
+        assertEquals(config.getRedisPassword(), "fake@123");
+        assertEquals(config.getRedisDatabase(), Integer.parseInt("1"));
+        assertEquals(config.getClientMode(), "Standalone");
+        assertEquals(config.getOperationTimeout(), Long.parseLong("2000"));
+        assertEquals(config.getBatchSize(), Integer.parseInt("100"));
+        assertEquals(config.getBatchTimeMs(), Long.parseLong("1000"));
+        assertEquals(config.getConnectTimeout(), Long.parseLong("3000"));
+    }
+
+    @Test
+    public final void loadFromMapCredentialsFromSecretTest() throws IOException {
+        Map<String, Object> map = new HashMap<String, Object>();
+        map.put("redisHosts", "localhost:6379");
+        map.put("redisDatabase", "1");
+        map.put("clientMode", "Standalone");
+        map.put("operationTimeout", "2000");
+        map.put("batchSize", "100");
+        map.put("batchTimeMs", "1000");
+        map.put("connectTimeout", "3000");
+
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        Mockito.when(sinkContext.getSecret("redisPassword"))
+                .thenReturn("fake@123");
+        RedisSinkConfig config = RedisSinkConfig.load(map, sinkContext);
         assertNotNull(config);
         assertEquals(config.getRedisHosts(), "localhost:6379");
         assertEquals(config.getRedisPassword(), "fake@123");
@@ -86,12 +115,13 @@ public class RedisSinkConfigTest {
         map.put("batchTimeMs", "1000");
         map.put("connectTimeout", "3000");
 
-        RedisSinkConfig config = RedisSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        RedisSinkConfig config = RedisSinkConfig.load(map, sinkContext);
         config.validate();
     }
 
-    @Test(expectedExceptions = NullPointerException.class,
-        expectedExceptionsMessageRegExp = "redisHosts property not set.")
+    @Test(expectedExceptions = IllegalArgumentException.class,
+        expectedExceptionsMessageRegExp = "redisHosts cannot be null")
     public final void missingValidValidateTableNameTest() throws IOException {
         Map<String, Object> map = new HashMap<String, Object>();
         map.put("redisPassword", "fake@123");
@@ -102,7 +132,8 @@ public class RedisSinkConfigTest {
         map.put("batchTimeMs", "1000");
         map.put("connectTimeout", "3000");
 
-        RedisSinkConfig config = RedisSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        RedisSinkConfig config = RedisSinkConfig.load(map, sinkContext);
         config.validate();
     }
 
@@ -119,7 +150,8 @@ public class RedisSinkConfigTest {
         map.put("batchTimeMs", "-100");
         map.put("connectTimeout", "3000");
 
-        RedisSinkConfig config = RedisSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        RedisSinkConfig config = RedisSinkConfig.load(map, sinkContext);
         config.validate();
     }
 
@@ -136,7 +168,8 @@ public class RedisSinkConfigTest {
         map.put("batchTimeMs", "1000");
         map.put("connectTimeout", "3000");
 
-        RedisSinkConfig config = RedisSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        RedisSinkConfig config = RedisSinkConfig.load(map, sinkContext);
         config.validate();
 
         RedisAbstractConfig.ClientMode.valueOf(config.getClientMode().toUpperCase());

--- a/pulsar-io/redis/src/test/java/org/apache/pulsar/io/redis/sink/RedisSinkTest.java
+++ b/pulsar-io/redis/src/test/java/org/apache/pulsar/io/redis/sink/RedisSinkTest.java
@@ -21,7 +21,9 @@ package org.apache.pulsar.io.redis.sink;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.instance.SinkRecord;
+import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.redis.EmbeddedRedisUtils;
+import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -66,7 +68,8 @@ public class RedisSinkTest {
         Record<byte[]> record = build("fakeTopic", "fakeKey", "fakeValue");
 
         // open should success
-        sink.open(configs, null);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        sink.open(configs, sinkContext);
 
         // write should success.
         sink.write(record);

--- a/pulsar-io/solr/pom.xml
+++ b/pulsar-io/solr/pom.xml
@@ -37,6 +37,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pulsar-io-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>pulsar-io-core</artifactId>
             <version>${project.parent.version}</version>

--- a/pulsar-io/solr/src/main/java/org/apache/pulsar/io/solr/SolrAbstractSink.java
+++ b/pulsar-io/solr/src/main/java/org/apache/pulsar/io/solr/SolrAbstractSink.java
@@ -48,7 +48,7 @@ public abstract class SolrAbstractSink<T> implements Sink<T> {
 
     @Override
     public void open(Map<String, Object> config, SinkContext sinkContext) throws Exception {
-        solrSinkConfig = SolrSinkConfig.load(config);
+        solrSinkConfig = SolrSinkConfig.load(config, sinkContext);
         solrSinkConfig.validate();
 
         enableBasicAuth = !Strings.isNullOrEmpty(solrSinkConfig.getUsername());

--- a/pulsar-io/solr/src/main/java/org/apache/pulsar/io/solr/SolrSinkConfig.java
+++ b/pulsar-io/solr/src/main/java/org/apache/pulsar/io/solr/SolrSinkConfig.java
@@ -27,6 +27,8 @@ import java.io.Serializable;
 import java.util.Map;
 import lombok.Data;
 import lombok.experimental.Accessors;
+import org.apache.pulsar.io.common.IOConfigUtils;
+import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
 
 /**
@@ -84,9 +86,8 @@ public class SolrSinkConfig implements Serializable {
         return mapper.readValue(new File(yamlFile), SolrSinkConfig.class);
     }
 
-    public static SolrSinkConfig load(Map<String, Object> map) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(mapper.writeValueAsString(map), SolrSinkConfig.class);
+    public static SolrSinkConfig load(Map<String, Object> map, SinkContext sinkContext) throws IOException {
+        return IOConfigUtils.loadWithSecrets(map, SolrSinkConfig.class, sinkContext);
     }
 
     public void validate() {

--- a/pulsar-io/solr/src/test/java/org/apache/pulsar/io/solr/SolrSinkConfigTest.java
+++ b/pulsar-io/solr/src/test/java/org/apache/pulsar/io/solr/SolrSinkConfigTest.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.io.solr;
 
 import com.google.common.collect.Lists;
+import org.apache.pulsar.io.core.SinkContext;
+import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -61,7 +63,31 @@ public class SolrSinkConfigTest {
         map.put("username", "fakeuser");
         map.put("password", "fake@123");
 
-        SolrSinkConfig config = SolrSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        SolrSinkConfig config = SolrSinkConfig.load(map, sinkContext);
+        assertNotNull(config);
+        assertEquals(config.getSolrUrl(), "localhost:2181,localhost:2182/chroot");
+        assertEquals(config.getSolrMode(), "SolrCloud");
+        assertEquals(config.getSolrCollection(), "techproducts");
+        assertEquals(config.getSolrCommitWithinMs(), Integer.parseInt("100"));
+        assertEquals(config.getUsername(), "fakeuser");
+        assertEquals(config.getPassword(), "fake@123");
+    }
+
+    @Test
+    public final void loadFromMapCredentialsFromSecretTest() throws IOException {
+        Map<String, Object> map = new HashMap<>();
+        map.put("solrUrl", "localhost:2181,localhost:2182/chroot");
+        map.put("solrMode", "SolrCloud");
+        map.put("solrCollection", "techproducts");
+        map.put("solrCommitWithinMs", "100");
+
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        Mockito.when(sinkContext.getSecret("username"))
+                .thenReturn("fakeuser");
+        Mockito.when(sinkContext.getSecret("password"))
+                .thenReturn("fake@123");
+        SolrSinkConfig config = SolrSinkConfig.load(map, sinkContext);
         assertNotNull(config);
         assertEquals(config.getSolrUrl(), "localhost:2181,localhost:2182/chroot");
         assertEquals(config.getSolrMode(), "SolrCloud");
@@ -81,12 +107,13 @@ public class SolrSinkConfigTest {
         map.put("username", "fakeuser");
         map.put("password", "fake@123");
 
-        SolrSinkConfig config = SolrSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        SolrSinkConfig config = SolrSinkConfig.load(map, sinkContext);
         config.validate();
     }
 
-    @Test(expectedExceptions = NullPointerException.class,
-        expectedExceptionsMessageRegExp = "solrUrl property not set.")
+    @Test(expectedExceptions = IllegalArgumentException.class,
+        expectedExceptionsMessageRegExp = "solrUrl cannot be null")
     public final void missingValidValidateSolrModeTest() throws IOException {
         Map<String, Object> map = new HashMap<>();
         map.put("solrMode", "SolrCloud");
@@ -95,7 +122,8 @@ public class SolrSinkConfigTest {
         map.put("username", "fakeuser");
         map.put("password", "fake@123");
 
-        SolrSinkConfig config = SolrSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        SolrSinkConfig config = SolrSinkConfig.load(map, sinkContext);
         config.validate();
     }
 
@@ -110,7 +138,8 @@ public class SolrSinkConfigTest {
         map.put("username", "fakeuser");
         map.put("password", "fake@123");
 
-        SolrSinkConfig config = SolrSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        SolrSinkConfig config = SolrSinkConfig.load(map, sinkContext);
         config.validate();
     }
 
@@ -125,7 +154,8 @@ public class SolrSinkConfigTest {
         map.put("username", "fakeuser");
         map.put("password", "fake@123");
 
-        SolrSinkConfig config = SolrSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        SolrSinkConfig config = SolrSinkConfig.load(map, sinkContext);
         config.validate();
 
         SolrAbstractSink.SolrMode.valueOf(config.getSolrMode().toUpperCase());
@@ -141,7 +171,8 @@ public class SolrSinkConfigTest {
         map.put("username", "fakeuser");
         map.put("password", "fake@123");
 
-        SolrSinkConfig config = SolrSinkConfig.load(map);
+        SinkContext sinkContext = Mockito.mock(SinkContext.class);
+        SolrSinkConfig config = SolrSinkConfig.load(map, sinkContext);
         config.validate();
 
         String url = config.getSolrUrl();


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #21674

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

Some connectors are using config to pass sensitive fields , like `token`, `password`, which is not secure

### Modifications

use the `IOConfileUtils.loadWithSecrets` to load config for connectors

### Verifying this change

- [x] Make sure that the change passes the CI checks.

- [x] This change added tests and can be verified as follows:

  - *Added unittests for connectors load sensitive fields from secrets*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/jiangpengcheng/pulsar/pull/18

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
