### PR TITLE
[fix][broker][branch-3.1] Avoid PublishRateLimiter use an already closed RateLimiter

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupPublishLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupPublishLimiter.java
@@ -133,7 +133,7 @@ public class ResourceGroupPublishLimiter implements PublishRateLimiter, RateLimi
         });
     }
 
-    public synchronized boolean tryAcquire(int numbers, long bytes) {
+    public boolean tryAcquire(int numbers, long bytes) {
         return (publishRateLimiterOnMessage == null || publishRateLimiterOnMessage.tryAcquire(numbers))
                     && (publishRateLimiterOnByte == null || publishRateLimiterOnByte.tryAcquire(bytes));
     }
@@ -156,16 +156,14 @@ public class ResourceGroupPublishLimiter implements PublishRateLimiter, RateLimi
                 updater.run();
             }
         } finally {
-            synchronized (this) {
-                // Close previous limiters to prevent resource leakages.
-                // Delay closing of previous limiters after new ones are in place so that updating the limiter
-                // doesn't cause unavailability.
-                if (previousPublishRateLimiterOnMessage != null) {
-                    previousPublishRateLimiterOnMessage.close();
-                }
-                if (previousPublishRateLimiterOnByte != null) {
-                    previousPublishRateLimiterOnByte.close();
-                }
+            // Close previous limiters to prevent resource leakages.
+            // Delay closing of previous limiters after new ones are in place so that updating the limiter
+            // doesn't cause unavailability.
+            if (previousPublishRateLimiterOnMessage != null) {
+                previousPublishRateLimiterOnMessage.close();
+            }
+            if (previousPublishRateLimiterOnByte != null) {
+                previousPublishRateLimiterOnByte.close();
             }
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PrecisePublishLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PrecisePublishLimiter.java
@@ -123,7 +123,7 @@ public class PrecisePublishLimiter implements PublishRateLimiter {
     }
 
     @Override
-    public synchronized boolean tryAcquire(int numbers, long bytes) {
+    public boolean tryAcquire(int numbers, long bytes) {
         RateLimiter currentTopicPublishRateLimiterOnMessage = topicPublishRateLimiterOnMessage;
         RateLimiter currentTopicPublishRateLimiterOnByte = topicPublishRateLimiterOnByte;
         return (currentTopicPublishRateLimiterOnMessage == null
@@ -148,16 +148,14 @@ public class PrecisePublishLimiter implements PublishRateLimiter {
                 updater.run();
             }
         } finally {
-            synchronized (this) {
-                // Close previous limiters to prevent resource leakages.
-                // Delay closing of previous limiters after new ones are in place so that updating the limiter
-                // doesn't cause unavailability.
-                if (previousTopicPublishRateLimiterOnMessage != null) {
-                    previousTopicPublishRateLimiterOnMessage.close();
-                }
-                if (previousTopicPublishRateLimiterOnByte != null) {
-                    previousTopicPublishRateLimiterOnByte.close();
-                }
+            // Close previous limiters to prevent resource leakages.
+            // Delay closing of previous limiters after new ones are in place so that updating the limiter
+            // doesn't cause unavailability.
+            if (previousTopicPublishRateLimiterOnMessage != null) {
+                previousTopicPublishRateLimiterOnMessage.close();
+            }
+            if (previousTopicPublishRateLimiterOnByte != null) {
+                previousTopicPublishRateLimiterOnByte.close();
             }
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupRateLimiterTest.java
@@ -156,6 +156,8 @@ public class ResourceGroupRateLimiterTest extends BrokerTestBase {
 
     @Test
     public void testWithConcurrentUpdate() throws Exception {
+        cleanup();
+        setup();
         createResourceGroup(rgName, testAddRg);
         admin.namespaces().setNamespaceResourceGroup(namespaceName, rgName);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupRateLimiterTest.java
@@ -21,22 +21,29 @@ package org.apache.pulsar.broker.resourcegroup;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
-
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import lombok.Cleanup;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.util.RateLimiter;
 import org.awaitility.Awaitility;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public class ResourceGroupRateLimiterTest extends BrokerTestBase {
 
@@ -146,6 +153,74 @@ public class ResourceGroupRateLimiterTest extends BrokerTestBase {
         testRateLimit();
         testRateLimit();
     }
+
+    @Test
+    public void testWithConcurrentUpdate() throws Exception {
+        createResourceGroup(rgName, testAddRg);
+        admin.namespaces().setNamespaceResourceGroup(namespaceName, rgName);
+
+        Awaitility.await().untilAsserted(() ->
+                assertNotNull(pulsar.getResourceGroupServiceManager()
+                        .getNamespaceResourceGroup(NamespaceName.get(namespaceName))));
+
+        Awaitility.await().untilAsserted(() ->
+                assertNotNull(pulsar.getResourceGroupServiceManager()
+                        .resourceGroupGet(rgName).getResourceGroupPublishLimiter()));
+
+        ResourceGroupPublishLimiter resourceGroupPublishLimiter = Mockito.spy(pulsar.getResourceGroupServiceManager()
+                .resourceGroupGet(rgName).getResourceGroupPublishLimiter());
+
+        AtomicBoolean blocking = new AtomicBoolean(false);
+        BiFunction<Function<Long, Boolean>, Long, Boolean> blockFunc = (function, acquirePermit) -> {
+            blocking.set(true);
+            while (blocking.get()) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            return function.apply(acquirePermit);
+        };
+
+        Mockito.doAnswer(invocation -> {
+            RateLimiter publishRateLimiterOnMessage =
+                    (RateLimiter) FieldUtils.readDeclaredField(resourceGroupPublishLimiter,
+                            "publishRateLimiterOnMessage", true);
+            RateLimiter publishRateLimiterOnByte =
+                    (RateLimiter) FieldUtils.readDeclaredField(resourceGroupPublishLimiter,
+                            "publishRateLimiterOnByte", true);
+            int numbers = invocation.getArgument(0);
+            long bytes = invocation.getArgument(1);
+            return (publishRateLimiterOnMessage == null || publishRateLimiterOnMessage.tryAcquire(numbers))
+            && (publishRateLimiterOnByte == null || blockFunc.apply(publishRateLimiterOnByte::tryAcquire, bytes));
+        }).when(resourceGroupPublishLimiter).tryAcquire(Mockito.anyInt(), Mockito.anyLong());
+
+        ConcurrentHashMap resourceGroupsMap =
+                (ConcurrentHashMap) FieldUtils.readDeclaredField(pulsar.getResourceGroupServiceManager(),
+                        "resourceGroupsMap", true);
+        FieldUtils.writeDeclaredField(resourceGroupsMap.get(rgName), "resourceGroupPublishLimiter",
+                resourceGroupPublishLimiter, true);
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                    .topic(namespaceName + "/test-topic")
+                    .create();
+
+        CompletableFuture<MessageId> sendFuture = producer.sendAsync(new byte[MESSAGE_SIZE]);
+
+        Awaitility.await().untilAsserted(() -> Assert.assertTrue(blocking.get()));
+
+        testAddRg.setPublishRateInBytes(Long.valueOf(MESSAGE_SIZE) + 1);
+        admin.resourcegroups().updateResourceGroup(rgName, testAddRg);
+        blocking.set(false);
+
+        sendFuture.join();
+
+        // Now detach the namespace
+        admin.namespaces().removeNamespaceResourceGroup(namespaceName);
+        deleteResourceGroup(rgName);
+    }
+
 
     private void prepareData() {
         testAddRg.setPublishRateInBytes(Long.valueOf(MESSAGE_SIZE));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PrecisTopicPublishRateThrottleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PrecisTopicPublishRateThrottleTest.java
@@ -18,16 +18,25 @@
  */
 package org.apache.pulsar.broker.service;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.policies.data.PublishRate;
+import org.apache.pulsar.common.util.RateLimiter;
 import org.awaitility.Awaitility;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 @Test(groups = "broker")
+@Slf4j
 public class PrecisTopicPublishRateThrottleTest extends BrokerTestBase{
 
     @Override
@@ -178,6 +187,66 @@ public class PrecisTopicPublishRateThrottleTest extends BrokerTestBase{
         Assert.assertEquals(limiter.publishMaxMessageRate, rateInMsg);
 
         producer.close();
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testWithConcurrentUpdate() throws Exception {
+        PublishRate publishRate = new PublishRate(-1,10);
+        conf.setPreciseTopicPublishRateLimiterEnable(true);
+        conf.setMaxPendingPublishRequestsPerConnection(1000);
+        super.baseSetup();
+        admin.namespaces().setPublishRate("prop/ns-abc", publishRate);
+        final String topic = "persistent://prop/ns-abc/testWithConcurrentUpdate";
+        @Cleanup
+        org.apache.pulsar.client.api.Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topic)
+                .producerName("producer-name")
+                .create();
+
+        AbstractTopic topicRef = (AbstractTopic) pulsar.getBrokerService().getTopicReference(topic).get();
+        Assert.assertNotNull(topicRef);
+
+        PublishRateLimiter topicPublishRateLimiter = Mockito.spy(topicRef.getTopicPublishRateLimiter());
+
+        AtomicBoolean blocking = new AtomicBoolean(false);
+        BiFunction<Function<Long, Boolean>, Long, Boolean> blockFunc = (function, acquirePermit) -> {
+            blocking.set(true);
+            while (blocking.get()) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            return function.apply(acquirePermit);
+        };
+
+        Mockito.doAnswer(invocation -> {
+            log.info("tryAcquire: {}, {}", invocation.getArgument(0), invocation.getArgument(1));
+            RateLimiter publishRateLimiterOnMessage =
+                    (RateLimiter) FieldUtils.readDeclaredField(topicPublishRateLimiter,
+                            "topicPublishRateLimiterOnMessage", true);
+            RateLimiter publishRateLimiterOnByte =
+                    (RateLimiter) FieldUtils.readDeclaredField(topicPublishRateLimiter,
+                            "topicPublishRateLimiterOnByte", true);
+            int numbers = invocation.getArgument(0);
+            long bytes = invocation.getArgument(1);
+            return (publishRateLimiterOnMessage == null || publishRateLimiterOnMessage.tryAcquire(numbers))
+            && (publishRateLimiterOnByte == null || blockFunc.apply(publishRateLimiterOnByte::tryAcquire, bytes));
+        }).when(topicPublishRateLimiter).tryAcquire(Mockito.anyInt(), Mockito.anyLong());
+
+        FieldUtils.writeField(topicRef, "topicPublishRateLimiter", topicPublishRateLimiter, true);
+
+        CompletableFuture<MessageId> sendFuture = producer.sendAsync(new byte[10]);
+
+        Awaitility.await().untilAsserted(() -> Assert.assertTrue(blocking.get()));
+        publishRate.publishThrottlingRateInByte = 20;
+        admin.namespaces().setPublishRate("prop/ns-abc", publishRate);
+        blocking.set(false);
+
+        sendFuture.join();
+
         super.internalCleanup();
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/RateLimiter.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/RateLimiter.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * A Rate Limiter that distributes permits at a configurable rate. Each {@link #acquire()} blocks if necessary until a
@@ -50,6 +51,7 @@ import lombok.Builder;
  * <li><b>Faster: </b>RateLimiter is light-weight and faster than Guava-RateLimiter</li>
  * </ul>
  */
+@Slf4j
 public class RateLimiter implements AutoCloseable{
     private final ScheduledExecutorService executorService;
     private long rateTime;
@@ -175,7 +177,10 @@ public class RateLimiter implements AutoCloseable{
      * @return {@code true} if the permits were acquired, {@code false} otherwise
      */
     public synchronized boolean tryAcquire(long acquirePermit) {
-        checkArgument(!isClosed(), "Rate limiter is already shutdown");
+        if (isClosed()) {
+            log.info("The current rate limiter is already shutdown, acquire permits directly.");
+            return true;
+        }
         // lazy init and start task only once application start using it
         if (renewTask == null) {
             renewTask = createTask();


### PR DESCRIPTION
### Motivation

We found the following error logs on the broker when we used ResourceGroupPublishLimiter. This root cause is `tryAcquire` method has a race condition with the `replaceLimiters` method, leading to publishRateLimiter using an already closed RateLimiter. PrecisePublishLimiter also has the same issue.

```java
[pulsar-io-4-54] WARN  org.apache.pulsar.broker.service.ServerCnx - [/127.0.0.6:59173] Got exception java.lang.IllegalArgumentException: Rate limiter is already shutdown
 at com.google.common.base.Preconditions.checkArgument(Preconditions.java:145)
 at org.apache.pulsar.common.util.RateLimiter.tryAcquire(RateLimiter.java:176)
 at org.apache.pulsar.broker.resourcegroup.ResourceGroupPublishLimiter.tryAcquire(ResourceGroupPublishLimiter.java:138)
 at org.apache.pulsar.broker.service.AbstractTopic.isResourceGroupPublishRateExceeded(AbstractTopic.java:1036)
 at org.apache.pulsar.broker.service.ServerCnx.startSendOperation(ServerCnx.java:2611)
 at org.apache.pulsar.broker.service.ServerCnx.handleSend(ServerCnx.java:1508)
 at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:207)
 at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
 at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
 at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
 at io.netty.handler.flow.FlowControlHandler.dequeue(FlowControlHandler.java:200)
 at io.netty.handler.flow.FlowControlHandler.channelRead(FlowControlHandler.java:162)
 at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
 at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
 at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
 at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
 at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:333)
 at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:454)
 at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
 at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
 at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
 at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
 at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
 at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
 at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
 at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
 at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:800)
 at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:499)
 at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:397)
 at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
 at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
 at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
 at java.base/java.lang.Thread.run(Thread.java:829)
```

### Modifications

If the current RateLimiter is already shutdown, we only return true and print the info log. Due to [pip-322](https://github.com/apache/pulsar/blob/master/pip/pip-322.md)  refactor pulsar rate limiting on version 3.2, so we only need to fix versions before 3.2.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
