### PR TITLE
[improve][ci] Improve doc template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -18,7 +18,7 @@
 name: Bug report
 description: Problems with the software
 title: "[Bug] "
-labels: ["type/bug"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/doc.yml
+++ b/.github/ISSUE_TEMPLATE/doc.yml
@@ -18,7 +18,7 @@
 name: Document
 description: Suggest document changes
 title: "[Doc] "
-labels: ["doc-required"]
+labels: ["doc"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -17,7 +17,7 @@
 
 name: Enhancement
 description: Add new feature, improve code, and more
-labels: [ "type/enhancement" ]
+labels: [ "enhancement" ]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
### Motivation
Simplify the label name and change the default doc template label from `doc-required` to `doc`


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


