### PR TITLE
[improve][broker] Cache the internal writer when sent to system topic.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/TopicPoliciesSystemTopicClient.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/TopicPoliciesSystemTopicClient.java
@@ -30,6 +30,8 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.client.api.schema.SchemaDefinition;
+import org.apache.pulsar.client.internal.DefaultImplementation;
 import org.apache.pulsar.common.events.ActionType;
 import org.apache.pulsar.common.events.PulsarEvent;
 import org.apache.pulsar.common.naming.TopicName;
@@ -41,13 +43,17 @@ import org.slf4j.LoggerFactory;
  */
 public class TopicPoliciesSystemTopicClient extends SystemTopicClientBase<PulsarEvent> {
 
+    static Schema<PulsarEvent> avroSchema = DefaultImplementation.getDefaultImplementation()
+            .newAvroSchema(SchemaDefinition.builder().withPojo(PulsarEvent.class).build());
+
     public TopicPoliciesSystemTopicClient(PulsarClient client, TopicName topicName) {
         super(client, topicName);
+
     }
 
     @Override
     protected  CompletableFuture<Writer<PulsarEvent>> newWriterAsyncInternal() {
-        return client.newProducer(Schema.AVRO(PulsarEvent.class))
+        return client.newProducer(avroSchema)
                 .topic(topicName.toString())
                 .enableBatching(false)
                 .createAsync()
@@ -61,7 +67,7 @@ public class TopicPoliciesSystemTopicClient extends SystemTopicClientBase<Pulsar
 
     @Override
     protected CompletableFuture<Reader<PulsarEvent>> newReaderAsyncInternal() {
-        return client.newReader(Schema.AVRO(PulsarEvent.class))
+        return client.newReader(avroSchema)
                 .topic(topicName.toString())
                 .startMessageId(MessageId.earliest)
                 .readCompacted(true)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
@@ -440,6 +440,7 @@ public class SystemTopicBasedTopicPoliciesServiceTest extends MockedPulsarServic
             admin.topics().createNonPartitionedTopic(topicName);
             pulsarClient.newProducer(Schema.STRING).topic(topicName).create().close();
         }
+        @Cleanup("shutdown")
         ExecutorService executorService = Executors.newFixedThreadPool(5);
         for (int i = 1; i <= 5; i ++) {
             int finalI = i;


### PR DESCRIPTION
Fixes #22087


### Motivation

Cache the internal writer when sent to system topic.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
