### PR TITLE
[fix] [broker] correct compaction phase one timeout meaning

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -534,8 +534,8 @@ brokerServiceCompactionMonitorIntervalInSeconds=60
 # Using a value of 0, is disabling compression check.
 brokerServiceCompactionThresholdInBytes=0
 
-# Timeout for the compaction phase one loop.
-# If the execution time of the compaction phase one loop exceeds this time, the compaction will not proceed.
+# Timeout for each read request in the compaction phase one loop.
+# If the execution time of one single message read operation exceeds this time, the compaction will not proceed.
 brokerServiceCompactionPhaseOneLoopTimeInSeconds=30
 
 # Whether retain null-key message during topic compaction

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2803,8 +2803,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
             category = CATEGORY_SERVER,
-            doc = "Timeout for the compaction phase one loop, If the execution time of the compaction "
-                    + "phase one loop exceeds this time, the compaction will not proceed."
+            doc = "Timeout for each read request in the compaction phase one loop, If the execution time of one "
+                    + "single message read operation exceeds this time, the compaction will not proceed."
     )
     private long brokerServiceCompactionPhaseOneLoopTimeInSeconds = 30;
 


### PR DESCRIPTION

### Motivation
Configuratioin `brokerServiceCompactionPhaseOneLoopTimeInSeconds` is defined as the total timeout of phase one.
```
    @FieldContext(
            category = CATEGORY_SERVER,
            doc = "Timeout for the compaction phase one loop, If the execution time of the compaction "
                    + "phase one loop exceeds this time, the compaction will not proceed."
    )
    private long brokerServiceCompactionPhaseOneLoopTimeInSeconds = 30;
```
But current implementation just set a timeout for a single message read operation, which is different with the meaning of `brokerServiceCompactionPhaseOneLoopTimeInSeconds` and will result into thousands of timer tasks be scheduled and cancelled in the scheduler because we may iterate many messages.

### Modifications
Set a timer task for the tatol phase one.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/32

