### PR TITLE
[fix][broker] Fix getMessageById throws 500

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2826,6 +2826,9 @@ public class PersistentTopicsBase extends AdminResource {
                         @Override
                         public void readEntryFailed(ManagedLedgerException exception,
                                                     Object ctx) {
+                            if (exception instanceof ManagedLedgerException.LedgerNotExistException) {
+                                throw new RestException(Status.NOT_FOUND, "Message id not found");
+                            }
                             throw new RestException(exception);
                         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -1364,21 +1364,12 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         Message<byte[]> message2 = admin.topics().getMessageById(topicName2, id2.getLedgerId(), id2.getEntryId());
         Assert.assertEquals(message2.getData(), data2.getBytes());
 
-        Message<byte[]> message3 = null;
-        try {
-            message3 = admin.topics().getMessageById(topicName2, id1.getLedgerId(), id1.getEntryId());
-            Assert.fail();
-        } catch (Exception e) {
-            Assert.assertNull(message3);
-        }
-
-        Message<byte[]> message4 = null;
-        try {
-            message4 = admin.topics().getMessageById(topicName1, id2.getLedgerId(), id2.getEntryId());
-            Assert.fail();
-        } catch (Exception e) {
-            Assert.assertNull(message4);
-        }
+        Assert.expectThrows(PulsarAdminException.NotFoundException.class, () -> {
+            admin.topics().getMessageById(topicName2, id1.getLedgerId(), id1.getEntryId());
+        });
+        Assert.expectThrows(PulsarAdminException.NotFoundException.class, () -> {
+            admin.topics().getMessageById(topicName1, id2.getLedgerId(), id2.getEntryId());
+        });
     }
 
     @Test

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -987,21 +987,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     @Override
     public CompletableFuture<Message<byte[]>> getMessageByIdAsync(String topic, long ledgerId, long entryId) {
-        CompletableFuture<Message<byte[]>> future = new CompletableFuture<>();
-        getRemoteMessageById(topic, ledgerId, entryId).handle((r, ex) -> {
-            if (ex != null) {
-                if (ex instanceof NotFoundException) {
-                    log.warn("Exception '{}' occurred while trying to get message.", ex.getMessage());
-                    future.complete(r);
-                } else {
-                    future.completeExceptionally(ex);
-                }
-                return null;
-            }
-            future.complete(r);
-            return null;
-        });
-        return future;
+        return getRemoteMessageById(topic, ledgerId, entryId);
     }
 
     private CompletableFuture<Message<byte[]>> getRemoteMessageById(String topic, long ledgerId, long entryId) {


### PR DESCRIPTION
### Motivation

When using ` bin/pulsar-admin topics get-message-by-id public/default/my-topic-1 -e 0 -l 1024` with a non-existent ledger, I expect to throw the 400 error instead of 500.

CLI log:
```
$ bin/pulsar-admin topics get-message-by-id public/default/my-topic-1 -e 0 -l 1024

 --- An unexpected error occurred in the server ---

Message: Message not found, the ledgerId does not belong to this topic or has been deleted

Stacktrace:

org.apache.bookkeeper.mledger.ManagedLedgerException$LedgerNotExistException: Message not found, the ledgerId does not belong to this topic or has been deleted


Reason: 
 --- An unexpected error occurred in the server ---

Message: Message not found, the ledgerId does not belong to this topic or has been deleted

Stacktrace:

org.apache.bookkeeper.mledger.ManagedLedgerException$LedgerNotExistException: Message not found, the ledgerId does not belong to this topic or has been deleted
```

Broker log:
```
2024-01-18T18:03:46,824+0800 [pulsar-web-47-14] INFO  org.eclipse.jetty.server.RequestLog - 127.0.0.1 - - [18/1月/2024:18:03:46 +0800] "GET /admin/v2/persistent/public/default/my-topic-1/ledger/1024/entry/0 HTTP/1.1" 500 340 "-" "Pulsar-Java-v3.2.0" 29
```

### Modifications

- In the `internalGetMessageById`, when `readEntryFailed` returns LedgerNotExitException, convert this exception to 400 error.
- When the admin receives the 400 error, skip `handle` recovery.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->