### PR TITLE
[fix][broker] Fix typo in the config key

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -539,7 +539,7 @@ brokerServiceCompactionThresholdInBytes=0
 brokerServiceCompactionPhaseOneLoopTimeInSeconds=30
 
 # Whether retain null-key message during topic compaction
-topicCompactionRemainNullKey=false
+topicCompactionRetainNullKey=false
 
 # Whether to enable the delayed delivery for messages.
 # If disabled, messages will be immediately delivered and there will

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -1288,4 +1288,4 @@ brokerInterceptors=
 disableBrokerInterceptors=true
 
 # Whether retain null-key message during topic compaction
-topicCompactionRemainNullKey=false
+topicCompactionRetainNullKey=false

--- a/pip/pip-318.md
+++ b/pip/pip-318.md
@@ -25,22 +25,22 @@ If the configuration is true, we will retain null-key messages during topic comp
 
 Add config to broker.conf/standalone.conf
 ```properties
-topicCompactionRemainNullKey=false
+topicCompactionRetainNullKey=false
 ```
 
 # Backward & Forward Compatibility
 
-- Make `topicCompactionRemainNullKey=false` default  in the 3.2.0.
-- Cherry-pick it to a branch less than 3.2.0 make `topicCompactionRemainNullKey=true` default.
-- Delete the configuration `topicCompactionRemainNullKey` in 3.3.0 and don't supply an option to retain null-keys.
+- Make `topicCompactionRetainNullKey=false` default  in the 3.2.0.
+- Cherry-pick it to a branch less than 3.2.0 make `topicCompactionRetainNullKey=true` default.
+- Delete the configuration `topicCompactionRetainNullKey` in 3.3.0 and don't supply an option to retain null-keys.
 
 ## Revert
 
-Make `topicCompactionRemainNullKey=true` in broker.conf/standalone.conf.
+Make `topicCompactionRetainNullKey=true` in broker.conf/standalone.conf.
 
 ## Upgrade
 
-Make `topicCompactionRemainNullKey=false` in broker.conf/standalone.conf.
+Make `topicCompactionRetainNullKey=false` in broker.conf/standalone.conf.
 
 
 # Links

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2797,7 +2797,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             category = CATEGORY_SERVER,
             doc = "Whether retain null-key message during topic compaction."
     )
-    private boolean topicCompactionRemainNullKey = false;
+    private boolean topicCompactionRetainNullKey = false;
 
     @FieldContext(
         category = CATEGORY_SERVER,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -26,7 +26,6 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
-
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.buffer.ByteBuf;
@@ -648,9 +647,9 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
 
     @Test(dataProvider = "retainNullKey")
     public void testKeyLessMessagesPassThrough(boolean retainNullKey) throws Exception {
-        conf.setTopicCompactionRemainNullKey(retainNullKey);
+        conf.setTopicCompactionRetainNullKey(retainNullKey);
         restartBroker();
-        FieldUtils.writeDeclaredField(compactor, "topicCompactionRemainNullKey", retainNullKey, true);
+        FieldUtils.writeDeclaredField(compactor, "topicCompactionRetainNullKey", retainNullKey, true);
 
         String topic = "persistent://my-property/use/my-ns/my-topic1";
 


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/21578#discussion_r1416731165

Since we haven't had a release since #21578 merged, so we can just fix it.

### Modifications

`topicCompactionRemainNullKey` -> `topicCompactionRetainNullKey`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
