### PR TITLE
[improve][broker] Avoid repeatedly loading EntryFilters for each topic if only broker-level EntryFilters are set

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -1146,6 +1146,11 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
         if (entryFilters != null && entryFilterNames.equals(entryFilters.getLeft())) {
             return;
         }
+        if (topicPolicies.getEntryFilters().getNamespaceValue() == null
+                || topicPolicies.getEntryFilters().getTopicValue() == null) {
+            entryFilters = Pair.of(entryFilterNames, brokerService.getEntryFilterProvider().getBrokerEntryFilters());
+            return;
+        }
         try {
             final List<EntryFilter> filters =
                     brokerService.getEntryFilterProvider().loadEntryFiltersForPolicy(entryFiltersPolicy);


### PR DESCRIPTION
### Motivation

Currently, if only broker-level EntryFilters are used,  each topic will repeatedly load EntryFilters, which is unnecessary.

### Modifications

If only broker-level EntryFilters are set, then we don't load EntryFilters on `updateEntryFilters`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
