### PR TITLE
[fix] [broker] Fix replicator send message error but cursor not set back to rewind position

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -332,10 +332,9 @@ public abstract class PersistentReplicator extends AbstractReplicator
         public void sendComplete(Exception exception) {
             if (exception != null && !(exception instanceof PulsarClientException.InvalidMessageException)) {
                 log.error("[{}] Error producing on remote broker", replicator.replicatorId, exception);
+                replicator.cursor.cancelPendingReadRequest();
                 // cursor should be rewinded since it was incremented when readMoreEntries
                 replicator.cursor.rewind();
-
-                replicator.cursor.cancelPendingReadRequest();
                 HAVE_PENDING_READ_UPDATER.set(replicator, FALSE);
             } else {
                 if (log.isDebugEnabled()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -334,6 +334,9 @@ public abstract class PersistentReplicator extends AbstractReplicator
                 log.error("[{}] Error producing on remote broker", replicator.replicatorId, exception);
                 // cursor should be rewinded since it was incremented when readMoreEntries
                 replicator.cursor.rewind();
+
+                replicator.cursor.cancelPendingReadRequest();
+                HAVE_PENDING_READ_UPDATER.set(replicator, FALSE);
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Message persisted on remote broker", replicator.replicatorId, exception);


### PR DESCRIPTION

### Motivation

When message send message failed and there is a pending read, cursor.rewind() set the read position back to mark delete position, but pending read will use old position, this will cause ack hole in replication cursor, and remote cluster will lost messages unless replicator reloaded.

We discovered this issue while developing rop, and I think it's a common problem with pulsar.


Here is some debug log, and I added some logs marked in circles. 

1. add log when start readMoreEntries()
<img width="964" alt="image" src="https://github.com/apache/pulsar/assets/5668441/90142535-0c36-4ced-b7fb-7cd291b27db3">
2. add log in send message error callback.
<img width="896" alt="image" src="https://github.com/apache/pulsar/assets/5668441/b800d28e-d824-485c-aded-5d4204dbcb28">

3. debug log when send message error.
![image](https://github.com/apache/pulsar/assets/5668441/e3ab6670-c20d-463b-9800-fe835097b48f)




### Modifications

- Remove pending read when send message error.
- The failed scenario is difficult to reproduce, so I did not add a test cases.


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
