### PR TITLE
[improve][broker] Change log level to reduce duplicated logs

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -202,8 +202,9 @@ public class LinuxInfoUtils {
             // wireless NICs don't report speed, ignore them.
             return Integer.parseInt(type) == ARPHRD_ETHER;
         } catch (Exception e) {
-            log.warn("[LinuxInfo] Failed to read {} NIC type, the detail is: {}", nicPath, e.getMessage());
-            // Read type got error.
+            if (log.isDebugEnabled()) {
+                log.debug("[LinuxInfo] Failed to read {} NIC type, the detail is: {}", nicPath, e.getMessage());
+            }
             return false;
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -199,7 +199,7 @@ public class LinuxInfoUtils {
             }
             // Check the type to make sure it's ethernet (type "1")
             final Path nicTypePath = nicPath.resolve("type");
-            if(!Files.exists(nicTypePath)) {
+            if (!Files.exists(nicTypePath)) {
                 if (log.isDebugEnabled()) {
                     log.debug("Failed to read NIC type, the expected linux type file does not exist."
                               + " nic_type_path={}", nicTypePath);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -210,7 +210,7 @@ public class LinuxInfoUtils {
             return Integer.parseInt(readTrimStringFromFile(nicTypePath)) == ARPHRD_ETHER;
         } catch (Exception ex) {
             if (log.isDebugEnabled()) {
-                log.debug("Failed to read nic type. nic_path={}", nicPath, ex);
+                log.debug("Failed to read NIC type. nic_path={}", nicPath, ex);
             }
             return false;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -198,12 +198,19 @@ public class LinuxInfoUtils {
                 return false;
             }
             // Check the type to make sure it's ethernet (type "1")
-            String type = readTrimStringFromFile(nicPath.resolve("type"));
+            final Path nicTypePath = nicPath.resolve("type");
+            if(!Files.exists(nicTypePath)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Failed to read NIC type, the expected linux type file does not exist."
+                              + " nic_type_path={}", nicTypePath);
+                }
+               return false;
+            }
             // wireless NICs don't report speed, ignore them.
-            return Integer.parseInt(type) == ARPHRD_ETHER;
-        } catch (Exception e) {
+            return Integer.parseInt(readTrimStringFromFile(nicTypePath)) == ARPHRD_ETHER;
+        } catch (Exception ex) {
             if (log.isDebugEnabled()) {
-                log.debug("[LinuxInfo] Failed to read {} NIC type, the detail is: {}", nicPath, e.getMessage());
+                log.debug("Failed to read nic type. nic_path={}", nicPath, ex);
             }
             return false;
         }


### PR DESCRIPTION
### Motivation

Some vendors' environments do not support reading virtual NIC type. The broker will constantly print the useless warning log, which will increase the storage cost.  

The demo logs is as follows:

```
[pulsar-load-manager-1-1] WARN  org.apache.pulsar.broker.loadbalance.LinuxInfoUtils - [LinuxInfo] Failed to read /sys/class/net/nc1 NIC type, the detail is: /sys/class/net/nc1/type: Not a directory
[pulsar-load-manager-1-1] WARN  org.apache.pulsar.broker.loadbalance.LinuxInfoUtils - [LinuxInfo] Failed to read /sys/class/net/nc1 NIC type, the detail is: /sys/class/net/nc1/type: Not a directory
[pulsar-load-manager-1-1] WARN  org.apache.pulsar.broker.loadbalance.LinuxInfoUtils - [LinuxInfo] Failed to read /sys/class/net/nc1 NIC type, the detail is: /sys/class/net/nc1/type: Not a directory
```

### Modifications

- Because this is the judgement of boolean. It's okay to move the log to be debug level.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->