### PR TITLE
[improve][ci] Upgrade Gradle Enterprise maven extension version

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -24,11 +24,11 @@
   <extension>
     <groupId>com.gradle</groupId>
     <artifactId>gradle-enterprise-maven-extension</artifactId>
-    <version>1.19.3</version>
+    <version>1.20.1</version>
   </extension>
   <extension>
     <groupId>com.gradle</groupId>
     <artifactId>common-custom-user-data-maven-extension</artifactId>
-    <version>1.12.4</version>
+    <version>1.12.5</version>
   </extension>
 </extensions>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -22,7 +22,9 @@
 <gradleEnterprise
         xmlns="https://www.gradle.com/gradle-enterprise-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="https://www.gradle.com/gradle-enterprise-maven https://www.gradle.com/schema/gradle-enterprise-maven.xsd">
-  <enabled>#{env['GRADLE_ENTERPRISE_ACCESS_KEY']?.trim() > ''}</enabled>
+  <!-- Enable Gradle Enterprise extension when GRADLE_ENTERPRISE_ACCESS_KEY is set and the build isn't
+       a pull request from a branch or forked repository with a name that indicates it's a work in progress. -->
+  <enabled>#{env['GRADLE_ENTERPRISE_ACCESS_KEY']?.trim() > '' and !(env['GITHUB_HEAD_REF']?.matches('(?i).*(experiment|wip|private).*') or env['GITHUB_REPOSITORY']?.matches('(?i).*(experiment|wip|private).*'))}</enabled>
   <server>
     <url>https://ge.apache.org</url>
     <allowUntrusted>false</allowUntrusted>


### PR DESCRIPTION
### Motivation & Modifications

- keep the Gradle Enterprise maven extension version up-to-date
- skip activating Gradle Enterprise maven extension for builds in GitHub Actions when the pull request branch or forked repository has a name that indicates it's a work in progress.
  - it's better not to clutter the GE server with unnecessary builds for experiments.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->