### PR TITLE
[improve][misc] Pin Netty version in pulsar-io/alluxio

### DIFF
--- a/pulsar-io/alluxio/pom.xml
+++ b/pulsar-io/alluxio/pom.xml
@@ -32,6 +32,7 @@
         <alluxio.version>2.9.3</alluxio.version>
         <metrics.version>4.1.11</metrics.version>
         <grpc.version>1.37.0</grpc.version>
+        <netty.version>4.1.100.Final</netty.version>
     </properties>
 
     <artifactId>pulsar-io-alluxio</artifactId>
@@ -56,12 +57,6 @@
             <groupId>org.alluxio</groupId>
             <artifactId>alluxio-core-client-fs</artifactId>
             <version>${alluxio.version}</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>grpc-netty</artifactId>
-                    <groupId>io.grpc</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
@@ -73,10 +68,6 @@
                 <exclusion>
                     <groupId>org.glassfish</groupId>
                     <artifactId>javax.el</artifactId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>grpc-netty</artifactId>
-                    <groupId>io.grpc</groupId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -90,21 +81,31 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-
-        <!-- alluxio grpc dependency need higher version -->
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty</artifactId>
-            <version>${grpc.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-jvm</artifactId>
-            <version>${metrics.version}</version>
-        </dependency>
-
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-bom</artifactId>
+                <version>${grpc.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-jvm</artifactId>
+                <version>${metrics.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>


### PR DESCRIPTION
### Motivation

Upgrade to Netty 4.1.103.Final fails with errors in pulsar-io/alluxio (see comments in #21723). Prepare for the upgrade by pinning the Netty version in pulsar-io/alluxio.

### Modifications

- Use dependencyManagement to pin versions
- Use 4.1.100.Final since it should be compatible

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->