### PR TITLE
[improve][client]  Not allowed sendTimeout less than batchingMaxPublishDelay

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -97,7 +97,7 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
                 "Batching and chunking of messages can't be enabled together");
         checkArgument(!(conf.isBatchingEnabled() && conf.getBatchingMaxPublishDelayMicros()
                         >= conf.getSendTimeoutMs() * 1000L),
-                "Send timeout can't be less than batching max publish delay");
+                "Send timeout can't be equal to or less than batching max publish delay");
         if (conf.getTopicName() == null) {
             return FutureUtil
                     .failedFuture(new IllegalArgumentException("Topic name must be set on the producer builder"));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -95,6 +95,9 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
         // config validation
         checkArgument(!(conf.isBatchingEnabled() && conf.isChunkingEnabled()),
                 "Batching and chunking of messages can't be enabled together");
+        checkArgument(!(conf.isBatchingEnabled() && conf.getBatchingMaxPublishDelayMicros()
+                        >= conf.getSendTimeoutMs() * 1000L),
+                "Send timeout can't be less than batching max publish delay");
         if (conf.getTopicName() == null) {
             return FutureUtil
                     .failedFuture(new IllegalArgumentException("Topic name must be set on the producer builder"));

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
@@ -374,6 +374,14 @@ public class ProducerBuilderImplTest {
         producerBuilderImpl.maxPendingMessagesAcrossPartitions(-1);
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Send timeout can't be less than batching max publish delay")
+    public void testProducerBuilderImplWhenSendTimeoutLessThanBatchingMaxPublishDelay() throws PulsarClientException {
+        producerBuilderImpl.enableBatching(true)
+                .topic(TOPIC_NAME)
+                .sendTimeout(1, TimeUnit.MILLISECONDS)
+                .batchingMaxPublishDelay(1, TimeUnit.MILLISECONDS).create();
+    }
+
     @Test
     public void testProducerBuilderImplWhenNumericPropertiesAreValid() {
         producerBuilderImpl.batchingMaxPublishDelay(1, TimeUnit.SECONDS);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
@@ -374,7 +374,7 @@ public class ProducerBuilderImplTest {
         producerBuilderImpl.maxPendingMessagesAcrossPartitions(-1);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Send timeout can't be less than batching max publish delay")
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Send timeout can't be equal to or less than batching max publish delay")
     public void testProducerBuilderImplWhenSendTimeoutLessThanBatchingMaxPublishDelay() throws PulsarClientException {
         producerBuilderImpl.enableBatching(true)
                 .topic(TOPIC_NAME)


### PR DESCRIPTION
### Motivation

Avoid  client config sendTimeout less than batchingMaxPublishDelay, bringing incorrect configuration into the runtime.

### Modifications

In the createAsync method, add checkArgument.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
