### PR TITLE
[improve] [broker] PIP-299-part-3: Add dynamic config support: dispatcherPauseOnAckStatePersistentEnabled

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -397,7 +397,8 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
         topicPolicies.getSchemaValidationEnforced().updateBrokerValue(config.isSchemaValidationEnforced());
         topicPolicies.getEntryFilters().updateBrokerValue(new EntryFilters(String.join(",",
                 config.getEntryFilterNames())));
-
+        topicPolicies.getDispatcherPauseOnAckStatePersistentEnabled()
+                .updateBrokerValue(config.isDispatcherPauseOnAckStatePersistentEnabled());
         updateEntryFilters();
     }
 
@@ -1265,6 +1266,11 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
     public void updateBrokerDispatchRate() {
         topicPolicies.getDispatchRate().updateBrokerValue(
             dispatchRateInBroker(brokerService.pulsar().getConfiguration()));
+    }
+
+    public void updateDispatchPauseOnAckStatePersistentEnabled() {
+        topicPolicies.getDispatcherPauseOnAckStatePersistentEnabled().updateBrokerValue(
+                brokerService.pulsar().getConfiguration().isDispatcherPauseOnAckStatePersistentEnabled());
     }
 
     public void addFilteredEntriesCount(int filtered) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -1268,7 +1268,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
             dispatchRateInBroker(brokerService.pulsar().getConfiguration()));
     }
 
-    public void updateDispatchPauseOnAckStatePersistentEnabled() {
+    public void updateBrokerDispatchPauseOnAckStatePersistentEnabled() {
         topicPolicies.getDispatcherPauseOnAckStatePersistentEnabled().updateBrokerValue(
                 brokerService.pulsar().getConfiguration().isDispatcherPauseOnAckStatePersistentEnabled());
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2605,7 +2605,7 @@ public class BrokerService implements Closeable {
         registerConfigurationListener("dispatchThrottlingRatePerSubscriptionInByte", (dispatchRatePerTopicInByte) -> {
             updateSubscriptionMessageDispatchRate();
         });
-        // add listener to update message-dispatch-rate in byte for subscription
+        // add listener to update "dispatcherPauseOnAckStatePersistentEnabled" in byte for subscription
         registerConfigurationListener("dispatcherPauseOnAckStatePersistentEnabled", (dispatchRatePerTopicInByte) -> {
             updateDispatchPauseOnAckStatePersistentEnabled();
         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2753,7 +2753,7 @@ public class BrokerService implements Closeable {
                 if (topic instanceof PersistentTopic) {
                     // Update policies.
                     PersistentTopic persistentTopic = (PersistentTopic) topic;
-                    persistentTopic.updateDispatchPauseOnAckStatePersistentEnabled();
+                    persistentTopic.updateBrokerDispatchPauseOnAckStatePersistentEnabled();
                 }
             });
         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2605,6 +2605,10 @@ public class BrokerService implements Closeable {
         registerConfigurationListener("dispatchThrottlingRatePerSubscriptionInByte", (dispatchRatePerTopicInByte) -> {
             updateSubscriptionMessageDispatchRate();
         });
+        // add listener to update message-dispatch-rate in byte for subscription
+        registerConfigurationListener("dispatcherPauseOnAckStatePersistentEnabled", (dispatchRatePerTopicInByte) -> {
+            updateDispatchPauseOnAckStatePersistentEnabled();
+        });
 
         // add listener to update message-dispatch-rate in msg for replicator
         registerConfigurationListener("dispatchThrottlingRatePerReplicatorInMsg",
@@ -2738,6 +2742,28 @@ public class BrokerService implements Closeable {
                 if (topic instanceof AbstractTopic) {
                     ((AbstractTopic) topic).updateBrokerDispatchRate();
                     ((AbstractTopic) topic).updateDispatchRateLimiter();
+                }
+            });
+        });
+    }
+
+    private void updateDispatchPauseOnAckStatePersistentEnabled() {
+        this.pulsar().getExecutor().execute(() -> {
+            forEachTopic(topic -> {
+                if (topic instanceof PersistentTopic) {
+                    // Update policies.
+                    PersistentTopic persistentTopic = (PersistentTopic) topic;
+                    persistentTopic.updateDispatchPauseOnAckStatePersistentEnabled();
+                    // Trigger new read if subscriptions has been paused before.
+                    if (!pulsar().getConfiguration().isDispatcherPauseOnAckStatePersistentEnabled()) {
+                        persistentTopic.updateDispatchPauseOnAckStatePersistentEnabled();
+                        persistentTopic.getSubscriptions().forEach((sName, subscription) -> {
+                            if (subscription.getDispatcher() == null) {
+                                return;
+                            }
+                            subscription.getDispatcher().afterAckMessages(null, 0);
+                        });
+                    }
                 }
             });
         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2754,16 +2754,6 @@ public class BrokerService implements Closeable {
                     // Update policies.
                     PersistentTopic persistentTopic = (PersistentTopic) topic;
                     persistentTopic.updateDispatchPauseOnAckStatePersistentEnabled();
-                    // Trigger new read if subscriptions has been paused before.
-                    if (!pulsar().getConfiguration().isDispatcherPauseOnAckStatePersistentEnabled()) {
-                        persistentTopic.updateDispatchPauseOnAckStatePersistentEnabled();
-                        persistentTopic.getSubscriptions().forEach((sName, subscription) -> {
-                            if (subscription.getDispatcher() == null) {
-                                return;
-                            }
-                            subscription.getDispatcher().afterAckMessages(null, 0);
-                        });
-                    }
                 }
             });
         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
@@ -155,7 +155,7 @@ public interface Dispatcher {
      * Trigger a new "readMoreEntries" if the dispatching has been paused before. This method is only implemented in
      * {@link org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers} right now, other
      * implements are not necessary to implement this method.
-     * @return should or not pause the dispatching.
+     * @return did a resume.
      */
     default boolean checkAndResumeIfPaused(){
         return false;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
@@ -151,6 +151,16 @@ public interface Dispatcher {
      */
     default void afterAckMessages(Throwable exOfDeletion, Object ctxOfDeletion){}
 
+    /**
+     * Trigger a new "readMoreEntries" if the dispatching has been paused before. This method is only implemented in
+     * {@link org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers} right now, other
+     * implements are not necessary to implement this method.
+     * @return should or not pause the dispatching.
+     */
+    default boolean checkAndResumeIfPaused(){
+        return false;
+    }
+
     default long getFilterProcessedMsgCount() {
         return 0;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -1039,11 +1039,11 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
 
     @Override
     public void afterAckMessages(Throwable exOfDeletion, Object ctxOfDeletion) {
-        boolean paused = blockedDispatcherOnCursorDataCanNotFullyPersist == TRUE;
+        boolean unPaused = blockedDispatcherOnCursorDataCanNotFullyPersist == FALSE;
         // Trigger a new read if needed.
-        boolean shouldPauseNow = checkAndResumeIfPaused();
+        boolean shouldPauseNow = !checkAndResumeIfPaused();
         // Switch stat to "paused" if needed.
-        if (!paused && shouldPauseNow) {
+        if (unPaused && shouldPauseNow) {
             if (!BLOCKED_DISPATCHER_ON_CURSOR_DATA_CAN_NOT_FULLY_PERSIST_UPDATER
                     .compareAndSet(this, FALSE, TRUE)) {
                 // Retry due to conflict update.
@@ -1059,7 +1059,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
                 && topic.isDispatcherPauseOnAckStatePersistentEnabled();
         // No need to change.
         if (paused == shouldPauseNow) {
-            return shouldPauseNow;
+            return !shouldPauseNow;
         }
         // Should change to "un-pause".
         if (paused && !shouldPauseNow) {
@@ -1072,7 +1072,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
                 checkAndResumeIfPaused();
             }
         }
-        return shouldPauseNow;
+        return !shouldPauseNow;
     }
 
     public boolean isBlockedDispatcherOnUnackedMsgs() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3771,8 +3771,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     @Override
-    public void updateDispatchPauseOnAckStatePersistentEnabled() {
-        super.updateDispatchPauseOnAckStatePersistentEnabled();
+    public void updateBrokerDispatchPauseOnAckStatePersistentEnabled() {
+        super.updateBrokerDispatchPauseOnAckStatePersistentEnabled();
         // Trigger new read if subscriptions has been paused before.
         if (!topicPolicies.getDispatcherPauseOnAckStatePersistentEnabled().get()) {
             getSubscriptions().forEach((sName, subscription) -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3771,6 +3771,21 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     @Override
+    public void updateDispatchPauseOnAckStatePersistentEnabled() {
+        super.updateDispatchPauseOnAckStatePersistentEnabled();
+        // Trigger new read if subscriptions has been paused before.
+        if (!brokerService.getPulsar().getConfiguration().isDispatcherPauseOnAckStatePersistentEnabled()) {
+            updateDispatchPauseOnAckStatePersistentEnabled();
+            getSubscriptions().forEach((sName, subscription) -> {
+                if (subscription.getDispatcher() == null) {
+                    return;
+                }
+                subscription.getDispatcher().afterAckMessages(null, 0);
+            });
+        }
+    }
+
+    @Override
     public void onUpdate(TopicPolicies policies) {
         if (log.isDebugEnabled()) {
             log.debug("[{}] update topic policy: {}", topic, policies);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3774,8 +3774,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     public void updateDispatchPauseOnAckStatePersistentEnabled() {
         super.updateDispatchPauseOnAckStatePersistentEnabled();
         // Trigger new read if subscriptions has been paused before.
-        if (!brokerService.getPulsar().getConfiguration().isDispatcherPauseOnAckStatePersistentEnabled()) {
-            updateDispatchPauseOnAckStatePersistentEnabled();
+        if (!topicPolicies.getDispatcherPauseOnAckStatePersistentEnabled().get()) {
             getSubscriptions().forEach((sName, subscription) -> {
                 if (subscription.getDispatcher() == null) {
                     return;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionPauseOnAckStatPersistTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionPauseOnAckStatPersistTest.java
@@ -247,6 +247,7 @@ public class SubscriptionPauseOnAckStatPersistTest extends ProducerConsumerBase 
                 .receiverQueueSize(incomingQueueSize).isAckReceiptEnabled(true)
                 .subscriptionType(SubscriptionType.Shared).subscribe();
         ackOddMessagesOnly(c1);
+        verifyAckHolesIsMuchThanLimit(tpName, subscription);
 
         cancelPendingRead(tpName, subscription);
         triggerNewReadMoreEntries(tpName, subscription);
@@ -276,6 +277,13 @@ public class SubscriptionPauseOnAckStatPersistTest extends ProducerConsumerBase 
         admin.topics().delete(tpName, false);
     }
 
+    private void verifyAckHolesIsMuchThanLimit(String tpName, String subscription) {
+        Awaitility.await().untilAsserted(() -> {
+            Assert.assertTrue(MAX_UNACKED_RANGES_TO_PERSIST < admin.topics()
+                    .getInternalStats(tpName).cursors.get(subscription).totalNonContiguousDeletedMessagesRange);
+        });
+    }
+
     @Test(dataProvider = "multiConsumerSubscriptionTypes")
     public void testPauseOnAckStatPersist(SubscriptionType subscriptionType) throws Exception {
         final String tpName = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
@@ -299,6 +307,7 @@ public class SubscriptionPauseOnAckStatPersistTest extends ProducerConsumerBase 
                 .receiverQueueSize(incomingQueueSize).isAckReceiptEnabled(true).subscriptionType(subscriptionType)
                 .subscribe();
         ackOddMessagesOnly(c1);
+        verifyAckHolesIsMuchThanLimit(tpName, subscription);
 
         cancelPendingRead(tpName, subscription);
         triggerNewReadMoreEntries(tpName, subscription);
@@ -344,6 +353,7 @@ public class SubscriptionPauseOnAckStatPersistTest extends ProducerConsumerBase 
                 .receiverQueueSize(incomingQueueSize).isAckReceiptEnabled(true)
                 .subscriptionType(SubscriptionType.Shared).subscribe();
         ackOddMessagesOnly(c1);
+        verifyAckHolesIsMuchThanLimit(tpName, subscription);
 
         cancelPendingRead(tpName, subscription);
         triggerNewReadMoreEntries(tpName, subscription);
@@ -423,6 +433,7 @@ public class SubscriptionPauseOnAckStatPersistTest extends ProducerConsumerBase 
                 .subscriptionType(subscriptionType)
                 .subscribe();
         ackOddMessagesOnly(c1);
+        verifyAckHolesIsMuchThanLimit(tpName, subscription);
 
         cancelPendingRead(tpName, subscription);
         triggerNewReadMoreEntries(tpName, subscription);
@@ -463,6 +474,7 @@ public class SubscriptionPauseOnAckStatPersistTest extends ProducerConsumerBase 
         }
         // Make ack holes.
         ReceivedMessages receivedMessagesC1 = ackOddMessagesOnly(c1);
+        verifyAckHolesIsMuchThanLimit(tpName, subscription);
 
         cancelPendingRead(tpName, subscription);
         triggerNewReadMoreEntries(tpName, subscription);
@@ -519,6 +531,7 @@ public class SubscriptionPauseOnAckStatPersistTest extends ProducerConsumerBase 
         }
         // Make ack holes.
         ReceivedMessages receivedMessagesC1AndC2 = ackOddMessagesOnly(c1, c2);
+        verifyAckHolesIsMuchThanLimit(tpName, subscription);
 
         cancelPendingRead(tpName, subscription);
         triggerNewReadMoreEntries(tpName, subscription);


### PR DESCRIPTION
The part 3 of [PIP-299](https://github.com/apache/pulsar/pull/21118/files?short_path=cf766b5#diff-cf766b5d463b6832017e482baad14832f6a4d41dc969da279b98b69e26ec6f6a): the implementation of "Add dynamic config support: dispatcherPauseOnAckStatePersistentEnabled"

Related PRs:
- [x] https://github.com/apache/pulsar/pull/21423
- [x] https://github.com/apache/pulsar/pull/21370
- [ ] **(Current PR)** part-3: Dynamic broker config
- part-4: Topic policies support.
- part-5: Doc

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
