### PR TITLE
[fix][txn] Fix PendingAckHandleImpl potential thread safety issue

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
@@ -78,7 +78,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
      *     If the position is batch position and it exits the map, will do operation `and` for this
      *     two positions bit set.
      */
-    private LinkedMap<TxnID, HashMap<PositionImpl, PositionImpl>> individualAckOfTransaction;
+    private volatile LinkedMap<TxnID, HashMap<PositionImpl, PositionImpl>> individualAckOfTransaction;
 
     /**
      * The map is for individual ack of positions for transaction.
@@ -98,7 +98,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
      *     <p>
      *         If it does not exits the map, the position will be added to the map.
      */
-    private ConcurrentSkipListMap<PositionImpl, MutablePair<PositionImpl, Integer>> individualAckPositions;
+    private volatile ConcurrentSkipListMap<PositionImpl, MutablePair<PositionImpl, Integer>> individualAckPositions;
 
     /**
      * The map is for transaction with position witch was cumulative acked by this transaction.
@@ -196,7 +196,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
         acceptQueue.add(() -> internalIndividualAcknowledgeMessage(txnID, positions, completableFuture));
     }
 
-    public void internalIndividualAcknowledgeMessage(TxnID txnID, List<MutablePair<PositionImpl, Integer>> positions,
+    private void internalIndividualAcknowledgeMessage(TxnID txnID, List<MutablePair<PositionImpl, Integer>> positions,
                                                      CompletableFuture<Void> completableFuture) {
         if (txnID == null) {
             completableFuture.completeExceptionally(new NotAllowedException("txnID can not be null."));
@@ -209,7 +209,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
         }
 
         this.pendingAckStoreFuture.thenAccept(pendingAckStore ->
-                pendingAckStore.appendIndividualAck(txnID, positions).thenAccept(v -> {
+                pendingAckStore.appendIndividualAck(txnID, positions).thenAcceptAsync(v -> {
                     synchronized (org.apache.pulsar.broker.transaction.pendingack.impl.PendingAckHandleImpl.this) {
                         for (MutablePair<PositionImpl, Integer> positionIntegerMutablePair : positions) {
 
@@ -285,7 +285,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
                         handleIndividualAck(txnID, positions);
                         completableFuture.complete(null);
                     }
-                }).exceptionally(e -> {
+                }, internalPinnedExecutor).exceptionallyAsync(e -> {
                     synchronized (PendingAckHandleImpl.this) {
                         // we also modify the in memory state when append fail,
                         // because we don't know the persistent state, when were replay it,
@@ -295,7 +295,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
                         completableFuture.completeExceptionally(e.getCause());
                     }
                     return null;
-                })).exceptionally(e -> {
+                }, internalPinnedExecutor)).exceptionally(e -> {
             completableFuture.completeExceptionally(e);
             return null;
         });
@@ -471,7 +471,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
             }
         } else {
             pendingAckStoreFuture.thenAccept(pendingAckStore ->
-                    pendingAckStore.appendCommitMark(txnID, AckType.Individual).thenAccept(v -> {
+                    pendingAckStore.appendCommitMark(txnID, AckType.Individual).thenAcceptAsync(v -> {
                         synchronized (PendingAckHandleImpl.this) {
                             if (individualAckOfTransaction != null && individualAckOfTransaction.containsKey(txnID)) {
                                 HashMap<PositionImpl, PositionImpl> pendingAckMessageForCurrentTxn =
@@ -487,7 +487,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
                                 commitFuture.complete(null);
                             }
                         }
-                    }).exceptionally(e -> {
+                    }, internalPinnedExecutor).exceptionally(e -> {
                         log.error("[{}] Transaction pending ack store commit txnId : [{}] fail!",
                                 topicName, txnID, e);
                         commitFuture.completeExceptionally(e.getCause());
@@ -536,7 +536,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
         acceptQueue.add(() -> internalAbortTxn(txnId, consumer, lowWaterMark, completableFuture));
     }
 
-    public CompletableFuture<Void> internalAbortTxn(TxnID txnId, Consumer consumer,
+    private CompletableFuture<Void> internalAbortTxn(TxnID txnId, Consumer consumer,
                                  long lowWaterMark, CompletableFuture<Void> abortFuture) {
         if (this.cumulativeAckOfTransaction != null) {
             pendingAckStoreFuture.thenAccept(pendingAckStore ->
@@ -564,7 +564,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
             });
         } else if (this.individualAckOfTransaction != null) {
             pendingAckStoreFuture.thenAccept(pendingAckStore ->
-                    pendingAckStore.appendAbortMark(txnId, AckType.Individual).thenAccept(v -> {
+                    pendingAckStore.appendAbortMark(txnId, AckType.Individual).thenAcceptAsync(v -> {
                         synchronized (PendingAckHandleImpl.this) {
                             HashMap<PositionImpl, PositionImpl> pendingAckMessageForCurrentTxn =
                                     individualAckOfTransaction.get(txnId);
@@ -582,7 +582,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
                                 abortFuture.complete(null);
                             }
                         }
-                    }).exceptionally(e -> {
+                    }, internalPinnedExecutor).exceptionally(e -> {
                         log.error("[{}] Transaction pending ack store abort txnId : [{}] fail!",
                                 topicName, txnId, e);
                         abortFuture.completeExceptionally(e);
@@ -921,7 +921,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
     }
 
     @Override
-    public TransactionPendingAckStats getStats(boolean lowWaterMarks) {
+    public synchronized TransactionPendingAckStats getStats(boolean lowWaterMarks) {
         TransactionPendingAckStats transactionPendingAckStats = new TransactionPendingAckStats();
         transactionPendingAckStats.state = this.getState().name();
         if (lowWaterMarks) {


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/21304

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

Fix PendingAckHandleImpl potential thread safety issue

### Modifications

1. Make all the access operations to `individualAckOfTransaction` is `sync` scope.
2. For MutablePair, make all the access operations in a single thread except `checkPositionInPendingAckState`, 'cause the method is for Admin API
3. Make `individualAckOfTransaction`, `individualAckPositions` volatile to prevent potential visibility issues
4. Use `internalPinnedExecutor` to prevent blocking bk client thread.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository:  https://github.com/dao-jun/pulsar/pull/10
