### PR TITLE
[improve][ci] Improve OWASP dependency checks

### DIFF
--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -40,6 +40,7 @@ jobs:
       matrix:
         include:
           - branch: master
+          - branch: branch-3.2
           - branch: branch-3.1
           - branch: branch-3.0
           - branch: branch-2.11

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -84,6 +84,9 @@ jobs:
       - name: run OWASP Dependency Check for distribution/server (-DfailBuildOnAnyVulnerability=true)
         run: mvn -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl distribution/server -DfailBuildOnAnyVulnerability=true
 
+      - name: run OWASP Dependency Check for distribution/offloaders and distribution/io
+        run: mvn -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl distribution/offloaders,distribution/io
+
       - name: Upload OWASP Dependency Check reports
         uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -46,10 +46,6 @@ jobs:
           - branch: branch-2.11
           - branch: branch-2.10
             jdk: 11
-          - branch: branch-2.9
-            jdk: 11
-          - branch: branch-2.8
-            jdk: 11
 
     steps:
       - name: checkout

--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,7 @@ flexible messaging model and an intuitive client API.</description>
     <errorprone-slf4j.version>0.1.4</errorprone-slf4j.version>
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
-    <dependency-check-maven.version>8.2.1</dependency-check-maven.version>
+    <dependency-check-maven.version>9.0.7</dependency-check-maven.version>
     <roaringbitmap.version>0.9.44</roaringbitmap.version>
     <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
     <oshi.version>6.4.0</oshi.version>

--- a/src/owasp-dependency-check-false-positives.xml
+++ b/src/owasp-dependency-check-false-positives.xml
@@ -201,4 +201,12 @@
     <notes>flat_project is not used at all.</notes>
     <cpe>cpe:/a:flat_project:flat</cpe>
   </suppress>
+
+  <suppress>
+    <notes><![CDATA[
+   CVE-2023-36479 has been addressed in jetty-servlets-9.4.53.v20231009.jar and newer
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty\-servlets@.*$</packageUrl>
+    <cve>CVE-2023-36479</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### Motivation & Modifications

OWASP dependency check improvements:
- restore checks for distribution/offloaders and distribution/io which were accidentially removed by #21795
- upgrade OWASP version to keep up-to-date
- add suppression for false positive in jetty-servlets jar
- scan branch-3.2
- remove scanning of EOL branches branch-2.8 and branch-2.9

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->