### PR TITLE
[fix][txn] Avoid message redelivering when consumer changes 

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
@@ -129,6 +129,10 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
 
         if (ACTIVE_CONSUMER_UPDATER.get(this) != null
                 && !ACTIVE_CONSUMER_UPDATER.get(this).getTransactionalAckTasks().isEmpty()) {
+            if (hasPriorityConsumer.get()) {
+                // Pick active consumer again by disconnect the current active consumer.
+                ACTIVE_CONSUMER_UPDATER.get(this).disconnect(false);
+            }
             // Active consumer did not change. Do nothing at this point
             return false;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
@@ -127,6 +127,12 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
                 ? partitionIndex % consumersSize
                 : peekConsumerIndexFromHashRing(makeHashRing(consumersSize));
 
+        if (ACTIVE_CONSUMER_UPDATER.get(this) != null
+                && !ACTIVE_CONSUMER_UPDATER.get(this).getTransactionalAckTasks().isEmpty()) {
+            // Active consumer did not change. Do nothing at this point
+            return false;
+        }
+
         Consumer prevConsumer = ACTIVE_CONSUMER_UPDATER.getAndSet(this, consumers.get(index));
 
         Consumer activeConsumer = ACTIVE_CONSUMER_UPDATER.get(this);
@@ -303,6 +309,7 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
     }
 
     public boolean isConsumerConnected() {
+        log.info("isConsumerConnected {}", ACTIVE_CONSUMER_UPDATER.get(this) != null);
         return ACTIVE_CONSUMER_UPDATER.get(this) != null;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -149,7 +149,7 @@ public class Consumer {
     @Getter
     private final SchemaType schemaType;
 
-    private final List<CompletableFuture<Void>> transactionAckTasks = new CopyOnWriteArrayList<>();
+    private final List<CompletableFuture<Void>> transactionalAckTasks = new CopyOnWriteArrayList<>();
 
     public Consumer(Subscription subscription, SubType subType, String topicName, long consumerId,
                     int priorityLevel, String consumerName,
@@ -606,7 +606,7 @@ public class Consumer {
         } else {
             ackTask.complete(null);
         }
-        transactionAckTasks.add(ackTask);
+        transactionalAckTasks.add(ackTask);
         return completableFuture.thenApply(__ -> totalAckCount.sum());
     }
 
@@ -1156,8 +1156,8 @@ public class Consumer {
         return StickyKeyConsumerSelector.makeStickyKeyHash(stickyKey);
     }
 
-    public List<CompletableFuture<Void>> getTransactionAckTasks() {
-        return transactionAckTasks;
+    public List<CompletableFuture<Void>> getTransactionalAckTasks() {
+        return transactionalAckTasks;
     }
 
     private static final Logger log = LoggerFactory.getLogger(Consumer.class);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -202,7 +202,9 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         addUnAckedMessages(-consumer.getUnackedMessages());
         if (consumerSet.removeAll(consumer) == 1) {
             consumerList.remove(consumer);
-            FutureUtil.waitForAll(consumer.getTransactionAckTasks()).join();
+            // Transactional acknowledgment is not executed in the `pulsar-io` thread.
+            // So, wait the all the transactional acknowledgment completely to avoid redeliver twice.
+            FutureUtil.waitForAll(consumer.getTransactionalAckTasks()).join();
             log.info("Removed consumer {} with pending {} acks", consumer, consumer.getPendingAcks().size());
             if (consumerList.isEmpty()) {
                 cancelPendingRead();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -204,9 +204,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
             consumerList.remove(consumer);
             // Transactional acknowledgment is not executed in the `pulsar-io` thread.
             // So, wait the all the transactional acknowledgment completely to avoid redeliver twice.
-            List<CompletableFuture<Void>> tasks = consumer.getTransactionalAckTasks();
-            FutureUtil.waitForAll(tasks).join();
-            consumer.getTransactionalAckTasks().removeAll(tasks);
+            FutureUtil.waitForAll(consumer.getTransactionalAckTasks()).join();
 
             log.info("Removed consumer {} with pending {} acks", consumer, consumer.getPendingAcks().size());
             if (consumerList.isEmpty()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -202,10 +202,6 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         addUnAckedMessages(-consumer.getUnackedMessages());
         if (consumerSet.removeAll(consumer) == 1) {
             consumerList.remove(consumer);
-            // Transactional acknowledgment is not executed in the `pulsar-io` thread.
-            // So, wait the all the transactional acknowledgment completely to avoid redeliver twice.
-            FutureUtil.waitForAll(consumer.getTransactionalAckTasks()).join();
-
             log.info("Removed consumer {} with pending {} acks", consumer, consumer.getPendingAcks().size());
             if (consumerList.isEmpty()) {
                 cancelPendingRead();
@@ -226,7 +222,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
                 });
                 totalAvailablePermits -= consumer.getAvailablePermits();
                 if (log.isDebugEnabled()) {
-                    log.debug("[{}] Decreased totalAvailablePermits by {} in PersistentDispatcherMultipleConsumers. "
+                    log.debug("[{}] Decreased totalAvailablePermits by {} in PersistentDispatcherMultipleConsumers."
                                     + "New dispatcher permit count is {}", name, consumer.getAvailablePermits(),
                             totalAvailablePermits);
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -202,6 +202,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         addUnAckedMessages(-consumer.getUnackedMessages());
         if (consumerSet.removeAll(consumer) == 1) {
             consumerList.remove(consumer);
+            FutureUtil.waitForAll(consumer.getTransactionAckTasks()).join();
             log.info("Removed consumer {} with pending {} acks", consumer, consumer.getPendingAcks().size());
             if (consumerList.isEmpty()) {
                 cancelPendingRead();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -204,7 +204,10 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
             consumerList.remove(consumer);
             // Transactional acknowledgment is not executed in the `pulsar-io` thread.
             // So, wait the all the transactional acknowledgment completely to avoid redeliver twice.
-            FutureUtil.waitForAll(consumer.getTransactionalAckTasks()).join();
+            List<CompletableFuture<Void>> tasks = consumer.getTransactionalAckTasks();
+            FutureUtil.waitForAll(tasks).join();
+            consumer.getTransactionalAckTasks().removeAll(tasks);
+
             log.info("Removed consumer {} with pending {} acks", consumer, consumer.getPendingAcks().size());
             if (consumerList.isEmpty()) {
                 cancelPendingRead();


### PR DESCRIPTION
### Motivation

There are three race conditions that can cause messages to be redelivered repeatedly. These are:

#### 1. Exclusive

- **Problem**: 
    1. Ack task is in process. Acking for msg 1,2,3 with transaction1.
    2. Old consumer disconnects.
    3. New consumer connects. 
    4. Cursor is rewound, redelivering msg 1,2,3,4.
    5. Transaction1 is aborted, redelivering msg 1,2,3.
    6. Consumer receives msg 1,2,3,4,1,2,3.

- **Root Cause**: 
    - New consumer can connect to the broker before the last one completes its tasks.

- **Solution**: 
    - Throw `ServiceUnitNotReadyException` and let the consumer reconnect later when the last consumer has ongoing tasks.

#### 2. Failover

- **Problem**: 
    1. Ack task is in process. Acking for msg 1,2,3 with transaction1.
    2. New consumer connects. 
    3. The active consumer changes even though there is an active consumer.
    4. Cursor is rewound, redelivering msg 1,2,3,4.
    5. Transaction1 is aborted, redelivering msg 1,2,3.
    6. Consumer receives msg 1,2,3,4,1,2,3.

- **Root Cause**: 
    - Active consumer changes when a new consumer connects, even if there is a consumer with the same priority.

- **Solution**: 
    - Do not change the active consumer when there are ongoing tasks for this consumer.
    - Pick the active consumer again by disconnecting the current active consumer if there are consumers with higher priority.

#### 3. Shared or Key_Shared

- **Problem**: 
    1. Ack task of consumer1 is in process. Acking for msg 1,2,3 with transaction1.
    2. Consumer1 disconnects.
    3. Message is sent to consumer2 when consumer1 closes.
    4. Consumer2 receives msg 1,2,3.
    5. Transaction1 is aborted, redelivering msg 1,2,3.
    6. Consumer2 receives msg 1,2,3 again.

- **Root Cause**: 
    - Msg 1,2,3 have not been removed from the pending acks of consumer1 when consumer1 closes.

- **Solution**: 
    - Wait for the ack task completely before close consumer

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
