### PR TITLE
[fix][sec] Upgrade commons-compress to 1.26.0

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -285,7 +285,7 @@ The Apache Software License, Version 2.0
     - commons-lang-commons-lang-2.6.jar
     - commons-logging-commons-logging-1.1.1.jar
     - org.apache.commons-commons-collections4-4.4.jar
-    - org.apache.commons-commons-compress-1.21.jar
+    - org.apache.commons-commons-compress-1.26.0.jar
     - org.apache.commons-commons-lang3-3.11.jar
     - org.apache.commons-commons-text-1.10.0.jar
  * Netty

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -342,7 +342,7 @@ The Apache Software License, Version 2.0
     - commons-logging-1.2.jar
     - commons-lang3-3.11.jar
     - commons-text-1.10.0.jar
-    - commons-compress-1.21.jar
+    - commons-compress-1.26.0.jar
  * Netty
     - netty-buffer-4.1.105.Final.jar
     - netty-codec-4.1.105.Final.jar

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@ flexible messaging model and an intuitive client API.</description>
     <narPluginPhase>package</narPluginPhase>
 
     <!-- apache commons -->
-    <commons-compress.version>1.21</commons-compress.version>
+    <commons-compress.version>1.26.0</commons-compress.version>
 
     <bookkeeper.version>4.16.4</bookkeeper.version>
     <zookeeper.version>3.9.1</zookeeper.version>

--- a/pulsar-functions/runtime-all/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceDepsTest.java
+++ b/pulsar-functions/runtime-all/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceDepsTest.java
@@ -46,6 +46,8 @@ import java.util.zip.ZipInputStream;
  *     8. Apache AVRO
  *     9. Jackson Mapper and Databind (dependency of AVRO)
  *     10. Apache Commons Compress (dependency of AVRO)
+ *     11. Apache Commons Lang (dependency of Apache Commons Compress)
+ *     12. Apache Commons IO (dependency of Apache Commons Compress)
  */
 public class JavaInstanceDepsTest {
 
@@ -71,6 +73,8 @@ public class JavaInstanceDepsTest {
                         && !name.startsWith("org/apache/avro")
                         && !name.startsWith("com/fasterxml/jackson")
                         && !name.startsWith("org/apache/commons/compress")
+                        && !name.startsWith("org/apache/commons/lang3")
+                        && !name.startsWith("org/apache/commons/io")
                         && !name.startsWith("com/google")
                         && !name.startsWith("org/checkerframework")
                         && !name.startsWith("javax/annotation")


### PR DESCRIPTION
### Motivation

commons-compress 1.21 has the following vulnerability and should be upgraded to 1.26.0.
https://nvd.nist.gov/vuln/detail/CVE-2024-25710

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->