### PR TITLE
[fix] [broker] fix write all compacted out entry into compacted topic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
@@ -135,7 +135,8 @@ public class RawBatchConverter {
                                                       msg.getMessageIdData().getPartition(),
                                                       i);
                 if (!singleMessageMetadata.hasPartitionKey()) {
-                    if (retainNullKey) {
+                    // we may read compacted out message from compacted topic, which do not have partition key too.
+                    if (retainNullKey && !singleMessageMetadata.isCompactedOut()) {
                         messagesRetained++;
                         Commands.serializeSingleMessageInBatchWithPayload(singleMessageMetadata,
                                 singleMessagePayload, batchBuffer);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
@@ -134,9 +134,12 @@ public class RawBatchConverter {
                                                       msg.getMessageIdData().getEntryId(),
                                                       msg.getMessageIdData().getPartition(),
                                                       i);
-                if (!singleMessageMetadata.hasPartitionKey()) {
-                    // we may read compacted out message from compacted topic, which do not have partition key too.
-                    if (retainNullKey && !singleMessageMetadata.isCompactedOut()) {
+                if (singleMessageMetadata.isCompactedOut()) {
+                    // we may read compacted out message from the compacted topic
+                    Commands.serializeSingleMessageInBatchWithPayload(emptyMetadata,
+                            Unpooled.EMPTY_BUFFER, batchBuffer);
+                } else if (!singleMessageMetadata.hasPartitionKey()) {
+                    if (retainNullKey) {
                         messagesRetained++;
                         Commands.serializeSingleMessageInBatchWithPayload(singleMessageMetadata,
                                 singleMessagePayload, batchBuffer);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TwoPhaseCompactor.java
@@ -63,7 +63,7 @@ public class TwoPhaseCompactor extends Compactor {
     private static final Logger log = LoggerFactory.getLogger(TwoPhaseCompactor.class);
     private static final int MAX_OUTSTANDING = 500;
     private final Duration phaseOneLoopReadTimeout;
-    private boolean topicCompactionRetainNullKey;
+    private final boolean topicCompactionRetainNullKey;
 
     public TwoPhaseCompactor(ServiceConfiguration conf,
                              PulsarClient pulsar,
@@ -466,9 +466,5 @@ public class TwoPhaseCompactor extends Compactor {
 
     public long getPhaseOneLoopReadTimeoutInSeconds() {
         return phaseOneLoopReadTimeout.getSeconds();
-    }
-
-    public void setTopicCompactionRetainNullKey(boolean topicCompactionRetainNullKey) {
-        this.topicCompactionRetainNullKey = topicCompactionRetainNullKey;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TwoPhaseCompactor.java
@@ -63,7 +63,7 @@ public class TwoPhaseCompactor extends Compactor {
     private static final Logger log = LoggerFactory.getLogger(TwoPhaseCompactor.class);
     private static final int MAX_OUTSTANDING = 500;
     private final Duration phaseOneLoopReadTimeout;
-    private final boolean topicCompactionRetainNullKey;
+    private boolean topicCompactionRetainNullKey;
 
     public TwoPhaseCompactor(ServiceConfiguration conf,
                              PulsarClient pulsar,
@@ -466,5 +466,9 @@ public class TwoPhaseCompactor extends Compactor {
 
     public long getPhaseOneLoopReadTimeoutInSeconds() {
         return phaseOneLoopReadTimeout.getSeconds();
+    }
+
+    public void setTopicCompactionRetainNullKey(boolean topicCompactionRetainNullKey) {
+        this.topicCompactionRetainNullKey = topicCompactionRetainNullKey;
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
@@ -228,8 +228,10 @@ public class CompactorTest extends MockedPulsarServiceBaseTest {
             Message<String> message = reader.readNext(3, TimeUnit.SECONDS);
             Assert.assertNotNull(message);
         }
+        // set retain null key back to false
+        pulsar.getConfig().setTopicCompactionRetainNullKey(false);
+        this.restartBroker();
     }
-
 
     @Test
     public void testCompactAddCompact() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
@@ -228,9 +228,6 @@ public class CompactorTest extends MockedPulsarServiceBaseTest {
             Message<String> message = reader.readNext(3, TimeUnit.SECONDS);
             Assert.assertNotNull(message);
         }
-        // set retain null key back to false
-        pulsar.getConfig().setTopicCompactionRetainNullKey(false);
-        this.restartBroker();
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
@@ -188,9 +188,8 @@ public class CompactorTest extends MockedPulsarServiceBaseTest {
     public void testAllCompactedOut() throws Exception {
         String topicName = "persistent://my-property/use/my-ns/testAllCompactedOut";
         // set retain null key to true
-        TwoPhaseCompactor compactor = (TwoPhaseCompactor) ((PulsarCompactionServiceFactory)
-                pulsar.getCompactionServiceFactory()).getCompactor();
-        compactor.setTopicCompactionRetainNullKey(true);
+        pulsar.getConfig().setTopicCompactionRetainNullKey(true);
+        this.restartBroker();
 
         @Cleanup
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
@@ -229,7 +229,7 @@ public class CompactorTest extends MockedPulsarServiceBaseTest {
             Message<String> message = reader.readNext(3, TimeUnit.SECONDS);
             Assert.assertNotNull(message);
         }
-        // set retain null key back to false
+        // set retain null key back to avoid affecting other tests
         pulsar.getConfig().setTopicCompactionRetainNullKey(oldRetainNullKey);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
@@ -36,6 +36,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
 import lombok.Cleanup;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerEntry;
@@ -46,11 +48,17 @@ import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.admin.LongRunningProcessStatus;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.RawMessage;
+import org.apache.pulsar.client.api.Reader;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.ConnectionPool;
+import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.RawMessageImpl;
 import org.apache.pulsar.common.policies.data.ClusterData;
@@ -176,6 +184,54 @@ public class CompactorTest extends MockedPulsarServiceBaseTest {
         }
         compactAndVerify(topic, expected, true);
     }
+
+    @Test
+    public void testAllCompactedOut() throws Exception {
+        String topicName = "persistent://my-property/use/my-ns/testAllCompactedOut";
+        // set retain null key to true
+        TwoPhaseCompactor compactor = (TwoPhaseCompactor) ((PulsarCompactionServiceFactory)pulsar.getCompactionServiceFactory()).getCompactor();
+        compactor.setTopicCompactionRetainNullKey(true);
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .enableBatching(true).topic(topicName).batchingMaxMessages(3).create();
+
+        producer.newMessage().key("K1").value("V1").sendAsync();
+        producer.newMessage().key("K2").value("V2").sendAsync();
+        producer.newMessage().key("K2").value(null).sendAsync();
+        producer.flush();
+
+        admin.topics().triggerCompaction(topicName);
+
+        Awaitility.await().untilAsserted(() -> {
+            Assert.assertEquals(admin.topics().compactionStatus(topicName).status,
+                    LongRunningProcessStatus.Status.SUCCESS);
+        });
+
+        producer.newMessage().key("K1").value(null).sendAsync();
+        producer.flush();
+
+        admin.topics().triggerCompaction(topicName);
+
+        Awaitility.await().untilAsserted(() -> {
+            Assert.assertEquals(admin.topics().compactionStatus(topicName).status,
+                    LongRunningProcessStatus.Status.SUCCESS);
+        });
+
+        @Cleanup
+        Reader<String> reader = pulsarClient.newReader(Schema.STRING)
+                .subscriptionName("reader-test")
+                .topic(topicName)
+                .readCompacted(true)
+                .startMessageId(MessageId.earliest)
+                .create();
+        Assert.assertNotEquals(reader.getLastMessageIds().get(0), MessageIdImpl.earliest);
+        while (reader.hasMessageAvailable()) {
+            Message<String> message = reader.readNext(3, TimeUnit.SECONDS);
+            Assert.assertNotNull(message);
+        }
+    }
+
 
     @Test
     public void testCompactAddCompact() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
@@ -58,7 +58,6 @@ import org.apache.pulsar.client.api.RawMessage;
 import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.ConnectionPool;
-import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.RawMessageImpl;
 import org.apache.pulsar.common.policies.data.ClusterData;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
@@ -188,6 +188,7 @@ public class CompactorTest extends MockedPulsarServiceBaseTest {
     public void testAllCompactedOut() throws Exception {
         String topicName = "persistent://my-property/use/my-ns/testAllCompactedOut";
         // set retain null key to true
+        boolean oldRetainNullKey = pulsar.getConfig().isTopicCompactionRetainNullKey();
         pulsar.getConfig().setTopicCompactionRetainNullKey(true);
         this.restartBroker();
 
@@ -228,6 +229,8 @@ public class CompactorTest extends MockedPulsarServiceBaseTest {
             Message<String> message = reader.readNext(3, TimeUnit.SECONDS);
             Assert.assertNotNull(message);
         }
+        // set retain null key back to false
+        pulsar.getConfig().setTopicCompactionRetainNullKey(oldRetainNullKey);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
@@ -189,7 +189,8 @@ public class CompactorTest extends MockedPulsarServiceBaseTest {
     public void testAllCompactedOut() throws Exception {
         String topicName = "persistent://my-property/use/my-ns/testAllCompactedOut";
         // set retain null key to true
-        TwoPhaseCompactor compactor = (TwoPhaseCompactor) ((PulsarCompactionServiceFactory)pulsar.getCompactionServiceFactory()).getCompactor();
+        TwoPhaseCompactor compactor = (TwoPhaseCompactor) ((PulsarCompactionServiceFactory)
+                pulsar.getCompactionServiceFactory()).getCompactor();
         compactor.setTopicCompactionRetainNullKey(true);
 
         @Cleanup
@@ -225,7 +226,6 @@ public class CompactorTest extends MockedPulsarServiceBaseTest {
                 .readCompacted(true)
                 .startMessageId(MessageId.earliest)
                 .create();
-        Assert.assertNotEquals(reader.getLastMessageIds().get(0), MessageIdImpl.earliest);
         while (reader.hasMessageAvailable()) {
             Message<String> message = reader.readNext(3, TimeUnit.SECONDS);
             Assert.assertNotNull(message);


### PR DESCRIPTION
Fixes #21916 

### Motivation

The method `reader.hasMessageAvailable()` return true, but `reader.readNext` can't return any messages because the messages in compacted topic are all compacted out.


### Modifications

Check if the message without partition key is a valid message.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.



### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/33
