### PR TITLE
[fix][broker] Sanitize values before logging in apply-config-from-env.py script

### DIFF
--- a/docker/pulsar/scripts/apply-config-from-env.py
+++ b/docker/pulsar/scripts/apply-config-from-env.py
@@ -25,17 +25,28 @@
 ## ./apply-config-from-env file.conf
 ##
 
-import os, sys
+import os, sys, argparse
 
-if len(sys.argv) < 2:
-    print('Usage: %s' % (sys.argv[0]))
+parser = argparse.ArgumentParser(description='Pulsar configuration file customizer based on environment variables')
+parser.add_argument('--prefix', default='PULSAR_PREFIX_', help='Prefix for environment variables, default is PULSAR_PREFIX_')
+parser.add_argument('conf_files', nargs='*', help='Configuration files')
+args = parser.parse_args()
+if not args.conf_files:
+    parser.print_help()
     sys.exit(1)
 
-# Always apply env config to env scripts as well
-conf_files = sys.argv[1:]
+env_prefix = args.prefix
+conf_files = args.conf_files
 
-PF_ENV_PREFIX = 'PULSAR_PREFIX_'
 PF_ENV_DEBUG = (os.environ.get('PF_ENV_DEBUG','0') == '1')
+
+# List of keys where the value should not be displayed in logs
+sensitive_keys = ["brokerClientAuthenticationParameters", "bookkeeperClientAuthenticationParameters", "tokenSecretKey"]
+
+def sanitize_display_value(k, v):
+    if "password" in k.lower() or k in sensitive_keys or (k == "tokenSecretKey" and v.startswith("data:")):
+        return "********"
+    return v
 
 for conf_filename in conf_files:
     lines = []  # List of config file lines
@@ -47,7 +58,6 @@ for conf_filename in conf_files:
         line = line.strip()
         if not line:
             continue
-
         try:
             k,v = line.split('=', 1)
             if k.startswith('#'):
@@ -61,37 +71,26 @@ for conf_filename in conf_files:
     for k in sorted(os.environ.keys()):
         v = os.environ[k].strip()
 
-        # Hide the value in logs if is password.
-        if "password" in k.lower():
-            displayValue = "********"
-        else:
-            displayValue = v
-
-        if k.startswith(PF_ENV_PREFIX):
-            k = k[len(PF_ENV_PREFIX):]
         if k in keys:
+            displayValue = sanitize_display_value(k, v)
             print('[%s] Applying config %s = %s' % (conf_filename, k, displayValue))
             idx = keys[k]
             lines[idx] = '%s=%s\n' % (k, v)
 
-
     # Ensure we have a new-line at the end of the file, to avoid issue
     # when appending more lines to the config
     lines.append('\n')
-    
-    # Add new keys from Env    
+
+    # Add new keys from Env
     for k in sorted(os.environ.keys()):
-        v = os.environ[k]
-        if not k.startswith(PF_ENV_PREFIX):
+        if not k.startswith(env_prefix):
             continue
 
-        # Hide the value in logs if is password.
-        if "password" in k.lower():
-            displayValue = "********"
-        else:
-            displayValue = v
+        v = os.environ[k].strip()
+        k = k[len(env_prefix):]
 
-        k = k[len(PF_ENV_PREFIX):]
+        displayValue = sanitize_display_value(k, v)
+
         if k not in keys:
             print('[%s] Adding config %s = %s' % (conf_filename, k, displayValue))
             lines.append('%s=%s\n' % (k, v))
@@ -99,10 +98,8 @@ for conf_filename in conf_files:
             print('[%s] Updating config %s = %s' % (conf_filename, k, displayValue))
             lines[keys[k]] = '%s=%s\n' % (k, v)
 
-
     # Store back the updated config in the same file
     f = open(conf_filename, 'w')
     for line in lines:
         f.write(line)
     f.close()
-


### PR DESCRIPTION
Fixes #22043 

### Motivation

See #22043 

### Modifications

- add value sanitization logic to `apply-config-from-env.py` script
- refactor the script
- add support for passing the prefix so that there isn't a need for code duplication in the apply-config-from-env-with-prefix.py script. That can be deprecated.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->