### PR TITLE
[feat][broker] Implementation of PIP-323: Complete Backlog Quota Telemetry

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
@@ -46,7 +47,6 @@ import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedCursorMXBean;
 import org.apache.bookkeeper.mledger.ManagedLedger;
-import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
 import org.testng.annotations.Test;
 
@@ -105,7 +105,7 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
-        public List<Entry> readEntries(int numberOfEntriesToRead) throws ManagedLedgerException {
+        public List<Entry> readEntries(int numberOfEntriesToRead) {
             return new ArrayList();
         }
 
@@ -137,14 +137,14 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
-        public void markDelete(Position position) throws ManagedLedgerException {
+        public void markDelete(Position position) {
             markDelete(position, Collections.emptyMap());
         }
 
         @Override
-        public void markDelete(Position position, Map<String, Long> properties) throws ManagedLedgerException {
+        public void markDelete(Position position, Map<String, Long> properties) {
             this.position = position;
-            container.cursorUpdated(this, (PositionImpl) position);
+            container.cursorUpdated(this, position);
         }
 
         @Override
@@ -209,7 +209,7 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
-        public void delete(Position position) throws InterruptedException, ManagedLedgerException {
+        public void delete(Position position) {
         }
 
         @Override
@@ -217,7 +217,7 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
-        public void delete(Iterable<Position> positions) throws InterruptedException, ManagedLedgerException {
+        public void delete(Iterable<Position> positions) {
         }
 
         @Override
@@ -225,7 +225,7 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
-        public void clearBacklog() throws InterruptedException, ManagedLedgerException {
+        public void clearBacklog() {
         }
 
         @Override
@@ -233,8 +233,7 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
-        public void skipEntries(int numEntriesToSkip, IndividualDeletedEntries deletedEntries)
-                throws InterruptedException, ManagedLedgerException {
+        public void skipEntries(int numEntriesToSkip, IndividualDeletedEntries deletedEntries) {
         }
 
         @Override
@@ -243,13 +242,12 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
-        public Position findNewestMatching(Predicate<Entry> condition)
-                throws InterruptedException, ManagedLedgerException {
+        public Position findNewestMatching(Predicate<Entry> condition) {
             return null;
         }
 
         @Override
-        public Position findNewestMatching(FindPositionConstraint constraint, Predicate<Entry> condition) throws InterruptedException, ManagedLedgerException {
+        public Position findNewestMatching(FindPositionConstraint constraint, Predicate<Entry> condition) {
             return null;
         }
 
@@ -270,7 +268,7 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
-        public void resetCursor(final Position position) throws ManagedLedgerException, InterruptedException {
+        public void resetCursor(final Position position) {
 
         }
 
@@ -284,8 +282,7 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
-        public List<Entry> replayEntries(Set<? extends Position> positions)
-                throws InterruptedException, ManagedLedgerException {
+        public List<Entry> replayEntries(Set<? extends Position> positions) {
             return null;
         }
 
@@ -300,8 +297,7 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
-        public List<Entry> readEntriesOrWait(int numberOfEntriesToRead)
-                throws InterruptedException, ManagedLedgerException {
+        public List<Entry> readEntriesOrWait(int numberOfEntriesToRead) {
             return null;
         }
 
@@ -322,8 +318,7 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
-        public Entry getNthEntry(int N, IndividualDeletedEntries deletedEntries)
-                throws InterruptedException, ManagedLedgerException {
+        public Entry getNthEntry(int N, IndividualDeletedEntries deletedEntries) {
             return null;
         }
 
@@ -399,13 +394,8 @@ public class ManagedCursorContainerTest {
             return null;
         }
 
-        public void asyncReadEntriesOrWait(int maxEntries, long maxSizeBytes, ReadEntriesCallback callback,
-                Object ctx) {
-        }
-
         @Override
-        public List<Entry> readEntriesOrWait(int maxEntries, long maxSizeBytes)
-                throws InterruptedException, ManagedLedgerException {
+        public List<Entry> readEntriesOrWait(int maxEntries, long maxSizeBytes) {
             return null;
         }
 
@@ -421,7 +411,7 @@ public class ManagedCursorContainerTest {
     }
 
     @Test
-    public void testSlowestReadPositionForActiveCursors() throws Exception {
+    public void testSlowestReadPositionForActiveCursors() {
         ManagedCursorContainer container = new ManagedCursorContainer();
         assertNull(container.getSlowestReaderPosition());
 
@@ -466,14 +456,20 @@ public class ManagedCursorContainerTest {
         ManagedCursor cursor1 = new MockManagedCursor(container, "test1", new PositionImpl(5, 5));
         container.add(cursor1, cursor1.getMarkDeletedPosition());
         assertEquals(container.getSlowestReaderPosition(), new PositionImpl(5, 5));
+        assertEqualsCursorAndMarkDelete(container.getCursorWithOldestMarkDeletePosition(),
+                cursor1, new PositionImpl(5, 5));
 
         ManagedCursor cursor2 = new MockManagedCursor(container, "test2", new PositionImpl(2, 2));
         container.add(cursor2, cursor2.getMarkDeletedPosition());
         assertEquals(container.getSlowestReaderPosition(), new PositionImpl(2, 2));
+        assertEqualsCursorAndMarkDelete(container.getCursorWithOldestMarkDeletePosition(),
+                cursor2, new PositionImpl(2, 2));
 
         ManagedCursor cursor3 = new MockManagedCursor(container, "test3", new PositionImpl(2, 0));
         container.add(cursor3, cursor3.getMarkDeletedPosition());
         assertEquals(container.getSlowestReaderPosition(), new PositionImpl(2, 0));
+        assertEqualsCursorAndMarkDelete(container.getCursorWithOldestMarkDeletePosition(),
+                cursor3, new PositionImpl(2, 0));
 
         assertEquals(container.toString(), "[test1=5:5, test2=2:2, test3=2:0]");
 
@@ -487,6 +483,8 @@ public class ManagedCursorContainerTest {
 
         cursor3.markDelete(new PositionImpl(3, 0));
         assertEquals(container.getSlowestReaderPosition(), new PositionImpl(2, 2));
+        assertEqualsCursorAndMarkDelete(container.getCursorWithOldestMarkDeletePosition(),
+                cursor2, new PositionImpl(2, 2));
 
         cursor2.markDelete(new PositionImpl(10, 5));
         assertEquals(container.getSlowestReaderPosition(), new PositionImpl(3, 0));
@@ -498,6 +496,8 @@ public class ManagedCursorContainerTest {
         container.removeCursor(cursor5.getName());
         container.removeCursor(cursor1.getName());
         assertEquals(container.getSlowestReaderPosition(), new PositionImpl(4, 0));
+        assertEqualsCursorAndMarkDelete(container.getCursorWithOldestMarkDeletePosition(),
+                cursor4, new PositionImpl(4, 0));
 
         assertTrue(container.hasDurableCursors());
 
@@ -514,7 +514,7 @@ public class ManagedCursorContainerTest {
     }
 
     @Test
-    public void updatingCursorOutsideContainer() throws Exception {
+    public void updatingCursorOutsideContainer() {
         ManagedCursorContainer container = new ManagedCursorContainer();
 
         ManagedCursor cursor1 = new MockManagedCursor(container, "test1", new PositionImpl(5, 5));
@@ -533,10 +533,19 @@ public class ManagedCursorContainerTest {
         container.cursorUpdated(cursor2, cursor2.position);
 
         assertEquals(container.getSlowestReaderPosition(), new PositionImpl(5, 5));
+        assertEqualsCursorAndMarkDelete(container.getCursorWithOldestMarkDeletePosition(),
+                cursor1, new PositionImpl(5, 5));
+    }
+
+    private void assertEqualsCursorAndMarkDelete(ManagedCursorContainer.CursorInfo cursorInfo,
+                                                 ManagedCursor expectedCursor,
+                                                 PositionImpl expectedMarkDeletePosition) {
+        assertThat(cursorInfo.getCursor().getName()).isEqualTo(expectedCursor.getName());
+        assertThat(cursorInfo.getMarkDeletePosition()).isEqualTo(expectedMarkDeletePosition);
     }
 
     @Test
-    public void removingCursor() throws Exception {
+    public void removingCursor() {
         ManagedCursorContainer container = new ManagedCursorContainer();
 
         ManagedCursor cursor1 = new MockManagedCursor(container, "test1", new PositionImpl(5, 5));
@@ -607,7 +616,7 @@ public class ManagedCursorContainerTest {
     }
 
     @Test
-    public void orderingWithUpdates() throws Exception {
+    public void orderingWithUpdates() {
         ManagedCursorContainer container = new ManagedCursorContainer();
 
         MockManagedCursor c1 = new MockManagedCursor(container, "test1", new PositionImpl(5, 5));
@@ -672,7 +681,7 @@ public class ManagedCursorContainerTest {
     }
 
     @Test
-    public void orderingWithUpdatesAndReset() throws Exception {
+    public void orderingWithUpdatesAndReset() {
         ManagedCursorContainer container = new ManagedCursorContainer();
 
         MockManagedCursor c1 = new MockManagedCursor(container, "test1", new PositionImpl(5, 5));
@@ -734,5 +743,57 @@ public class ManagedCursorContainerTest {
         container.removeCursor("test3");
 
         assertFalse(container.hasDurableCursors());
+    }
+
+    @Test
+    public void testDataVersion() {
+        assertThat(ManagedCursorContainer.DataVersion.compareVersions(1L, 3L)).isNegative();
+        assertThat(ManagedCursorContainer.DataVersion.compareVersions(3L, 1L)).isPositive();
+        assertThat(ManagedCursorContainer.DataVersion.compareVersions(3L, 3L)).isZero();
+
+        long v1 = Long.MAX_VALUE - 1;
+        long v2 = ManagedCursorContainer.DataVersion.incrementVersion(v1);
+
+        assertThat(ManagedCursorContainer.DataVersion.compareVersions(v1, v2)).isNegative();
+
+        v2 = ManagedCursorContainer.DataVersion.incrementVersion(v2);
+        assertThat(ManagedCursorContainer.DataVersion.compareVersions(v1, v2)).isNegative();
+
+        v1 = ManagedCursorContainer.DataVersion.incrementVersion(v1);
+        assertThat(ManagedCursorContainer.DataVersion.compareVersions(v1, v2)).isNegative();
+
+        v1 = ManagedCursorContainer.DataVersion.incrementVersion(v1);
+        assertThat(ManagedCursorContainer.DataVersion.compareVersions(v1, v2)).isZero();
+
+        v1 = ManagedCursorContainer.DataVersion.incrementVersion(v1);
+        assertThat(ManagedCursorContainer.DataVersion.compareVersions(v1, v2)).isPositive();
+    }
+
+    @Test
+    public void testVersions() {
+        ManagedCursorContainer container = new ManagedCursorContainer();
+
+        MockManagedCursor c1 = new MockManagedCursor(container, "test1", new PositionImpl(5, 5));
+        MockManagedCursor c2 = new MockManagedCursor(container, "test2", new PositionImpl(5, 1));
+
+        container.add(c1, c1.getMarkDeletedPosition());
+        long version = container.getCursorWithOldestMarkDeletePosition().getVersion();
+
+        container.add(c2, c2.getMarkDeletedPosition());
+        long newVersion = container.getCursorWithOldestMarkDeletePosition().getVersion();
+        // newVersion > version
+        assertThat(ManagedCursorContainer.DataVersion.compareVersions(newVersion, version)).isPositive();
+        version = newVersion;
+
+        container.cursorUpdated(c2, new PositionImpl(5, 8));
+        newVersion = container.getCursorWithOldestMarkDeletePosition().getVersion();
+        // newVersion > version
+        assertThat(ManagedCursorContainer.DataVersion.compareVersions(newVersion, version)).isPositive();
+        version = newVersion;
+
+        container.removeCursor("test2");
+        newVersion = container.getCursorWithOldestMarkDeletePosition().getVersion();
+        // newVersion > version
+        assertThat(ManagedCursorContainer.DataVersion.compareVersions(newVersion, version)).isPositive();
     }
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -456,19 +456,19 @@ public class ManagedCursorContainerTest {
         ManagedCursor cursor1 = new MockManagedCursor(container, "test1", new PositionImpl(5, 5));
         container.add(cursor1, cursor1.getMarkDeletedPosition());
         assertEquals(container.getSlowestReaderPosition(), new PositionImpl(5, 5));
-        assertEqualsCursorAndMarkDelete(container.getCursorWithOldestMarkDeletePosition(),
+        assertEqualsCursorAndPosition(container.getCursorWithOldestPosition(),
                 cursor1, new PositionImpl(5, 5));
 
         ManagedCursor cursor2 = new MockManagedCursor(container, "test2", new PositionImpl(2, 2));
         container.add(cursor2, cursor2.getMarkDeletedPosition());
         assertEquals(container.getSlowestReaderPosition(), new PositionImpl(2, 2));
-        assertEqualsCursorAndMarkDelete(container.getCursorWithOldestMarkDeletePosition(),
+        assertEqualsCursorAndPosition(container.getCursorWithOldestPosition(),
                 cursor2, new PositionImpl(2, 2));
 
         ManagedCursor cursor3 = new MockManagedCursor(container, "test3", new PositionImpl(2, 0));
         container.add(cursor3, cursor3.getMarkDeletedPosition());
         assertEquals(container.getSlowestReaderPosition(), new PositionImpl(2, 0));
-        assertEqualsCursorAndMarkDelete(container.getCursorWithOldestMarkDeletePosition(),
+        assertEqualsCursorAndPosition(container.getCursorWithOldestPosition(),
                 cursor3, new PositionImpl(2, 0));
 
         assertEquals(container.toString(), "[test1=5:5, test2=2:2, test3=2:0]");
@@ -483,7 +483,7 @@ public class ManagedCursorContainerTest {
 
         cursor3.markDelete(new PositionImpl(3, 0));
         assertEquals(container.getSlowestReaderPosition(), new PositionImpl(2, 2));
-        assertEqualsCursorAndMarkDelete(container.getCursorWithOldestMarkDeletePosition(),
+        assertEqualsCursorAndPosition(container.getCursorWithOldestPosition(),
                 cursor2, new PositionImpl(2, 2));
 
         cursor2.markDelete(new PositionImpl(10, 5));
@@ -496,7 +496,7 @@ public class ManagedCursorContainerTest {
         container.removeCursor(cursor5.getName());
         container.removeCursor(cursor1.getName());
         assertEquals(container.getSlowestReaderPosition(), new PositionImpl(4, 0));
-        assertEqualsCursorAndMarkDelete(container.getCursorWithOldestMarkDeletePosition(),
+        assertEqualsCursorAndPosition(container.getCursorWithOldestPosition(),
                 cursor4, new PositionImpl(4, 0));
 
         assertTrue(container.hasDurableCursors());
@@ -533,15 +533,15 @@ public class ManagedCursorContainerTest {
         container.cursorUpdated(cursor2, cursor2.position);
 
         assertEquals(container.getSlowestReaderPosition(), new PositionImpl(5, 5));
-        assertEqualsCursorAndMarkDelete(container.getCursorWithOldestMarkDeletePosition(),
+        assertEqualsCursorAndPosition(container.getCursorWithOldestPosition(),
                 cursor1, new PositionImpl(5, 5));
     }
 
-    private void assertEqualsCursorAndMarkDelete(ManagedCursorContainer.CursorInfo cursorInfo,
-                                                 ManagedCursor expectedCursor,
-                                                 PositionImpl expectedMarkDeletePosition) {
+    private void assertEqualsCursorAndPosition(ManagedCursorContainer.CursorInfo cursorInfo,
+                                               ManagedCursor expectedCursor,
+                                               PositionImpl expectedPosition) {
         assertThat(cursorInfo.getCursor().getName()).isEqualTo(expectedCursor.getName());
-        assertThat(cursorInfo.getMarkDeletePosition()).isEqualTo(expectedMarkDeletePosition);
+        assertThat(cursorInfo.getPosition()).isEqualTo(expectedPosition);
     }
 
     @Test
@@ -777,22 +777,22 @@ public class ManagedCursorContainerTest {
         MockManagedCursor c2 = new MockManagedCursor(container, "test2", new PositionImpl(5, 1));
 
         container.add(c1, c1.getMarkDeletedPosition());
-        long version = container.getCursorWithOldestMarkDeletePosition().getVersion();
+        long version = container.getCursorWithOldestPosition().getVersion();
 
         container.add(c2, c2.getMarkDeletedPosition());
-        long newVersion = container.getCursorWithOldestMarkDeletePosition().getVersion();
+        long newVersion = container.getCursorWithOldestPosition().getVersion();
         // newVersion > version
         assertThat(ManagedCursorContainer.DataVersion.compareVersions(newVersion, version)).isPositive();
         version = newVersion;
 
         container.cursorUpdated(c2, new PositionImpl(5, 8));
-        newVersion = container.getCursorWithOldestMarkDeletePosition().getVersion();
+        newVersion = container.getCursorWithOldestPosition().getVersion();
         // newVersion > version
         assertThat(ManagedCursorContainer.DataVersion.compareVersions(newVersion, version)).isPositive();
         version = newVersion;
 
         container.removeCursor("test2");
-        newVersion = container.getCursorWithOldestMarkDeletePosition().getVersion();
+        newVersion = container.getCursorWithOldestPosition().getVersion();
         // newVersion > version
         assertThat(ManagedCursorContainer.DataVersion.compareVersions(newVersion, version)).isPositive();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,7 @@ flexible messaging model and an intuitive client API.</description>
     <!-- test dependencies -->
     <testcontainers.version>1.18.3</testcontainers.version>
     <hamcrest.version>2.2</hamcrest.version>
+    <restassured.version>5.4.0</restassured.version>
 
     <!-- Set docker-java.version to the version of docker-java used in Testcontainers -->
     <docker-java.version>3.3.0</docker-java.version>
@@ -1422,6 +1423,13 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
         <version>${checkerframework.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.rest-assured</groupId>
+        <artifactId>rest-assured</artifactId>
+        <version>${restassured.version}</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.2.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>pulsar-broker</artifactId>
@@ -428,6 +428,12 @@
     <dependency>
       <groupId>com.sun.activation</groupId>
       <artifactId>javax.activation</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <!-- transaction related dependencies (begin) -->

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -18,10 +18,12 @@
  */
 package org.apache.pulsar.broker.service;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedCursor.IndividualDeletedEntries;
@@ -32,6 +34,7 @@ import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.resources.NamespaceResources;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.service.persistent.PersistentTopicMetrics.BacklogQuotaMetrics;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
@@ -41,8 +44,11 @@ import org.apache.pulsar.metadata.api.MetadataStoreException;
 
 @Slf4j
 public class BacklogQuotaManager {
+    @Getter
     private final BacklogQuotaImpl defaultQuota;
     private final NamespaceResources namespaceResources;
+
+
 
     public BacklogQuotaManager(PulsarService pulsar) {
         double backlogQuotaGB = pulsar.getConfiguration().getBacklogQuotaDefaultLimitGB();
@@ -53,10 +59,6 @@ public class BacklogQuotaManager {
                 .retentionPolicy(pulsar.getConfiguration().getBacklogQuotaDefaultRetentionPolicy())
                 .build();
         this.namespaceResources = pulsar.getPulsarResources().getNamespaceResources();
-    }
-
-    public BacklogQuotaImpl getDefaultQuota() {
-        return this.defaultQuota;
     }
 
     public BacklogQuotaImpl getBacklogQuota(NamespaceName namespace, BacklogQuotaType backlogQuotaType) {
@@ -86,17 +88,21 @@ public class BacklogQuotaManager {
     public void handleExceededBacklogQuota(PersistentTopic persistentTopic, BacklogQuotaType backlogQuotaType,
                                            boolean preciseTimeBasedBacklogQuotaCheck) {
         BacklogQuota quota = persistentTopic.getBacklogQuota(backlogQuotaType);
+        BacklogQuotaMetrics topicBacklogQuotaMetrics =
+                persistentTopic.getPersistentTopicMetrics().getBacklogQuotaMetrics();
         log.info("Backlog quota type {} exceeded for topic [{}]. Applying [{}] policy", backlogQuotaType,
                 persistentTopic.getName(), quota.getPolicy());
         switch (quota.getPolicy()) {
-        case consumer_backlog_eviction:
+            case consumer_backlog_eviction:
             switch (backlogQuotaType) {
                 case destination_storage:
-                        dropBacklogForSizeLimit(persistentTopic, quota);
-                        break;
+                    dropBacklogForSizeLimit(persistentTopic, quota);
+                    topicBacklogQuotaMetrics.recordSizeBasedBacklogEviction();
+                    break;
                 case message_age:
-                        dropBacklogForTimeLimit(persistentTopic, quota, preciseTimeBasedBacklogQuotaCheck);
-                        break;
+                    dropBacklogForTimeLimit(persistentTopic, quota, preciseTimeBasedBacklogQuotaCheck);
+                    topicBacklogQuotaMetrics.recordTimeBasedBacklogEviction();
+                    break;
                 default:
                     break;
             }
@@ -194,6 +200,7 @@ public class BacklogQuotaManager {
      * @param quota
      *            Backlog quota set for the topic
      */
+    @SuppressWarnings("checkstyle:LineLength")
     private void dropBacklogForTimeLimit(PersistentTopic persistentTopic, BacklogQuota quota,
                                          boolean preciseTimeBasedBacklogQuotaCheck) {
         // If enabled precise time based backlog quota check, will expire message based on the timeBaseQuota
@@ -210,7 +217,7 @@ public class BacklogQuotaManager {
             );
         } else {
             // If disabled precise time based backlog quota check, will try to remove whole ledger from cursor's backlog
-            Long currentMillis = ((ManagedLedgerImpl) persistentTopic.getManagedLedger()).getClock().millis();
+            long currentMillis = ((ManagedLedgerImpl) persistentTopic.getManagedLedger()).getClock().millis();
             ManagedLedgerImpl mLedger = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
             try {
                 for (; ; ) {
@@ -229,7 +236,7 @@ public class BacklogQuotaManager {
                     }
                     // Timestamp only > 0 if ledger has been closed
                     if (ledgerInfo.getTimestamp() > 0
-                            && currentMillis - ledgerInfo.getTimestamp() > quota.getLimitTime() * 1000) {
+                            && currentMillis - ledgerInfo.getTimestamp() > SECONDS.toMillis(quota.getLimitTime())) {
                         // skip whole ledger for the slowest cursor
                         PositionImpl nextPosition =
                                 PositionImpl.get(mLedger.getNextValidLedger(ledgerInfo.getLedgerId()), -1);
@@ -263,19 +270,20 @@ public class BacklogQuotaManager {
             futures.add(producer.disconnect());
         });
 
-        FutureUtil.waitForAll(futures).thenRun(() -> {
-            log.info("All producers on topic [{}] are disconnected", persistentTopic.getName());
-        }).exceptionally(exception -> {
-            log.error("Error in disconnecting producers on topic [{}] [{}]", persistentTopic.getName(), exception);
-            return null;
-
+        FutureUtil.waitForAll(futures)
+                .thenRun(() ->
+                        log.info("All producers on topic [{}] are disconnected", persistentTopic.getName()))
+                .exceptionally(exception -> {
+                    log.error("Error in disconnecting producers on topic [{}] [{}]", persistentTopic.getName(),
+                            exception);
+                    return null;
         });
     }
 
     /**
      * Advances the slowest cursor if that is a system cursor.
      *
-     * @param persistentTopic
+     * @param persistentTopic Persistent topic
      * @return true if the slowest cursor is a system cursor
      */
     private boolean advanceSlowestSystemCursor(PersistentTopic persistentTopic) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -48,8 +48,6 @@ public class BacklogQuotaManager {
     private final BacklogQuotaImpl defaultQuota;
     private final NamespaceResources namespaceResources;
 
-
-
     public BacklogQuotaManager(PulsarService pulsar) {
         double backlogQuotaGB = pulsar.getConfiguration().getBacklogQuotaDefaultLimitGB();
         this.defaultQuota = BacklogQuotaImpl.builder()
@@ -94,28 +92,28 @@ public class BacklogQuotaManager {
                 persistentTopic.getName(), quota.getPolicy());
         switch (quota.getPolicy()) {
             case consumer_backlog_eviction:
-            switch (backlogQuotaType) {
-                case destination_storage:
-                    dropBacklogForSizeLimit(persistentTopic, quota);
-                    topicBacklogQuotaMetrics.recordSizeBasedBacklogEviction();
-                    break;
-                case message_age:
-                    dropBacklogForTimeLimit(persistentTopic, quota, preciseTimeBasedBacklogQuotaCheck);
-                    topicBacklogQuotaMetrics.recordTimeBasedBacklogEviction();
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case producer_exception:
-        case producer_request_hold:
-            if (!advanceSlowestSystemCursor(persistentTopic)) {
-                // The slowest is not a system cursor. Disconnecting producers to put backpressure.
-                disconnectProducers(persistentTopic);
-            }
-            break;
-        default:
-            break;
+                switch (backlogQuotaType) {
+                    case destination_storage:
+                        dropBacklogForSizeLimit(persistentTopic, quota);
+                        topicBacklogQuotaMetrics.recordSizeBasedBacklogEviction();
+                        break;
+                    case message_age:
+                        dropBacklogForTimeLimit(persistentTopic, quota, preciseTimeBasedBacklogQuotaCheck);
+                        topicBacklogQuotaMetrics.recordTimeBasedBacklogEviction();
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case producer_exception:
+            case producer_request_hold:
+                if (!advanceSlowestSystemCursor(persistentTopic)) {
+                    // The slowest is not a system cursor. Disconnecting producers to put backpressure.
+                    disconnectProducers(persistentTopic);
+                }
+                break;
+            default:
+                break;
         }
     }
 
@@ -200,7 +198,6 @@ public class BacklogQuotaManager {
      * @param quota
      *            Backlog quota set for the topic
      */
-    @SuppressWarnings("checkstyle:LineLength")
     private void dropBacklogForTimeLimit(PersistentTopic persistentTopic, BacklogQuota quota,
                                          boolean preciseTimeBasedBacklogQuotaCheck) {
         // If enabled precise time based backlog quota check, will expire message based on the timeBaseQuota

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -68,7 +68,7 @@ public interface Topic {
 
         /**
          * Return the producer name for the original producer.
-         *
+         * <p>
          * For messages published locally, this will return the same local producer name, though in case of replicated
          * messages, the original producer name will differ
          */
@@ -136,7 +136,7 @@ public interface Topic {
     /**
      * Tries to add a producer to the topic. Several validations will be performed.
      *
-     * @param producer
+     * @param producer Producer to add
      * @param producerQueuedFuture
      *            a future that will be triggered if the producer is being queued up prior of getting established
      * @return the "topic epoch" if there is one or empty
@@ -148,7 +148,7 @@ public interface Topic {
     /**
      * Wait TransactionBuffer Recovers completely.
      * Take snapshot after TB Recovers completely.
-     * @param isTxnEnabled
+     * @param isTxnEnabled isTxnEnabled
      * @return a future which has completely if isTxn = false. Or a future return by takeSnapshot.
      */
     CompletableFuture<Void> checkIfTransactionBufferRecoverCompletely(boolean isTxnEnabled);
@@ -262,6 +262,13 @@ public interface Topic {
     List<EntryFilter> getEntryFilters();
 
     BacklogQuota getBacklogQuota(BacklogQuotaType backlogQuotaType);
+
+    /**
+     * Uses the best-effort (not necessarily up-to-date) information available to return the age.
+     * @return The oldest unacknowledged message age in seconds, or -1 if not available
+     */
+    long getBestEffortOldestUnacknowledgedMessageAgeSeconds();
+
 
     void updateRates(NamespaceStats nsStats, NamespaceBundleStats currentBundleStats,
             StatsOutputStream topicStatsStream, ClusterReplicationMetrics clusterReplicationMetrics,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -65,6 +65,7 @@ import org.apache.pulsar.broker.service.SubscriptionOption;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.TopicPolicyListener;
 import org.apache.pulsar.broker.service.TransportCnx;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.stats.ClusterReplicationMetrics;
 import org.apache.pulsar.broker.stats.NamespaceStats;
 import org.apache.pulsar.client.api.MessageId;
@@ -1259,6 +1260,6 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
 
     @Override
     public long getBestEffortOldestUnacknowledgedMessageAgeSeconds() {
-        return -1;
+        return PersistentTopic.NOT_AVAILABLE_YET;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -168,7 +168,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                 .getPoliciesAsync(TopicName.get(topic).getNamespaceObject())
                 .thenCompose(optPolicies -> {
                     final Policies policies;
-                    if (!optPolicies.isPresent()) {
+                    if (optPolicies.isEmpty()) {
                         log.warn("[{}] Policies not present and isEncryptionRequired will be set to false", topic);
                         isEncryptionRequired = false;
                         policies = new Policies();
@@ -1255,5 +1255,10 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
     @Override
     public boolean isPersistent() {
         return false;
+    }
+
+    @Override
+    public long getBestEffortOldestUnacknowledgedMessageAgeSeconds() {
+        return -1;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopicMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopicMetrics.java
@@ -9,7 +9,6 @@ public class PersistentTopicMetrics {
     @Getter
     private final BacklogQuotaMetrics backlogQuotaMetrics = new BacklogQuotaMetrics();
 
-
     public static class BacklogQuotaMetrics {
         private final LongAdder timeBasedBacklogQuotaExceededEvictionCount = new LongAdder();
         private final LongAdder sizeBasedBacklogQuotaExceededEvictionCount = new LongAdder();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopicMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopicMetrics.java
@@ -1,0 +1,33 @@
+package org.apache.pulsar.broker.service.persistent;
+
+import java.util.concurrent.atomic.LongAdder;
+import lombok.Getter;
+
+@SuppressWarnings("LombokGetterMayBeUsed")
+public class PersistentTopicMetrics {
+
+    @Getter
+    private final BacklogQuotaMetrics backlogQuotaMetrics = new BacklogQuotaMetrics();
+
+
+    public static class BacklogQuotaMetrics {
+        private final LongAdder timeBasedBacklogQuotaExceededEvictionCount = new LongAdder();
+        private final LongAdder sizeBasedBacklogQuotaExceededEvictionCount = new LongAdder();
+
+        public void recordTimeBasedBacklogEviction() {
+            timeBasedBacklogQuotaExceededEvictionCount.increment();
+        }
+
+        public void recordSizeBasedBacklogEviction() {
+            sizeBasedBacklogQuotaExceededEvictionCount.increment();
+        }
+
+        public long getSizeBasedBacklogQuotaExceededEvictionCount() {
+            return sizeBasedBacklogQuotaExceededEvictionCount.longValue();
+        }
+
+        public long getTimeBasedBacklogQuotaExceededEvictionCount() {
+            return timeBasedBacklogQuotaExceededEvictionCount.longValue();
+        }
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedBrokerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedBrokerStats.java
@@ -33,7 +33,10 @@ public class AggregatedBrokerStats {
     public double storageReadRate;
     public double storageReadCacheMissesRate;
     public long msgBacklog;
+    public long sizeBasedBacklogQuotaExceededEvictionCount;
+    public long timeBasedBacklogQuotaExceededEvictionCount;
 
+    @SuppressWarnings("DuplicatedCode")
     void updateStats(TopicStats stats) {
         topicsCount++;
         subscriptionsCount += stats.subscriptionsCount;
@@ -49,8 +52,11 @@ public class AggregatedBrokerStats {
         storageReadRate += stats.managedLedgerStats.storageReadRate;
         storageReadCacheMissesRate += stats.managedLedgerStats.storageReadCacheMissesRate;
         msgBacklog += stats.msgBacklog;
+        timeBasedBacklogQuotaExceededEvictionCount += stats.timeBasedBacklogQuotaExceededEvictionCount;
+        sizeBasedBacklogQuotaExceededEvictionCount += stats.sizeBasedBacklogQuotaExceededEvictionCount;
     }
 
+    @SuppressWarnings("DuplicatedCode")
     public void reset() {
         topicsCount = 0;
         subscriptionsCount = 0;
@@ -66,5 +72,7 @@ public class AggregatedBrokerStats {
         storageReadRate = 0;
         storageReadCacheMissesRate = 0;
         msgBacklog = 0;
+        sizeBasedBacklogQuotaExceededEvictionCount = 0;
+        timeBasedBacklogQuotaExceededEvictionCount = 0;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedNamespaceStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/AggregatedNamespaceStats.java
@@ -51,6 +51,9 @@ public class AggregatedNamespaceStats {
     long backlogQuotaLimit;
     long backlogQuotaLimitTime;
 
+    public long sizeBasedBacklogQuotaExceededEvictionCount;
+    public long timeBasedBacklogQuotaExceededEvictionCount;
+
     public Map<String, AggregatedReplicationStats> replicationStats = new HashMap<>();
 
     public Map<String, AggregatedSubscriptionStats> subscriptionStats = new HashMap<>();
@@ -68,6 +71,7 @@ public class AggregatedNamespaceStats {
 
     Map<String, TopicMetricBean> bucketDelayedIndexStats = new HashMap<>();
 
+    @SuppressWarnings("DuplicatedCode")
     void updateStats(TopicStats stats) {
         topicsCount++;
 
@@ -104,6 +108,9 @@ public class AggregatedNamespaceStats {
         managedLedgerStats.offloadedStorageUsed += stats.managedLedgerStats.offloadedStorageUsed;
         backlogQuotaLimit = Math.max(backlogQuotaLimit, stats.backlogQuotaLimit);
         backlogQuotaLimitTime = Math.max(backlogQuotaLimitTime, stats.backlogQuotaLimitTime);
+
+        sizeBasedBacklogQuotaExceededEvictionCount += stats.sizeBasedBacklogQuotaExceededEvictionCount;
+        timeBasedBacklogQuotaExceededEvictionCount += stats.timeBasedBacklogQuotaExceededEvictionCount;
 
         managedLedgerStats.storageWriteRate += stats.managedLedgerStats.storageWriteRate;
         managedLedgerStats.storageReadRate += stats.managedLedgerStats.storageReadRate;
@@ -172,6 +179,7 @@ public class AggregatedNamespaceStats {
         compactionLatencyBuckets.addAll(stats.compactionLatencyBuckets);
     }
 
+    @SuppressWarnings("DuplicatedCode")
     public void reset() {
         managedLedgerStats.reset();
         topicsCount = 0;
@@ -200,6 +208,9 @@ public class AggregatedNamespaceStats {
 
         replicationStats.clear();
         subscriptionStats.clear();
+
+        sizeBasedBacklogQuotaExceededEvictionCount = 0;
+        timeBasedBacklogQuotaExceededEvictionCount = 0;
 
         compactionRemovedEventCount = 0;
         compactionSucceedCount = 0;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -32,7 +32,10 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
-import org.apache.pulsar.common.policies.data.BacklogQuota;
+import org.apache.pulsar.broker.service.persistent.PersistentTopicMetrics;
+import org.apache.pulsar.broker.service.persistent.PersistentTopicMetrics.BacklogQuotaMetrics;
+import org.apache.pulsar.broker.stats.prometheus.metrics.PrometheusLabels;
+import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
 import org.apache.pulsar.common.policies.data.stats.ConsumerStatsImpl;
 import org.apache.pulsar.common.policies.data.stats.NonPersistentSubscriptionStatsImpl;
 import org.apache.pulsar.common.policies.data.stats.NonPersistentTopicStatsImpl;
@@ -159,14 +162,15 @@ public class NamespaceStatsAggregator {
         subsStats.bucketDelayedIndexStats = subscriptionStats.bucketDelayedIndexStats;
     }
 
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     private static void getTopicStats(Topic topic, TopicStats stats, boolean includeConsumerMetrics,
                                       boolean includeProducerMetrics, boolean getPreciseBacklog,
                                       boolean subscriptionBacklogSize, Optional<CompactorMXBean> compactorMXBean) {
         stats.reset();
 
-        if (topic instanceof PersistentTopic) {
+        if (topic instanceof PersistentTopic persistentTopic) {
             // Managed Ledger stats
-            ManagedLedger ml = ((PersistentTopic) topic).getManagedLedger();
+            ManagedLedger ml = persistentTopic.getManagedLedger();
             ManagedLedgerMBeanImpl mlStats = (ManagedLedgerMBeanImpl) ml.getStats();
 
             stats.managedLedgerStats.storageSize = mlStats.getStoredMessagesSize();
@@ -174,9 +178,10 @@ public class NamespaceStatsAggregator {
             stats.managedLedgerStats.backlogSize = ml.getEstimatedBacklogSize();
             stats.managedLedgerStats.offloadedStorageUsed = ml.getOffloadedSize();
             stats.backlogQuotaLimit = topic
-                    .getBacklogQuota(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize();
+                    .getBacklogQuota(BacklogQuotaType.destination_storage).getLimitSize();
             stats.backlogQuotaLimitTime = topic
-                    .getBacklogQuota(BacklogQuota.BacklogQuotaType.message_age).getLimitTime();
+                    .getBacklogQuota(BacklogQuotaType.message_age).getLimitTime();
+            stats.backlogAgeSeconds = topic.getBestEffortOldestUnacknowledgedMessageAgeSeconds();
 
             stats.managedLedgerStats.storageWriteLatencyBuckets
                     .addAll(mlStats.getInternalAddEntryLatencyBuckets());
@@ -191,7 +196,17 @@ public class NamespaceStatsAggregator {
             stats.managedLedgerStats.storageWriteRate = mlStats.getAddEntryMessagesRate();
             stats.managedLedgerStats.storageReadRate = mlStats.getReadEntriesRate();
             stats.managedLedgerStats.storageReadCacheMissesRate = mlStats.getReadEntriesOpsCacheMissesRate();
+
+            // Topic Stats
+            PersistentTopicMetrics persistentTopicMetrics = persistentTopic.getPersistentTopicMetrics();
+
+            BacklogQuotaMetrics backlogQuotaMetrics = persistentTopicMetrics.getBacklogQuotaMetrics();
+            stats.sizeBasedBacklogQuotaExceededEvictionCount =
+                    backlogQuotaMetrics.getSizeBasedBacklogQuotaExceededEvictionCount();
+            stats.timeBasedBacklogQuotaExceededEvictionCount =
+                    backlogQuotaMetrics.getTimeBasedBacklogQuotaExceededEvictionCount();
         }
+
         TopicStatsImpl tStatus = topic.getStats(getPreciseBacklog, subscriptionBacklogSize, false);
         stats.msgInCounter = tStatus.msgInCounter;
         stats.bytesInCounter = tStatus.bytesInCounter;
@@ -334,6 +349,14 @@ public class NamespaceStatsAggregator {
         writeMetric(stream, "pulsar_broker_storage_read_rate", brokerStats.storageReadRate, cluster);
         writeMetric(stream, "pulsar_broker_storage_read_cache_misses_rate",
                 brokerStats.storageReadCacheMissesRate, cluster);
+
+        writePulsarBacklogQuotaMetricBrokerLevel(stream,
+                "pulsar_broker_storage_backlog_quota_exceeded_evictions_total",
+                brokerStats.sizeBasedBacklogQuotaExceededEvictionCount, cluster, BacklogQuotaType.destination_storage);
+        writePulsarBacklogQuotaMetricBrokerLevel(stream,
+                "pulsar_broker_storage_backlog_quota_exceeded_evictions_total",
+                brokerStats.timeBasedBacklogQuotaExceededEvictionCount, cluster, BacklogQuotaType.message_age);
+
         writeMetric(stream, "pulsar_broker_msg_backlog", brokerStats.msgBacklog, cluster);
     }
 
@@ -372,6 +395,7 @@ public class NamespaceStatsAggregator {
                 stats.managedLedgerStats.storageLogicalSize, cluster, namespace);
         writeMetric(stream, "pulsar_storage_backlog_size", stats.managedLedgerStats.backlogSize, cluster,
                 namespace);
+
         writeMetric(stream, "pulsar_storage_offloaded_size",
                 stats.managedLedgerStats.offloadedStorageUsed, cluster, namespace);
 
@@ -392,6 +416,14 @@ public class NamespaceStatsAggregator {
         });
 
         writePulsarMsgBacklog(stream, stats.msgBacklog, cluster, namespace);
+        writePulsarBacklogQuotaMetricNamespaceLevel(stream,
+                "pulsar_storage_backlog_quota_exceeded_evictions_total",
+                stats.sizeBasedBacklogQuotaExceededEvictionCount, cluster, namespace,
+                BacklogQuotaType.destination_storage);
+        writePulsarBacklogQuotaMetricNamespaceLevel(stream,
+                "pulsar_storage_backlog_quota_exceeded_evictions_total",
+                stats.timeBasedBacklogQuotaExceededEvictionCount, cluster, namespace,
+                BacklogQuotaType.message_age);
 
         stats.managedLedgerStats.storageWriteLatencyBuckets.refresh();
         long[] latencyBuckets = stats.managedLedgerStats.storageWriteLatencyBuckets.getBuckets();
@@ -469,6 +501,25 @@ public class NamespaceStatsAggregator {
                 replStats -> replStats.msgRateExpired, cluster, namespace);
         writeReplicationStat(stream, "pulsar_replication_delay_in_seconds", stats,
                 replStats -> replStats.replicationDelayInSeconds, cluster, namespace);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static void writePulsarBacklogQuotaMetricBrokerLevel(PrometheusMetricStreams stream, String metricName,
+                                                                 Number value, String cluster,
+                                                                 BacklogQuotaType backlogQuotaType) {
+        String quotaTypeLabelValue = PrometheusLabels.backlogQuotaTypeLabel(backlogQuotaType);
+        stream.writeSample(metricName, value, "cluster", cluster,
+                "quota_type", quotaTypeLabelValue);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static void writePulsarBacklogQuotaMetricNamespaceLevel(PrometheusMetricStreams stream, String metricName,
+                                                                    Number value, String cluster, String namespace,
+                                                                    BacklogQuotaType backlogQuotaType) {
+        String quotaTypeLabelValue = PrometheusLabels.backlogQuotaTypeLabel(backlogQuotaType);
+        stream.writeSample(metricName, value, "cluster", cluster,
+                "namespace", namespace,
+                "quota_type", quotaTypeLabelValue);
     }
 
     private static void writePulsarMsgBacklog(PrometheusMetricStreams stream, Number value,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
@@ -122,6 +122,7 @@ class TopicStats {
 
         timeBasedBacklogQuotaExceededEvictionCount = 0;
         sizeBasedBacklogQuotaExceededEvictionCount = 0;
+        backlogAgeSeconds = -1;
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
@@ -462,7 +463,7 @@ class TopicStats {
         writeTopicMetric(stream, metricName, value, cluster, namespace, topic, splitTopicAndPartitionIndexLabel);
     }
 
-    @SuppressWarnings({"CheckStyle", "SameParameterValue"})
+    @SuppressWarnings("SameParameterValue")
     private static void writeBacklogQuotaMetric(PrometheusMetricStreams stream, String metricName, Number value,
                                                 String cluster, String namespace, String topic,
                                                 boolean splitTopicAndPartitionIndexLabel,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
@@ -25,6 +25,8 @@ import java.util.Optional;
 import org.apache.bookkeeper.mledger.util.StatsBuckets;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.pulsar.broker.service.Consumer;
+import org.apache.pulsar.broker.stats.prometheus.metrics.PrometheusLabels;
+import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
 import org.apache.pulsar.common.policies.data.stats.TopicMetricBean;
 import org.apache.pulsar.compaction.CompactionRecord;
 import org.apache.pulsar.compaction.CompactorMXBean;
@@ -52,6 +54,7 @@ class TopicStats {
 
     long backlogQuotaLimit;
     long backlogQuotaLimitTime;
+    long backlogAgeSeconds;
 
     ManagedLedgerStats managedLedgerStats = new ManagedLedgerStats();
 
@@ -73,6 +76,11 @@ class TopicStats {
 
     Map<String, TopicMetricBean> bucketDelayedIndexStats = new HashMap<>();
 
+    public long sizeBasedBacklogQuotaExceededEvictionCount;
+    public long timeBasedBacklogQuotaExceededEvictionCount;
+
+
+    @SuppressWarnings("DuplicatedCode")
     public void reset() {
         subscriptionsCount = 0;
         producersCount = 0;
@@ -111,8 +119,12 @@ class TopicStats {
         compactionLatencyBuckets.reset();
         delayedMessageIndexSizeInBytes = 0;
         bucketDelayedIndexStats.clear();
+
+        timeBasedBacklogQuotaExceededEvictionCount = 0;
+        sizeBasedBacklogQuotaExceededEvictionCount = 0;
     }
 
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     public static void printTopicStats(PrometheusMetricStreams stream, TopicStats stats,
                                        Optional<CompactorMXBean> compactorMXBean, String cluster, String namespace,
                                        String topic, boolean splitTopicAndPartitionIndexLabel) {
@@ -165,6 +177,14 @@ class TopicStats {
                 cluster, namespace, topic, splitTopicAndPartitionIndexLabel);
         writeMetric(stream, "pulsar_storage_backlog_quota_limit_time", stats.backlogQuotaLimitTime,
                 cluster, namespace, topic, splitTopicAndPartitionIndexLabel);
+        writeMetric(stream, "pulsar_storage_backlog_age_seconds", stats.backlogAgeSeconds,
+                cluster, namespace, topic, splitTopicAndPartitionIndexLabel);
+        writeBacklogQuotaMetric(stream, "pulsar_storage_backlog_quota_exceeded_evictions_total",
+                stats.sizeBasedBacklogQuotaExceededEvictionCount, cluster, namespace, topic,
+                splitTopicAndPartitionIndexLabel, BacklogQuotaType.destination_storage);
+        writeBacklogQuotaMetric(stream, "pulsar_storage_backlog_quota_exceeded_evictions_total",
+                stats.timeBasedBacklogQuotaExceededEvictionCount, cluster, namespace, topic,
+                splitTopicAndPartitionIndexLabel, BacklogQuotaType.message_age);
 
         writeMetric(stream, "pulsar_delayed_message_index_size_bytes", stats.delayedMessageIndexSizeInBytes,
                 cluster, namespace, topic, splitTopicAndPartitionIndexLabel);
@@ -440,6 +460,17 @@ class TopicStats {
     private static void writeMetric(PrometheusMetricStreams stream, String metricName, Number value, String cluster,
                                     String namespace, String topic, boolean splitTopicAndPartitionIndexLabel) {
         writeTopicMetric(stream, metricName, value, cluster, namespace, topic, splitTopicAndPartitionIndexLabel);
+    }
+
+    @SuppressWarnings({"CheckStyle", "SameParameterValue"})
+    private static void writeBacklogQuotaMetric(PrometheusMetricStreams stream, String metricName, Number value,
+                                                String cluster, String namespace, String topic,
+                                                boolean splitTopicAndPartitionIndexLabel,
+                                                BacklogQuotaType backlogQuotaType) {
+
+        String quotaTypeLabelValue = PrometheusLabels.backlogQuotaTypeLabel(backlogQuotaType);
+        writeTopicMetric(stream, metricName, value, cluster, namespace, topic, splitTopicAndPartitionIndexLabel,
+                "quota_type", quotaTypeLabelValue);
     }
 
     private static void writeMetric(PrometheusMetricStreams stream, String metricName, Number value, String cluster,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/PrometheusLabels.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/PrometheusLabels.java
@@ -1,0 +1,14 @@
+package org.apache.pulsar.broker.stats.prometheus.metrics;
+
+import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
+
+public class PrometheusLabels {
+
+    public static String backlogQuotaTypeLabel(BacklogQuotaType backlogQuotaType) {
+        if (backlogQuotaType == BacklogQuotaType.message_age) {
+            return "time";
+        } else /* destination_storage */ {
+            return "size";
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -145,7 +145,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer().topic(testTopic).create();
         HashMap<String, String> properties = new HashMap<>();
-        properties.put("backlogQuotaTypeLabel", "message_age");
+        properties.put("backlogQuotaType", "message_age");
         admin.topics().updateProperties(testTopic, properties);
         admin.topics().delete(topicName.toString(), true);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -145,7 +145,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer().topic(testTopic).create();
         HashMap<String, String> properties = new HashMap<>();
-        properties.put("backlogQuotaType", "message_age");
+        properties.put("backlogQuotaTypeLabel", "message_age");
         admin.topics().updateProperties(testTopic, properties);
         admin.topics().delete(topicName.toString(), true);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -126,6 +127,29 @@ public class SubscriptionSeekTest extends BrokerTestBase {
         Awaitility.await().until(consumer::isConnected);
         consumer.seek(afterLatest);
         assertEquals(sub.getNumberOfEntriesInBacklog(false), 0);
+    }
+
+    @Test
+    public void testSeekIsByReceive() throws PulsarClientException {
+        final String topicName = "persistent://prop/use/ns-abc/testSeek";
+
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
+
+        String subscriptionName = "my-subscription";
+        org.apache.pulsar.client.api.Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName)
+                .subscriptionName(subscriptionName)
+                .subscribe();
+
+        List<MessageId> messageIds = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            String message = "my-message-" + i;
+            MessageId msgId = producer.send(message.getBytes());
+            messageIds.add(msgId);
+        }
+
+        consumer.seek(messageIds.get(5));
+        Message<byte[]> message = consumer.receive();
+        assertThat(message.getMessageId()).isEqualTo(messageIds.get(6));
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/BucketDelayedDeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/BucketDelayedDeliveryTest.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.broker.service.persistent;
 
 import static org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.CURSOR_INTERNAL_PROPERTY_PREFIX;
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.Metric;
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.parseMetrics;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -41,7 +43,6 @@ import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.delayed.BucketDelayedDeliveryTrackerFactory;
 import org.apache.pulsar.broker.service.Dispatcher;
-import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.MessageId;
@@ -219,9 +220,9 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, true, true, output);
         String metricsStr = output.toString(StandardCharsets.UTF_8);
-        Multimap<String, PrometheusMetricsClient.Metric> metricsMap = PrometheusMetricsClient.parseMetrics(metricsStr);
+        Multimap<String, Metric> metricsMap = parseMetrics(metricsStr);
 
-        List<PrometheusMetricsClient.Metric> bucketsMetrics =
+        List<Metric> bucketsMetrics =
                 metricsMap.get("pulsar_delayed_message_index_bucket_total").stream()
                         .filter(metric -> metric.tags.get("topic").equals(topic)).toList();
         MutableInt bucketsSum = new MutableInt();
@@ -230,12 +231,12 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
             bucketsSum.add(metric.value);
         });
         assertEquals(6, bucketsSum.intValue());
-        Optional<PrometheusMetricsClient.Metric> bucketsTopicMetric =
+        Optional<Metric> bucketsTopicMetric =
                 bucketsMetrics.stream().filter(metric -> !metric.tags.containsKey("subscription")).findFirst();
         assertTrue(bucketsTopicMetric.isPresent());
         assertEquals(bucketsSum.intValue(), bucketsTopicMetric.get().value);
 
-        List<PrometheusMetricsClient.Metric> loadedIndexMetrics =
+        List<Metric> loadedIndexMetrics =
                 metricsMap.get("pulsar_delayed_message_index_loaded").stream()
                         .filter(metric -> metric.tags.get("topic").equals(topic)).toList();
         MutableInt loadedIndexSum = new MutableInt();
@@ -244,12 +245,12 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
             loadedIndexSum.add(metric.value);
         }).count();
         assertEquals(2, count);
-        Optional<PrometheusMetricsClient.Metric> loadedIndexTopicMetrics =
+        Optional<Metric> loadedIndexTopicMetrics =
                 bucketsMetrics.stream().filter(metric -> !metric.tags.containsKey("subscription")).findFirst();
         assertTrue(loadedIndexTopicMetrics.isPresent());
         assertEquals(loadedIndexSum.intValue(), loadedIndexTopicMetrics.get().value);
 
-        List<PrometheusMetricsClient.Metric> snapshotSizeBytesMetrics =
+        List<Metric> snapshotSizeBytesMetrics =
                 metricsMap.get("pulsar_delayed_message_index_bucket_snapshot_size_bytes").stream()
                         .filter(metric -> metric.tags.get("topic").equals(topic)).toList();
         MutableInt snapshotSizeBytesSum = new MutableInt();
@@ -259,12 +260,12 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
                     snapshotSizeBytesSum.add(metric.value);
                 }).count();
         assertEquals(2, count);
-        Optional<PrometheusMetricsClient.Metric> snapshotSizeBytesTopicMetrics =
+        Optional<Metric> snapshotSizeBytesTopicMetrics =
                 snapshotSizeBytesMetrics.stream().filter(metric -> !metric.tags.containsKey("subscription")).findFirst();
         assertTrue(snapshotSizeBytesTopicMetrics.isPresent());
         assertEquals(snapshotSizeBytesSum.intValue(), snapshotSizeBytesTopicMetrics.get().value);
 
-        List<PrometheusMetricsClient.Metric> opCountMetrics =
+        List<Metric> opCountMetrics =
                 metricsMap.get("pulsar_delayed_message_index_bucket_op_count").stream()
                         .filter(metric -> metric.tags.get("topic").equals(topic)).toList();
         MutableInt opCountMetricsSum = new MutableInt();
@@ -276,14 +277,14 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
                     opCountMetricsSum.add(metric.value);
                 }).count();
         assertEquals(2, count);
-        Optional<PrometheusMetricsClient.Metric> opCountTopicMetrics =
+        Optional<Metric> opCountTopicMetrics =
                 opCountMetrics.stream()
                         .filter(metric -> metric.tags.get("state").equals("succeed") && metric.tags.get("type")
                                 .equals("create") && !metric.tags.containsKey("subscription")).findFirst();
         assertTrue(opCountTopicMetrics.isPresent());
         assertEquals(opCountMetricsSum.intValue(), opCountTopicMetrics.get().value);
 
-        List<PrometheusMetricsClient.Metric> opLatencyMetrics =
+        List<Metric> opLatencyMetrics =
                 metricsMap.get("pulsar_delayed_message_index_bucket_op_latency_ms").stream()
                         .filter(metric -> metric.tags.get("topic").equals(topic)).toList();
         MutableInt opLatencyMetricsSum = new MutableInt();
@@ -295,7 +296,7 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
                     opLatencyMetricsSum.add(metric.value);
                 }).count();
         assertTrue(count >= 2);
-        Optional<PrometheusMetricsClient.Metric> opLatencyTopicMetrics =
+        Optional<Metric> opLatencyTopicMetrics =
                 opCountMetrics.stream()
                         .filter(metric -> metric.tags.get("type").equals("create")
                                 && !metric.tags.containsKey("subscription")).findFirst();
@@ -304,9 +305,9 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
 
         ByteArrayOutputStream namespaceOutput = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, true, true, namespaceOutput);
-        Multimap<String, PrometheusMetricsClient.Metric> namespaceMetricsMap = PrometheusMetricsClient.parseMetrics(namespaceOutput.toString(StandardCharsets.UTF_8));
+        Multimap<String, Metric> namespaceMetricsMap = parseMetrics(namespaceOutput.toString(StandardCharsets.UTF_8));
 
-        Optional<PrometheusMetricsClient.Metric> namespaceMetric =
+        Optional<Metric> namespaceMetric =
                 namespaceMetricsMap.get("pulsar_delayed_message_index_bucket_total").stream().findFirst();
         assertTrue(namespaceMetric.isPresent());
         assertEquals(6, namespaceMetric.get().value);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.broker.service.persistent;
 
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.Metric;
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.parseMetrics;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
@@ -62,7 +64,6 @@ import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.broker.service.TopicPoliciesService;
-import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
@@ -356,14 +357,14 @@ public class PersistentTopicTest extends BrokerTestBase {
         PrometheusMetricsGenerator.generate(pulsar, exposeTopicLevelMetrics, true, true, output);
         String metricsStr = output.toString(StandardCharsets.UTF_8);
 
-        Multimap<String, PrometheusMetricsClient.Metric> metricsMap = PrometheusMetricsClient.parseMetrics(metricsStr);
-        Collection<PrometheusMetricsClient.Metric> metrics = metricsMap.get("pulsar_delayed_message_index_size_bytes");
+        Multimap<String, Metric> metricsMap = parseMetrics(metricsStr);
+        Collection<Metric> metrics = metricsMap.get("pulsar_delayed_message_index_size_bytes");
         Assert.assertTrue(metrics.size() > 0);
 
         int topicLevelNum = 0;
         int namespaceLevelNum = 0;
         int subscriptionLevelNum = 0;
-        for (PrometheusMetricsClient.Metric metric : metrics) {
+        for (Metric metric : metrics) {
             if (exposeTopicLevelMetrics && metric.tags.get("topic").equals(topic)) {
                 Assert.assertTrue(metric.value > 0);
                 topicLevelNum++;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -62,7 +62,7 @@ import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.broker.service.TopicPoliciesService;
-import org.apache.pulsar.broker.stats.PrometheusMetricsTest;
+import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
@@ -356,14 +356,14 @@ public class PersistentTopicTest extends BrokerTestBase {
         PrometheusMetricsGenerator.generate(pulsar, exposeTopicLevelMetrics, true, true, output);
         String metricsStr = output.toString(StandardCharsets.UTF_8);
 
-        Multimap<String, PrometheusMetricsTest.Metric> metricsMap = PrometheusMetricsTest.parseMetrics(metricsStr);
-        Collection<PrometheusMetricsTest.Metric> metrics = metricsMap.get("pulsar_delayed_message_index_size_bytes");
+        Multimap<String, PrometheusMetricsClient.Metric> metricsMap = PrometheusMetricsClient.parseMetrics(metricsStr);
+        Collection<PrometheusMetricsClient.Metric> metrics = metricsMap.get("pulsar_delayed_message_index_size_bytes");
         Assert.assertTrue(metrics.size() > 0);
 
         int topicLevelNum = 0;
         int namespaceLevelNum = 0;
         int subscriptionLevelNum = 0;
-        for (PrometheusMetricsTest.Metric metric : metrics) {
+        for (PrometheusMetricsClient.Metric metric : metrics) {
             if (exposeTopicLevelMetrics && metric.tags.get("topic").equals(topic)) {
                 Assert.assertTrue(metric.value > 0);
                 topicLevelNum++;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/SchemaServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/SchemaServiceTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.broker.service.schema;
 
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.Metric;
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.parseMetrics;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertEquals;
@@ -45,7 +47,6 @@ import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.service.schema.SchemaRegistry.SchemaAndMetadata;
-import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.impl.schema.KeyValueSchemaInfo;
@@ -123,29 +124,29 @@ public class SchemaServiceTest extends MockedPulsarServiceBaseTest {
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, output);
         output.flush();
         String metricsStr = output.toString(StandardCharsets.UTF_8);
-        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
+        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsClient.Metric> delMetrics = metrics.get("pulsar_schema_del_ops_failed_total");
+        Collection<Metric> delMetrics = metrics.get("pulsar_schema_del_ops_failed_total");
         Assert.assertEquals(delMetrics.size(), 0);
-        Collection<PrometheusMetricsClient.Metric> getMetrics = metrics.get("pulsar_schema_get_ops_failed_total");
+        Collection<Metric> getMetrics = metrics.get("pulsar_schema_get_ops_failed_total");
         Assert.assertEquals(getMetrics.size(), 0);
-        Collection<PrometheusMetricsClient.Metric> putMetrics = metrics.get("pulsar_schema_put_ops_failed_total");
+        Collection<Metric> putMetrics = metrics.get("pulsar_schema_put_ops_failed_total");
         Assert.assertEquals(putMetrics.size(), 0);
 
-        Collection<PrometheusMetricsClient.Metric> deleteLatency = metrics.get("pulsar_schema_del_ops_latency_count");
-        for (PrometheusMetricsClient.Metric metric : deleteLatency) {
+        Collection<Metric> deleteLatency = metrics.get("pulsar_schema_del_ops_latency_count");
+        for (Metric metric : deleteLatency) {
             Assert.assertEquals(metric.tags.get("namespace"), namespace);
             Assert.assertTrue(metric.value > 0);
         }
 
-        Collection<PrometheusMetricsClient.Metric> getLatency = metrics.get("pulsar_schema_get_ops_latency_count");
-        for (PrometheusMetricsClient.Metric metric : getLatency) {
+        Collection<Metric> getLatency = metrics.get("pulsar_schema_get_ops_latency_count");
+        for (Metric metric : getLatency) {
             Assert.assertEquals(metric.tags.get("namespace"), namespace);
             Assert.assertTrue(metric.value > 0);
         }
 
-        Collection<PrometheusMetricsClient.Metric> putLatency = metrics.get("pulsar_schema_put_ops_latency_count");
-        for (PrometheusMetricsClient.Metric metric : putLatency) {
+        Collection<Metric> putLatency = metrics.get("pulsar_schema_put_ops_latency_count");
+        for (Metric metric : putLatency) {
             Assert.assertEquals(metric.tags.get("namespace"), namespace);
             Assert.assertTrue(metric.value > 0);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/SchemaServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/SchemaServiceTest.java
@@ -45,7 +45,7 @@ import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.service.schema.SchemaRegistry.SchemaAndMetadata;
-import org.apache.pulsar.broker.stats.PrometheusMetricsTest;
+import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.impl.schema.KeyValueSchemaInfo;
@@ -123,29 +123,29 @@ public class SchemaServiceTest extends MockedPulsarServiceBaseTest {
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, output);
         output.flush();
         String metricsStr = output.toString(StandardCharsets.UTF_8);
-        Multimap<String, PrometheusMetricsTest.Metric> metrics = PrometheusMetricsTest.parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsTest.Metric> delMetrics = metrics.get("pulsar_schema_del_ops_failed_total");
+        Collection<PrometheusMetricsClient.Metric> delMetrics = metrics.get("pulsar_schema_del_ops_failed_total");
         Assert.assertEquals(delMetrics.size(), 0);
-        Collection<PrometheusMetricsTest.Metric> getMetrics = metrics.get("pulsar_schema_get_ops_failed_total");
+        Collection<PrometheusMetricsClient.Metric> getMetrics = metrics.get("pulsar_schema_get_ops_failed_total");
         Assert.assertEquals(getMetrics.size(), 0);
-        Collection<PrometheusMetricsTest.Metric> putMetrics = metrics.get("pulsar_schema_put_ops_failed_total");
+        Collection<PrometheusMetricsClient.Metric> putMetrics = metrics.get("pulsar_schema_put_ops_failed_total");
         Assert.assertEquals(putMetrics.size(), 0);
 
-        Collection<PrometheusMetricsTest.Metric> deleteLatency = metrics.get("pulsar_schema_del_ops_latency_count");
-        for (PrometheusMetricsTest.Metric metric : deleteLatency) {
+        Collection<PrometheusMetricsClient.Metric> deleteLatency = metrics.get("pulsar_schema_del_ops_latency_count");
+        for (PrometheusMetricsClient.Metric metric : deleteLatency) {
             Assert.assertEquals(metric.tags.get("namespace"), namespace);
             Assert.assertTrue(metric.value > 0);
         }
 
-        Collection<PrometheusMetricsTest.Metric> getLatency = metrics.get("pulsar_schema_get_ops_latency_count");
-        for (PrometheusMetricsTest.Metric metric : getLatency) {
+        Collection<PrometheusMetricsClient.Metric> getLatency = metrics.get("pulsar_schema_get_ops_latency_count");
+        for (PrometheusMetricsClient.Metric metric : getLatency) {
             Assert.assertEquals(metric.tags.get("namespace"), namespace);
             Assert.assertTrue(metric.value > 0);
         }
 
-        Collection<PrometheusMetricsTest.Metric> putLatency = metrics.get("pulsar_schema_put_ops_latency_count");
-        for (PrometheusMetricsTest.Metric metric : putLatency) {
+        Collection<PrometheusMetricsClient.Metric> putLatency = metrics.get("pulsar_schema_put_ops_latency_count");
+        for (PrometheusMetricsClient.Metric metric : putLatency) {
             Assert.assertEquals(metric.tags.get("namespace"), namespace);
             Assert.assertTrue(metric.value > 0);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.broker.stats;
 
 import static org.apache.pulsar.broker.BrokerTestUtil.spyWithClassAndConstructorArgs;
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.Metric;
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.parseMetrics;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.AssertJUnit.assertEquals;
@@ -50,7 +52,6 @@ import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.service.plugin.EntryFilter;
 import org.apache.pulsar.broker.service.plugin.EntryFilterProducerTest;
 import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
-import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
@@ -337,11 +338,11 @@ public class ConsumerStatsTest extends ProducerConsumerBase {
         PrometheusMetricsGenerator.generate(pulsar, exposeTopicLevelMetrics, true, true, output);
         String metricStr = output.toString(StandardCharsets.UTF_8);
 
-        Multimap<String, PrometheusMetricsClient.Metric> metricsMap = PrometheusMetricsClient.parseMetrics(metricStr);
-        Collection<PrometheusMetricsClient.Metric> ackRateMetric = metricsMap.get("pulsar_consumer_msg_ack_rate");
+        Multimap<String, Metric> metricsMap = parseMetrics(metricStr);
+        Collection<Metric> ackRateMetric = metricsMap.get("pulsar_consumer_msg_ack_rate");
 
         String rateOutMetricName = exposeTopicLevelMetrics ? "pulsar_consumer_msg_rate_out" : "pulsar_rate_out";
-        Collection<PrometheusMetricsClient.Metric> rateOutMetric = metricsMap.get(rateOutMetricName);
+        Collection<Metric> rateOutMetric = metricsMap.get(rateOutMetricName);
         Assert.assertTrue(ackRateMetric.size() > 0);
         Assert.assertTrue(rateOutMetric.size() > 0);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
@@ -50,6 +50,7 @@ import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.service.plugin.EntryFilter;
 import org.apache.pulsar.broker.service.plugin.EntryFilterProducerTest;
 import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
+import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
@@ -336,11 +337,11 @@ public class ConsumerStatsTest extends ProducerConsumerBase {
         PrometheusMetricsGenerator.generate(pulsar, exposeTopicLevelMetrics, true, true, output);
         String metricStr = output.toString(StandardCharsets.UTF_8);
 
-        Multimap<String, PrometheusMetricsTest.Metric> metricsMap = PrometheusMetricsTest.parseMetrics(metricStr);
-        Collection<PrometheusMetricsTest.Metric> ackRateMetric = metricsMap.get("pulsar_consumer_msg_ack_rate");
+        Multimap<String, PrometheusMetricsClient.Metric> metricsMap = PrometheusMetricsClient.parseMetrics(metricStr);
+        Collection<PrometheusMetricsClient.Metric> ackRateMetric = metricsMap.get("pulsar_consumer_msg_ack_rate");
 
         String rateOutMetricName = exposeTopicLevelMetrics ? "pulsar_consumer_msg_rate_out" : "pulsar_rate_out";
-        Collection<PrometheusMetricsTest.Metric> rateOutMetric = metricsMap.get(rateOutMetricName);
+        Collection<PrometheusMetricsClient.Metric> rateOutMetric = metricsMap.get(rateOutMetricName);
         Assert.assertTrue(ackRateMetric.size() > 0);
         Assert.assertTrue(rateOutMetric.size() > 0);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/MetadataStoreStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/MetadataStoreStatsTest.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
 import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -101,12 +102,12 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, false, output);
         String metricsStr = output.toString();
-        Multimap<String, PrometheusMetricsTest.Metric> metricsMap = PrometheusMetricsTest.parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metricsMap = PrometheusMetricsClient.parseMetrics(metricsStr);
 
         String metricsDebugMessage = "Assertion failed with metrics:\n" + metricsStr + "\n";
 
-        Collection<PrometheusMetricsTest.Metric> opsLatency = metricsMap.get("pulsar_metadata_store_ops_latency_ms" + "_sum");
-        Collection<PrometheusMetricsTest.Metric> putBytes = metricsMap.get("pulsar_metadata_store_put_bytes" + "_total");
+        Collection<PrometheusMetricsClient.Metric> opsLatency = metricsMap.get("pulsar_metadata_store_ops_latency_ms" + "_sum");
+        Collection<PrometheusMetricsClient.Metric> putBytes = metricsMap.get("pulsar_metadata_store_put_bytes" + "_total");
 
         Assert.assertTrue(opsLatency.size() > 1, metricsDebugMessage);
         Assert.assertTrue(putBytes.size() > 1, metricsDebugMessage);
@@ -116,7 +117,7 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
         expectedMetadataStoreName.add(MetadataStoreConfig.CONFIGURATION_METADATA_STORE);
 
         AtomicInteger matchCount = new AtomicInteger(0);
-        for (PrometheusMetricsTest.Metric m : opsLatency) {
+        for (PrometheusMetricsClient.Metric m : opsLatency) {
             Assert.assertEquals(m.tags.get("cluster"), "test", metricsDebugMessage);
             String metadataStoreName = m.tags.get("name");
             if (!isExpectedLabel(metadataStoreName, expectedMetadataStoreName, matchCount)) {
@@ -150,7 +151,7 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
         Assert.assertEquals(matchCount.get(), expectedMetadataStoreName.size() * 6);
 
         matchCount = new AtomicInteger(0);
-        for (PrometheusMetricsTest.Metric m : putBytes) {
+        for (PrometheusMetricsClient.Metric m : putBytes) {
             Assert.assertEquals(m.tags.get("cluster"), "test", metricsDebugMessage);
             String metadataStoreName = m.tags.get("name");
             if (!isExpectedLabel(metadataStoreName, expectedMetadataStoreName, matchCount)) {
@@ -191,12 +192,12 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, false, output);
         String metricsStr = output.toString();
-        Multimap<String, PrometheusMetricsTest.Metric> metricsMap = PrometheusMetricsTest.parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metricsMap = PrometheusMetricsClient.parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsTest.Metric> executorQueueSize = metricsMap.get("pulsar_batch_metadata_store_executor_queue_size");
-        Collection<PrometheusMetricsTest.Metric> opsWaiting = metricsMap.get("pulsar_batch_metadata_store_queue_wait_time_ms" + "_sum");
-        Collection<PrometheusMetricsTest.Metric> batchExecuteTime = metricsMap.get("pulsar_batch_metadata_store_batch_execute_time_ms" + "_sum");
-        Collection<PrometheusMetricsTest.Metric> opsPerBatch = metricsMap.get("pulsar_batch_metadata_store_batch_size" + "_sum");
+        Collection<PrometheusMetricsClient.Metric> executorQueueSize = metricsMap.get("pulsar_batch_metadata_store_executor_queue_size");
+        Collection<PrometheusMetricsClient.Metric> opsWaiting = metricsMap.get("pulsar_batch_metadata_store_queue_wait_time_ms" + "_sum");
+        Collection<PrometheusMetricsClient.Metric> batchExecuteTime = metricsMap.get("pulsar_batch_metadata_store_batch_execute_time_ms" + "_sum");
+        Collection<PrometheusMetricsClient.Metric> opsPerBatch = metricsMap.get("pulsar_batch_metadata_store_batch_size" + "_sum");
 
         String metricsDebugMessage = "Assertion failed with metrics:\n" + metricsStr + "\n";
 
@@ -210,7 +211,7 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
         expectedMetadataStoreName.add(MetadataStoreConfig.CONFIGURATION_METADATA_STORE);
 
         AtomicInteger matchCount = new AtomicInteger(0);
-        for (PrometheusMetricsTest.Metric m : executorQueueSize) {
+        for (PrometheusMetricsClient.Metric m : executorQueueSize) {
             Assert.assertEquals(m.tags.get("cluster"), "test", metricsDebugMessage);
             String metadataStoreName = m.tags.get("name");
             if (isExpectedLabel(metadataStoreName, expectedMetadataStoreName, matchCount)) {
@@ -221,7 +222,7 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
         Assert.assertEquals(matchCount.get(), expectedMetadataStoreName.size());
 
         matchCount = new AtomicInteger(0);
-        for (PrometheusMetricsTest.Metric m : opsWaiting) {
+        for (PrometheusMetricsClient.Metric m : opsWaiting) {
             Assert.assertEquals(m.tags.get("cluster"), "test", metricsDebugMessage);
             String metadataStoreName = m.tags.get("name");
             if (isExpectedLabel(metadataStoreName, expectedMetadataStoreName, matchCount)) {
@@ -232,7 +233,7 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
         Assert.assertEquals(matchCount.get(), expectedMetadataStoreName.size());
 
         matchCount = new AtomicInteger(0);
-        for (PrometheusMetricsTest.Metric m : batchExecuteTime) {
+        for (PrometheusMetricsClient.Metric m : batchExecuteTime) {
             Assert.assertEquals(m.tags.get("cluster"), "test", metricsDebugMessage);
             String metadataStoreName = m.tags.get("name");
             if (isExpectedLabel(metadataStoreName, expectedMetadataStoreName, matchCount)) {
@@ -243,7 +244,7 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
         Assert.assertEquals(matchCount.get(), expectedMetadataStoreName.size());
 
         matchCount = new AtomicInteger(0);
-        for (PrometheusMetricsTest.Metric m : opsPerBatch) {
+        for (PrometheusMetricsClient.Metric m : opsPerBatch) {
             Assert.assertEquals(m.tags.get("cluster"), "test", metricsDebugMessage);
             String metadataStoreName = m.tags.get("name");
             if (isExpectedLabel(metadataStoreName, expectedMetadataStoreName, matchCount)) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/MetadataStoreStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/MetadataStoreStatsTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.broker.stats;
 
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.Metric;
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.parseMetrics;
 import com.google.common.collect.Multimap;
 import java.io.ByteArrayOutputStream;
 import java.util.Collection;
@@ -31,7 +33,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
 import org.apache.pulsar.broker.service.BrokerTestBase;
-import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -102,12 +103,12 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, false, output);
         String metricsStr = output.toString();
-        Multimap<String, PrometheusMetricsClient.Metric> metricsMap = PrometheusMetricsClient.parseMetrics(metricsStr);
+        Multimap<String, Metric> metricsMap = parseMetrics(metricsStr);
 
         String metricsDebugMessage = "Assertion failed with metrics:\n" + metricsStr + "\n";
 
-        Collection<PrometheusMetricsClient.Metric> opsLatency = metricsMap.get("pulsar_metadata_store_ops_latency_ms" + "_sum");
-        Collection<PrometheusMetricsClient.Metric> putBytes = metricsMap.get("pulsar_metadata_store_put_bytes" + "_total");
+        Collection<Metric> opsLatency = metricsMap.get("pulsar_metadata_store_ops_latency_ms" + "_sum");
+        Collection<Metric> putBytes = metricsMap.get("pulsar_metadata_store_put_bytes" + "_total");
 
         Assert.assertTrue(opsLatency.size() > 1, metricsDebugMessage);
         Assert.assertTrue(putBytes.size() > 1, metricsDebugMessage);
@@ -117,7 +118,7 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
         expectedMetadataStoreName.add(MetadataStoreConfig.CONFIGURATION_METADATA_STORE);
 
         AtomicInteger matchCount = new AtomicInteger(0);
-        for (PrometheusMetricsClient.Metric m : opsLatency) {
+        for (Metric m : opsLatency) {
             Assert.assertEquals(m.tags.get("cluster"), "test", metricsDebugMessage);
             String metadataStoreName = m.tags.get("name");
             if (!isExpectedLabel(metadataStoreName, expectedMetadataStoreName, matchCount)) {
@@ -151,7 +152,7 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
         Assert.assertEquals(matchCount.get(), expectedMetadataStoreName.size() * 6);
 
         matchCount = new AtomicInteger(0);
-        for (PrometheusMetricsClient.Metric m : putBytes) {
+        for (Metric m : putBytes) {
             Assert.assertEquals(m.tags.get("cluster"), "test", metricsDebugMessage);
             String metadataStoreName = m.tags.get("name");
             if (!isExpectedLabel(metadataStoreName, expectedMetadataStoreName, matchCount)) {
@@ -192,12 +193,12 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, false, output);
         String metricsStr = output.toString();
-        Multimap<String, PrometheusMetricsClient.Metric> metricsMap = PrometheusMetricsClient.parseMetrics(metricsStr);
+        Multimap<String, Metric> metricsMap = parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsClient.Metric> executorQueueSize = metricsMap.get("pulsar_batch_metadata_store_executor_queue_size");
-        Collection<PrometheusMetricsClient.Metric> opsWaiting = metricsMap.get("pulsar_batch_metadata_store_queue_wait_time_ms" + "_sum");
-        Collection<PrometheusMetricsClient.Metric> batchExecuteTime = metricsMap.get("pulsar_batch_metadata_store_batch_execute_time_ms" + "_sum");
-        Collection<PrometheusMetricsClient.Metric> opsPerBatch = metricsMap.get("pulsar_batch_metadata_store_batch_size" + "_sum");
+        Collection<Metric> executorQueueSize = metricsMap.get("pulsar_batch_metadata_store_executor_queue_size");
+        Collection<Metric> opsWaiting = metricsMap.get("pulsar_batch_metadata_store_queue_wait_time_ms" + "_sum");
+        Collection<Metric> batchExecuteTime = metricsMap.get("pulsar_batch_metadata_store_batch_execute_time_ms" + "_sum");
+        Collection<Metric> opsPerBatch = metricsMap.get("pulsar_batch_metadata_store_batch_size" + "_sum");
 
         String metricsDebugMessage = "Assertion failed with metrics:\n" + metricsStr + "\n";
 
@@ -211,7 +212,7 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
         expectedMetadataStoreName.add(MetadataStoreConfig.CONFIGURATION_METADATA_STORE);
 
         AtomicInteger matchCount = new AtomicInteger(0);
-        for (PrometheusMetricsClient.Metric m : executorQueueSize) {
+        for (Metric m : executorQueueSize) {
             Assert.assertEquals(m.tags.get("cluster"), "test", metricsDebugMessage);
             String metadataStoreName = m.tags.get("name");
             if (isExpectedLabel(metadataStoreName, expectedMetadataStoreName, matchCount)) {
@@ -222,7 +223,7 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
         Assert.assertEquals(matchCount.get(), expectedMetadataStoreName.size());
 
         matchCount = new AtomicInteger(0);
-        for (PrometheusMetricsClient.Metric m : opsWaiting) {
+        for (Metric m : opsWaiting) {
             Assert.assertEquals(m.tags.get("cluster"), "test", metricsDebugMessage);
             String metadataStoreName = m.tags.get("name");
             if (isExpectedLabel(metadataStoreName, expectedMetadataStoreName, matchCount)) {
@@ -233,7 +234,7 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
         Assert.assertEquals(matchCount.get(), expectedMetadataStoreName.size());
 
         matchCount = new AtomicInteger(0);
-        for (PrometheusMetricsClient.Metric m : batchExecuteTime) {
+        for (Metric m : batchExecuteTime) {
             Assert.assertEquals(m.tags.get("cluster"), "test", metricsDebugMessage);
             String metadataStoreName = m.tags.get("name");
             if (isExpectedLabel(metadataStoreName, expectedMetadataStoreName, matchCount)) {
@@ -244,7 +245,7 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
         Assert.assertEquals(matchCount.get(), expectedMetadataStoreName.size());
 
         matchCount = new AtomicInteger(0);
-        for (PrometheusMetricsClient.Metric m : opsPerBatch) {
+        for (Metric m : opsPerBatch) {
             Assert.assertEquals(m.tags.get("cluster"), "test", metricsDebugMessage);
             String metadataStoreName = m.tags.get("name");
             if (isExpectedLabel(metadataStoreName, expectedMetadataStoreName, matchCount)) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -23,9 +23,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.prometheus.client.Collector;
@@ -49,7 +47,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -73,6 +70,7 @@ import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentMessageExpiryMonitor;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.MessageRoutingMode;
@@ -169,7 +167,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
         assertTrue(metrics.containsKey("pulsar_publish_rate_limit_times"));
         metrics.get("pulsar_publish_rate_limit_times").forEach(item -> {
             if (ns1.equals(item.tags.get("namespace"))) {
@@ -205,7 +203,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut2 = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut2);
         String metricsStr2 = statsOut2.toString();
-        Multimap<String, Metric> metrics2 = parseMetrics(metricsStr2);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics2 = PrometheusMetricsClient.parseMetrics(metricsStr2);
         assertTrue(metrics2.containsKey("pulsar_publish_rate_limit_times"));
         metrics2.get("pulsar_publish_rate_limit_times").forEach(item -> {
             if (ns1.equals(item.tags.get("namespace"))) {
@@ -237,8 +235,8 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
-        Collection<Metric> metric = metrics.get("pulsar_topics_count");
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
+        Collection<PrometheusMetricsClient.Metric> metric = metrics.get("pulsar_topics_count");
         metric.forEach(item -> {
             if (ns1.equals(item.tags.get("namespace"))) {
                 assertEquals(item.value, 6.0);
@@ -247,12 +245,12 @@ public class PrometheusMetricsTest extends BrokerTestBase {
                 assertEquals(item.value, 3.0);
             }
         });
-        Collection<Metric> pulsarTopicLoadTimesMetrics = metrics.get("pulsar_topic_load_times");
-        Collection<Metric> pulsarTopicLoadTimesCountMetrics = metrics.get("pulsar_topic_load_times_count");
+        Collection<PrometheusMetricsClient.Metric> pulsarTopicLoadTimesMetrics = metrics.get("pulsar_topic_load_times");
+        Collection<PrometheusMetricsClient.Metric> pulsarTopicLoadTimesCountMetrics = metrics.get("pulsar_topic_load_times_count");
         assertEquals(pulsarTopicLoadTimesMetrics.size(), 6);
         assertEquals(pulsarTopicLoadTimesCountMetrics.size(), 1);
-        Collection<Metric> topicLoadTimeP999Metrics = metrics.get("pulsar_topic_load_time_99_9_percentile_ms");
-        Collection<Metric> topicLoadTimeFailedCountMetrics = metrics.get("pulsar_topic_load_failed_count");
+        Collection<PrometheusMetricsClient.Metric> topicLoadTimeP999Metrics = metrics.get("pulsar_topic_load_time_99_9_percentile_ms");
+        Collection<PrometheusMetricsClient.Metric> topicLoadTimeFailedCountMetrics = metrics.get("pulsar_topic_load_failed_count");
         assertEquals(topicLoadTimeP999Metrics.size(), 1);
         assertEquals(topicLoadTimeFailedCountMetrics.size(), 1);
     }
@@ -274,10 +272,10 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, true, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
         assertTrue(metrics.containsKey("pulsar_average_msg_size"));
         assertEquals(metrics.get("pulsar_average_msg_size").size(), 1);
-        Collection<Metric> avgMsgSizes = metrics.get("pulsar_average_msg_size");
+        Collection<PrometheusMetricsClient.Metric> avgMsgSizes = metrics.get("pulsar_average_msg_size");
         avgMsgSizes.forEach(item -> {
             if (ns1.equals(item.tags.get("namespace"))) {
                 assertEquals(item.value, 10);
@@ -317,50 +315,50 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
 
         metrics.entries().forEach(e -> {
             System.out.println(e.getKey() + ": " + e.getValue());
         });
 
         // There should be 2 metrics with different tags for each topic
-        List<Metric> cm = (List<Metric>) metrics.get("pulsar_storage_write_latency_le_1");
+        List<PrometheusMetricsClient.Metric> cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_storage_write_latency_le_1");
         assertEquals(cm.size(), 2);
         assertEquals(cm.get(0).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic2");
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
         assertEquals(cm.get(1).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic1");
         assertEquals(cm.get(1).tags.get("namespace"), "my-property/use/my-ns");
 
-        cm = (List<Metric>) metrics.get("pulsar_producers_count");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_producers_count");
         assertEquals(cm.size(), 2);
         assertEquals(cm.get(1).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic1");
         assertEquals(cm.get(1).tags.get("namespace"), "my-property/use/my-ns");
         assertEquals(cm.get(1).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic1");
         assertEquals(cm.get(1).tags.get("namespace"), "my-property/use/my-ns");
 
-        cm = (List<Metric>) metrics.get("pulsar_topic_load_times_count");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_topic_load_times_count");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).tags.get("cluster"), "test");
 
-        cm = (List<Metric>) metrics.get("topic_load_failed_total");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("topic_load_failed_total");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).tags.get("cluster"), "test");
 
-        cm = (List<Metric>) metrics.get("pulsar_in_bytes_total");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_in_bytes_total");
         assertEquals(cm.size(), 2);
         assertEquals(cm.get(0).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic2");
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
         assertEquals(cm.get(1).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic1");
         assertEquals(cm.get(1).tags.get("namespace"), "my-property/use/my-ns");
 
-        cm = (List<Metric>) metrics.get("pulsar_in_messages_total");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_in_messages_total");
         assertEquals(cm.size(), 2);
         assertEquals(cm.get(0).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic2");
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
         assertEquals(cm.get(1).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic1");
         assertEquals(cm.get(1).tags.get("namespace"), "my-property/use/my-ns");
 
-        cm = (List<Metric>) metrics.get("pulsar_out_bytes_total");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_out_bytes_total");
         assertEquals(cm.size(), 2);
         assertEquals(cm.get(0).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic2");
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
@@ -369,7 +367,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         assertEquals(cm.get(1).tags.get("namespace"), "my-property/use/my-ns");
         assertEquals(cm.get(1).tags.get("subscription"), "test");
 
-        cm = (List<Metric>) metrics.get("pulsar_out_messages_total");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_out_messages_total");
         assertEquals(cm.size(), 2);
         assertEquals(cm.get(0).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic2");
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
@@ -415,9 +413,9 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
 
-        Collection<Metric> brokerMetrics = metrics.get("pulsar_broker_topics_count");
+        Collection<PrometheusMetricsClient.Metric> brokerMetrics = metrics.get("pulsar_broker_topics_count");
         assertEquals(brokerMetrics.size(), 1);
         assertEquals(brokerMetrics.stream().toList().get(0).tags.get("cluster"), "test");
 
@@ -524,32 +522,32 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
 
         metrics.entries().forEach(e -> {
             System.out.println(e.getKey() + ": " + e.getValue());
         });
 
-        List<Metric> cm = (List<Metric>) metrics.get("pulsar_in_bytes_total");
+        List<PrometheusMetricsClient.Metric> cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_in_bytes_total");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).value, (messageSizeBytes * messages * 2));
         assertEquals(cm.get(0).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic1");
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
 
-        cm = (List<Metric>) metrics.get("pulsar_in_messages_total");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_in_messages_total");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).value, (messages * 2));
         assertEquals(cm.get(0).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic1");
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
 
-        cm = (List<Metric>) metrics.get("pulsar_out_bytes_total");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_out_bytes_total");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).value, (messageSizeBytes * messages * 2));
         assertEquals(cm.get(0).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic1");
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
         assertEquals(cm.get(0).tags.get("subscription"), "test");
 
-        cm = (List<Metric>) metrics.get("pulsar_out_messages_total");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_out_messages_total");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).value, (messages * 2));
         assertEquals(cm.get(0).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic1");
@@ -602,11 +600,11 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
 
         metrics.entries().forEach(e -> System.out.println(e.getKey() + ": " + e.getValue()));
 
-        List<Metric> cm = (List<Metric>) metrics.get("pulsar_storage_read_cache_misses_rate");
+        List<PrometheusMetricsClient.Metric> cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_storage_read_cache_misses_rate");
         assertEquals(cm.size(), 1);
         if (cacheEnable) {
             assertEquals(cm.get(0).value, 1.0);
@@ -618,7 +616,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         assertEquals(cm.get(0).tags.get("namespace"), ns);
         assertEquals(cm.get(0).tags.get("cluster"), "test");
 
-        List<Metric> brokerMetric = (List<Metric>) metrics.get("pulsar_broker_storage_read_cache_misses_rate");
+        List<PrometheusMetricsClient.Metric> brokerMetric = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_broker_storage_read_cache_misses_rate");
         assertEquals(brokerMetric.size(), 1);
         if (cacheEnable) {
             assertEquals(brokerMetric.get(0).value, 1.0);
@@ -634,11 +632,11 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut2 = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut2);
         String metricsStr2 = statsOut2.toString();
-        Multimap<String, Metric> metrics2 = parseMetrics(metricsStr2);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics2 = PrometheusMetricsClient.parseMetrics(metricsStr2);
 
         metrics2.entries().forEach(e -> System.out.println(e.getKey() + ": " + e.getValue()));
 
-        List<Metric> cm2 = (List<Metric>) metrics2.get("pulsar_storage_read_cache_misses_rate");
+        List<PrometheusMetricsClient.Metric> cm2 = (List<PrometheusMetricsClient.Metric>) metrics2.get("pulsar_storage_read_cache_misses_rate");
         assertEquals(cm2.size(), 1);
         if (cacheEnable) {
             assertEquals(cm2.get(0).value, 1.0);
@@ -650,7 +648,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         assertEquals(cm2.get(0).tags.get("namespace"), ns);
         assertEquals(cm2.get(0).tags.get("cluster"), "test");
 
-        List<Metric> brokerMetric2 = (List<Metric>) metrics.get("pulsar_broker_storage_read_cache_misses_rate");
+        List<PrometheusMetricsClient.Metric> brokerMetric2 = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_broker_storage_read_cache_misses_rate");
         assertEquals(brokerMetric2.size(), 1);
         if (cacheEnable) {
             assertEquals(brokerMetric2.get(0).value, 1.0);
@@ -662,7 +660,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         assertNull(brokerMetric2.get(0).tags.get("topic"));
 
         // test ManagedLedgerMetrics
-        List<Metric> mlMetric = ((List<Metric>) metrics.get("pulsar_ml_ReadEntriesOpsCacheMissesRate"));
+        List<PrometheusMetricsClient.Metric> mlMetric = ((List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_ml_ReadEntriesOpsCacheMissesRate"));
         assertEquals(mlMetric.size(), 1);
         if (cacheEnable) {
             assertEquals(mlMetric.get(0).value, 1.0);
@@ -718,9 +716,9 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
         // There should be 2 metrics with different tags for each topic
-        List<Metric> cm = (List<Metric>) metrics.get("pulsar_subscription_last_expire_timestamp");
+        List<PrometheusMetricsClient.Metric> cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_subscription_last_expire_timestamp");
         assertEquals(cm.size(), 2);
         assertEquals(cm.get(0).tags.get("topic"), topic2);
         assertEquals(cm.get(0).tags.get("namespace"), ns);
@@ -736,7 +734,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
             assertEquals((long) field.get(subscription), (long) cm.get(i).value);
         }
 
-        cm = (List<Metric>) metrics.get("pulsar_subscription_msg_rate_expired");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_subscription_msg_rate_expired");
         assertEquals(cm.size(), 2);
         assertEquals(cm.get(0).tags.get("topic"), topic2);
         assertEquals(cm.get(0).tags.get("namespace"), ns);
@@ -755,7 +753,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
             assertEquals(Double.valueOf(nf.format(monitor.getMessageExpiryRate())).doubleValue(), cm.get(i).value);
         }
 
-        cm = (List<Metric>) metrics.get("pulsar_subscription_total_msg_expired");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_subscription_total_msg_expired");
         assertEquals(cm.size(), 2);
         assertEquals(cm.get(0).tags.get("topic"), topic2);
         assertEquals(cm.get(0).tags.get("namespace"), ns);
@@ -799,7 +797,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
         assertTrue(metrics.containsKey("pulsar_bundle_msg_rate_in"));
         assertTrue(metrics.containsKey("pulsar_bundle_msg_rate_out"));
         assertTrue(metrics.containsKey("pulsar_bundle_topics_count"));
@@ -844,7 +842,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
         assertTrue(metrics.containsKey("pulsar_subscription_back_log"));
         assertTrue(metrics.containsKey("pulsar_subscription_back_log_no_delayed"));
         assertTrue(metrics.containsKey("pulsar_subscription_msg_throughput_out"));
@@ -892,36 +890,36 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
         String metricsStr = statsOut.toString();
 
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
 
         metrics.entries().forEach(e -> {
             System.out.println(e.getKey() + ": " + e.getValue());
         });
 
         // There should be 1 metric aggregated per namespace
-        List<Metric> cm = (List<Metric>) metrics.get("pulsar_storage_write_latency_le_1");
+        List<PrometheusMetricsClient.Metric> cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_storage_write_latency_le_1");
         assertEquals(cm.size(), 1);
         assertNull(cm.get(0).tags.get("topic"));
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
 
-        cm = (List<Metric>) metrics.get("pulsar_producers_count");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_producers_count");
         assertEquals(cm.size(), 1);
         assertNull(cm.get(0).tags.get("topic"));
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
 
-        cm = (List<Metric>) metrics.get("pulsar_in_bytes_total");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_in_bytes_total");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
 
-        cm = (List<Metric>) metrics.get("pulsar_in_messages_total");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_in_messages_total");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
 
-        cm = (List<Metric>) metrics.get("pulsar_out_bytes_total");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_out_bytes_total");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
 
-        cm = (List<Metric>) metrics.get("pulsar_out_messages_total");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_out_messages_total");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
 
@@ -965,13 +963,13 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         PrometheusMetricsGenerator.generate(pulsar, true, false, true, statsOut);
         String metricsStr = statsOut.toString();
 
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
 
         metrics.entries().forEach(e -> {
             System.out.println(e.getKey() + ": " + e.getValue());
         });
 
-        List<Metric> cm = (List<Metric>) metrics.get("pulsar_producer_msg_rate_in");
+        List<PrometheusMetricsClient.Metric> cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_producer_msg_rate_in");
         assertEquals(cm.size(), 2);
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
         assertEquals(cm.get(0).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic2");
@@ -983,7 +981,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         assertEquals(cm.get(1).tags.get("producer_name"), "producer1");
         assertEquals(cm.get(1).tags.get("producer_id"), "0");
 
-        cm = (List<Metric>) metrics.get("pulsar_producer_msg_throughput_in");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_producer_msg_throughput_in");
         assertEquals(cm.size(), 2);
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
         assertEquals(cm.get(0).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic2");
@@ -1033,14 +1031,14 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         PrometheusMetricsGenerator.generate(pulsar, true, true, false, statsOut);
         String metricsStr = statsOut.toString();
 
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
 
         metrics.entries().forEach(e -> {
             System.out.println(e.getKey() + ": " + e.getValue());
         });
 
         // There should be 1 metric aggregated per namespace
-        List<Metric> cm = (List<Metric>) metrics.get("pulsar_out_bytes_total");
+        List<PrometheusMetricsClient.Metric> cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_out_bytes_total");
         assertEquals(cm.size(), 4);
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
         assertEquals(cm.get(0).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic2");
@@ -1060,7 +1058,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         assertEquals(cm.get(3).tags.get("subscription"), "test");
         assertEquals(cm.get(3).tags.get("consumer_id"), "0");
 
-        cm = (List<Metric>) metrics.get("pulsar_out_messages_total");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_out_messages_total");
         assertEquals(cm.size(), 4);
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/use/my-ns");
         assertEquals(cm.get(0).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic2");
@@ -1224,17 +1222,17 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
         String metricsStr = statsOut.toString();
 
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
 
         metrics.entries().forEach(e ->
                 System.out.println(e.getKey() + ": " + e.getValue())
         );
 
-        List<Metric> cm = (List<Metric>) metrics.get("pulsar_ml_cache_evictions");
+        List<PrometheusMetricsClient.Metric> cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_ml_cache_evictions");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).tags.get("cluster"), "test");
 
-        cm = (List<Metric>) metrics.get("pulsar_ml_cache_hits_rate");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_ml_cache_hits_rate");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).tags.get("cluster"), "test");
 
@@ -1260,7 +1258,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
         String metricsStr = statsOut.toString();
 
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
 
         metrics.entries().forEach(e ->
                 System.out.println(e.getKey() + ": " + e.getValue())
@@ -1303,13 +1301,13 @@ public class PrometheusMetricsTest extends BrokerTestBase {
             }
         });
 
-        List<Metric> cm = (List<Metric>) metrics.get("pulsar_ml_AddEntryBytesRate");
+        List<PrometheusMetricsClient.Metric> cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_ml_AddEntryBytesRate");
         assertEquals(cm.size(), 2);
         assertEquals(cm.get(0).tags.get("cluster"), "test");
         String ns = cm.get(0).tags.get("namespace");
         assertTrue(ns.equals("my-property/use/my-ns") || ns.equals("my-property/use/my-ns2"));
 
-        cm = (List<Metric>) metrics.get("pulsar_ml_AddEntryMessagesRate");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_ml_AddEntryMessagesRate");
         assertEquals(cm.size(), 2);
         assertEquals(cm.get(0).tags.get("cluster"), "test");
         ns = cm.get(0).tags.get("namespace");
@@ -1338,32 +1336,32 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
         String metricsStr = statsOut.toString();
 
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
 
         metrics.entries().forEach(e ->
                 System.out.println(e.getKey() + ": " + e.getValue())
         );
 
-        List<Metric> cm = (List<Metric>) metrics.get(
+        List<PrometheusMetricsClient.Metric> cm = (List<PrometheusMetricsClient.Metric>) metrics.get(
                 keyNameBySubstrings(metrics,
                         "pulsar_managedLedger_client", "bookkeeper_ml_scheduler_threads"));
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).tags.get("cluster"), "test");
 
-        cm = (List<Metric>) metrics.get(
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get(
                 keyNameBySubstrings(metrics,
                         "pulsar_managedLedger_client", "bookkeeper_ml_scheduler_task_execution_sum"));
         assertEquals(cm.size(), 2);
         assertEquals(cm.get(0).tags.get("cluster"), "test");
 
-        cm = (List<Metric>) metrics.get(
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get(
                 keyNameBySubstrings(metrics,
                         "pulsar_managedLedger_client", "bookkeeper_ml_scheduler_max_queue_size"));
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).tags.get("cluster"), "test");
     }
 
-    private static String keyNameBySubstrings(Multimap<String, Metric> metrics, String... substrings) {
+    private static String keyNameBySubstrings(Multimap<String, PrometheusMetricsClient.Metric> metrics, String... substrings) {
         for (String key: metrics.keys()) {
             boolean found = true;
             for (String s: substrings) {
@@ -1418,10 +1416,10 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
-        List<Metric> cm = (List<Metric>) metrics.get("pulsar_authentication_success_total");
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
+        List<PrometheusMetricsClient.Metric> cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_authentication_success_total");
         boolean haveSucceed = false;
-        for (Metric metric : cm) {
+        for (PrometheusMetricsClient.Metric metric : cm) {
             if (Objects.equals(metric.tags.get("auth_method"), "token")
                     && Objects.equals(metric.tags.get("provider_name"), provider.getClass().getSimpleName())) {
                 haveSucceed = true;
@@ -1429,10 +1427,10 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         }
         Assert.assertTrue(haveSucceed);
 
-        cm = (List<Metric>) metrics.get("pulsar_authentication_failures_total");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_authentication_failures_total");
 
         boolean haveFailed = false;
-        for (Metric metric : cm) {
+        for (PrometheusMetricsClient.Metric metric : cm) {
             if (Objects.equals(metric.tags.get("auth_method"), "token")
                     && Objects.equals(metric.tags.get("reason"),
                     AuthenticationProviderToken.ErrorCode.INVALID_AUTH_DATA.name())
@@ -1479,8 +1477,8 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
-        List<Metric> cm = (List<Metric>) metrics.get("pulsar_expired_token_total");
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
+        List<PrometheusMetricsClient.Metric> cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_expired_token_total");
         assertEquals(cm.size(), 1);
 
         provider.close();
@@ -1520,10 +1518,10 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
-        Metric countMetric = ((List<Metric>) metrics.get("pulsar_expiring_token_minutes_count")).get(0);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
+        PrometheusMetricsClient.Metric countMetric = ((List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_expiring_token_minutes_count")).get(0);
         assertEquals(countMetric.value, tokenRemainTime.length);
-        List<Metric> cm = (List<Metric>) metrics.get("pulsar_expiring_token_minutes_bucket");
+        List<PrometheusMetricsClient.Metric> cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_expiring_token_minutes_bucket");
         assertEquals(cm.size(), 5);
         cm.forEach((e) -> {
             switch (e.tags.get("le")) {
@@ -1549,8 +1547,8 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
     @Test
     public void testParsingWithPositiveInfinityValue() {
-        Multimap<String, Metric> metrics = parseMetrics("pulsar_broker_publish_latency{cluster=\"test\",quantile=\"0.0\"} +Inf");
-        List<Metric> cm = (List<Metric>) metrics.get("pulsar_broker_publish_latency");
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics("pulsar_broker_publish_latency{cluster=\"test\",quantile=\"0.0\"} +Inf");
+        List<PrometheusMetricsClient.Metric> cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_broker_publish_latency");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).tags.get("cluster"), "test");
         assertEquals(cm.get(0).tags.get("quantile"), "0.0");
@@ -1559,8 +1557,8 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
     @Test
     public void testParsingWithNegativeInfinityValue() {
-        Multimap<String, Metric> metrics = parseMetrics("pulsar_broker_publish_latency{cluster=\"test\",quantile=\"0.0\"} -Inf");
-        List<Metric> cm = (List<Metric>) metrics.get("pulsar_broker_publish_latency");
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics("pulsar_broker_publish_latency{cluster=\"test\",quantile=\"0.0\"} -Inf");
+        List<PrometheusMetricsClient.Metric> cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_broker_publish_latency");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).tags.get("cluster"), "test");
         assertEquals(cm.get(0).tags.get("quantile"), "0.0");
@@ -1595,9 +1593,9 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
 
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
 
-        List<Metric> cm = (List<Metric>) metrics.get("pulsar_ml_cursor_persistLedgerSucceed");
+        List<PrometheusMetricsClient.Metric> cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_ml_cursor_persistLedgerSucceed");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).tags.get("cluster"), "test");
         assertEquals(cm.get(0).tags.get("cursor_name"), subName);
@@ -1607,8 +1605,8 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut2 = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut2);
         String metricsStr2 = statsOut2.toString();
-        Multimap<String, Metric> metrics2 = parseMetrics(metricsStr2);
-        List<Metric> cm2 = (List<Metric>) metrics2.get("pulsar_ml_cursor_persistLedgerSucceed");
+        Multimap<String, PrometheusMetricsClient.Metric> metrics2 = PrometheusMetricsClient.parseMetrics(metricsStr2);
+        List<PrometheusMetricsClient.Metric> cm2 = (List<PrometheusMetricsClient.Metric>) metrics2.get("pulsar_ml_cursor_persistLedgerSucceed");
         assertEquals(cm2.size(), 0);
 
         producer.close();
@@ -1626,17 +1624,17 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
-        List<Metric> cm = (List<Metric>) metrics.get("pulsar_connection_created_total_count");
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
+        List<PrometheusMetricsClient.Metric> cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_connection_created_total_count");
         compareBrokerConnectionStateCount(cm, 1.0);
 
-        cm = (List<Metric>) metrics.get("pulsar_connection_create_success_count");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_connection_create_success_count");
         compareBrokerConnectionStateCount(cm, 1.0);
 
-        cm = (List<Metric>) metrics.get("pulsar_connection_closed_total_count");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_connection_closed_total_count");
         compareBrokerConnectionStateCount(cm, 0.0);
 
-        cm = (List<Metric>) metrics.get("pulsar_active_connections");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_active_connections");
         compareBrokerConnectionStateCount(cm, 1.0);
 
         pulsarClient.close();
@@ -1644,8 +1642,8 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         metricsStr = statsOut.toString();
 
-        metrics = parseMetrics(metricsStr);
-        cm = (List<Metric>) metrics.get("pulsar_connection_closed_total_count");
+        metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_connection_closed_total_count");
         compareBrokerConnectionStateCount(cm, 1.0);
 
         pulsar.getConfiguration().setAuthenticationEnabled(true);
@@ -1667,24 +1665,24 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         metricsStr = statsOut.toString();
 
-        metrics = parseMetrics(metricsStr);
-        cm = (List<Metric>) metrics.get("pulsar_connection_closed_total_count");
+        metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_connection_closed_total_count");
         compareBrokerConnectionStateCount(cm, 2.0);
 
-        cm = (List<Metric>) metrics.get("pulsar_connection_create_fail_count");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_connection_create_fail_count");
         compareBrokerConnectionStateCount(cm, 1.0);
 
-        cm = (List<Metric>) metrics.get("pulsar_connection_create_success_count");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_connection_create_success_count");
         compareBrokerConnectionStateCount(cm, 1.0);
 
-        cm = (List<Metric>) metrics.get("pulsar_active_connections");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_active_connections");
         compareBrokerConnectionStateCount(cm, 0.0);
 
-        cm = (List<Metric>) metrics.get("pulsar_connection_created_total_count");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_connection_created_total_count");
         compareBrokerConnectionStateCount(cm, 2.0);
     }
 
-    private void compareBrokerConnectionStateCount(List<Metric> cm, double count) {
+    private void compareBrokerConnectionStateCount(List<PrometheusMetricsClient.Metric> cm, double count) {
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).tags.get("cluster"), "test");
         assertEquals(cm.get(0).tags.get("broker"), "localhost");
@@ -1695,7 +1693,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
     void testParseMetrics() throws IOException {
         String sampleMetrics = IOUtils.toString(getClass().getClassLoader()
                 .getResourceAsStream("prometheus_metrics_sample.txt"), StandardCharsets.UTF_8);
-        parseMetrics(sampleMetrics);
+        PrometheusMetricsClient.parseMetrics(sampleMetrics);
     }
 
     @Test
@@ -1710,22 +1708,22 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
-        List<Metric> cm = (List<Metric>) metrics.get("pulsar_compaction_removed_event_count");
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
+        List<PrometheusMetricsClient.Metric> cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_compaction_removed_event_count");
         assertEquals(cm.size(), 0);
-        cm = (List<Metric>) metrics.get("pulsar_compaction_succeed_count");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_compaction_succeed_count");
         assertEquals(cm.size(), 0);
-        cm = (List<Metric>) metrics.get("pulsar_compaction_failed_count");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_compaction_failed_count");
         assertEquals(cm.size(), 0);
-        cm = (List<Metric>) metrics.get("pulsar_compaction_duration_time_in_mills");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_compaction_duration_time_in_mills");
         assertEquals(cm.size(), 0);
-        cm = (List<Metric>) metrics.get("pulsar_compaction_read_throughput");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_compaction_read_throughput");
         assertEquals(cm.size(), 0);
-        cm = (List<Metric>) metrics.get("pulsar_compaction_write_throughput");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_compaction_write_throughput");
         assertEquals(cm.size(), 0);
-        cm = (List<Metric>) metrics.get("pulsar_compaction_compacted_entries_count");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_compaction_compacted_entries_count");
         assertEquals(cm.size(), 0);
-        cm = (List<Metric>) metrics.get("pulsar_compaction_compacted_entries_size");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_compaction_compacted_entries_size");
         assertEquals(cm.size(), 0);
         //
         final int numMessages = 1000;
@@ -1745,29 +1743,29 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         metricsStr = statsOut.toString();
-        metrics = parseMetrics(metricsStr);
-        cm = (List<Metric>) metrics.get("pulsar_compaction_removed_event_count");
+        metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_compaction_removed_event_count");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).value, 990);
-        cm = (List<Metric>) metrics.get("pulsar_compaction_succeed_count");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_compaction_succeed_count");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).value, 1);
-        cm = (List<Metric>) metrics.get("pulsar_compaction_failed_count");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_compaction_failed_count");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).value, 0);
-        cm = (List<Metric>) metrics.get("pulsar_compaction_duration_time_in_mills");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_compaction_duration_time_in_mills");
         assertEquals(cm.size(), 1);
         assertTrue(cm.get(0).value > 0);
-        cm = (List<Metric>) metrics.get("pulsar_compaction_read_throughput");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_compaction_read_throughput");
         assertEquals(cm.size(), 1);
         assertTrue(cm.get(0).value > 0);
-        cm = (List<Metric>) metrics.get("pulsar_compaction_write_throughput");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_compaction_write_throughput");
         assertEquals(cm.size(), 1);
         assertTrue(cm.get(0).value > 0);
-        cm = (List<Metric>) metrics.get("pulsar_compaction_compacted_entries_count");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_compaction_compacted_entries_count");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).value, 10);
-        cm = (List<Metric>) metrics.get("pulsar_compaction_compacted_entries_size");
+        cm = (List<PrometheusMetricsClient.Metric>) metrics.get("pulsar_compaction_compacted_entries_size");
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).value, 840);
 
@@ -1797,7 +1795,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
                 String metricsStr1 = statsOut1.toString();
                 String metricsStr2 = statsOut2.toString();
                 assertEquals(metricsStr1, metricsStr2);
-                Multimap<String, Metric> metrics = parseMetrics(metricsStr1);
+                Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr1);
             }
 
             Thread.sleep(TimeUnit.SECONDS.toMillis(period / 2));
@@ -1830,8 +1828,8 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, true,  statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
-        Collection<Metric> metric = metrics.get("pulsar_consumers_count");
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
+        Collection<PrometheusMetricsClient.Metric> metric = metrics.get("pulsar_consumers_count");
         assertTrue(metric.size() >= 15);
         metric.forEach(item -> {
             if (ns1.equals(item.tags.get("namespace"))) {
@@ -1846,7 +1844,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         consumer2.close();
     }
 
-    private void compareCompactionStateCount(List<Metric> cm, double count) {
+    private void compareCompactionStateCount(List<PrometheusMetricsClient.Metric> cm, double count) {
         assertEquals(cm.size(), 1);
         assertEquals(cm.get(0).tags.get("cluster"), "test");
         assertEquals(cm.get(0).tags.get("broker"), "localhost");
@@ -1908,62 +1906,6 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         p1.close();
         p2.close();
-    }
-
-    /**
-     * Hacky parsing of Prometheus text format. Should be good enough for unit tests
-     */
-    public static Multimap<String, Metric> parseMetrics(String metrics) {
-        Multimap<String, Metric> parsed = ArrayListMultimap.create();
-
-        // Example of lines are
-        // jvm_threads_current{cluster="standalone",} 203.0
-        // or
-        // pulsar_subscriptions_count{cluster="standalone", namespace="public/default",
-        // topic="persistent://public/default/test-2"} 0.0
-        Pattern pattern = Pattern.compile("^(\\w+)\\{([^\\}]+)\\}\\s([+-]?[\\d\\w\\.-]+)$");
-        Pattern tagsPattern = Pattern.compile("(\\w+)=\"([^\"]+)\"(,\\s?)?");
-
-        Splitter.on("\n").split(metrics).forEach(line -> {
-            if (line.isEmpty() || line.startsWith("#")) {
-                return;
-            }
-
-            Matcher matcher = pattern.matcher(line);
-            assertTrue(matcher.matches(), "line " + line + " does not match pattern " + pattern);
-            String name = matcher.group(1);
-
-            Metric m = new Metric();
-            String numericValue = matcher.group(3);
-            if (numericValue.equalsIgnoreCase("-Inf")) {
-                m.value = Double.NEGATIVE_INFINITY;
-            } else if (numericValue.equalsIgnoreCase("+Inf")) {
-                m.value = Double.POSITIVE_INFINITY;
-            } else {
-                m.value = Double.parseDouble(numericValue);
-            }
-            String tags = matcher.group(2);
-            Matcher tagsMatcher = tagsPattern.matcher(tags);
-            while (tagsMatcher.find()) {
-                String tag = tagsMatcher.group(1);
-                String value = tagsMatcher.group(2);
-                m.tags.put(tag, value);
-            }
-
-            parsed.put(name, m);
-        });
-
-        return parsed;
-    }
-
-    public static class Metric {
-        public Map<String, String> tags = new TreeMap<>();
-        public double value;
-
-        @Override
-        public String toString() {
-            return MoreObjects.toStringHelper(this).add("tags", tags).add("value", value).toString();
-        }
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/SubscriptionStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/SubscriptionStatsTest.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.broker.stats;
 
 import static org.apache.pulsar.broker.BrokerTestUtil.spyWithClassAndConstructorArgs;
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.Metric;
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.parseMetrics;
 import static org.mockito.Mockito.mock;
 import com.google.common.collect.Multimap;
 import java.io.ByteArrayOutputStream;
@@ -35,7 +37,6 @@ import org.apache.pulsar.broker.service.EntryFilterSupport;
 import org.apache.pulsar.broker.service.plugin.EntryFilter;
 import org.apache.pulsar.broker.service.plugin.EntryFilterTest;
 import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
-import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
@@ -85,7 +86,7 @@ public class SubscriptionStatsTest extends ProducerConsumerBase {
     @Test
     public void testConsumersAfterMarkDelete() throws PulsarClientException, PulsarAdminException {
         final String topicName = "persistent://my-property/my-ns/testConsumersAfterMarkDelete-"
-                + UUID.randomUUID().toString();
+                + UUID.randomUUID();
         final String subName = "my-sub";
 
         Consumer<byte[]> consumer1 = pulsarClient.newConsumer()
@@ -234,15 +235,15 @@ public class SubscriptionStatsTest extends ProducerConsumerBase {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, enableTopicStats, false, false, output);
         String metricsStr = output.toString();
-        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
+        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsClient.Metric> throughFilterMetrics =
+        Collection<Metric> throughFilterMetrics =
                 metrics.get("pulsar_subscription_filter_processed_msg_count");
-        Collection<PrometheusMetricsClient.Metric> acceptedMetrics =
+        Collection<Metric> acceptedMetrics =
                 metrics.get("pulsar_subscription_filter_accepted_msg_count");
-        Collection<PrometheusMetricsClient.Metric> rejectedMetrics =
+        Collection<Metric> rejectedMetrics =
                 metrics.get("pulsar_subscription_filter_rejected_msg_count");
-        Collection<PrometheusMetricsClient.Metric> rescheduledMetrics =
+        Collection<Metric> rescheduledMetrics =
                 metrics.get("pulsar_subscription_filter_rescheduled_msg_count");
 
         if (enableTopicStats) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/SubscriptionStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/SubscriptionStatsTest.java
@@ -35,6 +35,7 @@ import org.apache.pulsar.broker.service.EntryFilterSupport;
 import org.apache.pulsar.broker.service.plugin.EntryFilter;
 import org.apache.pulsar.broker.service.plugin.EntryFilterTest;
 import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
+import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
@@ -233,15 +234,15 @@ public class SubscriptionStatsTest extends ProducerConsumerBase {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, enableTopicStats, false, false, output);
         String metricsStr = output.toString();
-        Multimap<String, PrometheusMetricsTest.Metric> metrics = PrometheusMetricsTest.parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsTest.Metric> throughFilterMetrics =
+        Collection<PrometheusMetricsClient.Metric> throughFilterMetrics =
                 metrics.get("pulsar_subscription_filter_processed_msg_count");
-        Collection<PrometheusMetricsTest.Metric> acceptedMetrics =
+        Collection<PrometheusMetricsClient.Metric> acceptedMetrics =
                 metrics.get("pulsar_subscription_filter_accepted_msg_count");
-        Collection<PrometheusMetricsTest.Metric> rejectedMetrics =
+        Collection<PrometheusMetricsClient.Metric> rejectedMetrics =
                 metrics.get("pulsar_subscription_filter_rejected_msg_count");
-        Collection<PrometheusMetricsTest.Metric> rescheduledMetrics =
+        Collection<PrometheusMetricsClient.Metric> rescheduledMetrics =
                 metrics.get("pulsar_subscription_filter_rescheduled_msg_count");
 
         if (enableTopicStats) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionMetricsTest.java
@@ -19,7 +19,7 @@
 package org.apache.pulsar.broker.stats;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.apache.pulsar.broker.stats.PrometheusMetricsTest.parseMetrics;
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.parseMetrics;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -39,6 +39,7 @@ import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.MessageId;
@@ -119,8 +120,8 @@ public class TransactionMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, PrometheusMetricsTest.Metric> metrics = parseMetrics(metricsStr);
-        Collection<PrometheusMetricsTest.Metric> metric = metrics.get("pulsar_txn_active_count");
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = parseMetrics(metricsStr);
+        Collection<PrometheusMetricsClient.Metric> metric = metrics.get("pulsar_txn_active_count");
         assertEquals(metric.size(), 2);
         metric.forEach(item -> {
             if ("0".equals(item.tags.get("coordinator_id"))) {
@@ -187,9 +188,9 @@ public class TransactionMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, PrometheusMetricsTest.Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsTest.Metric> metric = metrics.get("pulsar_txn_created_total");
+        Collection<PrometheusMetricsClient.Metric> metric = metrics.get("pulsar_txn_created_total");
         assertEquals(metric.size(), 1);
         metric.forEach(item -> assertEquals(item.value, txnCount));
 
@@ -274,9 +275,9 @@ public class TransactionMetricsTest extends BrokerTestBase {
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
 
-        Multimap<String, PrometheusMetricsTest.Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsTest.Metric> metric = metrics.get("pulsar_storage_size");
+        Collection<PrometheusMetricsClient.Metric> metric = metrics.get("pulsar_storage_size");
         checkManagedLedgerMetrics(subName, 32, metric);
         checkManagedLedgerMetrics(MLTransactionLogImpl.TRANSACTION_SUBSCRIPTION_NAME, 252, metric);
 
@@ -336,12 +337,12 @@ public class TransactionMetricsTest extends BrokerTestBase {
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
 
-        Multimap<String, PrometheusMetricsTest.Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsTest.Metric> metric = metrics.get("pulsar_storage_size");
+        Collection<PrometheusMetricsClient.Metric> metric = metrics.get("pulsar_storage_size");
         checkManagedLedgerMetrics(subName, 32, metric);
         //No statistics of the pendingAck are generated when the pendingAck is not initialized.
-        for (PrometheusMetricsTest.Metric metric1 : metric) {
+        for (PrometheusMetricsClient.Metric metric1 : metric) {
             if (metric1.tags.containsValue(subName2)) {
                 Assert.fail();
             }
@@ -431,9 +432,9 @@ public class TransactionMetricsTest extends BrokerTestBase {
 
     }
 
-    private void checkManagedLedgerMetrics(String tag, double value, Collection<PrometheusMetricsTest.Metric> metrics) {
+    private void checkManagedLedgerMetrics(String tag, double value, Collection<PrometheusMetricsClient.Metric> metrics) {
         boolean exist = false;
-        for (PrometheusMetricsTest.Metric metric1 : metrics) {
+        for (PrometheusMetricsClient.Metric metric1 : metrics) {
             if (metric1.tags.containsValue(tag)) {
                 assertEquals(metric1.value, value);
                 exist = true;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionMetricsTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.stats;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.Metric;
 import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.parseMetrics;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -39,7 +40,6 @@ import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.BrokerTestBase;
-import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.MessageId;
@@ -120,8 +120,8 @@ public class TransactionMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, PrometheusMetricsClient.Metric> metrics = parseMetrics(metricsStr);
-        Collection<PrometheusMetricsClient.Metric> metric = metrics.get("pulsar_txn_active_count");
+        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
+        Collection<Metric> metric = metrics.get("pulsar_txn_active_count");
         assertEquals(metric.size(), 2);
         metric.forEach(item -> {
             if ("0".equals(item.tags.get("coordinator_id"))) {
@@ -188,9 +188,9 @@ public class TransactionMetricsTest extends BrokerTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, PrometheusMetricsClient.Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsClient.Metric> metric = metrics.get("pulsar_txn_created_total");
+        Collection<Metric> metric = metrics.get("pulsar_txn_created_total");
         assertEquals(metric.size(), 1);
         metric.forEach(item -> assertEquals(item.value, txnCount));
 
@@ -275,9 +275,9 @@ public class TransactionMetricsTest extends BrokerTestBase {
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
 
-        Multimap<String, PrometheusMetricsClient.Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsClient.Metric> metric = metrics.get("pulsar_storage_size");
+        Collection<Metric> metric = metrics.get("pulsar_storage_size");
         checkManagedLedgerMetrics(subName, 32, metric);
         checkManagedLedgerMetrics(MLTransactionLogImpl.TRANSACTION_SUBSCRIPTION_NAME, 252, metric);
 
@@ -337,12 +337,12 @@ public class TransactionMetricsTest extends BrokerTestBase {
         PrometheusMetricsGenerator.generate(pulsar, true, false, false, statsOut);
         String metricsStr = statsOut.toString();
 
-        Multimap<String, PrometheusMetricsClient.Metric> metrics = parseMetrics(metricsStr);
+        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsClient.Metric> metric = metrics.get("pulsar_storage_size");
+        Collection<Metric> metric = metrics.get("pulsar_storage_size");
         checkManagedLedgerMetrics(subName, 32, metric);
         //No statistics of the pendingAck are generated when the pendingAck is not initialized.
-        for (PrometheusMetricsClient.Metric metric1 : metric) {
+        for (Metric metric1 : metric) {
             if (metric1.tags.containsValue(subName2)) {
                 Assert.fail();
             }
@@ -432,9 +432,9 @@ public class TransactionMetricsTest extends BrokerTestBase {
 
     }
 
-    private void checkManagedLedgerMetrics(String tag, double value, Collection<PrometheusMetricsClient.Metric> metrics) {
+    private void checkManagedLedgerMetrics(String tag, double value, Collection<Metric> metrics) {
         boolean exist = false;
-        for (PrometheusMetricsClient.Metric metric1 : metrics) {
+        for (Metric metric1 : metrics) {
             if (metric1.tags.containsValue(tag)) {
                 assertEquals(metric1.value, value);
                 exist = true;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsClient.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsClient.java
@@ -1,0 +1,105 @@
+package org.apache.pulsar.broker.stats.prometheus;
+
+import static org.testng.Assert.assertTrue;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import io.restassured.RestAssured;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PrometheusMetricsClient {
+    private final String host;
+    private final int port;
+
+    public PrometheusMetricsClient(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    @SuppressWarnings("HttpUrlsUsage")
+    public Metrics getMetrics() {
+        String metrics = RestAssured.given().baseUri("http://" + host).port(port).get("/metrics").asString();
+        return new Metrics(parseMetrics(metrics));
+    }
+
+    /**
+     * Hacky parsing of Prometheus text format. Should be good enough for unit tests
+     */
+    public static Multimap<String, Metric> parseMetrics(String metrics) {
+        Multimap<String, Metric> parsed = ArrayListMultimap.create();
+
+        // Example of lines are
+        // jvm_threads_current{cluster="standalone",} 203.0
+        // or
+        // pulsar_subscriptions_count{cluster="standalone", namespace="public/default",
+        // topic="persistent://public/default/test-2"} 0.0
+        Pattern pattern = Pattern.compile("^(\\w+)\\{([^\\}]+)\\}\\s([+-]?[\\d\\w\\.-]+)$");
+        Pattern tagsPattern = Pattern.compile("(\\w+)=\"([^\"]+)\"(,\\s?)?");
+
+        Splitter.on("\n").split(metrics).forEach(line -> {
+            if (line.isEmpty() || line.startsWith("#")) {
+                return;
+            }
+
+            Matcher matcher = pattern.matcher(line);
+            assertTrue(matcher.matches(), "line " + line + " does not match pattern " + pattern);
+            String name = matcher.group(1);
+
+            Metric m = new Metric();
+            String numericValue = matcher.group(3);
+            if (numericValue.equalsIgnoreCase("-Inf")) {
+                m.value = Double.NEGATIVE_INFINITY;
+            } else if (numericValue.equalsIgnoreCase("+Inf")) {
+                m.value = Double.POSITIVE_INFINITY;
+            } else {
+                m.value = Double.parseDouble(numericValue);
+            }
+            String tags = matcher.group(2);
+            Matcher tagsMatcher = tagsPattern.matcher(tags);
+            while (tagsMatcher.find()) {
+                String tag = tagsMatcher.group(1);
+                String value = tagsMatcher.group(2);
+                m.tags.put(tag, value);
+            }
+
+            parsed.put(name, m);
+        });
+
+        return parsed;
+    }
+
+    public static class Metric {
+        public Map<String, String> tags = new TreeMap<>();
+        public double value;
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this).add("tags", tags).add("value", value).toString();
+        }
+
+        public boolean contains(String labelName, String labelValue) {
+            String value = tags.get(labelName);
+            return value != null && value.equals(labelValue);
+        }
+    }
+
+    public static class Metrics {
+        final Multimap<String, Metric> nameToDataPoints;
+
+        public Metrics(Multimap<String, Metric> nameToDataPoints) {
+            this.nameToDataPoints = nameToDataPoints;
+        }
+
+        public List<Metric> findByNameAndLabels(String metricName, String labelName, String labelValue) {
+            return nameToDataPoints.get(metricName)
+                    .stream()
+                    .filter(metric -> metric.contains(labelName, labelValue))
+                    .toList();
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ExecutionException;
 
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
-import org.apache.pulsar.broker.stats.PrometheusMetricsTest;
+import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.broker.transaction.TransactionTestBase;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferClientImpl;
@@ -228,28 +228,28 @@ public class TransactionBufferClientTest extends TransactionTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsarServiceList.get(0), true, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, PrometheusMetricsTest.Metric> metricsMap = PrometheusMetricsTest.parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metricsMap = PrometheusMetricsClient.parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsTest.Metric> abortFailed = metricsMap.get("pulsar_txn_tb_client_abort_failed_total");
-        Collection<PrometheusMetricsTest.Metric> commitFailed = metricsMap.get("pulsar_txn_tb_client_commit_failed_total");
-        Collection<PrometheusMetricsTest.Metric> abortLatencyCount =
+        Collection<PrometheusMetricsClient.Metric> abortFailed = metricsMap.get("pulsar_txn_tb_client_abort_failed_total");
+        Collection<PrometheusMetricsClient.Metric> commitFailed = metricsMap.get("pulsar_txn_tb_client_commit_failed_total");
+        Collection<PrometheusMetricsClient.Metric> abortLatencyCount =
                 metricsMap.get("pulsar_txn_tb_client_abort_latency_count");
-        Collection<PrometheusMetricsTest.Metric> commitLatencyCount =
+        Collection<PrometheusMetricsClient.Metric> commitLatencyCount =
                 metricsMap.get("pulsar_txn_tb_client_commit_latency_count");
-        Collection<PrometheusMetricsTest.Metric> pending = metricsMap.get("pulsar_txn_tb_client_pending_requests");
+        Collection<PrometheusMetricsClient.Metric> pending = metricsMap.get("pulsar_txn_tb_client_pending_requests");
 
         assertEquals(abortFailed.stream().mapToDouble(metric -> metric.value).sum(), 0);
         assertEquals(commitFailed.stream().mapToDouble(metric -> metric.value).sum(), 0);
 
         for (int i = 0; i < partitions; i++) {
             String topic = partitionedTopicName.getPartition(i).toString();
-            Optional<PrometheusMetricsTest.Metric> optional = abortLatencyCount.stream()
+            Optional<PrometheusMetricsClient.Metric> optional = abortLatencyCount.stream()
                     .filter(metric -> metric.tags.get("topic").equals(topic)).findFirst();
 
             assertTrue(optional.isPresent());
             assertEquals(optional.get().value, 1D);
 
-            Optional<PrometheusMetricsTest.Metric> optional1 = commitLatencyCount.stream()
+            Optional<PrometheusMetricsClient.Metric> optional1 = commitLatencyCount.stream()
                     .filter(metric -> metric.tags.get("topic").equals(topic)).findFirst();
             assertTrue(optional1.isPresent());
             assertEquals(optional1.get().value, 1D);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferClientTest.java
@@ -18,27 +18,35 @@
  */
 package org.apache.pulsar.broker.transaction.buffer;
 
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.Metric;
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.parseMetrics;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.concurrent.DefaultThreadFactory;
-import lombok.Cleanup;
 import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutionException;
-
+import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
-import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.broker.transaction.TransactionTestBase;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferClientImpl;
@@ -70,14 +78,6 @@ import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import java.lang.reflect.Field;
-import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.concurrent.TimeUnit;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 @Test(groups = "broker")
 public class TransactionBufferClientTest extends TransactionTestBase {
@@ -228,28 +228,28 @@ public class TransactionBufferClientTest extends TransactionTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsarServiceList.get(0), true, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, PrometheusMetricsClient.Metric> metricsMap = PrometheusMetricsClient.parseMetrics(metricsStr);
+        Multimap<String, Metric> metricsMap = parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsClient.Metric> abortFailed = metricsMap.get("pulsar_txn_tb_client_abort_failed_total");
-        Collection<PrometheusMetricsClient.Metric> commitFailed = metricsMap.get("pulsar_txn_tb_client_commit_failed_total");
-        Collection<PrometheusMetricsClient.Metric> abortLatencyCount =
+        Collection<Metric> abortFailed = metricsMap.get("pulsar_txn_tb_client_abort_failed_total");
+        Collection<Metric> commitFailed = metricsMap.get("pulsar_txn_tb_client_commit_failed_total");
+        Collection<Metric> abortLatencyCount =
                 metricsMap.get("pulsar_txn_tb_client_abort_latency_count");
-        Collection<PrometheusMetricsClient.Metric> commitLatencyCount =
+        Collection<Metric> commitLatencyCount =
                 metricsMap.get("pulsar_txn_tb_client_commit_latency_count");
-        Collection<PrometheusMetricsClient.Metric> pending = metricsMap.get("pulsar_txn_tb_client_pending_requests");
+        Collection<Metric> pending = metricsMap.get("pulsar_txn_tb_client_pending_requests");
 
         assertEquals(abortFailed.stream().mapToDouble(metric -> metric.value).sum(), 0);
         assertEquals(commitFailed.stream().mapToDouble(metric -> metric.value).sum(), 0);
 
         for (int i = 0; i < partitions; i++) {
             String topic = partitionedTopicName.getPartition(i).toString();
-            Optional<PrometheusMetricsClient.Metric> optional = abortLatencyCount.stream()
+            Optional<Metric> optional = abortLatencyCount.stream()
                     .filter(metric -> metric.tags.get("topic").equals(topic)).findFirst();
 
             assertTrue(optional.isPresent());
             assertEquals(optional.get().value, 1D);
 
-            Optional<PrometheusMetricsClient.Metric> optional1 = commitLatencyCount.stream()
+            Optional<Metric> optional1 = commitLatencyCount.stream()
                     .filter(metric -> metric.tags.get("topic").equals(topic)).findFirst();
             assertTrue(optional1.isPresent());
             assertEquals(optional1.get().value, 1D);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckPersistentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckPersistentTest.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.broker.transaction.pendingack;
 
 
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.Metric;
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.parseMetrics;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -26,6 +28,7 @@ import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.fail;
+import com.google.common.collect.Multimap;
 import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -38,7 +41,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import com.google.common.collect.Multimap;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;
@@ -49,7 +51,6 @@ import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
-import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.broker.transaction.TransactionTestBase;
 import org.apache.pulsar.broker.transaction.pendingack.impl.MLPendingAckStore;
@@ -62,9 +63,9 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.transaction.Transaction;
+import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
-import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.transaction.TransactionImpl;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.SystemTopicNames;
@@ -256,28 +257,28 @@ public class PendingAckPersistentTest extends TransactionTestBase {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsarServiceList.get(0), true, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, PrometheusMetricsClient.Metric> metricsMap = PrometheusMetricsClient.parseMetrics(metricsStr);
+        Multimap<String, Metric> metricsMap = parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsClient.Metric> abortedCount = metricsMap.get("pulsar_txn_tp_aborted_count_total");
-        Collection<PrometheusMetricsClient.Metric> committedCount = metricsMap.get("pulsar_txn_tp_committed_count_total");
-        Collection<PrometheusMetricsClient.Metric> commitLatency = metricsMap.get("pulsar_txn_tp_commit_latency");
+        Collection<Metric> abortedCount = metricsMap.get("pulsar_txn_tp_aborted_count_total");
+        Collection<Metric> committedCount = metricsMap.get("pulsar_txn_tp_committed_count_total");
+        Collection<Metric> commitLatency = metricsMap.get("pulsar_txn_tp_commit_latency");
         Assert.assertTrue(commitLatency.size() > 0);
 
         int count = 0;
-        for (PrometheusMetricsClient.Metric metric : commitLatency) {
+        for (Metric metric : commitLatency) {
             if (metric.tags.get("topic").endsWith(PENDING_ACK_REPLAY_TOPIC) && metric.value > 0) {
                 count++;
             }
         }
         Assert.assertTrue(count > 0);
 
-        for (PrometheusMetricsClient.Metric metric : abortedCount) {
+        for (Metric metric : abortedCount) {
             if (metric.tags.get("subscription").equals(subName) && metric.tags.get("status").equals("succeed")) {
                 assertTrue(metric.tags.get("topic").endsWith(PENDING_ACK_REPLAY_TOPIC));
                 assertTrue(metric.value > 0);
             }
         }
-        for (PrometheusMetricsClient.Metric metric : committedCount) {
+        for (Metric metric : committedCount) {
             if (metric.tags.get("subscription").equals(subName) && metric.tags.get("status").equals("succeed")) {
                 assertTrue(metric.tags.get("topic").endsWith(PENDING_ACK_REPLAY_TOPIC));
                 assertTrue(metric.value > 0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.broker.web;
 
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.Metric;
+import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.parseMetrics;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -51,7 +53,6 @@ import lombok.Cleanup;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.admin.PulsarAdmin;
@@ -104,31 +105,31 @@ public class WebServiceTest {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
+        Multimap<String, Metric> metrics = parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsClient.Metric> maxThreads = metrics.get("pulsar_web_executor_max_threads");
-        Collection<PrometheusMetricsClient.Metric> minThreads = metrics.get("pulsar_web_executor_min_threads");
-        Collection<PrometheusMetricsClient.Metric> activeThreads = metrics.get("pulsar_web_executor_active_threads");
-        Collection<PrometheusMetricsClient.Metric> idleThreads = metrics.get("pulsar_web_executor_idle_threads");
-        Collection<PrometheusMetricsClient.Metric> currentThreads = metrics.get("pulsar_web_executor_current_threads");
+        Collection<Metric> maxThreads = metrics.get("pulsar_web_executor_max_threads");
+        Collection<Metric> minThreads = metrics.get("pulsar_web_executor_min_threads");
+        Collection<Metric> activeThreads = metrics.get("pulsar_web_executor_active_threads");
+        Collection<Metric> idleThreads = metrics.get("pulsar_web_executor_idle_threads");
+        Collection<Metric> currentThreads = metrics.get("pulsar_web_executor_current_threads");
 
-        for (PrometheusMetricsClient.Metric metric : maxThreads) {
+        for (Metric metric : maxThreads) {
             Assert.assertNotNull(metric.tags.get("cluster"));
             Assert.assertTrue(metric.value > 0);
         }
-        for (PrometheusMetricsClient.Metric metric : minThreads) {
+        for (Metric metric : minThreads) {
             Assert.assertNotNull(metric.tags.get("cluster"));
             Assert.assertTrue(metric.value > 0);
         }
-        for (PrometheusMetricsClient.Metric metric : activeThreads) {
+        for (Metric metric : activeThreads) {
             Assert.assertNotNull(metric.tags.get("cluster"));
             Assert.assertTrue(metric.value >= 0);
         }
-        for (PrometheusMetricsClient.Metric metric : idleThreads) {
+        for (Metric metric : idleThreads) {
             Assert.assertNotNull(metric.tags.get("cluster"));
             Assert.assertTrue(metric.value >= 0);
         }
-        for (PrometheusMetricsClient.Metric metric : currentThreads) {
+        for (Metric metric : currentThreads) {
             Assert.assertNotNull(metric.tags.get("cluster"));
             Assert.assertTrue(metric.value > 0);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
@@ -51,7 +51,7 @@ import lombok.Cleanup;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.broker.stats.PrometheusMetricsTest;
+import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGenerator;
 import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.admin.PulsarAdmin;
@@ -104,31 +104,31 @@ public class WebServiceTest {
         ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
         PrometheusMetricsGenerator.generate(pulsar, false, false, false, statsOut);
         String metricsStr = statsOut.toString();
-        Multimap<String, PrometheusMetricsTest.Metric> metrics = PrometheusMetricsTest.parseMetrics(metricsStr);
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = PrometheusMetricsClient.parseMetrics(metricsStr);
 
-        Collection<PrometheusMetricsTest.Metric> maxThreads = metrics.get("pulsar_web_executor_max_threads");
-        Collection<PrometheusMetricsTest.Metric> minThreads = metrics.get("pulsar_web_executor_min_threads");
-        Collection<PrometheusMetricsTest.Metric> activeThreads = metrics.get("pulsar_web_executor_active_threads");
-        Collection<PrometheusMetricsTest.Metric> idleThreads = metrics.get("pulsar_web_executor_idle_threads");
-        Collection<PrometheusMetricsTest.Metric> currentThreads = metrics.get("pulsar_web_executor_current_threads");
+        Collection<PrometheusMetricsClient.Metric> maxThreads = metrics.get("pulsar_web_executor_max_threads");
+        Collection<PrometheusMetricsClient.Metric> minThreads = metrics.get("pulsar_web_executor_min_threads");
+        Collection<PrometheusMetricsClient.Metric> activeThreads = metrics.get("pulsar_web_executor_active_threads");
+        Collection<PrometheusMetricsClient.Metric> idleThreads = metrics.get("pulsar_web_executor_idle_threads");
+        Collection<PrometheusMetricsClient.Metric> currentThreads = metrics.get("pulsar_web_executor_current_threads");
 
-        for (PrometheusMetricsTest.Metric metric : maxThreads) {
+        for (PrometheusMetricsClient.Metric metric : maxThreads) {
             Assert.assertNotNull(metric.tags.get("cluster"));
             Assert.assertTrue(metric.value > 0);
         }
-        for (PrometheusMetricsTest.Metric metric : minThreads) {
+        for (PrometheusMetricsClient.Metric metric : minThreads) {
             Assert.assertNotNull(metric.tags.get("cluster"));
             Assert.assertTrue(metric.value > 0);
         }
-        for (PrometheusMetricsTest.Metric metric : activeThreads) {
+        for (PrometheusMetricsClient.Metric metric : activeThreads) {
             Assert.assertNotNull(metric.tags.get("cluster"));
             Assert.assertTrue(metric.value >= 0);
         }
-        for (PrometheusMetricsTest.Metric metric : idleThreads) {
+        for (PrometheusMetricsClient.Metric metric : idleThreads) {
             Assert.assertNotNull(metric.tags.get("cluster"));
             Assert.assertTrue(metric.value >= 0);
         }
-        for (PrometheusMetricsTest.Metric metric : currentThreads) {
+        for (PrometheusMetricsClient.Metric metric : currentThreads) {
             Assert.assertNotNull(metric.tags.get("cluster"));
             Assert.assertTrue(metric.value > 0);
         }

--- a/pulsar-broker/src/test/resources/log4j2.xml
+++ b/pulsar-broker/src/test/resources/log4j2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<Configuration xmlns="http://logging.apache.org/log4j/2.0/config"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://logging.apache.org/log4j/2.0/config https://logging.apache.org/log4j/2.0/log4j-core.xsd">
+  <Appenders>
+    <Console name="CONSOLE" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+<!--    <Logger name="org.apache.bookkeeper.mledger.impl.ManagedCursorImpl" level="DEBUG">-->
+<!--       <AppenderRef ref="CONSOLE"/>-->
+<!--    </Logger>-->
+
+    <Root level="INFO">
+      <AppenderRef ref="CONSOLE"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TopicStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/TopicStats.java
@@ -64,6 +64,31 @@ public interface TopicStats {
     /** Get the publish time of the earliest message over all the backlogs. */
     long getEarliestMsgPublishTimeInBacklogs();
 
+    /** the size in bytes of the topic backlog quota. */
+    long getBacklogQuotaLimitSize();
+
+    /** the topic backlog age quota, in seconds. */
+    long getBacklogQuotaLimitTime();
+
+    /**
+     * Age of oldest unacknowledged message, as recorded in last backlog quota check interval.
+     * <p>
+     * The age of the oldest unacknowledged (i.e. backlog) message, measured by the time elapsed from its published
+     * time, in seconds. This value is recorded every backlog quota check interval, hence it represents the value
+     * seen in the last check.
+     * </p>
+     */
+    long getOldestBacklogMessageAgeSeconds();
+
+    /**
+     * The subscription name containing oldest unacknowledged message as recorded in last backlog quota check.
+     * <p>
+     * The name of the subscription containing the oldest unacknowledged message. This value is recorded every backlog
+     * quota check interval, hence it represents the value seen in the last check.
+     * </p>
+     */
+    String getOldestBacklogMessageSubscriptionName();
+
     /** Space used to store the offloaded messages for the topic/. */
     long getOffloadedStorageSize();
 

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -474,6 +474,9 @@ public interface Consumer<T> extends Closeable, MessageAcknowledger {
      * <li><code>MessageId.earliest</code> : Reset the subscription on the earliest message available in the topic
      * <li><code>MessageId.latest</code> : Reset the subscription on the latest message in the topic
      * </ul>
+     * <p>
+     * This effectively resets the acknowledgement state of the subscription: all messages up to and
+     * <b>including</b> <code>messageId</code> will be marked as acknowledged and the rest unacknowledged.
      *
      * <p>Note: For multi-topics consumer, if `messageId` is a {@link TopicMessageId}, the seek operation will happen
      * on the owner topic of the message, which is returned by {@link TopicMessageId#getOwnerTopic()}. Otherwise, you

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/TopicStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/TopicStatsImpl.java
@@ -84,6 +84,31 @@ public class TopicStatsImpl implements TopicStats {
     /** Get estimated total unconsumed or backlog size in bytes. */
     public long backlogSize;
 
+    /** the size in bytes of the topic backlog quota. */
+    public long backlogQuotaLimitSize;
+
+    /** the topic backlog age quota, in seconds. */
+    public long backlogQuotaLimitTime;
+
+    /**
+     * Age of oldest unacknowledged message, as recorded in last backlog quota check interval.
+     * <p>
+     * The age of the oldest unacknowledged (i.e. backlog) message, measured by the time elapsed from its published
+     * time, in seconds. This value is recorded every backlog quota check interval, hence it represents the value
+     * seen in the last check.
+     * </p>
+     */
+    public long oldestBacklogMessageAgeSeconds;
+
+    /**
+     * The subscription name containing oldest unacknowledged message as recorded in last backlog quota check.
+     * <p>
+     * The name of the subscription containing the oldest unacknowledged message. This value is recorded every backlog
+     * quota check interval, hence it represents the value seen in the last check.
+     * </p>
+     */
+    public String oldestBacklogMessageSubscriptionName;
+
     /** The number of times the publishing rate limit was triggered. */
     public long publishRateLimitedTimes;
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/TopicStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/TopicStatsImpl.java
@@ -246,6 +246,10 @@ public class TopicStatsImpl implements TopicStats {
         this.compaction.reset();
         this.ownerBroker = null;
         this.bucketDelayedIndexStats.clear();
+        this.backlogQuotaLimitSize = 0;
+        this.backlogQuotaLimitTime = 0;
+        this.oldestBacklogMessageAgeSeconds = -1;
+        this.oldestBacklogMessageSubscriptionName = null;
     }
 
     // if the stats are added for the 1st time, we will need to make a copy of these stats and add it to the current
@@ -275,6 +279,12 @@ public class TopicStatsImpl implements TopicStats {
         this.ongoingTxnCount = stats.ongoingTxnCount;
         this.abortedTxnCount = stats.abortedTxnCount;
         this.committedTxnCount = stats.committedTxnCount;
+        this.backlogQuotaLimitTime = stats.backlogQuotaLimitTime;
+        this.backlogQuotaLimitSize = stats.backlogQuotaLimitSize;
+        if (stats.oldestBacklogMessageAgeSeconds > this.oldestBacklogMessageAgeSeconds) {
+            this.oldestBacklogMessageAgeSeconds = stats.oldestBacklogMessageAgeSeconds;
+            this.oldestBacklogMessageSubscriptionName = stats.oldestBacklogMessageSubscriptionName;
+        }
 
         stats.bucketDelayedIndexStats.forEach((k, v) -> {
             TopicMetricBean topicMetricBean =


### PR DESCRIPTION
PIP: https://github.com/apache/pulsar/pull/21709

### Motivation

As explained in the PIP, the motivation is to allow users of Pulsar to set an alert when the actual age of the oldest unacknowledged message for a topic is nearing its defined backlog quota time limit. 

### Modifications

* Four fields related to backlog telemetry were added to `TopicStats` per the PIP
* Four metrics related to backlog telemetry added per the PIP
* Cleaned up roughly 25 IntelliJ warnings
* A new auxiliary class named `PrometheusMetricsClient` was introduced, making retrieving and querying Prometheus metrics easier. The primary parsing method was refactored out of `PrometheusMetricsTest` as at least 7 test classes used this parse method directly, which didn't seem appropriate.
* Javadoc of `Consumer.seek()` was enhanced as it lacked an important distinction to the effect of it. Added test to verify.
* Added `log4j.xml` to `pulsar-broker/src/test/resources`, making it easy for developers to change the log level when running unit tests. Before they copy-paste a file into it and delete it.
 
### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
