### PR TITLE
[improve][broker] Use the Producer stats instead of msgOut in geo

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1240,7 +1240,7 @@ public class BrokerService implements Closeable {
                 ClientBuilder clientBuilder = PulsarClient.builder()
                         .enableTcpNoDelay(false)
                         .connectionsPerBroker(pulsar.getConfiguration().getReplicationConnectionsPerBroker())
-                        .statsInterval(0, TimeUnit.SECONDS);
+                        .statsInterval(pulsar.getConfiguration().getStatsUpdateFrequencyInSecs(), TimeUnit.SECONDS);
 
                 // Disable memory limit for replication client
                 clientBuilder.memoryLimit(0, SizeUnit.BYTES);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
@@ -166,7 +166,6 @@ public class GeoPersistentReplicator extends PersistentReplicator {
                     msg.setSchemaInfoForReplicator(schemaFuture.get());
                     msg.getMessageBuilder().clearTxnidMostBits();
                     msg.getMessageBuilder().clearTxnidLeastBits();
-                    msgOut.recordEvent(headersAndPayload.readableBytes());
                     // Increment pending messages for messages produced locally
                     PENDING_MESSAGES_UPDATER.incrementAndGet(this);
                     producer.sendAsync(msg, ProducerSendCallback.create(this, entry, msg));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -93,7 +93,6 @@ public abstract class PersistentReplicator extends AbstractReplicator
                     .newUpdater(PersistentReplicator.class, "havePendingRead");
     private volatile int havePendingRead = FALSE;
 
-    protected final Rate msgOut = new Rate();
     protected final Rate msgExpired = new Rate();
 
     protected int messageTTLInSeconds = 0;
@@ -570,12 +569,9 @@ public abstract class PersistentReplicator extends AbstractReplicator
     }
 
     public void updateRates() {
-        msgOut.calculateRate();
         msgExpired.calculateRate();
         expiryMonitor.updateRates();
 
-        stats.msgRateOut = msgOut.getRate();
-        stats.msgThroughputOut = msgOut.getValueRate();
         stats.msgRateExpired = msgExpired.getRate() + expiryMonitor.getMessageExpiryRate();
     }
 
@@ -588,6 +584,8 @@ public abstract class PersistentReplicator extends AbstractReplicator
         if (producer != null) {
             stats.outboundConnection = producer.getConnectionId();
             stats.outboundConnectedSince = producer.getConnectedSince();
+            stats.msgRateOut = producer.getStats().getSendMsgsRate();
+            stats.msgThroughputOut = producer.getStats().getSendBytesRate();
         } else {
             stats.outboundConnection = null;
             stats.outboundConnectedSince = null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ShadowReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ShadowReplicator.java
@@ -91,8 +91,6 @@ public class ShadowReplicator extends PersistentReplicator {
 
                 dispatchRateLimiter.ifPresent(rateLimiter -> rateLimiter.consumeDispatchQuota(1, entry.getLength()));
 
-                msgOut.recordEvent(headersAndPayload.readableBytes());
-
                 msg.setReplicatedFrom(localCluster);
 
                 msg.setMessageId(new MessageIdImpl(entry.getLedgerId(), entry.getEntryId(), -1));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -104,7 +104,9 @@ import org.apache.pulsar.common.policies.data.PartitionedTopicStats;
 import org.apache.pulsar.common.policies.data.ReplicatorStats;
 import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.TopicStats;
+import org.apache.pulsar.common.policies.data.stats.ReplicatorStatsImpl;
 import org.apache.pulsar.common.protocol.Commands;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.apache.pulsar.schema.Schemas;
 import org.awaitility.Awaitility;
@@ -1875,5 +1877,46 @@ public class ReplicatorTest extends ReplicatorTestBase {
         }
 
         assertEquals(result, Lists.newArrayList("V1", "V2", "V3", "V4"));
+    }
+
+    @Test
+    public void testReplicatorProducerStats() throws Exception {
+        pulsar1.getConfiguration().setStatsUpdateFrequencyInSecs(5);
+
+        String namespace1 = "pulsar/" + UUID.randomUUID();
+        admin1.namespaces().createNamespace(namespace1);
+        admin1.namespaces().setNamespaceReplicationClusters(namespace1, Sets.newHashSet("r1", "r2"));
+        final TopicName dest = TopicName.get(
+                BrokerTestUtil.newUniqueName("persistent://" + namespace1 + "/test-producer-stats"));
+        admin1.topics().createPartitionedTopic(dest.toString(), 1);
+
+        @Cleanup
+        PulsarClient client = pulsar1.getClient();
+        @Cleanup
+        Producer<byte[]> producer = client.newProducer()
+                .topic(dest.toString())
+                .enableBatching(true)
+                .batchingMaxPublishDelay(2, TimeUnit.SECONDS)
+                .batchingMaxMessages(2)
+                .create();
+
+        List<CompletableFuture<MessageId>> list = new ArrayList<>();
+        for (int i = 0; i < 8; i++) {
+            list.add(producer.sendAsync(Integer.toString(i).getBytes(StandardCharsets.UTF_8)));
+        }
+
+        Awaitility.await().untilAsserted(FutureUtil.waitForAll(list)::get);
+
+        String referenceName = TopicName.getTopicPartitionNameString(dest.toString(), 0);
+        Optional<Topic> topicReferenceOpt = pulsar1.getBrokerService().getTopicReference(referenceName);
+        Assert.assertTrue(topicReferenceOpt.isPresent());
+        PersistentTopic topic = (PersistentTopic) topicReferenceOpt.get();
+        Replicator replicator = topic.getPersistentReplicator("r2");
+
+        Awaitility.await().untilAsserted(() -> {
+            ReplicatorStatsImpl stats = replicator.getStats();
+            assertNotEquals(stats.msgRateOut, 0D);
+            assertNotEquals(stats.msgThroughputOut, 0D);
+        });
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ShadowReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ShadowReplicatorTest.java
@@ -118,11 +118,6 @@ public class ShadowReplicatorTest extends BrokerTestBase {
         Message<byte[]> sourceMessage = sourceConsumer.receive();
         Assert.assertEquals(sourceMessage.getMessageId(), sourceMessageId);
 
-        //Wait until msg is replicated to shadow topic.
-        Awaitility.await().until(() -> {
-            replicator.msgOut.calculateRate();
-            return replicator.msgOut.getCount() >= 1;
-        });
         Awaitility.await().until(() -> PersistentReplicator.PENDING_MESSAGES_UPDATER.get(replicator) == 0);
 
         PersistentTopic shadowTopic =


### PR DESCRIPTION
### Motivation

In geo, the `msgOut` is inaccurate:

1. When `Entry` is batch message, the `org.apache.pulsar.common.stats.Rate#countAdder` and `org.apache.pulsar.common.stats.Rate#totalCountAdder` increment only once.
2. When the network fails, the `org.apache.pulsar.common.stats.Rate#recordEvent(long)` shouldn't be called, due to the message cannot be sent to the remote cluster.

### Modifications

Use the Producer stats instead of msgOut in geo.

### Verifying this change

Just to verify the `msgRateOut` and `msgThroughputOut` doesn't equal to 0.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
