### PR TITLE
[improve][broker] Skip loading the NAR packages if not configured

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/plugin/servlet/AdditionalServlets.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/plugin/servlet/AdditionalServlets.java
@@ -79,12 +79,16 @@ public class AdditionalServlets implements AutoCloseable {
             return null;
         }
 
+        String[] additionalServletsList = additionalServlets.split(",");
+        if (additionalServletsList.length == 0) {
+            return null;
+        }
+
         AdditionalServletDefinitions definitions =
                 AdditionalServletUtils.searchForServlets(additionalServletDirectory
                         , narExtractionDirectory);
         ImmutableMap.Builder<String, AdditionalServletWithClassLoader> builder = ImmutableMap.builder();
 
-        String[] additionalServletsList = additionalServlets.split(",");
         for (String servletName : additionalServletsList) {
             AdditionalServletMetadata definition = definitions.servlets().get(servletName);
             if (null == definition) {
@@ -106,7 +110,7 @@ public class AdditionalServlets implements AutoCloseable {
         }
 
         Map<String, AdditionalServletWithClassLoader> servlets = builder.build();
-        if (servlets != null && !servlets.isEmpty()) {
+        if (!servlets.isEmpty()) {
             return new AdditionalServlets(servlets);
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptors.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptors.java
@@ -59,6 +59,9 @@ public class BrokerInterceptors implements BrokerInterceptor {
      * @return the collection of broker event interceptor
      */
     public static BrokerInterceptor load(ServiceConfiguration conf) throws IOException {
+        if (conf.getBrokerInterceptors().isEmpty()) {
+            return null;
+        }
         BrokerInterceptorDefinitions definitions =
                 BrokerInterceptorUtils.searchForInterceptors(conf.getBrokerInterceptorsDirectory(),
                         conf.getNarExtractionDirectory());
@@ -87,7 +90,7 @@ public class BrokerInterceptors implements BrokerInterceptor {
         });
 
         Map<String, BrokerInterceptorWithClassLoader> interceptors = builder.build();
-        if (interceptors != null && !interceptors.isEmpty()) {
+        if (!interceptors.isEmpty()) {
             return new BrokerInterceptors(interceptors);
         } else {
             return null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/protocol/ProtocolHandlers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/protocol/ProtocolHandlers.java
@@ -24,6 +24,7 @@ import io.netty.channel.socket.SocketChannel;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -51,6 +52,9 @@ public class ProtocolHandlers implements AutoCloseable {
      * @return the collection of protocol handlers
      */
     public static ProtocolHandlers load(ServiceConfiguration conf) throws IOException {
+        if (conf.getMessagingProtocols().isEmpty()) {
+            return new ProtocolHandlers(Collections.emptyMap());
+        }
         ProtocolHandlerDefinitions definitions =
                 ProtocolHandlerUtils.searchForHandlers(
                         conf.getProtocolHandlerDirectory(), conf.getNarExtractionDirectory());


### PR DESCRIPTION
### Motivation

When loading NAR packages, including broker interceptors, additional servlets and protocol handlers, even if they are not configured, the NAR packages are still loaded, which is unnecessary and slows the restarting of a broker.

### Modifications

Skip searching the directories and loading NAR packages when no plugin is configured, including:
- `BrokerInterceptors#load`
- `AdditionalServlets#load`
- `ProtocolHandlers#load`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 