### PR TITLE
[fix][sec] Validate the user input avoiding unexpected truncation of user-controlled arithmetic data

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TransactionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TransactionsBase.java
@@ -562,10 +562,10 @@ public abstract class TransactionsBase extends AdminResource {
         return completableFuture;
     }
 
-    protected CompletableFuture<Void> internalAbortTransaction(boolean authoritative, long mostSigBits,
+    protected CompletableFuture<Void> internalAbortTransaction(boolean authoritative, int mostSigBits,
                                                                long leastSigBits) {
         return validateTopicOwnershipAsync(
-                SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN.getPartition((int) mostSigBits), authoritative)
+                SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN.getPartition(mostSigBits), authoritative)
                 .thenCompose(__ -> validateSuperUserAccessAsync())
                 .thenCompose(__ -> pulsar().getTransactionMetadataStoreService()
                         .endTransaction(new TxnID(mostSigBits, leastSigBits), TxnAction.ABORT_VALUE, false));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
@@ -458,7 +458,10 @@ public class Transactions extends TransactionsBase {
                                  @PathParam("leastSigBits") String leastSigBits) {
         try {
             checkTransactionCoordinatorEnabled();
-            internalAbortTransaction(authoritative, Long.parseLong(mostSigBits), Long.parseLong(leastSigBits))
+            // The `mostSigBits` is the partition index of the system topic TRANSACTION_COORDINATOR_ASSIGN,
+            // which is a integer. If the input is a long, there will throw a NumberFormatException instead of
+            // truncating it.
+            internalAbortTransaction(authoritative, Integer.parseInt(mostSigBits), Long.parseLong(leastSigBits))
                     .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                     .exceptionally(ex -> {
                         resumeAsyncResponseExceptionally(asyncResponse, ex);


### PR DESCRIPTION
Fix https://github.com/apache/pulsar/security/code-scanning/21
### Motivation

Casting a user-controlled numeric value to a narrower type can result in truncated values unless the input is validated.

### Modifications

Validate the user input.  If `mostSigBits` can not be parsed to an integer, a NumberFormatException will be thrown instead of truncating it.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
