### PR TITLE
[fix][doc] Fix typos in class PersistentReplicator and PersistentDispatcherSingleActiveConsumer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -262,7 +262,7 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
             }
         } else if (readOnActiveConsumerTask != null) {
             if (log.isDebugEnabled()) {
-                log.debug("[{}-{}] Ignoring flow control message since consumer is waiting for cursor to be rewinded",
+                log.debug("[{}-{}] Ignoring flow control message since consumer is waiting for cursor to be rewound",
                         name, consumer);
             }
         } else {
@@ -295,7 +295,7 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
         }
 
         if (readOnActiveConsumerTask != null) {
-            log.info("[{}-{}] Ignoring reDeliverUnAcknowledgedMessages: consumer is waiting for cursor to be rewinded",
+            log.info("[{}-{}] Ignoring reDeliverUnAcknowledgedMessages: consumer is waiting for cursor to be rewound",
                     name, consumer);
             return;
         }
@@ -303,7 +303,7 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
         havePendingRead = false;
         cursor.rewind(consumer.readCompacted());
         if (log.isDebugEnabled()) {
-            log.debug("[{}-{}] Cursor rewinded, redelivering unacknowledged messages. ", name, consumer);
+            log.debug("[{}-{}] Cursor rewound, redelivering unacknowledged messages. ", name, consumer);
         }
         readMoreEntries(consumer);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -400,7 +400,7 @@ public abstract class PersistentReplicator extends AbstractReplicator
         public void sendComplete(Throwable exception, OpSendMsgStats opSendMsgStats) {
             if (exception != null && !(exception instanceof PulsarClientException.InvalidMessageException)) {
                 log.error("[{}] Error producing on remote broker", replicator.replicatorId, exception);
-                // cursor should be rewinded since it was incremented when readMoreEntries
+                // cursor should be rewound since it was incremented when readMoreEntries
                 replicator.cursor.rewind();
             } else {
                 if (log.isDebugEnabled()) {


### PR DESCRIPTION
### Motivation

Fix typos in class PersistentReplicator and PersistentDispatcherSingleActiveConsumer


### Modifications

The past participle of the word `rewind` is `rewound` rather than `rewinded`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->