### PR TITLE
[improve][sec] Revert "Add group pulsar and add user pulsar to it instead of root"

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -95,12 +95,7 @@ RUN mkdir /pulsar && chmod g+w /pulsar
 
 ENV PULSAR_ROOT_LOGGER=INFO,CONSOLE
 
-RUN groupadd -g 10000 pulsar && \
-    useradd -r -u 10000 -g pulsar pulsar
-
-COPY --from=pulsar --chown=10000:10000 /pulsar /pulsar
-RUN chown pulsar:pulsar /pulsar
-
+COPY --from=pulsar /pulsar /pulsar
 WORKDIR /pulsar
 
 ARG PULSAR_CLIENT_PYTHON_VERSION
@@ -111,4 +106,4 @@ RUN chmod +x /pulsar/bin/install-pulsar-client.sh
 RUN /pulsar/bin/install-pulsar-client.sh
 
 # The UID must be non-zero. Otherwise, it is arbitrary. No logic should rely on its specific value.
-USER 10000:10000
+USER 10000

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -19,8 +19,8 @@
 
 FROM ubuntu:22.04
 
-RUN groupadd -g 10000 pulsar && \
-    useradd -r -u 10000 -g pulsar pulsar
+RUN groupadd -g 10001 pulsar
+RUN adduser -u 10000 --gid 10001 --disabled-login --disabled-password --gecos '' pulsar
 
 ARG PULSAR_TARBALL=target/pulsar-server-distribution-bin.tar.gz
 ADD ${PULSAR_TARBALL} /
@@ -76,7 +76,7 @@ COPY target/java-test-functions.jar /pulsar/examples/
 
 ENV PULSAR_ROOT_LOGGER=INFO,CONSOLE
 
-RUN chown -R pulsar:pulsar /pulsar
+RUN chown -R pulsar:0 /pulsar && chmod -R g=u /pulsar
 
 # cleanup
 RUN apt-get -y --purge autoremove \

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -40,6 +40,10 @@ FROM apachepulsar/pulsar:latest
 # However, any processes exec'ing into the containers will run as root, by default.
 USER root
 
+# We need to define the user in order for supervisord to work correctly
+# We don't need a user defined in the public docker image, though.
+RUN adduser -u 10000 --gid 0 --disabled-login --disabled-password --gecos '' pulsar
+
 RUN rm -rf /var/lib/apt/lists/* && apt update
 
 RUN apt-get clean && apt-get update && apt-get install -y supervisor vim procps curl


### PR DESCRIPTION
### Motivation

Reverts apache/pulsar#21084. Because the change breaks OpenShift support.

### Modifications


### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

