### PR TITLE
[improve][broker] Add an error log to troubleshoot the failure of starting broker registry.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -444,9 +444,9 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
             this.initWaiter.countDown();
             this.started = true;
         } catch (Exception ex) {
-            log.error("Failed to start the extensible load balance.", ex);
+            log.error("Failed to start the extensible load balance and close broker registry {}.",
+                    this.brokerRegistry, ex);
             if (this.brokerRegistry != null) {
-                log.error("Close broker registry because the extensible load balance start failed.", ex);
                 brokerRegistry.close();
             }
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -444,7 +444,9 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
             this.initWaiter.countDown();
             this.started = true;
         } catch (Exception ex) {
+            log.error("Failed to start the extensible load balance.", ex);
             if (this.brokerRegistry != null) {
+                log.error("Close broker registry because the extensible load balance start failed.", ex);
                 brokerRegistry.close();
             }
         }


### PR DESCRIPTION
### Motivation
When the `ExtensibleLoadManagerImpl.java` fails to start, it will close `brokerRegistry`. But we cannot directly determine why the broker register is closed. 

```log
2024-02-15T20:09:18,675+0000 [main] ERROR org.apache.pulsar.broker.namespace.NamespaceService - java.lang.IllegalStateException: The registry already closed.
java.util.concurrent.ExecutionException: java.lang.IllegalStateException: The registry already closed.
	at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396) ~[?:?]
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073) ~[?:?]
	at org.apache.pulsar.broker.namespace.NamespaceService.registerNamespace(NamespaceService.java:380) ~[io.streamnative-pulsar-broker-3.1.2.1.jar:3.1.2.1]
	at org.apache.pulsar.broker.namespace.NamespaceService.registerBootstrapNamespaces(NamespaceService.java:343) ~[io.streamnative-pulsar-broker-3.1.2.1.jar:3.1.2.1]
	at org.apache.pulsar.broker.PulsarService.start(PulsarService.java:867) ~[io.streamnative-pulsar-broker-3.1.2.1.jar:3.1.2.1]
	at org.apache.pulsar.PulsarBrokerStarter$BrokerStarter.start(PulsarBrokerStarter.java:276) ~[io.streamnative-pulsar-broker-3.1.2.1.jar:3.1.2.1]
	at org.apache.pulsar.PulsarBrokerStarter.main(PulsarBrokerStarter.java:356) ~[io.streamnative-pulsar-broker-3.1.2.1.jar:3.1.2.1]
Caused by: java.lang.IllegalStateException: The registry already closed.
```

### Modifications
Add an error log when the `ExtensibleLoadManagerImpl.java` fails to start,

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
