### PR TITLE
[feat][ci] Add Trivy container scan Github workflow

### DIFF
--- a/.github/workflows/ci-trivy-container-scan.yaml
+++ b/.github/workflows/ci-trivy-container-scan.yaml
@@ -23,14 +23,6 @@ on:
     - cron: '0 8 * * *' # Every day at 8am UTC
   workflow_dispatch:
     inputs:
-      report-format:
-        description: 'Format of the report'
-        type: choice
-        default: table
-        options:
-          - table
-          - json
-          - sarif
       severity:
         description: "Severities to include (comma-separated or 'ALL' to include all)"
         required: false
@@ -48,7 +40,7 @@ jobs:
           - 'apachepulsar/pulsar'
           - 'apachepulsar/pulsar-all'
         docker-tag:
-          - '3.2.0'
+          - '3.2.1'
     env:
       IMAGE_REF: '${{ matrix.docker-image }}:${{ matrix.docker-tag }}'
     steps:
@@ -58,6 +50,7 @@ jobs:
           IMAGE_REF_CLEAN="$(echo $IMAGE_REF | sed 's/-/_/g; s/\./_/g; s/:/_/g; s/\//_/g')"
           echo "image_ref_clean=$IMAGE_REF_CLEAN" >> "$GITHUB_OUTPUT"
           echo "report_filename=trivy-scan-$IMAGE_REF_CLEAN.${{ inputs.report-format }}" >> "$GITHUB_OUTPUT"
+
       - name: Run Trivy container scan
         uses: aquasecurity/trivy-action@master
         with:
@@ -65,24 +58,10 @@ jobs:
           scanners: vuln
           severity: ${{ inputs.severity != 'ALL' && inputs.severity ||  'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'  }}
           limit-severities-for-sarif: true
-          format: ${{ inputs.report-format }}
+          format: 'sarif'
           output: ${{ steps.prepare-vars.outputs.report_filename }}
           exit-code: 1
-      - name: Email Trivy container scan report
-        uses: dawidd6/action-send-mail@v3
-        if: ${{ failure() }}
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          secure: true
-          username: ${{secrets.TRIVY_SCAN_MAIL_USERNAME}}
-          password: ${{secrets.TRIVY_SCAN_MAIL_PASSWORD}}
-          subject: Trivy container scan results for ${{ env.IMAGE_REF }}
-          to: dev@pulsar.apache.org
-          from: Github Trivy Container Scanner
-          body: Trivy reported vulnerabilities (${{ inputs.severity }}) for ${{ env.IMAGE_REF }}
-          ignore_cert: true
-          attachments: '${{ github.workspace }}/${{ steps.prepare-vars.outputs.report_filename }}'
+
       - name: Upload Trivy container scan report
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
@@ -90,8 +69,9 @@ jobs:
           name: trivy-vuln-report-${{ steps.prepare-vars.outputs.image_ref_clean }}
           path: '${{ github.workspace }}/${{ steps.prepare-vars.outputs.report_filename }}'
           retention-days: 15
+
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
-        if: ${{ failure() && inputs.report-format == 'sarif' }}
+        if: ${{ failure() }}
         with:
           sarif_file: '${{ github.workspace }}/${{ steps.prepare-vars.outputs.report_filename }}'

--- a/.github/workflows/ci-trivy-container-scan.yaml
+++ b/.github/workflows/ci-trivy-container-scan.yaml
@@ -38,9 +38,8 @@ jobs:
       matrix:
         docker-image:
           - 'apachepulsar/pulsar'
-          - 'apachepulsar/pulsar-all'
         docker-tag:
-          - '3.2.1'
+          - 'latest'
     env:
       IMAGE_REF: '${{ matrix.docker-image }}:${{ matrix.docker-tag }}'
     steps:

--- a/.github/workflows/ci-trivy-container-scan.yaml
+++ b/.github/workflows/ci-trivy-container-scan.yaml
@@ -50,7 +50,6 @@ jobs:
           IMAGE_REF_CLEAN="$(echo $IMAGE_REF | sed 's/-/_/g; s/\./_/g; s/:/_/g; s/\//_/g')"
           echo "image_ref_clean=$IMAGE_REF_CLEAN" >> "$GITHUB_OUTPUT"
           echo "report_filename=trivy-scan-$IMAGE_REF_CLEAN.${{ inputs.report-format }}" >> "$GITHUB_OUTPUT"
-
       - name: Run Trivy container scan
         uses: aquasecurity/trivy-action@master
         with:
@@ -61,15 +60,6 @@ jobs:
           format: 'sarif'
           output: ${{ steps.prepare-vars.outputs.report_filename }}
           exit-code: 1
-
-      - name: Upload Trivy container scan report
-        uses: actions/upload-artifact@v4
-        if: ${{ failure() }}
-        with:
-          name: trivy-vuln-report-${{ steps.prepare-vars.outputs.image_ref_clean }}
-          path: '${{ github.workspace }}/${{ steps.prepare-vars.outputs.report_filename }}'
-          retention-days: 15
-
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         if: ${{ failure() }}

--- a/.github/workflows/ci-trivy-container-scan.yaml
+++ b/.github/workflows/ci-trivy-container-scan.yaml
@@ -90,3 +90,8 @@ jobs:
           name: trivy-vuln-report-${{ steps.prepare-vars.outputs.image_ref_clean }}
           path: '${{ github.workspace }}/${{ steps.prepare-vars.outputs.report_filename }}'
           retention-days: 15
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        if: ${{ failure() && inputs.report-format == 'sarif' }}
+        with:
+          sarif_file: '${{ github.workspace }}/${{ steps.prepare-vars.outputs.report_filename }}'

--- a/.github/workflows/ci-trivy-container-scan.yaml
+++ b/.github/workflows/ci-trivy-container-scan.yaml
@@ -1,0 +1,92 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: CI - Trivy Container Scan
+on:
+  schedule:
+    - cron: '0 8 * * *' # Every day at 8am UTC
+  workflow_dispatch:
+    inputs:
+      report-format:
+        description: 'Format of the report'
+        type: choice
+        default: table
+        options:
+          - table
+          - json
+          - sarif
+      severity:
+        description: "Severities to include (comma-separated or 'ALL' to include all)"
+        required: false
+        default: 'CRITICAL,HIGH'
+
+jobs:
+  container_scan:
+    if: ${{ github.repository == 'apache/pulsar' }}
+    name: Trivy Docker image vulnerability scan
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        docker-image:
+          - 'apachepulsar/pulsar'
+          - 'apachepulsar/pulsar-all'
+        docker-tag:
+          - '3.2.0'
+    env:
+      IMAGE_REF: '${{ matrix.docker-image }}:${{ matrix.docker-tag }}'
+    steps:
+      - id: prepare-vars
+        shell: bash
+        run: |
+          IMAGE_REF_CLEAN="$(echo $IMAGE_REF | sed 's/-/_/g; s/\./_/g; s/:/_/g; s/\//_/g')"
+          echo "image_ref_clean=$IMAGE_REF_CLEAN" >> "$GITHUB_OUTPUT"
+          echo "report_filename=trivy-scan-$IMAGE_REF_CLEAN.${{ inputs.report-format }}" >> "$GITHUB_OUTPUT"
+      - name: Run Trivy container scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.IMAGE_REF }}
+          scanners: vuln
+          severity: ${{ inputs.severity != 'ALL' && inputs.severity ||  'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'  }}
+          limit-severities-for-sarif: true
+          format: ${{ inputs.report-format }}
+          output: ${{ steps.prepare-vars.outputs.report_filename }}
+          exit-code: 1
+      - name: Email Trivy container scan report
+        uses: dawidd6/action-send-mail@v3
+        if: ${{ failure() }}
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          secure: true
+          username: ${{secrets.TRIVY_SCAN_MAIL_USERNAME}}
+          password: ${{secrets.TRIVY_SCAN_MAIL_PASSWORD}}
+          subject: Trivy container scan results for ${{ env.IMAGE_REF }}
+          to: dev@pulsar.apache.org
+          from: Github Trivy Container Scanner
+          body: Trivy reported vulnerabilities (${{ inputs.severity }}) for ${{ env.IMAGE_REF }}
+          ignore_cert: true
+          attachments: '${{ github.workspace }}/${{ steps.prepare-vars.outputs.report_filename }}'
+      - name: Upload Trivy container scan report
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: trivy-vuln-report-${{ steps.prepare-vars.outputs.image_ref_clean }}
+          path: '${{ github.workspace }}/${{ steps.prepare-vars.outputs.report_filename }}'
+          retention-days: 15


### PR DESCRIPTION
This commit introduces a Github Actions workflow that runs a Trivy container scan on the following Docker containers:

- apachepulsar/pulsar:3.2.0
- apachepulsar/pulsar-all:3.2.0

The workflow runs daily @ 0800 UTC and if it finds any vulnerabilities of HIGH or CRITICAL severity it sends an email including the report to the Pulsar DEV mailing list as well as upload the report to the workflow run in Github.

### Motivation
Our dependencies are currently scanned via the OWASP dependency checker but we have nothing checking on the vulnerability of our published Docker containers. 

### Modifications
As described in the summary, this adds a scheduled workflow that uses [Trivy](https://trivy.dev/) to run a scan against our published Docker containers. 

### Verifying this change
As always, Github Actions workflow are a pain to test. I have tested this one in isolation in prototype repository and it works well. We will not be able to verify it until it gets merged into mainline branch. 

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/onobc/pulsar/pull/4

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->

I tested this thoroughly in a personal repo before submitting this PR. Here is what the output looks like:

### Github Actions UI 

<img width="1261" alt="Screenshot 2024-02-16 at 15 46 06" src="https://github.com/apache/pulsar/assets/28907971/419f24e9-60e4-4588-a342-c1c32494e451">

### Generated email

<img width="754" alt="Screenshot 2024-02-16 at 15 50 03" src="https://github.com/apache/pulsar/assets/28907971/335a09c9-fd75-4737-b073-b7a28ff0753c">

### Attached email report

> [!NOTE]
> This is the report in `table` format, we could instead use `json`

<img width="1111" alt="Screenshot 2024-02-16 at 15 50 29" src="https://github.com/apache/pulsar/assets/28907971/eebb4996-1834-4b37-83d4-0d78c832cd5c">


