### PR TITLE
[improve][client] add externalListenerThreadName parameter

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -267,6 +267,20 @@ public interface ClientBuilder extends Serializable, Cloneable {
     ClientBuilder listenerThreads(int numListenerThreads);
 
     /**
+     * Sets the name for the message listener thread executor.
+     *
+     * <p>The application receives messages consumer through message listener thread,
+     * This option aim to overide the default thread name "pulsar-external-listener".
+     *
+     * @param externalListenerThreadName
+     *            thread name executor
+     * @return the consumer builder instance
+     */
+    ClientBuilder externalListenerThreadName(String externalListenerThreadName);
+
+
+
+    /**
      * Sets the max number of connection that the client library will open to a single broker.
      *
      * <p>By default, the connection pool will use a single connection for all the producers and consumers.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -106,6 +106,14 @@ public class ClientBuilderImpl implements ClientBuilder {
     }
 
     @Override
+    public ClientBuilder externalListenerThreadName(String externalListenerThreadName) {
+        checkArgument(StringUtils.isNotBlank(externalListenerThreadName),
+                "Param externalListenerThreadName must not be blank.");
+        conf.setExternalListenerThreadName(externalListenerThreadName);
+        return this;
+    }
+
+    @Override
     public ClientBuilder connectionMaxIdleSeconds(int connectionMaxIdleSeconds) {
         checkArgument(connectionMaxIdleSeconds < 0
                         || connectionMaxIdleSeconds >= ConnectionPool.IDLE_DETECTION_INTERVAL_SECONDS_MIN,

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -199,7 +199,7 @@ public class PulsarClientImpl implements PulsarClient {
                     connectionPool != null ? connectionPool : new ConnectionPool(conf, this.eventLoopGroup);
             this.cnxPool = connectionPoolReference;
             this.externalExecutorProvider = externalExecutorProvider != null ? externalExecutorProvider :
-                    new ExecutorProvider(conf.getNumListenerThreads(), "pulsar-external-listener");
+                    new ExecutorProvider(conf.getNumListenerThreads(), conf.getExternalListenerThreadName());
             this.internalExecutorProvider = internalExecutorProvider != null ? internalExecutorProvider :
                     new ExecutorProvider(conf.getNumIoThreads(), "pulsar-client-internal");
             this.scheduledExecutorProvider = scheduledExecutorProvider != null ? scheduledExecutorProvider :

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -116,6 +116,12 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private int numIoThreads = Runtime.getRuntime().availableProcessors();
 
     @ApiModelProperty(
+            name = "externalListenerThreadName",
+            value = "External Listener Pool Consumer name"
+    )
+    private String externalListenerThreadName = "pulsar-external-listener";
+
+    @ApiModelProperty(
             name = "numListenerThreads",
             value = "Number of consumer listener threads."
     )


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #22170

### Motivation

Add a configuration option in the client to set the external-listener-thread name.

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

Modified client configuration

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
- added a integration test to check the parameter is working

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
