### PR TITLE
[fix][broker] Fix hash collision when using a consumer name that ends with a number

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
@@ -154,17 +154,17 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
         }
         Map<Consumer, List<Range>> expectedResult = new HashMap<>();
         expectedResult.put(consumers.get(0), Arrays.asList(
-                Range.of(0, 330121749),
-                Range.of(330121750, 618146114),
-                Range.of(1797637922, 1976098885)));
+                Range.of(119056335, 242013991),
+                Range.of(722195657, 1656011842),
+                Range.of(1707482098, 1914695766)));
         expectedResult.put(consumers.get(1), Arrays.asList(
-                Range.of(938427576, 1094135919),
-                Range.of(1138613629, 1342907082),
-                Range.of(1342907083, 1797637921)));
+                Range.of(0, 90164503),
+                Range.of(90164504, 119056334),
+                Range.of(382436668, 722195656)));
         expectedResult.put(consumers.get(2), Arrays.asList(
-                Range.of(618146115, 772640562),
-                Range.of(772640563, 938427575),
-                Range.of(1094135920, 1138613628)));
+                Range.of(242013992, 242377547),
+                Range.of(242377548, 382436667),
+                Range.of(1656011843, 1707482097)));
         for (Map.Entry<Consumer, List<Range>> entry : selector.getConsumerKeyHashRanges().entrySet()) {
             System.out.println(entry.getValue());
             Assert.assertEquals(entry.getValue(), expectedResult.get(entry.getKey()));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersTest.java
@@ -262,7 +262,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumersTest {
         redeliverEntries.add(EntryImpl.create(1, 1, createMessage("message1", 1, "key1")));
         final List<Entry> readEntries = new ArrayList<>();
         readEntries.add(EntryImpl.create(1, 2, createMessage("message2", 2, "key1")));
-        readEntries.add(EntryImpl.create(1, 3, createMessage("message3", 3, "key2")));
+        readEntries.add(EntryImpl.create(1, 3, createMessage("message3", 3, "key22")));
 
         try {
             Field totalAvailablePermitsField = PersistentDispatcherMultipleConsumers.class.getDeclaredField("totalAvailablePermits");
@@ -358,7 +358,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumersTest {
 
         // Messages with key1 are routed to consumer1 and messages with key2 are routed to consumer2
         final List<Entry> allEntries = new ArrayList<>();
-        allEntries.add(EntryImpl.create(1, 1, createMessage("message1", 1, "key2")));
+        allEntries.add(EntryImpl.create(1, 1, createMessage("message1", 1, "key22")));
         allEntries.add(EntryImpl.create(1, 2, createMessage("message2", 2, "key1")));
         allEntries.add(EntryImpl.create(1, 3, createMessage("message3", 3, "key1")));
         allEntries.forEach(entry -> ((EntryImpl) entry).retain());


### PR DESCRIPTION
Fixes #22050

### Motivation

See #22050, there's a hash collision in ConsistentHashingStickyKeyConsumerSelector when the consumer name ends with a number for example "consumer1" and "consumer11" would collide for the key "consumer111" (consumer1, i=11 & consumer11, i=1).

### Modifications

Fix hash collision by adding a separator between the 2 fields used in the hash calculation. Use the NUL character (`\0`) as a separator.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->