### PR TITLE
[fix][build] Fix building java-test-image without setting IMAGE_JDK_MAJOR_VERSION

### DIFF
--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -47,12 +47,6 @@
     </dependency>
   </dependencies>
 
-  <properties>
-    <UBUNTU_MIRROR>http://archive.ubuntu.com/ubuntu/</UBUNTU_MIRROR>
-    <UBUNTU_SECURITY_MIRROR>http://security.ubuntu.com/ubuntu/</UBUNTU_SECURITY_MIRROR>
-    <IMAGE_JDK_MAJOR_VERSION>17</IMAGE_JDK_MAJOR_VERSION>
-  </properties>
-
   <profiles>
     <profile>
       <id>git-commit-id-no-git</id>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,10 @@ flexible messaging model and an intuitive client API.</description>
 
     <pulsar.client.python.version>3.4.0</pulsar.client.python.version>
 
+    <UBUNTU_MIRROR>http://archive.ubuntu.com/ubuntu/</UBUNTU_MIRROR>
+    <UBUNTU_SECURITY_MIRROR>http://security.ubuntu.com/ubuntu/</UBUNTU_SECURITY_MIRROR>
+    <IMAGE_JDK_MAJOR_VERSION>17</IMAGE_JDK_MAJOR_VERSION>
+
     <!--config keys to configure test selection -->
     <include>**/Test*.java,**/*Test.java,**/*Tests.java,**/*TestCase.java</include>
     <exclude/>
@@ -2606,6 +2610,44 @@ flexible messaging model and an intuitive client API.</description>
         <checkstyle.skip>true</checkstyle.skip>
       </properties>
     </profile>
+
+    <profile>
+      <id>ubuntu-mirror-set</id>
+      <activation>
+        <property>
+          <name>env.UBUNTU_MIRROR</name>
+        </property>
+      </activation>
+      <properties>
+        <!-- Override the default value with the environment variable -->
+        <UBUNTU_MIRROR>${env.UBUNTU_MIRROR}</UBUNTU_MIRROR>
+      </properties>
+    </profile>
+    <profile>
+      <id>ubuntu-security-mirror-set</id>
+      <activation>
+        <property>
+          <name>env.UBUNTU_SECURITY_MIRROR</name>
+        </property>
+      </activation>
+      <properties>
+        <!-- Override the default value with the environment variable -->
+        <UBUNTU_SECURITY_MIRROR>${env.UBUNTU_SECURITY_MIRROR}</UBUNTU_SECURITY_MIRROR>
+      </properties>
+    </profile>
+    <profile>
+      <id>jdk-major-version-set</id>
+      <activation>
+        <property>
+          <name>env.IMAGE_JDK_MAJOR_VERSION</name>
+        </property>
+      </activation>
+      <properties>
+        <!-- Override the default value with the environment variable -->
+        <IMAGE_JDK_MAJOR_VERSION>${env.IMAGE_JDK_MAJOR_VERSION}</IMAGE_JDK_MAJOR_VERSION>
+      </properties>
+    </profile>
+
   </profiles>
 
   <repositories>

--- a/tests/docker-images/java-test-image/pom.xml
+++ b/tests/docker-images/java-test-image/pom.xml
@@ -35,9 +35,9 @@
       <id>docker</id>
       <properties>
         <docker.buildArg.PULSAR_TARBALL>target/pulsar-server-distribution-bin.tar.gz</docker.buildArg.PULSAR_TARBALL>
-        <docker.buildArg.UBUNTU_MIRROR>${env.UBUNTU_MIRROR}</docker.buildArg.UBUNTU_MIRROR>
-        <docker.buildArg.UBUNTU_SECURITY_MIRROR>${env.UBUNTU_SECURITY_MIRROR}</docker.buildArg.UBUNTU_SECURITY_MIRROR>
-        <docker.buildArg.JDK_MAJOR_VERSION>${env.IMAGE_JDK_MAJOR_VERSION}</docker.buildArg.JDK_MAJOR_VERSION>
+        <docker.buildArg.UBUNTU_MIRROR>${UBUNTU_MIRROR}</docker.buildArg.UBUNTU_MIRROR>
+        <docker.buildArg.UBUNTU_SECURITY_MIRROR>${UBUNTU_SECURITY_MIRROR}</docker.buildArg.UBUNTU_SECURITY_MIRROR>
+        <docker.buildArg.JDK_MAJOR_VERSION>${IMAGE_JDK_MAJOR_VERSION}</docker.buildArg.JDK_MAJOR_VERSION>
       </properties>
       <activation>
         <property>


### PR DESCRIPTION
### Motivation

In the current build, it is necessary to set IMAGE_JDK_MAJOR_VERSION environment variable. It's better to have the values set by default

### Modifications

- add a solution to properly set defaults for `IMAGE_JDK_MAJOR_VERSION`, `UBUNTU_MIRROR` and `UBUNTU_SECURITY_MIRROR`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->