### PR TITLE
[improve][ci] Require all conversations on code to be resolve before merging PRs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -58,6 +58,9 @@ github:
 
       required_signatures: false
 
+      # Requires all conversations on code to be resolved before a pull request can be merged.
+      required_conversation_resolution: true
+
     # The following branch protections only ensure that force pushes are not allowed
     branch-1.15: {}
     branch-1.16: {}


### PR DESCRIPTION
### Motivation

In GitHub, there's a feature that requires resolving conversations on code before the PR can be merged. 
It would be good to enable this feature for the PRs that target the master branch.
This was made possible in `.asf.yaml` with https://github.com/apache/infrastructure-p6/pull/1740 changes.

### Modifications

- set `required_conversation_resolution: true` for master branch in `.asf.yaml`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->