### PR TITLE
[improve][client] Mention partitioning in failover priorityLevel javaDoc

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -511,9 +511,9 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * Order in which broker dispatches messages to consumers: C1, C2, C3, C1, C4, C5, C4
      * </pre>
      *
-     * <p><b>Failover subscription</b>
-     * The broker selects the active consumer for a failover subscription based on consumer's priority-level and
-     * lexicographical sorting of consumer name.
+     * <p><b>Failover subscription for partitioned topic</b>
+     * The broker selects the active consumer for a failover subscription for a patitioned topic
+     * based on consumer's priority-level and lexicographical sorting of consumer name.
      * eg:
      * <pre>
      * 1. Active consumer = C1 : Same priority-level and lexicographical sorting
@@ -529,6 +529,8 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * Partitioned-topics:
      * Broker evenly assigns partitioned topics to highest priority consumers.
      * </pre>
+     *
+     * <p>Priority level has no effect on failover subscriptions for non-partitioned topics.
      *
      * @param priorityLevel the priority of this consumer
      * @return the consumer builder instance

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -512,7 +512,7 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * </pre>
      *
      * <p><b>Failover subscription for partitioned topic</b>
-     * The broker selects the active consumer for a failover subscription for a patitioned topic
+     * The broker selects the active consumer for a failover subscription for a partitioned topic
      * based on consumer's priority-level and lexicographical sorting of consumer name.
      * eg:
      * <pre>


### PR DESCRIPTION
Fixes: #21922

### Motivation

Clarify when priorityLevel is active for failover subscriptions.

### Modifications

Update javaDoc comment to specify paritioned topics and indicate insignificance for non-partitioned.

### Verifying this change

- [X] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [X] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: N/A