### PR TITLE
[draft] [fix] [client] fix ack failed when consumer is reconnecting

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.client.api;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,6 +51,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -93,6 +93,7 @@ import org.apache.pulsar.broker.service.ServerCnx;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.ClientBuilderImpl;
 import org.apache.pulsar.client.impl.ClientCnx;
 import org.apache.pulsar.client.impl.ConsumerBase;
@@ -107,9 +108,8 @@ import org.apache.pulsar.client.impl.crypto.MessageCryptoBc;
 import org.apache.pulsar.client.impl.schema.writer.AvroWriter;
 import org.apache.pulsar.common.api.EncryptionContext;
 import org.apache.pulsar.common.api.EncryptionContext.EncryptionKey;
-import org.apache.pulsar.common.api.proto.BaseCommand;
+import org.apache.pulsar.common.api.proto.CommandAck;
 import org.apache.pulsar.common.api.proto.CommandSuccess;
-import org.apache.pulsar.common.api.proto.CommandWatchTopicListSuccess;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.api.proto.SingleMessageMetadata;
 import org.apache.pulsar.common.compression.CompressionCodec;
@@ -4697,17 +4697,40 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         admin.topics().delete(topic, false);
     }
 
-    @Test
-    public void testAckWhenReconnecting() throws Exception {
+    @DataProvider(name = "ackArgs")
+    public Object[] ackArgs() {
+        int batchSize = 10;
+        BitSet bitSet = new BitSet(batchSize);
+        bitSet.set(0);
+        return new Object[][]{
+            // no batch.
+            {CommandAck.AckType.Cumulative, new MessageIdImpl(1,1,1)},
+            {CommandAck.AckType.Individual, new MessageIdImpl(1,1,1)},
+            // batch without ackSet.
+            {CommandAck.AckType.Individual, new BatchMessageIdImpl(1,1,1,0)},
+            {CommandAck.AckType.Cumulative, new BatchMessageIdImpl(1,1,1,0)},
+            // batch with ackSe.
+            {CommandAck.AckType.Cumulative, new BatchMessageIdImpl(1,1,1,0, batchSize, bitSet)},
+            {CommandAck.AckType.Individual, new BatchMessageIdImpl(1,1,1,0, batchSize, bitSet)}
+        };
+    }
+
+    @Test(dataProvider = "ackArgs")
+    public void testImmediateAckWhenReconnecting(CommandAck.AckType ackType, MessageId messageId) throws Exception {
         final String topic = BrokerTestUtil.newUniqueName("persistent://my-property/my-ns/tp_");
         final String subscriptionName = "s1";
         PulsarClient delayConnectClient = createDelayReconnectClient();
 
         Consumer<String> consumer = delayConnectClient.newConsumer(Schema.STRING).topic(topic)
+                .acknowledgmentGroupTime(0, TimeUnit.MILLISECONDS)
                 .subscriptionName(subscriptionName).subscribe();
 
         admin.topics().unload(topic);
-        consumer.acknowledge(MessageId.earliest);
+        if (ackType == CommandAck.AckType.Individual) {
+            consumer.acknowledge(messageId);
+        } else {
+            consumer.acknowledgeCumulative(messageId);
+        }
 
         consumer.close();
         admin.topics().delete(topic, false);
@@ -4716,14 +4739,14 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     private PulsarClient createDelayReconnectClient() throws Exception {
         ClientBuilderImpl clientBuilder = (ClientBuilderImpl) PulsarClient.builder().serviceUrl(lookupUrl.toString());
         return InjectedClientCnxClientBuilder.create(clientBuilder,
-                (conf, eventLoopGroup) -> new ClientCnx(conf, eventLoopGroup) {
-                    @Override
-                    protected void handleSuccess(CommandSuccess success) {
-                        new Thread(() -> {
-                            sleepSeconds(2);
-                            super.handleSuccess(success);
-                        }).start();
-                    }
-                });
+            (conf, eventLoopGroup) -> new ClientCnx(conf, eventLoopGroup) {
+                @Override
+                protected void handleSuccess(CommandSuccess success) {
+                    new Thread(() -> {
+                        sleepSeconds(5);
+                        super.handleSuccess(success);
+                    }).start();
+                }
+            });
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.api;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -106,6 +107,9 @@ import org.apache.pulsar.client.impl.crypto.MessageCryptoBc;
 import org.apache.pulsar.client.impl.schema.writer.AvroWriter;
 import org.apache.pulsar.common.api.EncryptionContext;
 import org.apache.pulsar.common.api.EncryptionContext.EncryptionKey;
+import org.apache.pulsar.common.api.proto.BaseCommand;
+import org.apache.pulsar.common.api.proto.CommandSuccess;
+import org.apache.pulsar.common.api.proto.CommandWatchTopicListSuccess;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.api.proto.SingleMessageMetadata;
 import org.apache.pulsar.common.compression.CompressionCodec;
@@ -4691,5 +4695,35 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         producer.close();
         consumer.close();
         admin.topics().delete(topic, false);
+    }
+
+    @Test
+    public void testAckWhenReconnecting() throws Exception {
+        final String topic = BrokerTestUtil.newUniqueName("persistent://my-property/my-ns/tp_");
+        final String subscriptionName = "s1";
+        PulsarClient delayConnectClient = createDelayReconnectClient();
+
+        Consumer<String> consumer = delayConnectClient.newConsumer(Schema.STRING).topic(topic)
+                .subscriptionName(subscriptionName).subscribe();
+
+        admin.topics().unload(topic);
+        consumer.acknowledge(MessageId.earliest);
+
+        consumer.close();
+        admin.topics().delete(topic, false);
+    }
+
+    private PulsarClient createDelayReconnectClient() throws Exception {
+        ClientBuilderImpl clientBuilder = (ClientBuilderImpl) PulsarClient.builder().serviceUrl(lookupUrl.toString());
+        return InjectedClientCnxClientBuilder.create(clientBuilder,
+                (conf, eventLoopGroup) -> new ClientCnx(conf, eventLoopGroup) {
+                    @Override
+                    protected void handleSuccess(CommandSuccess success) {
+                        new Thread(() -> {
+                            sleepSeconds(2);
+                            super.handleSuccess(success);
+                        }).start();
+                    }
+                });
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -4709,7 +4709,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             // batch without ackSet.
             {CommandAck.AckType.Individual, new BatchMessageIdImpl(1,1,1,0)},
             {CommandAck.AckType.Cumulative, new BatchMessageIdImpl(1,1,1,0)},
-            // batch with ackSe.
+            // batch with ackSet.
             {CommandAck.AckType.Cumulative, new BatchMessageIdImpl(1,1,1,0, batchSize, bitSet)},
             {CommandAck.AckType.Individual, new BatchMessageIdImpl(1,1,1,0, batchSize, bitSet)}
         };
@@ -4733,6 +4733,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         }
 
         consumer.close();
+        delayConnectClient.close();
         admin.topics().delete(topic, false);
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AcknowledgmentsGroupingTracker.java
@@ -42,6 +42,4 @@ public interface AcknowledgmentsGroupingTracker extends AutoCloseable {
     void close();
 
     void flushAndClean();
-
-    default void afterConsumerReconnected() {}
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AcknowledgmentsGroupingTracker.java
@@ -42,4 +42,6 @@ public interface AcknowledgmentsGroupingTracker extends AutoCloseable {
     void close();
 
     void flushAndClean();
+
+    default void afterConsumerReconnected() {}
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -871,7 +871,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 if (!(firstTimeConnect && hasParentConsumer) && getCurrentReceiverQueueSize() != 0) {
                     increaseAvailablePermits(cnx, getCurrentReceiverQueueSize());
                 }
-                acknowledgmentsGroupingTracker.afterConsumerReconnected();
+                acknowledgmentsGroupingTracker.flush();
                 future.complete(null);
             }).exceptionally((e) -> {
                 deregisterFromClientCnx();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -871,6 +871,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 if (!(firstTimeConnect && hasParentConsumer) && getCurrentReceiverQueueSize() != 0) {
                     increaseAvailablePermits(cnx, getCurrentReceiverQueueSize());
                 }
+                acknowledgmentsGroupingTracker.afterConsumerReconnected();
                 future.complete(null);
             }).exceptionally((e) -> {
                 deregisterFromClientCnx();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -231,8 +231,8 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
             case Individual:
                 return addIndividualAcknowledgment(msgId,
                         batchMessageId,
-                        __ -> doIndividualAck(__, properties),
-                        __ -> doIndividualBatchAck(__, properties));
+                        __ -> doIndividualAck(__, properties, false),
+                        __ -> doIndividualBatchAck(__, properties, false));
             case Cumulative:
                 if (batchMessageId != null) {
                     consumer.onAcknowledgeCumulative(batchMessageId, null);
@@ -240,11 +240,11 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
                     consumer.onAcknowledgeCumulative(msgId, null);
                 }
                 if (batchMessageId == null || MessageIdAdvUtils.acknowledge(batchMessageId, false)) {
-                    return doCumulativeAck(msgId, properties, null);
+                    return doCumulativeAck(msgId, properties, null, false);
                 } else if (batchIndexAckEnabled) {
-                    return doCumulativeBatchIndexAck(batchMessageId, properties);
+                    return doCumulativeBatchIndexAck(batchMessageId, properties, false);
                 } else {
-                    doCumulativeAck(MessageIdAdvUtils.prevMessageId(batchMessageId), properties, null);
+                    doCumulativeAck(MessageIdAdvUtils.prevMessageId(batchMessageId), properties, null, false);
                     return CompletableFuture.completedFuture(null);
                 }
             default:
@@ -252,8 +252,10 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
         }
     }
 
-    private CompletableFuture<Void> doIndividualAck(MessageIdAdv messageId, Map<String, Long> properties) {
-        if (acknowledgementGroupTimeMicros == 0 || (properties != null && !properties.isEmpty())) {
+    private CompletableFuture<Void> doIndividualAck(MessageIdAdv messageId, Map<String, Long> properties,
+                                                    boolean queueDueToConnecting) {
+        if (!queueDueToConnecting
+                && (acknowledgementGroupTimeMicros == 0 || (properties != null && !properties.isEmpty()))) {
             // We cannot group acks if the delay is 0 or when there are properties attached to it. Fortunately that's an
             // uncommon condition since it's only used for the compaction subscription.
             return doImmediateAck(messageId, AckType.Individual, properties, null);
@@ -279,8 +281,10 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
     }
 
     private CompletableFuture<Void> doIndividualBatchAck(MessageIdAdv batchMessageId,
-                                                         Map<String, Long> properties) {
-        if (acknowledgementGroupTimeMicros == 0 || (properties != null && !properties.isEmpty())) {
+                                                         Map<String, Long> properties,
+                                                         boolean queueDueToConnecting) {
+        if (!queueDueToConnecting
+                && (acknowledgementGroupTimeMicros == 0 || (properties != null && !properties.isEmpty()))) {
             return doImmediateBatchIndexAck(batchMessageId, batchMessageId.getBatchIndex(),
                     batchMessageId.getBatchSize(), AckType.Individual, properties);
         } else {
@@ -302,9 +306,10 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
     }
 
     private CompletableFuture<Void> doCumulativeAck(MessageIdAdv messageId, Map<String, Long> properties,
-                                                    BitSetRecyclable bitSet) {
+                                                    BitSetRecyclable bitSet, boolean queueDueToConnecting) {
         consumer.getStats().incrementNumAcksSent(consumer.getUnAckedMessageTracker().removeMessagesTill(messageId));
-        if (acknowledgementGroupTimeMicros == 0 || (properties != null && !properties.isEmpty())) {
+        if (!queueDueToConnecting
+                && (acknowledgementGroupTimeMicros == 0 || (properties != null && !properties.isEmpty()))) {
             // We cannot group acks if the delay is 0 or when there are properties attached to it. Fortunately that's an
             // uncommon condition since it's only used for the compaction subscription.
             return doImmediateAck(messageId, AckType.Cumulative, properties, bitSet);
@@ -342,15 +347,17 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
     }
 
     private CompletableFuture<Void> doCumulativeBatchIndexAck(MessageIdAdv batchMessageId,
-                                                              Map<String, Long> properties) {
-        if (acknowledgementGroupTimeMicros == 0 || (properties != null && !properties.isEmpty())) {
+                                                              Map<String, Long> properties,
+                                                              boolean queueDueToConnecting) {
+        if (!queueDueToConnecting
+                && (acknowledgementGroupTimeMicros == 0 || (properties != null && !properties.isEmpty()))) {
             return doImmediateBatchIndexAck(batchMessageId, batchMessageId.getBatchIndex(),
                     batchMessageId.getBatchSize(), AckType.Cumulative, properties);
         } else {
             BitSetRecyclable bitSet = BitSetRecyclable.create();
             bitSet.set(0, batchMessageId.getBatchSize());
             bitSet.clear(0, batchMessageId.getBatchIndex() + 1);
-            return doCumulativeAck(batchMessageId, null, bitSet);
+            return doCumulativeAck(batchMessageId, null, bitSet, false);
         }
     }
 
@@ -358,6 +365,13 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
                                                    BitSetRecyclable bitSet) {
         ClientCnx cnx = consumer.getClientCnx();
 
+        if (cnx == null && consumer.getState() == HandlerState.State.Connecting) {
+            if (ackType == AckType.Cumulative) {
+                return doCumulativeAck(msgId, properties, bitSet, true);
+            } else {
+                return doIndividualAck(msgId, properties, true);
+            }
+        }
         if (cnx == null) {
             return FutureUtil.failedFuture(new PulsarClientException
                     .ConnectException("Consumer connect fail! consumer state:" + consumer.getState()));
@@ -365,9 +379,22 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
         return newImmediateAckAndFlush(consumer.consumerId, msgId, bitSet, ackType, properties, cnx);
     }
 
+    @Override
+    public void afterConsumerReconnected() {
+        flush();
+    }
+
     private CompletableFuture<Void> doImmediateBatchIndexAck(MessageIdAdv msgId, int batchIndex, int batchSize,
                                                              AckType ackType, Map<String, Long> properties) {
         ClientCnx cnx = consumer.getClientCnx();
+
+        if (cnx == null && consumer.getState() == HandlerState.State.Connecting) {
+            if (ackType == AckType.Cumulative) {
+                return doCumulativeBatchIndexAck(msgId, properties, true);
+            } else {
+                return doIndividualBatchAck(msgId, properties, true);
+            }
+        }
 
         if (cnx == null) {
             return FutureUtil.failedFuture(new PulsarClientException

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -379,11 +379,6 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
         return newImmediateAckAndFlush(consumer.consumerId, msgId, bitSet, ackType, properties, cnx);
     }
 
-    @Override
-    public void afterConsumerReconnected() {
-        flush();
-    }
-
     private CompletableFuture<Void> doImmediateBatchIndexAck(MessageIdAdv msgId, int batchIndex, int batchSize,
                                                              AckType ackType, Map<String, Long> properties) {
         ClientCnx cnx = consumer.getClientCnx();


### PR DESCRIPTION
### Motivation

The `ack` command will fail when the consumer is reconnecting when setting `acknowledgmentGroupTime  ->0`. see https://github.com/apache/pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java#L361-L364

```java
private CompletableFuture<Void> doImmediateAck(MessageIdAdv msgId, AckType ackType, Map<String, Long> properties,
                                               BitSetRecyclable bitSet) {
    ClientCnx cnx = consumer.getClientCnx();

    if (cnx == null) {
        return FutureUtil.failedFuture(new PulsarClientException
                .ConnectException("Consumer connect fail! consumer state:" + consumer.getState()));
    }
    return newImmediateAckAndFlush(consumer.consumerId, msgId, bitSet, ackType, properties, cnx);
}
```

### Modifications

 Call `ack` after the consumer is connected.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
