### PR TITLE
[improve][misc] Upgrade Netty version to 4.1.105.Final

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -289,26 +289,26 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-lang3-3.11.jar
     - org.apache.commons-commons-text-1.10.0.jar
  * Netty
-    - io.netty-netty-buffer-4.1.104.Final.jar
-    - io.netty-netty-codec-4.1.104.Final.jar
-    - io.netty-netty-codec-dns-4.1.104.Final.jar
-    - io.netty-netty-codec-http-4.1.104.Final.jar
-    - io.netty-netty-codec-http2-4.1.104.Final.jar
-    - io.netty-netty-codec-socks-4.1.104.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.104.Final.jar
-    - io.netty-netty-common-4.1.104.Final.jar
-    - io.netty-netty-handler-4.1.104.Final.jar
-    - io.netty-netty-handler-proxy-4.1.104.Final.jar
-    - io.netty-netty-resolver-4.1.104.Final.jar
-    - io.netty-netty-resolver-dns-4.1.104.Final.jar
-    - io.netty-netty-resolver-dns-classes-macos-4.1.104.Final.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.104.Final-osx-aarch_64.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.104.Final-osx-x86_64.jar
-    - io.netty-netty-transport-4.1.104.Final.jar
-    - io.netty-netty-transport-classes-epoll-4.1.104.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-unix-common-4.1.104.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.104.Final-linux-x86_64.jar
+    - io.netty-netty-buffer-4.1.105.Final.jar
+    - io.netty-netty-codec-4.1.105.Final.jar
+    - io.netty-netty-codec-dns-4.1.105.Final.jar
+    - io.netty-netty-codec-http-4.1.105.Final.jar
+    - io.netty-netty-codec-http2-4.1.105.Final.jar
+    - io.netty-netty-codec-socks-4.1.105.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.105.Final.jar
+    - io.netty-netty-common-4.1.105.Final.jar
+    - io.netty-netty-handler-4.1.105.Final.jar
+    - io.netty-netty-handler-proxy-4.1.105.Final.jar
+    - io.netty-netty-resolver-4.1.105.Final.jar
+    - io.netty-netty-resolver-dns-4.1.105.Final.jar
+    - io.netty-netty-resolver-dns-classes-macos-4.1.105.Final.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.105.Final-osx-aarch_64.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.105.Final-osx-x86_64.jar
+    - io.netty-netty-transport-4.1.105.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.105.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.105.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-unix-common-4.1.105.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.105.Final-linux-x86_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -344,22 +344,22 @@ The Apache Software License, Version 2.0
     - commons-text-1.10.0.jar
     - commons-compress-1.21.jar
  * Netty
-    - netty-buffer-4.1.104.Final.jar
-    - netty-codec-4.1.104.Final.jar
-    - netty-codec-dns-4.1.104.Final.jar
-    - netty-codec-http-4.1.104.Final.jar
-    - netty-codec-socks-4.1.104.Final.jar
-    - netty-codec-haproxy-4.1.104.Final.jar
-    - netty-common-4.1.104.Final.jar
-    - netty-handler-4.1.104.Final.jar
-    - netty-handler-proxy-4.1.104.Final.jar
-    - netty-resolver-4.1.104.Final.jar
-    - netty-resolver-dns-4.1.104.Final.jar
-    - netty-transport-4.1.104.Final.jar
-    - netty-transport-classes-epoll-4.1.104.Final.jar
-    - netty-transport-native-epoll-4.1.104.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.104.Final.jar
-    - netty-transport-native-unix-common-4.1.104.Final-linux-x86_64.jar
+    - netty-buffer-4.1.105.Final.jar
+    - netty-codec-4.1.105.Final.jar
+    - netty-codec-dns-4.1.105.Final.jar
+    - netty-codec-http-4.1.105.Final.jar
+    - netty-codec-socks-4.1.105.Final.jar
+    - netty-codec-haproxy-4.1.105.Final.jar
+    - netty-common-4.1.105.Final.jar
+    - netty-handler-4.1.105.Final.jar
+    - netty-handler-proxy-4.1.105.Final.jar
+    - netty-resolver-4.1.105.Final.jar
+    - netty-resolver-dns-4.1.105.Final.jar
+    - netty-transport-4.1.105.Final.jar
+    - netty-transport-classes-epoll-4.1.105.Final.jar
+    - netty-transport-native-epoll-4.1.105.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.105.Final.jar
+    - netty-transport-native-unix-common-4.1.105.Final-linux-x86_64.jar
     - netty-tcnative-boringssl-static-2.0.61.Final.jar
     - netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar
     - netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -370,9 +370,9 @@ The Apache Software License, Version 2.0
     - netty-incubator-transport-classes-io_uring-0.0.24.Final.jar
     - netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar
     - netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
-    - netty-resolver-dns-classes-macos-4.1.104.Final.jar
-    - netty-resolver-dns-native-macos-4.1.104.Final-osx-aarch_64.jar
-    - netty-resolver-dns-native-macos-4.1.104.Final-osx-x86_64.jar
+    - netty-resolver-dns-classes-macos-4.1.105.Final.jar
+    - netty-resolver-dns-native-macos-4.1.105.Final-osx-aarch_64.jar
+    - netty-resolver-dns-native-macos-4.1.105.Final-osx-x86_64.jar
  * Prometheus client
     - simpleclient-0.16.0.jar
     - simpleclient_log4j2-0.16.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.10.5</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
-    <netty.version>4.1.104.Final</netty.version>
+    <netty.version>4.1.105.Final</netty.version>
     <netty-iouring.version>0.0.24.Final</netty-iouring.version>
     <jetty.version>9.4.53.v20231009</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>


### PR DESCRIPTION
### Motivation

Release note :
https://netty.io/news/2024/01/16/4-1-105-Final.html


### Modifications

- Upgrade Netty to 4.1.105.Final (from 4.1.104.Final)

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


