### PR TITLE
[fix][proxy] Fix outboundChannel close

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
@@ -290,7 +290,7 @@ public class DirectProxyHandler {
     };
 
     public void close() {
-        if (outboundChannel != null) {
+        if (outboundChannel != null && outboundChannel.isOpen()) {
             outboundChannel.close();
         }
     }


### PR DESCRIPTION
### Motivation

When the remote has been closed, the `outboundChannel.close()` throws the following error:

```
2024-02-02T00:46:50,901+0000 [pulsar-proxy-io-2-3] WARN  io.netty.util.concurrent.DefaultPromise - An exception was thrown by io.netty.channel.epoll.AbstractEpollStreamChannel$SpliceInChannelTask.operationComplete()
java.lang.IllegalStateException: complete already: DefaultChannelPromise@3c441997(failure: java.nio.channels.ClosedChannelException)
	at io.netty.util.concurrent.DefaultPromise.setFailure(DefaultPromise.java:113) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.DefaultChannelPromise.setFailure(DefaultChannelPromise.java:89) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.epoll.AbstractEpollStreamChannel$SpliceInChannelTask.operationComplete(AbstractEpollStreamChannel.java:894) ~[io.netty-netty-transport-classes-epoll-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.epoll.AbstractEpollStreamChannel$SpliceInChannelTask.operationComplete(AbstractEpollStreamChannel.java:883) ~[io.netty-netty-transport-classes-epoll-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:590) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:557) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:492) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:636) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.util.concurrent.DefaultPromise.setFailure0(DefaultPromise.java:629) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.util.concurrent.DefaultPromise.tryFailure(DefaultPromise.java:118) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.util.internal.PromiseNotificationUtil.tryFailure(PromiseNotificationUtil.java:64) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.ChannelOutboundBuffer.safeFail(ChannelOutboundBuffer.java:734) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.ChannelOutboundBuffer.remove0(ChannelOutboundBuffer.java:319) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.ChannelOutboundBuffer.failFlushed(ChannelOutboundBuffer.java:671) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.close(AbstractChannel.java:735) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.close(AbstractChannel.java:620) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.close(DefaultChannelPipeline.java:1352) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeClose(AbstractChannelHandlerContext.java:749) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.AbstractChannelHandlerContext.close(AbstractChannelHandlerContext.java:727) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.handler.flush.FlushConsolidationHandler.close(FlushConsolidationHandler.java:173) ~[io.netty-netty-handler-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeClose(AbstractChannelHandlerContext.java:751) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.AbstractChannelHandlerContext.close(AbstractChannelHandlerContext.java:727) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.AbstractChannelHandlerContext.close(AbstractChannelHandlerContext.java:560) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.DefaultChannelPipeline.close(DefaultChannelPipeline.java:957) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.AbstractChannel.close(AbstractChannel.java:244) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at org.apache.pulsar.proxy.server.DirectProxyHandler.close(DirectProxyHandler.java:294) ~[org.apache.pulsar-pulsar-proxy-3.0.1.jar:3.0.1]
	at org.apache.pulsar.proxy.server.ProxyConnection.channelInactive(ProxyConnection.java:202) ~[org.apache.pulsar-pulsar-proxy-3.0.1.jar:3.0.1]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:305) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:281) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:274) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelInactive(DefaultChannelPipeline.java:1405) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:301) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:281) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelInactive(DefaultChannelPipeline.java:901) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe$7.run(AbstractChannel.java:813) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:403) ~[io.netty-netty-transport-classes-epoll-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.93.Final.jar:4.1.93.Final]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: io.netty.channel.StacklessClosedChannelException
	at io.netty.channel.AbstractChannel.close(ChannelPromise)(Unknown Source) ~[io.netty-netty-transport-4.1.93.Final.jar:4.1.93.Final]
```

### Modifications

Check if the channel is open, then call to close.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->