### PR TITLE
[fix] [client] fix huge permits if acked a half batched message

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageWithBatchIndexLevelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageWithBatchIndexLevelTest.java
@@ -583,4 +583,89 @@ public class BatchMessageWithBatchIndexLevelTest extends BatchMessageTest {
         consumerSet.add(spyServiceConsumer);
         return originalConsumer;
     }
+
+    /***
+     * 1. Send a batch message contains 100 single messages.
+     * 2. Ack 2 messages.
+     * 3. Redeliver the batch message and ack them.
+     * 4. Verify: the permits is correct.
+     */
+    @Test
+    public void testPermitsIfHalfAckBatchMessage() throws Exception {
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/tp");
+        final String subName = "s1";
+        final int receiverQueueSize = 1000;
+        final int ackedMessagesCountInTheFistStep = 2;
+        admin.topics().createNonPartitionedTopic(topicName);
+        admin.topics(). createSubscription(topicName, subName, MessageId.earliest);
+        ConsumerBuilder<String> consumerBuilder = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topicName)
+                .receiverQueueSize(receiverQueueSize)
+                .subscriptionName(subName)
+                .enableBatchIndexAcknowledgment(true)
+                .subscriptionType(SubscriptionType.Shared)
+                .isAckReceiptEnabled(true);
+
+        // Send 100 messages.
+        Producer<String>  producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topicName)
+                .enableBatching(true)
+                .batchingMaxPublishDelay(1, TimeUnit.HOURS)
+                .create();
+        CompletableFuture<MessageId>  lastSent = null;
+        for (int i = 1;  i <=  100;  i++) {
+            lastSent = producer. sendAsync(i + "");
+        }
+        producer.flush();
+        lastSent.join();
+
+        // Ack 2 messages, and trigger a redelivery.
+        Consumer<String>  consumer1 = consumerBuilder.subscribe();
+        for (int i = 0;  i <  ackedMessagesCountInTheFistStep;  i++) {
+            Message msg = consumer1. receive(2, TimeUnit.SECONDS);
+            assertNotNull(msg);
+            consumer1.acknowledge(msg);
+        }
+        consumer1.close();
+
+        // Receive the left 98 messages, and ack them.
+        // Verify the permits is correct.
+        ConsumerImpl<String> consumer2 = (ConsumerImpl<String>) consumerBuilder.subscribe();
+        Awaitility.await().until(() ->  consumer2.isConnected());
+        List<MessageId>  messages = new ArrayList<>();
+        int nextMessageValue = ackedMessagesCountInTheFistStep + 1;
+        while (true) {
+            Message<String> msg = consumer2.receive(2, TimeUnit.SECONDS);
+            if (msg == null) {
+                break;
+            }
+            assertEquals(msg.getValue(), nextMessageValue + "");
+            messages.add(msg.getMessageId());
+            nextMessageValue++;
+        }
+        assertEquals(messages.size(), 98);
+        consumer2.acknowledge(messages);
+
+        org.apache.pulsar.broker.service.Consumer serviceConsumer2 =
+                getTheUniqueServiceConsumer(topicName, subName);
+        Awaitility.await().untilAsserted(() ->  {
+            // After the messages were pop out, the permits in the client memory went to 98.
+            int permitsInClientMemory = consumer2.getAvailablePermits();
+            int permitsInBroker = serviceConsumer2.getAvailablePermits();
+            assertEquals(permitsInClientMemory + permitsInBroker, receiverQueueSize);
+        });
+
+        // cleanup.
+        producer.close();
+        consumer2.close();
+        admin.topics().delete(topicName, false);
+    }
+
+    private org.apache.pulsar.broker.service.Consumer getTheUniqueServiceConsumer(String topic, String sub) {
+        PersistentTopic persistentTopic =
+                (PersistentTopic) pulsar.getBrokerService(). getTopic(topic, false).join().get();
+        PersistentDispatcherMultipleConsumers dispatcher =
+                (PersistentDispatcherMultipleConsumers) persistentTopic.getSubscription(sub).getDispatcher();
+        return dispatcher.getConsumers().iterator().next();
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -64,6 +64,7 @@ import org.apache.pulsar.common.api.proto.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.common.util.collections.BitSetRecyclable;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.apache.pulsar.common.util.collections.GrowableArrayBlockingQueue;
 import org.slf4j.Logger;
@@ -1274,6 +1275,10 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
             return false;
         }
         return true;
+    }
+
+    protected boolean isSingleMessageAcked(BitSetRecyclable ackBitSet, int batchIndex) {
+        return ackBitSet != null && !ackBitSet.get(batchIndex);
     }
 
     public boolean hasBatchReceiveTimeout() {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1643,15 +1643,14 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                         singleMessageMetadata, uncompressedPayload, batchMessage, schema, true,
                         ackBitSet, ackSetInMessageId, redeliveryCount, consumerEpoch);
                 if (message == null) {
-                    if (ackBitSet != null && !ackBitSet.get(i)) {
-                        // If it is not in ackBitSet, it means Broker does not want to deliver it to the client, and
-                        // did not decrease the permits in the broker-side.
-                        // So do not acquire more permits for this message.
-                        // Why not skip this single message in the first line of for-loop block? We need call
-                        // "newSingleMessage" to move "payload.readerIndex" to a correct value to get the correct data.
-                        continue;
+                    // If it is not in ackBitSet, it means Broker does not want to deliver it to the client, and
+                    // did not decrease the permits in the broker-side.
+                    // So do not acquire more permits for this message.
+                    // Why not skip this single message in the first line of for-loop block? We need call
+                    // "newSingleMessage" to move "payload.readerIndex" to a correct value to get the correct data.
+                    if (!isSingleMessageAcked(ackBitSet, i)) {
+                        skippedMessages++;
                     }
-                    skippedMessages++;
                     continue;
                 }
                 if (possibleToDeadLetter != null) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1192,7 +1192,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 return null;
             }
 
-            if (ackBitSet != null && !ackBitSet.get(index)) {
+            if (isSingleMessageAcked(ackBitSet, index)) {
                 return null;
             }
 


### PR DESCRIPTION
### Motivation

Context:
- The broker decreases the permits after delivering messages to the client.
  -  It only decreases the un-acked part for permits when delivering batched messages to the client.
- The client acquires more permits after consuming messages.
  - **(Highlight)** It acquires the whole batch for permits even if it only received half of the batched message.

Reproduce step:
- The permits were initialized as `1000`
- Send a batch message containing 100 single messages.
- Ack a half of batched messages(`2` single messages).
- Redeliver the batch message.
- Receive the `98` messages left on the topic.
- **(Highlight)** permits is `1002`.

One our ENV, the permits went to `100,000+`(it was initialized as `50`), and leading the set `pendingAcks` went to a huge value. This may causes a client side OOM.

<img width="1103" alt="Screenshot 2024-02-21 at 22 55 42" src="https://github.com/apache/pulsar/assets/25195800/fc10e76a-585d-4ec3-b56b-04aca7e735b2">
<img width="1082" alt="Screenshot 2024-02-21 at 23 39 11" src="https://github.com/apache/pulsar/assets/25195800/57034843-f61c-49bf-a6d3-b8ef6a9a019a">



### Modifications

- The client acquires more permits after consuming messages.
  - It acquires the half batch for permits if it only received half of the batched message.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
