### PR TITLE
[fix][ci] Disable `testReuseFork` when runs pulsar-metadata

### DIFF
--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -104,7 +104,7 @@ function test_group_client() {
 }
 
 function test_group_metadata() {
-  mvn_test -pl pulsar-metadata
+  mvn_test -pl pulsar-metadata -DtestReuseFork=false
 }
 
 # prints summaries of failed tests to console


### PR DESCRIPTION
### Motivation

Pulsar-metadata ran into crash many times.  
https://github.com/apache/pulsar/actions/runs/7218881587/job/19669156766?pr=21687
https://github.com/apache/pulsar/actions/runs/7203408406/job/19623430478

The dump log shows:

![image](https://github.com/apache/pulsar/assets/6297296/54df8969-ecef-4b58-a3e3-bc9f875cbe02)
![image](https://github.com/apache/pulsar/assets/6297296/b52534a9-015e-4cd7-809d-2d3455585572)



Reference comes from thread : https://github.com/facebook/rocksdb/issues/5038


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


