### PR TITLE
[improve][pip] PIP-329: Strategy for maintaining the latest tag to Pulsar docker images

### DIFF
--- a/pip/pip-329.md
+++ b/pip/pip-329.md
@@ -1,0 +1,62 @@
+<!--
+RULES
+* Never place a link to an external site like Google Doc. The proposal should be in this issue entirely.
+* Use a spelling and grammar checker tools if available for you (there are plenty of free ones).
+
+PROPOSAL HEALTH CHECK
+I can read the design document and understand the problem statement and what you plan to change *without* resorting to a couple of hours of code reading just to start having a high level understanding of the change.
+
+IMAGES
+If you need diagrams, avoid attaching large files. You can use [MermaidJS]([url](https://mermaid.js.org/)) as a simple language to describe many types of diagrams.
+
+THIS COMMENTS
+Please remove them when done.
+-->
+
+# PIP-329: Strategy for maintaining the latest tag to Pulsar docker images
+
+# Motivation
+
+We've noticed an issue with our current release process. Specifically, we're unsure which Pulsar version the 'latest'
+tag should refer to in our Docker images. We've had initial agreement from previous discussions, found
+here: https://lists.apache.org/thread/h4m90ff7dgx0110onctf5ntq0ktydzv1. 
+
+Now, we need to formally propose a PIP to address this.
+
+# Goals
+
+## In Scope
+
+- Define the strategy for maintaining the latest tag to Pulsar docker images in the release process
+
+## Out of Scope
+
+- None
+
+# High Level Design
+
+Refine the release process to clearly demonstrate the strategy for managing the 'latest' tag for Pulsar Docker images:
+
+> The 'latest' tag should be pointed to the most recent feature release or any subsequent patch of that feature
+> release. For example, it could refer to 3.1.2 (assuming it's the latest patch of 3.1) or to 3.2.0.
+
+# Alternatives
+
+An alternative strategy is
+
+> The latest tag could point to the most recent feature release or
+> the subsequent patch of that feature release. For instance, it could
+> currently point to 3.1.1, and in the future, it could point to 3.1.2
+> or 3.2.0.
+
+Feedback from the community indicates a preference for the solution proposed by this PIP.
+
+# General Notes
+
+Discussion
+of `Strategy for pushing the latest tag to Pulsar docker images`: https://lists.apache.org/thread/h4m90ff7dgx0110onctf5ntq0ktydzv1
+
+# Links
+
+* Mailing List discussion thread:
+* Mailing List voting thread:

--- a/pip/pip-329.md
+++ b/pip/pip-329.md
@@ -66,5 +66,5 @@ Feedback from the community indicates a preference for the solution proposed by 
 
 # Links
 
-* Mailing List discussion thread:
-* Mailing List voting thread:
+* Mailing List discussion thread: https://lists.apache.org/thread/x7r1f2vgmowykwdcb3mmrv0d8lj4y1t9
+* Mailing List voting thread: https://lists.apache.org/thread/f9j0xjjlyz54880zyzon3xm5y0zn37xb

--- a/pip/pip-329.md
+++ b/pip/pip-329.md
@@ -17,9 +17,12 @@ Please remove them when done.
 
 # Motivation
 
-We've noticed an issue with our current release process. Specifically, we're unsure which Pulsar version the 'latest'
-tag should refer to in our Docker images. We've had initial agreement from previous discussions, found
-here: https://lists.apache.org/thread/h4m90ff7dgx0110onctf5ntq0ktydzv1. 
+There is a gap in our current release process concerning the
+pushing of the latest tag to our Docker images. Specifically, we need
+to decide which version of Pulsar the latest tag should point to.
+
+We've had initial agreement from previous discussions, found
+here: https://lists.apache.org/thread/h4m90ff7dgx0110onctf5ntq0ktydzv1.
 
 Now, we need to formally propose a PIP to address this.
 
@@ -37,8 +40,12 @@ Now, we need to formally propose a PIP to address this.
 
 Refine the release process to clearly demonstrate the strategy for managing the 'latest' tag for Pulsar Docker images:
 
-> The 'latest' tag should be pointed to the most recent feature release or any subsequent patch of that feature
-> release. For example, it could refer to 3.1.2 (assuming it's the latest patch of 3.1) or to 3.2.0.
+The 'latest' tag should be pointed to the most recent feature release or any subsequent patch of that feature
+release. For instance, if the most recent feature release is version 3.1, and it has been updated with patches, the '
+latest' tag could point to version 3.1.2, assuming this is the latest patch for the 3.1 feature. Alternatively, if a new
+feature release, say 3.2.0, is introduced, the 'latest' tag would then point to this new version.
+
+In simpler terms, the `latest` tag will always point to the newest version of a feature.
 
 # Alternatives
 

--- a/pip/pip-329.md
+++ b/pip/pip-329.md
@@ -60,8 +60,9 @@ Feedback from the community indicates a preference for the solution proposed by 
 
 # General Notes
 
-Discussion
-of `Strategy for pushing the latest tag to Pulsar docker images`: https://lists.apache.org/thread/h4m90ff7dgx0110onctf5ntq0ktydzv1
+- Discussion
+  of `Strategy for pushing the latest tag to Pulsar docker images`: https://lists.apache.org/thread/h4m90ff7dgx0110onctf5ntq0ktydzv1
+- The implementation PR for this PIP: https://github.com/apache/pulsar-site/pull/745
 
 # Links
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

There is a gap in our current release process concerning the
pushing of the latest tag to our Docker images. Specifically, we need
to decide which version of Pulsar the latest tag should point to.

We've had initial agreement from previous discussions, found
here: https://lists.apache.org/thread/h4m90ff7dgx0110onctf5ntq0ktydzv1.

Now, we need to formally propose a PIP to address this.

### Modifications

- Define the strategy for maintaining the latest tag to Pulsar docker images in the release process

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
