### PR TITLE
[fix] [test] fix test code create namespace conflict

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -1797,7 +1797,7 @@ public class TransactionTest extends TransactionTestBase {
 
     @Test
     public void testReadCommittedWithReadCompacted() throws Exception{
-        final String namespace = "tnx/ns-prechecks";
+        final String namespace = "tnx/ns-read-committed-compacted";
         final String topic = "persistent://" + namespace + "/test_transaction_topic";
         admin.namespaces().createNamespace(namespace);
         admin.topics().createNonPartitionedTopic(topic);
@@ -1853,7 +1853,7 @@ public class TransactionTest extends TransactionTestBase {
 
     @Test
     public void testReadCommittedWithCompaction() throws Exception{
-        final String namespace = "tnx/ns-prechecks";
+        final String namespace = "tnx/ns-read-committed-compaction";
         final String topic = "persistent://" + namespace + "/test_transaction_topic" + UUID.randomUUID();
         admin.namespaces().createNamespace(namespace);
         admin.topics().createNonPartitionedTopic(topic);


### PR DESCRIPTION
### Motivation
Running test code `org.apache.pulsar.broker.transaction.TransactionTest`, exceptions will be throw as:
![image](https://github.com/apache/pulsar/assets/52550727/c5f24e93-a582-4e50-9440-646dac75b16e)
```
org.apache.pulsar.client.admin.PulsarAdminException$ConflictException: Namespace already exists

	at org.apache.pulsar.client.admin.PulsarAdminException.wrap(PulsarAdminException.java:252)
	at org.apache.pulsar.client.admin.internal.BaseResource.sync(BaseResource.java:352)
	at org.apache.pulsar.client.admin.internal.NamespacesImpl.createNamespace(NamespacesImpl.java:211)
	at org.apache.pulsar.broker.transaction.TransactionTest.testReadCommittedWithCompaction(TransactionTest.java:1858)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```
This is because the previous test code has created the same namespace.

### Modifications

Using a different namespace to avoid confliction.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/35