### PR TITLE
[fix] [client] Messages lost due to TopicListWatcher reconnect

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -708,5 +708,13 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         private PersistentTopic persistentTopic;
     }
 
+    protected void sleepSeconds(int seconds){
+        try {
+            Thread.currentThread().sleep(1000 * seconds);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private static final Logger log = LoggerFactory.getLogger(MockedPulsarServiceBaseTest.class);
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -712,7 +712,7 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         try {
             Thread.currentThread().sleep(1000 * seconds);
         } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -710,7 +710,7 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
 
     protected void sleepSeconds(int seconds){
         try {
-            Thread.currentThread().sleep(1000 * seconds);
+            Thread.sleep(1000 * seconds);
         } catch (InterruptedException e) {
             log.warn("This thread has been interrupted", e);
             Thread.currentThread().interrupt();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -712,6 +712,7 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         try {
             Thread.currentThread().sleep(1000 * seconds);
         } catch (InterruptedException e) {
+            log.warn("This thread has been interrupted", e);
             Thread.currentThread().interrupt();
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
@@ -37,14 +37,18 @@ import java.util.stream.IntStream;
 import io.netty.util.Timeout;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.InjectedClientCnxClientBuilder;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.RegexSubscriptionMode;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.common.api.proto.BaseCommand;
+import org.apache.pulsar.common.api.proto.CommandWatchTopicListSuccess;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.awaitility.Awaitility;
@@ -53,6 +57,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker-impl")
@@ -620,13 +625,28 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         producer3.close();
     }
 
-    @Test(timeOut = testTimeout)
-    public void testAutoSubscribePatterConsumerFromBrokerWatcher() throws Exception {
-        String key = "AutoSubscribePatternConsumer";
-        String subscriptionName = "my-ex-subscription-" + key;
+    @DataProvider(name= "delayTypesOfWatchingTopics")
+    public Object[][] delayTypesOfWatchingTopics(){
+        return new Object[][]{
+            {true},
+            {false}
+        };
+    }
 
-        Pattern pattern = Pattern.compile("persistent://my-property/my-ns/pattern-topic.*");
-        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+    @Test(timeOut = testTimeout, dataProvider = "delayTypesOfWatchingTopics")
+    public void testAutoSubscribePatterConsumerFromBrokerWatcher(boolean delayWatchingTopics) throws Exception {
+        final String key = "AutoSubscribePatternConsumer";
+        final String subscriptionName = "my-ex-subscription-" + key;
+        final Pattern pattern = Pattern.compile("persistent://my-property/my-ns/pattern-topic.*");
+
+        PulsarClient client = null;
+        if (delayWatchingTopics) {
+            client = createDelayWatchTopicsClient();
+        } else {
+            client = pulsarClient;
+        }
+
+        Consumer<byte[]> consumer = client.newConsumer()
                 .topicsPattern(pattern)
                 // Disable automatic discovery.
                 .patternAutoDiscoveryPeriod(1000)
@@ -635,12 +655,6 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
                 .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
                 .receiverQueueSize(4)
                 .subscribe();
-
-        // Wait topic list watcher creation.
-        Awaitility.await().untilAsserted(() -> {
-            CompletableFuture completableFuture = WhiteboxImpl.getInternalState(consumer, "watcherFuture");
-            assertTrue(completableFuture.isDone() && !completableFuture.isCompletedExceptionally());
-        });
 
         // 1. create partition
         String topicName = "persistent://my-property/my-ns/pattern-topic-1-" + key;
@@ -657,7 +671,32 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitionedTopics().size(), 1);
         });
 
+        // cleanup.
         consumer.close();
+        admin.topics().deletePartitionedTopic(topicName);
+    }
+
+    private PulsarClient createDelayWatchTopicsClient() throws Exception {
+        ClientBuilderImpl clientBuilder = (ClientBuilderImpl) PulsarClient.builder().serviceUrl(lookupUrl.toString());
+        return InjectedClientCnxClientBuilder.create(clientBuilder,
+            (conf, eventLoopGroup) -> new ClientCnx(conf, eventLoopGroup) {
+                public CompletableFuture<CommandWatchTopicListSuccess> newWatchTopicList(
+                        BaseCommand command, long requestId) {
+                    // Inject 2 seconds delay when sending command New Watch Topics.
+                    CompletableFuture<CommandWatchTopicListSuccess> res = new CompletableFuture<>();
+                    new Thread(() -> {
+                        sleepSeconds(2);
+                        super.newWatchTopicList(command, requestId).whenComplete((v, ex) -> {
+                            if (ex != null) {
+                                res.completeExceptionally(ex);
+                            } else {
+                                res.complete(v);
+                            }
+                        });
+                    }).start();
+                    return res;
+                }
+            });
     }
 
     // simulate subscribe a pattern which has 3 topics, but then matched topic added in.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
@@ -674,6 +674,9 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         // cleanup.
         consumer.close();
         admin.topics().deletePartitionedTopic(topicName);
+        if (delayWatchingTopics) {
+            client.close();
+        }
     }
 
     private PulsarClient createDelayWatchTopicsClient() throws Exception {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -160,7 +160,9 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
         return client.getLookup().getTopicsUnderNamespace(namespaceName, subscriptionMode, pattern, topicsHash)
             .thenCompose(getTopicsResult -> {
                 // If "recheckTopicsChange" has been called more than one times, only make the last one take affects.
-                synchronized (recheckPatternEpoch) {
+                // Use "synchronized (recheckPatternTaskBackoff)" instead of
+                // `synchronized(PatternMultiTopicsConsumerImpl.this)` to avoid locking in a wider range.
+                synchronized (recheckPatternTaskBackoff) {
                     if (recheckPatternEpoch.get() > epoch) {
                         return CompletableFuture.completedFuture(null);
                     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -124,15 +124,16 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
     }
 
     private void recheckTopicsChangeRetryIfFailed(Timeout retryTask) {
-        // This method will be called by A New Call or Timeout scheduled call.
-        final boolean isNew = (retryTask == null);
         // Skip if closed or the task has been cancelled.
         if (getState() == State.Closing || getState() == State.Closed
                 || (retryTask != null && retryTask.isCancelled())) {
             retryRecheckPatternTask.compareAndSet(retryTask, null);
             return;
         }
+        // If the argument "retryTask" is not null, it means this method was called by the timer. Otherwise, it is a
+        // new call.
         // Skip the new check if contains a retry task.
+        final boolean isNew = (retryTask == null);
         Timeout pendingRetryTask = retryRecheckPatternTask.get();
         if (isNew && pendingRetryTask != null) {
             return;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -160,7 +160,7 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
         return client.getLookup().getTopicsUnderNamespace(namespaceName, subscriptionMode, pattern, topicsHash)
             .thenCompose(getTopicsResult -> {
                 // If "recheckTopicsChange" has been called more than one times, only make the last one take affects.
-                synchronized (PatternMultiTopicsConsumerImpl.this) {
+                synchronized (recheckPatternEpoch) {
                     if (recheckPatternEpoch.get() > epoch) {
                         return CompletableFuture.completedFuture(null);
                     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -144,10 +144,7 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                 log.warn("[{}] Failed to recheck topics change: {}", topic, ex.getMessage());
                 long delayMs = retryRecheckPatternTaskBackoff.next();
                 Timeout newTask = client.timer().newTimeout(timeout -> {
-                    if (timeout.cancel()) {
-                        return;
-                    }
-                    recheckTopicsChangeRetryIfFailed();
+                    recheckTopicsChangeRetryIfFailed(timeout);
                 }, delayMs, TimeUnit.MILLISECONDS);
                 if (!retryRecheckPatternTask.compareAndSet(retryTask, newTask)) {
                     // Another thread added a new task, so cancel current one.

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TopicListWatcherTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TopicListWatcherTest.java
@@ -71,7 +71,7 @@ public class TopicListWatcherTest {
         watcherFuture = new CompletableFuture<>();
         watcher = new TopicListWatcher(listener, client,
                 Pattern.compile(topic), 7,
-                NamespaceName.get("tenant/ns"), null, watcherFuture);
+                NamespaceName.get("tenant/ns"), null, watcherFuture, () -> {});
     }
 
     @Test


### PR DESCRIPTION
### Motivation

#### Issue
- Start a consumer subscribe with regexp `public/default/*`
- Create a new topic `public/default/tp-1`
- Send messages to the new topic
- Consumers will not receive any messages, and the messages will be deleted due to there are no subscription.

#### Root cause

**Case-1:**
| Time | Thread `start consumer` | Thread `create topic` |
| --- | --- | --- |
| 1 | Start subscribe |
| 2 | Start to register `TopicListWatcher` | Create new topic |
| 3 | | Topic created |
| 4 | | Since there are no listeners registered, there is no need to notice clients |
| 5 | `TopicListWatcher` registered, the consumer will not receive any messages from the new topic |

**Case-2:**
| Time | Thread `TopicListWatcher reconnect` | Thread `create topic` |
| --- | --- | --- |
| 1 | Start reconnect |
| 2 |  | Create new topic |
| 3 | | Topic created |
| 4 | | Since there are no listeners registered, there is no need to notice clients |
| 5 | `TopicListWatcher` reconnected |
| 6 | The consumer will not receive any messages from the new topic |

This issue only affects the releases `>=3.1`, because before `3.1` there is a supplementary mechanism `scheduled recheckPatternTimeout`, it makes the issues will not occur.  This supplementary mechanism was removed at `3.1`, see https://github.com/apache/pulsar/pull/20779

### Modifications
- After `TopicListWatcher` reconnected, re-check the topics list.


### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs, and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
