### PR TITLE
[improve][ci] Upgrade codecov-action version

### DIFF
--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -51,7 +51,7 @@ runs:
     - name: "Upload to Codecov (attempt #1)"
       id: codecov-upload-1
       if: steps.repo-check.outputs.passed == 'true'
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       continue-on-error: true
       with:
         flags: ${{ inputs.flags }}
@@ -64,7 +64,7 @@ runs:
     - name: "Upload to Codecov (attempt #2)"
       id: codecov-upload-2
       if: steps.codecov-upload-1.outcome == 'failure'
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       continue-on-error: true
       with:
         flags: ${{ inputs.flags }}
@@ -77,7 +77,7 @@ runs:
     - name: "Upload to Codecov (attempt #3)"
       id: codecov-upload-3
       if: steps.codecov-upload-2.outcome == 'failure'
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       # fail on last attempt
       continue-on-error: false
       with:


### PR DESCRIPTION
### Motivation

In GitHub Actions workflows there's a warning about codecov-action@v3:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: codecov/codecov-action@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

### Modifications

- upgrade codecov-action to v4

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->