### PR TITLE
[improve][broker] Improve isTopicPublishRateExceeded to uniformly check publish rate

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -227,14 +227,30 @@ public interface Topic {
 
     void resetBrokerPublishCountAndEnableReadIfRequired(boolean doneReset);
 
+    /**
+     * @deprecated use {@link #isTopicPublishRateExceeded(int, int)} instead.
+     */
+    @Deprecated
     boolean isPublishRateExceeded();
 
     boolean isTopicPublishRateExceeded(int msgSize, int numMessages);
 
+    /**
+     * @deprecated meaningless.
+     */
+    @Deprecated
     boolean isResourceGroupRateLimitingEnabled();
 
+    /**
+     * @deprecated use {@link #isTopicPublishRateExceeded(int, int)} instead.
+     */
+    @Deprecated
     boolean isResourceGroupPublishRateExceeded(int msgSize, int numMessages);
 
+    /**
+     * @deprecated use {@link #isTopicPublishRateExceeded(int, int)} instead.
+     */
+    @Deprecated
     boolean isBrokerPublishRateExceeded();
 
     boolean shouldProducerMigrate();


### PR DESCRIPTION
### Motivation

1. When `isPreciseTopicPublishRateExceeded` or `resourceGroupPublishRateExceeded` is `true`, the `throttledConnections.inc()` is not called. 
2. We have multiple publish limiters, I think we can uniformly check the publish rate by `org.apache.pulsar.broker.service.Topic#isTopicPublishRateExceeded`.

### Modifications

- Deprecate the following methods to avoid making incorrect rate checks.
  - `org.apache.pulsar.broker.service.Topic#isPublishRateExceeded`
  - `org.apache.pulsar.broker.service.Topic#isResourceGroupRateLimitingEnabled`
  - `org.apache.pulsar.broker.service.Topic#isResourceGroupPublishRateExceeded`
  - `org.apache.pulsar.broker.service.Topic#isBrokerPublishRateExceeded`
- Using `org.apache.pulsar.broker.service.Topic#isTopicPublishRateExceeded` to uniformly check the publish rate.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->