### PR TITLE
 [fix] [broker] Fix break change: could not subscribe partitioned topic with a suffix-matched regexp due to a mistake of PIP-145

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -22,6 +22,7 @@ import static org.apache.pulsar.broker.BrokerTestUtil.spyWithoutRecordingInvocat
 import static org.testng.Assert.assertEquals;
 import com.google.common.collect.Sets;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URL;
@@ -55,7 +56,9 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.ConnectionPool;
 import org.apache.pulsar.client.impl.ProducerImpl;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
 import org.apache.pulsar.client.impl.auth.AuthenticationTls;
 import org.apache.pulsar.common.policies.data.ClusterData;
@@ -715,6 +718,17 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
             log.warn("This thread has been interrupted", e);
             Thread.currentThread().interrupt();
         }
+    }
+
+    public static void reconnectAllConnections(PulsarClientImpl c) throws Exception {
+        ConnectionPool pool = c.getCnxPool();
+        Method closeAllConnections = ConnectionPool.class.getDeclaredMethod("closeAllConnections", new Class[]{});
+        closeAllConnections.setAccessible(true);
+        closeAllConnections.invoke(pool, new Object[]{});
+    }
+
+    public void reconnectAllConnections() throws Exception {
+        reconnectAllConnections((PulsarClientImpl) pulsarClient);
     }
 
     private static final Logger log = LoggerFactory.getLogger(MockedPulsarServiceBaseTest.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
@@ -52,7 +52,6 @@ import org.apache.pulsar.common.api.proto.BaseCommand;
 import org.apache.pulsar.common.api.proto.CommandWatchTopicListSuccess;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
-import org.apache.pulsar.common.topics.TopicList;
 import org.awaitility.Awaitility;
 import org.awaitility.reflect.WhiteboxImpl;
 import org.slf4j.Logger;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
@@ -705,18 +705,17 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
                 .receiverQueueSize(4)
                 .subscribe();
 
-        // 1. create topics.
+        // 1. create topic.
         if (partitioned) {
             admin.topics().createPartitionedTopic(topicName, 1);
         } else {
             admin.topics().createNonPartitionedTopic(topicName);
         }
 
-        // 2. verify consumer get methods. There is no need to trigger discovery, because the broker will push the
-        // changes to update(CommandWatchTopicUpdate).
+        // 2. verify consumer can subscribe the topic.
         assertSame(pattern, ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern());
         Awaitility.await().untilAsserted(() -> {
-            //assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitions().size(), 1);
+            assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitions().size(), 1);
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getConsumers().size(), 1);
             if (partitioned) {
                 assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitionedTopics().size(), 1);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicList.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicList.java
@@ -82,7 +82,7 @@ public class TopicList {
         return s1;
     }
 
-    public static String removeTopicDomainSchema(String originalRegexp) {
+    private static String removeTopicDomainSchema(String originalRegexp) {
         if (!originalRegexp.toString().contains(SCHEME_SEPARATOR)) {
             return originalRegexp;
         }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicList.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicList.java
@@ -47,14 +47,14 @@ public class TopicList {
     }
     public static List<String> filterTopics(List<String> original, Pattern topicsPattern) {
 
-        final Pattern shortenedTopicsPattern = Pattern.compile(removeTopicDomainSchema(topicsPattern.toString()));
+        final Pattern shortenedTopicsPattern = Pattern.compile(removeTopicDomainScheme(topicsPattern.toString()));
 
         return original.stream()
                 .map(TopicName::get)
                 .filter(topicName -> {
                     String partitionedTopicName = topicName.getPartitionedTopicName();
-                    String removedSchema = SCHEME_SEPARATOR_PATTERN.split(partitionedTopicName)[1];
-                    return shortenedTopicsPattern.matcher(removedSchema).matches();
+                    String removedScheme = SCHEME_SEPARATOR_PATTERN.split(partitionedTopicName)[1];
+                    return shortenedTopicsPattern.matcher(removedScheme).matches();
                 })
                 .map(TopicName::toString)
                 .collect(Collectors.toList());
@@ -82,7 +82,7 @@ public class TopicList {
         return s1;
     }
 
-    private static String removeTopicDomainSchema(String originalRegexp) {
+    private static String removeTopicDomainScheme(String originalRegexp) {
         if (!originalRegexp.toString().contains(SCHEME_SEPARATOR)) {
             return originalRegexp;
         }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicList.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicList.java
@@ -47,13 +47,16 @@ public class TopicList {
     }
     public static List<String> filterTopics(List<String> original, Pattern topicsPattern) {
 
-        final Pattern shortenedTopicsPattern = topicsPattern.toString().contains(SCHEME_SEPARATOR)
-                ? Pattern.compile(SCHEME_SEPARATOR_PATTERN.split(topicsPattern.toString())[1]) : topicsPattern;
+        final Pattern shortenedTopicsPattern = Pattern.compile(removeTopicDomainSchema(topicsPattern.toString()));
 
         return original.stream()
                 .map(TopicName::get)
+                .filter(topicName -> {
+                    String partitionedTopicName = topicName.getPartitionedTopicName();
+                    String removedSchema = SCHEME_SEPARATOR_PATTERN.split(partitionedTopicName)[1];
+                    return shortenedTopicsPattern.matcher(removedSchema).matches();
+                })
                 .map(TopicName::toString)
-                .filter(topic -> shortenedTopicsPattern.matcher(SCHEME_SEPARATOR_PATTERN.split(topic)[1]).matches())
                 .collect(Collectors.toList());
     }
 
@@ -77,5 +80,17 @@ public class TopicList {
         HashSet<String> s1 = new HashSet<>(list1);
         s1.removeAll(list2);
         return s1;
+    }
+
+    public static String removeTopicDomainSchema(String originalRegexp) {
+        if (!originalRegexp.toString().contains(SCHEME_SEPARATOR)) {
+            return originalRegexp;
+        }
+        String removedTopicDomain = SCHEME_SEPARATOR_PATTERN.split(originalRegexp.toString())[1];
+        if (originalRegexp.contains("^")) {
+            return String.format("^%s", removedTopicDomain);
+        } else {
+            return removedTopicDomain;
+        }
     }
 }


### PR DESCRIPTION
### Motivation

- Before [PIP-145](https://github.com/apache/pulsar/issues/14505), it used the Partitioned topic name to match the Regexp. For example, the partitioned topic `public/default/tp` has one partition named `public/default/tp-partition-0`. Pulsar will use `public/default/tp` to match the Regexp<sup>[1]</sup>.
- After [PIP-145](https://github.com/apache/pulsar/issues/14505), it used the partition name to match the Regexp. For example, the partitioned topic `public/default/tp` has one partition named `public/default/tp-partition-0`. Pulsar will use `public/default/tp-partition-0` to match the Regexp<sup>[2]</sup>.

It is a break change that is not expected; these changes are due to a mistake, and we should correct it.

### Issue

If a consumer tries to subscribe to a partitioned topic with a suffix-matched regexp, it does not work.
- create topic `persistent://public/default/tp`
- create a consumer with regexp `persistent://public/default/tp$`
- the pattern consumer has no internal consumers.

You can reproduce the issue by the test `testPreciseRegexpSubscribe`.
- it can work when using `2.10.x`
- it can not work when using `>=2.11.0`

### Modifications

Revert the behavior as the original implementation(before PIP-145)

### Footnotes
**[1]**: the implementation of `2.10.x`
- Pulsar did the check of regexp on the client-side.
- `BinaryProtoLookupService.getTopicsUnderNamespace` merge partitions to one partitioned topic. E.g.) Pulsar client merges `public/default/tp-partition-0` and `public/default/tp-partition-1` to ``public/default/tp`
- `PulsarClientImpl.topicsPatternFilter` Use the partitioned topic name to match the regexp.

`BinaryProtoLookupService.getTopicsUnderNamespace`: https://github.com/apache/pulsar/blob/branch-2.10/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java#L332-L338
```java
List<String> result = new ArrayList<>();
r.forEach(topic -> {
    String filtered = TopicName.get(topic).getPartitionedTopicName();
    if (!result.contains(filtered)) {
        result.add(filtered);
    }
});
```

`PulsarClientImpl.topicsPatternFilter` : https://github.com/apache/pulsar/blob/branch-2.10/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java#L568-L577
```java
public static List<String> topicsPatternFilter(List<String> original, Pattern topicsPattern) {
    final Pattern shortenedTopicsPattern = topicsPattern.toString().contains("://")
        ? Pattern.compile(topicsPattern.toString().split("\\:\\/\\/")[1]) : topicsPattern;

    return original.stream()
        .map(TopicName::get)
        .map(TopicName::toString)
        .filter(topic -> shortenedTopicsPattern.matcher(topic.split("\\:\\/\\/")[1]).matches())
        .collect(Collectors.toList());
}
```

**[2]**: the implementation of `>=2.11.0`
- Pulsar did the check of regexp on the broker-side.
- `TopicList.filterTopics()` uses the partition name to match the regexp directly. See: https://github.com/apache/pulsar/blob/master/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicList.java#L53-L57

```java
public static List<String> filterTopics(List<String> original, Pattern topicsPattern) {

    final Pattern shortenedTopicsPattern = topicsPattern.toString().contains(SCHEME_SEPARATOR)
            ? Pattern.compile(SCHEME_SEPARATOR_PATTERN.split(topicsPattern.toString())[1]) : topicsPattern;

    return original.stream()
            .map(TopicName::get)
            .map(TopicName::toString)
            .filter(topic -> shortenedTopicsPattern.matcher(SCHEME_SEPARATOR_PATTERN.split(topic)[1]).matches())
            .collect(Collectors.toList());
}
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x