### PR TITLE
[fix][broker] Fix dynamic change the log4j2 log level

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -89,7 +89,7 @@ Environment variables:
    PULSAR_EXTRA_CLASSPATH        Add extra paths to the pulsar classpath
    PULSAR_PID_DIR                Folder where the pulsar server PID file should be stored
    PULSAR_STOP_TIMEOUT           Wait time before forcefully kill the pulsar server instance, if the stop is not successful
-   PULSAR_LOG_LEVEL              Log level for the command run (default: info)
+   PULSAR_LOG_LEVEL              Log level for the command run, default to unset
    PULSAR_LOG_ROOT_LEVEL         Log root level for the command run (default: \$PULSAR_LOG_LEVEL)
 
 These variable can also be set in conf/pulsar_env.sh
@@ -286,8 +286,6 @@ else
 fi
 
 PULSAR_LOG_APPENDER=${PULSAR_LOG_APPENDER:-"RoutingAppender"}
-PULSAR_LOG_LEVEL=${PULSAR_LOG_LEVEL:-"info"}
-PULSAR_LOG_ROOT_LEVEL=${PULSAR_LOG_ROOT_LEVEL:-"${PULSAR_LOG_LEVEL}"}
 PULSAR_ROUTING_APPENDER_DEFAULT=${PULSAR_ROUTING_APPENDER_DEFAULT:-"Console"}
 if [ ! -d "$PULSAR_LOG_DIR" ]; then
   mkdir -p "$PULSAR_LOG_DIR"
@@ -295,10 +293,17 @@ fi
 PULSAR_LOG_IMMEDIATE_FLUSH="${PULSAR_LOG_IMMEDIATE_FLUSH:-"false"}"
 
 #Configure log configuration system properties
+if [[ -n "$PULSAR_LOG_LEVEL" ]]; then
+  OPTS="$OPTS -Dpulsar.log.level=$PULSAR_LOG_LEVEL"
+fi
+
+PULSAR_LOG_ROOT_LEVEL=${PULSAR_LOG_ROOT_LEVEL:-"${PULSAR_LOG_LEVEL}"}
+if [[ -n "$PULSAR_LOG_ROOT_LEVEL" ]]; then
+  OPTS="$OPTS -Dpulsar.log.level=$PULSAR_LOG_LEVEL"
+fi
+
 OPTS="$OPTS -Dpulsar.log.appender=$PULSAR_LOG_APPENDER"
 OPTS="$OPTS -Dpulsar.log.dir=$PULSAR_LOG_DIR"
-OPTS="$OPTS -Dpulsar.log.level=$PULSAR_LOG_LEVEL"
-OPTS="$OPTS -Dpulsar.log.root.level=$PULSAR_LOG_ROOT_LEVEL"
 OPTS="$OPTS -Dpulsar.log.immediateFlush=$PULSAR_LOG_IMMEDIATE_FLUSH"
 OPTS="$OPTS -Dpulsar.routing.appender.default=$PULSAR_ROUTING_APPENDER_DEFAULT"
 # Configure log4j2 to disable servlet webapp detection so that Garbage free logging can be used


### PR DESCRIPTION
### Motivation

I switched the log level from info to debug by `log4j2.yaml` file, but there is no debug log for pulsar in the console.

The following is the log4j2 debug log(`LOG4J_DEBUG=true bin/pulsar standalone -nfw`):
```
DEBUG StatusLogger Watching configuration '/Users/zixuan/repo/pulsar/conf/log4j2.yaml' for lastModified Sat Feb 03 18:07:39 CST 2024 (1706954859387)
DEBUG StatusLogger Apache Log4j Core 2.18.0 initializing configuration YamlConfiguration[location=/Users/zixuan/repo/pulsar/conf/log4j2.yaml]
...
DEBUG StatusLogger Completed parsing configuration
DEBUG StatusLogger Building Plugin[name=property, class=org.apache.logging.log4j.core.config.Property].
DEBUG StatusLogger createProperty(name="pulsar.log.dir", value="logs", Configuration(pulsar))
DEBUG StatusLogger Building Plugin[name=property, class=org.apache.logging.log4j.core.config.Property].
DEBUG StatusLogger createProperty(name="pulsar.log.file", value="pulsar.log", Configuration(pulsar))
DEBUG StatusLogger Building Plugin[name=property, class=org.apache.logging.log4j.core.config.Property].
DEBUG StatusLogger createProperty(name="pulsar.log.immediateFlush", value="false", Configuration(pulsar))
DEBUG StatusLogger Building Plugin[name=property, class=org.apache.logging.log4j.core.config.Property].
DEBUG StatusLogger createProperty(name="pulsar.log.appender", value="RoutingAppender", Configuration(pulsar))
DEBUG StatusLogger Building Plugin[name=property, class=org.apache.logging.log4j.core.config.Property].
DEBUG StatusLogger createProperty(name="pulsar.log.root.level", value="debug", Configuration(pulsar))
DEBUG StatusLogger Building Plugin[name=property, class=org.apache.logging.log4j.core.config.Property].
DEBUG StatusLogger createProperty(name="pulsar.log.level", value="debug", Configuration(pulsar))
DEBUG StatusLogger Building Plugin[name=property, class=org.apache.logging.log4j.core.config.Property].
DEBUG StatusLogger createProperty(name="pulsar.routing.appender.default", value="Console", Configuration(pulsar))
DEBUG StatusLogger Building Plugin[name=properties, class=org.apache.logging.log4j.core.config.PropertiesPlugin].
DEBUG StatusLogger configureSubstitutor(={pulsar.log.dir=logs, pulsar.log.file=pulsar.log, pulsar.log.immediateFlush=false, pulsar.log.appender=RoutingAppender, pulsar.log.root.level=debug, pulsar.log.level=debug, pulsar.routing.appender.default=Console}, Configuration(pulsar))
...
DEBUG StatusLogger Building Plugin[name=AppenderRef, class=org.apache.logging.log4j.core.config.AppenderRef].
DEBUG StatusLogger createAppenderRef(ref="RoutingAppender", level="INFO", Filter=null)
...
DEBUG StatusLogger Started configuration YamlConfiguration[location=/Users/zixuan/repo/pulsar/conf/log4j2.yaml] OK.
```

You can see the `RoutingAppender` uses the `INFO` level in the above log.

In the `bin/pulsar`, we use the system properties to set the log4j2 log level, and it looks higher priority than the `log4j2.yaml` file. 

When I remove the `PULSAR_LOG_LEVEL` and `PULSAR_LOG_ROOT_LEVEL` variables in the `bin/pulsar`, and then change the log level from info to debug in the `log4j2.yaml` file, it works fine.

### Modifications

When the `PULSAR_LOG_LEVEL` or `PULSAR_LOG_ROOT_LEVEL` is set by the user, we set the log level by system properties. 

**Note:** This way doesn't support changing the log level by the `log4j2.yaml`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->