### PR TITLE
[improve][broker] Improve NamespaceUnloadStrategy error message

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/UnloadScheduler.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/UnloadScheduler.java
@@ -219,9 +219,8 @@ public class UnloadScheduler implements LoadManagerScheduler {
                     Thread.currentThread().getContextClassLoader());
             log.info("Created namespace unload strategy:{}", unloadStrategy.getClass().getCanonicalName());
         } catch (Exception e) {
-            log.error("Error when trying to create namespace unload strategy: {}",
-                    conf.getLoadBalancerLoadPlacementStrategy(), e);
-            log.error("create namespace unload strategy failed. using TransferShedder instead.");
+            log.error("Error when trying to create namespace unload strategy: {}. Using {} instead.",
+                    conf.getLoadBalancerLoadPlacementStrategy(), TransferShedder.class.getName(), e);
             unloadStrategy = new TransferShedder();
         }
         unloadStrategy.initialize(pulsar);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/UnloadScheduler.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/UnloadScheduler.java
@@ -220,7 +220,7 @@ public class UnloadScheduler implements LoadManagerScheduler {
             log.info("Created namespace unload strategy:{}", unloadStrategy.getClass().getCanonicalName());
         } catch (Exception e) {
             log.error("Error when trying to create namespace unload strategy: {}. Using {} instead.",
-                    conf.getLoadBalancerLoadPlacementStrategy(), TransferShedder.class.getCanonicalName(), e);
+                    conf.getLoadBalancerLoadSheddingStrategy(), TransferShedder.class.getCanonicalName(), e);
             unloadStrategy = new TransferShedder();
         }
         unloadStrategy.initialize(pulsar);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/UnloadScheduler.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/UnloadScheduler.java
@@ -220,7 +220,7 @@ public class UnloadScheduler implements LoadManagerScheduler {
             log.info("Created namespace unload strategy:{}", unloadStrategy.getClass().getCanonicalName());
         } catch (Exception e) {
             log.error("Error when trying to create namespace unload strategy: {}. Using {} instead.",
-                    conf.getLoadBalancerLoadPlacementStrategy(), TransferShedder.class.getName(), e);
+                    conf.getLoadBalancerLoadPlacementStrategy(), TransferShedder.class.getCanonicalName(), e);
             unloadStrategy = new TransferShedder();
         }
         unloadStrategy.initialize(pulsar);

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithExtensibleLoadManagerTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithExtensibleLoadManagerTest.java
@@ -47,6 +47,7 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
+import org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedder;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -97,6 +98,7 @@ public class ProxyWithExtensibleLoadManagerTest extends MultiBrokerBaseTest {
         config.setLoadBalancerInFlightServiceUnitStateWaitingTimeInMillis(5 * 1000);
         config.setLoadBalancerServiceUnitStateMonitorIntervalInSeconds(1);
         config.setLoadManagerClassName(ExtensibleLoadManagerImpl.class.getName());
+        config.setLoadBalancerLoadSheddingStrategy(TransferShedder.class.getName());
         config.setLoadBalancerSheddingEnabled(false);
         return config;
     }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

The log message printed when failing to create the `NamespaceUnloadStrategy` class instance mistakenly references a different config option.
Additionally fixes setup for tests in `ProxyWithExtensibleLoadManagerTest`, where the option was defaulting to value `org.apache.pulsar.broker.loadbalance.impl.ThresholdShedder`, which is incompatible with the extensible load manager, and was producing the following error message during test runs:

```
2024-01-10T14:57:28,347 - ERROR - [main:UnloadScheduler@222] - Error when trying to create namespace unload strategy: org.apache.pul
sar.broker.loadbalance.impl.LeastLongTermMessageRate
java.lang.RuntimeException: org.apache.pulsar.broker.loadbalance.impl.ThresholdShedder does not implement org.apache.pulsar.broker.l
oadbalance.extensions.scheduler.NamespaceUnloadStrategy
        at org.apache.pulsar.common.util.Reflections.createInstance(Reflections.java:75) ~[pulsar-common-3.3.0-SNAPSHOT.jar:3.3.0-SN
APSHOT]
        at org.apache.pulsar.broker.loadbalance.extensions.scheduler.UnloadScheduler.createNamespaceUnloadStrategy(UnloadScheduler.j
ava:217) ~[pulsar-broker-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
```

### Modifications

Alter the log message in `org.apache.pulsar.broker.loadbalance.extensions.scheduler.UnloadScheduler#createNamespaceUnloadStrategy` to properly reference config option `loadBalancerLoadSheddingStrategy`.
Set `loadBalancerLoadSheddingStrategy` to `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedder` in `ProxyWithExtensibleLoadManagerTest#configureExtensibleLoadManager`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dragosvictor/pulsar/pull/8/files
