### PR TITLE
[improve] [proxy] Add a check for brokerServiceURL that does not support multi uri yet

### DIFF
--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -28,7 +28,7 @@ metadataStoreUrl=
 # The metadata store URL for the configuration data. If empty, we fall back to use metadataStoreUrl
 configurationMetadataStoreUrl=
 
-# If did not set metadataStoreUrl or configurationMetadataStoreUrl, this url should point to the discovery service
+# If does not set metadataStoreUrl or configurationMetadataStoreUrl, this url should point to the discovery service
 # provider.
 # The URL must begin with pulsar:// for plaintext or with pulsar+ssl:// for TLS.
 brokerServiceURL=

--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -29,17 +29,18 @@ metadataStoreUrl=
 configurationMetadataStoreUrl=
 
 # If does not set metadataStoreUrl or configurationMetadataStoreUrl, this url should point to the discovery service
-# provider.
+# provider, and does not support multi urls yet.
 # The URL must begin with pulsar:// for plaintext or with pulsar+ssl:// for TLS.
 brokerServiceURL=
 brokerServiceURLTLS=
 
-# These settings are unnecessary if `zookeeperServers` is specified
+# If does not set metadataStoreUrl or configurationMetadataStoreUrl, this url should point to the discovery service
+# provider, and does not support multi urls yet.
 brokerWebServiceURL=
 brokerWebServiceURLTLS=
 
-# If function workers are setup in a separate cluster, configure the following 2 settings
-# to point to the function workers cluster
+# If function workers are setup in a separate cluster, configure the following 2 settings. This url should point to
+# the discovery service provider of the function workers cluster, and does not support multi urls yet.
 functionWorkerWebServiceURL=
 functionWorkerWebServiceURLTLS=
 

--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -28,7 +28,8 @@ metadataStoreUrl=
 # The metadata store URL for the configuration data. If empty, we fall back to use metadataStoreUrl
 configurationMetadataStoreUrl=
 
-# If Service Discovery is Disabled this url should point to the discovery service provider.
+# If did not set metadataStoreUrl or configurationMetadataStoreUrl, this url should point to the discovery service
+# provider.
 # The URL must begin with pulsar:// for plaintext or with pulsar+ssl:// for TLS.
 brokerServiceURL=
 brokerServiceURLTLS=

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -173,14 +173,14 @@ public class ProxyConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_BROKER_DISCOVERY,
-        doc = "If did not set metadataStoreUrl or configurationMetadataStoreUrl, this url should point to the"
+        doc = "If does not set metadataStoreUrl or configurationMetadataStoreUrl, this url should point to the"
                 + " discovery service provider."
                 + " URL must have the pulsar:// prefix. And does not support multi url yet."
     )
     private String brokerServiceURL;
     @FieldContext(
         category = CATEGORY_BROKER_DISCOVERY,
-            doc = "If did not set metadataStoreUrl or configurationMetadataStoreUrl, this url should point to the"
+            doc = "If does not set metadataStoreUrl or configurationMetadataStoreUrl, this url should point to the"
                     + " discovery service provider."
                 + " URL must have the pulsar+ssl:// prefix. And does not support multi url yet."
     )

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -188,24 +188,28 @@ public class ProxyConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_BROKER_DISCOVERY,
-        doc = "The web service url points to the broker cluster"
+        doc = "The web service url points to the discovery service provider of the broker cluster, and does not support"
+                + " multi url yet."
     )
     private String brokerWebServiceURL;
     @FieldContext(
         category = CATEGORY_BROKER_DISCOVERY,
-        doc = "The tls web service url points to the broker cluster"
+        doc = "The tls web service url points to the discovery service provider of the broker cluster, and does not"
+                + " support multi url yet."
     )
     private String brokerWebServiceURLTLS;
 
     @FieldContext(
         category = CATEGORY_BROKER_DISCOVERY,
-        doc = "The web service url points to the function worker cluster."
+        doc = "The web service url points to the discovery service provider of the function worker cluster, and does"
+                + " not support multi url yet."
             + " Only configure it when you setup function workers in a separate cluster"
     )
     private String functionWorkerWebServiceURL;
     @FieldContext(
         category = CATEGORY_BROKER_DISCOVERY,
-        doc = "The tls web service url points to the function worker cluster."
+        doc = "The tls web service url points to the discovery service provider of the function worker cluster, and"
+                + " does not support multi url yet."
             + " Only configure it when you setup function workers in a separate cluster"
     )
     private String functionWorkerWebServiceURLTLS;

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -173,12 +173,16 @@ public class ProxyConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_BROKER_DISCOVERY,
-        doc = "The service url points to the broker cluster. URL must have the pulsar:// prefix."
+        doc = "If did not set metadataStoreUrl or configurationMetadataStoreUrl, this url should point to the"
+                + " discovery service provider."
+                + " URL must have the pulsar:// prefix. And does not support multi url yet."
     )
     private String brokerServiceURL;
     @FieldContext(
         category = CATEGORY_BROKER_DISCOVERY,
-        doc = "The tls service url points to the broker cluster. URL must have the pulsar+ssl:// prefix."
+            doc = "If did not set metadataStoreUrl or configurationMetadataStoreUrl, this url should point to the"
+                    + " discovery service provider."
+                + " URL must have the pulsar+ssl:// prefix. And does not support multi url yet."
     )
     private String brokerServiceURLTLS;
 

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
@@ -162,11 +162,17 @@ public class ProxyServiceStarter {
             if (isNotBlank(config.getBrokerServiceURL())) {
                 checkArgument(config.getBrokerServiceURL().startsWith("pulsar://"),
                         "brokerServiceURL must start with pulsar://");
+                checkArgument(!config.getBrokerServiceURL().contains(","),
+                        "brokerServiceURL did not support multi urls yet, it should point to the"
+                                + " discovery service provider.");
             }
 
             if (isNotBlank(config.getBrokerServiceURLTLS())) {
                 checkArgument(config.getBrokerServiceURLTLS().startsWith("pulsar+ssl://"),
                         "brokerServiceURLTLS must start with pulsar+ssl://");
+                checkArgument(!config.getBrokerServiceURLTLS().contains(","),
+                        "brokerServiceURL did not support multi urls yet, it should point to the"
+                                + " discovery service provider.");
             }
 
             if ((isBlank(config.getBrokerServiceURL()) && isBlank(config.getBrokerServiceURLTLS()))

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
@@ -162,41 +162,28 @@ public class ProxyServiceStarter {
             if (isNotBlank(config.getBrokerServiceURL())) {
                 checkArgument(config.getBrokerServiceURL().startsWith("pulsar://"),
                         "brokerServiceURL must start with pulsar://");
-                checkArgument(!config.getBrokerServiceURL().contains(","),
-                        "brokerServiceURL does not support multi urls yet, it should point to the"
-                                + " discovery service provider.");
+                ensureUrlNotContainsComma("brokerServiceURL", config.getBrokerServiceURL());
             }
-
             if (isNotBlank(config.getBrokerServiceURLTLS())) {
                 checkArgument(config.getBrokerServiceURLTLS().startsWith("pulsar+ssl://"),
                         "brokerServiceURLTLS must start with pulsar+ssl://");
-                checkArgument(!config.getBrokerServiceURLTLS().contains(","),
-                        "brokerServiceURL does not support multi urls yet, it should point to the"
-                                + " discovery service provider.");
+                ensureUrlNotContainsComma("brokerServiceURLTLS", config.getBrokerServiceURLTLS());
             }
 
             if (isNotBlank(config.getBrokerWebServiceURL())) {
-                checkArgument(!config.getBrokerWebServiceURL().contains(","),
-                        "brokerWebServiceURL does not support multi urls yet, it should point to the"
-                                + " discovery service provider.");
+                ensureUrlNotContainsComma("brokerWebServiceURL", config.getBrokerWebServiceURL());
             }
-
             if (isNotBlank(config.getBrokerWebServiceURLTLS())) {
-                checkArgument(!config.getBrokerWebServiceURLTLS().contains(","),
-                        "brokerWebServiceURLTLS does not support multi urls yet, it should point to the"
-                                + " discovery service provider.");
+                ensureUrlNotContainsComma("brokerWebServiceURLTLS", config.getBrokerWebServiceURLTLS());
             }
 
             if (isNotBlank(config.getFunctionWorkerWebServiceURL())) {
-                checkArgument(!config.getFunctionWorkerWebServiceURL().contains(","),
-                        "functionWorkerWebServiceURLTLS does not support multi urls yet, it should point"
-                                + " to the discovery service provider.");
+                ensureUrlNotContainsComma("functionWorkerWebServiceURLTLS",
+                        config.getFunctionWorkerWebServiceURL());
             }
-
             if (isNotBlank(config.getFunctionWorkerWebServiceURLTLS())) {
-                checkArgument(!config.getFunctionWorkerWebServiceURLTLS().contains(","),
-                        "functionWorkerWebServiceURLTLS does not support multi urls yet, it should point"
-                                + " to the discovery service provider.");
+                ensureUrlNotContainsComma("functionWorkerWebServiceURLTLS",
+                        config.getFunctionWorkerWebServiceURLTLS());
             }
 
             if ((isBlank(config.getBrokerServiceURL()) && isBlank(config.getBrokerServiceURLTLS()))
@@ -215,6 +202,11 @@ public class ProxyServiceStarter {
             log.error("Failed to start pulsar proxy service. error msg " + e.getMessage(), e);
             throw new PulsarServerException(e);
         }
+    }
+
+    private void ensureUrlNotContainsComma(String paramName, String paramValue) {
+        checkArgument(!paramValue.contains(","), paramName + " does not support multi urls yet,"
+                + " it should point to the discovery service provider.");
     }
 
     public static void main(String[] args) throws Exception {

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
@@ -175,6 +175,30 @@ public class ProxyServiceStarter {
                                 + " discovery service provider.");
             }
 
+            if (isNotBlank(config.getBrokerWebServiceURL())) {
+                checkArgument(!config.getBrokerWebServiceURL().contains(","),
+                        "brokerWebServiceURL does not support multi urls yet, it should point to the"
+                                + " discovery service provider.");
+            }
+
+            if (isNotBlank(config.getBrokerWebServiceURLTLS())) {
+                checkArgument(!config.getBrokerWebServiceURLTLS().contains(","),
+                        "brokerWebServiceURLTLS does not support multi urls yet, it should point to the"
+                                + " discovery service provider.");
+            }
+
+            if (isNotBlank(config.getFunctionWorkerWebServiceURL())) {
+                checkArgument(!config.getFunctionWorkerWebServiceURL().contains(","),
+                        "functionWorkerWebServiceURLTLS does not support multi urls yet, it should point"
+                                + " to the discovery service provider.");
+            }
+
+            if (isNotBlank(config.getFunctionWorkerWebServiceURLTLS())) {
+                checkArgument(!config.getFunctionWorkerWebServiceURLTLS().contains(","),
+                        "functionWorkerWebServiceURLTLS does not support multi urls yet, it should point"
+                                + " to the discovery service provider.");
+            }
+
             if ((isBlank(config.getBrokerServiceURL()) && isBlank(config.getBrokerServiceURLTLS()))
                     || config.isAuthorizationEnabled()) {
                 checkArgument(!isEmpty(config.getMetadataStoreUrl()), "metadataStoreUrl must be provided");

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
@@ -163,7 +163,7 @@ public class ProxyServiceStarter {
                 checkArgument(config.getBrokerServiceURL().startsWith("pulsar://"),
                         "brokerServiceURL must start with pulsar://");
                 checkArgument(!config.getBrokerServiceURL().contains(","),
-                        "brokerServiceURL did not support multi urls yet, it should point to the"
+                        "brokerServiceURL does not support multi urls yet, it should point to the"
                                 + " discovery service provider.");
             }
 
@@ -171,7 +171,7 @@ public class ProxyServiceStarter {
                 checkArgument(config.getBrokerServiceURLTLS().startsWith("pulsar+ssl://"),
                         "brokerServiceURLTLS must start with pulsar+ssl://");
                 checkArgument(!config.getBrokerServiceURLTLS().contains(","),
-                        "brokerServiceURL did not support multi urls yet, it should point to the"
+                        "brokerServiceURL does not support multi urls yet, it should point to the"
                                 + " discovery service provider.");
             }
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConfigurationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConfigurationTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.proxy.server;
 
 
-import org.apache.pulsar.PulsarBrokerStarter;
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -154,8 +153,9 @@ public class ProxyConfigurationTest {
                 assertTrue(ex.getMessage().contains("brokerServiceURL must start with pulsar://"));
             }
         }
-        // brokerServiceURLTLS must start with pulsar+ssl://
         configuration.setBrokerServiceURL("pulsar://127.0.0.1:6650");
+
+        // brokerServiceURLTLS must start with pulsar+ssl://
         configuration.setBrokerServiceURLTLS("pulsar://127.0.0.1:6650");
         try (MockedStatic<PulsarConfigurationLoader> theMock = Mockito.mockStatic(PulsarConfigurationLoader.class)) {
             theMock.when(PulsarConfigurationLoader.create(Mockito.anyString(), Mockito.any()))
@@ -167,6 +167,7 @@ public class ProxyConfigurationTest {
                 assertTrue(ex.getMessage().contains("brokerServiceURLTLS must start with pulsar+ssl://"));
             }
         }
+
         // brokerServiceURL did not support multi urls yet.
         configuration.setBrokerServiceURL("pulsar://127.0.0.1:6650,pulsar://127.0.0.2:6650");
         try (MockedStatic<PulsarConfigurationLoader> theMock = Mockito.mockStatic(PulsarConfigurationLoader.class)) {
@@ -174,24 +175,82 @@ public class ProxyConfigurationTest {
                     .thenReturn(configuration);
             try {
                 new ProxyServiceStarter(ProxyServiceStarterTest.ARGS);
-                fail("brokerServiceURL did not support multi urls yet");
+                fail("brokerServiceURL does not support multi urls yet");
             } catch (Exception ex) {
-                assertTrue(ex.getMessage().contains("did not support multi urls yet"));
+                assertTrue(ex.getMessage().contains("does not support multi urls yet"));
             }
         }
-        // brokerServiceURLTLS did not support multi urls yet.
         configuration.setBrokerServiceURL("pulsar://127.0.0.1:6650");
+
+        // brokerServiceURLTLS did not support multi urls yet.
         configuration.setBrokerServiceURLTLS("pulsar+ssl://127.0.0.1:6650,pulsar+ssl:127.0.0.2:6650");
         try (MockedStatic<PulsarConfigurationLoader> theMock = Mockito.mockStatic(PulsarConfigurationLoader.class)) {
             theMock.when(PulsarConfigurationLoader.create(Mockito.anyString(), Mockito.any()))
                     .thenReturn(configuration);
             try {
                 new ProxyServiceStarter(ProxyServiceStarterTest.ARGS);
-                fail("brokerServiceURLTLS did not support multi urls yet");
+                fail("brokerServiceURLTLS does not support multi urls yet");
             } catch (Exception ex) {
-                assertTrue(ex.getMessage().contains("did not support multi urls yet"));
+                assertTrue(ex.getMessage().contains("does not support multi urls yet"));
             }
         }
+        configuration.setBrokerServiceURLTLS("pulsar+ssl://127.0.0.1:6650");
+
+        // brokerWebServiceURL did not support multi urls yet.
+        configuration.setBrokerWebServiceURL("http://127.0.0.1:8080,http://127.0.0.2:8080");
+        try (MockedStatic<PulsarConfigurationLoader> theMock = Mockito.mockStatic(PulsarConfigurationLoader.class)) {
+            theMock.when(PulsarConfigurationLoader.create(Mockito.anyString(), Mockito.any()))
+                    .thenReturn(configuration);
+            try {
+                new ProxyServiceStarter(ProxyServiceStarterTest.ARGS);
+                fail("brokerWebServiceURL does not support multi urls yet");
+            } catch (Exception ex) {
+                assertTrue(ex.getMessage().contains("does not support multi urls yet"));
+            }
+        }
+        configuration.setBrokerWebServiceURL("http://127.0.0.1:8080");
+
+        // brokerWebServiceURLTLS did not support multi urls yet.
+        configuration.setBrokerWebServiceURLTLS("https://127.0.0.1:443,https://127.0.0.2:443");
+        try (MockedStatic<PulsarConfigurationLoader> theMock = Mockito.mockStatic(PulsarConfigurationLoader.class)) {
+            theMock.when(PulsarConfigurationLoader.create(Mockito.anyString(), Mockito.any()))
+                    .thenReturn(configuration);
+            try {
+                new ProxyServiceStarter(ProxyServiceStarterTest.ARGS);
+                fail("brokerWebServiceURLTLS does not support multi urls yet");
+            } catch (Exception ex) {
+                assertTrue(ex.getMessage().contains("does not support multi urls yet"));
+            }
+        }
+        configuration.setBrokerWebServiceURLTLS("https://127.0.0.1:443");
+
+        // functionWorkerWebServiceURL did not support multi urls yet.
+        configuration.setFunctionWorkerWebServiceURL("http://127.0.0.1:8080,http://127.0.0.2:8080");
+        try (MockedStatic<PulsarConfigurationLoader> theMock = Mockito.mockStatic(PulsarConfigurationLoader.class)) {
+            theMock.when(PulsarConfigurationLoader.create(Mockito.anyString(), Mockito.any()))
+                    .thenReturn(configuration);
+            try {
+                new ProxyServiceStarter(ProxyServiceStarterTest.ARGS);
+                fail("functionWorkerWebServiceURL does not support multi urls yet");
+            } catch (Exception ex) {
+                assertTrue(ex.getMessage().contains("does not support multi urls yet"));
+            }
+        }
+        configuration.setFunctionWorkerWebServiceURL("http://127.0.0.1:8080");
+
+        // functionWorkerWebServiceURLTLS did not support multi urls yet.
+        configuration.setFunctionWorkerWebServiceURLTLS("http://127.0.0.1:443,http://127.0.0.2:443");
+        try (MockedStatic<PulsarConfigurationLoader> theMock = Mockito.mockStatic(PulsarConfigurationLoader.class)) {
+            theMock.when(PulsarConfigurationLoader.create(Mockito.anyString(), Mockito.any()))
+                    .thenReturn(configuration);
+            try {
+                new ProxyServiceStarter(ProxyServiceStarterTest.ARGS);
+                fail("functionWorkerWebServiceURLTLS does not support multi urls yet");
+            } catch (Exception ex) {
+                assertTrue(ex.getMessage().contains("does not support multi urls yet"));
+            }
+        }
+        configuration.setFunctionWorkerWebServiceURLTLS("http://127.0.0.1:443");
     }
 
 }

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyServiceStarterTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyServiceStarterTest.java
@@ -45,7 +45,7 @@ import org.testng.annotations.Test;
 
 public class ProxyServiceStarterTest extends MockedPulsarServiceBaseTest {
 
-    static final String[] ARGS = new String[]{"-c", "./src/test/resources/proxy.conf"};
+    public static final String[] ARGS = new String[]{"-c", "./src/test/resources/proxy.conf"};
 
     protected ProxyServiceStarter serviceStarter;
     protected String serviceUrl;


### PR DESCRIPTION
### Motivation

At the beginning of the design, these two configurations(`brokerServiceURL & brokerServiceURLTLS`) do not support setting multiple broker addresses, which should instead be set to a “discovery service provider.” see: https://github.com/apache/pulsar/pull/1002 and https://github.com/apache/pulsar/pull/14682

Users will get the below error if they set A to a multi-broker URLs

```
"2024-01-09 00:20:10,261 -0800 [pulsar-proxy-io-4-7] WARN  io.netty.channel.DefaultChannelPipeline - An exceptionCaught() event was fired, and it reached at the tail of the pipeline. It usually means the last handler in the pipeline did not handle the exception.
java.lang.IllegalArgumentException: port out of range:-1
        at java.net.InetSocketAddress.checkPort(InetSocketAddress.java:143) ~[?:?]
        at java.net.InetSocketAddress.createUnresolved(InetSocketAddress.java:254) ~[?:?]
        at org.apache.pulsar.proxy.server.LookupProxyHandler.getAddr(LookupProxyHandler.java:432) ~[org.apache.pulsar-pulsar-proxy-2.9.0.jar:2.9.0]
        at org.apache.pulsar.proxy.server.LookupProxyHandler.handleGetSchema(LookupProxyHandler.java:357) ~[org.apache.pulsar-pulsar-proxy-2.9.0.jar:2.9.0]
        at org.apache.pulsar.proxy.server.ProxyConnection.handleGetSchema(ProxyConnection.java:463) ~[org.apache.pulsar-pulsar-proxy-2.9.0.jar:2.9.0]
        at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:326) ~[io.streamnative-pulsar-common-2.9.2.12.jar:2.9.2.12]
        at org.apache.pulsar.proxy.server.ProxyConnection.channelRead(ProxyConnection.java:221) ~[org.apache.pulsar-pulsar-proxy-2.9.0.jar:2.9.0]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:327) ~[io.netty-netty-codec-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:299) ~[io.netty-netty-codec-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1372) ~[io.netty-netty-handler-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.handler.ssl.SslHandler.decodeNonJdkCompatible(SslHandler.java:1246) ~[io.netty-netty-handler-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1286) ~[io.netty-netty-handler-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:510) ~[io.netty-netty-codec-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:449) ~[io.netty-netty-codec-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:279) ~[io.netty-netty-codec-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:795) ~[io.netty-netty-transport-classes-epoll-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:480) ~[io.netty-netty-transport-classes-epoll-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378) ~[io.netty-netty-transport-classes-epoll-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) ~[io.netty-netty-common-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[io.netty-netty-common-4.1.74.Final.jar:4.1.74.Final]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.74.Final.jar:4.1.74.Final]
```

### Modifications
- Improve the description
- Add a check to prevent wrong settings



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x