### PR TITLE
[fix][broker] Handle negative hashes safely in all Key_Shared selector implementations

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelector.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service;
 
+import static org.apache.pulsar.client.util.MathUtils.signSafeMod;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -124,7 +125,7 @@ public class ConsistentHashingStickyKeyConsumerSelector implements StickyKeyCons
                 consumerList = hashRing.firstEntry().getValue();
             }
 
-            return consumerList.get(hash % consumerList.size());
+            return consumerList.get(signSafeMod(hash, consumerList.size()));
         } finally {
             rwLock.readLock().unlock();
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeAutoSplitStickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeAutoSplitStickyKeyConsumerSelector.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service;
 
+import static org.apache.pulsar.client.util.MathUtils.signSafeMod;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -111,7 +112,7 @@ public class HashRangeAutoSplitStickyKeyConsumerSelector implements StickyKeyCon
     @Override
     public Consumer select(int hash) {
         if (!rangeMap.isEmpty()) {
-            int slot = hash % rangeSize;
+            int slot = signSafeMod(hash, rangeSize);
             return rangeMap.ceilingEntry(slot).getValue();
         } else {
             return null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelector.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service;
 
+import static org.apache.pulsar.client.util.MathUtils.signSafeMod;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -103,7 +104,7 @@ public class HashRangeExclusiveStickyKeyConsumerSelector implements StickyKeyCon
     @Override
     public Consumer select(int hash) {
         if (rangeMap.size() > 0) {
-            int slot = hash % rangeSize;
+            int slot = signSafeMod(hash, rangeSize);
             Map.Entry<Integer, Consumer> ceilingEntry = rangeMap.ceilingEntry(slot);
             Map.Entry<Integer, Consumer> floorEntry = rangeMap.floorEntry(slot);
             Consumer ceilingConsumer = ceilingEntry != null ? ceilingEntry.getValue() : null;


### PR DESCRIPTION
### Motivation

A hash could be negative. A "sign safe modulo" calculation must be used instead of modulo alone.

### Modifications

- Use `MathUtils.signSafeMod` to handle the operation since it does the right thing.

### Additional Context

* In ConsistentHashingStickyKeyConsumerSelector, there is hardly any impact after #22053 since hash collisions are very rare. It would be an `IndexOutOfBoundsException` in a problem case.
* In HashRangeAutoSplitStickyKeyConsumerSelector and HashRangeExclusiveStickyKeyConsumerSelector, it's possible that negative hashes could cause skewed results.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->