### PR TITLE
[fix][fn] Unwrap type from CompletableFuture when getting function's type args

### DIFF
--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionCommon.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionCommon.java
@@ -41,6 +41,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -120,7 +121,7 @@ public class FunctionCommon {
                 typeArgs[0] = (Class<?>) unwrapType(classParent, userClass, 0);
             }
         }
-        if (typeArgs[1].equals(Record.class)) {
+        if (typeArgs[1].equals(Record.class) || typeArgs[1].equals(CompletableFuture.class)) {
             typeArgs[1] = (Class<?>) unwrapType(classParent, userClass, 1);
         }
 

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionCommonTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionCommonTest.java
@@ -30,6 +30,7 @@ import static org.testng.Assert.assertEquals;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import java.io.File;
 import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
 import lombok.Cleanup;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.util.FutureUtil;
@@ -151,6 +152,14 @@ public class FunctionCommonTest {
                 }, false
             },
             {
+                new Function<String, CompletableFuture<Integer>>() {
+                    @Override
+                    public CompletableFuture<Integer> process(String input, Context context) throws Exception {
+                        return null;
+                    }
+                }, false
+            },
+            {
                 new java.util.function.Function<String, Integer>() {
                     @Override
                     public Integer apply(String s) {
@@ -162,6 +171,14 @@ public class FunctionCommonTest {
                 new java.util.function.Function<String, Record<Integer>>() {
                     @Override
                     public Record<Integer> apply(String s) {
+                        return null;
+                    }
+                }, false
+            },
+            {
+                new java.util.function.Function<String, CompletableFuture<Integer>>() {
+                    @Override
+                    public CompletableFuture<Integer> apply(String s) {
                         return null;
                     }
                 }, false
@@ -183,6 +200,14 @@ public class FunctionCommonTest {
                 }, true
             },
             {
+                new WindowFunction<String, CompletableFuture<Integer>>() {
+                    @Override
+                    public CompletableFuture<Integer> process(Collection<Record<String>> input, WindowContext context) throws Exception {
+                        return null;
+                    }
+                }, true
+            },
+            {
                 new java.util.function.Function<Collection<String>, Integer>() {
                     @Override
                     public Integer apply(Collection<String> strings) {
@@ -194,6 +219,14 @@ public class FunctionCommonTest {
                 new java.util.function.Function<Collection<String>, Record<Integer>>() {
                     @Override
                     public Record<Integer> apply(Collection<String> strings) {
+                        return null;
+                    }
+                }, true
+            },
+            {
+                new java.util.function.Function<Collection<String>, CompletableFuture<Integer>>() {
+                    @Override
+                    public CompletableFuture<Integer> apply(Collection<String> strings) {
                         return null;
                     }
                 }, true


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #22067

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

When inferring function type args, it doesn't unwrap the `CompletableFuture` type

### Modifications

unwrap the `CompletableFuture` type for the output

### Verifying this change

- [x] Make sure that the change passes the CI checks.

- [x] This change added tests and can be verified as follows:

*(example:)*
  - *Added unittests in `org.apache.pulsar.functions.utils.FunctionCommonTest#testGetFunctionTypes`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/jiangpengcheng/pulsar/pull/26

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
