### PR TITLE
[improve][broker] Include runtime dependencies in server distribution

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -500,6 +500,7 @@ The Apache Software License, Version 2.0
     - io.reactivex.rxjava3-rxjava-3.0.1.jar
   * RoaringBitmap
     - org.roaringbitmap-RoaringBitmap-0.9.44.jar
+    - org.roaringbitmap-shims-0.9.44.jar
 
 BSD 3-clause "New" or "Revised" License
  * Google auth library
@@ -532,7 +533,6 @@ Protocol Buffers License
 
 CDDL-1.1 -- ../licenses/LICENSE-CDDL-1.1.txt
  * Java Annotations API
-    - javax.annotation-javax.annotation-api-1.3.2.jar
     - com.sun.activation-javax.activation-1.2.0.jar
     - javax.xml.bind-jaxb-api-2.3.1.jar
  * Java Servlet API -- javax.servlet-javax.servlet-api-3.1.0.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -342,6 +342,7 @@ The Apache Software License, Version 2.0
     - org.apache.logging.log4j-log4j-slf4j-impl-2.18.0.jar
     - org.apache.logging.log4j-log4j-web-2.18.0.jar
  * Java Native Access JNA
+    - net.java.dev.jna-jna-5.12.1.jar
     - net.java.dev.jna-jna-jpms-5.12.1.jar
     - net.java.dev.jna-jna-platform-jpms-5.12.1.jar
  * BookKeeper

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -342,7 +342,6 @@ The Apache Software License, Version 2.0
     - org.apache.logging.log4j-log4j-slf4j-impl-2.18.0.jar
     - org.apache.logging.log4j-log4j-web-2.18.0.jar
  * Java Native Access JNA
-    - net.java.dev.jna-jna-5.12.1.jar
     - net.java.dev.jna-jna-jpms-5.12.1.jar
     - net.java.dev.jna-jna-platform-jpms-5.12.1.jar
  * BookKeeper

--- a/distribution/server/src/assemble/bin.xml
+++ b/distribution/server/src/assemble/bin.xml
@@ -128,6 +128,8 @@
         <!-- prevent adding annotation libraries -->
         <exclude>org.codehaus.mojo:animal-sniffer-annotations</exclude>
         <exclude>com.google.android:annotations</exclude>
+        <!-- Needed only in the pulsar-shell distro only -->
+        <exclude>net.java.dev.jna:jna</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>

--- a/distribution/server/src/assemble/bin.xml
+++ b/distribution/server/src/assemble/bin.xml
@@ -119,8 +119,6 @@
       <excludes>
         <exclude>org.apache.pulsar:pulsar-functions-runtime-all</exclude>
 
-        <exclude>org.projectlombok:lombok</exclude>
-
         <!-- prevent adding pulsar-functions-api-examples in lib -->
         <exclude>org.apache.pulsar:pulsar-functions-api-examples</exclude>
         <!-- prevent adding any distribution .tar.gz files in lib -->

--- a/distribution/server/src/assemble/bin.xml
+++ b/distribution/server/src/assemble/bin.xml
@@ -125,6 +125,9 @@
         <exclude>org.apache.pulsar:pulsar-functions-api-examples</exclude>
         <!-- prevent adding any distribution .tar.gz files in lib -->
         <exclude>*:tar.gz</exclude>
+        <!-- prevent adding annotation libraries -->
+        <exclude>org.codehaus.mojo:animal-sniffer-annotations</exclude>
+        <exclude>com.google.android:annotations</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>

--- a/distribution/server/src/assemble/bin.xml
+++ b/distribution/server/src/assemble/bin.xml
@@ -110,7 +110,7 @@
     <dependencySet>
       <outputDirectory>lib</outputDirectory>
       <unpack>false</unpack>
-      <scope>compile</scope>
+      <scope>runtime</scope>
       <useProjectArtifact>false</useProjectArtifact>
       <!-- Include 'groupId' in the dependencies Jar names to better identify
            the provenance of the jar -->


### PR DESCRIPTION
### Motivation

The server distribution assembly does not currently include artifact runtime dependencies, pulling only the compile dependencies instead. While this has not impacted the customers, a class loading issue can always crop up. This is what happened while importing OpenTelemetry dependencies related to PIP-320. OpenTelemetry itself marks its many dependencies as `runtime` (see, for instance, https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-exporter-otlp/1.34.1). Including each of them manually in our POM is both tedious and error-prone.

### Modifications

- Reverts the dependency scope for the server assembly to the default value, `runtime`.
- Manually excludes some of the libraries that would be needlessly pulled.
- Allows `org.roaringbitmap-shims-0.9.44.jar` to be included in the assembly.
- Removes assembly exclusion for `lombok` as it is not needed anymore.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing integration tests.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dragosvictor/pulsar/pull/9

