### PR TITLE
[fix][test] Make base test class method protected so that it passes ReportUnannotatedMethods validation

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -720,14 +720,14 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         }
     }
 
-    public static void reconnectAllConnections(PulsarClientImpl c) throws Exception {
+    private static void reconnectAllConnections(PulsarClientImpl c) throws Exception {
         ConnectionPool pool = c.getCnxPool();
         Method closeAllConnections = ConnectionPool.class.getDeclaredMethod("closeAllConnections", new Class[]{});
         closeAllConnections.setAccessible(true);
         closeAllConnections.invoke(pool, new Object[]{});
     }
 
-    public void reconnectAllConnections() throws Exception {
+    protected void reconnectAllConnections() throws Exception {
         reconnectAllConnections((PulsarClientImpl) pulsarClient);
     }
 


### PR DESCRIPTION
### Motivation

- PulsarSQL / Trino tests in branch-3.1 fail with this error log: 
```
FATAL: io.trino.testng.services.ReportUnannotatedMethods: Test class org.apache.pulsar.sql.presto.TestPulsarAuth has methods which are public but not explicitly annotated. Are they missing @Test?
		public void org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.reconnectAllConnections() throws java.lang.Exception
JVM will be terminated
```

### Modifications

- make `reconnectAllConnections` method `protected` and the static method `private`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->