### PR TITLE
[improve][cli] error out when --destinationBroker is set when --bundle is empty

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -468,6 +468,11 @@ public class PulsarAdminToolTest {
         namespaces.run(split("remove-replicator-dispatch-rate myprop/clust/ns1"));
         verify(mockNamespaces).removeReplicatorDispatchRate("myprop/clust/ns1");
 
+
+        assertFalse(namespaces.run(split("unload myprop/clust/ns1 -d broker")));
+        verify(mockNamespaces, times(0)).unload("myprop/clust/ns1");
+
+        namespaces = new CmdNamespaces(() -> admin);
         namespaces.run(split("unload myprop/clust/ns1"));
         verify(mockNamespaces).unload("myprop/clust/ns1");
 
@@ -483,6 +488,10 @@ public class PulsarAdminToolTest {
 
         namespaces.run(split("unload myprop/clust/ns1 -b 0x80000000_0xffffffff"));
         verify(mockNamespaces).unloadNamespaceBundle("myprop/clust/ns1", "0x80000000_0xffffffff", null);
+
+        namespaces = new CmdNamespaces(() -> admin);
+        namespaces.run(split("unload myprop/clust/ns1 -b 0x80000000_0xffffffff -d broker"));
+        verify(mockNamespaces).unloadNamespaceBundle("myprop/clust/ns1", "0x80000000_0xffffffff", "broker");
 
         namespaces.run(split("split-bundle myprop/clust/ns1 -b 0x00000000_0xffffffff"));
         verify(mockNamespaces).splitNamespaceBundle("myprop/clust/ns1", "0x00000000_0xffffffff", false, null);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -866,13 +866,19 @@ public class CmdNamespaces extends CmdBase {
         private String bundle;
 
         @Parameter(names = { "--destinationBroker", "-d" },
-                description = "Target brokerWebServiceAddress to which the bundle has to be allocated to")
+                description = "Target brokerWebServiceAddress to which the bundle has to be allocated to. "
+                        + "--destinationBroker cannot be set when --bundle is not specified.")
         private String destinationBroker;
 
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
+
+
             if (bundle == null) {
+                if (StringUtils.isNotBlank(destinationBroker)) {
+                    throw new ParameterException("--destinationBroker cannot be set when --bundle is not specified.");
+                }
                 getAdmin().namespaces().unload(namespace);
             } else {
                 getAdmin().namespaces().unloadNamespaceBundle(namespace, bundle, destinationBroker);


### PR DESCRIPTION


<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->



<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

The 'pulsar-admin namespaces unload' cli silently ignores --destinationBroker when --bundle is empty. I think we can error out in this case and clarify the usage of destinationBroker.

### Modifications

- error out when --destinationBroker is set when --bundle is empty
- updated the --destinationBroker option description.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
