### PR TITLE
[improve][pip] PIP-328: Add a topicDeleteProtectionEnable configuration option.

### DIFF
--- a/pip/pip-328.md
+++ b/pip/pip-328.md
@@ -1,0 +1,91 @@
+
+
+# PIP-328: Add a `topicDeleteProtectionEnable` configuration option.
+
+# Background knowledge
+
+In this [issue](https://github.com/apache/pulsar/pull/21704), the topic was accidentally deleted.
+
+Some [cloud services](https://www.alibabacloud.com/help/en/ros/user-guide/enable-deletion-protection) also provide similar options.
+
+# Motivation
+
+
+There are now three scenarios that will delete the topic:
+- Admin api: `DELETE /admin/v2/:schema/:tenant/:namespace/:topic/deleteTopic`
+- Enable the `brokerDeleteInactiveTopicsEnabled` option
+- No repl-cluster configured: `org.apache.pulsar.broker.service.persistent.PersistentTopic.checkReplication`
+
+I hope we can add an option to protect important resources (e.g., `Topic`) from being accidentally deleted.
+
+# Goals
+
+## In Scope
+
+
+Protect important resources from accidental deletion, improving data security.
+
+
+# High Level Design
+
+
+Add a new `topicDeleteProtectionEnable` configuration in `broker.conf`.
+
+
+
+
+# Detailed Design
+
+## Design & Implementation Details
+
+
+Add the following logic in `org.apache.pulsar.broker.service.persistent.PersistentTopic.delete(boolean, boolean, boolean)`:
+
+```java
+if (topicDeleteProtectionEnable){
+    log.warn("The topicDeleteProtectionEnable configuration is enabled, if you are determined to delete the topic:{}, turn off topicDeleteProtectionEnable", topic);
+    return new CompletableFuture<>();
+}
+```
+
+## Public-facing Changes
+
+
+### Public API
+
+
+### Binary protocol
+
+### Configuration
+
+### CLI
+
+### Metrics
+
+
+
+# Monitoring
+
+# Security Considerations
+
+
+# Backward & Forward Compatibility
+
+## Revert
+
+
+## Upgrade
+
+
+# Alternatives
+
+
+# General Notes
+
+# Links
+
+<!--
+Updated afterwards
+-->
+* Mailing List discussion thread:
+* Mailing List voting thread:


### PR DESCRIPTION
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
