### PR TITLE
[fix] [broker] network package lost if enable haProxyProtocolEnabled

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EnableProxyProtocolTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EnableProxyProtocolTest.java
@@ -19,9 +19,12 @@
 package org.apache.pulsar.broker.service;
 
 import io.netty.buffer.Unpooled;
+import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
-import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.ClientCnx;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.policies.data.SubscriptionStats;
@@ -34,7 +37,6 @@ import org.testng.annotations.Test;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 @Test(groups = "broker")
 public class EnableProxyProtocolTest extends BrokerTestBase  {
@@ -53,7 +55,7 @@ public class EnableProxyProtocolTest extends BrokerTestBase  {
     }
 
     @Test
-    public void testSimpleProduceAndConsume() throws PulsarClientException {
+    public void testSimpleProduceAndConsume() throws Exception {
         final String namespace = "prop/ns-abc";
         final String topicName = "persistent://" + namespace + "/testSimpleProduceAndConsume";
         final String subName = "my-subscriber-name";
@@ -76,30 +78,86 @@ public class EnableProxyProtocolTest extends BrokerTestBase  {
         }
 
         Assert.assertEquals(received, messages);
+
+        // cleanup.
+        org.apache.pulsar.broker.service.Consumer serverConsumer = pulsar.getBrokerService().getTopicReference(topicName)
+                .get().getSubscription(subName).getConsumers().get(0);
+        ((ServerCnx) serverConsumer.cnx()).close();
+        consumer.close();
+        producer.close();
+        admin.topics().delete(topicName);
     }
 
     @Test
-    public void testProxyProtocol() throws PulsarClientException, ExecutionException, InterruptedException, PulsarAdminException {
+    public void testProxyProtocol() throws Exception {
         final String namespace = "prop/ns-abc";
         final String topicName = "persistent://" + namespace + "/testProxyProtocol";
         final String subName = "my-subscriber-name";
         PulsarClientImpl client = (PulsarClientImpl) pulsarClient;
-        CompletableFuture<ClientCnx> cnx = client.getCnxPool().getConnection(InetSocketAddress.createUnresolved("localhost", pulsar.getBrokerListenPort().get()));
+        CompletableFuture<ClientCnx> cnx = client.getCnxPool().getConnection(
+                InetSocketAddress.createUnresolved("localhost", pulsar.getBrokerListenPort().get()));
         // Simulate the proxy protcol message
-        cnx.get().ctx().channel().writeAndFlush(Unpooled.copiedBuffer("PROXY TCP4 198.51.100.22 203.0.113.7 35646 80\r\n".getBytes()));
-        pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
-                .subscribe();
-        org.apache.pulsar.broker.service.Consumer c = pulsar.getBrokerService().getTopicReference(topicName).get().getSubscription(subName).getConsumers().get(0);
-        Awaitility.await().untilAsserted(() -> Assert.assertTrue(c.cnx().hasHAProxyMessage()));
+        cnx.get().ctx().channel().writeAndFlush(
+                Unpooled.copiedBuffer("PROXY TCP4 198.51.100.22 203.0.113.7 35646 80\r\n".getBytes()));
+
+        // Verify the addr can be handled correctly.
+        testPubAndSub(topicName, subName, "198.51.100.22:35646");
+
+        // cleanup.
+        admin.topics().delete(topicName);
+    }
+
+    @Test
+    public void testSlowNetwork() throws Exception {
+        final String namespace = "prop/ns-abc";
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://" + namespace + "/tp");
+        final String subName = "my-subscriber-name";
+        PulsarClientImpl client = (PulsarClientImpl) pulsarClient;
+        CompletableFuture<ClientCnx> cnx = client.getCnxPool().getConnection(
+                InetSocketAddress.createUnresolved("localhost", pulsar.getBrokerListenPort().get()));
+        // Simulate the proxy protcol message
+        byte[] bs = "PROXY TCP4 198.51.100.22 203.0.113.7 35646 80\r\n".getBytes();
+        for (int i = 0; i < bs.length; i++) {
+            cnx.get().ctx().channel().writeAndFlush(Unpooled.copiedBuffer(new byte[]{bs[i]}));
+            Thread.sleep(100);
+        }
+
+        // Verify the addr can be handled correctly.
+        testPubAndSub(topicName, subName, "198.51.100.22:35646");
+
+        // cleanup.
+        admin.topics().delete(topicName);
+    }
+
+    private void testPubAndSub(String topicName, String subName, String expectedHostAndPort) throws Exception {
+        // Verify: subscribe
+        org.apache.pulsar.client.api.Consumer<String> clientConsumer = pulsarClient.newConsumer(Schema.STRING).topic(topicName)
+                .subscriptionName(subName).subscribe();
+        org.apache.pulsar.broker.service.Consumer serverConsumer = pulsar.getBrokerService()
+                .getTopicReference(topicName).get().getSubscription(subName).getConsumers().get(0);
+        Awaitility.await().untilAsserted(() -> Assert.assertTrue(serverConsumer.cnx().hasHAProxyMessage()));
         TopicStats topicStats = admin.topics().getStats(topicName);
         Assert.assertEquals(topicStats.getSubscriptions().size(), 1);
         SubscriptionStats subscriptionStats = topicStats.getSubscriptions().get(subName);
         Assert.assertEquals(subscriptionStats.getConsumers().size(), 1);
-        Assert.assertEquals(subscriptionStats.getConsumers().get(0).getAddress(), "198.51.100.22:35646");
+        Assert.assertEquals(subscriptionStats.getConsumers().get(0).getAddress(), expectedHostAndPort);
 
-        pulsarClient.newProducer().topic(topicName).create();
-        topicStats = admin.topics().getStats(topicName);
-        Assert.assertEquals(topicStats.getPublishers().size(), 1);
-        Assert.assertEquals(topicStats.getPublishers().get(0).getAddress(), "198.51.100.22:35646");
+        // Verify: producer register.
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName).create();
+        TopicStats topicStats2 = admin.topics().getStats(topicName);
+        Assert.assertEquals(topicStats2.getPublishers().size(), 1);
+        Assert.assertEquals(topicStats2.getPublishers().get(0).getAddress(), expectedHostAndPort);
+
+        // Verify: Pub & Sub
+        producer.send("1");
+        Message<String> msg = clientConsumer.receive(2, TimeUnit.SECONDS);
+        Assert.assertNotNull(msg);
+        Assert.assertEquals(msg.getValue(), "1");
+        clientConsumer.acknowledge(msg);
+
+        // cleanup.
+        ((ServerCnx) serverConsumer.cnx()).close();
+        producer.close();
+        clientConsumer.close();
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/OptionalProxyProtocolDecoder.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/OptionalProxyProtocolDecoder.java
@@ -19,35 +19,66 @@
 package org.apache.pulsar.common.protocol;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.ProtocolDetectionResult;
 import io.netty.handler.codec.ProtocolDetectionState;
 import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
 import io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Decoder that added whether a new connection is prefixed with the ProxyProtocol.
  * More about the ProxyProtocol see: http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt.
  */
+@Slf4j
 public class OptionalProxyProtocolDecoder extends ChannelInboundHandlerAdapter {
 
     public static final String NAME = "optional-proxy-protocol-decoder";
 
+    ByteBuf cumulatedByteBuf;
+
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        doChannelRead(ctx, msg);
+    }
+
+    /**
+     * @return the msg has been handled correctly, so not need to keep it.
+     */
+    public void doChannelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         if (msg instanceof ByteBuf) {
-            ProtocolDetectionResult<HAProxyProtocolVersion> result =
-                    HAProxyMessageDecoder.detectProtocol((ByteBuf) msg);
-            // should accumulate data if need more data to detect the protocol
-            if (result.state() == ProtocolDetectionState.NEEDS_MORE_DATA) {
-                return;
+            // Combine cumulated buffers.
+            ByteBuf buf = (ByteBuf) msg;
+            if (cumulatedByteBuf != null) {
+                buf = new CompositeByteBuf(ByteBufAllocator.DEFAULT, false, 2, cumulatedByteBuf, buf);
             }
 
+            ProtocolDetectionResult<HAProxyProtocolVersion> result = HAProxyMessageDecoder.detectProtocol(buf);
+            if (result.state() == ProtocolDetectionState.NEEDS_MORE_DATA) {
+                // Accumulate data if need more data to detect the protocol.
+                cumulatedByteBuf = ByteToMessageDecoder.MERGE_CUMULATOR.cumulate(ctx.alloc(),
+                        cumulatedByteBuf == null ? Unpooled.EMPTY_BUFFER : cumulatedByteBuf, (ByteBuf) msg);
+                return;
+            }
             if (result.state() == ProtocolDetectionState.DETECTED) {
                 ctx.pipeline().addAfter(NAME, null, new HAProxyMessageDecoder());
                 ctx.pipeline().remove(this);
             }
+            try {
+                super.channelRead(ctx, buf);
+            } finally {
+                // After the cumulated buffer has been handle correctly, release it.
+                if (cumulatedByteBuf != null && !cumulatedByteBuf.isReadable()) {
+                    cumulatedByteBuf.release();
+                    cumulatedByteBuf = null;
+                }
+            }
+            return;
         }
         super.channelRead(ctx, msg);
     }


### PR DESCRIPTION
Fixes #21557

### Motivation

There is a network package loss issue after enabling `haProxyProtocolEnabled`, which leads the error `Checksum failed on the broker` and `Adjusted frame length exceeds`, you can reproduce the issue by the test `testSlowNetwork`. See: https://github.com/apache/pulsar/blob/master/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/OptionalProxyProtocolDecoder.java#L43-L44

```java
public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
    if (msg instanceof ByteBuf) {
        ProtocolDetectionResult<HAProxyProtocolVersion> result =
                HAProxyMessageDecoder.detectProtocol((ByteBuf) msg);
        if (result.state() == ProtocolDetectionState.NEEDS_MORE_DATA) {
            return; // package lost here
        }

        if (result.state() == ProtocolDetectionState.DETECTED) {
            ctx.pipeline().addAfter(NAME, null, new HAProxyMessageDecoder());
            ctx.pipeline().remove(this);
        }
    }
    super.channelRead(ctx, msg);
}

```


**Error logs:**
```
2023-11-08T04:45:06,474-0800 [pulsar-io-4-47] WARN  org.apache.pulsar.broker.service.ServerCnx - [/10.139.120.143:45029] Got exception io.netty.handler.codec.TooLongFrameException: Adjusted frame length exceeds 5253120: 336070198 - discarded
	at io.netty.handler.codec.LengthFieldBasedFrameDecoder.fail(LengthFieldBasedFrameDecoder.java:507)
	at io.netty.handler.codec.LengthFieldBasedFrameDecoder.failIfNecessary(LengthFieldBasedFrameDecoder.java:493)
	at io.netty.handler.codec.LengthFieldBasedFrameDecoder.exceededFrameLength(LengthFieldBasedFrameDecoder.java:377)
	at io.netty.handler.codec.LengthFieldBasedFrameDecoder.decode(LengthFieldBasedFrameDecoder.java:423)
	at io.netty.handler.codec.LengthFieldBasedFrameDecoder.decode(LengthFieldBasedFrameDecoder.java:333)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:529)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:468)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
	at org.apache.pulsar.common.protocol.OptionalProxyProtocolDecoder.channelRead(OptionalProxyProtocolDecoder.java:52)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1373)
	at io.netty.handler.ssl.SslHandler.decodeNonJdkCompatible(SslHandler.java:1247)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1287)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:529)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:468)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler.flush.FlushConsolidationHandler.channelRead(FlushConsolidationHandler.java:152)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:800)
	at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:499)
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:397)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

### Modifications

Fix the bug.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
