### PR TITLE
[fix][test] Fix flaky test ReplicatorGlobalNSTest#testRemoveLocalClusterOnGlobalNamespace

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorGlobalNSTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorGlobalNSTest.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.impl.ConsumerImpl;
 import org.apache.pulsar.client.impl.ProducerImpl;
+import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -90,14 +91,12 @@ public class ReplicatorGlobalNSTest extends ReplicatorTestBase {
 
         admin1.namespaces().setNamespaceReplicationClusters(namespace, Sets.newHashSet("r2", "r3"));
 
-        MockedPulsarServiceBaseTest
-                .retryStrategically((test) -> !pulsar1.getBrokerService().getTopics().containsKey(topicName), 50, 150);
-
-        Assert.assertFalse(pulsar1.getBrokerService().getTopics().containsKey(topicName));
-        Assert.assertFalse(producer1.isConnected());
-        Assert.assertFalse(consumer1.isConnected());
-        Assert.assertTrue(consumer2.isConnected());
-
+        Awaitility.await().atMost(1, TimeUnit.MINUTES).untilAsserted(() -> {
+            Assert.assertFalse(pulsar1.getBrokerService().getTopics().containsKey(topicName));
+            Assert.assertFalse(producer1.isConnected());
+            Assert.assertFalse(consumer1.isConnected());
+            Assert.assertTrue(consumer2.isConnected());
+        });
     }
 
     @Test


### PR DESCRIPTION
Fixes #21534 

### Motivation

The root cause is that `retryStrategically` only tries to test 50 times, not caring about the result. So the result can be false after 50 times. Then the broker deletes the topic and `pulsar1.getBrokerService().getTopics().containsKey(topicName)=false`.
But the `close` command from broker to producer is async, so the `producer1(line-97)` can be connected at that time.

```
MockedPulsarServiceBaseTest.retryStrategically((test) -> !pulsar1.getBrokerService().getTopics().containsKey(topicName), 50, 150);
```


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


