### PR TITLE
[fix][broker][branch-3.0] Return getOwnerAsync without waiting on source broker upon Assigning and Releasing and handle role change during role init (#22112)

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -777,8 +777,13 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
         log.info("This broker:{} is setting the role from {} to {}",
                 pulsar.getBrokerId(), role, Leader);
         int retry = 0;
+        boolean becameFollower = false;
         while (!Thread.currentThread().isInterrupted()) {
             try {
+                if (!serviceUnitStateChannel.isChannelOwner()) {
+                    becameFollower = true;
+                    break;
+                }
                 initWaiter.await();
                 // Confirm the system topics have been created or create them if they do not exist.
                 // If the leader has changed, the new leader need to reset
@@ -802,6 +807,13 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
                 }
             }
         }
+
+        if (becameFollower) {
+            log.warn("The broker:{} became follower while initializing leader role.", pulsar.getBrokerId());
+            playFollower();
+            return;
+        }
+
         role = Leader;
         log.info("This broker:{} plays the leader now.", pulsar.getBrokerId());
 
@@ -815,8 +827,13 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
         log.info("This broker:{} is setting the role from {} to {}",
                 pulsar.getBrokerId(), role, Follower);
         int retry = 0;
+        boolean becameLeader = false;
         while (!Thread.currentThread().isInterrupted()) {
             try {
+                if (serviceUnitStateChannel.isChannelOwner()) {
+                    becameLeader = true;
+                    break;
+                }
                 initWaiter.await();
                 unloadScheduler.close();
                 serviceUnitStateChannel.cancelOwnershipMonitor();
@@ -836,6 +853,13 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
                 }
             }
         }
+
+        if (becameLeader) {
+            log.warn("This broker:{} became leader while initializing follower role.", pulsar.getBrokerId());
+            playLeader();
+            return;
+        }
+
         role = Follower;
         log.info("This broker:{} plays a follower now.", pulsar.getBrokerId());
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.broker.loadbalance.extensions;
 
+import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Releasing;
+import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelTest.overrideTableView;
 import static org.apache.pulsar.broker.loadbalance.extensions.models.SplitDecision.Reason.Admin;
 import static org.apache.pulsar.broker.loadbalance.extensions.models.SplitDecision.Reason.Bandwidth;
 import static org.apache.pulsar.broker.loadbalance.extensions.models.SplitDecision.Reason.MsgRate;
@@ -70,6 +72,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
@@ -78,6 +81,7 @@ import org.apache.pulsar.broker.loadbalance.LeaderBroker;
 import org.apache.pulsar.broker.loadbalance.LeaderElectionService;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelImpl;
+import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateData;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLoadData;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.loadbalance.extensions.data.TopBundlesLoadData;
@@ -95,12 +99,14 @@ import org.apache.pulsar.broker.namespace.LookupOptions;
 import org.apache.pulsar.broker.namespace.NamespaceBundleOwnershipListener;
 import org.apache.pulsar.broker.namespace.NamespaceEphemeralData;
 import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.impl.TableViewImpl;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.ServiceUnitId;
+import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.naming.TopicVersion;
 import org.apache.pulsar.common.policies.data.BrokerAssignment;
@@ -775,7 +781,6 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
             reset();
             return null;
         }).when(topBundlesLoadDataStorePrimarySpy).closeTableView();
-        FieldUtils.writeDeclaredField(primaryLoadManager, "topBundlesLoadDataStore", topBundlesLoadDataStorePrimarySpy, true);
 
         var topBundlesLoadDataStoreSecondary = (LoadDataStore<TopBundlesLoadData>)
                 FieldUtils.readDeclaredField(secondaryLoadManager, "topBundlesLoadDataStore", true);
@@ -798,36 +803,65 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
             reset();
             return null;
         }).when(topBundlesLoadDataStoreSecondarySpy).closeTableView();
-        FieldUtils.writeDeclaredField(secondaryLoadManager, "topBundlesLoadDataStore", topBundlesLoadDataStoreSecondarySpy, true);
 
-        if (channel1.isChannelOwnerAsync().get(5, TimeUnit.SECONDS)) {
-            primaryLoadManager.playFollower(); // close 3 times
-            primaryLoadManager.playFollower(); // close 1 time
-            secondaryLoadManager.playLeader();
-            secondaryLoadManager.playLeader();
-            primaryLoadManager.playLeader(); // close 3 times and open 3 times
-            primaryLoadManager.playLeader(); // close 1 time and open 1 time,
-            secondaryLoadManager.playFollower();
-            secondaryLoadManager.playFollower();
-        } else {
-            primaryLoadManager.playLeader();
-            primaryLoadManager.playLeader();
-            secondaryLoadManager.playFollower();
-            secondaryLoadManager.playFollower();
+        try {
+            FieldUtils.writeDeclaredField(primaryLoadManager, "topBundlesLoadDataStore",
+                    topBundlesLoadDataStorePrimarySpy, true);
+            FieldUtils.writeDeclaredField(secondaryLoadManager, "topBundlesLoadDataStore",
+                    topBundlesLoadDataStoreSecondarySpy, true);
+
+
+            if (channel1.isChannelOwnerAsync().get(5, TimeUnit.SECONDS)) {
+                primaryLoadManager.playLeader();
+                secondaryLoadManager.playFollower();
+                verify(topBundlesLoadDataStorePrimarySpy, times(3)).startTableView();
+                verify(topBundlesLoadDataStorePrimarySpy, times(5)).closeTableView();
+                verify(topBundlesLoadDataStoreSecondarySpy, times(0)).startTableView();
+                verify(topBundlesLoadDataStoreSecondarySpy, times(3)).closeTableView();
+            } else {
+                primaryLoadManager.playFollower();
+                secondaryLoadManager.playLeader();
+                verify(topBundlesLoadDataStoreSecondarySpy, times(3)).startTableView();
+                verify(topBundlesLoadDataStoreSecondarySpy, times(5)).closeTableView();
+                verify(topBundlesLoadDataStorePrimarySpy, times(0)).startTableView();
+                verify(topBundlesLoadDataStorePrimarySpy, times(3)).closeTableView();
+            }
+
             primaryLoadManager.playFollower();
-            primaryLoadManager.playFollower();
+            secondaryLoadManager.playFollower();
+
+            if (channel1.isChannelOwnerAsync().get(5, TimeUnit.SECONDS)) {
+                assertEquals(ExtensibleLoadManagerImpl.Role.Leader,
+                        FieldUtils.readDeclaredField(primaryLoadManager, "role", true));
+                assertEquals(ExtensibleLoadManagerImpl.Role.Follower,
+                        FieldUtils.readDeclaredField(secondaryLoadManager, "role", true));
+            } else {
+                assertEquals(ExtensibleLoadManagerImpl.Role.Follower,
+                        FieldUtils.readDeclaredField(primaryLoadManager, "role", true));
+                assertEquals(ExtensibleLoadManagerImpl.Role.Leader,
+                        FieldUtils.readDeclaredField(secondaryLoadManager, "role", true));
+            }
+
+            primaryLoadManager.playLeader();
             secondaryLoadManager.playLeader();
-            secondaryLoadManager.playLeader();
+
+            if (channel1.isChannelOwnerAsync().get(5, TimeUnit.SECONDS)) {
+                assertEquals(ExtensibleLoadManagerImpl.Role.Leader,
+                        FieldUtils.readDeclaredField(primaryLoadManager, "role", true));
+                assertEquals(ExtensibleLoadManagerImpl.Role.Follower,
+                        FieldUtils.readDeclaredField(secondaryLoadManager, "role", true));
+            } else {
+                assertEquals(ExtensibleLoadManagerImpl.Role.Follower,
+                        FieldUtils.readDeclaredField(primaryLoadManager, "role", true));
+                assertEquals(ExtensibleLoadManagerImpl.Role.Leader,
+                        FieldUtils.readDeclaredField(secondaryLoadManager, "role", true));
+            }
+        } finally {
+            FieldUtils.writeDeclaredField(primaryLoadManager, "topBundlesLoadDataStore",
+                    topBundlesLoadDataStorePrimary, true);
+            FieldUtils.writeDeclaredField(secondaryLoadManager, "topBundlesLoadDataStore",
+                    topBundlesLoadDataStoreSecondary, true);
         }
-
-
-        verify(topBundlesLoadDataStorePrimarySpy, times(4)).startTableView();
-        verify(topBundlesLoadDataStorePrimarySpy, times(8)).closeTableView();
-        verify(topBundlesLoadDataStoreSecondarySpy, times(4)).startTableView();
-        verify(topBundlesLoadDataStoreSecondarySpy, times(8)).closeTableView();
-
-        FieldUtils.writeDeclaredField(primaryLoadManager, "topBundlesLoadDataStore", topBundlesLoadDataStorePrimary, true);
-        FieldUtils.writeDeclaredField(secondaryLoadManager, "topBundlesLoadDataStore", topBundlesLoadDataStoreSecondary, true);
     }
 
     @Test
@@ -1233,6 +1267,32 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
                 });
     }
 
+    @Test(timeOut = 10 * 1000)
+    public void unloadTimeoutCheckTest()
+            throws Exception {
+        Pair<TopicName, NamespaceBundle> topicAndBundle = getBundleIsNotOwnByChangeEventTopic("unload-timeout");
+        String topic = topicAndBundle.getLeft().toString();
+        var bundle = topicAndBundle.getRight().toString();
+        var releasing = new ServiceUnitStateData(Releasing, pulsar2.getBrokerId(), pulsar1.getBrokerId(), 1);
+        overrideTableView(channel1, bundle, releasing);
+        var topicFuture = pulsar1.getBrokerService().getOrCreateTopic(topic);
+
+
+        try {
+            topicFuture.get(1, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.info("getOrCreateTopic failed", e);
+            if (!(e.getCause() instanceof BrokerServiceException.ServiceUnitNotReadyException && e.getMessage()
+                    .contains("Please redo the lookup"))) {
+                fail();
+            }
+        }
+
+        pulsar1.getBrokerService()
+                .unloadServiceUnit(topicAndBundle.getRight(), true, 5,
+                        TimeUnit.SECONDS).get(2, TimeUnit.SECONDS);
+    }
+
     private static abstract class MockBrokerFilter implements BrokerFilter {
 
         @Override
@@ -1264,5 +1324,21 @@ public class ExtensibleLoadManagerImplTest extends MockedPulsarServiceBaseTest {
 
     private CompletableFuture<NamespaceBundle> getBundleAsync(PulsarService pulsar, TopicName topic) {
         return pulsar.getNamespaceService().getBundleAsync(topic);
+    }
+
+    private Pair<TopicName, NamespaceBundle> getBundleIsNotOwnByChangeEventTopic(String topicNamePrefix)
+            throws Exception {
+        TopicName changeEventsTopicName =
+                TopicName.get(defaultTestNamespace + "/" + SystemTopicNames.NAMESPACE_EVENTS_LOCAL_NAME);
+        NamespaceBundle changeEventsBundle = getBundleAsync(pulsar1, changeEventsTopicName).get();
+        int i = 0;
+        while (true) {
+            TopicName topicName = TopicName.get(defaultTestNamespace + "/" + topicNamePrefix + "-" + i);
+            NamespaceBundle bundle = getBundleAsync(pulsar1, topicName).get();
+            if (!bundle.equals(changeEventsBundle)) {
+                return Pair.of(topicName, bundle);
+            }
+            i++;
+        }
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
@@ -324,8 +324,8 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
         assertEquals(result.size(), NUM_BROKERS);
     }
 
-    @Test(timeOut = 40 * 1000)
-    public void testIsolationPolicy() throws PulsarAdminException {
+    @Test(timeOut = 300 * 1000)
+    public void testIsolationPolicy() throws Exception {
         final String namespaceIsolationPolicyName = "my-isolation-policy";
         final String isolationEnabledNameSpace = DEFAULT_TENANT + "/my-isolation-policy" + nsSuffix;
         Map<String, String> parameters1 = new HashMap<>();
@@ -334,7 +334,8 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
 
         Awaitility.await().atMost(10, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(
                 () -> {
-                    List<String> activeBrokers = admin.brokers().getActiveBrokers();
+                    List<String> activeBrokers = admin.brokers().getActiveBrokersAsync()
+                            .get(5, TimeUnit.SECONDS);
                     assertEquals(activeBrokers.size(), NUM_BROKERS);
                 }
         );
@@ -377,15 +378,16 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
             }
         }
 
-        Awaitility.await().atMost(30, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(
+        Awaitility.await().atMost(60, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(
                 () -> {
-                    List<String> activeBrokers = admin.brokers().getActiveBrokers();
+                    List<String> activeBrokers = admin.brokers().getActiveBrokersAsync()
+                            .get(5, TimeUnit.SECONDS);
                     assertEquals(activeBrokers.size(), 2);
                 }
         );
 
         Awaitility.await().atMost(60, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(() -> {
-            String ownerBroker = admin.lookups().lookupTopic(topic);
+            String ownerBroker = admin.lookups().lookupTopicAsync(topic).get(5, TimeUnit.SECONDS);
             assertEquals(extractBrokerIndex(ownerBroker), 1);
         });
 
@@ -396,20 +398,23 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
             }
         }
 
-        Awaitility.await().atMost(30, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(
+        Awaitility.await().atMost(60, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(
             () -> {
-                List<String> activeBrokers = admin.brokers().getActiveBrokers();
+                List<String> activeBrokers = admin.brokers().getActiveBrokersAsync().get(5, TimeUnit.SECONDS);
                 assertEquals(activeBrokers.size(), 1);
             }
         );
 
-        try {
-            admin.lookups().lookupTopic(topic);
-            fail();
-        } catch (Exception ex) {
-            log.error("Failed to lookup topic: ", ex);
-            assertThat(ex.getMessage()).contains("Failed to select the new owner broker for bundle");
-        }
+        Awaitility.await().atMost(60, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(
+                () -> {
+                    try {
+                        admin.lookups().lookupTopicAsync(topic).get(5, TimeUnit.SECONDS);
+                    } catch (Exception ex) {
+                        log.error("Failed to lookup topic: ", ex);
+                        assertThat(ex.getMessage()).contains("Failed to select the new owner broker for bundle");
+                    }
+                }
+        );
     }
 
     private String getBrokerUrl(int index) {


### PR DESCRIPTION

PR: https://github.com/apache/pulsar/pull/22112
(cherry picked from commit 56eb7589d7d1e427dd0ff8daaa5fbff0d097411d)
