### PR TITLE
[fix][ci] Fix OWASP dep check GH actions workflow

### DIFF
--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -98,11 +98,12 @@ jobs:
             owasp-dependency-check-data-
 
       - name: Update OWASP Dependency Check data
+        id: update-owasp-dependency-check-data
         if: ${{ matrix.branch == 'master' && (steps.restore-owasp-dependency-check-data.outputs.cache-hit != 'true' || steps.restore-owasp-dependency-check-data.outputs.cache-matched-key != steps.restore-owasp-dependency-check-data.outputs.cache-primary-key) }}
         run: mvn -B -ntp -Powasp-dependency-check initialize -pl . dependency-check:update-only
 
       - name: Save OWASP Dependency Check data
-        if: ${{ matrix.branch == 'master' && (steps.restore-owasp-dependency-check-data.outputs.cache-hit != 'true' || steps.restore-owasp-dependency-check-data.outputs.cache-matched-key != steps.restore-owasp-dependency-check-data.outputs.cache-primary-key) }}
+        if: ${{ steps.update-owasp-dependency-check-data.outcome == 'success' }}
         uses: actions/cache/save@v3
         timeout-minutes: 5
         with:

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -37,6 +37,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         include:
           - branch: master
@@ -95,11 +96,11 @@ jobs:
           enableCrossOsArchive: true
 
       - name: Update OWASP Dependency Check data
-        if: ${{ steps.restore-owasp-dependency-check-data.outputs.cache-hit != 'true' }}
+        if: ${{ steps.restore-owasp-dependency-check-data.outputs.cache-hit != 'true' && matrix.branch == 'master' }}
         run: mvn -B -ntp -Powasp-dependency-check initialize -pl . dependency-check:update-only
 
       - name: Save OWASP Dependency Check data
-        if: ${{ steps.restore-owasp-dependency-check-data.outputs.cache-hit != 'true' }}
+        if: ${{ steps.restore-owasp-dependency-check-data.outputs.cache-hit != 'true' && matrix.branch == 'master' }}
         uses: actions/cache/save@v3
         timeout-minutes: 5
         with:

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -123,7 +123,7 @@ jobs:
           mvn --fail-at-end -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -DfailOnError=false -pl "${mvnprojects}"
 
       - name: Upload OWASP Dependency Check reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: owasp-dependency-check-reports-${{ matrix.branch }}

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -98,11 +98,11 @@ jobs:
             owasp-dependency-check-data-
 
       - name: Update OWASP Dependency Check data
-        if: ${{ steps.restore-owasp-dependency-check-data.outputs.cache-hit != 'true' && matrix.branch == 'master' }}
+        if: ${{ matrix.branch == 'master' && (steps.restore-owasp-dependency-check-data.outputs.cache-hit != 'true' || steps.restore-owasp-dependency-check-data.outputs.cache-matched-key != steps.restore-owasp-dependency-check-data.outputs.cache-primary-key) }}
         run: mvn -B -ntp -Powasp-dependency-check initialize -pl . dependency-check:update-only
 
       - name: Save OWASP Dependency Check data
-        if: ${{ steps.restore-owasp-dependency-check-data.outputs.cache-hit != 'true' && matrix.branch == 'master' }}
+        if: ${{ matrix.branch == 'master' && (steps.restore-owasp-dependency-check-data.outputs.cache-hit != 'true' || steps.restore-owasp-dependency-check-data.outputs.cache-matched-key != steps.restore-owasp-dependency-check-data.outputs.cache-primary-key) }}
         uses: actions/cache/save@v3
         timeout-minutes: 5
         with:

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -34,7 +34,7 @@ jobs:
       JOB_NAME: Check ${{ matrix.branch }}
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 45
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -63,11 +63,20 @@ jobs:
           path: |
             ~/.m2/repository/*/*/*
             !~/.m2/repository/org/apache/pulsar
-          key: ${{ runner.os }}-m2-dependencies-owasp-${{ hashFiles('**/pom.xml') }}
+            !~/.m2/repository/org/owasp/dependency-check-data
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          lookup-only: true
           restore-keys: |
-            ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
+
+      - name: Cache OWASP Dependency Check data
+        uses: actions/cache@v3
+        timeout-minutes: 5
+        with:
+          path: ~/.m2/repository/org/owasp/dependency-check-data
+          key: owasp-dependency-check-data
+          enableCrossOsArchive: true
 
       - name: Set up JDK ${{ matrix.jdk || '17' }}
         uses: actions/setup-java@v3

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: run OWASP Dependency Check for distribution/server (-DfailBuildOnAnyVulnerability=true)
         run: mvn -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl distribution/server -DfailBuildOnAnyVulnerability=true
 
-      - name: run OWASP Dependency Check for offloaders/tiered-storage and pulsar-io connectors
+      - name: run OWASP Dependency Check for offloaders/tiered-storage and pulsar-io connectors (-DfailOnError=false)
         if: ${{ !cancelled() }}
         run: |
           mvnprojects=$(mvn -B -ntp -Dscan=false initialize \
@@ -99,7 +99,7 @@ jobs:
             | grep -E 'pulsar-io-|tiered-storage-|offloader' \
             | tr '\n' ',' | sed 's/,$/\n/' )
           set -xe
-          mvn --fail-at-end -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl "${mvnprojects}"
+          mvn --fail-at-end -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -DfailOnError=false -pl "${mvnprojects}"
 
       - name: Upload OWASP Dependency Check reports
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -81,9 +81,16 @@ jobs:
       - name: run OWASP Dependency Check for distribution/server (-DfailBuildOnAnyVulnerability=true)
         run: mvn -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl distribution/server -DfailBuildOnAnyVulnerability=true
 
-      - name: run OWASP Dependency Check for distribution/offloaders and distribution/io
-        run: mvn -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl distribution/offloaders,distribution/io
+      - name: run OWASP Dependency Check for offloaders/tiered-storage and pulsar-io connectors
         if: ${{ !cancelled() }}
+        run: |
+          mvnprojects=$(mvn -B -ntp -Dscan=false initialize \
+            | grep -- "-< .* >-" \
+            | sed -E 's/.*-< (.*) >-.*/\1/' \
+            | grep -E 'pulsar-io-|tiered-storage-|offloader' \
+            | tr '\n' ',' | sed 's/,$/\n/' )
+          set -xe
+          mvn -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl "${mvnprojects}"
 
       - name: Upload OWASP Dependency Check reports
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -94,6 +94,8 @@ jobs:
           path: ~/.m2/repository/org/owasp/dependency-check-data
           key: owasp-dependency-check-data-${{ steps.get-weeknum.outputs.weeknum }}
           enableCrossOsArchive: true
+          restore-keys: |
+            owasp-dependency-check-data-
 
       - name: Update OWASP Dependency Check data
         if: ${{ steps.restore-owasp-dependency-check-data.outputs.cache-hit != 'true' && matrix.branch == 'master' }}

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -83,7 +83,7 @@ jobs:
 
       - name: run OWASP Dependency Check for distribution/offloaders and distribution/io
         run: mvn -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl distribution/offloaders,distribution/io
-        if: !cancelled()
+        if: ${{ !cancelled() }}
 
       - name: Upload OWASP Dependency Check reports
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -70,14 +70,6 @@ jobs:
             ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
             ${{ runner.os }}-m2-dependencies-core-modules-
 
-      - name: Cache OWASP Dependency Check data
-        uses: actions/cache@v3
-        timeout-minutes: 5
-        with:
-          path: ~/.m2/repository/org/owasp/dependency-check-data
-          key: owasp-dependency-check-data
-          enableCrossOsArchive: true
-
       - name: Set up JDK ${{ matrix.jdk || '17' }}
         uses: actions/setup-java@v3
         with:
@@ -86,6 +78,34 @@ jobs:
 
       - name: run install by skip tests
         run: mvn -B -ntp clean install -DskipTests -Dspotbugs.skip=true  -Dlicense.skip=true -Dcheckstyle.skip=true -Drat.skip=true -DskipDocker=true
+
+      - name: OWASP cache key weeknum
+        id: get-weeknum
+        run: |
+          echo "weeknum=$(date -u +"%Y-%U")" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Restore OWASP Dependency Check data
+        id: restore-owasp-dependency-check-data
+        uses: actions/cache/restore@v3
+        timeout-minutes: 5
+        with:
+          path: ~/.m2/repository/org/owasp/dependency-check-data
+          key: owasp-dependency-check-data-${{ steps.get-weeknum.outputs.weeknum }}
+          enableCrossOsArchive: true
+
+      - name: Update OWASP Dependency Check data
+        if: ${{ steps.restore-owasp-dependency-check-data.outputs.cache-hit != 'true' }}
+        run: mvn -B -ntp -Powasp-dependency-check initialize -pl . dependency-check:update-only
+
+      - name: Save OWASP Dependency Check data
+        if: ${{ steps.restore-owasp-dependency-check-data.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v3
+        timeout-minutes: 5
+        with:
+          path: ~/.m2/repository/org/owasp/dependency-check-data
+          key: ${{ steps.restore-owasp-dependency-check-data.outputs.cache-primary-key }}
+          enableCrossOsArchive: true
 
       - name: run OWASP Dependency Check for distribution/server (-DfailBuildOnAnyVulnerability=true)
         run: mvn -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl distribution/server -DfailBuildOnAnyVulnerability=true

--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -90,7 +90,7 @@ jobs:
             | grep -E 'pulsar-io-|tiered-storage-|offloader' \
             | tr '\n' ',' | sed 's/,$/\n/' )
           set -xe
-          mvn -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl "${mvnprojects}"
+          mvn --fail-at-end -B -ntp -Pmain,skip-all,skipDocker,owasp-dependency-check initialize verify -pl "${mvnprojects}"
 
       - name: Upload OWASP Dependency Check reports
         uses: actions/upload-artifact@v3
@@ -98,6 +98,4 @@ jobs:
         with:
           name: owasp-dependency-check-reports-${{ matrix.branch }}
           path: |
-            distribution/server/target/dependency-check-report.html
-            distribution/offloaders/target/dependency-check-report.html
-            distribution/io/target/dependency-check-report.html
+            **/target/dependency-check-report.html

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -1361,16 +1361,9 @@ jobs:
             !~/.m2/repository/org/apache/pulsar
             !~/.m2/repository/org/owasp/dependency-check-data
           key: ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+          lookup-only: true
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-core-modules-
-
-      - name: Cache OWASP Dependency Check data
-        uses: actions/cache@v3
-        timeout-minutes: 5
-        with:
-          path: ~/.m2/repository/org/owasp/dependency-check-data
-          key: owasp-dependency-check-data
-          enableCrossOsArchive: true
 
       - name: Set up JDK ${{ matrix.jdk || env.CI_JDK_MAJOR_VERSION }}
         uses: actions/setup-java@v3
@@ -1388,6 +1381,22 @@ jobs:
         run: |
           cd $HOME
           $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh restore_tar_from_github_actions_artifacts pulsar-maven-repository-binaries
+
+      - name: OWASP cache key weeknum
+        id: get-weeknum
+        run: |
+          echo "weeknum=$(date -u +"%Y-%U")" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Restore OWASP Dependency Check data
+        id: restore-owasp-dependency-check-data
+        uses: actions/cache/restore@v3
+        timeout-minutes: 5
+        with:
+          path: ~/.m2/repository/org/owasp/dependency-check-data
+          key: owasp-dependency-check-data-${{ steps.get-weeknum.outputs.weeknum }}
+          enableCrossOsArchive: true
+
       # Projects dependent on flume, hdfs, and hbase currently excluded from the scan.
       - name: trigger dependency check
         run: |

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -1396,6 +1396,8 @@ jobs:
           path: ~/.m2/repository/org/owasp/dependency-check-data
           key: owasp-dependency-check-data-${{ steps.get-weeknum.outputs.weeknum }}
           enableCrossOsArchive: true
+          restore-keys: |
+            owasp-dependency-check-data-
 
       # Projects dependent on flume, hdfs, and hbase currently excluded from the scan.
       - name: trigger dependency check

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -1359,9 +1359,19 @@ jobs:
           path: |
             ~/.m2/repository/*/*/*
             !~/.m2/repository/org/apache/pulsar
+            !~/.m2/repository/org/owasp/dependency-check-data
           key: ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-m2-dependencies-core-modules-
+
+      - name: Cache OWASP Dependency Check data
+        uses: actions/cache@v3
+        timeout-minutes: 5
+        with:
+          path: ~/.m2/repository/org/owasp/dependency-check-data
+          key: owasp-dependency-check-data
+          enableCrossOsArchive: true
+
       - name: Set up JDK ${{ matrix.jdk || env.CI_JDK_MAJOR_VERSION }}
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
### Motivation

- Fix ["Invalid workflow file" error](https://github.com/apache/pulsar/actions/runs/7380947338)
- follow up for #21826
- GHA requires "if: ${{ !cancelled() }}"

- The scan results for offloaders and pulsar-io don't contain any results when the distributions are scanned. It is necessary to scan each individual project. 

### Modifications

- `if: !cancelled()` -> `if: ${{ !cancelled() }}`
- Modify tiered-storage and pulsar-io scanning to scan each individual project.
- Add caching for vulnerability database download

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->