### PR TITLE
[cleanup] [broker] fix doc for TransactionBuffer#isTxnAborted

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
@@ -139,7 +139,7 @@ public interface TransactionBuffer {
     CompletableFuture<Void> closeAsync();
 
     /**
-     * check if the txn is aborted.
+     * Check if the txn is aborted.
      * TODO: To avoid broker oom, we will load the aborted txn from snapshot on demand.
      *       So we need the readPosition to check if the txn is loaded.
      * @param txnID {@link TxnID} txnId.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
@@ -139,10 +139,12 @@ public interface TransactionBuffer {
     CompletableFuture<Void> closeAsync();
 
     /**
-     * Close the buffer asynchronously.
+     * check if the txn is aborted.
+     * TODO: To avoid broker oom, we will load the aborted txn from snapshot on demand.
+     *       So we need the readPosition to check if the txn is loaded.
      * @param txnID {@link TxnID} txnId.
      * @param readPosition the persistent position of the txn message.
-     * @return the txnId is aborted.
+     * @return whether the txn is aborted.
      */
     boolean isTxnAborted(TxnID txnID, PositionImpl readPosition);
 


### PR DESCRIPTION
### Motivation
~~The argument `PositionImpl readPosition` of method `org.apache.pulsar.broker.transaction.buffer.TransactionBuffer#isTxnAborted` is weird and unneccessary, we have better remove it to avoid confusion.~~
Argument `PositionImpl readPosition` is used for future.

### Modifications
~~Remove the argument `PositionImpl readPosition`.~~
fix the doc and add to-do to avoid confusion.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/36