### PR TITLE
[improve][ci] Run CodeQL within Pulsar CI workflow as mandatory check

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -22,9 +22,6 @@ name: "CodeQL"
 on:
   push:
     branches: [ 'master' ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ 'master' ]
   schedule:
     - cron: '27 21 * * 4'
   workflow_dispatch:
@@ -36,8 +33,7 @@ concurrency:
 jobs:
   analyze:
     # only run scheduled analysis in apache/pulsar repository
-    # and only run pull request analysis for pull requests that aren't from forks since otherwise there isn't write access for writing the CodeQL results
-    if: ${{ (github.event_name == 'schedule' && github.repository == 'apache/pulsar') || github.event_name != 'schedule' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login) || github.event_name != 'pull_request' }}
+    if: ${{ (github.event_name == 'schedule' && github.repository == 'apache/pulsar') || github.event_name != 'schedule' }}
     name: Analyze
     runs-on: 'ubuntu-latest'
     timeout-minutes: 360

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -35,7 +35,9 @@ concurrency:
 
 jobs:
   analyze:
-    if: ${{ (github.event_name != 'schedule' || github.repository != 'apache/pulsar') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'apache') }}
+    # only run scheduled analysis in apache/pulsar repository
+    # and only run pull request analysis for pull requests that aren't from forks since otherwise there isn't write access for writing the CodeQL results
+    if: ${{ (github.event_name == 'schedule' && github.repository == 'apache/pulsar') || github.event_name != 'schedule' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login) || github.event_name != 'pull_request' }}
     name: Analyze
     runs-on: 'ubuntu-latest'
     timeout-minutes: 360

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -27,9 +27,15 @@ on:
     branches: [ 'master' ]
   schedule:
     - cron: '27 21 * * 4'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
 
 jobs:
   analyze:
+    if: ${{ (github.event_name != 'schedule' || github.repository != 'apache/pulsar') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'apache') }}
     name: Analyze
     runs-on: 'ubuntu-latest'
     timeout-minutes: 360

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -22,6 +22,8 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
+      - pulsar-*
   schedule:
     # scheduled job with JDK 17
     - cron: '0 12 * * *'

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -22,6 +22,8 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
+      - pulsar-*
   schedule:
     # scheduled job with JDK 17
     - cron: '0 12 * * *'

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -1333,6 +1333,71 @@ jobs:
       - name: build package
         run: mvn -B clean package -DskipTests -T 1C -ntp
 
+  codeql:
+    name: Run CodeQL Analysis
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    needs: ['preconditions', 'unit-tests']
+    if: ${{ needs.preconditions.outputs.docs_only != 'true' && (github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name != 'pull_request' && github.ref_name == 'master') }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    env:
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
+      CODEQL_LANGUAGE: java-kotlin
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
+      - name: Clean Disk when needed
+        if: ${{ matrix.clean_disk }}
+        uses: ./.github/actions/clean-disk
+
+      - name: Setup ssh access to build runner VM
+        # ssh access is enabled for builds in own forks
+        if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'pull_request' }}
+        uses: ./.github/actions/ssh-access
+        continue-on-error: true
+        with:
+          limit-access-to-actor: true
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v4
+        timeout-minutes: 5
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/pulsar
+          key: ${{ runner.os }}-m2-dependencies-all-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-dependencies-core-modules-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-dependencies-core-modules-
+
+      - name: Set up JDK ${{ env.CI_JDK_MAJOR_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ env.CODEQL_LANGUAGE }}
+
+      - name: Build Java code
+        run: |
+          mvn -B -ntp -Pcore-modules,-main install -DskipTests -Dlicense.skip=true -Drat.skip=true -Dcheckstyle.skip=true
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ env.CODEQL_LANGUAGE }}"
+
   owasp-dep-check:
     name: OWASP dependency check
     runs-on: ubuntu-22.04
@@ -1445,6 +1510,7 @@ jobs:
       'integration-tests-upload-coverage',
       'system-tests-upload-coverage',
       'owasp-dep-check'
+      'codeql'
     ]
     steps:
       - name: Check that all required jobs were completed successfully
@@ -1455,6 +1521,7 @@ jobs:
                 && "${{ needs.integration-tests.result }}" == "success" \
                 && "${{ needs.system-tests.result }}" == "success" \
                 && "${{ needs.macos-build.result }}" == "success" \
+                && ( "${{ needs.codeql.result }}" == "success" || "${{ needs.codeql.result }}" == "skipped" ) \
                ) ]]; then
             echo "Required jobs haven't been completed successfully."
             exit 1

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -1496,7 +1496,7 @@ jobs:
   # It cleans up the binaries in the same job in order to not spin up another runner for basically doing nothing.
   pulsar-ci-checks-completed:
     name: "Pulsar CI checks completed"
-    if: ${{ always() && needs.preconditions.result == "success" }}
+    if: ${{ always() && needs.preconditions.result == 'success' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     needs: [

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -1338,7 +1338,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     needs: ['preconditions', 'unit-tests']
-    if: ${{ needs.preconditions.outputs.docs_only != 'true' && (github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name != 'pull_request' && github.ref_name == 'master') }}
+    if: ${{ needs.preconditions.outputs.docs_only != 'true' && ((github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name != 'pull_request' && github.ref_name == 'master')) }}
     permissions:
       actions: read
       contents: read
@@ -1496,7 +1496,7 @@ jobs:
   # It cleans up the binaries in the same job in order to not spin up another runner for basically doing nothing.
   pulsar-ci-checks-completed:
     name: "Pulsar CI checks completed"
-    if: ${{ always() && ((github.event_name != 'schedule') || (github.repository == 'apache/pulsar')) }}
+    if: ${{ always() && needs.preconditions.result == "success" }}
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     needs: [
@@ -1509,7 +1509,7 @@ jobs:
       'unit-tests-upload-coverage',
       'integration-tests-upload-coverage',
       'system-tests-upload-coverage',
-      'owasp-dep-check'
+      'owasp-dep-check',
       'codeql'
     ]
     steps:


### PR DESCRIPTION
### Motivation & Modifications

Improvements to CI:
- run CodeQL within Pulsar CI workflow for PRs
  - This ensures that the PR cannot be merged unless the CodeQL step passes
- don't run CodeQL scheduled build for forked repositories
- enable Pulsar CI for branches
  - for some reason CI didn't run for this PR in branch-3.0: #22130
- cancel duplicate builds running CodeQL

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->