### PR TITLE
[fix][test] Fix Thread.getThreadGroup().getName() NPE

### DIFF
--- a/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
@@ -177,7 +177,8 @@ public class ThreadLeakDetectorListener extends BetweenTestClassesListenerAdapte
             return true;
         }
         // skip Testcontainers threads
-        if (thread.getThreadGroup() != null && "testcontainers".equals(thread.getThreadGroup().getName())) {
+        final ThreadGroup threadGroup = thread.getThreadGroup();
+        if (threadGroup != null && "testcontainers".equals(threadGroup.getName())) {
             return true;
         }
         String threadName = thread.getName();


### PR DESCRIPTION
Fixes #22056

### Motivation



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


