### PR TITLE
[improve][broker] defer the ownership checks if the owner is inactive (ExtensibleLoadManager)

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerWrapper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerWrapper.java
@@ -118,13 +118,11 @@ public class ExtensibleLoadManagerWrapper implements LoadManager {
     @Override
     public void writeLoadReportOnZookeeper() throws Exception {
         // No-op, this operation is not useful, the load data reporter will automatically write.
-        throw new UnsupportedOperationException();
     }
 
     @Override
     public void writeResourceQuotasToZooKeeper() throws Exception {
         // No-op, this operation is not useful, the load data reporter will automatically write.
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -495,13 +495,10 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                 ? brokerRegistry.lookupAsync(owner.get()).thenApply(lookupData -> lookupData.flatMap(__ -> owner))
                 : CompletableFuture.completedFuture(Optional.empty());
 
-
         return activeOwner
                 .thenCompose(broker -> broker
                         .map(__ -> activeOwner)
-                        .orElseGet(() -> deferGetOwnerRequest(serviceUnit).thenApply(
-                                ownerAfterDeferred -> ownerAfterDeferred == null ? Optional.empty()
-                                        : Optional.of(ownerAfterDeferred))))
+                        .orElseGet(() -> deferGetOwnerRequest(serviceUnit).thenApply(Optional::ofNullable)))
                 .whenComplete((__, e) -> {
                     if (e != null) {
                         log.error("Failed to get active owner broker. serviceUnit:{}, state:{}, owner:{}",
@@ -1252,8 +1249,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                             + "totalCleanupErrorCnt:{}",
                     serviceUnit, orphanData, totalCleanupErrorCnt.incrementAndGet());
         }
-        var override = getOverrideInactiveBrokerStateData(
-                orphanData, selectedBroker, inactiveBroker);
+        var override = getOverrideInactiveBrokerStateData(orphanData, selectedBroker, inactiveBroker);
         log.info("Overriding ownership serviceUnit:{} from orphanData:{} to overrideData:{}",
                 serviceUnit, orphanData, override);
         publishOverrideEventAsync(serviceUnit, orphanData, override)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -487,6 +487,30 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         return isOwner(serviceUnit, lookupServiceAddress);
     }
 
+    private CompletableFuture<Optional<String>> getActiveOwnerAsync(
+            String serviceUnit,
+            ServiceUnitState state,
+            Optional<String> owner) {
+        CompletableFuture<Optional<String>> activeOwner = owner.isPresent()
+                ? brokerRegistry.lookupAsync(owner.get()).thenApply(lookupData -> lookupData.flatMap(__ -> owner))
+                : CompletableFuture.completedFuture(Optional.empty());
+
+
+        return activeOwner
+                .thenCompose(broker -> broker
+                        .map(__ -> activeOwner)
+                        .orElseGet(() -> deferGetOwnerRequest(serviceUnit).thenApply(
+                                ownerAfterDeferred -> ownerAfterDeferred == null ? Optional.empty()
+                                        : Optional.of(ownerAfterDeferred))))
+                .whenComplete((__, e) -> {
+                    if (e != null) {
+                        log.error("Failed to get active owner broker. serviceUnit:{}, state:{}, owner:{}",
+                                serviceUnit, state, owner, e);
+                        ownerLookUpCounters.get(state).getFailure().incrementAndGet();
+                    }
+                });
+    }
+
     public CompletableFuture<Optional<String>> getOwnerAsync(String serviceUnit) {
         if (!validateChannelState(Started, true)) {
             return CompletableFuture.failedFuture(
@@ -498,18 +522,13 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         ownerLookUpCounters.get(state).getTotal().incrementAndGet();
         switch (state) {
             case Owned -> {
-                return CompletableFuture.completedFuture(Optional.of(data.dstBroker()));
+                return getActiveOwnerAsync(serviceUnit, state, Optional.of(data.dstBroker()));
             }
             case Splitting -> {
-                return CompletableFuture.completedFuture(Optional.of(data.sourceBroker()));
+                return getActiveOwnerAsync(serviceUnit, state, Optional.of(data.sourceBroker()));
             }
             case Assigning, Releasing -> {
-                return deferGetOwnerRequest(serviceUnit).whenComplete((__, e) -> {
-                    if (e != null) {
-                        ownerLookUpCounters.get(state).getFailure().incrementAndGet();
-                    }
-                }).thenApply(
-                        broker -> broker == null ? Optional.empty() : Optional.of(broker));
+                return getActiveOwnerAsync(serviceUnit, state, Optional.empty());
             }
             case Init, Free -> {
                 return CompletableFuture.completedFuture(Optional.empty());
@@ -812,9 +831,14 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         if (getOwnerRequest != null) {
             getOwnerRequest.complete(null);
         }
-        stateChangeListeners.notify(serviceUnit, data, null);
+
         if (isTargetBroker(data.sourceBroker())) {
-            log(null, serviceUnit, data, null);
+            stateChangeListeners.notifyOnCompletion(
+                            data.force() ? closeServiceUnit(serviceUnit, true)
+                                    : CompletableFuture.completedFuture(0), serviceUnit, data)
+                    .whenComplete((__, e) -> log(e, serviceUnit, data, null));
+        } else {
+            stateChangeListeners.notify(serviceUnit, data, null);
         }
     }
 
@@ -1202,38 +1226,44 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
 
 
     private ServiceUnitStateData getOverrideInactiveBrokerStateData(ServiceUnitStateData orphanData,
-                                                                    String selectedBroker,
+                                                                    Optional<String> selectedBroker,
                                                                     String inactiveBroker) {
+
+
+        if (selectedBroker.isEmpty()) {
+            return new ServiceUnitStateData(Free, null, inactiveBroker,
+                    true, getNextVersionId(orphanData));
+        }
+
         if (orphanData.state() == Splitting) {
-            return new ServiceUnitStateData(Splitting, orphanData.dstBroker(), selectedBroker,
+            return new ServiceUnitStateData(Splitting, orphanData.dstBroker(), selectedBroker.get(),
                     Map.copyOf(orphanData.splitServiceUnitToDestBroker()),
                     true, getNextVersionId(orphanData));
         } else {
-            return new ServiceUnitStateData(Owned, selectedBroker, inactiveBroker,
+            return new ServiceUnitStateData(Owned, selectedBroker.get(), inactiveBroker,
                     true, getNextVersionId(orphanData));
         }
     }
 
     private void overrideOwnership(String serviceUnit, ServiceUnitStateData orphanData, String inactiveBroker) {
         Optional<String> selectedBroker = selectBroker(serviceUnit, inactiveBroker);
-        if (selectedBroker.isPresent()) {
-            var override = getOverrideInactiveBrokerStateData(
-                    orphanData, selectedBroker.get(), inactiveBroker);
-            log.info("Overriding ownership serviceUnit:{} from orphanData:{} to overrideData:{}",
-                    serviceUnit, orphanData, override);
-            publishOverrideEventAsync(serviceUnit, orphanData, override)
-                    .exceptionally(e -> {
-                        log.error(
-                                "Failed to override the ownership serviceUnit:{} orphanData:{}. "
-                                        + "Failed to publish override event. totalCleanupErrorCnt:{}",
-                                serviceUnit, orphanData, totalCleanupErrorCnt.incrementAndGet());
-                        return null;
-                    });
-        } else {
-            log.error("Failed to override the ownership serviceUnit:{} orphanData:{}. Empty selected broker. "
+        if (selectedBroker.isEmpty()) {
+            log.warn("Empty selected broker for ownership serviceUnit:{} orphanData:{}."
                             + "totalCleanupErrorCnt:{}",
                     serviceUnit, orphanData, totalCleanupErrorCnt.incrementAndGet());
         }
+        var override = getOverrideInactiveBrokerStateData(
+                orphanData, selectedBroker, inactiveBroker);
+        log.info("Overriding ownership serviceUnit:{} from orphanData:{} to overrideData:{}",
+                serviceUnit, orphanData, override);
+        publishOverrideEventAsync(serviceUnit, orphanData, override)
+                .exceptionally(e -> {
+                    log.error(
+                            "Failed to override the ownership serviceUnit:{} orphanData:{}. "
+                                    + "Failed to publish override event. totalCleanupErrorCnt:{}",
+                            serviceUnit, orphanData, totalCleanupErrorCnt.incrementAndGet());
+                    return null;
+                });
     }
 
     private void waitForCleanups(String broker, boolean excludeSystemTopics, int maxWaitTimeInMillis) {
@@ -1335,7 +1365,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                 broker,
                 cleanupTime,
                 orphanServiceUnitCleanupCnt,
-                totalCleanupErrorCntStart - totalCleanupErrorCnt.get(),
+                totalCleanupErrorCnt.get() - totalCleanupErrorCntStart,
                 printCleanupMetrics());
 
     }
@@ -1524,7 +1554,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                     inactiveBrokers, inactiveBrokers.size(),
                     orphanServiceUnitCleanupCnt,
                     serviceUnitTombstoneCleanupCnt,
-                    totalCleanupErrorCntStart - totalCleanupErrorCnt.get(),
+                    totalCleanupErrorCnt.get() - totalCleanupErrorCntStart,
                     printCleanupMetrics());
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
@@ -39,6 +39,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -1560,6 +1561,89 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         cleanTableViews();
     }
 
+    @Test(priority = 19)
+    public void testActiveGetOwner()
+            throws IllegalAccessException, ExecutionException, InterruptedException, TimeoutException {
+
+
+        // set the bundle owner is the broker
+        String broker = lookupServiceAddress2;
+        String bundle = "public/owned/0xfffffff0_0xffffffff";
+        overrideTableViews(bundle,
+                new ServiceUnitStateData(Owned, broker, null, 1));
+        var owner = channel1.getOwnerAsync(bundle).get(5, TimeUnit.SECONDS).get();
+        assertEquals(owner, broker);
+
+        // simulate the owner is inactive
+        var spyRegistry = spy(new BrokerRegistryImpl(pulsar));
+        doReturn(CompletableFuture.completedFuture(Optional.empty()))
+                .when(spyRegistry).lookupAsync(eq(broker));
+        FieldUtils.writeDeclaredField(channel1,
+                "brokerRegistry", spyRegistry , true);
+        FieldUtils.writeDeclaredField(channel1,
+                "inFlightStateWaitingTimeInMillis", 1000, true);
+
+
+        // verify getOwnerAsync times out because the owner is inactive now.
+        long start = System.currentTimeMillis();
+        try {
+            channel1.getOwnerAsync(bundle).get();
+            fail();
+        } catch (Exception e) {
+            if (e.getCause() instanceof TimeoutException) {
+                // expected
+            } else {
+                fail();
+            }
+        }
+        assertTrue(System.currentTimeMillis() - start >= 1000);
+
+        // simulate ownership cleanup(no selected owner) by the leader channel
+        doReturn(CompletableFuture.completedFuture(Optional.empty()))
+                .when(loadManager).selectAsync(any(), any());
+        var leaderChannel = channel1;
+        String leader = channel1.getChannelOwnerAsync().get(2, TimeUnit.SECONDS).get();
+        String leader2 = channel2.getChannelOwnerAsync().get(2, TimeUnit.SECONDS).get();
+        assertEquals(leader, leader2);
+        if (leader.equals(lookupServiceAddress2)) {
+            leaderChannel = channel2;
+        }
+        leaderChannel.handleMetadataSessionEvent(SessionReestablished);
+        FieldUtils.writeDeclaredField(leaderChannel, "lastMetadataSessionEventTimestamp",
+                System.currentTimeMillis() - (MAX_CLEAN_UP_DELAY_TIME_IN_SECS * 1000 + 1000), true);
+        leaderChannel.handleBrokerRegistrationEvent(broker, NotificationType.Deleted);
+
+        // verify the ownership cleanup, and channel's getOwnerAsync returns empty result without timeout
+        FieldUtils.writeDeclaredField(channel1,
+                "inFlightStateWaitingTimeInMillis", 20 * 1000, true);
+        start = System.currentTimeMillis();
+        assertTrue(channel1.getOwnerAsync(bundle).get().isEmpty());
+        assertTrue(System.currentTimeMillis() - start < 20_000);
+
+        // simulate ownership cleanup(lookupServiceAddress1 selected owner) by the leader channel
+        overrideTableViews(bundle,
+                new ServiceUnitStateData(Owned, broker, null, 1));
+        doReturn(CompletableFuture.completedFuture(Optional.of(lookupServiceAddress1)))
+                .when(loadManager).selectAsync(any(), any());
+        leaderChannel.handleMetadataSessionEvent(SessionReestablished);
+        FieldUtils.writeDeclaredField(leaderChannel, "lastMetadataSessionEventTimestamp",
+                System.currentTimeMillis() - (MAX_CLEAN_UP_DELAY_TIME_IN_SECS * 1000 + 1000), true);
+        getCleanupJobs(leaderChannel).clear();
+        leaderChannel.handleBrokerRegistrationEvent(broker, NotificationType.Deleted);
+
+        // verify the ownership cleanup, and channel's getOwnerAsync returns lookupServiceAddress1 without timeout
+        start = System.currentTimeMillis();
+        assertEquals(lookupServiceAddress1, channel1.getOwnerAsync(bundle).get().get());
+        assertTrue(System.currentTimeMillis() - start < 20_000);
+
+        // test clean-up
+        FieldUtils.writeDeclaredField(channel1,
+                "inFlightStateWaitingTimeInMillis", 30 * 1000, true);
+        FieldUtils.writeDeclaredField(channel1,
+                "brokerRegistry", registry , true);
+        cleanTableViews();
+
+    }
 
     private static ConcurrentHashMap<String, CompletableFuture<Optional<String>>> getOwnerRequests(
             ServiceUnitStateChannel channel) throws IllegalAccessException {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
@@ -126,7 +126,7 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
                 }
             });
             String topicName = "persistent://" + DEFAULT_NAMESPACE + "/startBrokerCheck";
-            Awaitility.await().atMost(120, TimeUnit.SECONDS).until(
+            Awaitility.await().atMost(120, TimeUnit.SECONDS).ignoreExceptions().until(
                     () -> {
                         for (BrokerContainer brokerContainer : pulsarCluster.getBrokers()) {
                             try (PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(
@@ -140,8 +140,6 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
                                     // expected
                                 }
                                 admin.lookups().lookupPartitionedTopic(topicName);
-                            } catch (Throwable e) {
-                                return false;
                             }
                         }
                         return true;
@@ -265,7 +263,7 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
         assertFalse(admin.namespaces().getNamespaces(DEFAULT_TENANT).contains(namespace));
     }
 
-    @Test(timeOut = 40 * 1000)
+    @Test(timeOut = 120 * 1000)
     public void testStopBroker() throws Exception {
         String topicName = "persistent://" + DEFAULT_NAMESPACE + "/test-stop-broker-topic";
 
@@ -404,7 +402,7 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
             fail();
         } catch (Exception ex) {
             log.error("Failed to lookup topic: ", ex);
-            assertThat(ex.getMessage()).containsAnyOf("Failed to select the new owner broker for bundle");
+            assertThat(ex.getMessage()).contains("Failed to select the new owner broker for bundle");
         }
     }
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->



<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

When a broker shutdown or gets killed, the leader broker will get notified and soon reassign the orphan bundle ownerships. Meanwhile, the ownership lookup to these orphan bundles should be deferred til the new brokers own them. This will further reduce the lookup request retries when brokers are shutdown or get killed.

### Modifications

- In `ServiceUnitStateChannelImpl.getOwnerAsync`, additionally, check if the current owner broker is active or not in the broker registry. If active, return the current owner. Otherwise, defer the ownership lookup requests til the new owner owns it.
- During the orphan ownership cleanup, when there is no selected owner, the leader overrides the orphan states to `Free`.
- Do not throw exception from `writeLoadReportOnZookeeper` `writeResourceQuotasToZooKeeper`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

Added a test case `testActiveGetOwner` to cover this.
### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/heesung-sn/pulsar/pull/58

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
