### PR TITLE
[improve][ci] Upgrade pulsar-client-python to 3.4.0 to avoid CVE-2023-1428

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@ flexible messaging model and an intuitive client API.</description>
     <pulsar.broker.compiler.release>${maven.compiler.target}</pulsar.broker.compiler.release>
     <pulsar.client.compiler.release>8</pulsar.client.compiler.release>
 
-    <pulsar.client.python.version>3.2.0</pulsar.client.python.version>
+    <pulsar.client.python.version>3.4.0</pulsar.client.python.version>
 
     <!--config keys to configure test selection -->
     <include>**/Test*.java,**/*Test.java,**/*Tests.java,**/*TestCase.java</include>


### PR DESCRIPTION
### Motivation

Currently pulsar-client-python 3.2.0 is used for Python Functions in Pulsar images, which suffers the CVE-2023-1428 due to the old `grpc.io` dependency.

### Modifications

Upgrade the depended pulsar-client-python version to include https://github.com/apache/pulsar-client-python/pull/174

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
