### PR TITLE
[fix][broker] Fix TableViewLoadDataStoreImpl NPE

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/store/LoadDataStoreTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/store/LoadDataStoreTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.loadbalance.extensions.store;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertTrue;
 
 import com.google.common.collect.Sets;
@@ -39,6 +40,7 @@ import org.testng.annotations.Test;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 
 @Test(groups = "broker")
 public class LoadDataStoreTest extends MockedPulsarServiceBaseTest {
@@ -152,6 +154,34 @@ public class LoadDataStoreTest extends MockedPulsarServiceBaseTest {
         assertNotNull(ex);
         loadDataStore.startTableView();
         Awaitility.await().untilAsserted(() -> assertEquals(loadDataStore.get("1").get(), 2));
+    }
+
+    @Test
+    public void testProducerStop() throws Exception {
+        String topic = TopicDomain.persistent + "://" + NamespaceName.SYSTEM_NAMESPACE + "/" + UUID.randomUUID();
+        LoadDataStore<Integer> loadDataStore =
+                LoadDataStoreFactory.create(pulsar.getClient(), topic, Integer.class);
+        loadDataStore.startProducer();
+        loadDataStore.pushAsync("1", 1).get();
+        loadDataStore.removeAsync("1").get();
+
+        loadDataStore.close();
+
+        try {
+            loadDataStore.pushAsync("2", 2).get();
+            fail();
+        } catch (ExecutionException ex) {
+            assertTrue(ex.getCause() instanceof IllegalStateException);
+        }
+        try {
+            loadDataStore.removeAsync("2").get();
+            fail();
+        } catch (ExecutionException ex) {
+            assertTrue(ex.getCause() instanceof IllegalStateException);
+        }
+        loadDataStore.startProducer();
+        loadDataStore.pushAsync("3", 3).get();
+        loadDataStore.removeAsync("3").get();
     }
 
 }


### PR DESCRIPTION
### Motivation
```
2023-12-21T06:06:15,824+0000 [broker-client-shared-internal-executor-5-1] ERROR org.apache.pulsar.broker.loadbalance.extensions.channel.StateChangeListeners - StateChangeListener: org.apache.pulsar.broker.loadbalance.extensions.reporter.BrokerLoadDataReporter@6ad7c72 exception while handling ServiceUnitStateData[state=Owned, dstBroker=pulsar-broker-1:8080, sourceBroker=pulsar-broker-2:8080, splitServiceUnitToDestBroker=null, force=true, timestamp=1703138775734, versionId=3] for service unit my-tenant/my-namespace/0x66666640_0x68f5c268
java.lang.NullPointerException: Cannot invoke "org.apache.pulsar.client.api.Producer.newMessage()" because "this.producer" is null
	at org.apache.pulsar.broker.loadbalance.extensions.store.TableViewLoadDataStoreImpl.removeAsync(TableViewLoadDataStoreImpl.java:67) ~[org.apache.pulsar-pulsar-broker-3.2.0-SNAPSHOT.jar:3.2
2023-12-21T14:06:16,721 - INFO  - [docker-java-stream-955670787:DockerUtils$4@383] - DOCKER.exec(MultiLoadManagerTest-98becc32-e058-4038-94f1-a57c348113b8-pulsar-broker-1:tail -f /var/log/pulsar/broker.log): STDOUT: .0-SNAPSHOT]
	at org.apache.pulsar.broker.loadbalance.extensions.reporter.BrokerLoadDataReporter.tombstone(BrokerLoadDataReporter.java:188) ~[org.apache.pulsar-pulsar-broker-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at org.apache.pulsar.broker.loadbalance.extensions.reporter.BrokerLoadDataReporter.handleEvent(BrokerLoadDataReporter.java:220) ~[org.apache.pulsar-pulsar-broker-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at org.apache.pulsar.broker.loadbalance.extensions.channel.StateChangeListeners.lambda$notify$1(StateChangeListeners.java:60) ~[org.apache.pulsar-pulsar-broker-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:807) ~[?:?]
	at org.apache.pulsar.broker.loadbalance.extensions.channel.StateChangeListeners.notify(StateChangeListeners.java:58) ~[org.apache.pulsar-pulsar-broker-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelImpl.handleOwnEvent(ServiceUnitStateChannelImpl.java:764) ~
```
The producer can be null when the `TableViewLoadDataStoreImpl` is closed.

### Modifications

* Checking the producer is null when `removeAsync` and `pushAsync` methods.
* Make `TableViewLoadDataStoreImpl ` sync.



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
