### PR TITLE
[fix] [broker] make rest api PersistentTopic#getLastMessageId consistent with binary api ServerCnx#handleGetLastMessageId

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -30,7 +30,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.concurrent.FastThreadLocal;
-
 import java.io.IOException;
 import java.time.Clock;
 import java.util.ArrayList;
@@ -3622,7 +3621,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             if (entry == null) {
                 completableFuture.complete(MessageId.earliest);
             } else {
-                try{
+                try {
                     MessageMetadata metadata = Commands.parseMessageMetadata(entry.getDataBuffer());
                     int lastBatchIndexInBatch = calculateTheLastBatchIndexInBatch(metadata, entry.getDataBuffer());
                     if (lastBatchIndexInBatch != -1) {
@@ -3655,7 +3654,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             if (log.isDebugEnabled()) {
                 log.debug("getLastMessageId {}, partitionIndex{}, lastPosition {}", name, partitionIndex, lastPosition);
             }
-            CompletableFuture<Position> compactionHorizonFuture = getTopicCompactionService().getLastCompactedPosition();
+            CompletableFuture<Position> compactionHorizonFuture =
+                    getTopicCompactionService().getLastCompactedPosition();
             compactionHorizonFuture.thenAccept(compactionHorizon -> {
                 if (lastPosition.getEntryId() == -1 || (compactionHorizon != null
                         && lastPosition.compareTo((PositionImpl) compactionHorizon) <= 0)) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/GetLastMessageIdCompactedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/GetLastMessageIdCompactedTest.java
@@ -268,7 +268,7 @@ public class GetLastMessageIdCompactedTest extends ProducerConsumerBase {
     public void testGetLastMessageIdAfterCompactionAndExpire(boolean enabledBatch) throws Exception {
         String topicName = "persistent://public/default/" + BrokerTestUtil.newUniqueName("tp");
         Producer<String> producer = createProducer(enabledBatch, topicName);
-        // produce 3 messages
+        // produce messages
         producer.newMessage().key("k0").value("v0").sendAsync();
         producer.newMessage().key("k0").value("v1").sendAsync();
         producer.flush();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/GetLastMessageIdCompactedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/GetLastMessageIdCompactedTest.java
@@ -265,6 +265,39 @@ public class GetLastMessageIdCompactedTest extends ProducerConsumerBase {
     }
 
     @Test(dataProvider = "enabledBatch")
+    public void testGetLastMessageIdAfterCompactionAndExpire(boolean enabledBatch) throws Exception {
+        String topicName = "persistent://public/default/" + BrokerTestUtil.newUniqueName("tp");
+        Producer<String> producer = createProducer(enabledBatch, topicName);
+        // produce 3 messages
+        producer.newMessage().key("k0").value("v0").sendAsync();
+        producer.newMessage().key("k0").value("v1").sendAsync();
+        producer.flush();
+
+        // trigger compaction
+        triggerCompactionAndWait(topicName);
+
+        triggerLedgerSwitch(topicName);
+        clearAllTheLedgersOutdated(topicName);
+
+        MessageIdImpl lastMessageIdByTopic = getLastMessageIdByTopic(topicName);
+        Consumer<String> consumer = createConsumer(topicName, "sub");
+        MessageIdImpl messageId = (MessageIdImpl) consumer.getLastMessageId();
+        assertEquals(messageId.getLedgerId(), lastMessageIdByTopic.getLedgerId());
+        assertEquals(messageId.getEntryId(), lastMessageIdByTopic.getEntryId());
+        if (enabledBatch) {
+            BatchMessageIdImpl lastBatchMessageIdByTopic = (BatchMessageIdImpl) lastMessageIdByTopic;
+            BatchMessageIdImpl batchMessageId = (BatchMessageIdImpl) messageId;
+            assertEquals(batchMessageId.getBatchSize(), lastBatchMessageIdByTopic.getBatchSize());
+            assertEquals(batchMessageId.getBatchIndex(), lastBatchMessageIdByTopic.getBatchIndex());
+        }
+
+        // cleanup.
+        consumer.close();
+        producer.close();
+        admin.topics().delete(topicName, false);
+    }
+
+    @Test(dataProvider = "enabledBatch")
     public void testGetLastMessageIdAfterCompactionWithCompression(boolean enabledBatch) throws Exception {
         String topicName = "persistent://public/default/" + BrokerTestUtil.newUniqueName("tp");
         String subName = "sub";


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/21968

### Motivation
The implementation of `org.apache.pulsar.broker.service.persistent.PersistentTopic#getLastMessageId` is not consistent with `org.apache.pulsar.broker.service.ServerCnx#handleGetLastMessageId`, for example, `ServerCnx#handleGetLastMessageId` may get last message id from the compacted topic, while `PersistentTopic#getLastMessageId` don't.

~~And flink-pulsar-connector also rely on the rest api `PersistentTopic#getLastMessageId`, we have better fix this problem.~~
Older version of flink-pulsar-connector use it, latest version change to call `consumer.getLastMessageId();`.

### Modifications
Refactor `PersistentTopic#getLastMessageId` to be simillar with `ServerCnx#handleGetLastMessageId`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added tests and can be verified as follows:


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [x] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/37
