### PR TITLE
[fix][client] Fix clearIncomingMessages so that it doesn't leak memory while new entries are added

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
@@ -212,9 +212,10 @@ public class RawReaderImpl implements RawReader {
         }
 
         @Override
-        protected void clearIncomingMessages() {
-            super.clearIncomingMessages();
+        protected int clearIncomingMessages() {
+            int clearedIncomingMessages = super.clearIncomingMessages();
             clearIncomingRawMessages();
+            return clearedIncomingMessages;
         }
 
         @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -1225,12 +1225,22 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         int releasedCount = 0;
         Message<T> message;
         while ((message = incomingMessages.poll()) != null) {
-            decreaseIncomingMessageSize(message);
-            unAckedMessageTracker.remove(message.getMessageId());
-            message.release();
+            discardIncomingMessage(message);
             releasedCount++;
         }
         return releasedCount;
+    }
+
+    /**
+     * Discard the incoming message.
+     * Unregister the tracked entries related to the message from internal datastructures and release any
+     * resources held by the message.
+     * @param message the message to discard.
+     */
+    protected void discardIncomingMessage(Message<?> message) {
+        decreaseIncomingMessageSize(message);
+        unAckedMessageTracker.remove(message.getMessageId());
+        message.release();
     }
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -1226,6 +1226,7 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         Message<T> message;
         while ((message = incomingMessages.poll()) != null) {
             decreaseIncomingMessageSize(message);
+            unAckedMessageTracker.remove(message.getMessageId());
             message.release();
             releasedCount++;
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -1221,11 +1221,15 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         return incomingMessages.size();
     }
 
-    protected void clearIncomingMessages() {
-        // release messages if they are pooled messages
-        incomingMessages.forEach(Message::release);
-        incomingMessages.clear();
-        resetIncomingMessageSize();
+    protected int clearIncomingMessages() {
+        int releasedCount = 0;
+        Message<T> message;
+        while ((message = incomingMessages.poll()) != null) {
+            decreaseIncomingMessageSize(message);
+            message.release();
+            releasedCount++;
+        }
+        return releasedCount;
     }
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -976,8 +976,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             }
         } finally {
             for (Message<?> message : currentMessageQueue) {
-                decreaseIncomingMessageSize(message);
-                message.release();
+                discardIncomingMessage(message);
             }
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2004,8 +2004,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 }
 
                 // clear local message
-                currentSize = incomingMessages.size();
-                clearIncomingMessages();
+                currentSize = clearIncomingMessages();
                 unAckedMessageTracker.clear();
             } finally {
                 incomingQueueLock.unlock();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2008,7 +2008,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
                 // clear local message
                 currentSize = clearIncomingMessages();
-                unAckedMessageTracker.clear();
             } finally {
                 incomingQueueLock.unlock();
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -751,8 +751,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         List<CompletableFuture<Void>> futures = new ArrayList<>(consumers.size());
         consumers.values().forEach(consumer -> futures.add(consumer.seekAsync(function)));
         unAckedMessageTracker.clear();
-        incomingMessages.clear();
-        resetIncomingMessageSize();
+        clearIncomingMessages();
         return FutureUtil.waitForAll(futures);
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -675,7 +675,6 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     consumer.unAckedChunkedMessageIdSequenceMap.clear();
                 });
                 clearIncomingMessages();
-                unAckedMessageTracker.clear();
                 resumeReceivingFromPausedConsumersIfNeeded();
             } finally {
                 incomingQueueLock.unlock();
@@ -750,7 +749,6 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     public CompletableFuture<Void> seekAsync(Function<String, Object> function) {
         List<CompletableFuture<Void>> futures = new ArrayList<>(consumers.size());
         consumers.values().forEach(consumer -> futures.add(consumer.seekAsync(function)));
-        unAckedMessageTracker.clear();
         clearIncomingMessages();
         return FutureUtil.waitForAll(futures);
     }
@@ -783,7 +781,6 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             seekFuture = internalConsumer.seekAsync(messageId);
         }
 
-        unAckedMessageTracker.clear();
         clearIncomingMessages();
         return seekFuture;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
@@ -97,8 +97,7 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
         // Just being cautious
         if (incomingMessages.size() > 0) {
             log.error("The incoming message queue should never be greater than 0 when Queue size is 0");
-            incomingMessages.forEach(Message::release);
-            incomingMessages.clear();
+            clearIncomingMessages();
         }
 
         Message<T> message;
@@ -134,7 +133,7 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
             // Finally blocked is invoked in case the block on incomingMessages is interrupted
             waitingOnReceiveForZeroQueueSize = false;
             // Clearing the queue in case there was a race with messageReceived
-            incomingMessages.clear();
+            clearIncomingMessages();
         }
     }
 


### PR DESCRIPTION
### Motivation

The current ConsumerBase.clearIncomingMessage has a race condition when using Shared or Key_Shared subscription type.

https://github.com/apache/pulsar/blob/69a45a11e22c1d963391110fb3488c9b9f98f759/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java#L1224-L1229

When using Shared or Key_Shared, this method is called in `redeliverUnacknowledgedMessages` while new entries are flowing to the client. This would leak memory and memory limit counters would get skewed.

### Modifications

- Pull messages from the queue and release them one by one.
- Return the number of messages that were removed.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->