### PR TITLE
[improve][ci] Run OWASP dependency check for offloaders and pulsar-io even when main check fails

### DIFF
--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -83,6 +83,7 @@ jobs:
 
       - name: run OWASP Dependency Check for distribution/offloaders and distribution/io
         run: mvn -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl distribution/offloaders,distribution/io
+        if: !cancelled()
 
       - name: Upload OWASP Dependency Check reports
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
### Motivation

Currently the OWASP dependency check won't run for distribution/offloaders and distribution/io (Pulsar IO connectors) when the main distribution's check fails. Example: https://github.com/apache/pulsar/actions/runs/7352401899/job/20017097977
Follow up for #21817.

### Modifications

Add `if: !cancelled()` to run the second step also when the first step fails. ([GitHub Actions docs](https://docs.github.com/en/actions/learn-github-actions/expressions#always))

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->