### PR TITLE
[fix] [test] Fix flaky test testPerTopicExpiredStat

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -32,9 +32,9 @@ import io.prometheus.client.Collector;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
-import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -727,14 +727,13 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         //check value
         field = PersistentSubscription.class.getDeclaredField("expiryMonitor");
         field.setAccessible(true);
-        NumberFormat nf = NumberFormat.getNumberInstance();
-        nf.setMaximumFractionDigits(3);
-        nf.setRoundingMode(RoundingMode.DOWN);
         for (int i = 0; i < topicList.size(); i++) {
             PersistentSubscription subscription = (PersistentSubscription) pulsar.getBrokerService()
                     .getTopicIfExists(topicList.get(i)).get().get().getSubscription(subName);
             PersistentMessageExpiryMonitor monitor = (PersistentMessageExpiryMonitor) field.get(subscription);
-            assertEquals(Double.valueOf(nf.format(monitor.getMessageExpiryRate())).doubleValue(), cm.get(i).value);
+            BigDecimal bigDecimal = BigDecimal.valueOf(monitor.getMessageExpiryRate());
+            bigDecimal = bigDecimal.setScale(3, RoundingMode.DOWN);
+            assertEquals(bigDecimal.doubleValue(), cm.get(i).value);
         }
 
         cm = (List<Metric>) metrics.get("pulsar_subscription_total_msg_expired");


### PR DESCRIPTION
### Motivation
Large floats may fail to convert because of commas in the string
<img width="1016" alt="image" src="https://github.com/apache/pulsar/assets/9758905/bf43083b-5a2a-42a7-966b-a38da4465b0e">

### Modifications
Change to BigDecimal

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: [<!-- ENTER URL HERE -->](https://github.com/315157973/pulsar/pull/15)
