### PR TITLE
[fix][broker] Support running docker container with gid != 0

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -36,10 +36,14 @@ COPY scripts/install-pulsar-client.sh /pulsar/bin
 
 # The final image needs to give the root group sufficient permission for Pulsar components
 # to write to specific directories within /pulsar
+# The ownership is changed to uid 10000 to allow using a different root group. This is necessary when running the
+# container when gid=0 is prohibited. In that case, the container must be run with uid 10000 with
+# any group id != 0 (for example 10001).
 # The file permissions are preserved when copying files from this builder image to the target image.
 RUN for SUBDIRECTORY in conf data download logs; do \
      [ -d /pulsar/$SUBDIRECTORY ] || mkdir /pulsar/$SUBDIRECTORY; \
-     chmod -R g+w /pulsar/$SUBDIRECTORY; \
+     chmod -R ug+w /pulsar/$SUBDIRECTORY; \
+     chown -R 10000:0 /pulsar/$SUBDIRECTORY; \
      done
 
 ### Create 2nd stage from Ubuntu image


### PR DESCRIPTION
### Motivation

Currently Pulsar's docker image must be run with gid=0. There are environments where the group id 0 is prohibited by default. One example is Tanzu Kubernetes Grid <=1.24 where a default Pod Security Policy called `vmware-system-restricted` is used. That PSP contains this type of rule:

```yaml
supplementalGroups:
  rule: MustRunAs
  ranges:
    - min: 1
      max: 65535
runAsUser:
  rule: MustRunAsNonRoot
fsGroup:
  rule: MustRunAs
  ranges:
    - min: 1
      max: 65535
```

In this case, it's not possible to use Pulsar's docker image since Pulsar needs write access to a few directories.

### Modifications

change the owner of the writable directories to user id 10000.

This will allow Tanzu to work with this type of securityContext for each Pulsar component (Broker, Zookeeper, Bookkeeper)
```
  securityContext:
    runAsNonRoot: true
    runAsGroup: 10001
    fsGroup: 10001
    runAsUser: 10000
```

### Workaround

Before this fix is included, it's possible to create an overlay image where the ownership is modified for the required directories

Dockerfile
```Dockerfile
ARG IMAGE=apachepulsar/pulsar-all
ARG TAG=3.0.2
FROM ${IMAGE}:${TAG}
USER 0
RUN for SUBDIRECTORY in conf data download logs; do \
     chown -R 10000:0 /pulsar/$SUBDIRECTORY; \
     done
USER 10000
```

sample of building and pushing a patched image:
```
docker build -t lhotari/pulsar-all-user10000:3.0.2 .
docker push lhotari/pulsar-all-user10000:3.0.2
```



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->