### PR TITLE
[improve][broker] cleanup the empty subscriptionAuthenticationMap in zk when revoke subscription permission

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -357,6 +357,9 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                                     policies.auth_policies.getSubscriptionAuthentication().get(subscriptionName);
                             if (subscriptionAuth != null) {
                                 subscriptionAuth.removeAll(roles);
+                                if (subscriptionAuth.isEmpty()) {
+                                    policies.auth_policies.getSubscriptionAuthentication().remove(subscriptionName);
+                                }
                             } else {
                                 log.info("[{}] Couldn't find role {} while revoking for sub = {}", namespace,
                                         roles, subscriptionName);


### PR DESCRIPTION
### Motivation

This is a similar improve as #16815 . After we revoke subscription permission, we would see zk still remain many empty record. 

![企业微信截图_f30a9f1f-b0ed-441c-9eac-bf397c917009](https://github.com/apache/pulsar/assets/13505225/3242a862-8624-4ce6-8050-802665987625)

### Modifications

If isEmpty, remove the record in zk.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

