### PR TITLE
[fix][test] Fix auto recovery test thread leak problem.

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -288,6 +288,7 @@ public abstract class BookKeeperClusterTestCase {
 
         for (ServerTester t : servers) {
             t.shutdown();
+            t.stopAutoRecovery();
         }
         servers.clear();
         bookiePorts.removeIf(PortManager::releaseLockedPort);

--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/BookKeeperClusterTestCase.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/BookKeeperClusterTestCase.java
@@ -304,6 +304,7 @@ public abstract class BookKeeperClusterTestCase {
 
         for (ServerTester t : servers) {
             t.shutdown();
+            t.stopAutoRecovery();
         }
         servers.clear();
         bookiePorts.removeIf(PortManager::releaseLockedPort);

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -282,6 +282,7 @@ public abstract class BookKeeperClusterTestCase {
 
         for (ServerTester t : servers) {
             t.shutdown();
+            t.stopAutoRecovery();
         }
         servers.clear();
         bookiePorts.removeIf(PortManager::releaseLockedPort);


### PR DESCRIPTION
There are thread leak in the Auto Recovery test, you can see the pictures. It show that it create many threads and not destroyed.

<img width="1222" alt="image" src="https://github.com/apache/pulsar/assets/22524871/89b189a4-8763-48d1-95ed-59a14bfd4d3f">


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
