### PR TITLE
[fix][broker] Fixed the ExtensibleLoadManagerImpl internal system getTopic failure when the leadership changes

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -297,11 +297,16 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
             log.info("Created topic {}.", topic);
         } catch (PulsarAdminException.ConflictException ex) {
             if (debug(pulsar.getConfiguration(), log)) {
-                log.info("Topic {} already exists.", topic, ex);
+                log.info("Topic {} already exists.", topic);
             }
         } catch (PulsarAdminException e) {
             throw new PulsarServerException(e);
         }
+    }
+
+    private static void createSystemTopics(PulsarService pulsar) throws PulsarServerException {
+        createSystemTopic(pulsar, BROKER_LOAD_DATA_STORE_TOPIC);
+        createSystemTopic(pulsar, TOP_BUNDLES_LOAD_DATA_STORE_TOPIC);
     }
 
     /**
@@ -370,13 +375,9 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
             this.isolationPoliciesHelper = new IsolationPoliciesHelper(policies);
             this.brokerFilterPipeline.add(new BrokerIsolationPoliciesFilter(isolationPoliciesHelper));
 
-            createSystemTopic(pulsar, BROKER_LOAD_DATA_STORE_TOPIC);
-            createSystemTopic(pulsar, TOP_BUNDLES_LOAD_DATA_STORE_TOPIC);
-
             try {
                 this.brokerLoadDataStore = LoadDataStoreFactory
                         .create(pulsar.getClient(), BROKER_LOAD_DATA_STORE_TOPIC, BrokerLoadData.class);
-                this.brokerLoadDataStore.startTableView();
                 this.topBundlesLoadDataStore = LoadDataStoreFactory
                         .create(pulsar.getClient(), TOP_BUNDLES_LOAD_DATA_STORE_TOPIC, TopBundlesLoadData.class);
             } catch (LoadDataStoreException e) {
@@ -431,7 +432,6 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
             this.unloadScheduler = new UnloadScheduler(
                     pulsar, pulsar.getLoadManagerExecutor(), unloadManager, context,
                     serviceUnitStateChannel, unloadCounter, unloadMetrics);
-            this.unloadScheduler.start();
             this.splitScheduler = new SplitScheduler(
                     pulsar, serviceUnitStateChannel, splitManager, splitCounter, splitMetrics, context);
             this.splitScheduler.start();
@@ -789,74 +789,70 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
 
     @VisibleForTesting
     void playLeader() {
-        if (role != Leader) {
-            log.info("This broker:{} is changing the role from {} to {}",
-                    pulsar.getLookupServiceAddress(), role, Leader);
-            int retry = 0;
-            while (true) {
+        log.info("This broker:{} is setting the role from {} to {}",
+                pulsar.getLookupServiceAddress(), role, Leader);
+        int retry = 0;
+        while (true) {
+            try {
+                initWaiter.await();
+                // Confirm the system topics have been created or create them if they do not exist.
+                // If the leader has changed, the new leader need to reset
+                // the local brokerService.topics (by this topic creations).
+                // Otherwise, the system topic existence check will fail on the leader broker.
+                createSystemTopics(pulsar);
+                brokerLoadDataStore.init();
+                topBundlesLoadDataStore.init();
+                unloadScheduler.start();
+                serviceUnitStateChannel.scheduleOwnershipMonitor();
+                break;
+            } catch (Throwable e) {
+                log.error("The broker:{} failed to set the role. Retrying {} th ...",
+                        pulsar.getLookupServiceAddress(), ++retry, e);
                 try {
-                    initWaiter.await();
-                    serviceUnitStateChannel.scheduleOwnershipMonitor();
-                    topBundlesLoadDataStore.startTableView();
-                    unloadScheduler.start();
-                    break;
-                } catch (Throwable e) {
-                    log.error("The broker:{} failed to change the role. Retrying {} th ...",
-                            pulsar.getLookupServiceAddress(), ++retry, e);
-                    try {
-                        Thread.sleep(Math.min(retry * 10, MAX_ROLE_CHANGE_RETRY_DELAY_IN_MILLIS));
-                    } catch (InterruptedException ex) {
-                        log.warn("Interrupted while sleeping.");
-                    }
+                    Thread.sleep(Math.min(retry * 10, MAX_ROLE_CHANGE_RETRY_DELAY_IN_MILLIS));
+                } catch (InterruptedException ex) {
+                    log.warn("Interrupted while sleeping.");
                 }
             }
-            role = Leader;
-            log.info("This broker:{} plays the leader now.", pulsar.getLookupServiceAddress());
         }
+        role = Leader;
+        log.info("This broker:{} plays the leader now.", pulsar.getLookupServiceAddress());
 
         // flush the load data when the leader is elected.
-        if (brokerLoadDataReporter != null) {
-            brokerLoadDataReporter.reportAsync(true);
-        }
-        if (topBundleLoadDataReporter != null) {
-            topBundleLoadDataReporter.reportAsync(true);
-        }
+        brokerLoadDataReporter.reportAsync(true);
+        topBundleLoadDataReporter.reportAsync(true);
     }
 
     @VisibleForTesting
     void playFollower() {
-        if (role != Follower) {
-            log.info("This broker:{} is changing the role from {} to {}",
-                    pulsar.getLookupServiceAddress(), role, Follower);
-            int retry = 0;
-            while (true) {
+        log.info("This broker:{} is setting the role from {} to {}",
+                pulsar.getLookupServiceAddress(), role, Follower);
+        int retry = 0;
+        while (true) {
+            try {
+                initWaiter.await();
+                unloadScheduler.close();
+                serviceUnitStateChannel.cancelOwnershipMonitor();
+                brokerLoadDataStore.init();
+                topBundlesLoadDataStore.close();
+                topBundlesLoadDataStore.startProducer();
+                break;
+            } catch (Throwable e) {
+                log.error("The broker:{} failed to set the role. Retrying {} th ...",
+                        pulsar.getLookupServiceAddress(), ++retry, e);
                 try {
-                    initWaiter.await();
-                    serviceUnitStateChannel.cancelOwnershipMonitor();
-                    topBundlesLoadDataStore.closeTableView();
-                    unloadScheduler.close();
-                    break;
-                } catch (Throwable e) {
-                    log.error("The broker:{} failed to change the role. Retrying {} th ...",
-                            pulsar.getLookupServiceAddress(), ++retry, e);
-                    try {
-                        Thread.sleep(Math.min(retry * 10, MAX_ROLE_CHANGE_RETRY_DELAY_IN_MILLIS));
-                    } catch (InterruptedException ex) {
-                        log.warn("Interrupted while sleeping.");
-                    }
+                    Thread.sleep(Math.min(retry * 10, MAX_ROLE_CHANGE_RETRY_DELAY_IN_MILLIS));
+                } catch (InterruptedException ex) {
+                    log.warn("Interrupted while sleeping.");
                 }
             }
-            role = Follower;
-            log.info("This broker:{} plays a follower now.", pulsar.getLookupServiceAddress());
         }
+        role = Follower;
+        log.info("This broker:{} plays a follower now.", pulsar.getLookupServiceAddress());
 
         // flush the load data when the leader is elected.
-        if (brokerLoadDataReporter != null) {
-            brokerLoadDataReporter.reportAsync(true);
-        }
-        if (topBundleLoadDataReporter != null) {
-            topBundleLoadDataReporter.reportAsync(true);
-        }
+        brokerLoadDataReporter.reportAsync(true);
+        topBundleLoadDataReporter.reportAsync(true);
     }
 
     public List<Metrics> getMetrics() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -792,7 +792,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
         log.info("This broker:{} is setting the role from {} to {}",
                 pulsar.getLookupServiceAddress(), role, Leader);
         int retry = 0;
-        while (true) {
+        while (!Thread.currentThread().isInterrupted()) {
             try {
                 initWaiter.await();
                 // Confirm the system topics have been created or create them if they do not exist.
@@ -812,6 +812,8 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
                     Thread.sleep(Math.min(retry * 10, MAX_ROLE_CHANGE_RETRY_DELAY_IN_MILLIS));
                 } catch (InterruptedException ex) {
                     log.warn("Interrupted while sleeping.");
+                    // preserve thread's interrupt status
+                    Thread.currentThread().interrupt();
                 }
             }
         }
@@ -828,7 +830,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
         log.info("This broker:{} is setting the role from {} to {}",
                 pulsar.getLookupServiceAddress(), role, Follower);
         int retry = 0;
-        while (true) {
+        while (!Thread.currentThread().isInterrupted()) {
             try {
                 initWaiter.await();
                 unloadScheduler.close();
@@ -844,6 +846,8 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
                     Thread.sleep(Math.min(retry * 10, MAX_ROLE_CHANGE_RETRY_DELAY_IN_MILLIS));
                 } catch (InterruptedException ex) {
                     log.warn("Interrupted while sleeping.");
+                    // preserve thread's interrupt status
+                    Thread.currentThread().interrupt();
                 }
             }
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/store/LoadDataStore.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/store/LoadDataStore.java
@@ -81,9 +81,26 @@ public interface LoadDataStore<T> extends Closeable {
      */
     void closeTableView() throws IOException;
 
+
+    /**
+     * Starts the data store (both producer and table view).
+     */
+    void start() throws LoadDataStoreException;
+
+    /**
+     * Inits the data store (close and start the data store).
+     */
+    void init() throws IOException;
+
     /**
      * Starts the table view.
      */
     void startTableView() throws LoadDataStoreException;
+
+
+    /**
+     * Starts the producer.
+     */
+    void startProducer() throws LoadDataStoreException;
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/store/TableViewLoadDataStoreImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/store/TableViewLoadDataStoreImpl.java
@@ -37,9 +37,9 @@ import org.apache.pulsar.client.api.TableView;
  */
 public class TableViewLoadDataStoreImpl<T> implements LoadDataStore<T> {
 
-    private TableView<T> tableView;
+    private volatile TableView<T> tableView;
 
-    private Producer<T> producer;
+    private volatile Producer<T> producer;
 
     private final PulsarClient client;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -1099,12 +1099,12 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
         FieldUtils.writeDeclaredField(secondaryLoadManager, "topBundlesLoadDataStore", topBundlesLoadDataStoreSecondarySpy, true);
 
         if (channel1.isChannelOwnerAsync().get(5, TimeUnit.SECONDS)) {
-            primaryLoadManager.playFollower();
-            primaryLoadManager.playFollower();
+            primaryLoadManager.playFollower(); // close 3 times
+            primaryLoadManager.playFollower(); // close 1 time
             secondaryLoadManager.playLeader();
             secondaryLoadManager.playLeader();
-            primaryLoadManager.playLeader();
-            primaryLoadManager.playLeader();
+            primaryLoadManager.playLeader(); // close 3 times and open 3 times
+            primaryLoadManager.playLeader(); // close 1 time and open 1 time,
             secondaryLoadManager.playFollower();
             secondaryLoadManager.playFollower();
         } else {
@@ -1119,10 +1119,10 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
         }
 
 
-        verify(topBundlesLoadDataStorePrimarySpy, times(3)).startTableView();
-        verify(topBundlesLoadDataStorePrimarySpy, times(3)).closeTableView();
-        verify(topBundlesLoadDataStoreSecondarySpy, times(3)).startTableView();
-        verify(topBundlesLoadDataStoreSecondarySpy, times(3)).closeTableView();
+        verify(topBundlesLoadDataStorePrimarySpy, times(4)).startTableView();
+        verify(topBundlesLoadDataStorePrimarySpy, times(8)).closeTableView();
+        verify(topBundlesLoadDataStoreSecondarySpy, times(4)).startTableView();
+        verify(topBundlesLoadDataStoreSecondarySpy, times(8)).closeTableView();
 
         FieldUtils.writeDeclaredField(primaryLoadManager, "topBundlesLoadDataStore", topBundlesLoadDataStorePrimary, true);
         FieldUtils.writeDeclaredField(secondaryLoadManager, "topBundlesLoadDataStore", topBundlesLoadDataStoreSecondary, true);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerFilterTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerFilterTestBase.java
@@ -91,7 +91,22 @@ public class BrokerFilterTestBase {
             }
 
             @Override
+            public void start() throws LoadDataStoreException {
+
+            }
+
+            @Override
+            public void init() throws IOException {
+
+            }
+
+            @Override
             public void startTableView() throws LoadDataStoreException {
+
+            }
+
+            @Override
+            public void startProducer() throws LoadDataStoreException {
 
             }
         };

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedderTest.java
@@ -384,7 +384,22 @@ public class TransferShedderTest {
             }
 
             @Override
+            public void start() throws LoadDataStoreException {
+
+            }
+
+            @Override
+            public void init() throws IOException {
+
+            }
+
+            @Override
             public void startTableView() throws LoadDataStoreException {
+
+            }
+
+            @Override
+            public void startProducer() throws LoadDataStoreException {
 
             }
         };
@@ -437,7 +452,22 @@ public class TransferShedderTest {
             }
 
             @Override
+            public void start() throws LoadDataStoreException {
+
+            }
+
+            @Override
+            public void init() throws IOException {
+
+            }
+
+            @Override
             public void startTableView() throws LoadDataStoreException {
+
+            }
+
+            @Override
+            public void startProducer() throws LoadDataStoreException {
 
             }
         };

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/store/LoadDataStoreTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/store/LoadDataStoreTest.java
@@ -75,6 +75,7 @@ public class LoadDataStoreTest extends MockedPulsarServiceBaseTest {
         @Cleanup
         LoadDataStore<MyClass> loadDataStore =
                 LoadDataStoreFactory.create(pulsar.getClient(), topic, MyClass.class);
+        loadDataStore.startProducer();
         loadDataStore.startTableView();
         MyClass myClass1 = new MyClass("1", 1);
         loadDataStore.pushAsync("key1", myClass1).get();
@@ -108,6 +109,7 @@ public class LoadDataStoreTest extends MockedPulsarServiceBaseTest {
         @Cleanup
         LoadDataStore<Integer> loadDataStore =
                 LoadDataStoreFactory.create(pulsar.getClient(), topic, Integer.class);
+        loadDataStore.startProducer();
         loadDataStore.startTableView();
 
         Map<String, Integer> map = new HashMap<>();
@@ -132,6 +134,7 @@ public class LoadDataStoreTest extends MockedPulsarServiceBaseTest {
         String topic = TopicDomain.persistent + "://" + NamespaceName.SYSTEM_NAMESPACE + "/" + UUID.randomUUID();
         LoadDataStore<Integer> loadDataStore =
                 LoadDataStoreFactory.create(pulsar.getClient(), topic, Integer.class);
+        loadDataStore.startProducer();
 
         loadDataStore.startTableView();
         loadDataStore.pushAsync("1", 1).get();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/LeastResourceUsageWithWeightTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/LeastResourceUsageWithWeightTest.java
@@ -253,7 +253,22 @@ public class LeastResourceUsageWithWeightTest {
             }
 
             @Override
+            public void start() throws LoadDataStoreException {
+
+            }
+
+            @Override
+            public void init() throws IOException {
+
+            }
+
+            @Override
             public void startTableView() throws LoadDataStoreException {
+
+            }
+
+            @Override
+            public void startProducer() throws LoadDataStoreException {
 
             }
         };


### PR DESCRIPTION

### Motivation

After this fix, https://github.com/apache/pulsar/pull/21729, we need to recreate the non-persistent internal system topics when the leadership changes because we disabled the auto-creation of the non-persistent internal system topics. 

Also, the non-persistent consumers and producers might be in a closed state, as they could receive `TopicNotFoundException` when the new leader broker has not created the internal topics yet. To cover this case, we need to update the leader and follower role change logic to be more idempotent.

### Modifications

- Make the new leader always try to create internal non-persistent system topics.
- Init the load data stores whenever the leader broker has changed.



### Verifying this change

- [x] Make sure that the change passes the CI checks.

ExtensibleLoadManager.testIsolationPolicy test was flaky because of the this issue.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/heesung-sn/pulsar/pull/55

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
