### PR TITLE
[improve][broker] PIP-300: Add custom dynamic configuration for plugins

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2528,8 +2528,6 @@ public class BrokerService implements Closeable {
                                 } catch (Exception e) {
                                     log.error("Failed to update config {}/{}", configKey, newValue);
                                 }
-                            } else {
-                                log.error("Found non-dynamic field in dynamicConfigMap {}/{}", configKey, newValue);
                             }
                         });
                     });
@@ -3682,6 +3680,15 @@ public class BrokerService implements Closeable {
     @VisibleForTesting
     public void setPulsarChannelInitializerFactory(PulsarChannelInitializer.Factory factory) {
         this.pulsarChannelInitFactory = factory;
+    }
+
+    public void registerCustomDynamicConfiguration(String key, Predicate<String> validator) {
+        if (dynamicConfigurationMap.containsKey(key)) {
+            throw new IllegalArgumentException(key + " already exists in the dynamicConfigurationMap");
+        }
+        var configField = new ConfigField(null);
+        configField.validator = validator;
+        dynamicConfigurationMap.put(key, configField);
     }
 
     @AllArgsConstructor

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -740,10 +740,8 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
         admin.brokers().updateDynamicConfiguration(key, "valid-value");
 
-        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
-            final var configs = admin.brokers().getAllDynamicConfigurations();
-            assertEquals(configs.get(key), "valid-value");
-        });
+        final var configs = admin.brokers().getAllDynamicConfigurations();
+        assertEquals(configs.get(key), "valid-value");
 
         assertThrows(PulsarAdminException.PreconditionFailedException.class,
                 () -> admin.brokers().updateDynamicConfiguration(key, invalidValue));


### PR DESCRIPTION
### Motivation

See [PIP-300](https://github.com/apache/pulsar/pull/21127)

### Modifications

Implement `registerCustomDynamicConfiguration`, which just adds a customized key to `dynamicConfigurationMap` so that updating such a key will be possible. The value is a `ConfigField` object whose `Field` field is null.

Add `testUpdateCustomDynamicConfiguration` to verify it works.

It should be noted the implementation is slightly different from the original proposal, which also does not express the design clearly.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->