### PR TITLE
[improve][admin] getMessageById gets message by batch index

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1679,7 +1679,9 @@ public interface Topics {
      * @return the message indexed by the messageId
      * @throws PulsarAdminException
      *            Unexpected error
+     * @deprecated Use {@link #getMessageById(String, long, long, int)} instead.
      */
+    @Deprecated
     Message<byte[]> getMessageById(String topic, long ledgerId, long entryId) throws PulsarAdminException;
 
     /**
@@ -1691,7 +1693,9 @@ public interface Topics {
      * @param entryId
      *            Entry id
      * @return a future that can be used to track when the message is returned
+     * @deprecated Use {@link #getMessageByIdAsync(String, long, long, int)} instead.
      */
+    @Deprecated
     CompletableFuture<Message<byte[]>> getMessageByIdAsync(String topic, long ledgerId, long entryId);
 
     /**
@@ -4477,4 +4481,29 @@ public interface Topics {
     default CompletableFuture<Void> createShadowTopicAsync(String shadowTopic, String sourceTopic) {
         return createShadowTopicAsync(shadowTopic, sourceTopic, null);
     }
+
+    /**
+     * Get the message by its messageId via a topic subscription asynchronously.
+     *
+     * @param topic      Topic name
+     * @param ledgerId   Ledger id
+     * @param entryId    Entry id
+     * @param batchIndex Batch Index, -1 returns all batch message
+     * @return a future that can be used to track when the message is returned
+     */
+    CompletableFuture<List<Message<byte[]>>> getMessageByIdAsync(String topic, long ledgerId, long entryId,
+                                                                 int batchIndex);
+
+    /**
+     * Get the message by its messageId via a topic subscription.
+     *
+     * @param topic      Topic name
+     * @param ledgerId   Ledger id
+     * @param entryId    Entry id
+     * @param batchIndex Batch Index, -1 returns all batch message
+     * @return the message indexed by the messageId
+     * @throws PulsarAdminException Unexpected error
+     */
+    List<Message<byte[]>> getMessageById(String topic, long ledgerId, long entryId, int batchIndex)
+            throws PulsarAdminException;
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
@@ -632,10 +632,13 @@ public class CmdPersistentTopics extends CmdBase {
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
 
-            Message<byte[]> message = getPersistentTopics().getMessageById(persistentTopic, ledgerId, entryId);
+            List<Message<byte[]>> messages = getPersistentTopics().getMessageById(persistentTopic, ledgerId, entryId,
+                    -1);
 
-            ByteBuf date = Unpooled.wrappedBuffer(message.getData());
-            System.out.println(ByteBufUtil.prettyHexDump(date));
+            messages.forEach(message -> {
+                ByteBuf date = Unpooled.wrappedBuffer(message.getData());
+                System.out.println(ByteBufUtil.prettyHexDump(date));
+            });
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -1351,45 +1351,49 @@ public class CmdTopics extends CmdBase {
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
 
-            MessageImpl message = (MessageImpl) getTopics().getMessageById(persistentTopic, ledgerId, entryId);
-            if (message == null) {
+            List<Message<byte[]>> messages = getTopics()
+                    .getMessageById(persistentTopic, ledgerId, entryId, -1);
+            if (messages == null || messages.size() == 0) {
                 System.out.println("Cannot find any messages based on ledgerId:"
                         + ledgerId + " entryId:" + entryId);
             } else {
-                if (message.getMessageId() instanceof BatchMessageIdImpl) {
-                    BatchMessageIdImpl msgId = (BatchMessageIdImpl) message.getMessageId();
-                    System.out.println("Batch Message ID: " + msgId.getLedgerId() + ":" + msgId.getEntryId() + ":"
-                            + msgId.getBatchIndex());
-                } else {
-                    MessageIdImpl msgId = (MessageIdImpl) message.getMessageId();
-                    System.out.println("Message ID: " + msgId.getLedgerId() + ":" + msgId.getEntryId());
-                }
-
-                System.out.println("Publish time: " + message.getPublishTime());
-                System.out.println("Event time: " + message.getEventTime());
-                System.out.println("Redelivery count: " + message.getRedeliveryCount());
-
-                if (message.getDeliverAtTime() != 0) {
-                    System.out.println("Deliver at time: " + message.getDeliverAtTime());
-                }
-
-                if (message.getBrokerEntryMetadata() != null) {
-                    if (message.getBrokerEntryMetadata().hasBrokerTimestamp()) {
-                        System.out.println("Broker entry metadata timestamp: "
-                                + message.getBrokerEntryMetadata().getBrokerTimestamp());
+                messages.forEach(messageInterface -> {
+                    MessageImpl<byte[]> message = (MessageImpl<byte[]>) messageInterface;
+                    if (message.getMessageId() instanceof BatchMessageIdImpl) {
+                        BatchMessageIdImpl msgId = (BatchMessageIdImpl) message.getMessageId();
+                        System.out.println("Batch Message ID: " + msgId.getLedgerId() + ":" + msgId.getEntryId() + ":"
+                                + msgId.getBatchIndex());
+                    } else {
+                        MessageIdImpl msgId = (MessageIdImpl) message.getMessageId();
+                        System.out.println("Message ID: " + msgId.getLedgerId() + ":" + msgId.getEntryId());
                     }
-                    if (message.getBrokerEntryMetadata().hasIndex()) {
-                        System.out.println("Broker entry metadata index: "
-                                + message.getBrokerEntryMetadata().getIndex());
-                    }
-                }
 
-                if (message.getProperties().size() > 0) {
-                    System.out.println("Properties:");
-                    print(message.getProperties());
-                }
-                ByteBuf date = Unpooled.wrappedBuffer(message.getData());
-                System.out.println(ByteBufUtil.prettyHexDump(date));
+                    System.out.println("Publish time: " + message.getPublishTime());
+                    System.out.println("Event time: " + message.getEventTime());
+                    System.out.println("Redelivery count: " + message.getRedeliveryCount());
+
+                    if (message.getDeliverAtTime() != 0) {
+                        System.out.println("Deliver at time: " + message.getDeliverAtTime());
+                    }
+
+                    if (message.getBrokerEntryMetadata() != null) {
+                        if (message.getBrokerEntryMetadata().hasBrokerTimestamp()) {
+                            System.out.println("Broker entry metadata timestamp: "
+                                    + message.getBrokerEntryMetadata().getBrokerTimestamp());
+                        }
+                        if (message.getBrokerEntryMetadata().hasIndex()) {
+                            System.out.println("Broker entry metadata index: "
+                                    + message.getBrokerEntryMetadata().getIndex());
+                        }
+                    }
+
+                    if (message.getProperties().size() > 0) {
+                        System.out.println("Properties:");
+                        print(message.getProperties());
+                    }
+                    ByteBuf date = Unpooled.wrappedBuffer(message.getData());
+                    System.out.println(ByteBufUtil.prettyHexDump(date));
+                });
             }
         }
     }


### PR DESCRIPTION
### Motivation

When the message is a batch message, the `org.apache.pulsar.client.admin.Topics#getMessageByIdAsync(java.lang.String, long, long)` only returns the first message from the batch message, this affects our troubleshooting.

### Modifications

- Add `org.apache.pulsar.client.admin.Topics#getMessageByIdAsync(java.lang.String, long, long, int)` instead of `org.apache.pulsar.client.admin.Topics#getMessageByIdAsync(java.lang.String, long, long)`.
- Add `org.apache.pulsar.client.admin.Topics#getMessageById(java.lang.String, long, long, int)` instead of `org.apache.pulsar.client.admin.Topics#getMessageById(java.lang.String, long, long)`.
- Update `org.apache.pulsar.admin.cli.CmdPersistentTopics.GetMessageById#run` to print all message.
- Update `org.apache.pulsar.admin.cli.CmdTopics.GetMessageById#run` to print all message.

### Verifying this change

Test added.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
