### PR TITLE
[improve][build] Upgrade mysql connector version from 8.0.30 to 8.1.0 to avoid CVE-202…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@ flexible messaging model and an intuitive client API.</description>
     <elasticsearch-java.version>8.5.2</elasticsearch-java.version>
     <debezium.version>1.9.7.Final</debezium.version>
     <debezium.postgresql.version>42.5.0</debezium.postgresql.version>
-    <debezium.mysql.version>8.0.30</debezium.mysql.version>
+    <debezium.mysql.version>8.1.0</debezium.mysql.version>
     <!-- Override version that brings CVE-2022-3143 with debezium -->
     <wildfly-elytron.version>1.15.16.Final</wildfly-elytron.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>


### PR DESCRIPTION
Fixes #21784


### Motivation

Upgrade mysql connector version from 8.0.30 to 8.1.0 to avoid CVE-2023-22102


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


