### PR TITLE
[improve] [client] Prevent reserve memory with a negative memory size to avoid send task stuck

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MemoryLimitController.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MemoryLimitController.java
@@ -22,7 +22,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class MemoryLimitController {
 
     private final long memoryLimit;
@@ -72,7 +74,9 @@ public class MemoryLimitController {
 
     private static void ensureReservedMemoryIsPositive(long reservedMemorySize) {
         if (reservedMemorySize < 0) {
-            String errorMsg = "Try to reserve memory failed, the param reservedMemorySize is a negative value";
+            String errorMsg = String.format("Try to reserve memory failed, the param reservedMemorySize"
+                    + " is a negative value: %s", reservedMemorySize);
+            log.error(errorMsg);
             throw new IllegalArgumentException(errorMsg);
         }
     }
@@ -104,6 +108,12 @@ public class MemoryLimitController {
     }
 
     public void releaseMemory(long size) {
+        if (size < 0) {
+            String errorMsg = String.format("Try to release memory failed, the param releasedMemorySize"
+                    + " is a negative value: %s", size);
+            log.error(errorMsg);
+            throw new IllegalArgumentException(errorMsg);
+        }
         long newUsage = currentUsage.addAndGet(-size);
         if (newUsage + size > memoryLimit
                 && newUsage <= memoryLimit) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MemoryLimitController.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MemoryLimitController.java
@@ -49,12 +49,18 @@ public class MemoryLimitController {
 
     public void forceReserveMemory(long size) {
         ensureReservedMemoryIsPositive(size);
+        if (size == 0) {
+            return;
+        }
         long newUsage = currentUsage.addAndGet(size);
         checkTrigger(newUsage - size, newUsage);
     }
 
     public boolean tryReserveMemory(long size) {
         ensureReservedMemoryIsPositive(size);
+        if (size == 0) {
+            return true;
+        }
         while (true) {
             long current = currentUsage.get();
             long newUsage = current + size;
@@ -95,6 +101,9 @@ public class MemoryLimitController {
 
     public void reserveMemory(long size) throws InterruptedException {
         ensureReservedMemoryIsPositive(size);
+        if (size == 0) {
+            return;
+        }
         if (!tryReserveMemory(size)) {
             mutex.lock();
             try {
@@ -113,6 +122,9 @@ public class MemoryLimitController {
                     + " is a negative value: %s", size);
             log.error(errorMsg);
             throw new IllegalArgumentException(errorMsg);
+        }
+        if (size == 0) {
+            return;
         }
         long newUsage = currentUsage.addAndGet(-size);
         if (newUsage + size > memoryLimit

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MemoryLimitController.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MemoryLimitController.java
@@ -48,7 +48,7 @@ public class MemoryLimitController {
     }
 
     public void forceReserveMemory(long size) {
-        ensureReservedMemoryIsPositive(size);
+        checkPositive(size);
         if (size == 0) {
             return;
         }
@@ -57,7 +57,7 @@ public class MemoryLimitController {
     }
 
     public boolean tryReserveMemory(long size) {
-        ensureReservedMemoryIsPositive(size);
+        checkPositive(size);
         if (size == 0) {
             return true;
         }
@@ -78,10 +78,10 @@ public class MemoryLimitController {
         }
     }
 
-    private static void ensureReservedMemoryIsPositive(long reservedMemorySize) {
-        if (reservedMemorySize < 0) {
-            String errorMsg = String.format("Try to reserve memory failed, the param reservedMemorySize"
-                    + " is a negative value: %s", reservedMemorySize);
+    private static void checkPositive(long memorySize) {
+        if (memorySize < 0) {
+            String errorMsg = String.format("Try to reserve/release memory failed, the param memorySize"
+                    + " is a negative value: %s", memorySize);
             log.error(errorMsg);
             throw new IllegalArgumentException(errorMsg);
         }
@@ -100,7 +100,7 @@ public class MemoryLimitController {
     }
 
     public void reserveMemory(long size) throws InterruptedException {
-        ensureReservedMemoryIsPositive(size);
+        checkPositive(size);
         if (size == 0) {
             return;
         }
@@ -117,12 +117,7 @@ public class MemoryLimitController {
     }
 
     public void releaseMemory(long size) {
-        if (size < 0) {
-            String errorMsg = String.format("Try to release memory failed, the param releasedMemorySize"
-                    + " is a negative value: %s", size);
-            log.error(errorMsg);
-            throw new IllegalArgumentException(errorMsg);
-        }
+        checkPositive(size);
         if (size == 0) {
             return;
         }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MemoryLimitControllerTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MemoryLimitControllerTest.java
@@ -200,7 +200,7 @@ public class MemoryLimitControllerTest {
     }
 
     @Test
-    public void testReserveMemoryFailedDueToNegativeParam() throws Exception {
+    public void testModifyMemoryFailedDueToNegativeParam() throws Exception {
         MemoryLimitController mlc = new MemoryLimitController(100);
 
         try {
@@ -212,14 +212,21 @@ public class MemoryLimitControllerTest {
 
         try {
             mlc.reserveMemory(-1);
-            fail("The test should fail due to calling tryReserveMemory with a negative value.");
+            fail("The test should fail due to calling reserveMemory with a negative value.");
         } catch (IllegalArgumentException e) {
             // Expected ex.
         }
 
         try {
             mlc.forceReserveMemory(-1);
-            fail("The test should fail due to calling tryReserveMemory with a negative value.");
+            fail("The test should fail due to calling forceReserveMemory with a negative value.");
+        } catch (IllegalArgumentException e) {
+            // Expected ex.
+        }
+
+        try {
+            mlc.releaseMemory(-1);
+            fail("The test should fail due to calling releaseMemory with a negative value.");
         } catch (IllegalArgumentException e) {
             // Expected ex.
         }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MemoryLimitControllerTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MemoryLimitControllerTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.impl;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -196,5 +197,33 @@ public class MemoryLimitControllerTest {
         assertTrue(l2.await(1, TimeUnit.SECONDS));
         assertTrue(l3.await(1, TimeUnit.SECONDS));
         assertEquals(mlc.currentUsage(), 101);
+    }
+
+    @Test
+    public void testReserveMemoryFailedDueToNegativeParam() throws Exception {
+        MemoryLimitController mlc = new MemoryLimitController(100);
+
+        try {
+            mlc.tryReserveMemory(-1);
+            fail("The test should fail due to calling tryReserveMemory with a negative value.");
+        } catch (IllegalArgumentException e) {
+            // Expected ex.
+        }
+
+        try {
+            mlc.reserveMemory(-1);
+            fail("The test should fail due to calling tryReserveMemory with a negative value.");
+        } catch (IllegalArgumentException e) {
+            // Expected ex.
+        }
+
+        try {
+            mlc.forceReserveMemory(-1);
+            fail("The test should fail due to calling tryReserveMemory with a negative value.");
+        } catch (IllegalArgumentException e) {
+            // Expected ex.
+        }
+
+        assertEquals(mlc.currentUsage(), 0);
     }
 }


### PR DESCRIPTION
### Motivation

**Context** : The previous PR is https://github.com/apache/pulsar/pull/21790

**Background of MemoryLimitController**
- When there is not enough memory to use, the method `MemoryLimitController.reserveMemory` will stuck until some memory is released<sup>[1]</sup>.
- After calling `MemoryLimitController.releaseMemory`, it would wake up all stuck threads.

**Issue**
- the method `tryReserveMemory`, `reserveMemory`, `forceReserveMemory` will also release the memory if it accepted a negative value, but it will not wake up the stuck threads. This would cause the stuck threads to remain stuck forever.
- https://github.com/apache/pulsar/pull/17936  used this method incorrectly and caused a Producer stuck bug that fixed by https://github.com/apache/pulsar/pull/21790.

**Make sure that all use cases are correct**
- `reserveMemory`
  - used by `ProducerImpl.canEnqueueRequest`, will not set a negative argument
- `tryReserveMemory`
  - used by `ProducerImpl.canEnqueueRequest`, will not set a negative argument
- `forceReserveMemory`
  - used by `BatchMessageContainerImpl.updateAndReserveBatchAllocatedSize`, will not set a negative argument
  - used by `ConsumerBase.enqueueMessageAndCheckBatchReceive`, will not set a negative argument

Just like @lhotari's [suggestion](https://github.com/apache/pulsar/pull/21790#issuecomment-1869402727), we should add a check to prevent new PRs incorrectly using `tryReserveMemory`, `reserveMemory`, `forceReserveMemory`

#### Footnotes
**[1]**:
https://github.com/apache/pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MemoryLimitController.java#L88

```java
if (!tryReserveMemory(size)) {
    while (!tryReserveMemory(size)) {
        condition.await();
    }
}

```

### Modifications

Just like @lhotari's [suggestion](https://github.com/apache/pulsar/pull/21790#issuecomment-1869402727), add validation to prevent calling `tryReserveMemory`, `reserveMemory`, `forceReserveMemory` with a negative argument.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-coplete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
