### PR TITLE
[fix][admin] Map empty content to null

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminRestTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminRestTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.admin;
 
+import static org.testng.Assert.assertNull;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -34,6 +35,7 @@ import javax.ws.rs.core.Response;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.awaitility.Awaitility;
@@ -99,6 +101,12 @@ public class AdminRestTest extends MockedPulsarServiceBaseTest {
             stringBuilder.append(line);
         }
         return stringBuilder.toString();
+    }
+
+    @Test
+    protected void testMapEmptyContentToNull() throws PulsarAdminException {
+        String namespaceResourceGroup = admin.namespaces().getNamespaceResourceGroup(namespaceName);
+        assertNull(namespaceResourceGroup);
     }
 
     @BeforeMethod

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
@@ -189,11 +189,23 @@ public abstract class BaseResource {
     }
 
     protected <T> CompletableFuture<T> asyncGetRequest(final WebTarget target, Class<? extends T> type) {
-        return asyncGetRequest(target, response -> response.readEntity(type));
+        return asyncGetRequest(target, response -> {
+            if (response != null) {
+                return response.readEntity(type);
+            } else {
+                return null;
+            }
+        });
     }
 
     protected <T> CompletableFuture<T> asyncGetRequest(final WebTarget target, GenericType<T> type) {
-        return asyncGetRequest(target, response -> response.readEntity(type));
+        return asyncGetRequest(target, response -> {
+            if (response != null) {
+                return response.readEntity(type);
+            } else {
+                return null;
+            }
+        });
     }
 
     private <T> CompletableFuture<T> asyncGetRequest(final WebTarget target, Function<Response, T> readResponse) {
@@ -206,7 +218,11 @@ public abstract class BaseResource {
                             future.completeExceptionally(getApiException(response));
                         } else {
                             try {
-                                future.complete(readResponse.apply(response));
+                                if (response.hasEntity()) {
+                                    future.complete(readResponse.apply(response));
+                                } else {
+                                    future.complete(null);
+                                }
                             } catch (Exception e) {
                                 future.completeExceptionally(getApiException(e));
                             }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
@@ -381,6 +381,10 @@ public abstract class BaseResource {
 
         @Override
         public void completed(T value) {
+            if ("".equals(value)) {
+                future.complete(null);
+                return;
+            }
             future.complete(value);
         }
 


### PR DESCRIPTION
### Motivation

When using `asyncResponse.resume(null)` to write data to the admin, we will get an empty content, not null.

Please see the Jersey implementation: https://github.com/eclipse-ee4j/jersey/blob/2.34/core-server/src/main/java/org/glassfish/jersey/server/ServerRuntime.java#L603-L610

### Modifications

In the `asyncGetRequest` method, when the content is empty, use `null` as the completion value.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->