### PR TITLE
[fix][broker] Allow namespace roles consume any subs

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -115,7 +115,11 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                             // list is empty)
                             Set<String> roles = policies.get().auth_policies
                                     .getSubscriptionAuthentication().get(subscription);
-                            if (roles != null && !roles.isEmpty() && !roles.contains(role)) {
+                            Map<String, Set<AuthAction>> namespaceRolesAuth =
+                                    policies.get().auth_policies.getNamespaceAuthentication();
+                            if (!(namespaceRolesAuth != null && namespaceRolesAuth.containsKey(role)
+                                    && namespaceRolesAuth.get(role).contains(AuthAction.consume))
+                                    && roles != null && !roles.isEmpty() && !roles.contains(role)) {
                                 log.warn("[{}] is not authorized to subscribe on {}-{}", role, topicName, subscription);
                                 return CompletableFuture.completedFuture(false);
                             }


### PR DESCRIPTION
### Motivation

When I have an auth role user in a namespace and give it the AuthAction.CONSUME permission, I have read-only permissions on all topics under the namespace, but when I subscribe to a topic, I have to apply for subscription permissions separately.

### Modifications

Allow namespace roles consume any subscriptions.

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
