### PR TITLE
[fix][client] Fix producer thread block forever on memory limit controller

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -324,9 +324,13 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
     protected void updateAndReserveBatchAllocatedSize(int updatedSizeBytes) {
         int delta = updatedSizeBytes - batchAllocatedSizeBytes;
         batchAllocatedSizeBytes = updatedSizeBytes;
-        if (delta != 0) {
+        if (delta > 0) {
             if (producer != null) {
                 producer.client.getMemoryLimitController().forceReserveMemory(delta);
+            }
+        } else if (delta < 0) {
+            if (producer != null) {
+                producer.client.getMemoryLimitController().releaseMemory(-delta);
             }
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -324,12 +324,10 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
     protected void updateAndReserveBatchAllocatedSize(int updatedSizeBytes) {
         int delta = updatedSizeBytes - batchAllocatedSizeBytes;
         batchAllocatedSizeBytes = updatedSizeBytes;
-        if (delta > 0) {
-            if (producer != null) {
+        if (producer != null) {
+            if (delta > 0) {
                 producer.client.getMemoryLimitController().forceReserveMemory(delta);
-            }
-        } else if (delta < 0) {
-            if (producer != null) {
+            } else if (delta < 0) {
                 producer.client.getMemoryLimitController().releaseMemory(-delta);
             }
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MemoryLimitController.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MemoryLimitController.java
@@ -47,16 +47,6 @@ public class MemoryLimitController {
 
     public void forceReserveMemory(long size) {
         long newUsage = currentUsage.addAndGet(size);
-        if (size < 0 && newUsage - size > memoryLimit
-                && newUsage <= memoryLimit) {
-            // We just crossed the limit. Now we have more space
-            mutex.lock();
-            try {
-                condition.signalAll();
-            } finally {
-                mutex.unlock();
-            }
-        }
         checkTrigger(newUsage - size, newUsage);
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MemoryLimitController.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MemoryLimitController.java
@@ -47,6 +47,16 @@ public class MemoryLimitController {
 
     public void forceReserveMemory(long size) {
         long newUsage = currentUsage.addAndGet(size);
+        if (size < 0 && newUsage - size > memoryLimit
+                && newUsage <= memoryLimit) {
+            // We just crossed the limit. Now we have more space
+            mutex.lock();
+            try {
+                condition.signalAll();
+            } finally {
+                mutex.unlock();
+            }
+        }
         checkTrigger(newUsage - size, newUsage);
     }
 


### PR DESCRIPTION
### Motivation

When the modification of the current PR is rolled back, the following unit test will fail, and the main producer thread will be stuck forever in org.apache.pulsar.client.impl.MemoryLimitController#reserveMemory condition.await();

```java
 @Test(timeOut = 10_000)
    public void testProducerBlockReserveMemory() throws Exception {
        replacePulsarClient(PulsarClient.builder().
                serviceUrl(lookupUrl.toString())
                .memoryLimit(1, SizeUnit.KILO_BYTES));
        @Cleanup
        ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) pulsarClient.newProducer()
                .topic("testProducerMemoryLimit")
                .sendTimeout(5, TimeUnit.SECONDS)
                .compressionType(CompressionType.SNAPPY)
                .messageRoutingMode(MessageRoutingMode.RoundRobinPartition)
                .maxPendingMessages(0)
                .blockIfQueueFull(true)
                .enableBatching(true)
                .batchingMaxMessages(100)
                .batchingMaxBytes(65536)
                .batchingMaxPublishDelay(100, TimeUnit.MILLISECONDS)
                .create();
        int msgCount = 5;
        CountDownLatch cdl = new CountDownLatch(msgCount);
        for (int i = 0; i < msgCount; i++) {
            producer.sendAsync("memory-test".getBytes(StandardCharsets.UTF_8)).whenComplete(((messageId, throwable) -> {
                cdl.countDown();
            }));
        }

        cdl.await();

        producer.close();
        PulsarClientImpl clientImpl = (PulsarClientImpl) this.pulsarClient;
        final MemoryLimitController memoryLimitController = clientImpl.getMemoryLimitController();
        Assert.assertEquals(memoryLimitController.currentUsage(), 0);
    }
```

According to my investigation this is related to this PR #17936 

1. When the producer turns on the following parameters and uses asynchronous sending:
                 .compressionType(CompressionType.SNAPPY)
                 .blockIfQueueFull(true)
                 .enableBatching(true)
Set .memoryLimit(1, SizeUnit.KILO_BYTES)); small enough to make it easier to reproduce the problem.

2. BatchMessageContainer will apply for a batchAllocatedSize from MemoryLimitController when building BatchMsgMetadata for the first time. At this time, MemoryLimitController.currentUsage=(msg payload size + batchedMessageMetadataAndPayload size),

3. The main production thread continues to send data asynchronously, but at this time the MemoryLimitController has reached the memoryLimit limit, and the main thread will be stuck in condition.await(); waiting to wake up;
4. When the batch message compression is completed, the BatchMessageContainer will call updateAndReserveBatchAllocatedSize again. At this time, the memory will be released to the MemoryLimitController to the actual batch message size, but it will not wake up those threads that are blocked and waiting due to insufficient memory.
5. After the batch message is sent, call org.apache.pulsar.client.impl.MemoryLimitController#releaseMemory to release the batch size memory. However, since the size released by MemoryLimitController.currentUsage + is smaller than memoryLimit, no threads are awakened.

6. The main production thread is always stuck in condition.await();



### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->