### PR TITLE
[fix][broker] Automatically create topic for remote cluster in geo

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -65,7 +65,6 @@ import org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaExce
 import org.apache.pulsar.broker.stats.prometheus.metrics.Summary;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException.ConflictException;
-import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
@@ -42,6 +43,7 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.ToLongFunction;
 import javax.annotation.Nonnull;
+import javax.ws.rs.core.Response.Status;
 import lombok.Getter;
 import org.apache.bookkeeper.mledger.util.StatsBuckets;
 import org.apache.commons.collections4.CollectionUtils;
@@ -61,10 +63,14 @@ import org.apache.pulsar.broker.service.plugin.EntryFilter;
 import org.apache.pulsar.broker.service.schema.SchemaRegistryService;
 import org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException;
 import org.apache.pulsar.broker.stats.prometheus.metrics.Summary;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException.ConflictException;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
+import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.DelayedDeliveryPolicies;
 import org.apache.pulsar.common.policies.data.EntryFilters;
@@ -1418,5 +1424,41 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
             log.warn("Failed to get migration cluster URL", e);
         }
         return Optional.empty();
+    }
+
+    private CompletableFuture<Void> catchCreateTopicForRemoteCluster(CompletableFuture<Void> createTopicFuture) {
+        return createTopicFuture.exceptionally(ex -> {
+            Throwable throwable = FutureUtil.unwrapCompletionException(ex);
+            if (throwable instanceof ConflictException) {
+                int code = ((ConflictException) throwable).getStatusCode();
+                if (code == Status.CONFLICT.getStatusCode()) {
+                    // topic exists in the remote cluster
+                    return null;
+                }
+            }
+            throw new CompletionException(throwable);
+        });
+    }
+
+    protected CompletableFuture<Void> createTopicForRemoteCluster(String remoteCluster,
+                                                                  Optional<ClusterData> clusterData) {
+        PulsarAdmin admin = brokerService.getClusterPulsarAdmin(remoteCluster, clusterData);
+        TopicName topicName = TopicName.get(topic);
+        if (!topicName.isPartitioned()) {
+            return catchCreateTopicForRemoteCluster(admin.topics().createNonPartitionedTopicAsync(topic));
+        }
+
+        TopicName baseTopicName = TopicName.get(topicName.getPartitionedTopicName());
+        return brokerService.fetchPartitionedTopicMetadataAsync(baseTopicName)
+                .thenCompose(metadata -> {
+                    int partitions = metadata.partitions;
+                    if (partitions == 0) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+
+                    return catchCreateTopicForRemoteCluster(admin
+                            .topics()
+                            .createPartitionedTopicAsync(baseTopicName.toString(), partitions));
+                });
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -631,8 +631,8 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
         return AbstractReplicator.validatePartitionedTopicAsync(nonPersistentTopic.getName(), brokerService)
                 .thenCompose(__ -> brokerService.pulsar().getPulsarResources().getClusterResources()
                         .getClusterAsync(remoteCluster)
-                        .thenApply(clusterData ->
-                                brokerService.getReplicationClient(remoteCluster, clusterData)))
+                        .thenCompose(clusterData -> createTopicForRemoteCluster(remoteCluster, clusterData)
+                                .thenApply(___ -> brokerService.getReplicationClient(remoteCluster, clusterData))))
                 .thenAccept(replicationClient -> {
                     replicators.computeIfAbsent(remoteCluster, r -> {
                         try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1841,8 +1841,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     }
                     return brokerService.pulsar().getPulsarResources().getClusterResources()
                             .getClusterAsync(remoteCluster)
-                            .thenApply(clusterData ->
-                                    brokerService.getReplicationClient(remoteCluster, clusterData));
+                            .thenCompose(clusterData -> createTopicForRemoteCluster(remoteCluster, clusterData)
+                                    .thenApply(__ -> brokerService.getReplicationClient(remoteCluster, clusterData)));
                 })
                 .thenAccept(replicationClient -> {
                     if (replicationClient == null) {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/CSContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/CSContainer.java
@@ -26,13 +26,15 @@ public class CSContainer extends PulsarContainer<CSContainer> {
     public static final String NAME = "configuration-store";
 
     public CSContainer(String clusterName) {
-        super(
-            clusterName,
-            NAME,
-            NAME,
-            "bin/run-global-zk.sh",
-            CS_PORT,
-            INVALID_PORT);
+        this(clusterName, NAME);
+    }
+
+    public CSContainer(String clusterName, String hostname) {
+        super(clusterName, hostname, hostname, "bin/run-global-zk.sh", CS_PORT, INVALID_PORT);
+    }
+
+    public String getUrl() {
+        return getHostname() + ":" + CS_PORT;
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ChaosContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ChaosContainer.java
@@ -19,11 +19,10 @@
 package org.apache.pulsar.tests.integration.containers;
 
 import com.github.dockerjava.api.DockerClient;
-
 import java.util.Base64;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
 import org.apache.pulsar.tests.integration.utils.DockerUtils;
@@ -35,6 +34,7 @@ import org.testcontainers.containers.GenericContainer;
 @Slf4j
 public class ChaosContainer<SelfT extends ChaosContainer<SelfT>> extends GenericContainer<SelfT> {
 
+    @Getter
     protected final String clusterName;
 
     protected ChaosContainer(String clusterName, String image) {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PulsarContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PulsarContainer.java
@@ -19,13 +19,13 @@
 package org.apache.pulsar.tests.integration.containers;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.UUID;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
@@ -70,6 +70,7 @@ public abstract class PulsarContainer<SelfT extends PulsarContainer<SelfT>> exte
     public static final boolean PULSAR_CONTAINERS_LEAVE_RUNNING =
             Boolean.parseBoolean(System.getenv("PULSAR_CONTAINERS_LEAVE_RUNNING"));
 
+    @Getter
     protected final String hostname;
     private final String serviceName;
     private final String serviceEntryPoint;
@@ -319,5 +320,13 @@ public abstract class PulsarContainer<SelfT extends PulsarContainer<SelfT>> exte
 
     public String getHttpsServiceUrl() {
         return "https://" + getHost() + ":" + getMappedPort(httpsPort);
+    }
+
+    public String getInternalBrokerServiceUrl() {
+        return "pulsar://" + getNetworkAliases().get(0) + ":" + servicePort;
+    }
+
+    public String getInternalHttpServiceUrl() {
+        return "http://" + getNetworkAliases().get(0) + ":" + httpPort;
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
@@ -116,14 +116,14 @@ public class PulsarCluster {
             prestoWorkerContainer = null;
         }
 
-
+        String configurationStore = csContainer.getUrl();
         this.zkContainer = new ZKContainer(clusterName);
         this.zkContainer
             .withNetwork(network)
             .withNetworkAliases(appendClusterName(ZKContainer.NAME))
             .withEnv("clusterName", clusterName)
             .withEnv("zkServers", appendClusterName(ZKContainer.NAME))
-            .withEnv("configurationStore", CSContainer.NAME + ":" + CS_PORT)
+            .withEnv("configurationStore", configurationStore)
             .withEnv("forceSync", "no")
             .withEnv("pulsarNode", appendClusterName("pulsar-broker-0"));
 
@@ -138,7 +138,7 @@ public class PulsarCluster {
                 .withNetworkAliases(appendClusterName("pulsar-proxy"))
                 .withEnv("zkServers", appendClusterName(ZKContainer.NAME))
                 .withEnv("zookeeperServers", appendClusterName(ZKContainer.NAME))
-                .withEnv("configurationStoreServers", CSContainer.NAME + ":" + CS_PORT)
+                .withEnv("configurationStoreServers", configurationStore)
                 .withEnv("clusterName", clusterName);
                 // enable mTLS
         if (spec.enableTls) {
@@ -200,7 +200,7 @@ public class PulsarCluster {
                         .withNetworkAliases(appendClusterName(name))
                         .withEnv("zkServers", appendClusterName(ZKContainer.NAME))
                         .withEnv("zookeeperServers", appendClusterName(ZKContainer.NAME))
-                        .withEnv("configurationStoreServers", CSContainer.NAME + ":" + CS_PORT)
+                        .withEnv("configurationStoreServers", configurationStore)
                         .withEnv("clusterName", clusterName)
                         .withEnv("brokerServiceCompactionMonitorIntervalInSeconds", "1")
                         .withEnv("loadBalancerOverrideBrokerNicSpeedGbps", "1")
@@ -253,6 +253,14 @@ public class PulsarCluster {
 
     public String getHttpServiceUrl() {
         return proxyContainer.getHttpServiceUrl();
+    }
+
+    public String getInternalBrokerServiceUrl() {
+        return proxyContainer.getInternalBrokerServiceUrl();
+    }
+
+    public String getInternalHttpServiceUrl() {
+        return proxyContainer.getInternalHttpServiceUrl();
     }
 
     public String getAnyBrokersHttpsServiceUrl() {


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/21153

### Motivation

Enable the geo-replication only on the topic level to replicate the partitioned topic, if the topic was not created in the remote cluster, it becomes the non-partition topic by the `allowAutoTopicCreation=true` and `allowAutoTopicCreationType=non-partitioned` configurations, which is not in line with the expected behavior. Therefore, I suggest that geo-replication automatically creates the topic for the remote cluster.

How to reproduce this issue:

1. Create two clusters(cluster-a and cluster-b) and use the different configuration stores.
2. Add cluster data to each cluster
3. Create a tenant in each cluster:
```
bin/pulsar-admin tenants create my-tenant --allowed-clusters cluster-a,cluster-b
```
5. Create a namespace in the cluster-a: 
```
bin/pulsar-admin namespaces set-clusters my-tenant/my-namespace --clusters cluster-a
```
7. Create a namespace in the cluster-b
```
bin/pulsar-admin namespaces set-clusters my-tenant/my-namespace --clusters cluster-b
```
9. Create a topic and enable the geo-replication in the cluster-a:
```
bin/pulsar-admin topics create-partitioned-topic -p 5 my-tenant/my-namespace/geo-p-5
bin/pulsar-admin topics set-replication-clusters --clusters cluster-a,cluster-b my-tenant/my-namespace/geo-p-5
```
10. List the partitioned topics in the cluster-b:
```
bin/pulsar-admin topics list-partitioned-topics my-tenant/my-namespace
empty
```

### Modifications

- For `NonPersistentTopic` and `PersistentTopic`, the geo automatically creates the topic for the remote cluster.
- Use the different configuration stores in the geo-replication test

### Verifying this change

- Add a `GeoReplicationOnTopicLevelTest` to cover these changes.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
