### PR TITLE
[fix][fn] Add missing `version` field back to `querystate` API

### DIFF
--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/state/ByteBufferStateStore.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/state/ByteBufferStateStore.java
@@ -80,7 +80,7 @@ public interface ByteBufferStateStore extends StateStore {
      * @return the StateValue.
      */
     default StateValue getStateValue(String key) {
-        return new StateValue(get(key), null, null);
+        return getStateValueAsync(key).join();
     }
 
     /**
@@ -90,6 +90,14 @@ public interface ByteBufferStateStore extends StateStore {
      * @return the StateValue.
      */
     default CompletableFuture<StateValue> getStateValueAsync(String key) {
-        return getAsync(key).thenApply(val -> new StateValue(val, null, null));
+        return getAsync(key).thenApply(val -> {
+            if (val != null && val.remaining() > 0) {
+                byte[] data = new byte[val.remaining()];
+                val.get(data);
+                return new StateValue(data, null, null);
+            } else {
+                return null;
+            }
+        });
     }
 }

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/state/ByteBufferStateStore.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/state/ByteBufferStateStore.java
@@ -73,4 +73,23 @@ public interface ByteBufferStateStore extends StateStore {
      */
     CompletableFuture<ByteBuffer> getAsync(String key);
 
+    /**
+     * Retrieve the StateValue for the key.
+     *
+     * @param key name of the key
+     * @return the StateValue.
+     */
+    default StateValue getStateValue(String key) {
+        return new StateValue(get(key), null, null);
+    }
+
+    /**
+     * Retrieve the StateValue for the key, but don't wait for the operation to be completed.
+     *
+     * @param key name of the key
+     * @return the StateValue.
+     */
+    default CompletableFuture<StateValue> getStateValueAsync(String key) {
+        return getAsync(key).thenApply(val -> new StateValue(val, null, null));
+    }
 }

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/state/ByteBufferStateStore.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/state/ByteBufferStateStore.java
@@ -91,7 +91,7 @@ public interface ByteBufferStateStore extends StateStore {
      */
     default CompletableFuture<StateValue> getStateValueAsync(String key) {
         return getAsync(key).thenApply(val -> {
-            if (val != null && val.remaining() > 0) {
+            if (val != null && val.remaining() >= 0) {
                 byte[] data = new byte[val.remaining()];
                 val.get(data);
                 return new StateValue(data, null, null);

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/state/StateValue.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/state/StateValue.java
@@ -18,21 +18,19 @@
  */
 package org.apache.pulsar.functions.api.state;
 
-import java.nio.ByteBuffer;
-
 public class StateValue {
-    private final ByteBuffer value;
+    private final byte[] value;
     private final Long version;
     private final Boolean isNumber;
 
-    public StateValue(ByteBuffer value, Long version, Boolean isNumber) {
-        this.value = value == null ? null : ByteBuffer.wrap(value.array());
+    public StateValue(byte[] value, Long version, Boolean isNumber) {
+        this.value = value == null ? null : value.clone();
         this.version = version;
         this.isNumber = isNumber;
     }
 
-    public ByteBuffer getValue() {
-        return value == null ? null : ByteBuffer.wrap(value.array());
+    public byte[] getValue() {
+        return this.value == null ? null : this.value.clone();
     }
 
     public Long getVersion() {

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/state/StateValue.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/state/StateValue.java
@@ -18,26 +18,13 @@
  */
 package org.apache.pulsar.functions.api.state;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public class StateValue {
     private final byte[] value;
     private final Long version;
     private final Boolean isNumber;
-
-    public StateValue(byte[] value, Long version, Boolean isNumber) {
-        this.value = value == null ? null : value.clone();
-        this.version = version;
-        this.isNumber = isNumber;
-    }
-
-    public byte[] getValue() {
-        return this.value == null ? null : this.value.clone();
-    }
-
-    public Long getVersion() {
-        return version;
-    }
-
-    public Boolean getIsNumber() {
-        return isNumber;
-    }
 }

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/state/StateValue.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/state/StateValue.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.api.state;
+
+import java.nio.ByteBuffer;
+
+public class StateValue {
+    private final ByteBuffer value;
+    private final Long version;
+    private final Boolean isNumber;
+
+    public StateValue(ByteBuffer value, Long version, Boolean isNumber) {
+        this.value = value == null ? null : ByteBuffer.wrap(value.array());
+        this.version = version;
+        this.isNumber = isNumber;
+    }
+
+    public ByteBuffer getValue() {
+        return value == null ? null : ByteBuffer.wrap(value.array());
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    public Boolean getIsNumber() {
+        return isNumber;
+    }
+}

--- a/pulsar-functions/api-java/src/main/resources/findbugsExclude.xml
+++ b/pulsar-functions/api-java/src/main/resources/findbugsExclude.xml
@@ -30,6 +30,11 @@
     <Bug pattern="EI_EXPOSE_REP"/>
   </Match>
   <Match>
+    <Class name="org.apache.pulsar.functions.api.state.StateValue"/>
+    <Method name="getValue"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+  <Match>
     <Class name="org.apache.pulsar.functions.api.utils.FunctionRecord$FunctionRecordBuilder"/>
     <Method name="properties"/>
     <Bug pattern="EI_EXPOSE_REP2"/>
@@ -37,6 +42,10 @@
   <Match>
     <Class name="org.apache.pulsar.functions.api.utils.FunctionRecord$FunctionRecordBuilder"/>
     <Method name="schema"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+  <Match>
+    <Class name="org.apache.pulsar.functions.api.state.StateValue"/>
     <Bug pattern="EI_EXPOSE_REP2"/>
   </Match>
 </FindBugsFilter>

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/BKStateStoreImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/BKStateStoreImpl.java
@@ -206,7 +206,7 @@ public class BKStateStoreImpl implements DefaultStateStore {
         return table.getKv(Unpooled.wrappedBuffer(key.getBytes(UTF_8))).thenApply(
                 data -> {
                     try {
-                        if (data != null && data.value() != null && data.value().readableBytes() > 0) {
+                        if (data != null && data.value() != null && data.value().readableBytes() >= 0) {
                             byte[] result = new byte[data.value().readableBytes()];
                             data.value().readBytes(result);
                             return new StateValue(result, data.version(), data.isNumber());

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/BKStateStoreImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/BKStateStoreImpl.java
@@ -206,15 +206,9 @@ public class BKStateStoreImpl implements DefaultStateStore {
         return table.getKv(Unpooled.wrappedBuffer(key.getBytes(UTF_8))).thenApply(
                 data -> {
                     try {
-                        if (data != null && data.value() != null) {
-                            ByteBuffer result = ByteBuffer.allocate(data.value().readableBytes());
+                        if (data != null && data.value() != null && data.value().readableBytes() > 0) {
+                            byte[] result = new byte[data.value().readableBytes()];
                             data.value().readBytes(result);
-                            // Set position to off the buffer to the beginning, since the position after the
-                            // read is going to be end of the buffer
-                            // If we do not rewind to the beginning here, users will have to explicitly do
-                            // this in their function code
-                            // in order to use any of the ByteBuffer operations
-                            result.position(0);
                             return new StateValue(result, data.version(), data.isNumber());
                         }
                         return null;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/BKStateStoreImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/BKStateStoreImpl.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.api.kv.Table;
 import org.apache.bookkeeper.api.kv.options.Options;
 import org.apache.pulsar.functions.api.StateStoreContext;
+import org.apache.pulsar.functions.api.state.StateValue;
 import org.apache.pulsar.functions.utils.FunctionCommon;
 
 /**
@@ -189,5 +190,40 @@ public class BKStateStoreImpl implements DefaultStateStore {
         } catch (Exception e) {
             throw new RuntimeException("Failed to retrieve the state value for key '" + key + "'", e);
         }
+    }
+
+    @Override
+    public StateValue getStateValue(String key) {
+        try {
+            return result(getStateValueAsync(key));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to retrieve the state value for key '" + key + "'", e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<StateValue> getStateValueAsync(String key) {
+        return table.getKv(Unpooled.wrappedBuffer(key.getBytes(UTF_8))).thenApply(
+                data -> {
+                    try {
+                        if (data != null && data.value() != null) {
+                            ByteBuffer result = ByteBuffer.allocate(data.value().readableBytes());
+                            data.value().readBytes(result);
+                            // Set position to off the buffer to the beginning, since the position after the
+                            // read is going to be end of the buffer
+                            // If we do not rewind to the beginning here, users will have to explicitly do
+                            // this in their function code
+                            // in order to use any of the ByteBuffer operations
+                            result.position(0);
+                            return new StateValue(result, data.version(), data.isNumber());
+                        }
+                        return null;
+                    } finally {
+                        if (data != null) {
+                            ReferenceCountUtil.safeRelease(data);
+                        }
+                    }
+                }
+        );
     }
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/PulsarMetadataStateStoreImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/PulsarMetadataStateStoreImpl.java
@@ -122,7 +122,7 @@ public class PulsarMetadataStateStoreImpl implements DefaultStateStore {
         return store.get(getPath(key))
                 .thenApply(optRes ->
                         optRes.map(x ->
-                            new StateValue(ByteBuffer.wrap(x.getValue()), x.getStat().getVersion(), null))
+                            new StateValue(x.getValue(), x.getStat().getVersion(), null))
                                 .orElse(null));
     }
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/PulsarMetadataStateStoreImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/PulsarMetadataStateStoreImpl.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.functions.api.StateStoreContext;
+import org.apache.pulsar.functions.api.state.StateValue;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStore;
 
@@ -108,6 +109,20 @@ public class PulsarMetadataStateStoreImpl implements DefaultStateStore {
         return store.get(getPath(key))
                 .thenApply(optRes ->
                         optRes.map(x -> ByteBuffer.wrap(x.getValue()))
+                                .orElse(null));
+    }
+
+    @Override
+    public StateValue getStateValue(String key) {
+        return getStateValueAsync(key).join();
+    }
+
+    @Override
+    public CompletableFuture<StateValue> getStateValueAsync(String key) {
+        return store.get(getPath(key))
+                .thenApply(optRes ->
+                        optRes.map(x ->
+                            new StateValue(ByteBuffer.wrap(x.getValue()), x.getStat().getVersion(), null))
                                 .orElse(null));
     }
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/state/BKStateStoreImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/state/BKStateStoreImplTest.java
@@ -35,7 +35,9 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.api.kv.Table;
 import org.apache.bookkeeper.api.kv.options.Options;
 import org.apache.bookkeeper.api.kv.result.DeleteResult;
+import org.apache.bookkeeper.api.kv.result.KeyValue;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
+import org.apache.pulsar.functions.api.state.StateValue;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -115,6 +117,24 @@ public class BKStateStoreImplTest {
     }
 
     @Test
+    public void testGetStateValue() throws Exception {
+        KeyValue returnedKeyValue = mock(KeyValue.class);
+        ByteBuf returnedValue = Unpooled.copiedBuffer("test-value", UTF_8);
+        when(returnedKeyValue.value()).thenReturn(returnedValue);
+        when(returnedKeyValue.version()).thenReturn(1l);
+        when(returnedKeyValue.isNumber()).thenReturn(false);
+        when(mockTable.getKv(any(ByteBuf.class)))
+            .thenReturn(FutureUtils.value(returnedKeyValue));
+        StateValue result = stateContext.getStateValue("test-key");
+        assertEquals("test-value", new String(result.getValue().array(), UTF_8));
+        assertEquals(1l, result.getVersion().longValue());
+        assertEquals(false, result.getIsNumber().booleanValue());
+        verify(mockTable, times(1)).getKv(
+            eq(Unpooled.copiedBuffer("test-key", UTF_8))
+        );
+    }
+
+    @Test
     public void testGetAmount() throws Exception {
         when(mockTable.getNumber(any(ByteBuf.class)))
             .thenReturn(FutureUtils.value(10L));
@@ -131,6 +151,12 @@ public class BKStateStoreImplTest {
         CompletableFuture<ByteBuffer> result = stateContext.getAsync("test-key");
         assertTrue(result != null);
         assertEquals(result.get(), null);
+
+        when(mockTable.getKv(any(ByteBuf.class)))
+                .thenReturn(FutureUtils.value(null));
+        CompletableFuture<StateValue> stateValueResult = stateContext.getStateValueAsync("test-key");
+        assertTrue(stateValueResult != null);
+        assertEquals(stateValueResult.get(), null);
 
     }
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/state/BKStateStoreImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/state/BKStateStoreImplTest.java
@@ -126,7 +126,7 @@ public class BKStateStoreImplTest {
         when(mockTable.getKv(any(ByteBuf.class)))
             .thenReturn(FutureUtils.value(returnedKeyValue));
         StateValue result = stateContext.getStateValue("test-key");
-        assertEquals("test-value", new String(result.getValue().array(), UTF_8));
+        assertEquals("test-value", new String(result.getValue(), UTF_8));
         assertEquals(1l, result.getVersion().longValue());
         assertEquals(false, result.getIsNumber().booleanValue());
         verify(mockTable, times(1)).getKv(

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/state/PulsarMetadataStateStoreImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/state/PulsarMetadataStateStoreImplTest.java
@@ -24,6 +24,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.functions.api.state.StateValue;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
@@ -101,6 +102,10 @@ public class PulsarMetadataStateStoreImplTest {
         CompletableFuture<ByteBuffer> result = stateContext.getAsync("test-key");
         assertTrue(result != null);
         assertEquals(result.get(), null);
+
+        CompletableFuture<StateValue> stateValueResult = stateContext.getStateValueAsync("test-key");
+        assertTrue(stateValueResult != null);
+        assertEquals(stateValueResult.get(), null);
     }
 
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1222,7 +1222,7 @@ public abstract class ComponentImpl implements Component<PulsarWorkerService> {
         try {
             DefaultStateStore store = worker().getStateStoreProvider().getStateStore(tenant, namespace, functionName);
             ByteBuffer data;
-            if (StringUtils.isNotEmpty(state.getStringValue())) {
+            if (state.getStringValue() != null) {
                 data = ByteBuffer.wrap(state.getStringValue().getBytes(UTF_8));
             } else if (state.getByteValue() != null) {
                 data = ByteBuffer.wrap(state.getByteValue());

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1157,7 +1157,7 @@ public abstract class ComponentImpl implements Component<PulsarWorkerService> {
                 throw new RestException(Status.NOT_FOUND, "key '" + key + "' doesn't exist.");
             }
             byte[] data = value.getValue();
-            if (data == null || data.length == 0) {
+            if (data == null) {
                 throw new RestException(Status.NOT_FOUND, "key '" + key + "' doesn't exist.");
             }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
@@ -481,6 +481,8 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         );
         assertTrue(result.getStdout().contains("\"numberValue\": " + amount));
         assertTrue(result.getStdout().contains("\"version\": " + version));
+        assertFalse(result.getStdout().contains("stringValue"));
+        assertFalse(result.getStdout().contains("byteValue"));
     }
 
     private void putAndQueryState(String functionName, String key, String state, String expect)

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
@@ -97,10 +97,10 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         getFunctionStatus(functionName, numMessages);
 
         // get state
-        queryState(functionName, "hello", numMessages);
-        queryState(functionName, "test", numMessages);
+        queryState(functionName, "hello", numMessages, numMessages - 1);
+        queryState(functionName, "test", numMessages, numMessages - 1);
         for (int i = 0; i < numMessages; i++) {
-            queryState(functionName, "message-" + i, 1);
+            queryState(functionName, "message-" + i, 1, 0);
         }
 
         // test put state
@@ -468,7 +468,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         assertTrue(result.getStdout().contains("\"numSuccessfullyProcessed\" : " + numMessages));
     }
 
-    private void queryState(String functionName, String key, int amount)
+    private void queryState(String functionName, String key, int amount, long version)
         throws Exception {
         ContainerExecResult result = container.execCmd(
             PulsarCluster.ADMIN_SCRIPT,
@@ -480,6 +480,7 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
             "--key", key
         );
         assertTrue(result.getStdout().contains("\"numberValue\": " + amount));
+        assertTrue(result.getStdout().contains("\"version\": " + version));
     }
 
     private void putAndQueryState(String functionName, String key, String state, String expect)


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

https://github.com/apache/pulsar/pull/21597 introduce a change that always uses `null` for the `version` field for the `querystate` API. This may break users' behavior, need to add it back

### Modifications

1. Add a new class `org.apache.pulsar.functions.api.state.StateValue`, which contains `value`, `version`, and `isNumber` fields.
2. Add two new methods to the `org.apache.pulsar.functions.api.state.ByteBufferStateStore` interface, both of which return a `StateValue`:
    1. default StateValue getStateValue(String key)
    2. default StateValue getStateValueAsync(String key)
3.  Use `DefaultStateStore#getStateValue` method instead of `DefaultStateStore#get` in `org.apache.pulsar.functions.worker.rest.api.ComponentImpl` to get the `version` field from the backend state store and return it to users.


### Verifying this change

- [x] Make sure that the change passes the CI checks.

- [x] This change added tests and can be verified as follows:
  - *Add unit tests for `getStateValue` and `getStateValueAsync`*
  - *Update integration test of `PulsarStateTest#testPythonWordCountFunction`, now it will check the `version` field too.*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/jiangpengcheng/pulsar/pull/24

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
