### PR TITLE
[improve][pip] PIP-332: peek messages from topic subscription with offset value

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1643,6 +1643,27 @@ public interface Topics {
      *            topic name
      * @param subName
      *            Subscription name
+     * @param  offset
+     *            Start index to start reading messages.
+     * @param numMessages
+     *            Number of messages
+     * @return
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Topic or subscription does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    List<Message<byte[]>> peekMessages(String topic, String subName, int offset, int numMessages) throws PulsarAdminException;
+
+    /**
+     * Peek messages from a topic subscription.
+     *
+     * @param topic
+     *            topic name
+     * @param subName
+     *            Subscription name
      * @param numMessages
      *            Number of messages
      * @return
@@ -1654,6 +1675,22 @@ public interface Topics {
      *             Unexpected error
      */
     List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages) throws PulsarAdminException;
+
+    /**
+     * Peek messages from a topic subscription asynchronously.
+     *
+     * @param topic
+     *            topic name
+     * @param subName
+     *            Subscription name
+     * @param offset
+     *            Start index to start reading messages
+     * @param numMessages
+     *            Number of messages
+     * @return a future that can be used to track when the messages are returned
+     */
+    CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int offset,
+                                                               int numMessages);
 
     /**
      * Peek messages from a topic subscription asynchronously.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -894,17 +894,29 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
+    public List<Message<byte[]>> peekMessages(String topic, String subName, int offset, int numMessages)
+            throws PulsarAdminException {
+        return sync(() -> peekMessagesAsync(topic, subName, offset, numMessages));
+    }
+
+    @Override
     public List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages)
             throws PulsarAdminException {
-        return sync(() -> peekMessagesAsync(topic, subName, numMessages));
+        return sync(() -> peekMessagesAsync(topic, subName, 1, numMessages));
+    }
+
+    @Override
+    public CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int offset, int numMessages) {
+        checkArgument(numMessages > 0);
+        CompletableFuture<List<Message<byte[]>>> future = new CompletableFuture<List<Message<byte[]>>>();
+        peekMessagesAsync(topic, subName, numMessages, new ArrayList<>(), future, offset);
+        return future;
     }
 
     @Override
     public CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages) {
         checkArgument(numMessages > 0);
-        CompletableFuture<List<Message<byte[]>>> future = new CompletableFuture<List<Message<byte[]>>>();
-        peekMessagesAsync(topic, subName, numMessages, new ArrayList<>(), future, 1);
-        return future;
+        return peekMessagesAsync(topic, subName, 1, numMessages);
     }
 
     private void peekMessagesAsync(String topic, String subName, int numMessages,


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: 332

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
Currently we are able to peek any number of messages using the Pulsar Java Admin API.

However, we are only able to view these messages starting from the most recent message. If we want to view the 100th message, we have to peek all the top 100 messages.

We want to display these messages on our UI in a table. When the number of messages to be viewed is large, we want to split them by page and display them on the UI. So, we would like the ability to view any batch of messages instead of all of the top messages.

### Modifications

<!-- Describe the modifications you've done. -->

The Pulsar Admin API in Java currently provides a way to peek messages using [this](https://pulsar.apache.org/docs/3.1.x/admin-api-topics/#peek-messages)

This function includes a default hardcoded offset value of 1. We want to give the user the option to input a different offset value.

The current `peekMessages(String topic, String subName, int numMessages)` method will remain the same and use offset 1.

We will be overloading this method with offset. It will default to 1 if not specified.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

<!-- *(Please pick either of the following options)* -->

This change is a trivial rework / code cleanup without any test coverage.

<!-- *(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure* -->

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
