### PR TITLE
[improve][broker] PIP-307: Add feature flag config option

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2695,7 +2695,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
                     + "to consumers and producers during bundle unload, allowing them to quickly reconnect to the "
                     + "broker without performing an additional topic lookup."
     )
-    private boolean loadBalancerMultiPhasePhaseBundleUnload = true;
+    private boolean loadBalancerMultiPhaseBundleUnload = true;
 
     /**** --- Replication. --- ****/
     @FieldContext(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2692,11 +2692,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
             category = CATEGORY_LOAD_BALANCER,
             dynamic = true,
-            doc = "Enables the fast unloading of bundles. Set to true, forwards destination broker information to "
-                    + "consumers and producers during bundle unload, allowing them to quickly reconnect to the broker "
-                    + "without performing an additional topic lookup."
+            doc = "Enables the multi-phase unloading of bundles. Set to true, forwards destination broker information "
+                    + "to consumers and producers during bundle unload, allowing them to quickly reconnect to the "
+                    + "broker without performing an additional topic lookup."
     )
-    private boolean loadBalancerOptimizeBundleUnload = true;
+    private boolean loadBalancerMultiPhasePhaseBundleUnload = true;
 
     /**** --- Replication. --- ****/
     @FieldContext(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2691,7 +2691,6 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
             category = CATEGORY_LOAD_BALANCER,
-            dynamic = true,
             doc = "Enables the multi-phase unloading of bundles. Set to true, forwards destination broker information "
                     + "to consumers and producers during bundle unload, allowing them to quickly reconnect to the "
                     + "broker without performing an additional topic lookup."

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2689,6 +2689,15 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private long loadBalancerServiceUnitStateMonitorIntervalInSeconds = 60;
 
+    @FieldContext(
+            category = CATEGORY_LOAD_BALANCER,
+            dynamic = true,
+            doc = "Enables the fast unloading of bundles. Set to true, forwards destination broker information to "
+                    + "consumers and producers during bundle unload, allowing them to quickly reconnect to the broker "
+                    + "without performing an additional topic lookup."
+    )
+    private boolean loadBalancerOptimizeBundleUnload = true;
+
     /**** --- Replication. --- ****/
     @FieldContext(
         category = CATEGORY_REPLICATION,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -320,7 +320,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
                                                                           String topic) {
         var config = pulsar.getConfig();
         if (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(config)
-                && config.isLoadBalancerMultiPhasePhaseBundleUnload()) {
+                && config.isLoadBalancerMultiPhaseBundleUnload()) {
             var topicName = TopicName.get(topic);
             try {
                 return pulsar.getNamespaceService().getBundleAsync(topicName)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -313,11 +313,14 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
      * Gets the assigned broker for the given topic.
      * @param pulsar PulsarService instance
      * @param topic Topic Name
-     * @return the assigned broker's BrokerLookupData instance. Empty, if not assigned by Extensible LoadManager.
+     * @return the assigned broker's BrokerLookupData instance. Empty, if not assigned by Extensible LoadManager or the
+     *         optimized bundle unload process is disabled.
      */
     public static CompletableFuture<Optional<BrokerLookupData>> getAssignedBrokerLookupData(PulsarService pulsar,
                                                                           String topic) {
-        if (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(pulsar.getConfig())) {
+        var config = pulsar.getConfig();
+        if (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(config)
+                && config.isLoadBalancerOptimizeBundleUnload()) {
             var topicName = TopicName.get(topic);
             try {
                 return pulsar.getNamespaceService().getBundleAsync(topicName)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -320,7 +320,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
                                                                           String topic) {
         var config = pulsar.getConfig();
         if (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(config)
-                && config.isLoadBalancerOptimizeBundleUnload()) {
+                && config.isLoadBalancerMultiPhasePhaseBundleUnload()) {
             var topicName = TopicName.get(topic);
             try {
                 return pulsar.getNamespaceService().getBundleAsync(topicName)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -779,8 +779,9 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             lastOwnEventHandledAt = System.currentTimeMillis();
             stateChangeListeners.notify(serviceUnit, data, null);
             log(null, serviceUnit, data, null);
-        } else if ((data.force() || isTransferCommand(data)) && isTargetBroker(data.sourceBroker())
-                && pulsar.getConfig().isLoadBalancerMultiPhaseBundleUnload()) {
+        } else if (isTargetBroker(data.sourceBroker())
+                && (data.force() // orphan cleanup
+                || (isTransferCommand(data) && pulsar.getConfig().isLoadBalancerMultiPhaseBundleUnload()))) { // txfer
             stateChangeListeners.notifyOnCompletion(
                             closeServiceUnit(serviceUnit, true), serviceUnit, data)
                     .whenComplete((__, e) -> log(e, serviceUnit, data, null));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -780,7 +780,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             stateChangeListeners.notify(serviceUnit, data, null);
             log(null, serviceUnit, data, null);
         } else if ((data.force() || isTransferCommand(data)) && isTargetBroker(data.sourceBroker())
-                && pulsar.getConfig().isLoadBalancerMultiPhasePhaseBundleUnload()) {
+                && pulsar.getConfig().isLoadBalancerMultiPhaseBundleUnload()) {
             stateChangeListeners.notifyOnCompletion(
                             closeServiceUnit(serviceUnit, true), serviceUnit, data)
                     .whenComplete((__, e) -> log(e, serviceUnit, data, null));
@@ -806,7 +806,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                 next = new ServiceUnitStateData(
                         Assigning, data.dstBroker(), data.sourceBroker(), getNextVersionId(data));
                 // If the optimized bundle unload is disabled, disconnect the clients at time of RELEASE.
-                var disconnectClients = !pulsar.getConfig().isLoadBalancerMultiPhasePhaseBundleUnload();
+                var disconnectClients = !pulsar.getConfig().isLoadBalancerMultiPhaseBundleUnload();
                 unloadFuture = closeServiceUnit(serviceUnit, disconnectClients);
             } else {
                 next = new ServiceUnitStateData(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -804,7 +804,9 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             if (isTransferCommand(data)) {
                 next = new ServiceUnitStateData(
                         Assigning, data.dstBroker(), data.sourceBroker(), getNextVersionId(data));
-                unloadFuture = closeServiceUnit(serviceUnit, false);
+                // If the optimized bundle unload is disabled, disconnect the clients at the RELEASE state.
+                unloadFuture = closeServiceUnit(serviceUnit,
+                        !pulsar.getConfiguration().isLoadBalancerOptimizeBundleUnload());
             } else {
                 next = new ServiceUnitStateData(
                         Free, null, data.sourceBroker(), getNextVersionId(data));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -805,8 +805,8 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                 next = new ServiceUnitStateData(
                         Assigning, data.dstBroker(), data.sourceBroker(), getNextVersionId(data));
                 // If the optimized bundle unload is disabled, disconnect the clients at time of RELEASE.
-                unloadFuture = closeServiceUnit(serviceUnit,
-                        !pulsar.getConfig().isLoadBalancerOptimizeBundleUnload());
+                var disconnectClients = !pulsar.getConfig().isLoadBalancerOptimizeBundleUnload();
+                unloadFuture = closeServiceUnit(serviceUnit, disconnectClients);
             } else {
                 next = new ServiceUnitStateData(
                         Free, null, data.sourceBroker(), getNextVersionId(data));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -805,7 +805,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                 next = new ServiceUnitStateData(
                         Assigning, data.dstBroker(), data.sourceBroker(), getNextVersionId(data));
                 // If the optimized bundle unload is disabled, disconnect the clients at time of RELEASE.
-                var disconnectClients = !pulsar.getConfig().isLoadBalancerOptimizeBundleUnload();
+                var disconnectClients = !pulsar.getConfig().isLoadBalancerMultiPhasePhaseBundleUnload();
                 unloadFuture = closeServiceUnit(serviceUnit, disconnectClients);
             } else {
                 next = new ServiceUnitStateData(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -804,9 +804,9 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             if (isTransferCommand(data)) {
                 next = new ServiceUnitStateData(
                         Assigning, data.dstBroker(), data.sourceBroker(), getNextVersionId(data));
-                // If the optimized bundle unload is disabled, disconnect the clients at the RELEASE state.
+                // If the optimized bundle unload is disabled, disconnect the clients at time of RELEASE.
                 unloadFuture = closeServiceUnit(serviceUnit,
-                        !pulsar.getConfiguration().isLoadBalancerOptimizeBundleUnload());
+                        !pulsar.getConfig().isLoadBalancerOptimizeBundleUnload());
             } else {
                 next = new ServiceUnitStateData(
                         Free, null, data.sourceBroker(), getNextVersionId(data));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -779,7 +779,8 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             lastOwnEventHandledAt = System.currentTimeMillis();
             stateChangeListeners.notify(serviceUnit, data, null);
             log(null, serviceUnit, data, null);
-        } else if ((data.force() || isTransferCommand(data)) && isTargetBroker(data.sourceBroker())) {
+        } else if ((data.force() || isTransferCommand(data)) && isTargetBroker(data.sourceBroker())
+                && pulsar.getConfig().isLoadBalancerMultiPhasePhaseBundleUnload()) {
             stateChangeListeners.notifyOnCompletion(
                             closeServiceUnit(serviceUnit, true), serviceUnit, data)
                     .whenComplete((__, e) -> log(e, serviceUnit, data, null));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -224,8 +224,8 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
         admin.namespaces().unload(defaultTestNamespace);
         reset(primaryLoadManager, secondaryLoadManager);
         FieldUtils.writeDeclaredField(pulsarClient, "lookup", lookupService, true);
-        pulsar1.getConfig().setLoadBalancerOptimizeBundleUnload(true);
-        pulsar2.getConfig().setLoadBalancerOptimizeBundleUnload(true);
+        pulsar1.getConfig().setLoadBalancerMultiPhasePhaseBundleUnload(true);
+        pulsar2.getConfig().setLoadBalancerMultiPhasePhaseBundleUnload(true);
     }
 
     @Test
@@ -667,8 +667,8 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
         var topic = String.format("%s://%s/%s", topicDomain, defaultTestNamespace, id);
         var topicName = TopicName.get(topic);
 
-        pulsar1.getConfig().setLoadBalancerOptimizeBundleUnload(false);
-        pulsar2.getConfig().setLoadBalancerOptimizeBundleUnload(false);
+        pulsar1.getConfig().setLoadBalancerMultiPhasePhaseBundleUnload(false);
+        pulsar2.getConfig().setLoadBalancerMultiPhasePhaseBundleUnload(false);
 
         @Cleanup
         var producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -224,8 +224,8 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
         admin.namespaces().unload(defaultTestNamespace);
         reset(primaryLoadManager, secondaryLoadManager);
         FieldUtils.writeDeclaredField(pulsarClient, "lookup", lookupService, true);
-        pulsar1.getConfig().setLoadBalancerMultiPhasePhaseBundleUnload(true);
-        pulsar2.getConfig().setLoadBalancerMultiPhasePhaseBundleUnload(true);
+        pulsar1.getConfig().setLoadBalancerMultiPhaseBundleUnload(true);
+        pulsar2.getConfig().setLoadBalancerMultiPhaseBundleUnload(true);
     }
 
     @Test
@@ -667,8 +667,8 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
         var topic = String.format("%s://%s/%s", topicDomain, defaultTestNamespace, id);
         var topicName = TopicName.get(topic);
 
-        pulsar1.getConfig().setLoadBalancerMultiPhasePhaseBundleUnload(false);
-        pulsar2.getConfig().setLoadBalancerMultiPhasePhaseBundleUnload(false);
+        pulsar1.getConfig().setLoadBalancerMultiPhaseBundleUnload(false);
+        pulsar2.getConfig().setLoadBalancerMultiPhaseBundleUnload(false);
 
         @Cleanup
         var producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: [PIP-307](https://github.com/apache/pulsar/blob/master/pip/pip-307.md)

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

This PR adds a non-dynamic option `loadBalancerMultiPhaseBundleUnload` that allows administrators to enable/disable the graceful producer/consumer shutdown upon bundle unloading (PIP-307). Without this, the only means to disable the new mechanism would be disabling the new Extensible Load Manager altogether, which might otherwise work as expected.

### Modifications

Adds configuration option `loadBalancerMultiPhaseBundleUnload` with the default value set to true, enabling the mechanism described in PIP-307 out-of-the-box. With the flag disabled, the clients are disconnected immediately on the source broker upon reaching the `RELEASE` state in the service channel. No lookup information is forwarded to the clients, causing them to fall back on the old behavior, wherein they have to issue lookup calls to locate the new broker serving the topic.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - Added unit test `org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImplTest#testOptimizeUnloadDisable` that verifies client lookups occur on both producers and consumers when the flag is set to disabled
  - Manually verified enablement/disablement of flag in a k8s deployment

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dragosvictor/pulsar/pull/5

