### PR TITLE
[improve][ci] Only run CodeQL when the PR contains changes to non-test java code

### DIFF
--- a/.github/changes-filter.yaml
+++ b/.github/changes-filter.yaml
@@ -12,6 +12,8 @@ docs:
   - 'deployment/**'
   - 'wiki/**'
   - 'pip/**'
+java_non_tests:
+  - '**/src/main/java/**/*.java'
 tests:
   - added|modified: '**/src/test/java/**/*.java'
 need_owasp:

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -81,7 +81,7 @@ jobs:
       need_owasp: ${{ steps.changes.outputs.need_owasp }}
       collect_coverage: ${{ steps.check_coverage.outputs.collect_coverage }}
       jdk_major_version: ${{ steps.jdk_major_version.outputs.jdk_major_version }}
-
+      java_non_tests: ${{ steps.changes.outputs.java_non_tests }}
     steps:
       - name: Cancel scheduled jobs in forks by default
         if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'schedule' }}
@@ -1338,7 +1338,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     needs: ['preconditions', 'unit-tests']
-    if: ${{ needs.preconditions.outputs.docs_only != 'true' && ((github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name != 'pull_request' && github.ref_name == 'master')) }}
+    if: ${{ (needs.preconditions.outputs.java_non_tests == 'true' || github.event_name != 'pull_request') && ((github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name != 'pull_request' && github.ref_name == 'master')) }}
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
### Motivation

For Pull Requests, running CodeQL isn't necessary when there isn't changes to production (non-test) java code.

### Modifications

Only run CodeQL when the PR contains changes to files matching `**/src/main/java/**/*.java`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->