### PR TITLE
[improve][bookie] Change majorCompactionThreshold=0.8

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -568,7 +568,7 @@ compactionMaxOutstandingRequests=100000
 # Those entry log files whose remaining size percentage is still
 # higher than the threshold will never be compacted.
 # If it is set to less than zero, the minor compaction is disabled.
-majorCompactionThreshold=0.5
+majorCompactionThreshold=0.8
 
 # Interval to run major compaction, in seconds
 # If it is set to less than zero, the major compaction is disabled.


### PR DESCRIPTION


Fixes #21861

### Motivation
Keep the value of `majorCompactionThreshold` with `bookkeeper`

### Modifications

```
majorCompactionThreshold=0.8
```


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
