### PR TITLE
[improve][build] Configure https timeout for apt, copy config to java-test-image

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -59,7 +59,7 @@ ARG JDK_MAJOR_VERSION=17
 # Install some utilities
 RUN sed -i -e "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-http://archive.ubuntu.com/ubuntu/}|g" \
      -e "s|http://security\.ubuntu\.com/ubuntu/|${UBUNTU_SECURITY_MIRROR:-http://security.ubuntu.com/ubuntu/}|g" /etc/apt/sources.list \
-     && echo 'Acquire::http::Timeout "30";\nAcquire::ftp::Timeout "30";\nAcquire::Retries "3";' > /etc/apt/apt.conf.d/99timeout_and_retries \
+     && echo 'Acquire::http::Timeout "30";\nAcquire::https::Timeout "30";\nAcquire::ftp::Timeout "30";\nAcquire::Retries "3";' > /etc/apt/apt.conf.d/99timeout_and_retries \
      && apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install netcat dnsutils less procps iputils-ping \

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -42,7 +42,7 @@ RUN sed -i -e "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-http://arc
      && echo 'Acquire::http::Timeout "30";\nAcquire::https::Timeout "30";\nAcquire::ftp::Timeout "30";\nAcquire::Retries "3";' > /etc/apt/apt.conf.d/99timeout_and_retries \
      && apt-get update \
      && apt-get -y dist-upgrade \
-     && apt-get -y install wget apt-transport-https
+     && apt-get -y install ca-certificates wget apt-transport-https
 
 # Install Eclipse Temurin Package
 RUN mkdir -p /etc/apt/keyrings \

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -39,6 +39,7 @@ ARG JDK_MAJOR_VERSION=17
 
 RUN sed -i -e "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-http://archive.ubuntu.com/ubuntu/}|g" \
      -e "s|http://security\.ubuntu\.com/ubuntu/|${UBUNTU_SECURITY_MIRROR:-http://security.ubuntu.com/ubuntu/}|g" /etc/apt/sources.list \
+     && echo 'Acquire::http::Timeout "30";\nAcquire::https::Timeout "30";\nAcquire::ftp::Timeout "30";\nAcquire::Retries "3";' > /etc/apt/apt.conf.d/99timeout_and_retries \
      && apt-get update \
      && apt-get -y dist-upgrade \
      && apt-get -y install wget apt-transport-https


### PR DESCRIPTION
### Motivation

java-test-image docker image build fails fairly often
```
[INFO] DOCKER> Err:30 https://packages.adoptium.net/artifactory/deb jammy/main amd64 temurin-17-jdk amd64 17.0.9.0.0+9
  403  Forbidden [IP: 146.75.31.42 443]
[INFO] DOCKER> Fetched 6128 kB in 0s (15.7 MB/s)
[INFO] DOCKER> [91mE: Failed to fetch https://packages.adoptium.net/artifactory/deb/pool/main/t/temurin-17/temurin-17-jdk_17.0.9.0.0%2b9_amd64.deb  403  Forbidden [IP: 146.75.31.42 443]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```
example: https://github.com/apache/pulsar/actions/runs/7194966954/job/19597006556#step:10:10074

### Modifications

- configure https timeout for apt
- copy `/etc/apt/apt.conf.d/99timeout_and_retries` configuration to java-test-image

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->