### PR TITLE
[fix][broker] Ignore non-retryable errors when loading topic-level policies before loading topics

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -1158,6 +1158,7 @@ public class PulsarClientException extends IOException {
 
     public static boolean isRetriableError(Throwable t) {
         if (t instanceof AuthorizationException
+                || t instanceof AuthenticationException
                 || t instanceof InvalidServiceURL
                 || t instanceof InvalidConfigurationException
                 || t instanceof NotFoundException


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/21445 introduces an implicit requirement that if the topic policies cannot be loaded, `BrokerService#getTopic` will fail and then the client will retry loading the topic.

It could break some existing usages like the tests in the C++ client: https://github.com/apache/pulsar-client-cpp/pull/394

This change is applied only to avoid the race condition when unloading a namespace bundle. However, the client should not fail if the topic-level policies are not available.

### Modifications

If the topic policies cannot be loaded due to a non-retryable error, we should not fail the `getTopic`. For retryable errors, the client will still retry until the broker gets the topic-level policies successfully after some attempts.

Modify `TokenAuthenticatedProducerConsumerTest` to protect the change.

**Note: This PR also changes the `isRetriableError` semantics. To keep the compatibility, should we avoid this change?**

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: