### PR TITLE
[improve] [broker] PIP-299-part-4: Add topic-level policy: dispatcherPauseOnAckStatePersistent

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3539,7 +3539,8 @@ public class PersistentTopicsBase extends AdminResource {
             });
     }
 
-    protected CompletableFuture<Boolean> internalGetDispatcherPauseOnAckStatePersistent(boolean applied, boolean isGlobal) {
+    protected CompletableFuture<Boolean> internalGetDispatcherPauseOnAckStatePersistent(boolean applied,
+                                                                                        boolean isGlobal) {
         return getTopicPoliciesAsyncWithRetry(topicName, isGlobal)
             .thenApply(op -> op.map(TopicPolicies::getDispatcherPauseOnAckStatePersistentEnabled)
                 .orElse(false));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3518,6 +3518,33 @@ public class PersistentTopicsBase extends AdminResource {
                 });
     }
 
+    protected CompletableFuture<Void> internalSetDispatcherPauseOnAckStatePersistent(boolean isGlobal) {
+        return getTopicPoliciesAsyncWithRetry(topicName, isGlobal)
+            .thenCompose(op -> {
+                TopicPolicies topicPolicies = op.orElseGet(TopicPolicies::new);
+                topicPolicies.setDispatcherPauseOnAckStatePersistentEnabled(true);
+                topicPolicies.setIsGlobal(isGlobal);
+                return pulsar().getTopicPoliciesService().updateTopicPoliciesAsync(topicName, topicPolicies);
+            });
+    }
+
+    protected CompletableFuture<Void> internalRemoveDispatcherPauseOnAckStatePersistent(boolean isGlobal) {
+        return getTopicPoliciesAsyncWithRetry(topicName, isGlobal)
+            .thenCompose(op -> {
+                if (!op.isPresent()) {
+                    return CompletableFuture.completedFuture(null);
+                }
+                op.get().setDispatcherPauseOnAckStatePersistentEnabled(false);
+                return pulsar().getTopicPoliciesService().updateTopicPoliciesAsync(topicName, op.get());
+            });
+    }
+
+    protected CompletableFuture<Boolean> internalGetDispatcherPauseOnAckStatePersistent(boolean applied, boolean isGlobal) {
+        return getTopicPoliciesAsyncWithRetry(topicName, isGlobal)
+            .thenApply(op -> op.map(TopicPolicies::getDispatcherPauseOnAckStatePersistentEnabled)
+                .orElse(false));
+}
+
     protected CompletableFuture<PersistencePolicies> internalGetPersistence(boolean applied, boolean isGlobal) {
         return getTopicPoliciesAsyncWithRetry(topicName, isGlobal)
             .thenApply(op -> op.map(TopicPolicies::getPersistence)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -2515,13 +2515,12 @@ public class PersistentTopics extends PersistentTopicsBase {
 
     @POST
     @Path("/{tenant}/{namespace}/{topic}/dispatcherPauseOnAckStatePersistent")
-    @ApiOperation(value = "Set retention configuration for specified topic.")
+    @ApiOperation(value = "Set dispatcher pause on ack state persistent configuration for specified topic.")
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace or topic doesn't exist"),
             @ApiResponse(code = 405, message =
                     "Topic level policy is disabled, to enable the topic level policy and retry"),
-            @ApiResponse(code = 409, message = "Concurrent modification"),
-            @ApiResponse(code = 412, message = "Retention Quota must exceed backlog quota")})
+            @ApiResponse(code = 409, message = "Concurrent modification")})
     public void setDispatcherPauseOnAckStatePersistent(@Suspended final AsyncResponse asyncResponse,
             @PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace,
@@ -2545,13 +2544,12 @@ public class PersistentTopics extends PersistentTopicsBase {
 
     @DELETE
     @Path("/{tenant}/{namespace}/{topic}/dispatcherPauseOnAckStatePersistent")
-    @ApiOperation(value = "Remove retention configuration for specified topic.")
+    @ApiOperation(value = "Remove dispatcher pause on ack state persistent configuration for specified topic.")
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace or topic doesn't exist"),
             @ApiResponse(code = 405,
                     message = "Topic level policy is disabled, to enable the topic level policy and retry"),
-            @ApiResponse(code = 409, message = "Concurrent modification"),
-            @ApiResponse(code = 412, message = "Retention Quota must exceed backlog quota")})
+            @ApiResponse(code = 409, message = "Concurrent modification")})
     public void removeDispatcherPauseOnAckStatePersistent(@Suspended final AsyncResponse asyncResponse,
             @PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace,
@@ -2575,18 +2573,18 @@ public class PersistentTopics extends PersistentTopicsBase {
 
     @GET
     @Path("/{tenant}/{namespace}/{topic}/dispatcherPauseOnAckStatePersistent")
-    @ApiOperation(value = "Get max unacked messages per consumer config on a topic.", response = Integer.class)
+    @ApiOperation(value = "Get dispatcher pause on ack state persistent config on a topic.", response = Integer.class)
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Tenant or cluster or namespace or topic doesn't exist"),
             @ApiResponse(code = 500, message = "Internal server error"), })
     public void getDispatcherPauseOnAckStatePersistent(@Suspended final AsyncResponse asyncResponse,
-                                                @PathParam("tenant") String tenant,
-                                                @PathParam("namespace") String namespace,
-                                                @PathParam("topic") @Encoded String encodedTopic,
-                                                @QueryParam("applied") @DefaultValue("false") boolean applied,
-                                                @QueryParam("isGlobal") @DefaultValue("false") boolean isGlobal,
-                                                @ApiParam(value = "Whether leader broker redirected this call to this broker. For internal use.")
-                                                @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+                    @PathParam("tenant") String tenant,
+                    @PathParam("namespace") String namespace,
+                    @PathParam("topic") @Encoded String encodedTopic,
+                    @QueryParam("applied") @DefaultValue("false") boolean applied,
+                    @QueryParam("isGlobal") @DefaultValue("false") boolean isGlobal,
+                    @ApiParam(value = "Whether leader broker redirected this call to this broker. For internal use.")
+                    @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
         preValidation(authoritative)
                 .thenCompose(__ -> internalGetDispatcherPauseOnAckStatePersistent(applied, isGlobal))

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -218,6 +218,8 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
                     .updateTopicValue(formatSchemaCompatibilityStrategy(data.getSchemaCompatibilityStrategy()));
         }
         topicPolicies.getRetentionPolicies().updateTopicValue(data.getRetentionPolicies());
+        topicPolicies.getDispatcherPauseOnAckStatePersistentEnabled()
+                .updateTopicValue(data.getDispatcherPauseOnAckStatePersistentEnabled());
         topicPolicies.getMaxSubscriptionsPerTopic().updateTopicValue(data.getMaxSubscriptionsPerTopic());
         topicPolicies.getMaxUnackedMessagesOnConsumer().updateTopicValue(data.getMaxUnackedMessagesOnConsumer());
         topicPolicies.getMaxUnackedMessagesOnSubscription()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3138,6 +3138,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         applyPoliciesFutureList.add(FutureUtil.runWithCurrentThread(() -> checkPersistencePolicies()));
         applyPoliciesFutureList.add(FutureUtil.runWithCurrentThread(
                 () -> preCreateSubscriptionForCompactionIfNeeded()));
+        applyPoliciesFutureList.add(FutureUtil.runWithCurrentThread(
+                () -> updateBrokerDispatchPauseOnAckStatePersistentEnabled()));
 
         return applyPoliciesFutureList;
     }
@@ -3800,7 +3802,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 if (subscription.getDispatcher() == null) {
                     return;
                 }
-                subscription.getDispatcher().afterAckMessages(null, 0);
+                subscription.getDispatcher().checkAndResumeIfPaused();
             });
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionPauseOnAckStatPersistTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionPauseOnAckStatPersistTest.java
@@ -213,27 +213,74 @@ public class SubscriptionPauseOnAckStatPersistTest extends ProducerConsumerBase 
         }
     }
 
-    @Test
-    public void testBrokerDynamicConfig() throws Exception {
+    @DataProvider(name = "typesOfSetDispatcherPauseOnAckStatePersistent")
+    public Object[][] typesOfSetDispatcherPauseOnAckStatePersistent() {
+        return new Object[][]{
+          {TypeOfUpdateTopicConfig.BROKER_CONF},
+          //{TypeOfUpdateTopicConfig.NAMESPACE_LEVEL_POLICY},
+          {TypeOfUpdateTopicConfig.TOPIC_LEVEL_POLICY}
+        };
+    }
+
+    public enum TypeOfUpdateTopicConfig {
+        BROKER_CONF,
+        TOPIC_LEVEL_POLICY;
+    }
+
+    private void enableDispatcherPauseOnAckStatePersistentAndCreateTopic(String tpName, TypeOfUpdateTopicConfig type)
+            throws Exception {
+        if (type == TypeOfUpdateTopicConfig.BROKER_CONF) {
+            admin.brokers().updateDynamicConfiguration("dispatcherPauseOnAckStatePersistentEnabled", "true");
+            admin.topics().createNonPartitionedTopic(tpName);
+        } else if (type == TypeOfUpdateTopicConfig.TOPIC_LEVEL_POLICY) {
+            admin.topics().createNonPartitionedTopic(tpName);
+            admin.topicPolicies().setDispatcherPauseOnAckStatePersistent(tpName).join();
+        }
+        Awaitility.await().untilAsserted(() -> {
+            PersistentTopic persistentTopic =
+                    (PersistentTopic) pulsar.getBrokerService().getTopic(tpName, false).join().get();
+            HierarchyTopicPolicies policies = WhiteboxImpl.getInternalState(persistentTopic, "topicPolicies");
+            Assert.assertTrue(persistentTopic.isDispatcherPauseOnAckStatePersistentEnabled());
+            if (type == TypeOfUpdateTopicConfig.BROKER_CONF) {
+                Assert.assertTrue(pulsar.getConfig().isDispatcherPauseOnAckStatePersistentEnabled());
+            } else if (type == TypeOfUpdateTopicConfig.TOPIC_LEVEL_POLICY){
+                Assert.assertTrue(policies.getDispatcherPauseOnAckStatePersistentEnabled().getTopicValue());
+                Assert.assertTrue(admin.topicPolicies().getDispatcherPauseOnAckStatePersistent(tpName, false).join());
+            }
+        });
+    }
+
+    private void disableDispatcherPauseOnAckStatePersistent(String tpName, TypeOfUpdateTopicConfig type)
+            throws Exception {
+        if (type == TypeOfUpdateTopicConfig.BROKER_CONF) {
+            admin.brokers().updateDynamicConfiguration("dispatcherPauseOnAckStatePersistentEnabled", "false");
+        } else if (type == TypeOfUpdateTopicConfig.TOPIC_LEVEL_POLICY) {
+            admin.topicPolicies().removeDispatcherPauseOnAckStatePersistent(tpName).join();
+        }
+        Awaitility.await().untilAsserted(() -> {
+            PersistentTopic persistentTopic =
+                    (PersistentTopic) pulsar.getBrokerService().getTopic(tpName, false).join().get();
+            HierarchyTopicPolicies policies = WhiteboxImpl.getInternalState(persistentTopic, "topicPolicies");
+            Assert.assertFalse(persistentTopic.isDispatcherPauseOnAckStatePersistentEnabled());
+            if (type == TypeOfUpdateTopicConfig.BROKER_CONF) {
+                Assert.assertFalse(pulsar.getConfig().isDispatcherPauseOnAckStatePersistentEnabled());
+            } else if (type == TypeOfUpdateTopicConfig.TOPIC_LEVEL_POLICY){
+                Assert.assertFalse(policies.getDispatcherPauseOnAckStatePersistentEnabled().getTopicValue());
+                Assert.assertFalse(admin.topicPolicies().getDispatcherPauseOnAckStatePersistent(tpName, false).join());
+            }
+        });
+    }
+
+    @Test(dataProvider = "typesOfSetDispatcherPauseOnAckStatePersistent")
+    public void testBrokerDynamicConfig(TypeOfUpdateTopicConfig type) throws Exception {
         final String tpName = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
         final String subscription = "s1";
         final int msgSendCount = MAX_UNACKED_RANGES_TO_PERSIST * 4;
         final int incomingQueueSize = MAX_UNACKED_RANGES_TO_PERSIST * 10;
 
         // Enable "dispatcherPauseOnAckStatePersistentEnabled".
-        admin.brokers().updateDynamicConfiguration("dispatcherPauseOnAckStatePersistentEnabled", "true");
-        admin.topics().createNonPartitionedTopic(tpName);
+        enableDispatcherPauseOnAckStatePersistentAndCreateTopic(tpName, type);
         admin.topics().createSubscription(tpName, subscription, MessageId.earliest);
-
-        PersistentTopic persistentTopic =
-                (PersistentTopic) pulsar.getBrokerService().getTopic(tpName, false).join().get();
-        Awaitility.await().untilAsserted(() -> {
-            Assert.assertTrue(pulsar.getConfig().isDispatcherPauseOnAckStatePersistentEnabled());
-            HierarchyTopicPolicies policies = WhiteboxImpl.getInternalState(persistentTopic, "topicPolicies");
-            Boolean v = policies.getDispatcherPauseOnAckStatePersistentEnabled().get();
-            Assert.assertNotNull(v);
-            Assert.assertTrue(v.booleanValue());
-        });
 
         // Send double MAX_UNACKED_RANGES_TO_PERSIST messages.
         Producer<String> p1 = pulsarClient.newProducer(Schema.STRING).topic(tpName).enableBatching(false).create();
@@ -259,13 +306,7 @@ public class SubscriptionPauseOnAckStatPersistTest extends ProducerConsumerBase 
         Assert.assertNull(msg1, msg1 == null ? "null" : msg1.getValue());
 
         // Disable "dispatcherPauseOnAckStatePersistentEnabled".
-        admin.brokers().updateDynamicConfiguration("dispatcherPauseOnAckStatePersistentEnabled", "false");
-        Awaitility.await().untilAsserted(() -> {
-            Assert.assertFalse(pulsar.getConfig().isDispatcherPauseOnAckStatePersistentEnabled());
-            HierarchyTopicPolicies policies = WhiteboxImpl.getInternalState(persistentTopic, "topicPolicies");
-            Boolean v = policies.getDispatcherPauseOnAckStatePersistentEnabled().get();
-            Assert.assertTrue(v == null || !v.booleanValue());
-        });
+        disableDispatcherPauseOnAckStatePersistent(tpName, type);
 
         // Verify the new message can be received.
         Message<String> msg2 = c1.receive(2, TimeUnit.SECONDS);

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/TopicPolicies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/TopicPolicies.java
@@ -1913,4 +1913,20 @@ public interface TopicPolicies {
      *            Topic name
      */
     CompletableFuture<Void> removeAutoSubscriptionCreationAsync(String topic);
+
+    /**
+     * After enabling this feature, Pulsar will stop delivery messages to clients if the cursor metadata is too large to
+     * # persist, it will help to reduce the duplicates caused by the ack state that can not be fully persistent.
+     */
+    CompletableFuture<Void> setDispatcherPauseOnAckStatePersistent(String topic);
+
+    /**
+     * Removes the dispatcherPauseOnAckStatePersistentEnabled policy for a given topic asynchronously.
+     */
+    CompletableFuture<Void> removeDispatcherPauseOnAckStatePersistent(String topic);
+
+    /**
+     * Get the dispatcherPauseOnAckStatePersistentEnabled policy for a given topic asynchronously.
+     */
+    CompletableFuture<Boolean> getDispatcherPauseOnAckStatePersistent(String topic, boolean applied);
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicPoliciesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicPoliciesImpl.java
@@ -1260,6 +1260,27 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         return asyncDeleteRequest(path);
     }
 
+    @Override
+    public CompletableFuture<Void> setDispatcherPauseOnAckStatePersistent(String topic) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "dispatcherPauseOnAckStatePersistent");
+        return asyncPostRequest(path, Entity.entity("", MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public CompletableFuture<Void> removeDispatcherPauseOnAckStatePersistent(String topic) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "dispatcherPauseOnAckStatePersistent");
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> getDispatcherPauseOnAckStatePersistent(String topic, boolean applied) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "dispatcherPauseOnAckStatePersistent").queryParam("applied", applied);
+        return asyncGetRequest(path, new FutureCallback<Boolean>(){});
+    }
+
     /*
      * returns topic name with encoded Local Name
      */

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
@@ -1938,13 +1938,10 @@ public class CmdTopicPolicies extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Enable autoSubscriptionCreation for a topic")
+    @Parameters(commandDescription = "Enable dispatcherPauseOnAckStatePersistent for a topic")
     private class SetDispatcherPauseOnAckStatePersistent extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
-
-        @Parameter(names = {"--enable", "-e"}, description = "Enable allowAutoSubscriptionCreation on topic")
-        private boolean enable = false;
 
         @Parameter(names = { "--global", "-g" }, description = "Whether to set this policy globally. "
                 + "If set to true, the policy will be replicate to other clusters asynchronously")
@@ -1957,7 +1954,7 @@ public class CmdTopicPolicies extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Get the autoSubscriptionCreation for a topic")
+    @Parameters(commandDescription = "Get the dispatcherPauseOnAckStatePersistent for a topic")
     private class GetDispatcherPauseOnAckStatePersistent extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;
@@ -1976,7 +1973,7 @@ public class CmdTopicPolicies extends CmdBase {
         }
     }
 
-    @Parameters(commandDescription = "Remove override of autoSubscriptionCreation for a topic")
+    @Parameters(commandDescription = "Remove dispatcherPauseOnAckStatePersistent for a topic")
     private class RemoveDispatcherPauseOnAckStatePersistent extends CliCommand {
         @Parameter(description = "persistent://tenant/namespace/topic", required = true)
         private java.util.List<String> params;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
@@ -165,6 +165,13 @@ public class CmdTopicPolicies extends CmdBase {
         jcommander.addCommand("set-auto-subscription-creation", new SetAutoSubscriptionCreation());
         jcommander.addCommand("get-auto-subscription-creation", new GetAutoSubscriptionCreation());
         jcommander.addCommand("remove-auto-subscription-creation", new RemoveAutoSubscriptionCreation());
+
+        jcommander.addCommand("set-dispatcher-pause-on-ack-state-persistent",
+                new SetDispatcherPauseOnAckStatePersistent());
+        jcommander.addCommand("get-dispatcher-pause-on-ack-state-persistent",
+                new GetDispatcherPauseOnAckStatePersistent());
+        jcommander.addCommand("remove-dispatcher-pause-on-ack-state-persistent",
+                new RemoveDispatcherPauseOnAckStatePersistent());
     }
 
     @Parameters(commandDescription = "Get entry filters for a topic")
@@ -1928,6 +1935,60 @@ public class CmdTopicPolicies extends CmdBase {
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
             getTopicPolicies(isGlobal).removeAutoSubscriptionCreation(persistentTopic);
+        }
+    }
+
+    @Parameters(commandDescription = "Enable autoSubscriptionCreation for a topic")
+    private class SetDispatcherPauseOnAckStatePersistent extends CliCommand {
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = {"--enable", "-e"}, description = "Enable allowAutoSubscriptionCreation on topic")
+        private boolean enable = false;
+
+        @Parameter(names = { "--global", "-g" }, description = "Whether to set this policy globally. "
+                + "If set to true, the policy will be replicate to other clusters asynchronously")
+        private boolean isGlobal = false;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String persistentTopic = validatePersistentTopic(params);
+            getTopicPolicies(isGlobal).setDispatcherPauseOnAckStatePersistent(persistentTopic);
+        }
+    }
+
+    @Parameters(commandDescription = "Get the autoSubscriptionCreation for a topic")
+    private class GetDispatcherPauseOnAckStatePersistent extends CliCommand {
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = {"--applied", "-a"}, description = "Get the applied policy of the topic")
+        private boolean applied = false;
+
+        @Parameter(names = {"--global", "-g"}, description = "Whether to get this policy globally. "
+                + "If set to true, broker returned global topic policies")
+        private boolean isGlobal = false;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String persistentTopic = validatePersistentTopic(params);
+            print(getTopicPolicies(isGlobal).getDispatcherPauseOnAckStatePersistent(persistentTopic, applied));
+        }
+    }
+
+    @Parameters(commandDescription = "Remove override of autoSubscriptionCreation for a topic")
+    private class RemoveDispatcherPauseOnAckStatePersistent extends CliCommand {
+        @Parameter(description = "persistent://tenant/namespace/topic", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = {"--global", "-g"}, description = "Whether to remove this policy globally. "
+                + "If set to true, the policy will be replicate to other clusters asynchronously")
+        private boolean isGlobal = false;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String persistentTopic = validatePersistentTopic(params);
+            getTopicPolicies(isGlobal).removeDispatcherPauseOnAckStatePersistent(persistentTopic);
         }
     }
 


### PR DESCRIPTION
The part 3 of [PIP-299](https://github.com/apache/pulsar/pull/21118/files?short_path=cf766b5#diff-cf766b5d463b6832017e482baad14832f6a4d41dc969da279b98b69e26ec6f6a): the implementation of "Add dynamic config support: dispatcherPauseOnAckStatePersistentEnabled"

Related PRs:
- [x] https://github.com/apache/pulsar/pull/21423
- [x] https://github.com/apache/pulsar/pull/21370
- [x] https://github.com/apache/pulsar/pull/21837
- **(Current PR)** part-4: Topic level policies support.
- part-5: Namespace level policies support
- part-6: Doc

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
