### PR TITLE
[fix][client] Fix multi-topics consumer could receive old messages after seek

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiTopicsConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiTopicsConsumerTest.java
@@ -386,7 +386,7 @@ public class MultiTopicsConsumerTest extends ProducerConsumerBase {
     }
 
     @Test(timeOut = 30000, dataProvider = "seekByFunction")
-    public void testSeekByTimestamp(boolean seekByFunction) throws Exception {
+    public void testSeekToNewerPosition(boolean seekByFunction) throws Exception {
         final var topic1 = TopicName.get(newTopicName()).toString();
         final var topic2 = TopicName.get(newTopicName()).toString();
         @Cleanup final var producer1 = pulsarClient.newProducer(Schema.STRING).topic(topic1).create();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiTopicsConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiTopicsConsumerTest.java
@@ -29,22 +29,16 @@ import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeSet;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.Cleanup;
@@ -376,67 +370,5 @@ public class MultiTopicsConsumerTest extends ProducerConsumerBase {
                 .subscriptionName("sub").subscribe();
         assertTrue(consumer instanceof MultiTopicsConsumerImpl);
         assertTrue(consumer.isConnected());
-    }
-
-    @DataProvider
-    public static Object[][] seekByFunction() {
-        return new Object[][] {
-                { true }, { false }
-        };
-    }
-
-    @Test(timeOut = 30000, dataProvider = "seekByFunction")
-    public void testSeekToNewerPosition(boolean seekByFunction) throws Exception {
-        final var topic1 = TopicName.get(newTopicName()).toString();
-        final var topic2 = TopicName.get(newTopicName()).toString();
-        @Cleanup final var producer1 = pulsarClient.newProducer(Schema.STRING).topic(topic1).create();
-        @Cleanup final var producer2 = pulsarClient.newProducer(Schema.STRING).topic(topic2).create();
-        producer1.send("1-0");
-        producer2.send("2-0");
-        producer1.send("1-1");
-        producer2.send("2-1");
-        final var consumer1 = pulsarClient.newConsumer(Schema.STRING)
-                .topics(Arrays.asList(topic1, topic2)).subscriptionName("sub")
-                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe();
-        final var timestamps = new ArrayList<Long>();
-        for (int i = 0; i < 4; i++) {
-            timestamps.add(consumer1.receive().getPublishTime());
-        }
-        timestamps.sort(Comparator.naturalOrder());
-        final var timestamp = timestamps.get(2);
-        consumer1.close();
-
-        final Function<Consumer<String>, CompletableFuture<Void>> seekAsync = consumer ->
-                seekByFunction ? consumer.seekAsync(__ -> timestamp) : consumer.seekAsync(timestamp);
-
-        @Cleanup final var consumer2 = pulsarClient.newConsumer(Schema.STRING)
-                .topics(Arrays.asList(topic1, topic2)).subscriptionName("sub-2")
-                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe();
-        seekAsync.apply(consumer2).get();
-        final var values = new TreeSet<String>();
-        for (int i = 0; i < 2; i++) {
-            values.add(consumer2.receive().getValue());
-        }
-        assertEquals(values, new TreeSet<>(Arrays.asList("1-1", "2-1")));
-
-        final var valuesInListener = new CopyOnWriteArrayList<String>();
-        @Cleanup final var consumer3 = pulsarClient.newConsumer(Schema.STRING)
-                .topics(Arrays.asList(topic1, topic2)).subscriptionName("sub-3")
-                .messageListener((MessageListener<String>) (__, msg) -> valuesInListener.add(msg.getValue()))
-                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe();
-        seekAsync.apply(consumer3).get();
-        if (valuesInListener.isEmpty()) {
-            Awaitility.await().untilAsserted(() -> assertEquals(valuesInListener.size(), 2));
-            assertEquals(valuesInListener.stream().sorted().toList(), Arrays.asList("1-1", "2-1"));
-        } // else: consumer3 has passed messages to the listener before seek, in this case we cannot assume anything
-
-        @Cleanup final var consumer4 = pulsarClient.newConsumer(Schema.STRING)
-                .topics(Arrays.asList(topic1, topic2)).subscriptionName("sub-4")
-                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe();
-        seekAsync.apply(consumer4).get();
-        final var valuesInReceiveAsync = new ArrayList<String>();
-        valuesInReceiveAsync.add(consumer4.receiveAsync().get().getValue());
-        valuesInReceiveAsync.add(consumer4.receiveAsync().get().getValue());
-        assertEquals(valuesInReceiveAsync.stream().sorted().toList(), Arrays.asList("1-1", "2-1"));
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -34,6 +34,7 @@ import org.apache.pulsar.client.api.ConsumerEventListener;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageIdAdv;
+import org.apache.pulsar.client.api.MessageListener;
 import org.apache.pulsar.client.api.MessageRouter;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
@@ -57,22 +58,27 @@ import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Set;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -1394,4 +1400,76 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         }
     }
 
+    @DataProvider
+    public static Object[][] seekByFunction() {
+        return new Object[][] {
+                { true }, { false }
+        };
+    }
+
+    @Test(timeOut = 30000, dataProvider = "seekByFunction")
+    public void testSeekToNewerPosition(boolean seekByFunction) throws Exception {
+        final var topic1 = TopicName.get(newTopicName()).toString()
+                .replace("my-property", "public").replace("my-ns", "default");
+        final var topic2 = TopicName.get(newTopicName()).toString()
+                .replace("my-property", "public").replace("my-ns", "default");
+        @Cleanup final var producer1 = pulsarClient.newProducer(Schema.STRING).topic(topic1).create();
+        @Cleanup final var producer2 = pulsarClient.newProducer(Schema.STRING).topic(topic2).create();
+        producer1.send("1-0");
+        producer2.send("2-0");
+        producer1.send("1-1");
+        producer2.send("2-1");
+        final var consumer1 = pulsarClient.newConsumer(Schema.STRING)
+                .topics(Arrays.asList(topic1, topic2)).subscriptionName("sub")
+                .ackTimeout(1, TimeUnit.SECONDS)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe();
+        final var timestamps = new ArrayList<Long>();
+        for (int i = 0; i < 4; i++) {
+            timestamps.add(consumer1.receive().getPublishTime());
+        }
+        timestamps.sort(Comparator.naturalOrder());
+        final var timestamp = timestamps.get(2);
+        consumer1.close();
+
+        final Function<Consumer<String>, CompletableFuture<Void>> seekAsync = consumer -> {
+            final var future = seekByFunction ? consumer.seekAsync(__ -> timestamp) : consumer.seekAsync(timestamp);
+            assertEquals(((ConsumerBase<String>) consumer).getIncomingMessageSize(), 0L);
+            assertEquals(((ConsumerBase<String>) consumer).getTotalIncomingMessages(), 0);
+            assertTrue(((ConsumerBase<String>) consumer).getUnAckedMessageTracker().isEmpty());
+            return future;
+        };
+
+        @Cleanup final var consumer2 = pulsarClient.newConsumer(Schema.STRING)
+                .topics(Arrays.asList(topic1, topic2)).subscriptionName("sub-2")
+                .ackTimeout(1, TimeUnit.SECONDS)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe();
+        seekAsync.apply(consumer2).get();
+        final var values = new TreeSet<String>();
+        for (int i = 0; i < 2; i++) {
+            values.add(consumer2.receive().getValue());
+        }
+        assertEquals(values, new TreeSet<>(Arrays.asList("1-1", "2-1")));
+
+        final var valuesInListener = new CopyOnWriteArrayList<String>();
+        @Cleanup final var consumer3 = pulsarClient.newConsumer(Schema.STRING)
+                .topics(Arrays.asList(topic1, topic2)).subscriptionName("sub-3")
+                .messageListener((MessageListener<String>) (__, msg) -> valuesInListener.add(msg.getValue()))
+                .ackTimeout(1, TimeUnit.SECONDS)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe();
+        seekAsync.apply(consumer3).get();
+        if (valuesInListener.isEmpty()) {
+            Awaitility.await().untilAsserted(() -> assertEquals(valuesInListener.size(), 2));
+            assertEquals(valuesInListener.stream().sorted().toList(), Arrays.asList("1-1", "2-1"));
+        } // else: consumer3 has passed messages to the listener before seek, in this case we cannot assume anything
+
+        @Cleanup final var consumer4 = pulsarClient.newConsumer(Schema.STRING)
+                .topics(Arrays.asList(topic1, topic2)).subscriptionName("sub-4")
+                .ackTimeout(1, TimeUnit.SECONDS)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe();
+        seekAsync.apply(consumer4).get();
+        final var valuesInReceiveAsync = new ArrayList<String>();
+        valuesInReceiveAsync.add(consumer4.receiveAsync().get().getValue());
+        valuesInReceiveAsync.add(consumer4.receiveAsync().get().getValue());
+        assertEquals(valuesInReceiveAsync.stream().sorted().toList(), Arrays.asList("1-1", "2-1"));
+    }
 }


### PR DESCRIPTION
### Motivation

The multi-topics consumer supports seeking all internal consumers when accepting a timestamp as the argument. However, the multi-topics consumer could still read from earliest after seeking to a specific position. There are two reasons:
1. `incomingMessages` is not cleared before `seek(long timestamp)`
2. A race condition for a consumer whose start message ID is earliest:
    1. `seekAsync` was called and then `incomingMessages` was cleared
    2. Messages from the earliest position were prefetched to internal consumers and then added to `incomingMessages`
    3. Internal consumers were disconnected from the broker and then broker reset cursors
    4. Messages from the seek position were added to `incomingMessages`
    5. After `seekAsync` completed, `Consumer#receive` will poll the messages fetched before `seek` completed

### Modifications

Add a `duringSeek` flag that is set with true when the seek operation starts. Then do not handle messages via `messageReceive` and stop `receiveMessageFromConsumer` if `duringSeek` is true. After the seek option finishes, set `duringSeek` back to `false` and restart `receiveMessageFromConsumer` for all consumers again.

Add `testSeekToNewerPosition` to verify `receive`, `receiveAsync` and message listener all work for seeking by timestamp to a newer position on a multi-topics consumer.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: