### PR TITLE
[cleanup] [broker] fix return value of TransactionTimeoutTrackerImpl#addTransaction

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/timeout/TransactionTimeoutTrackerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/timeout/TransactionTimeoutTrackerImpl.java
@@ -57,10 +57,9 @@ public class TransactionTimeoutTrackerImpl implements TransactionTimeoutTracker,
     }
 
     @Override
-    public CompletableFuture<Boolean> addTransaction(long sequenceId, long timeout) {
+    public void addTransaction(long sequenceId, long timeout) {
         if (timeout < tickTimeMillis) {
             this.transactionMetadataStoreService.endTransactionForTimeout(new TxnID(tcId, sequenceId));
-            return CompletableFuture.completedFuture(false);
         }
         synchronized (this){
             long nowTime = clock.millis();
@@ -79,7 +78,6 @@ public class TransactionTimeoutTrackerImpl implements TransactionTimeoutTracker,
                 nowTaskTimeoutTime = transactionTimeoutTime;
             }
         }
-        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/timeout/TransactionTimeoutTrackerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/timeout/TransactionTimeoutTrackerImpl.java
@@ -79,7 +79,7 @@ public class TransactionTimeoutTrackerImpl implements TransactionTimeoutTracker,
                 nowTaskTimeoutTime = transactionTimeoutTime;
             }
         }
-        return CompletableFuture.completedFuture(false);
+        return CompletableFuture.completedFuture(true);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/timeout/TransactionTimeoutTrackerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/timeout/TransactionTimeoutTrackerImpl.java
@@ -59,6 +59,7 @@ public class TransactionTimeoutTrackerImpl implements TransactionTimeoutTracker,
     public void addTransaction(long sequenceId, long timeout) {
         if (timeout < tickTimeMillis) {
             this.transactionMetadataStoreService.endTransactionForTimeout(new TxnID(tcId, sequenceId));
+            return;
         }
         synchronized (this){
             long nowTime = clock.millis();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/timeout/TransactionTimeoutTrackerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/timeout/TransactionTimeoutTrackerImpl.java
@@ -22,7 +22,6 @@ import io.netty.util.Timeout;
 import io.netty.util.Timer;
 import io.netty.util.TimerTask;
 import java.time.Clock;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.TransactionMetadataStoreService;

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionTimeoutTracker.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionTimeoutTracker.java
@@ -34,10 +34,8 @@ public interface TransactionTimeoutTracker extends AutoCloseable {
      *            the sequenceId
      * @param timeout
      *            the absolute timestamp for transaction timeout
-     *
-     * @return true if the transaction was added to the tracker or false if had timed out
      */
-    CompletableFuture<Boolean> addTransaction(long sequenceId, long timeout);
+    void addTransaction(long sequenceId, long timeout);
 
     /**
      * When replay the log, add the txnMeta to timer task queue.

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionTimeoutTracker.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionTimeoutTracker.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.transaction.coordinator;
 
 import com.google.common.annotations.Beta;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Represent the tracker for the timeout of the transaction.

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/MLTransactionMetadataStoreTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/MLTransactionMetadataStoreTest.java
@@ -524,8 +524,7 @@ public class MLTransactionMetadataStoreTest extends MockedBookKeeperTestCase {
     public class TransactionTimeoutTrackerImpl implements TransactionTimeoutTracker {
 
         @Override
-        public CompletableFuture<Boolean> addTransaction(long sequenceId, long timeout) {
-            return null;
+        public void addTransaction(long sequenceId, long timeout) {
         }
 
         @Override


### PR DESCRIPTION
### Motivation
According to the method signature, we should return true when the transaction is added to the tracker.
```
    /**
     * Add a txnID to the tracker.
     *
     * @param sequenceId
     *            the sequenceId
     * @param timeout
     *            the absolute timestamp for transaction timeout
     *
     * @return true if the transaction was added to the tracker or false if had timed out
     */
    CompletableFuture<Boolean> addTransaction(long sequenceId, long timeout);
```
But actually, we return false for any cases.

Update: Moreover, we do not use the return value anyway, it is useless. We have better remove it.

### Modifications

~~Return true when the transaction is added to the tracker.~~
Remove the return value as it is useless.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/41
