### PR TITLE
[improve][broker] PIP-307: Implement broker and client consumer changes when topic is unloading

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
@@ -82,8 +82,6 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
 
     protected abstract void scheduleReadOnActiveConsumer();
 
-    protected abstract void readMoreEntries(Consumer consumer);
-
     protected abstract void cancelPendingRead();
 
     protected void notifyActiveConsumerChanged(Consumer activeConsumer) {
@@ -259,9 +257,12 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
         return (consumers.size() == 1) && Objects.equals(consumer, ACTIVE_CONSUMER_UPDATER.get(this));
     }
 
-    public CompletableFuture<Void> close(Optional<BrokerLookupData> assignedBrokerLookupData) {
+    @Override
+    public CompletableFuture<Void> close(boolean disconnectConsumers,
+                                         Optional<BrokerLookupData> assignedBrokerLookupData) {
         IS_CLOSED_UPDATER.set(this, TRUE);
-        return disconnectAllConsumers(false, assignedBrokerLookupData);
+        return disconnectConsumers
+                ? disconnectAllConsumers(false, assignedBrokerLookupData) : CompletableFuture.completedFuture(null);
     }
 
     public boolean isClosed() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
@@ -271,10 +271,17 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
 
     /**
      * Disconnect all consumers on this dispatcher (server side close). This triggers channelInactive on the inbound
-     * handler which calls dispatcher.removeConsumer(), where the closeFuture is completed
+     * handler which calls dispatcher.removeConsumer(), where the closeFuture is completed.
      *
-     * @return
+     * @param isResetCursor
+     *              Specifies if the cursor has been reset.
+     * @param assignedBrokerLookupData
+     *              Optional target broker redirect information. Allows the consumer to quickly reconnect to a broker
+     *              during bundle unloading.
+     *
+     * @return CompletableFuture indicating the completion of the operation.
      */
+    @Override
     public synchronized CompletableFuture<Void> disconnectAllConsumers(
             boolean isResetCursor, Optional<BrokerLookupData> assignedBrokerLookupData) {
         closeFuture = new CompletableFuture<>();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -157,6 +157,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
     protected final LongAdder msgOutFromRemovedSubscriptions = new LongAdder();
     protected final LongAdder bytesOutFromRemovedSubscriptions = new LongAdder();
     protected volatile Pair<String, List<EntryFilter>> entryFilters;
+    protected volatile boolean transferring = false;
 
     public AbstractTopic(String topic, BrokerService brokerService) {
         this.topic = topic;
@@ -1243,6 +1244,10 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
     protected abstract boolean isTerminated();
 
     protected abstract boolean isMigrated();
+
+    public boolean isTransferring() {
+        return transferring;
+    }
 
     private static final Logger log = LoggerFactory.getLogger(AbstractTopic.class);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -956,11 +956,6 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
         }
     }
 
-    @Override
-    public boolean isFenced() {
-        return isFenced;
-    }
-
     protected CompletableFuture<Void> internalAddProducer(Producer producer) {
         if (isProducersExceeded(producer)) {
             log.warn("[{}] Attempting to add producer to topic which reached max producers limit", topic);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
@@ -234,6 +234,12 @@ public class BrokerServiceException extends Exception {
         public TopicTransferringException(String msg) {
             super(msg);
         }
+
+        @Override
+        public Throwable fillInStackTrace() {
+            // Disable stack trace collection to improve performance.
+            return null;
+        }
     }
 
     public static org.apache.pulsar.common.api.proto.ServerError getClientErrorCode(Throwable t) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
@@ -71,6 +71,12 @@ public class BrokerServiceException extends Exception {
         }
     }
 
+    public static class TopicClosingOrDeletingException extends BrokerServiceException {
+        public TopicClosingOrDeletingException(String message) {
+            super(message);
+        }
+    }
+
     public static class TopicClosedException extends BrokerServiceException {
         public TopicClosedException(Throwable t) {
             super(t);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
@@ -230,6 +230,12 @@ public class BrokerServiceException extends Exception {
         }
     }
 
+    public static class TopicTransferringException extends BrokerServiceException {
+        public TopicTransferringException(String msg) {
+            super(msg);
+        }
+    }
+
     public static org.apache.pulsar.common.api.proto.ServerError getClientErrorCode(Throwable t) {
         return getClientErrorCode(t, true);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
@@ -234,12 +234,6 @@ public class BrokerServiceException extends Exception {
         public TopicTransferringException(String msg) {
             super(msg);
         }
-
-        @Override
-        public Throwable fillInStackTrace() {
-            // Disable stack trace collection to improve performance.
-            return null;
-        }
     }
 
     public static org.apache.pulsar.common.api.proto.ServerError getClientErrorCode(Throwable t) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
@@ -230,12 +230,6 @@ public class BrokerServiceException extends Exception {
         }
     }
 
-    public static class TopicTransferringException extends BrokerServiceException {
-        public TopicTransferringException(String msg) {
-            super(msg);
-        }
-    }
-
     public static org.apache.pulsar.common.api.proto.ServerError getClientErrorCode(Throwable t) {
         return getClientErrorCode(t, true);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
@@ -71,12 +71,6 @@ public class BrokerServiceException extends Exception {
         }
     }
 
-    public static class TopicClosingOrDeletingException extends BrokerServiceException {
-        public TopicClosingOrDeletingException(String message) {
-            super(message);
-        }
-    }
-
     public static class TopicClosedException extends BrokerServiceException {
         public TopicClosedException(Throwable t) {
             super(t);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -44,6 +44,7 @@ import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSubscription;
+import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.MessageId;
@@ -407,8 +408,12 @@ public class Consumer {
     }
 
     public void disconnect(boolean isResetCursor) {
+        disconnect(isResetCursor, Optional.empty());
+    }
+
+    public void disconnect(boolean isResetCursor, Optional<BrokerLookupData> assignedBrokerLookupData) {
         log.info("Disconnecting consumer: {}", this);
-        cnx.closeConsumer(this);
+        cnx.closeConsumer(this, assignedBrokerLookupData);
         try {
             close(isResetCursor);
         } catch (BrokerServiceException e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -444,15 +444,6 @@ public class Consumer {
                 .collect(Collectors.toMap(KeyLongValue::getKey, KeyLongValue::getValue));
         }
 
-        if (subscription.isTransferring()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Ignoring message acknowledgement on transferring topic, ack(s) count: {}",
-                        subscription, consumerId, ack.getMessageIdsCount());
-            }
-            return FutureUtil.failedFuture(new BrokerServiceException.TopicTransferringException(
-                    "Topic is transferring, ignoring message acknowledgement"));
-        }
-
         if (ack.getAckType() == AckType.Cumulative) {
             if (ack.getMessageIdsCount() != 1) {
                 log.warn("[{}] [{}] Received multi-message ack", subscription, consumerId);
@@ -729,7 +720,7 @@ public class Consumer {
 
     private boolean isTransactionEnabled() {
         return subscription instanceof PersistentSubscription
-                && subscription.getTopic()
+                && ((PersistentTopic) subscription.getTopic())
                 .getBrokerService().getPulsar().getConfig().isTransactionCoordinatorEnabled();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
@@ -51,10 +51,10 @@ public interface Dispatcher {
      * @return
      */
     default CompletableFuture<Void> close() {
-        return close(Optional.empty());
+        return close(true, Optional.empty());
     }
 
-    CompletableFuture<Void> close(Optional<BrokerLookupData> assignedBrokerLookupData);
+    CompletableFuture<Void> close(boolean disconnectClients, Optional<BrokerLookupData> assignedBrokerLookupData);
 
     boolean isClosed();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
@@ -49,7 +50,11 @@ public interface Dispatcher {
      *
      * @return
      */
-    CompletableFuture<Void> close();
+    default CompletableFuture<Void> close() {
+        return close(Optional.empty());
+    }
+
+    CompletableFuture<Void> close(Optional<BrokerLookupData> assignedBrokerLookupData);
 
     boolean isClosed();
 
@@ -63,11 +68,16 @@ public interface Dispatcher {
      *
      * @return
      */
-    CompletableFuture<Void> disconnectAllConsumers(boolean isResetCursor);
+    default CompletableFuture<Void> disconnectAllConsumers(boolean isResetCursor) {
+        return disconnectAllConsumers(isResetCursor, Optional.empty());
+    }
 
     default CompletableFuture<Void> disconnectAllConsumers() {
         return disconnectAllConsumers(false);
     }
+
+    CompletableFuture<Void> disconnectAllConsumers(boolean isResetCursor,
+                                                   Optional<BrokerLookupData> assignedBrokerLookupData);
 
     void resetCloseFuture();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -28,6 +28,7 @@ import static org.apache.pulsar.broker.lookup.TopicLookupBase.lookupTopicAsync;
 import static org.apache.pulsar.broker.service.persistent.PersistentTopic.getMigratedClusterUrl;
 import static org.apache.pulsar.common.api.proto.ProtocolVersion.v5;
 import static org.apache.pulsar.common.protocol.Commands.DEFAULT_CONSUMER_EPOCH;
+import static org.apache.pulsar.common.protocol.Commands.newCloseConsumer;
 import static org.apache.pulsar.common.protocol.Commands.newLookupErrorResponse;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -1321,7 +1322,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                                 topicName, remoteAddress, consumerId);
                                     }
                                     consumers.remove(consumerId, consumerFuture);
-                                    closeConsumer(consumerId);
+                                    closeConsumer(consumerId, Optional.empty());
                                     return null;
                                 }
                             } else if (exception.getCause() instanceof BrokerServiceException) {
@@ -1763,10 +1764,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         }
 
         PulsarService pulsar = getBrokerService().pulsar();
-        if (producer.getTopic().isFenced()
+        if (producer.getTopic().isClosingOrDeleting()
                 && ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(pulsar)) {
             long ignoredMsgCount = ExtensibleLoadManagerImpl.get(pulsar)
-                    .getIgnoredSendMsgCounter().incrementAndGet();
+                    .getIgnoredSendMsgCounter().addAndGet(send.getNumMessages());
             if (log.isDebugEnabled()) {
                 log.debug("Ignored send msg from:{}:{} to fenced topic:{} during unloading."
                                 + " Ignored message count:{}.",
@@ -3071,15 +3072,17 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     }
 
     @Override
-    public void closeConsumer(Consumer consumer) {
+    public void closeConsumer(Consumer consumer, Optional<BrokerLookupData> assignedBrokerLookupData) {
         // removes consumer-connection from map and send close command to consumer
         safelyRemoveConsumer(consumer);
-        closeConsumer(consumer.consumerId());
+        closeConsumer(consumer.consumerId(), assignedBrokerLookupData);
     }
 
-    private void closeConsumer(long consumerId) {
+    private void closeConsumer(long consumerId, Optional<BrokerLookupData> assignedBrokerLookupData) {
         if (getRemoteEndpointProtocolVersion() >= v5.getValue()) {
-            writeAndFlush(Commands.newCloseConsumer(consumerId, -1L));
+            writeAndFlush(newCloseConsumer(consumerId, -1L,
+                    assignedBrokerLookupData.map(BrokerLookupData::pulsarServiceUrl).orElse(null),
+                    assignedBrokerLookupData.map(BrokerLookupData::pulsarServiceUrlTls).orElse(null)));
         } else {
             close();
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1857,12 +1857,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 }
             }).exceptionally(e -> {
                 if (hasRequestId) {
-                    if (!(e instanceof BrokerServiceException.TopicTransferringException)) {
-                        // Message acks are silently ignored during topic transfer
-                        writeAndFlush(Commands.newAckResponse(requestId,
-                                BrokerServiceException.getClientErrorCode(e),
-                                e.getMessage(), consumerId));
-                    }
+                    writeAndFlush(Commands.newAckResponse(requestId,
+                            BrokerServiceException.getClientErrorCode(e),
+                            e.getMessage(), consumerId));
                 }
                 return null;
             });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1764,12 +1764,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         }
 
         PulsarService pulsar = getBrokerService().pulsar();
-        if (producer.getTopic().isClosingOrDeleting()
-                && ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(pulsar)) {
+        // if the topic is transferring, we ignore send msg.
+        if (producer.getTopic().isTransferring()) {
             long ignoredMsgCount = ExtensibleLoadManagerImpl.get(pulsar)
                     .getIgnoredSendMsgCounter().addAndGet(send.getNumMessages());
             if (log.isDebugEnabled()) {
-                log.debug("Ignored send msg from:{}:{} to fenced topic:{} during unloading."
+                log.debug("Ignored send msg from:{}:{} to fenced topic:{} while transferring."
                                 + " Ignored message count:{}.",
                         remoteAddress, send.getProducerId(), producer.getTopic().getName(), ignoredMsgCount);
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1857,9 +1857,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 }
             }).exceptionally(e -> {
                 if (hasRequestId) {
-                    writeAndFlush(Commands.newAckResponse(requestId,
-                            BrokerServiceException.getClientErrorCode(e),
-                            e.getMessage(), consumerId));
+                    if (!(e instanceof BrokerServiceException.TopicTransferringException)) {
+                        // Message acks are silently ignored during topic transfer
+                        writeAndFlush(Commands.newAckResponse(requestId,
+                                BrokerServiceException.getClientErrorCode(e),
+                                e.getMessage(), consumerId));
+                    }
                 }
                 return null;
             });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
@@ -105,10 +105,6 @@ public interface Subscription extends MessageExpirer {
 
     boolean isSubscriptionMigrated();
 
-    default boolean isTransferring() {
-        return getTopic().isTransferring();
-    }
-
     default void processReplicatedSubscriptionSnapshot(ReplicatedSubscriptionsSnapshot snapshot) {
         // Default is no-op
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
@@ -69,6 +69,8 @@ public interface Subscription extends MessageExpirer {
 
     CompletableFuture<Void> deleteForcefully();
 
+    CompletableFuture<Void> disconnect(Optional<BrokerLookupData> assignedBrokerLookupData);
+
     CompletableFuture<Void> close(boolean disconnectConsumers, Optional<BrokerLookupData> assignedBrokerLookupData);
 
     CompletableFuture<Void> doUnsubscribe(Consumer consumer);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
@@ -65,13 +65,12 @@ public interface Subscription extends MessageExpirer {
 
     List<Consumer> getConsumers();
 
-    CompletableFuture<Void> close();
-
     CompletableFuture<Void> delete();
 
     CompletableFuture<Void> deleteForcefully();
 
-    CompletableFuture<Void> disconnect(Optional<BrokerLookupData> assignedBrokerLookupData);
+    CompletableFuture<Void> disconnect(boolean disconnectConsumers,
+                                       Optional<BrokerLookupData> assignedBrokerLookupData);
 
     CompletableFuture<Void> doUnsubscribe(Consumer consumer);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
@@ -69,8 +69,7 @@ public interface Subscription extends MessageExpirer {
 
     CompletableFuture<Void> deleteForcefully();
 
-    CompletableFuture<Void> disconnect(boolean disconnectConsumers,
-                                       Optional<BrokerLookupData> assignedBrokerLookupData);
+    CompletableFuture<Void> close(boolean disconnectConsumers, Optional<BrokerLookupData> assignedBrokerLookupData);
 
     CompletableFuture<Void> doUnsubscribe(Consumer consumer);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
@@ -26,6 +26,7 @@ import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
+import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.common.api.proto.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.ReplicatedSubscriptionsSnapshot;
@@ -70,7 +71,7 @@ public interface Subscription extends MessageExpirer {
 
     CompletableFuture<Void> deleteForcefully();
 
-    CompletableFuture<Void> disconnect();
+    CompletableFuture<Void> disconnect(Optional<BrokerLookupData> assignedBrokerLookupData);
 
     CompletableFuture<Void> doUnsubscribe(Consumer consumer);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
@@ -105,6 +105,10 @@ public interface Subscription extends MessageExpirer {
 
     boolean isSubscriptionMigrated();
 
+    default boolean isTransferring() {
+        return getTopic().isTransferring();
+    }
+
     default void processReplicatedSubscriptionSnapshot(ReplicatedSubscriptionsSnapshot snapshot) {
         // Default is no-op
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -338,7 +338,7 @@ public interface Topic {
 
     boolean isPersistent();
 
-    boolean isFenced();
+    boolean isClosingOrDeleting();
 
     /* ------ Transaction related ------ */
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -338,7 +338,7 @@ public interface Topic {
 
     boolean isPersistent();
 
-    boolean isClosingOrDeleting();
+    boolean isTransferring();
 
     /* ------ Transaction related ------ */
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TransportCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TransportCnx.java
@@ -73,7 +73,7 @@ public interface TransportCnx {
 
     void removedConsumer(Consumer consumer);
 
-    void closeConsumer(Consumer consumer);
+    void closeConsumer(Consumer consumer, Optional<BrokerLookupData> assignedBrokerLookupData);
 
     boolean isPreciseDispatcherFlowControl();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
@@ -128,9 +128,11 @@ public class NonPersistentDispatcherMultipleConsumers extends AbstractDispatcher
     }
 
     @Override
-    public CompletableFuture<Void> close(Optional<BrokerLookupData> assignedBrokerLookupData) {
+    public CompletableFuture<Void> close(boolean disconnectConsumers,
+                                         Optional<BrokerLookupData> assignedBrokerLookupData) {
         IS_CLOSED_UPDATER.set(this, TRUE);
-        return disconnectAllConsumers(false, assignedBrokerLookupData);
+        return disconnectConsumers
+                ? disconnectAllConsumers(false, assignedBrokerLookupData) : CompletableFuture.completedFuture(null);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
@@ -19,10 +19,12 @@
 package org.apache.pulsar.broker.service.nonpersistent;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import org.apache.bookkeeper.mledger.Entry;
+import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.service.AbstractDispatcherMultipleConsumers;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.BrokerServiceException.ConsumerBusyException;
@@ -126,9 +128,9 @@ public class NonPersistentDispatcherMultipleConsumers extends AbstractDispatcher
     }
 
     @Override
-    public CompletableFuture<Void> close() {
+    public CompletableFuture<Void> close(Optional<BrokerLookupData> assignedBrokerLookupData) {
         IS_CLOSED_UPDATER.set(this, TRUE);
-        return disconnectAllConsumers();
+        return disconnectAllConsumers(false, assignedBrokerLookupData);
     }
 
     @Override
@@ -147,12 +149,13 @@ public class NonPersistentDispatcherMultipleConsumers extends AbstractDispatcher
     }
 
     @Override
-    public synchronized CompletableFuture<Void> disconnectAllConsumers(boolean isResetCursor) {
+    public synchronized CompletableFuture<Void> disconnectAllConsumers(
+            boolean isResetCursor, Optional<BrokerLookupData> assignedBrokerLookupData) {
         closeFuture = new CompletableFuture<>();
         if (consumerList.isEmpty()) {
             closeFuture.complete(null);
         } else {
-            consumerList.forEach(Consumer::disconnect);
+            consumerList.forEach(consumer -> consumer.disconnect(isResetCursor, assignedBrokerLookupData));
         }
         return closeFuture;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
@@ -102,11 +102,6 @@ public final class NonPersistentDispatcherSingleActiveConsumer extends AbstractD
     }
 
     @Override
-    protected void readMoreEntries(Consumer consumer) {
-        // No-op
-    }
-
-    @Override
     protected void cancelPendingRead() {
         // No-op
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -289,8 +289,8 @@ public class NonPersistentSubscription extends AbstractSubscription implements S
      * @return CompletableFuture indicating the completion of disconnect operation
      */
     @Override
-    public synchronized CompletableFuture<Void> disconnect(boolean disconnectConsumers,
-                                                           Optional<BrokerLookupData> assignedBrokerLookupData) {
+    public synchronized CompletableFuture<Void> close(boolean disconnectConsumers,
+                                                      Optional<BrokerLookupData> assignedBrokerLookupData) {
         CompletableFuture<Void> disconnectFuture = new CompletableFuture<>();
 
         // block any further consumers on this subscription
@@ -351,7 +351,7 @@ public class NonPersistentSubscription extends AbstractSubscription implements S
         CompletableFuture<Void> closeSubscriptionFuture = new CompletableFuture<>();
 
         if (closeIfConsumersConnected) {
-            this.disconnect(true, Optional.empty()).thenRun(() -> {
+            this.close(true, Optional.empty()).thenRun(() -> {
                 closeSubscriptionFuture.complete(null);
             }).exceptionally(ex -> {
                 log.error("[{}][{}] Error disconnecting and closing subscription", topicName, subName, ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -278,6 +278,11 @@ public class NonPersistentSubscription extends AbstractSubscription implements S
         return topic.isMigrated();
     }
 
+    /**
+     * Disconnect all consumers from this subscription.
+     *
+     * @return CompletableFuture indicating the completion of the operation.
+     */
     @Override
     public synchronized CompletableFuture<Void> disconnect(Optional<BrokerLookupData> assignedBrokerLookupData) {
         CompletableFuture<Void> closeFuture = new CompletableFuture<>();
@@ -303,10 +308,11 @@ public class NonPersistentSubscription extends AbstractSubscription implements S
         return CompletableFuture.completedFuture(null);
     }
 
+
     /**
-     * Disconnect all consumers attached to the dispatcher and close this subscription.
+     * Fence this subscription and optionally disconnect all consumers.
      *
-     * @return CompletableFuture indicating the completion of disconnect operation
+     * @return CompletableFuture indicating the completion of the operation.
      */
     @Override
     public synchronized CompletableFuture<Void> close(boolean disconnectConsumers,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -422,7 +422,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                 List<CompletableFuture<Void>> futures = new ArrayList<>();
                 replicators.forEach((cluster, replicator) -> futures.add(replicator.disconnect()));
                 producers.values().forEach(producer -> futures.add(producer.disconnect()));
-                subscriptions.forEach((s, sub) -> futures.add(sub.disconnect(true, Optional.empty())));
+                subscriptions.forEach((s, sub) -> futures.add(sub.close(true, Optional.empty())));
                 FutureUtil.waitForAll(futures).thenRun(() -> {
                     closeClientFuture.complete(null);
                 }).exceptionally(ex -> {
@@ -528,11 +528,11 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             futures.add(ExtensibleLoadManagerImpl.getAssignedBrokerLookupData(
                     brokerService.getPulsar(), topic).thenAccept(lookupData -> {
                         producers.values().forEach(producer -> futures.add(producer.disconnect(lookupData)));
-                        subscriptions.forEach((s, sub) -> futures.add(sub.disconnect(true, lookupData)));
+                        subscriptions.forEach((s, sub) -> futures.add(sub.close(true, lookupData)));
                     }
             ));
         } else {
-            subscriptions.forEach((s, sub) -> futures.add(sub.disconnect(false, Optional.empty())));
+            subscriptions.forEach((s, sub) -> futures.add(sub.close(false, Optional.empty())));
         }
         if (topicPublishRateLimiter != null) {
             topicPublishRateLimiter.close();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -528,7 +528,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             futures.add(ExtensibleLoadManagerImpl.getAssignedBrokerLookupData(
                     brokerService.getPulsar(), topic).thenAccept(lookupData -> {
                         producers.values().forEach(producer -> futures.add(producer.disconnect(lookupData)));
-                        subscriptions.forEach((s, sub) -> futures.add(sub.close(true, lookupData)));
+                        subscriptions.forEach((s, sub) -> futures.add(sub.disconnect(lookupData)));
                     }
             ));
         } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -185,11 +185,6 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
     }
 
     @Override
-    public boolean isClosingOrDeleting() {
-        return isFenced;
-    }
-
-    @Override
     public void publishMessage(ByteBuf data, PublishContext callback) {
         if (isExceedMaximumMessageSize(data.readableBytes(), callback)) {
             callback.completed(new NotAllowedException("Exceed maximum message size")
@@ -512,6 +507,9 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
 
         lock.writeLock().lock();
         try {
+            if (!disconnectClients) {
+                transferring = true;
+            }
             if (!isFenced || closeWithoutWaitingClientDisconnect) {
                 isFenced = true;
             } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -422,7 +422,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                 List<CompletableFuture<Void>> futures = new ArrayList<>();
                 replicators.forEach((cluster, replicator) -> futures.add(replicator.disconnect()));
                 producers.values().forEach(producer -> futures.add(producer.disconnect()));
-                subscriptions.forEach((s, sub) -> futures.add(sub.disconnect(Optional.empty())));
+                subscriptions.forEach((s, sub) -> futures.add(sub.disconnect(true, Optional.empty())));
                 FutureUtil.waitForAll(futures).thenRun(() -> {
                     closeClientFuture.complete(null);
                 }).exceptionally(ex -> {
@@ -528,9 +528,11 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             futures.add(ExtensibleLoadManagerImpl.getAssignedBrokerLookupData(
                     brokerService.getPulsar(), topic).thenAccept(lookupData -> {
                         producers.values().forEach(producer -> futures.add(producer.disconnect(lookupData)));
-                        subscriptions.forEach((s, sub) -> futures.add(sub.disconnect(lookupData)));
+                        subscriptions.forEach((s, sub) -> futures.add(sub.disconnect(true, lookupData)));
                     }
             ));
+        } else {
+            subscriptions.forEach((s, sub) -> futures.add(sub.disconnect(false, Optional.empty())));
         }
         if (topicPublishRateLimiter != null) {
             topicPublishRateLimiter.close();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -549,10 +549,6 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
 
     @Override
     public final synchronized void readEntriesComplete(List<Entry> entries, Object ctx) {
-        if (topic.isTransferring()) {
-            return;
-        }
-
         ReadType readType = (ReadType) ctx;
         if (readType == ReadType.Normal) {
             havePendingRead = false;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -672,15 +672,9 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         long totalEntries = 0;
         int avgBatchSizePerMsg = remainingMessages > 0 ? Math.max(remainingMessages / entries.size(), 1) : 1;
 
-        int firstAvailableConsumerPermits, currentTotalAvailablePermits;
-        boolean dispatchMessage;
-        while (entriesToDispatch > 0) {
-            firstAvailableConsumerPermits = getFirstAvailableConsumerPermits();
-            currentTotalAvailablePermits = Math.max(totalAvailablePermits, firstAvailableConsumerPermits);
-            dispatchMessage = currentTotalAvailablePermits > 0 && firstAvailableConsumerPermits > 0;
-            if (!dispatchMessage) {
-                break;
-            }
+        // If the dispatcher is closed, firstAvailableConsumerPermits will be 0, which skips dispatching the
+        // messages.
+        while (entriesToDispatch > 0 && getFirstAvailableConsumerPermits() > 0) {
             Consumer c = getNextConsumer();
             if (c == null) {
                 // Do nothing, cursor will be rewind at reconnection

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -544,7 +544,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
 
     @Override
     public final synchronized void readEntriesComplete(List<Entry> entries, Object ctx) {
-        if (topic.isClosingOrDeleting()) {
+        if (topic.isTransferring()) {
             return;
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -674,7 +674,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
 
         // If the dispatcher is closed, firstAvailableConsumerPermits will be 0, which skips dispatching the
         // messages.
-        while (entriesToDispatch > 0 && getFirstAvailableConsumerPermits() > 0) {
+        while (entriesToDispatch > 0 && isAtleastOneConsumerAvailable()) {
             Consumer c = getNextConsumer();
             if (c == null) {
                 // Do nothing, cursor will be rewind at reconnection

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -313,8 +313,7 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
         redeliverUnacknowledgedMessages(consumer, DEFAULT_CONSUMER_EPOCH);
     }
 
-    @Override
-    protected void readMoreEntries(Consumer consumer) {
+    private void readMoreEntries(Consumer consumer) {
         // consumer can be null when all consumers are disconnected from broker.
         // so skip reading more entries if currently there is no active consumer.
         if (null == consumer) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -154,7 +154,11 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
         executor.execute(() -> internalReadEntriesComplete(entries, obj));
     }
 
-    public synchronized void internalReadEntriesComplete(final List<Entry> entries, Object obj) {
+    private synchronized void internalReadEntriesComplete(final List<Entry> entries, Object obj) {
+        if (topic.isClosingOrDeleting()) {
+            return;
+        }
+
         ReadEntriesCtx readEntriesCtx = (ReadEntriesCtx) obj;
         Consumer readConsumer = readEntriesCtx.getConsumer();
         long epoch = readEntriesCtx.getEpoch();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -328,6 +328,12 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
             }
             return;
         }
+        if (topic.isTransferring()) {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Skipping read for the topic: topic is transferring", topic.getName());
+            }
+            return;
+        }
 
         if (consumer.getAvailablePermits() > 0) {
             synchronized (this) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -155,7 +155,7 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
     }
 
     private synchronized void internalReadEntriesComplete(final List<Entry> entries, Object obj) {
-        if (topic.isClosingOrDeleting()) {
+        if (topic.isTransferring()) {
             return;
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1515,9 +1515,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     // cases when Topic.close is called outside the scope of the ExtensibleLoadManager. In these
                     // situations, we must pursue the regular Subscription.close, as Topic.close is invoked just once.
                     if (isTransferring()) {
-                          subscriptions.forEach((s, sub) -> futures.add(sub.disconnect(lookupData)));
+                        subscriptions.forEach((s, sub) -> futures.add(sub.disconnect(lookupData)));
                     } else {
-                          subscriptions.forEach((s, sub) -> futures.add(sub.close(true, lookupData)));
+                        subscriptions.forEach((s, sub) -> futures.add(sub.close(true, lookupData)));
                     }
                 }
             ));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1510,7 +1510,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             futures.add(ExtensibleLoadManagerImpl.getAssignedBrokerLookupData(
                     brokerService.getPulsar(), topic).thenAccept(lookupData -> {
                       producers.values().forEach(producer -> futures.add(producer.disconnect(lookupData)));
-                      subscriptions.forEach((s, sub) -> futures.add(sub.close(true, lookupData)));
+                      subscriptions.forEach((s, sub) -> futures.add(sub.disconnect(lookupData)));
                     }
             ));
         } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -477,7 +477,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     new UnsupportedSubscriptionException(String.format("Unsupported subscription: %s", subName)));
         }
         // Fence old subscription -> Rewind cursor -> Replace with a new subscription.
-        return sub.disconnect(true, Optional.empty()).thenCompose(ignore -> {
+        return sub.close(true, Optional.empty()).thenCompose(ignore -> {
             if (!lock.writeLock().tryLock()) {
                 return CompletableFuture.failedFuture(new SubscriptionConflictUnloadException(String.format("Conflict"
                         + " topic-close, topic-delete, another-subscribe-unload, cannot unload subscription %s now",
@@ -1360,7 +1360,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
                 CompletableFuture<Void> closeClientFuture = new CompletableFuture<>();
                 List<CompletableFuture<Void>> futures = new ArrayList<>();
-                subscriptions.forEach((s, sub) -> futures.add(sub.disconnect(true, Optional.empty())));
+                subscriptions.forEach((s, sub) -> futures.add(sub.close(true, Optional.empty())));
                 if (closeIfClientsConnected) {
                     replicators.forEach((cluster, replicator) -> futures.add(replicator.disconnect()));
                     shadowReplicators.forEach((__, replicator) -> futures.add(replicator.disconnect()));
@@ -1510,11 +1510,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             futures.add(ExtensibleLoadManagerImpl.getAssignedBrokerLookupData(
                     brokerService.getPulsar(), topic).thenAccept(lookupData -> {
                       producers.values().forEach(producer -> futures.add(producer.disconnect(lookupData)));
-                      subscriptions.forEach((s, sub) -> futures.add(sub.disconnect(true, lookupData)));
+                      subscriptions.forEach((s, sub) -> futures.add(sub.close(true, lookupData)));
                     }
             ));
         } else {
-            subscriptions.forEach((s, sub) -> futures.add(sub.disconnect(false, Optional.empty())));
+            subscriptions.forEach((s, sub) -> futures.add(sub.close(false, Optional.empty())));
         }
         if (topicPublishRateLimiter != null) {
             topicPublishRateLimiter.close();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1508,10 +1508,18 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         shadowReplicators.forEach((__, replicator) -> futures.add(replicator.disconnect()));
         if (disconnectClients) {
             futures.add(ExtensibleLoadManagerImpl.getAssignedBrokerLookupData(
-                    brokerService.getPulsar(), topic).thenAccept(lookupData -> {
-                      producers.values().forEach(producer -> futures.add(producer.disconnect(lookupData)));
-                      subscriptions.forEach((s, sub) -> futures.add(sub.disconnect(lookupData)));
+                brokerService.getPulsar(), topic).thenAccept(lookupData -> {
+                    producers.values().forEach(producer -> futures.add(producer.disconnect(lookupData)));
+                    // Topics unloaded due to the ExtensibleLoadManager undergo closing twice: first with
+                    // disconnectClients = false, second with disconnectClients = true. The check below identifies the
+                    // cases when Topic.close is called outside the scope of the ExtensibleLoadManager. In these
+                    // situations, we must pursue the regular Subscription.close, as Topic.close is invoked just once.
+                    if (isTransferring()) {
+                          subscriptions.forEach((s, sub) -> futures.add(sub.disconnect(lookupData)));
+                    } else {
+                          subscriptions.forEach((s, sub) -> futures.add(sub.close(true, lookupData)));
                     }
+                }
             ));
         } else {
             subscriptions.forEach((s, sub) -> futures.add(sub.close(false, Optional.empty())));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -569,7 +569,7 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
         }
     }
 
-    @Test(timeOut = 30_000, dataProvider = "subscriptionTypeTest", invocationCount = 100, skipFailedInvocations = true)
+    @Test(timeOut = 30_000, dataProvider = "subscriptionTypeTest")
     public void testTransferNonPersistentClientReconnectionWithoutLookup(SubscriptionType subscriptionType)
             throws Exception {
         var id = String.format("test-tx-non-persistent-client-reconnect-%s-%s", subscriptionType, UUID.randomUUID());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractBaseDispatcherTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractBaseDispatcherTest.java
@@ -37,6 +37,7 @@ import org.apache.bookkeeper.mledger.impl.EntryImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -279,7 +280,7 @@ public class AbstractBaseDispatcherTest {
         }
 
         @Override
-        public CompletableFuture<Void> close() {
+        public CompletableFuture<Void> close(Optional<BrokerLookupData> assignedBrokerLookupData) {
             return null;
         }
 
@@ -294,7 +295,8 @@ public class AbstractBaseDispatcherTest {
         }
 
         @Override
-        public CompletableFuture<Void> disconnectAllConsumers(boolean isResetCursor) {
+        public CompletableFuture<Void> disconnectAllConsumers(boolean isResetCursor,
+                                                              Optional<BrokerLookupData> assignedBrokerLookupData) {
             return null;
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractBaseDispatcherTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractBaseDispatcherTest.java
@@ -280,7 +280,8 @@ public class AbstractBaseDispatcherTest {
         }
 
         @Override
-        public CompletableFuture<Void> close(Optional<BrokerLookupData> assignedBrokerLookupData) {
+        public CompletableFuture<Void> close(boolean disconnectConsumers,
+                                             Optional<BrokerLookupData> assignedBrokerLookupData) {
             return null;
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -2413,7 +2413,8 @@ public class ServerCnxTest {
                 "test" /* consumer name */, 0 /* avoid reseting cursor */);
         channel.writeInbound(subscribe1);
 
-        ByteBuf closeConsumer = Commands.newCloseConsumer(1 /* consumer id */, 2 /* request id */);
+        ByteBuf closeConsumer = Commands.newCloseConsumer(1 /* consumer id */, 2 /* request id */,
+                null /* assignedBrokerServiceUrl */, null /* assignedBrokerServiceUrlTls */);
         channel.writeInbound(closeConsumer);
 
         ByteBuf subscribe2 = Commands.newSubscribe(successTopicName, //

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -1378,7 +1378,7 @@ public class TransactionTest extends TransactionTestBase {
             producer.newMessage().value(Bytes.toBytes(i)).send();
         }
         ClientCnx cnx = (ClientCnx) MethodUtils.invokeMethod(consumer, true, "cnx");
-        MethodUtils.invokeMethod(consumer, true, "connectionClosed", cnx);
+        MethodUtils.invokeMethod(consumer, true, "connectionClosed", cnx, Optional.empty(), Optional.empty());
 
         Message<byte[]> message = consumer.receive();
         Transaction transaction = pulsarClient

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
@@ -270,7 +270,7 @@ public class ClientErrorsTest {
             if (subscribeCount == 1) {
                 ctx.writeAndFlush(Commands.newSuccess(subscribe.getRequestId()));
                 // Trigger reconnect
-                ctx.writeAndFlush(Commands.newCloseConsumer(subscribe.getConsumerId(), -1));
+                ctx.writeAndFlush(Commands.newCloseConsumer(subscribe.getConsumerId(), -1, null, null));
             } else if (subscribeCount != 2) {
                 // Respond to subsequent requests to prevent timeouts
                 ctx.writeAndFlush(Commands.newSuccess(subscribe.getRequestId()));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
@@ -909,7 +909,7 @@ public class SubscriptionMessageDispatchThrottlingTest extends MessageDispatchTh
 
         producer.close();
         consumer.close();
-        sub.disconnect(Optional.empty()).get();
+        sub.disconnect(true, Optional.empty()).get();
 
         // Make sure that the rate limiter is closed
         Assert.assertEquals(dispatchRateLimiter.getDispatchRateOnMsg(), -1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
@@ -909,7 +909,7 @@ public class SubscriptionMessageDispatchThrottlingTest extends MessageDispatchTh
 
         producer.close();
         consumer.close();
-        sub.disconnect(true, Optional.empty()).get();
+        sub.close(true, Optional.empty()).get();
 
         // Make sure that the rate limiter is closed
         Assert.assertEquals(dispatchRateLimiter.getDispatchRateOnMsg(), -1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.api;
 import static org.awaitility.Awaitility.await;
 import com.google.common.collect.Sets;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pulsar.broker.BrokerTestUtil;
@@ -908,7 +909,7 @@ public class SubscriptionMessageDispatchThrottlingTest extends MessageDispatchTh
 
         producer.close();
         consumer.close();
-        sub.disconnect().get();
+        sub.disconnect(Optional.empty()).get();
 
         // Make sure that the rate limiter is closed
         Assert.assertEquals(dispatchRateLimiter.getDispatchRateOnMsg(), -1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -179,18 +179,10 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         doAnswer(invocationOnMock -> prod1.getState()).when(producer1).getState();
         doAnswer(invocationOnMock -> prod1.getClientCnx()).when(producer1).getClientCnx();
         doAnswer(invocationOnMock -> prod1.cnx()).when(producer1).cnx();
-        doAnswer(invocationOnMock -> {
-            prod1.connectionClosed((ClientCnx) invocationOnMock.getArguments()[0]);
-            return null;
-        }).when(producer1).connectionClosed(any());
         ProducerImpl<byte[]> producer2 = spy(prod2);
         doAnswer(invocationOnMock -> prod2.getState()).when(producer2).getState();
         doAnswer(invocationOnMock -> prod2.getClientCnx()).when(producer2).getClientCnx();
         doAnswer(invocationOnMock -> prod2.cnx()).when(producer2).cnx();
-        doAnswer(invocationOnMock -> {
-            prod2.connectionClosed((ClientCnx) invocationOnMock.getArguments()[0]);
-            return null;
-        }).when(producer2).connectionClosed(any());
 
         ClientCnx clientCnx = producer1.getClientCnx();
 
@@ -221,11 +213,11 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         // let server send signal to close-connection and client close the connection
         Thread.sleep(1000);
         // [1] Verify: producer1 must get connectionClosed signal
-        verify(producer1, atLeastOnce()).connectionClosed(any());
+        verify(producer1, atLeastOnce()).connectionClosed(any(), any(), any());
         // [2] Verify: consumer1 must get connectionClosed signal
         verify(consumer1, atLeastOnce()).connectionClosed(any(), any(), any());
         // [3] Verify: producer2 should have not received connectionClosed signal
-        verify(producer2, never()).connectionClosed(any());
+        verify(producer2, never()).connectionClosed(any(), any(), any());
 
         // sleep for sometime to let other disconnected producer and consumer connect again: but they should not get
         // connected with same broker as that broker is already out from active-broker list
@@ -245,7 +237,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         pulsar.getNamespaceService().unloadNamespaceBundle((NamespaceBundle) bundle2).join();
         // let producer2 give some time to get disconnect signal and get disconnected
         Thread.sleep(200);
-        verify(producer2, atLeastOnce()).connectionClosed(any());
+        verify(producer2, atLeastOnce()).connectionClosed(any(), any(), any());
 
         // producer1 must not be able to connect again
         assertNull(prod1.getClientCnx());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -104,6 +104,7 @@ import org.apache.pulsar.common.util.collections.ConcurrentLongHashMap;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.awaitility.Awaitility;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -173,10 +174,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         doAnswer(invocationOnMock -> cons1.getState()).when(consumer1).getState();
         doAnswer(invocationOnMock -> cons1.getClientCnx()).when(consumer1).getClientCnx();
         doAnswer(invocationOnMock -> cons1.cnx()).when(consumer1).cnx();
-        doAnswer(invocationOnMock -> {
-            cons1.connectionClosed((ClientCnx) invocationOnMock.getArguments()[0]);
-            return null;
-        }).when(consumer1).connectionClosed(any());
+        doAnswer(InvocationOnMock::callRealMethod).when(consumer1).connectionClosed(any(), any(), any());
         ProducerImpl<byte[]> producer1 = spy(prod1);
         doAnswer(invocationOnMock -> prod1.getState()).when(producer1).getState();
         doAnswer(invocationOnMock -> prod1.getClientCnx()).when(producer1).getClientCnx();
@@ -225,7 +223,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         // [1] Verify: producer1 must get connectionClosed signal
         verify(producer1, atLeastOnce()).connectionClosed(any());
         // [2] Verify: consumer1 must get connectionClosed signal
-        verify(consumer1, atLeastOnce()).connectionClosed(any());
+        verify(consumer1, atLeastOnce()).connectionClosed(any(), any(), any());
         // [3] Verify: producer2 should have not received connectionClosed signal
         verify(producer2, never()).connectionClosed(any());
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PulsarTestClient.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PulsarTestClient.java
@@ -192,7 +192,7 @@ public class PulsarTestClient extends PulsarClientImpl {
 
         // make the existing connection between the producer and broker to break by explicitly closing it
         ClientCnx cnx = producer.cnx();
-        producer.connectionClosed(cnx);
+        producer.connectionClosed(cnx, Optional.empty(), Optional.empty());
         cnx.close();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -323,7 +323,7 @@ public class ClientCnx extends PulsarHandler {
         waitingLookupRequests.forEach(pair -> pair.getRight().getRight().completeExceptionally(e));
 
         // Notify all attached producers/consumers so they have a chance to reconnect
-        producers.forEach((id, producer) -> producer.connectionClosed(this));
+        producers.forEach((id, producer) -> producer.connectionClosed(this, Optional.empty(), Optional.empty()));
         consumers.forEach((id, consumer) -> consumer.connectionClosed(this, Optional.empty(), Optional.empty()));
         transactionMetaStoreHandlers.forEach((id, handler) -> handler.connectionClosed(this));
         topicListWatchers.forEach((__, watcher) -> watcher.connectionClosed(this));
@@ -803,51 +803,49 @@ public class ClientCnx extends PulsarHandler {
     @Override
     protected void handleCloseProducer(CommandCloseProducer closeProducer) {
         final long producerId = closeProducer.getProducerId();
+        log.info("[{}] Broker notification of closed producer: {}, assignedBrokerUrl: {}, assignedBrokerUrlTls: {}",
+                remoteAddress, producerId,
+                closeProducer.hasAssignedBrokerServiceUrl() ? closeProducer.getAssignedBrokerServiceUrl() : null,
+                closeProducer.hasAssignedBrokerServiceUrlTls() ? closeProducer.getAssignedBrokerServiceUrlTls() : null);
         ProducerImpl<?> producer = producers.remove(producerId);
         if (producer != null) {
-            if (closeProducer.hasAssignedBrokerServiceUrl() || closeProducer.hasAssignedBrokerServiceUrlTls()) {
-                try {
-                    final URI uri = new URI(producer.client.conf.isUseTls()
-                            ? closeProducer.getAssignedBrokerServiceUrlTls()
-                            : closeProducer.getAssignedBrokerServiceUrl());
-                    log.info("[{}] Broker notification of Closed producer: {}. Redirecting to {}.",
-                            remoteAddress, closeProducer.getProducerId(), uri);
-                    producer.getConnectionHandler().connectionClosed(
-                            this, Optional.of(0L), Optional.of(uri));
-                } catch (Throwable e) {
-                    log.error("[{}] Invalid redirect url {}/{} for {}", remoteAddress,
-                            closeProducer.hasAssignedBrokerServiceUrl()
-                                    ? closeProducer.getAssignedBrokerServiceUrl() : "",
-                            closeProducer.hasAssignedBrokerServiceUrlTls()
-                                    ? closeProducer.getAssignedBrokerServiceUrlTls() : "",
-                            closeProducer.getRequestId(), e);
-                    producer.connectionClosed(this);
-                }
-            } else {
-                log.info("[{}] Broker notification of Closed producer: {}.",
-                        remoteAddress, closeProducer.getProducerId());
-                producer.connectionClosed(this);
-            }
+            String brokerServiceUrl = getBrokerServiceUrl(closeProducer, producer);
+            Optional<URI> hostUri = parseUri(brokerServiceUrl,
+                                             closeProducer.hasRequestId() ? closeProducer.getRequestId() : null);
+            Optional<Long> initialConnectionDelayMs = hostUri.map(__ -> 0L);
+            producer.connectionClosed(this, initialConnectionDelayMs, hostUri);
         } else {
-            log.warn("Producer with id {} not found while closing producer ", producerId);
+            log.warn("[{}] Producer with id {} not found while closing producer", remoteAddress, producerId);
         }
+    }
+
+    private static String getBrokerServiceUrl(CommandCloseProducer closeProducer, ProducerImpl<?> producer) {
+        if (producer.getClient().getConfiguration().isUseTls()) {
+            if (closeProducer.hasAssignedBrokerServiceUrlTls()) {
+                return closeProducer.getAssignedBrokerServiceUrlTls();
+            }
+        } else if (closeProducer.hasAssignedBrokerServiceUrl()) {
+            return closeProducer.getAssignedBrokerServiceUrl();
+        }
+        return null;
     }
 
     @Override
     protected void handleCloseConsumer(CommandCloseConsumer closeConsumer) {
-        log.info("[{}] Broker notification of Closed consumer: {}, assignedBrokerUrl: {}, assignedBrokerUrlTls: {}",
-                remoteAddress, closeConsumer.getConsumerId(),
+        final long consumerId = closeConsumer.getConsumerId();
+        log.info("[{}] Broker notification of closed consumer: {}, assignedBrokerUrl: {}, assignedBrokerUrlTls: {}",
+                remoteAddress, consumerId,
                 closeConsumer.hasAssignedBrokerServiceUrl() ? closeConsumer.getAssignedBrokerServiceUrl() : null,
                 closeConsumer.hasAssignedBrokerServiceUrlTls() ? closeConsumer.getAssignedBrokerServiceUrlTls() : null);
-        final long consumerId = closeConsumer.getConsumerId();
         ConsumerImpl<?> consumer = consumers.remove(consumerId);
         if (consumer != null) {
             String brokerServiceUrl = getBrokerServiceUrl(closeConsumer, consumer);
-            Optional<URI> hostUri = parseUri(brokerServiceUrl, closeConsumer.getRequestId());
+            Optional<URI> hostUri = parseUri(brokerServiceUrl,
+                                             closeConsumer.hasRequestId() ? closeConsumer.getRequestId() : null);
             Optional<Long> initialConnectionDelayMs = hostUri.map(__ -> 0L);
             consumer.connectionClosed(this, initialConnectionDelayMs, hostUri);
         } else {
-            log.warn("Consumer with id {} not found while closing consumer ", consumerId);
+            log.warn("[{}] Consumer with id {} not found while closing consumer", remoteAddress, consumerId);
         }
     }
 
@@ -862,13 +860,13 @@ public class ClientCnx extends PulsarHandler {
         return null;
     }
 
-    private Optional<URI> parseUri(String url, long requestId) {
+    private Optional<URI> parseUri(String url, Long requestId) {
         try {
             if (url != null) {
                 return Optional.of(new URI(url));
             }
         } catch (URISyntaxException e) {
-            log.warn("[{}] Invalid redirect URL {} for {}: ", remoteAddress, url, requestId, e);
+            log.warn("[{}] Invalid redirect URL {}, requestId {}: ", remoteAddress, url, requestId, e);
         }
         return Optional.empty();
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java
@@ -182,11 +182,11 @@ public class ConnectionHandler {
             }
             long delayMs = initialConnectionDelayMs.orElse(backoff.next());
             state.setState(State.Connecting);
-            log.info("[{}] [{}] Closed connection {} -- Will try again in {} s",
-                    state.topic, state.getHandlerName(), cnx.channel(),
-                    delayMs / 1000.0);
+            log.info("[{}] [{}] Closed connection {} -- Will try again in {} s, hostUrl: {}",
+                    state.topic, state.getHandlerName(), cnx.channel(), delayMs / 1000.0, hostUrl.orElse(null));
             state.client.timer().newTimeout(timeout -> {
-                log.info("[{}] [{}] Reconnecting after timeout", state.topic, state.getHandlerName());
+                log.info("[{}] [{}] Reconnecting after {} s timeout, hostUrl: {}",
+                        state.topic, state.getHandlerName(), delayMs / 1000.0, hostUrl.orElse(null));
                 grabCnx(hostUrl);
             }, delayMs, TimeUnit.MILLISECONDS);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -35,6 +35,7 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.Timeout;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -888,7 +889,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                     // in case it was indeed created, otherwise it might prevent new create consumer operation,
                     // since we are not necessarily closing the connection.
                     long closeRequestId = client.newRequestId();
-                    ByteBuf cmd = Commands.newCloseConsumer(consumerId, closeRequestId);
+                    ByteBuf cmd = Commands.newCloseConsumer(consumerId, closeRequestId, null, null);
                     cnx.sendRequestWithId(cmd, closeRequestId);
                 }
 
@@ -1057,7 +1058,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         if (null == cnx) {
             cleanupAtClose(closeFuture, null);
         } else {
-            ByteBuf cmd = Commands.newCloseConsumer(consumerId, requestId);
+            ByteBuf cmd = Commands.newCloseConsumer(consumerId, requestId, null, null);
             cnx.sendRequestWithId(cmd, requestId).handle((v, exception) -> {
                 final ChannelHandlerContext ctx = cnx.ctx();
                 boolean ignoreException = ctx == null || !ctx.channel().isActive();
@@ -2669,8 +2670,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         this.connectionHandler.resetBackoff();
     }
 
-    void connectionClosed(ClientCnx cnx) {
-        this.connectionHandler.connectionClosed(cnx);
+    void connectionClosed(ClientCnx cnx, Optional<Long> initialConnectionDelayMs, Optional<URI> hostUrl) {
+        this.connectionHandler.connectionClosed(cnx, initialConnectionDelayMs, hostUrl);
     }
 
     public ClientCnx getClientCnx() {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -41,6 +41,7 @@ import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
 import io.netty.util.concurrent.ScheduledFuture;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -2372,8 +2373,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         this.connectionHandler.resetBackoff();
     }
 
-    void connectionClosed(ClientCnx cnx) {
-        this.connectionHandler.connectionClosed(cnx);
+    void connectionClosed(ClientCnx cnx, Optional<Long> initialConnectionDelayMs, Optional<URI> hostUrl) {
+        this.connectionHandler.connectionClosed(cnx, initialConnectionDelayMs, hostUrl);
     }
 
     public ClientCnx getClientCnx() {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientCnxTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientCnxTest.java
@@ -33,6 +33,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.lang.reflect.Field;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -278,12 +279,18 @@ public class ClientCnxTest {
         ClientCnx cnx = new ClientCnx(conf, eventLoop);
 
         long consumerId = 1;
-        cnx.registerConsumer(consumerId, mock(ConsumerImpl.class));
+        PulsarClientImpl pulsarClient = mock(PulsarClientImpl.class);
+        when(pulsarClient.getConfiguration()).thenReturn(conf);
+        ConsumerImpl consumer = mock(ConsumerImpl.class);
+        when(consumer.getClient()).thenReturn(pulsarClient);
+        cnx.registerConsumer(consumerId, consumer);
         assertEquals(cnx.consumers.size(), 1);
 
-        CommandCloseConsumer closeConsumer = new CommandCloseConsumer().setConsumerId(consumerId);
+        CommandCloseConsumer closeConsumer = new CommandCloseConsumer().setConsumerId(consumerId).setRequestId(1);
         cnx.handleCloseConsumer(closeConsumer);
         assertEquals(cnx.consumers.size(), 0);
+
+        verify(consumer).connectionClosed(cnx, Optional.empty(), Optional.empty());
 
         eventLoop.shutdownGracefully();
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientCnxTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientCnxTest.java
@@ -303,12 +303,18 @@ public class ClientCnxTest {
         ClientCnx cnx = new ClientCnx(conf, eventLoop);
 
         long producerId = 1;
-        cnx.registerProducer(producerId, mock(ProducerImpl.class));
+        PulsarClientImpl pulsarClient = mock(PulsarClientImpl.class);
+        when(pulsarClient.getConfiguration()).thenReturn(conf);
+        ProducerImpl producer = mock(ProducerImpl.class);
+        when(producer.getClient()).thenReturn(pulsarClient);
+        cnx.registerProducer(producerId, producer);
         assertEquals(cnx.producers.size(), 1);
 
-        CommandCloseProducer closeProducerCmd = new CommandCloseProducer().setProducerId(producerId);
+        CommandCloseProducer closeProducerCmd = new CommandCloseProducer().setProducerId(producerId).setRequestId(1);
         cnx.handleCloseProducer(closeProducerCmd);
         assertEquals(cnx.producers.size(), 0);
+
+        verify(producer).connectionClosed(cnx, Optional.empty(), Optional.empty());
 
         eventLoop.shutdownGracefully();
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -60,6 +60,7 @@ import org.apache.pulsar.common.api.proto.CommandAddPartitionToTxnResponse;
 import org.apache.pulsar.common.api.proto.CommandAddSubscriptionToTxn;
 import org.apache.pulsar.common.api.proto.CommandAddSubscriptionToTxnResponse;
 import org.apache.pulsar.common.api.proto.CommandAuthChallenge;
+import org.apache.pulsar.common.api.proto.CommandCloseConsumer;
 import org.apache.pulsar.common.api.proto.CommandCloseProducer;
 import org.apache.pulsar.common.api.proto.CommandConnect;
 import org.apache.pulsar.common.api.proto.CommandConnected;
@@ -737,11 +738,21 @@ public class Commands {
         return serializeWithSize(cmd);
     }
 
-    public static ByteBuf newCloseConsumer(long consumerId, long requestId) {
+    public static ByteBuf newCloseConsumer(
+            long consumerId, long requestId, String assignedBrokerUrl, String assignedBrokerUrlTls) {
         BaseCommand cmd = localCmd(Type.CLOSE_CONSUMER);
-        cmd.setCloseConsumer()
+        CommandCloseConsumer commandCloseConsumer = cmd.setCloseConsumer()
             .setConsumerId(consumerId)
             .setRequestId(requestId);
+
+        if (assignedBrokerUrl != null) {
+            commandCloseConsumer.setAssignedBrokerServiceUrl(assignedBrokerUrl);
+        }
+
+        if (assignedBrokerUrlTls != null) {
+            commandCloseConsumer.setAssignedBrokerServiceUrlTls(assignedBrokerUrlTls);
+        }
+
         return serializeWithSize(cmd);
     }
 

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -648,6 +648,8 @@ message CommandCloseProducer {
 message CommandCloseConsumer {
     required uint64 consumer_id = 1;
     required uint64 request_id = 2;
+    optional string assignedBrokerServiceUrl = 3;
+    optional string assignedBrokerServiceUrlTls = 4;
 }
 
 message CommandRedeliverUnacknowledgedMessages {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

PIP: [PIP-307](https://github.com/apache/pulsar/pull/20748)

### Motivation

Topic unloading can be sped up, as described by PIP-307, by forwarding the target broker lookup data to clients (both producers and consumers). PR https://github.com/apache/pulsar/pull/21408 added support for the producers, this PR introduces similar functionality for the consumers.

### Modifications

When the load balancer reassigns a bundle from an old 'source' broker to a new 'target' broker, the consumers are currently forcefully disconnected. The expectation is that they will issue topic lookup calls to locate the new broker.

This PR forwards this information to the consumers as part of the disconnect workflow, allowing them to connect directly to the target broker and skip the lookups in the process.

Specifically:
- Added an optional `assignedBrokerLookupData` to the `CloseConsumer` command. The consumer uses this information to attempt to connect to the broker once. If the connection fails, it falls back to topic lookups.
- When the ExtensibleLoadManager is unloading a bundle, the source broker first closes the topics _without_ disconnecting the clients. When the bundle has been fully migrated to the target broker, the source broker closes the topics again, this time disconnecting the clients, along with sending the target broker information to the clients.
- Message acknowledgments are silently ignored since the ledgers are being closed on the source broker too. When the topic loads up on the target broker, these in-progress messages will be re-delivered to the consumers.
- Closing the dispatchers has the effect of disabling any further BookKeeper reads on the source broker. This is a desired outcome because these messages would not get acknowledged anyway. Inflight reads are still delivered but will have their acks ignored, as described above.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - Extended existing unit tests `testTransferClientReconnectionWithoutLookup` and `testUnloadClientReconnectionWithLookup` to cover both producer and consumer behavior, as well as all subscription types. Ran the suite 100 times to make sure it was stable.
  - Manually verified the behavior using `pulsar-perf` in a k8s environment. Asserted that all messages pass through during a load balancing run, while no lookups are performed by the clients.
 
### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [x] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: (https://github.com/dragosvictor/pulsar/pull/1)

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
