### PR TITLE
[fix][client] Fix messages in the batch container timed out unexpectedly

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerConsumerInternalTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerConsumerInternalTest.java
@@ -20,22 +20,32 @@ package org.apache.pulsar.client.impl;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.service.ServerCnx;
+import org.apache.pulsar.client.api.BatcherBuilder;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.api.proto.CommandCloseProducer;
 import org.awaitility.Awaitility;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
  * Different with {@link org.apache.pulsar.client.api.SimpleProducerConsumerTest}, this class can visit the variables
- * of {@link ConsumerImpl} which are modified `protected`.
+ * of {@link ConsumerImpl} or {@link ProducerImpl} which have protected or default access modifiers.
  */
-@Test(groups = "broker-api")
+@Slf4j
+@Test(groups = "broker-impl")
 public class ProducerConsumerInternalTest extends ProducerConsumerBase {
 
     @BeforeClass(alwaysRun = true)
@@ -143,5 +153,37 @@ public class ProducerConsumerInternalTest extends ProducerConsumerBase {
         // cleanup.
         consumer.close();
         admin.topics().delete(topicName, false);
+    }
+
+    @DataProvider(name = "containerBuilder")
+    public Object[][] containerBuilderProvider() {
+        return new Object[][] {
+                { BatcherBuilder.DEFAULT },
+                { BatcherBuilder.KEY_BASED }
+        };
+    }
+
+    @Test(timeOut = 30000, dataProvider = "containerBuilder")
+    public void testSendTimerCheckForBatchContainer(BatcherBuilder batcherBuilder) throws Exception {
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://my-property/my-ns/tp_");
+        @Cleanup Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
+                .batcherBuilder(batcherBuilder)
+                .sendTimeout(1, TimeUnit.SECONDS)
+                .batchingMaxPublishDelay(100, TimeUnit.MILLISECONDS)
+                .batchingMaxMessages(1000)
+                .create();
+
+        log.info("Before sendAsync msg-0: {}", System.nanoTime());
+        CompletableFuture<MessageId> future = producer.sendAsync("msg-0".getBytes());
+        future.thenAccept(msgId -> log.info("msg-0 done: {} (msgId: {})", System.nanoTime(), msgId));
+        future.get(); // t: the current time point
+
+        ((ProducerImpl<byte[]>) producer).triggerSendTimer(); // t+1000ms && t+2000ms: run() will be called again
+
+        Thread.sleep(1950); // t+2050ms: the batch timer is expired, which happens after run() is called
+        log.info("Before sendAsync msg-1: {}", System.nanoTime());
+        future = producer.sendAsync("msg-1".getBytes());
+        future.thenAccept(msgId -> log.info("msg-1 done: {} (msgId: {})", System.nanoTime(), msgId));
+        future.get();
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
@@ -53,6 +53,7 @@ public abstract class AbstractBatchMessageContainer implements BatchMessageConta
     // allocate a new buffer that can hold the entire batch without needing costly reallocations
     protected int maxBatchSize = INITIAL_BATCH_BUFFER_SIZE;
     protected int maxMessagesNum = INITIAL_MESSAGES_NUM;
+    private volatile long nanoTimestamp = 0L;
 
     @Override
     public boolean haveEnoughSpace(MessageImpl<?> msg) {
@@ -126,5 +127,20 @@ public abstract class AbstractBatchMessageContainer implements BatchMessageConta
         }
         return currentTxnidMostBits == msg.getMessageBuilder().getTxnidMostBits()
                 && currentTxnidLeastBits == msg.getMessageBuilder().getTxnidLeastBits();
+    }
+
+    @Override
+    public long getNanoTimestamp() {
+        return nanoTimestamp;
+    }
+
+    protected void tryUpdateTimestamp() {
+        if (numMessagesInBatch == 1) {
+            nanoTimestamp = System.nanoTime();
+        }
+    }
+
+    protected void clearTimestamp() {
+        nanoTimestamp = 0L;
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerBase.java
@@ -82,4 +82,11 @@ public interface BatchMessageContainerBase extends BatchMessageContainer {
      * @return belong to the same txn or not
      */
     boolean hasSameTxn(MessageImpl<?> msg);
+
+    /**
+     * Get the timestamp in nanoseconds when the 1st message is added into the batch container.
+     *
+     * @return the timestamp in nanoseconds or 0L if the batch container is empty
+     */
+    long getNanoTimestamp();
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -127,6 +127,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
         previousCallback = callback;
         currentBatchSizeBytes += msg.getDataBuffer().readableBytes();
         messages.add(msg);
+        tryUpdateTimestamp();
 
         if (lowestSequenceId == -1L) {
             lowestSequenceId = msg.getSequenceId();
@@ -203,6 +204,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
 
     @Override
     public void clear() {
+        clearTimestamp();
         messages = new ArrayList<>(maxMessagesNum);
         firstCallback = null;
         previousCallback = null;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
@@ -57,11 +57,13 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
             numMessagesInBatch++;
             currentBatchSizeBytes += msg.getDataBuffer().readableBytes();
         }
+        tryUpdateTimestamp();
         return isBatchFull();
     }
 
     @Override
     public void clear() {
+        clearTimestamp();
         numMessagesInBatch = 0;
         currentBatchSizeBytes = 0;
         batches.clear();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1983,6 +1983,11 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         return producerName;
     }
 
+    @VisibleForTesting
+    void triggerSendTimer() throws Exception {
+        run(sendTimeout);
+    }
+
     /**
      * Process sendTimeout events.
      */
@@ -2001,7 +2006,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             }
 
             OpSendMsg firstMsg = pendingMessages.peek();
-            if (firstMsg == null && (batchMessageContainer == null || batchMessageContainer.isEmpty())) {
+            if (firstMsg == null && (batchMessageContainer == null || batchMessageContainer.isEmpty()
+                    || batchMessageContainer.getNanoTimestamp() == 0L)) {
                 // If there are no pending messages, reset the timeout to the configured value.
                 timeToWaitMs = conf.getSendTimeoutMs();
             } else {
@@ -2011,7 +2017,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 } else {
                     // Because we don't flush batch messages while disconnected, we consider them "createdAt" when
                     // they would have otherwise been flushed.
-                    createdAt = lastBatchSendNanoTime
+                    createdAt = batchMessageContainer.getNanoTimestamp()
                             + TimeUnit.MICROSECONDS.toNanos(conf.getBatchingMaxPublishDelayMicros());
                 }
                 // If there is at least one message, calculate the diff between the message timeout and the elapsed


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/21884

### Motivation

When `ProducerImpl#run` is called where `pendingMessages` is empty and `batchMessageContainer` is not empty, the whole batch's timestamp is treated as `lastBatchSendNanoTime + batch latency`.

Given send timeout as 5 seconds, assuming a batch was flushed at `t1` and the next message was sent after 5 seconds:
- t1: `ProducerImpl#batchFlushTask()`, `lastBatchSendNanoTime` is now `t1`
- t1 + 0.0011 s: `ProducerImpl#run()`, no pending message and the batch container is empty
- t1 + 5.0010 s: `sendAsync()`, the message is added to batch
- t1 + 5.0011 s: `ProducerImpl#run()` is called before `batchFlushTask()`

https://github.com/apache/pulsar/blob/176bdeacd309e8c1e49358987a1946abd30ba34a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java#L2014-L2015

`createdAt` will be `t1 + 0.001 s`. However, the current time point is `t1 + 5.0011 s`, the interval is 5.001 s, timeout happened.

### Modification

Record the timestamp when the 1st message is added to the batch container and use this timestamp instead of `lastBatchSendNanoTime` to compute the `createdAt`.

Add `testSendTimerCheckForBatchContainer` to cover this case.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->