### PR TITLE
[improve][misc] Upgrade Netty to 4.1.104 and io_uring to 0.0.24

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -47,7 +47,7 @@
     <license-maven-plugin.version>4.1</license-maven-plugin.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-    <netty.version>4.1.100.Final</netty.version>
+    <netty.version>4.1.104.Final</netty.version>
     <guice.version>4.2.3</guice.version>
     <guava.version>32.1.2-jre</guava.version>
     <ant.version>1.10.12</ant.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -289,26 +289,26 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-lang3-3.11.jar
     - org.apache.commons-commons-text-1.10.0.jar
  * Netty
-    - io.netty-netty-buffer-4.1.100.Final.jar
-    - io.netty-netty-codec-4.1.100.Final.jar
-    - io.netty-netty-codec-dns-4.1.100.Final.jar
-    - io.netty-netty-codec-http-4.1.100.Final.jar
-    - io.netty-netty-codec-http2-4.1.100.Final.jar
-    - io.netty-netty-codec-socks-4.1.100.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.100.Final.jar
-    - io.netty-netty-common-4.1.100.Final.jar
-    - io.netty-netty-handler-4.1.100.Final.jar
-    - io.netty-netty-handler-proxy-4.1.100.Final.jar
-    - io.netty-netty-resolver-4.1.100.Final.jar
-    - io.netty-netty-resolver-dns-4.1.100.Final.jar
-    - io.netty-netty-resolver-dns-classes-macos-4.1.100.Final.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.100.Final-osx-aarch_64.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.100.Final-osx-x86_64.jar
-    - io.netty-netty-transport-4.1.100.Final.jar
-    - io.netty-netty-transport-classes-epoll-4.1.100.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.100.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-unix-common-4.1.100.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.100.Final-linux-x86_64.jar
+    - io.netty-netty-buffer-4.1.104.Final.jar
+    - io.netty-netty-codec-4.1.104.Final.jar
+    - io.netty-netty-codec-dns-4.1.104.Final.jar
+    - io.netty-netty-codec-http-4.1.104.Final.jar
+    - io.netty-netty-codec-http2-4.1.104.Final.jar
+    - io.netty-netty-codec-socks-4.1.104.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.104.Final.jar
+    - io.netty-netty-common-4.1.104.Final.jar
+    - io.netty-netty-handler-4.1.104.Final.jar
+    - io.netty-netty-handler-proxy-4.1.104.Final.jar
+    - io.netty-netty-resolver-4.1.104.Final.jar
+    - io.netty-netty-resolver-dns-4.1.104.Final.jar
+    - io.netty-netty-resolver-dns-classes-macos-4.1.104.Final.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.104.Final-osx-aarch_64.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.104.Final-osx-x86_64.jar
+    - io.netty-netty-transport-4.1.104.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.104.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-unix-common-4.1.104.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.104.Final-linux-x86_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar
@@ -316,9 +316,9 @@ The Apache Software License, Version 2.0
     - io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar
     - io.netty-netty-tcnative-classes-2.0.61.Final.jar
-    - io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.21.Final.jar
-    - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.21.Final-linux-x86_64.jar
-    - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.21.Final-linux-aarch_64.jar
+    - io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.24.Final.jar
+    - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
+    - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar
  * Prometheus client
     - io.prometheus.jmx-collector-0.16.1.jar
     - io.prometheus-simpleclient-0.16.0.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -344,22 +344,22 @@ The Apache Software License, Version 2.0
     - commons-text-1.10.0.jar
     - commons-compress-1.21.jar
  * Netty
-    - netty-buffer-4.1.100.Final.jar
-    - netty-codec-4.1.100.Final.jar
-    - netty-codec-dns-4.1.100.Final.jar
-    - netty-codec-http-4.1.100.Final.jar
-    - netty-codec-socks-4.1.100.Final.jar
-    - netty-codec-haproxy-4.1.100.Final.jar
-    - netty-common-4.1.100.Final.jar
-    - netty-handler-4.1.100.Final.jar
-    - netty-handler-proxy-4.1.100.Final.jar
-    - netty-resolver-4.1.100.Final.jar
-    - netty-resolver-dns-4.1.100.Final.jar
-    - netty-transport-4.1.100.Final.jar
-    - netty-transport-classes-epoll-4.1.100.Final.jar
-    - netty-transport-native-epoll-4.1.100.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.100.Final.jar
-    - netty-transport-native-unix-common-4.1.100.Final-linux-x86_64.jar
+    - netty-buffer-4.1.104.Final.jar
+    - netty-codec-4.1.104.Final.jar
+    - netty-codec-dns-4.1.104.Final.jar
+    - netty-codec-http-4.1.104.Final.jar
+    - netty-codec-socks-4.1.104.Final.jar
+    - netty-codec-haproxy-4.1.104.Final.jar
+    - netty-common-4.1.104.Final.jar
+    - netty-handler-4.1.104.Final.jar
+    - netty-handler-proxy-4.1.104.Final.jar
+    - netty-resolver-4.1.104.Final.jar
+    - netty-resolver-dns-4.1.104.Final.jar
+    - netty-transport-4.1.104.Final.jar
+    - netty-transport-classes-epoll-4.1.104.Final.jar
+    - netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.104.Final.jar
+    - netty-transport-native-unix-common-4.1.104.Final-linux-x86_64.jar
     - netty-tcnative-boringssl-static-2.0.61.Final.jar
     - netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar
     - netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar
@@ -367,12 +367,12 @@ The Apache Software License, Version 2.0
     - netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar
     - netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar
     - netty-tcnative-classes-2.0.61.Final.jar
-    - netty-incubator-transport-classes-io_uring-0.0.21.Final.jar
-    - netty-incubator-transport-native-io_uring-0.0.21.Final-linux-aarch_64.jar
-    - netty-incubator-transport-native-io_uring-0.0.21.Final-linux-x86_64.jar
-    - netty-resolver-dns-classes-macos-4.1.100.Final.jar
-    - netty-resolver-dns-native-macos-4.1.100.Final-osx-aarch_64.jar
-    - netty-resolver-dns-native-macos-4.1.100.Final-osx-x86_64.jar
+    - netty-incubator-transport-classes-io_uring-0.0.24.Final.jar
+    - netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar
+    - netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
+    - netty-resolver-dns-classes-macos-4.1.104.Final.jar
+    - netty-resolver-dns-native-macos-4.1.104.Final-osx-aarch_64.jar
+    - netty-resolver-dns-native-macos-4.1.104.Final-osx-x86_64.jar
  * Prometheus client
     - simpleclient-0.16.0.jar
     - simpleclient_log4j2-0.16.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -140,8 +140,8 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.10.5</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
-    <netty.version>4.1.100.Final</netty.version>
-    <netty-iouring.version>0.0.21.Final</netty-iouring.version>
+    <netty.version>4.1.104.Final</netty.version>
+    <netty-iouring.version>0.0.24.Final</netty-iouring.version>
     <jetty.version>9.4.53.v20231009</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.34</jersey.version>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -231,21 +231,21 @@ The Apache Software License, Version 2.0
     - commons-compress-1.21.jar
     - commons-lang3-3.11.jar
  * Netty
-    - netty-buffer-4.1.100.Final.jar
-    - netty-codec-4.1.100.Final.jar
-    - netty-codec-dns-4.1.100.Final.jar
-    - netty-codec-http-4.1.100.Final.jar
-    - netty-codec-haproxy-4.1.100.Final.jar
-    - netty-codec-socks-4.1.100.Final.jar
-    - netty-handler-proxy-4.1.100.Final.jar
-    - netty-common-4.1.100.Final.jar
-    - netty-handler-4.1.100.Final.jar
+    - netty-buffer-4.1.104.Final.jar
+    - netty-codec-4.1.104.Final.jar
+    - netty-codec-dns-4.1.104.Final.jar
+    - netty-codec-http-4.1.104.Final.jar
+    - netty-codec-haproxy-4.1.104.Final.jar
+    - netty-codec-socks-4.1.104.Final.jar
+    - netty-handler-proxy-4.1.104.Final.jar
+    - netty-common-4.1.104.Final.jar
+    - netty-handler-4.1.104.Final.jar
     - netty-reactive-streams-2.0.6.jar
-    - netty-resolver-4.1.100.Final.jar
-    - netty-resolver-dns-4.1.100.Final.jar
-    - netty-resolver-dns-classes-macos-4.1.100.Final.jar
-    - netty-resolver-dns-native-macos-4.1.100.Final-osx-aarch_64.jar
-    - netty-resolver-dns-native-macos-4.1.100.Final-osx-x86_64.jar
+    - netty-resolver-4.1.104.Final.jar
+    - netty-resolver-dns-4.1.104.Final.jar
+    - netty-resolver-dns-classes-macos-4.1.104.Final.jar
+    - netty-resolver-dns-native-macos-4.1.104.Final-osx-aarch_64.jar
+    - netty-resolver-dns-native-macos-4.1.104.Final-osx-x86_64.jar
     - netty-tcnative-boringssl-static-2.0.61.Final.jar
     - netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar
     - netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar
@@ -253,15 +253,15 @@ The Apache Software License, Version 2.0
     - netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar
     - netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar
     - netty-tcnative-classes-2.0.61.Final.jar
-    - netty-transport-4.1.100.Final.jar
-    - netty-transport-classes-epoll-4.1.100.Final.jar
-    - netty-transport-native-epoll-4.1.100.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.100.Final.jar
-    - netty-transport-native-unix-common-4.1.100.Final-linux-x86_64.jar
-    - netty-codec-http2-4.1.100.Final.jar
-    - netty-incubator-transport-classes-io_uring-0.0.21.Final.jar
-    - netty-incubator-transport-native-io_uring-0.0.21.Final-linux-x86_64.jar
-    - netty-incubator-transport-native-io_uring-0.0.21.Final-linux-aarch_64.jar
+    - netty-transport-4.1.104.Final.jar
+    - netty-transport-classes-epoll-4.1.104.Final.jar
+    - netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.104.Final.jar
+    - netty-transport-native-unix-common-4.1.104.Final-linux-x86_64.jar
+    - netty-codec-http2-4.1.104.Final.jar
+    - netty-incubator-transport-classes-io_uring-0.0.24.Final.jar
+    - netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
+    - netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar
  * GRPC
     - grpc-api-1.55.3.jar
     - grpc-context-1.55.3.jar


### PR DESCRIPTION
### Motivation

Keep Netty and Netty's io_uring libraries up-to-date. 

Release notes since last upgrades:
- https://netty.io/news/2023/12/15/4-1-104-Final.html
- https://netty.io/news/2023/12/13/4-1-103-Final.html
- https://netty.io/news/2023/11/09/4-1-101-Final.html
- https://netty.io/news/2023/11/17/io_uring_0-0-24-Final.html
- https://netty.io/news/2023/10/02/multiple_releases_incubator.html

### Modifications

- Upgrade Netty to 4.1.104.Final (from 4.1.100.Final)
- Upgrade Netty io_uring to 0.0.24.Final (from 0.0.21.Final)

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->