### PR TITLE
[improve][pip] PIP-331: Replace configuration `brokerServiceCompactionPhaseOneLoopTimeInSeconds` with `brokerServiceCompactionPhaseOneReadTimeoutInSeconds`

### DIFF
--- a/pip/pip-331.md
+++ b/pip/pip-331.md
@@ -1,0 +1,55 @@
+# PIP-331: Replace configuration `brokerServiceCompactionPhaseOneLoopTimeInSeconds` with `brokerServiceCompactionPhaseOneMessageReadTimeoutInSeconds`
+
+# Background knowledge
+
+Configuration `brokerServiceCompactionPhaseOneLoopTimeInSeconds` is defined as the total timeout of phase one.
+```commandline
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Timeout for the compaction phase one loop, If the execution time of the compaction "
+                    + "phase one loop exceeds this time, the compaction will not proceed."
+    )
+    private long brokerServiceCompactionPhaseOneLoopTimeInSeconds = 30;
+```
+However, current implementation just set a timeout for a single message read operation, which is different with the meaning of `brokerServiceCompactionPhaseOneLoopTimeInSeconds`.
+
+
+# Motivation
+
+As we can't predict the number of messages need to be read in phase one, it's hard to set a proper timeout for a single message read operation.
+So it's good to set a timeout for one single message read operation which is predictable.
+So we can deprecate `brokerServiceCompactionPhaseOneLoopTimeInSeconds` and introduce `brokerServiceCompactionPhaseOneMessageReadTimeoutInSeconds` to replace it.
+
+# Goals
+### Configuration
+
+```commandline
+    @Deprecated
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            deprecated = true,
+            doc = "Timeout for the compaction phase one loop, If the execution time of the compaction "
+                    + "phase one loop exceeds this time, the compaction will not proceed."
+                    + "@deprecated - Use brokerServiceCompactionPhaseOneLoopReadTimeoutInSeconds instead" +
+                    "to control the timeout for each read request."
+    )
+    private long brokerServiceCompactionPhaseOneLoopTimeInSeconds = 30;
+
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Timeout for each read request in the compaction phase one loop, If the execution time of one "
+                    + "single message read operation exceeds this time, the compaction will not proceed."
+    )
+    private long brokerServiceCompactionPhaseOneLoopReadTimeoutInSeconds = 30;
+```
+
+
+# General Notes
+
+# Links
+
+<!--
+Updated afterwards
+-->
+* Mailing List discussion thread:
+* Mailing List voting thread:

--- a/pip/pip-331.md
+++ b/pip/pip-331.md
@@ -1,4 +1,4 @@
-# PIP-331: Replace configuration `brokerServiceCompactionPhaseOneLoopTimeInSeconds` with `brokerServiceCompactionPhaseOneMessageReadTimeoutInSeconds`
+# PIP-331: Replace configuration `brokerServiceCompactionPhaseOneLoopTimeInSeconds` with `brokerServiceCompactionPhaseOneReadTimeoutInSeconds`
 
 # Background knowledge
 
@@ -18,7 +18,7 @@ However, current implementation just set a timeout for a single message read ope
 
 As we can't predict the number of messages need to be read in phase one, it's hard to set a proper timeout for a single message read operation.
 So it's good to set a timeout for one single message read operation which is predictable.
-So we can deprecate `brokerServiceCompactionPhaseOneLoopTimeInSeconds` and introduce `brokerServiceCompactionPhaseOneMessageReadTimeoutInSeconds` to replace it.
+So we can deprecate `brokerServiceCompactionPhaseOneLoopTimeInSeconds` and introduce `brokerServiceCompactionPhaseOneReadTimeoutInSeconds` to replace it.
 
 # Goals
 ### Configuration

--- a/pip/pip-331.md
+++ b/pip/pip-331.md
@@ -51,5 +51,5 @@ So we can deprecate `brokerServiceCompactionPhaseOneLoopTimeInSeconds` and intro
 <!--
 Updated afterwards
 -->
-* Mailing List discussion thread:
+* Mailing List discussion thread: https://lists.apache.org/thread/qxs058o9vfwf056m1gvr5oht5hw7827t
 * Mailing List voting thread:


### PR DESCRIPTION

### Motivation

A PIP proposal to replace configuration `brokerServiceCompactionPhaseOneLoopTimeInSeconds` with `brokerServiceCompactionPhaseOneReadTimeoutInSeconds`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

