### PR TITLE
[improve][broker] Do not close the socket if lookup failed due to LockBusyException

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -30,6 +30,7 @@ import javax.ws.rs.Encoded;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
@@ -333,13 +334,16 @@ public class TopicLookupBase extends PulsarWebResource {
 
     private static void handleLookupError(CompletableFuture<ByteBuf> lookupFuture, String topicName, String clientAppId,
                                    long requestId, Throwable ex){
-        final Throwable unwrapEx = FutureUtil.unwrapCompletionException(ex);
+        Throwable unwrapEx = FutureUtil.unwrapCompletionException(ex);
         final String errorMsg = unwrapEx.getMessage();
+        if (unwrapEx instanceof PulsarServerException) {
+            unwrapEx = FutureUtil.unwrapCompletionException(unwrapEx.getCause());
+        }
         if (unwrapEx instanceof IllegalStateException) {
             // Current broker still hold the bundle's lock, but the bundle is being unloading.
             log.info("Failed to lookup {} for topic {} with error {}", clientAppId, topicName, errorMsg);
             lookupFuture.complete(newLookupErrorResponse(ServerError.MetadataError, errorMsg, requestId));
-        } else if (unwrapEx instanceof MetadataStoreException){
+        } else if (unwrapEx instanceof MetadataStoreException) {
             // Load bundle ownership or acquire lock failed.
             // Differ with "IllegalStateException", print warning log.
             log.warn("Failed to lookup {} for topic {} with error {}", clientAppId, topicName, errorMsg);


### PR DESCRIPTION
### Motivation

When a broker restarted, there is a case in
`NamespaceService#findBrokerServiceUrl`:
1. `ownershipCache.getOwnerAsync(bundle)` got an empty data, then `searchForCandidateBroker` will be called
2. The broker itself was elected as the candidate broker.
3. Meanwhile, the other broker has acquired the distributed lock of the bundle, then `ownershipCache.tryAcquiringOwnership` will fail with

```java
lookupFuture.completeExceptionally(new PulsarServerException(
        "Failed to acquire ownership for namespace bundle " + bundle, exception));
```

See https://github.com/apache/pulsar-client-cpp/pull/390 for the real world case.

Then in `TopicLookupBase#handleLookupError`, this exception will be wrapped into a `ServiceNotReady` error to client.

This case happens very frequently in our production environment when a broker restarted. If there is a `PulsarClient` that has many producers or consumers, the connection will be closed, which results in many reconnections, which brings much pressure to the cluster.

### Modifications

In `handleLookupError`, check the `PulsarServerException` and unwrap the `CompletionException`. If the unwrapped exception is `MetadataStoreException`, return the `MetadataError` to avoid closing the connection at client side.

Add `testLookupConnectionNotCloseIfFailedToAcquireOwnershipOfBundle` to simulate the case and verify the socket won't be closed.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: