### PR TITLE
[fix][broker] Fix NamespaceService#getListOfNonPersistentTopics not found the topic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -31,6 +31,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1464,7 +1465,7 @@ public class NamespaceService implements AutoCloseable {
                     } else {
                         // Non-persistent topics don't have managed ledgers. So we have to retrieve them from local
                         // cache.
-                        List<String> topics = new ArrayList<>();
+                        Set<String> topics = new HashSet<>();
                         synchronized (pulsar.getBrokerService().getMultiLayerTopicMap()) {
                             if (pulsar.getBrokerService().getMultiLayerTopicMap()
                                     .containsKey(namespaceName.toString())) {
@@ -1478,8 +1479,16 @@ public class NamespaceService implements AutoCloseable {
                             }
                         }
 
-                        topics.sort(null);
-                        return CompletableFuture.completedFuture(topics);
+                        return pulsar.getPulsarResources()
+                                .getNamespaceResources()
+                                .getPartitionedTopicResources()
+                                .listPartitionedTopicsAsync(namespaceName, TopicDomain.non_persistent)
+                                .thenApply(topicsFromMetadataStore -> {
+                                    topics.addAll(topicsFromMetadataStore);
+                                    ArrayList<String> allTopics = new ArrayList<>(topics);
+                                    allTopics.sort(null);
+                                    return allTopics;
+                                });
                     }
                 });
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -51,10 +51,12 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
@@ -3685,5 +3687,15 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
             admin.namespaces().setBacklogQuota(namespace, BacklogQuota.builder().limitTime(100 * 60).build());
         });
 
+    }
+
+    @Test
+    public void testCreateNonPersistentPartitionedTopicAndCheckExistsByGetListOfNonPersistentTopics()
+            throws PulsarAdminException, ExecutionException, InterruptedException, TimeoutException {
+        TopicName topicName = TopicName.get("non-persistent://prop-xyz/ns1/test-non-persistent-" + UUID.randomUUID());
+        admin.topics().createPartitionedTopic(topicName.toString(), 5);
+        List<String> nonPersistentTopics = pulsar.getNamespaceService().getListOfNonPersistentTopics(topicName.getNamespaceObject())
+                .get(5, TimeUnit.SECONDS);
+        assertTrue(nonPersistentTopics.contains(topicName.toString()));
     }
 }


### PR DESCRIPTION
### Motivation

When using the admin-client to set the replication cluster for non-persistent partitioned topic, the broker throws the topic not found, due to `org.apache.pulsar.broker.namespace.NamespaceService#getListOfNonPersistentTopics` didn't fetch the non-persistent partitioned topic list from the metadatastore.

### Modifications

- Fetch the non-persistent partitioned topic list from the metadatastore in `getListOfNonPersistentTopics` method

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->