### PR TITLE
[fix][sec] Upgrade org.bouncycastle:bc-fips to 1.0.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@ flexible messaging model and an intuitive client API.</description>
     <log4j2.version>2.18.0</log4j2.version>
     <bouncycastle.version>1.75</bouncycastle.version>
     <bouncycastle.bcpkix-fips.version>1.0.6</bouncycastle.bcpkix-fips.version>
-    <bouncycastle.bc-fips.version>1.0.2.3</bouncycastle.bc-fips.version>
+    <bouncycastle.bc-fips.version>1.0.2.4</bouncycastle.bc-fips.version>
     <jackson.version>2.14.2</jackson.version>
     <reflections.version>0.10.2</reflections.version>
     <swagger.version>1.6.2</swagger.version>


### PR DESCRIPTION
### Motivation

The currently used version of `org.bouncycastle:bc-fips` has the following vulnerability and should be upgraded to 1.0.2.4.
https://github.com/bcgit/bc-java/wiki/CVE-2022-45146

https://nvd.nist.gov/vuln/detail/CVE-2022-45146

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->