### PR TITLE
[bug][fn] Prevent `putstate` uses empty values

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1240,8 +1240,10 @@ public abstract class ComponentImpl implements Component<PulsarWorkerService> {
                     || state.getByteValue().length == 0)) {
                 data = ByteBuffer.allocate(Long.BYTES);
                 data.putLong(state.getNumberValue());
-            } else {
+            } else if (state.getByteValue() != null) {
                 data = ByteBuffer.wrap(state.getByteValue());
+            } else {
+                throw new IllegalArgumentException("Invalid state value");
             }
             store.put(key, data);
         } catch (Throwable e) {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1235,7 +1235,7 @@ public abstract class ComponentImpl implements Component<PulsarWorkerService> {
             DefaultStateStore store = worker().getStateStoreProvider().getStateStore(tenant, namespace, functionName);
             ByteBuffer data;
             if (state.getByteValue() == null || state.getByteValue().length == 0) {
-                if (StringUtils.isNotEmpty(state.getStringValue())) {
+                if (state.getStringValue() != null) {
                     data = ByteBuffer.wrap(state.getStringValue().getBytes(UTF_8));
                 }  else if (state.getNumberValue() != null) {
                     data = ByteBuffer.allocate(Long.BYTES);

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1236,7 +1236,8 @@ public abstract class ComponentImpl implements Component<PulsarWorkerService> {
             ByteBuffer data;
             if (state.getStringValue() != null && StringUtils.isNotEmpty(state.getStringValue())) {
                 data = ByteBuffer.wrap(state.getStringValue().getBytes(UTF_8));
-            }  else if (state.getNumberValue() != null) {
+            }  else if (state.getNumberValue() != null && (state.getByteValue() == null
+                    || state.getByteValue().length == 0)) {
                 data = ByteBuffer.allocate(Long.BYTES);
                 data.putLong(state.getNumberValue());
             } else {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1234,16 +1234,17 @@ public abstract class ComponentImpl implements Component<PulsarWorkerService> {
         try {
             DefaultStateStore store = worker().getStateStoreProvider().getStateStore(tenant, namespace, functionName);
             ByteBuffer data;
-            if (StringUtils.isNotEmpty(state.getStringValue())) {
-                data = ByteBuffer.wrap(state.getStringValue().getBytes(UTF_8));
-            }  else if (state.getNumberValue() != null && (state.getByteValue() == null
-                    || state.getByteValue().length == 0)) {
-                data = ByteBuffer.allocate(Long.BYTES);
-                data.putLong(state.getNumberValue());
-            } else if (state.getByteValue() != null) {
-                data = ByteBuffer.wrap(state.getByteValue());
+            if (state.getByteValue() == null || state.getByteValue().length == 0) {
+                if (StringUtils.isNotEmpty(state.getStringValue())) {
+                    data = ByteBuffer.wrap(state.getStringValue().getBytes(UTF_8));
+                }  else if (state.getNumberValue() != null) {
+                    data = ByteBuffer.allocate(Long.BYTES);
+                    data.putLong(state.getNumberValue());
+                } else {
+                    throw new IllegalArgumentException("Invalid state value");
+                }
             } else {
-                throw new IllegalArgumentException("Invalid state value");
+                data = ByteBuffer.wrap(state.getByteValue());
             }
             store.put(key, data);
         } catch (Throwable e) {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1234,15 +1234,13 @@ public abstract class ComponentImpl implements Component<PulsarWorkerService> {
         try {
             DefaultStateStore store = worker().getStateStoreProvider().getStateStore(tenant, namespace, functionName);
             ByteBuffer data;
-            if (state.getStringValue() != null) {
+            if (state.getStringValue() != null && StringUtils.isNotEmpty(state.getStringValue())) {
                 data = ByteBuffer.wrap(state.getStringValue().getBytes(UTF_8));
-            } else if (state.getByteValue() != null) {
-                data = ByteBuffer.wrap(state.getByteValue());
-            } else if (state.getNumberValue() != null) {
+            }  else if (state.getNumberValue() != null) {
                 data = ByteBuffer.allocate(Long.BYTES);
                 data.putLong(state.getNumberValue());
             } else {
-                throw new IllegalArgumentException("Invalid state value");
+                data = ByteBuffer.wrap(state.getByteValue());
             }
             store.put(key, data);
         } catch (Throwable e) {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1234,7 +1234,7 @@ public abstract class ComponentImpl implements Component<PulsarWorkerService> {
         try {
             DefaultStateStore store = worker().getStateStoreProvider().getStateStore(tenant, namespace, functionName);
             ByteBuffer data;
-            if (state.getStringValue() != null && StringUtils.isNotEmpty(state.getStringValue())) {
+            if (StringUtils.isNotEmpty(state.getStringValue())) {
                 data = ByteBuffer.wrap(state.getStringValue().getBytes(UTF_8));
             }  else if (state.getNumberValue() != null && (state.getByteValue() == null
                     || state.getByteValue().length == 0)) {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
@@ -112,6 +112,12 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         String expectNumber = "\"numberValue\": 20";
         putAndQueryState(functionName, "test-number", numberState, expectNumber);
 
+        byte[] valueBytes = Base64.getDecoder().decode(VALUE_BASE64);
+        String bytesString = Base64.getEncoder().encodeToString(valueBytes);
+        String byteState = "{\"key\":\"test-bytes\",\"byteValue\":\"" + bytesString + "\"}";
+        String expectBytes = "\"byteValue\": \"" + bytesString + "\"";
+        putAndQueryState(functionName, "test-bytes", byteState, expectBytes);
+
         // delete function
         deleteFunction(functionName);
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
@@ -109,14 +109,20 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         String expect = "\"stringValue\": \"test value\"";
         putAndQueryState(functionName, "test-string", state, expect);
 
-//        String numberState = "{\"key\":\"test-number\",\"numberValue\":20}";
-//        String expectNumber = "\"numberValue\": 20";
-//        putAndQueryState(functionName, "test-number", numberState, expectNumber);
+        String numberState = "{\"key\":\"test-number\",\"numberValue\":20}";
+        String expectNumber = "\"numberValue\": 20";
+        putAndQueryState(functionName, "test-number", numberState, expectNumber);
 
         byte[] valueBytes = Base64.getDecoder().decode(VALUE_BASE64);
         String bytesString = Base64.getEncoder().encodeToString(valueBytes);
         String byteState = "{\"key\":\"test-bytes\",\"byteValue\":\"" + bytesString + "\"}";
         putAndQueryStateByte(functionName, "test-bytes", byteState, valueBytes);
+
+        String valueStr = "hello pulsar";
+        byte[] valueStrBytes = valueStr.getBytes(UTF_8);
+        String bytesStrString = Base64.getEncoder().encodeToString(valueStrBytes);
+        String byteStrState = "{\"key\":\"test-str-bytes\",\"byteValue\":\"" + bytesStrString + "\"}";
+        putAndQueryState(functionName, "test-str-bytes", byteStrState, valueStr);
 
         // delete function
         deleteFunction(functionName);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
@@ -124,6 +124,9 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         String byteStrState = "{\"key\":\"test-str-bytes\",\"byteValue\":\"" + bytesStrString + "\"}";
         putAndQueryState(functionName, "test-str-bytes", byteStrState, valueStr);
 
+        String byteStrStateWithEmptyValues = "{\"key\":\"test-str-bytes\",\"byteValue\":\"" + bytesStrString + "\",\"stringValue\":\"\",\"numberValue\":0}";
+        putAndQueryState(functionName, "test-str-bytes", byteStrStateWithEmptyValues, valueStr);
+
         // delete function
         deleteFunction(functionName);
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarStateTest.java
@@ -109,12 +109,13 @@ public class PulsarStateTest extends PulsarStandaloneTestSuite {
         String expect = "\"stringValue\": \"test value\"";
         putAndQueryState(functionName, "test-string", state, expect);
 
-        String numberState = "{\"key\":\"test-number\",\"numberValue\":20}";
-        String expectNumber = "\"numberValue\": 20";
-        putAndQueryState(functionName, "test-number", numberState, expectNumber);
+//        String numberState = "{\"key\":\"test-number\",\"numberValue\":20}";
+//        String expectNumber = "\"numberValue\": 20";
+//        putAndQueryState(functionName, "test-number", numberState, expectNumber);
 
-        String byteState = "{\"key\":\"test-bytes\",\"byteValue\":\"" + VALUE_BASE64 + "\"}";
         byte[] valueBytes = Base64.getDecoder().decode(VALUE_BASE64);
+        String bytesString = Base64.getEncoder().encodeToString(valueBytes);
+        String byteState = "{\"key\":\"test-bytes\",\"byteValue\":\"" + bytesString + "\"}";
         putAndQueryStateByte(functionName, "test-bytes", byteState, valueBytes);
 
         // delete function


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes https://github.com/apache/pulsar/issues/22126

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

When submitting the `putstate` requests with other libs such as pulsar-admin-go, the `FunctionState` JSON string may contain the default value of string or int, so the functions worker may use an incorrect value when the user submits with `bytesString`. See https://github.com/apache/pulsar-client-go/issues/1184 for more details.

### Modifications

<!-- Describe the modifications you've done. -->

- Fix the logic
- Add more tests

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/freeznet/pulsar/pull/10

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
