### PR TITLE
[WIP][fix][broker] Fix topic lookup with Admin API when using advertised listeners

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/MultipleListenerValidator.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/MultipleListenerValidator.java
@@ -76,7 +76,7 @@ public final class MultipleListenerValidator {
         final Map<String, AdvertisedListener> result = new LinkedHashMap<>();
         final Map<String, Set<String>> reverseMappings = new LinkedHashMap<>();
         for (final Map.Entry<String, List<String>> entry : listeners.entrySet()) {
-            if (entry.getValue().size() > 2) {
+            if (entry.getValue().size() > 4) {
                 throw new IllegalArgumentException("there are redundant configure for listener `" + entry.getKey()
                         + "`");
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
@@ -63,7 +63,7 @@ public interface LoadManager {
     Optional<ResourceUnit> getLeastLoaded(ServiceUnitId su) throws Exception;
 
     default CompletableFuture<Optional<LookupResult>> findBrokerServiceUrl(
-            Optional<ServiceUnitId> topic, ServiceUnitId bundle) {
+            Optional<ServiceUnitId> topic, ServiceUnitId bundle, String advertisedListenerName) {
         throw new UnsupportedOperationException();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerWrapper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerWrapper.java
@@ -62,9 +62,9 @@ public class ExtensibleLoadManagerWrapper implements LoadManager {
 
     @Override
     public CompletableFuture<Optional<LookupResult>> findBrokerServiceUrl(
-            Optional<ServiceUnitId> topic, ServiceUnitId bundle) {
+            Optional<ServiceUnitId> topic, ServiceUnitId bundle, String advertisedListenerName) {
         return loadManager.assign(topic, bundle)
-                .thenApply(lookupData -> lookupData.map(BrokerLookupData::toLookupResult));
+                .thenApply(lookupData -> lookupData.map(ld -> ld.toLookupResult(advertisedListenerName)));
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupData.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupData.java
@@ -79,9 +79,8 @@ public record BrokerLookupData (String webServiceUrl,
         return this.startTimestamp;
     }
 
-    public LookupResult toLookupResult() {
-        return new LookupResult(webServiceUrl, webServiceUrlTls, pulsarServiceUrl, pulsarServiceUrlTls,
-                LookupResult.Type.BrokerUrl, false);
+    public LookupResult toLookupResult(String advertisedListenerName) {
+        return LookupResult.create(this, advertisedListenerName, false);
     }
 
     public NamespaceEphemeralData toNamespaceEphemeralData() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/LookupResult.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/LookupResult.java
@@ -18,8 +18,11 @@
  */
 package org.apache.pulsar.broker.lookup;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.namespace.NamespaceEphemeralData;
 import org.apache.pulsar.common.lookup.data.LookupData;
+import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 
 /**
  * Represent a lookup result.
@@ -65,6 +68,62 @@ public class LookupResult {
         this.authoritativeRedirect = false;
         this.lookupData = new LookupData(nativeUrl, nativeUrlTls, namespaceEphemeralData.getHttpUrl(),
                 namespaceEphemeralData.getHttpUrlTls());
+    }
+
+    public static LookupResult create(BrokerLookupData selectedBroker, String advertisedListenerName,
+                                      boolean authoritativeRedirect) {
+        String httpUrl = selectedBroker.getWebServiceUrl();
+        String httpUrlTls = selectedBroker.getWebServiceUrlTls();
+        String brokerServiceUrl = selectedBroker.getPulsarServiceUrl();
+        String brokerServiceUrlTls = selectedBroker.getPulsarServiceUrlTls();
+
+        if (StringUtils.isNotBlank(advertisedListenerName)) {
+            var advertisedListener = selectedBroker.advertisedListeners().get(advertisedListenerName);
+            if (advertisedListener != null) {
+                if (advertisedListener.getBrokerHttpUrl() != null) {
+                    httpUrl = advertisedListener.getBrokerHttpUrl().toString();
+                }
+                if (advertisedListener.getBrokerHttpsUrl() != null) {
+                    httpUrlTls = advertisedListener.getBrokerHttpsUrl().toString();
+                }
+                if (advertisedListener.getBrokerServiceUrl() != null) {
+                    brokerServiceUrl = advertisedListener.getBrokerServiceUrl().toString();
+                }
+                if (advertisedListener.getBrokerServiceUrlTls() != null) {
+                    brokerServiceUrlTls = advertisedListener.getBrokerServiceUrlTls().toString();
+                }
+            }
+        }
+
+        return new LookupResult(httpUrl, httpUrlTls, brokerServiceUrl, brokerServiceUrlTls, authoritativeRedirect);
+    }
+
+    public static LookupResult create(LocalBrokerData selectedBroker, String advertisedListenerName,
+                                      boolean authoritativeRedirect) {
+        String httpUrl = selectedBroker.getWebServiceUrl();
+        String httpUrlTls = selectedBroker.getWebServiceUrlTls();
+        String brokerServiceUrl = selectedBroker.getPulsarServiceUrl();
+        String brokerServiceUrlTls = selectedBroker.getPulsarServiceUrlTls();
+
+        if (StringUtils.isNotBlank(advertisedListenerName)) {
+            var advertisedListener = selectedBroker.getAdvertisedListeners().get(advertisedListenerName);
+            if (advertisedListener != null) {
+                if (advertisedListener.getBrokerHttpUrl() != null) {
+                    httpUrl = advertisedListener.getBrokerHttpUrl().toString();
+                }
+                if (advertisedListener.getBrokerHttpsUrl() != null) {
+                    httpUrlTls = advertisedListener.getBrokerHttpsUrl().toString();
+                }
+                if (advertisedListener.getBrokerServiceUrl() != null) {
+                    brokerServiceUrl = advertisedListener.getBrokerServiceUrl().toString();
+                }
+                if (advertisedListener.getBrokerServiceUrlTls() != null) {
+                    brokerServiceUrlTls = advertisedListener.getBrokerServiceUrlTls().toString();
+                }
+            }
+        }
+
+        return new LookupResult(httpUrl, httpUrlTls, brokerServiceUrl, brokerServiceUrlTls, authoritativeRedirect);
     }
 
     public boolean isBrokerUrl() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -24,9 +24,9 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.pulsar.common.naming.NamespaceName.SYSTEM_NAMESPACE;
+
 import com.google.common.hash.Hashing;
 import io.prometheus.client.Counter;
-import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -189,14 +189,16 @@ public class NamespaceService implements AutoCloseable {
         CompletableFuture<Optional<LookupResult>> future = getBundleAsync(topic)
                 .thenCompose(bundle -> {
                     // Do redirection if the cluster is in rollback or deploying.
-                    return findRedirectLookupResultAsync(bundle).thenCompose(optResult -> {
+                    return findRedirectLookupResultAsync(bundle, options.getAdvertisedListenerName()).thenCompose(
+                            optResult -> {
                         if (optResult.isPresent()) {
                             LOG.info("[{}] Redirect lookup request to {} for topic {}",
                                     pulsar.getBrokerId(), optResult.get(), topic);
                             return CompletableFuture.completedFuture(optResult);
                         }
                         if (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(config)) {
-                            return loadManager.get().findBrokerServiceUrl(Optional.of(topic), bundle);
+                            return loadManager.get().findBrokerServiceUrl(Optional.of(topic), bundle,
+                                    options.getAdvertisedListenerName());
                         } else {
                             // TODO: Add unit tests cover it.
                             return findBrokerServiceUrl(bundle, options);
@@ -221,11 +223,12 @@ public class NamespaceService implements AutoCloseable {
         return future;
     }
 
-    private CompletableFuture<Optional<LookupResult>> findRedirectLookupResultAsync(ServiceUnitId bundle) {
+    private CompletableFuture<Optional<LookupResult>> findRedirectLookupResultAsync(ServiceUnitId bundle,
+                                                                                    String advertisedListenerName) {
         if (isSLAOrHeartbeatNamespace(bundle.getNamespaceObject().toString())) {
             return CompletableFuture.completedFuture(Optional.empty());
         }
-        return redirectManager.findRedirectLookupResultAsync();
+        return redirectManager.findRedirectLookupResultAsync(advertisedListenerName);
     }
 
     public CompletableFuture<NamespaceBundle> getBundleAsync(TopicName topic) {
@@ -295,7 +298,7 @@ public class NamespaceService implements AutoCloseable {
     private CompletableFuture<Optional<URL>> internalGetWebServiceUrl(@Nullable ServiceUnitId topic,
                                                                       NamespaceBundle bundle,
                                                                       LookupOptions options) {
-        return findRedirectLookupResultAsync(bundle).thenCompose(optResult -> {
+        return findRedirectLookupResultAsync(bundle, options.getAdvertisedListenerName()).thenCompose(optResult -> {
             if (optResult.isPresent()) {
                 LOG.info("[{}] Redirect lookup request to {} for topic {}",
                         pulsar.getBrokerId(), optResult.get(), topic);
@@ -303,7 +306,8 @@ public class NamespaceService implements AutoCloseable {
                     LookupData lookupData = optResult.get().getLookupData();
                     final String redirectUrl = options.isRequestHttps()
                             ? lookupData.getHttpUrlTls() : lookupData.getHttpUrl();
-                    return CompletableFuture.completedFuture(Optional.of(new URL(redirectUrl)));
+                    return CompletableFuture.completedFuture(redirectUrl != null ? Optional.of(new URL(redirectUrl)) :
+                            Optional.empty());
                 } catch (Exception e) {
                     // just log the exception, nothing else to do
                     LOG.warn("internalGetWebServiceUrl [{}]", e.getMessage(), e);
@@ -312,7 +316,8 @@ public class NamespaceService implements AutoCloseable {
             }
             CompletableFuture<Optional<LookupResult>> future =
                     ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(config)
-                    ? loadManager.get().findBrokerServiceUrl(Optional.ofNullable(topic), bundle) :
+                    ? loadManager.get().findBrokerServiceUrl(Optional.ofNullable(topic), bundle,
+                            options.getAdvertisedListenerName()) :
                     findBrokerServiceUrl(bundle, options);
 
             return future.thenApply(lookupResult -> {
@@ -321,7 +326,7 @@ public class NamespaceService implements AutoCloseable {
                         LookupData lookupData = lookupResult.get().getLookupData();
                         final String redirectUrl = options.isRequestHttps()
                                 ? lookupData.getHttpUrlTls() : lookupData.getHttpUrl();
-                        return Optional.of(new URL(redirectUrl));
+                        return redirectUrl != null ? Optional.of(new URL(redirectUrl)) : Optional.empty();
                     } catch (Exception e) {
                         // just log the exception, nothing else to do
                         LOG.warn("internalGetWebServiceUrl [{}]", e.getMessage(), e);
@@ -463,24 +468,7 @@ public class NamespaceService implements AutoCloseable {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Namespace bundle {} already owned by {} ", bundle, nsData);
                     }
-                    // find the target
-                    if (options.hasAdvertisedListenerName()) {
-                        AdvertisedListener listener =
-                                nsData.get().getAdvertisedListeners().get(options.getAdvertisedListenerName());
-                        if (listener == null) {
-                            future.completeExceptionally(
-                                    new PulsarServerException("the broker do not have "
-                                            + options.getAdvertisedListenerName() + " listener"));
-                        } else {
-                            URI url = listener.getBrokerServiceUrl();
-                            URI urlTls = listener.getBrokerServiceUrlTls();
-                            future.complete(Optional.of(new LookupResult(nsData.get(),
-                                    url == null ? null : url.toString(),
-                                    urlTls == null ? null : urlTls.toString())));
-                        }
-                    } else {
-                        future.complete(Optional.of(new LookupResult(nsData.get())));
-                    }
+                    resolveBrokerServiceLookupResult(options, nsData.get(), future);
                 }
             }).exceptionally(exception -> {
                 LOG.warn("Failed to check owner for bundle {}: {}", bundle, exception.getMessage(), exception);
@@ -494,6 +482,43 @@ public class NamespaceService implements AutoCloseable {
 
             return future;
         });
+    }
+
+    private static void resolveBrokerServiceLookupResult(LookupOptions options, NamespaceEphemeralData nsData,
+                                                         CompletableFuture<Optional<LookupResult>> future) {
+        // find the target
+        if (options.hasAdvertisedListenerName()) {
+            AdvertisedListener listener =
+                    nsData.getAdvertisedListeners().get(options.getAdvertisedListenerName());
+            if (listener == null) {
+                future.completeExceptionally(
+                        new PulsarServerException("the broker does not have "
+                                + options.getAdvertisedListenerName() + " listener"));
+            } else {
+                String httpUrl =
+                        listener.getBrokerHttpUrl() != null ? listener.getBrokerHttpUrl().toString()
+                                : null;
+                String httpUrlTls =
+                        listener.getBrokerHttpsUrl() != null ? listener.getBrokerHttpsUrl().toString() :
+                                null;
+                String brokerServiceUrl =
+                        listener.getBrokerServiceUrl() != null ? listener.getBrokerServiceUrl().toString() :
+                                null;
+                String brokerServiceUrlTls =
+                        listener.getBrokerServiceUrlTls() != null
+                                ? listener.getBrokerServiceUrlTls().toString() : null;
+                if (httpUrl == null && httpUrlTls == null) {
+                    // fallback to the default listener for http/https since previously it wasn't possible
+                    // to share a single advertised listener name across the pulsar protocol and http/https protocol
+                    httpUrl = nsData.getHttpUrl();
+                    httpUrlTls = nsData.getHttpUrlTls();
+                }
+                future.complete(Optional.of(new LookupResult(httpUrl, httpUrlTls, brokerServiceUrl,
+                        brokerServiceUrlTls, false)));
+            }
+        } else {
+            future.complete(Optional.of(new LookupResult(nsData)));
+        }
     }
 
     private void searchForCandidateBroker(NamespaceBundle bundle,
@@ -607,25 +632,8 @@ public class NamespaceService implements AutoCloseable {
                             // Schedule the task to preload topics
                             pulsar.loadNamespaceTopics(bundle);
                         }
-                        // find the target
-                        if (options.hasAdvertisedListenerName()) {
-                            AdvertisedListener listener =
-                                    ownerInfo.getAdvertisedListeners().get(options.getAdvertisedListenerName());
-                            if (listener == null) {
-                                lookupFuture.completeExceptionally(
-                                        new PulsarServerException("the broker do not have "
-                                                + options.getAdvertisedListenerName() + " listener"));
-                            } else {
-                                URI url = listener.getBrokerServiceUrl();
-                                URI urlTls = listener.getBrokerServiceUrlTls();
-                                lookupFuture.complete(Optional.of(
-                                        new LookupResult(ownerInfo,
-                                                url == null ? null : url.toString(),
-                                                urlTls == null ? null : urlTls.toString())));
-                            }
-                        } else {
-                            lookupFuture.complete(Optional.of(new LookupResult(ownerInfo)));
-                        }
+
+                        resolveBrokerServiceLookupResult(options, ownerInfo, lookupFuture);
                     }
                 }).exceptionally(exception -> {
                     LOG.warn("Failed to acquire ownership for namespace bundle {}: {}", bundle, exception);
@@ -666,25 +674,9 @@ public class NamespaceService implements AutoCloseable {
 
             localBrokerDataCache.get(path).thenAccept(reportData -> {
                 if (reportData.isPresent()) {
-                    LocalBrokerData lookupData = reportData.get();
-                    if (StringUtils.isNotBlank(advertisedListenerName)) {
-                        AdvertisedListener listener = lookupData.getAdvertisedListeners().get(advertisedListenerName);
-                        if (listener == null) {
-                            lookupFuture.completeExceptionally(
-                                    new PulsarServerException(
-                                            "the broker do not have " + advertisedListenerName + " listener"));
-                        } else {
-                            URI url = listener.getBrokerServiceUrl();
-                            URI urlTls = listener.getBrokerServiceUrlTls();
-                            lookupFuture.complete(new LookupResult(lookupData.getWebServiceUrl(),
-                                    lookupData.getWebServiceUrlTls(), url == null ? null : url.toString(),
-                                    urlTls == null ? null : urlTls.toString(), authoritativeRedirect));
-                        }
-                    } else {
-                        lookupFuture.complete(new LookupResult(lookupData.getWebServiceUrl(),
-                                lookupData.getWebServiceUrlTls(), lookupData.getPulsarServiceUrl(),
-                                lookupData.getPulsarServiceUrlTls(), authoritativeRedirect));
-                    }
+                    LookupResult lookupResult =
+                            LookupResult.create(reportData.get(), advertisedListenerName, authoritativeRedirect);
+                    lookupFuture.complete(lookupResult);
                 } else {
                     lookupFuture.completeExceptionally(new MetadataStoreException.NotFoundException(path));
                 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupDataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupDataTest.java
@@ -56,7 +56,7 @@ public class BrokerLookupDataTest {
         assertEquals("3.0", lookupData.brokerVersion());
 
 
-        LookupResult lookupResult = lookupData.toLookupResult();
+        LookupResult lookupResult = lookupData.toLookupResult(null);
         assertEquals(webServiceUrl, lookupResult.getLookupData().getHttpUrl());
         assertEquals(webServiceUrlTls, lookupResult.getLookupData().getHttpUrlTls());
         assertEquals(pulsarServiceUrl, lookupResult.getLookupData().getBrokerUrl());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/manager/RedirectManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/manager/RedirectManagerTest.java
@@ -64,7 +64,7 @@ public class RedirectManagerTest {
         )).when(redirectManager).getAvailableBrokerLookupDataAsync();
 
         // Should redirect to broker-1, since broker-1 has the latest load manager, even though the class name is null.
-        Optional<LookupResult> lookupResult = redirectManager.findRedirectLookupResultAsync().get();
+        Optional<LookupResult> lookupResult = redirectManager.findRedirectLookupResultAsync(null).get();
         assertTrue(lookupResult.isPresent());
         assertTrue(lookupResult.get().getLookupData().getBrokerUrl().contains("broker-1"));
 
@@ -76,7 +76,7 @@ public class RedirectManagerTest {
                 }}
         )).when(redirectManager).getAvailableBrokerLookupDataAsync();
 
-        lookupResult = redirectManager.findRedirectLookupResultAsync().get();
+        lookupResult = redirectManager.findRedirectLookupResultAsync(null).get();
         assertTrue(lookupResult.isPresent());
         assertTrue(lookupResult.get().getLookupData().getBrokerUrl().contains("broker-1"));
 
@@ -89,7 +89,7 @@ public class RedirectManagerTest {
                 }}
         )).when(redirectManager).getAvailableBrokerLookupDataAsync();
 
-        lookupResult = redirectManager.findRedirectLookupResultAsync().get();
+        lookupResult = redirectManager.findRedirectLookupResultAsync(null).get();
         assertFalse(lookupResult.isPresent());
     }
 


### PR DESCRIPTION
This PR is WIP

### Motivation

PIP-61 and PIP-95 isn't fully implemented in the Pulsar code base.
For example, topic lookup with Admin API is broken when using advertised listeners.

### Modifications

- cover gaps in redirects to handle advertised listeners
- allow having both Pulsar binary protocol (pulsar & pulsar+ssl) and web api (http & https) with the same listener name by removing the unnecessary restriction of max 2 endpoints for a listener name

### Additional context

- [PIP-338](https://github.com/apache/pulsar/pull/22039) is related
- https://github.com/apache/pulsar/pull/17063 is related
- separate issue for [PIP-307 support for advertised listeners](https://github.com/apache/pulsar/issues/22061)

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->