### PR TITLE
[fix][monitor] Fix the incorrect metrics name

### DIFF
--- a/grafana/dashboards/bookkeeper.json
+++ b/grafana/dashboards/bookkeeper.json
@@ -383,7 +383,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "bookkeeper_server_ADD_ENTRY_REQUEST{cluster=~\"$cluster\", kubernetes_pod_name=~\"$bookie\", success=\"true\", quantile=\"0.5\"}",
+              "expr": "bookkeeper_server_ADD_ENTRY{cluster=~\"$cluster\", kubernetes_pod_name=~\"$bookie\", success=\"true\", quantile=\"0.5\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -461,7 +461,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "bookkeeper_server_READ_ENTRY_REQUEST{cluster=~\"$cluster\", kubernetes_pod_name=~\"$bookie\", success=\"true\", quantile=\"0.5\"}",
+              "expr": "bookkeeper_server_READ_ENTRY{cluster=~\"$cluster\", kubernetes_pod_name=~\"$bookie\", success=\"true\", quantile=\"0.5\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -551,7 +551,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "bookkeeper_server_ADD_ENTRY_REQUEST{cluster=~\"$cluster\", kubernetes_pod_name=~\"$bookie\", success=\"true\", quantile=\"0.99\"}",
+              "expr": "bookkeeper_server_ADD_ENTRY{cluster=~\"$cluster\", kubernetes_pod_name=~\"$bookie\", success=\"true\", quantile=\"0.99\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -629,7 +629,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "bookkeeper_server_READ_ENTRY_REQUEST{cluster=~\"$cluster\", kubernetes_pod_name=~\"$bookie\", success=\"true\", quantile=\"0.99\"}",
+              "expr": "bookkeeper_server_READ_ENTRY{cluster=~\"$cluster\", kubernetes_pod_name=~\"$bookie\", success=\"true\", quantile=\"0.99\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,


### PR DESCRIPTION

### Motivation

Fix the incorrect metrics name.

Reference links:
https://github.com/apache/pulsar/issues/21766#issuecomment-1903439335
https://github.com/apache/bookkeeper/releases/tag/release-4.16.0

### Modifications

`bookkeeper_server_ADD_ENTRY_REQUEST`->`bookkeeper_server_ADD_ENTRY`
`bookkeeper_server_READ_ENTRY_REQUEST`->`bookkeeper_server_READ_ENTRY`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
