### PR TITLE
[improve] [pip] PIP-344 Correct the behavior of the public API pulsarClient.getPartitionsForTopic(topicName)

### DIFF
--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -35,10 +35,8 @@ The param `create if not exists` of the Binary API is always `true.`
 
 # Goals
 
-Correct the behaviors of case 4 and case 5.
-
-- Do not create the partitioned metadata when calling `pulsarClient.getPartitionsForTopic`. The partitioned metadata will only be created when consumers/producers are trying to register.
-- Instead of returning a `0` partitioned metadata, respond to a not found error when calling `pulsarClient.getPartitionsForTopic` if the topic does not exist.
+- Regarding the case 4: Add a new API `PulsarClient.getPartitionsForTopic(String, boolean)` to support the feature that just get partitioned topic metadata and do not try to create one. See detail below.
+- Regarding the case 5: Instead of returning a `0` partitioned metadata, respond to a not found error when calling `pulsarClient.getPartitionsForTopic(String)` if the topic does not exist.
 
 # Detailed Design
 
@@ -58,6 +56,21 @@ CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicNam
 + CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName, boolean createIfAutoCreationEnabled);
 ```
 
+The behavior of the old API `LookupService.getPartitionedTopicMetadata(String)`.
+- It keeps the same behavior as before; in other words, it is the same as the case 1-4 below.
+
+The behavior of the new API `LookupService.getPartitionedTopicMetadata(TopicName, boolean)`.
+
+| case | client-side param: `createIfAutoCreationEnabled` | non-partitioned topic | partitioned topic                   | broker-side: topic auto-creation strategy                                                                          | current behavior                                                                            |
+|------|--------------------------------------------------|-----------------------|-------------------------------------|--------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
+| 1    | `true/false`                                     | `exists: true`        |                                     |                                                                                                                    | REST/Binary API: `{partitions: 0}`                                                          |
+| 2    | `true/false`                                     |                       | `exists: true` <br> `partitions: 2` |                                                                                                                    | REST/Binary API: `{partitions: 2}`                                                          |
+| 3    | `true`                                           |                       |                                     | `allowAutoTopicCreation`: `true` <be> `allowAutoTopicCreationType`: `non-partitioned`                              | REST/Binary API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `{partitions: 0}` |
+| 4    | `true`                                           |                       |                                     | `allowAutoTopicCreation`: `true` <be> `allowAutoTopicCreationType`: `partitioned` <br> `defaultNumPartitions`: `2` | REST/Binary API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `{partitions: 2}` |
+| 5    | `false`                                          |                       |                                     | `allowAutoTopicCreation`: `true`                                                                                   | REST/Binary API: <br> &nbsp;&nbsp;- Not found error                                         |
+| 6    | `true`                                           |                       |                                     | `allowAutoTopicCreation`: `false`                                                                                  | REST/Binary API: <br> &nbsp;&nbsp;- Not found error                                         |
+
+
 **PulsarClient.java**
 ```java
 // This API existed before. Not change it, thus ensuring compatibility.
@@ -68,16 +81,19 @@ CompletableFuture<List<String>> getPartitionsForTopic(String topic);
 + CompletableFuture<List<String>> getPartitionsForTopic(String topic, boolean createIfAutoCreationEnabled);
 ```
 
-The behavior of the old API `LookupService.getPartitionedTopicMetadata(TopicName)` and `PulsarClient.getPartitionsForTopic(String)`.
-- It keeps the same behavior as before; in other words, it also tries to create the partitioned topic metadata automatically.
+The behavior of the old API `PulsarClient.getPartitionsForTopic(String)`.
+- It keeps the same behavior as before; in other words, it is the same as the case 1-4 below.
 
-The behavior of the new API `LookupService.getPartitionedTopicMetadata(TopicName, boolean)` and `PulsarClient.getPartitionsForTopic(String, boolean)`.
-| case | `createIfAutoCreationEnabled` | non-partitioned topic | partitioned topic |  current behavior |
-| --- | --- | --- | --- | --- |
-| 1 | `true/false` | `exists: true` | | REST/Binary API: `partitions: 0` |
-| 2 | `true/false` | | `exists: true` <br> `partitions: 3` | REST/Binary API: `partitions: 3` |
-| 3 | `true` | | | REST/Binary API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` |
-| 4 | `false` | | | REST/Binary API: <br> &nbsp;&nbsp;- Not found error |
+The behavior of the new API `PulsarClient.getPartitionsForTopic(String, boolean)`.
+
+| case | client-side param: `createIfAutoCreationEnabled` | non-partitioned topic | partitioned topic                   | broker-side: topic autp-creation strategy                                                                          | current behavior                                                                                                                                |
+|------|--------------------------------------------------|----------------------|-------------------------------------|--------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1    | `true/false`                                     | `exists: true`       |                                     |                                                                                                                    | REST/Binary API: `["{tenat}/{ns}/topic"]`                                                                                                       |
+| 2    | `true/false`                                     |                      | `exists: true` <br> `partitions: 2` |                                                                                                                    | REST/Binary `API`: `["{tenat}/{ns}/topic-partition-0", "{tenat}/{ns}/topic-partition-1"]`                                                       |
+| 3    | `true`                                           |                      |                                     | `allowAutoTopicCreation`: `true` <be> `allowAutoTopicCreationType`: `non-partitioned`                              | REST/Binary API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `["{tenat}/{ns}/topic"]`                                              |
+| 4    | `true`                                           |                      |                                     | `allowAutoTopicCreation`: `true` <be> `allowAutoTopicCreationType`: `partitioned` <br> `defaultNumPartitions`: `2` | REST/Binary API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `["{tenat}/{ns}/topic-partition-0", "{tenat}/{ns}/topic-partition-1"]` |
+| 5    | `false`                                          |                      |                                     | `allowAutoTopicCreation`: `true`                                                                                   | REST/Binary API: <br> &nbsp;&nbsp;- Not found error                                                                                             |
+| 5    | `true`                                           |                      |                                     | `allowAutoTopicCreation`: `false`                                                                                  | REST/Binary API: <br> &nbsp;&nbsp;- Not found error                                                                                             |
 
 
 
@@ -99,15 +115,6 @@ message FeatureFlags {
 
 # Backward & Forward Compatibility
 
-- Old version client and New version Broker
-  - Pulsar will create the partitioned topic metadata when calling `pulsarClient.getPartitionsForTopic`.
-  - The client does not pass the `create_if_auto_creation_enabled` parameter of `CommandPartitionedTopicMetadata` to the Broker, which defaults to `true` and automatically creates the partitioned topic metadata.
+- Old version client and New version Broker: The client will call the old API.
 
-- New version client and Old version Broker
-  - Pulsar will create the partitioned topic metadata when calling `pulsarClient.getPartitionsForTopic`.
-  - The client passes the `create_if_auto_creation_enabled` parameter of `CommandPartitionedTopicMetadata` to the Broker;
-    - `create_if_auto_creation_enabled` is `true`: the Broker creates the partitioned topic metadata automatically.
-    - `create_if_auto_creation_enabled` is `false`: the feature flag `supports_binary_api_get_partitioned_meta_with_param_created_false` will be false, the client-side will prevent this request, and users will get an unsupported error.
-
-- New version client and New version Broker
-  - Pulsar will not create the partitioned topic metadata when calling `pulsarClient.getPartitionsForTopic`.
+- New version client and Old version Broker: the feature flag `supports_binary_api_get_partitioned_meta_with_param_created_false` will be `false`, call the deprecated old API. 

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -47,13 +47,8 @@ When you call the public API `pulsarClient.getPartitionsForTopic`, pulsar will n
 ### Public API
 **LookupService.java**
 ```java
-// This API existed before. Not change it, thus ensuring compatibility.
-// @Deprecated it is not suggested to use now; please use {@link #getPartitionedTopicMetadata(TopicName, boolean)}.
-+ @Deprecated
+
 - CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName);
-+ default CompletableFuture<List<String>> getPartitionedTopicMetadata(String topic) {
-+    getPartitionsForTopic(topic, true);
-+ }
 
 + // A new API that contains an additional param "createIfAutoCreationEnabled."
 + CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName, boolean createIfAutoCreationEnabled);

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -7,7 +7,6 @@
     - It triggers partitioned metadata creation by `pulsarClient.getPartitionsForTopic`
     - And triggers the topic partition creation by producers' registration and consumers' registration.
 - When calling `pulsarClient.getPartitionsForTopic(topicName)`, Pulsar will automatically create the partitioned topic metadata if it does not exist, either using `HttpLookupService` or `BinaryProtoLookupService`.
-- BTW, [flink-connector-pulsar](https://github.com/apache/flink-connector-pulsar/blob/main/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java#L221-L227) is using this API to create partitioned topic metadata.
 
 **Now `pulsarClient.getPartitionsForTopic`'s behavior**
 | case | broker allow `auto-create` | param allow <br> `create if not exists` | non-partitioned topic | partitioned topic |  current behavior |
@@ -32,6 +31,7 @@ The param `create if not exists` of the Binary API is always `true.`
 
 - For case 4 of `pulsarClient.getPartitionsForTopic`'s behavior, it always tries to create the partitioned metadata, but the API name is `getxxx`.
 - For case 5 of `pulsarClient.getPartitionsForTopic`'s behavior, it returns a `0` partitioned metadata, but the topic does not exist. For the correct behavior of this case, we had discussed [here](https://github.com/apache/pulsar/issues/8813) before.
+- BTW, [flink-connector-pulsar](https://github.com/apache/flink-connector-pulsar/blob/main/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java#L221-L227) is using this API to create partitioned topic metadata.
 
 # Goals
 

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -11,15 +11,23 @@
 **Now `pulsarClient.getPartitionsForTopic`'s behavior**
 | case | broker allow `auto-create` | param allow <br> `create if not exists` | non-partitioned topic | partitioned topic |  current behavior |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `true/false` | `true/false` | `exists: true` | | REST API: `partitions: 0`<br> Client API: `partitions: 0` |
-| 2 | `true/false` | `true/false` | | `exists: true` <br> `partitions: 3` | REST API: `partitions: 3`<br> Client API: `partitions: 3` |
-| 3 | `true` | `true` | | | REST API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` <br> Client API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` <br> |
-| 4 | `true` | `false` | | | REST API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> Client API: <br> &nbsp;&nbsp;not support <br> |
-| 5 | `false` | `true` | | | REST API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> Client API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> |
+| 1 | `true/false` | `true/false` | `exists: true` | | REST API: `partitions: 0`<br> Binary API: `partitions: 0` |
+| 2 | `true/false` | `true/false` | | `exists: true` <br> `partitions: 3` | REST API: `partitions: 3`<br> Binary API: `partitions: 3` |
+| 3 | `true` | `true` | | | REST API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` <br> Binary API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` <br> |
+| 4 | `true` | `false` | | | REST API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> Binary API: <br> &nbsp;&nbsp;not support <br> |
+| 5 | `false` | `true` | | | REST API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> Binary API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> |
+
+- Broker allows `auto-create`: see also the config `allowAutoTopicCreation` in `broker.conf`.
+- Param allow <br> `create if not exists`
+  - Regarding the HTTP API `PersistentTopics.getPartitionedMetadata`, it is an optional param which named `checkAllowAutoCreation,` and the default value is `false`.
+  - Regarding the `pulsar-admin` API, it depends on the HTTP API `PersistentTopics.getPartitionedMetadata`, and it always sets the param `checkAllowAutoCreation` to `false` and can not be set manually.
+  - Regarding the client API `HttpLookupService.getPartitionedTopicMetadata`, it depends on the HTTP API `PersistentTopics.getPartitionedMetadata`, and it always sets the param `checkAllowAutoCreation` to `true` and can not be set manually.
+  - Regarding the client API `BinaryProtoLookupService.getPartitionedTopicMetadata`, it always tries to create partitioned metadata.
+- `REST API & HTTP API`: Since there are only two implementations of the 4 ways to get partitioned metadata, we call HTTP API `PersistentTopics.getPartitionedMetadata`, `pulsar-admin`, and `HttpLookupService.getPartitionedTopicMetadata` HTTP API, and call `BinaryProtoLookupService.getPartitionedTopicMetadata` Binary API.
 
 # Motivation
 
-The param `create if not exists` of the Client API is always `true.`
+The param `create if not exists` of the Binary API is always `true.`
 
 - For case 4 of `pulsarClient.getPartitionsForTopic`'s behavior, it always tries to create the partitioned metadata, but the API name is `getxxx`.
 - For case 5 of `pulsarClient.getPartitionsForTopic`'s behavior, it returns a `0` partitioned metadata, but the topic does not exist. For the correct behavior of this case, we had discussed [here](https://github.com/apache/pulsar/issues/8813) before.
@@ -52,10 +60,10 @@ CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicNam
 
 | case | do create partitioned metadata | non-partitioned topic | partitioned topic |  current behavior |
 | --- | --- | --- | --- | --- |
-| 1 | `true/false` | `exists: true` | | REST/Client API: `partitions: 0` |
-| 2 | `true/false` | | `exists: true` <br> `partitions: 3` | REST/Client API: `partitions: 3` |
-| 3 | `true` | | | REST/Client API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` |
-| 4 | `false` | | | REST/Client API: <br> &nbsp;&nbsp;- Not found error |
+| 1 | `true/false` | `exists: true` | | REST/Binary API: `partitions: 0` |
+| 2 | `true/false` | | `exists: true` <br> `partitions: 3` | REST/Binary API: `partitions: 3` |
+| 3 | `true` | | | REST/Binary API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` |
+| 4 | `false` | | | REST/Binary API: <br> &nbsp;&nbsp;- Not found error |
 
 ### Binary protocol
 

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -53,7 +53,7 @@ When you call the public API `pulsarClient.getPartitionsForTopic`, pulsar will n
 /**
  * 1. Get the partitions if the topic exists. Return "{partition: n}" if a partitioned topic exists; return "{partition: 0}" if a non-partitioned topic exists.
  * 2. When {@param createIfAutoCreationEnabled} is "false," neither partitioned topic nor non-partitioned topic does not exist. You will get an {@link PulsarClientException.NotFoundException}.
- *  2-1. You will get a {@link PulsarClientException.NotSupportedException} if the broker's version is an older one that does not support this feature.
+ *  2-1. You will get a {@link PulsarClientException.NotSupportedException} if the broker's version is an older one that does not support this feature and the Pulsar client is using a binary protocol "serviceUrl".
  * 3. When {@param createIfAutoCreationEnabled} is "true," it will trigger an auto-creation for this topic(using the default topic auto-creation strategy you set for the broker), and the corresponding result is returned. For the result, see case 1.
  * @version 3.3.0
  */
@@ -84,7 +84,7 @@ The behavior of the new API `LookupService.getPartitionedTopicMetadata(TopicName
 /**
  * 1. Get the partitions if the topic exists. Return "[{partition-0}, {partition-1}....{partition-n}}]" if a partitioned topic exists; return "[{topic}]" if a non-partitioned topic exists.
  * 2. When {@param createIfAutoCreationEnabled} is "false", neither the partitioned topic nor non-partitioned topic does not exist. You will get an {@link PulsarClientException.NotFoundException}.
- *  2-1. You will get a {@link PulsarClientException.NotSupportedException} if the broker's version is an older one that does not support this feature.
+ *  2-1. You will get a {@link PulsarClientException.NotSupportedException} if the broker's version is an older one that does not support this feature and the Pulsar client is using a binary protocol "serviceUrl".
  * 3. When {@param createIfAutoCreationEnabled} is "true," it will trigger an auto-creation for this topic(using the default topic auto-creation strategy you set for the broker), and the corresponding result is returned. For the result, see case 1.
  * @version 3.3.0
  */

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -112,4 +112,4 @@ message FeatureFlags {
 
 - Old version client and New version Broker: The client will call the old API.
 
-- New version client and Old version Broker: the feature flag `supports_binary_api_get_partitioned_meta_with_param_created_false` will be `false`, call the old API. 
+- New version client and Old version Broker: The feature flag `supports_binary_api_get_partitioned_meta_with_param_created_false` will be `false`. The client will get a not-support error if the param `createIfAutoCreationEnabled` is false.

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -64,6 +64,13 @@ message CommandPartitionedTopicMetadata {
 }
 ```
 
+**FeatureFlags**
+```
+message FeatureFlags {
+  + optional bool supports_binary_api_get_partitioned_meta_with_param_created_false = 5 [default = false];
+}
+```
+
 # Backward & Forward Compatibility
 
 - Old version client and New version Broker
@@ -72,7 +79,9 @@ message CommandPartitionedTopicMetadata {
 
 - New version client and Old version Broker
   - Pulsar will create the partitioned topic metadata when calling `pulsarClient.getPartitionsForTopic`.
-  - The client passes the `create_if_auto_creation_enabled` parameter of `CommandPartitionedTopicMetadata` to the Broker; the Broker will discard it and create the partitioned topic metadata automatically.
+  - The client passes the `create_if_auto_creation_enabled` parameter of `CommandPartitionedTopicMetadata` to the Broker;
+    - `create_if_auto_creation_enabled` is `true`: the Broker creates the partitioned topic metadata automatically.
+    - `create_if_auto_creation_enabled` is `false`: the feature flag `supports_binary_api_get_partitioned_meta_with_param_created_false` will be false, the client-side will prevent this request, and users will get an unsupported error.
 
 - New version client and New version Broker
   - Pulsar will not create the partitioned topic metadata when calling `pulsarClient.getPartitionsForTopic`.

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -7,6 +7,7 @@
     - It triggers partitioned metadata creation by `pulsarClient.getPartitionsForTopic`
     - And triggers the topic partition creation by producers' registration and consumers' registration.
 - When calling `pulsarClient.getPartitionsForTopic(topicName)`, Pulsar will automatically create the partitioned topic metadata if it does not exist, either using `HttpLookupService` or `BinaryProtoLookupService`.
+- BTW, [flink-connector-pulsar](https://github.com/apache/flink-connector-pulsar/blob/main/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java#L221-L227) is using this API to create partitioned topic metadata.
 
 **Now `pulsarClient.getPartitionsForTopic`'s behavior**
 | case | broker allow `auto-create` | param allow <br> `create if not exists` | non-partitioned topic | partitioned topic |  current behavior |
@@ -44,11 +45,10 @@ Correct the behaviors of case 4 and case 5.
 ## Public-facing Changes
 
 When you call the public API `pulsarClient.getPartitionsForTopic`, pulsar will not create the partitioned metadata anymore.
-- [flink-connector-pulsar](https://github.com/apache/flink-connector-pulsar/blob/main/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java#L221-L227) is using this API to create partitioned topic metadata.
 
 ### Public API
 **LookupService.java**
-```
+```java
 // This API existed before. Not change it, thus ensuring compatibility.
 // @Deprecated it is not suggested to use now; please use {@link #getPartitionedTopicMetadata(TopicName, boolean)}.
 @Deprecated
@@ -58,12 +58,28 @@ CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicNam
 + CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName, boolean createIfAutoCreationEnabled);
 ```
 
-| case | do create partitioned metadata | non-partitioned topic | partitioned topic |  current behavior |
+**PulsarClient.java**
+```java
+// This API existed before. Not change it, thus ensuring compatibility.
+// @Deprecated it is not suggested to use now; please use {@link #getPartitionsForTopic(TopicName, boolean)}.
+CompletableFuture<List<String>> getPartitionsForTopic(String topic);
+
++ // A new API that contains an additional param "createIfAutoCreationEnabled."
++ CompletableFuture<List<String>> getPartitionsForTopic(String topic, boolean createIfAutoCreationEnabled);
+```
+
+The behavior of the old API `LookupService.getPartitionedTopicMetadata(TopicName)` and `PulsarClient.getPartitionsForTopic(String)`.
+- It keeps the same behavior as before; in other words, it also tries to create the partitioned topic metadata automatically.
+
+The behavior of the new API `LookupService.getPartitionedTopicMetadata(TopicName, boolean)` and `PulsarClient.getPartitionsForTopic(String, boolean)`.
+| case | `createIfAutoCreationEnabled` | non-partitioned topic | partitioned topic |  current behavior |
 | --- | --- | --- | --- | --- |
 | 1 | `true/false` | `exists: true` | | REST/Binary API: `partitions: 0` |
 | 2 | `true/false` | | `exists: true` <br> `partitions: 3` | REST/Binary API: `partitions: 3` |
 | 3 | `true` | | | REST/Binary API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` |
 | 4 | `false` | | | REST/Binary API: <br> &nbsp;&nbsp;- Not found error |
+
+
 
 ### Binary protocol
 

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -49,8 +49,11 @@ When you call the public API `pulsarClient.getPartitionsForTopic`, pulsar will n
 ```java
 // This API existed before. Not change it, thus ensuring compatibility.
 // @Deprecated it is not suggested to use now; please use {@link #getPartitionedTopicMetadata(TopicName, boolean)}.
-@Deprecated
-CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName);
++ @Deprecated
+- CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName);
++ default CompletableFuture<List<String>> getPartitionedTopicMetadata(String topic) {
++    getPartitionsForTopic(topic, true);
++ }
 
 + // A new API that contains an additional param "createIfAutoCreationEnabled."
 + CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName, boolean createIfAutoCreationEnabled);
@@ -74,8 +77,11 @@ The behavior of the new API `LookupService.getPartitionedTopicMetadata(TopicName
 **PulsarClient.java**
 ```java
 // This API existed before. Not change it, thus ensuring compatibility.
-// @Deprecated it is not suggested to use now; please use {@link #getPartitionsForTopic(TopicName, boolean)}.
-CompletableFuture<List<String>> getPartitionsForTopic(String topic);
++ @Deprecated it is not suggested to use now; please use {@link #getPartitionsForTopic(TopicName, boolean)}.
+- CompletableFuture<List<String>> getPartitionsForTopic(String topic);
++ default CompletableFuture<List<String>> getPartitionsForTopic(String topic) {
++    getPartitionsForTopic(topic, true);
++ }
 
 + // A new API that contains an additional param "createIfAutoCreationEnabled."
 + CompletableFuture<List<String>> getPartitionsForTopic(String topic, boolean createIfAutoCreationEnabled);

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -59,9 +59,6 @@ When you call the public API `pulsarClient.getPartitionsForTopic`, pulsar will n
 + CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName, boolean createIfAutoCreationEnabled);
 ```
 
-The behavior of the old API `LookupService.getPartitionedTopicMetadata(String)`.
-- It keeps the same behavior as before; in other words, it is the same as the case 1-4 below.
-
 The behavior of the new API `LookupService.getPartitionedTopicMetadata(TopicName, boolean)`.
 
 | case | client-side param: `createIfAutoCreationEnabled` | non-partitioned topic | partitioned topic                   | broker-side: topic auto-creation strategy                                                                          | current behavior                                                                            |
@@ -86,9 +83,6 @@ The behavior of the new API `LookupService.getPartitionedTopicMetadata(TopicName
 + // A new API that contains an additional param "createIfAutoCreationEnabled."
 + CompletableFuture<List<String>> getPartitionsForTopic(String topic, boolean createIfAutoCreationEnabled);
 ```
-
-The behavior of the old API `PulsarClient.getPartitionsForTopic(String)`.
-- It keeps the same behavior as before; in other words, it is the same as the case 1-4 below.
 
 The behavior of the new API `PulsarClient.getPartitionsForTopic(String, boolean)`.
 

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -42,6 +42,8 @@ When you call the public API `pulsarClient.getPartitionsForTopic`, pulsar will n
 **LookupService.java**
 ```
 // This API existed before. Not change it, thus ensuring compatibility.
+// @Deprecated it is not suggested to use now; please use {@link #getPartitionedTopicMetadata(TopicName, boolean)}.
+@Deprecated
 CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName);
 
 + // A new API that contains an additional param "createIfAutoCreationEnabled."

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -117,4 +117,4 @@ message FeatureFlags {
 
 - Old version client and New version Broker: The client will call the old API.
 
-- New version client and Old version Broker: the feature flag `supports_binary_api_get_partitioned_meta_with_param_created_false` will be `false`, call the deprecated old API. 
+- New version client and Old version Broker: the feature flag `supports_binary_api_get_partitioned_meta_with_param_created_false` will be `false`, call the old API. 

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -50,7 +50,13 @@ When you call the public API `pulsarClient.getPartitionsForTopic`, pulsar will n
 
 - CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName);
 
-+ // A new API that contains an additional param "createIfAutoCreationEnabled."
+/**
+ * 1. Get the partitions if the topic exists. Return "{partition: n}" if a partitioned topic exists; return "{partition: 0}" if a non-partitioned topic exists.
+ * 2. When {@param createIfAutoCreationEnabled} is "false," neither partitioned topic nor non-partitioned topic does not exist. You will get an {@link PulsarClientException.NotFoundException}.
+ *  2-1. You will get a {@link PulsarClientException.NotSupportedException} if the broker's version is an older one that does not support this feature.
+ * 3. When {@param createIfAutoCreationEnabled} is "true," it will trigger an auto-creation for this topic(using the default topic auto-creation strategy you set for the broker), and the corresponding result is returned. For the result, see case 1.
+ * @version 3.3.0
+ */
 + CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName, boolean createIfAutoCreationEnabled);
 ```
 
@@ -75,8 +81,14 @@ The behavior of the new API `LookupService.getPartitionedTopicMetadata(TopicName
 +    getPartitionsForTopic(topic, true);
 + }
 
-+ // A new API that contains an additional param "createIfAutoCreationEnabled."
-+ CompletableFuture<List<String>> getPartitionsForTopic(String topic, boolean createIfAutoCreationEnabled);
+/**
+ * 1. Get the partitions if the topic exists. Return "[{partition-0}, {partition-1}....{partition-n}}]" if a partitioned topic exists; return "[{topic}]" if a non-partitioned topic exists.
+ * 2. When {@param createIfAutoCreationEnabled} is "false", neither the partitioned topic nor non-partitioned topic does not exist. You will get an {@link PulsarClientException.NotFoundException}.
+ *  2-1. You will get a {@link PulsarClientException.NotSupportedException} if the broker's version is an older one that does not support this feature.
+ * 3. When {@param createIfAutoCreationEnabled} is "true," it will trigger an auto-creation for this topic(using the default topic auto-creation strategy you set for the broker), and the corresponding result is returned. For the result, see case 1.
+ * @version 3.3.0
+ */
+CompletableFuture<List<String>> getPartitionsForTopic(String topic, boolean createIfAutoCreationEnabled);
 ```
 
 The behavior of the new API `PulsarClient.getPartitionsForTopic(String, boolean)`.

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -19,61 +19,43 @@
 
 # Motivation
 
-- For the case 4 of `pulsarClient.getPartitionsForTopic`'s behavior, it always tries to create the partitioned metadata, but the API name is `getxxx`.
-- For the case 5 of `pulsarClient.getPartitionsForTopic`'s behavior, it returns a `0` partitioned metadata, but the topic not exists. For this behavior, we had discussed [here](https://github.com/apache/pulsar/issues/8813) before.
+The param `create if not exists` of the Client API is always `true.`
+
+- For case 4 of `pulsarClient.getPartitionsForTopic`'s behavior, it always tries to create the partitioned metadata, but the API name is `getxxx`.
+- For case 5 of `pulsarClient.getPartitionsForTopic`'s behavior, it returns a `0` partitioned metadata, but the topic does not exist. For the correct behavior of this case, we had discussed [here](https://github.com/apache/pulsar/issues/8813) before.
 
 # Goals
 
-- Do not try to create the partitioned metadata when calling 
+Correct the behaviors of case 4 and case 5.
 
-
-# High Level Design
-
-<!--
-Describe the design of your solution in *high level*.
-Describe the solution end to end, from a birds-eye view.
-Don't go into implementation details in this section.
-
-I should be able to finish reading from beginning of the PIP to here (including) and understand the feature and 
-how you intend to solve it, end to end.
-
-DON'T
-* Avoid code snippets, unless it's essential to explain your intent.
--->
+- Do not create the partitioned metadata when calling `pulsarClient.getPartitionsForTopic`, the partitioned metadata only will be created when consumers/producers are trying to register.
+- Instead of returning a `0` partitioned metadata, respond to a not found error when calling `pulsarClient.getPartitionsForTopic` if the topic does not exist.
 
 # Detailed Design
 
-## Design & Implementation Details
-
-<!--
-This is the section where you dive into the details. It can be:
-* Concrete class names and their roles and responsibility, including methods.
-* Code snippets of existing code.
-* Interface names and its methods.
-* ...
--->
-
 ## Public-facing Changes
 
-<!--
-Describe the additions you plan to make for each public facing component. 
-Remove the sections you are not changing.
-Clearly mark any changes which are BREAKING backward compatability.
--->
+When you call the public API `pulsarClient.getPartitionsForTopic`, pulsar will not create the partitioned metadata anymore.
 
 ### Public API
-<!--
-When adding a new endpoint to the REST API, please make sure to document the following:
+**LookupService.java**
+```
+// This API existed before. Not change it, thus ensuring compatibility.
+CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName);
 
-* path
-* query parameters
-* HTTP body parameters, usually as JSON.
-* Response codes, and for each what they mean.
-  For each response code, please include a detailed description of the response body JSON, specifying each field and what it means.
-  This is the place to document the errors.
--->
+// A new API that contains an additional param "createIfAutoCreationEnabled".
+CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName, boolean createIfAutoCreationEnabled);
+```
 
 ### Binary protocol
+
+**CommandPartitionedTopicMetadata**
+```
+message CommandPartitionedTopicMetadata {
+    + optional bool create_if_auto_creation_enabled = 6 [default = true];
+}
+```
+
 
 ### Configuration
 

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -31,14 +31,6 @@ Correct the behaviors of case 4 and case 5.
 - Do not create the partitioned metadata when calling `pulsarClient.getPartitionsForTopic`. The partitioned metadata will only be created when consumers/producers are trying to register.
 - Instead of returning a `0` partitioned metadata, respond to a not found error when calling `pulsarClient.getPartitionsForTopic` if the topic does not exist.
 
-**`pulsarClient.getPartitionsForTopic`'s behavior**
-| case | do `auto-create` | non-partitioned topic | partitioned topic |  current behavior |
-| --- | --- | --- | --- | --- |
-| 1 | `true/false` | `exists: true` | | REST/Client API: `partitions: 0` |
-| 2 | `true/false` | | `exists: true` <br> `partitions: 3` | REST/Client API: `partitions: 3` |
-| 3 | `true` | | | REST/Client API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` |
-| 4 | `false` | | | REST/Client API: <br> &nbsp;&nbsp;- Not found error |
-
 # Detailed Design
 
 ## Public-facing Changes
@@ -54,6 +46,14 @@ CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicNam
 + // A new API that contains an additional param "createIfAutoCreationEnabled."
 + CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName, boolean createIfAutoCreationEnabled);
 ```
+
+**`LookupService.getPartitionedTopicMetadata`'s behavior**
+| case | do create partitioned metadata | non-partitioned topic | partitioned topic |  current behavior |
+| --- | --- | --- | --- | --- |
+| 1 | `true/false` | `exists: true` | | REST/Client API: `partitions: 0` |
+| 2 | `true/false` | | `exists: true` <br> `partitions: 3` | REST/Client API: `partitions: 3` |
+| 3 | `true` | | | REST/Client API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` |
+| 4 | `false` | | | REST/Client API: <br> &nbsp;&nbsp;- Not found error |
 
 ### Binary protocol
 

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -2,13 +2,13 @@
 
 # Background knowledge
 
-### Topic auto-creation.
+**Topic auto-creation**
 - The partitioned topic auto-creation is dependent on `pulsarClient.getPartitionsForTopic`
     - It triggers partitioned metadata creation by `pulsarClient.getPartitionsForTopic`
     - And triggers the topic partition creation by producers' registration and consumers' registration.
 - When calling `pulsarClient.getPartitionsForTopic(topicName)`, Pulsar will automatically create the partitioned topic metadata if it does not exist, either using `HttpLookupService` or `BinaryProtoLookupService`.
 
-### Now `pulsarClient.getPartitionsForTopic`'s behavior.
+**Now `pulsarClient.getPartitionsForTopic`'s behavior**
 | case | broker allow `auto-create` | param allow <br> `create if not exists` | non-partitioned topic | partitioned topic |  current behavior |
 | --- | --- | --- | --- | --- | --- |
 | 1 | `true/false` | `true/false` | `exists: true` | | REST API: `partitions: 0`<br> Client API: `partitions: 0` |
@@ -28,7 +28,7 @@ The param `create if not exists` of the Client API is always `true.`
 
 Correct the behaviors of case 4 and case 5.
 
-- Do not create the partitioned metadata when calling `pulsarClient.getPartitionsForTopic`, the partitioned metadata only will be created when consumers/producers are trying to register.
+- Do not create the partitioned metadata when calling `pulsarClient.getPartitionsForTopic`. The partitioned metadata will only be created when consumers/producers are trying to register.
 - Instead of returning a `0` partitioned metadata, respond to a not found error when calling `pulsarClient.getPartitionsForTopic` if the topic does not exist.
 
 # Detailed Design
@@ -43,8 +43,8 @@ When you call the public API `pulsarClient.getPartitionsForTopic`, pulsar will n
 // This API existed before. Not change it, thus ensuring compatibility.
 CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName);
 
-// A new API that contains an additional param "createIfAutoCreationEnabled".
-CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName, boolean createIfAutoCreationEnabled);
++ // A new API that contains an additional param "createIfAutoCreationEnabled."
++ CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName, boolean createIfAutoCreationEnabled);
 ```
 
 ### Binary protocol
@@ -52,69 +52,19 @@ CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicNam
 **CommandPartitionedTopicMetadata**
 ```
 message CommandPartitionedTopicMetadata {
-    + optional bool create_if_auto_creation_enabled = 6 [default = true];
+  + optional bool create_if_auto_creation_enabled = 6 [default = true];
 }
 ```
 
-
-### Configuration
-
-### CLI
-
-### Metrics
-
-<!--
-For each metric provide:
-* Full name
-* Description
-* Attributes (labels)
-* Unit
--->
-
-
-# Monitoring
-
-<!-- 
-Describe how the changes you make in this proposal should be monitored. 
-Don't describe the detailed metrics - they should be at "Public-facing Changes" / "Metrics" section.
-Describe how the user will use the metrics to monitor the feature: Which alerts they should set up, which thresholds, ...
--->
-
-# Security Considerations
-<!--
-A detailed description of the security details that ought to be considered for the PIP. This is most relevant for any new HTTP endpoints, new Pulsar Protocol Commands, and new security features. The goal is to describe details like which role will have permission to perform an action.
-
-An important aspect to consider is also multi-tenancy: Does the feature I'm adding have the permissions / roles set in such a way that prevent one tenant accessing another tenant's data/configuration? For example, the Admin API to read a specific message for a topic only allows a client to read messages for the target topic. However, that was not always the case. CVE-2021-41571 (https://github.com/apache/pulsar/wiki/CVE-2021-41571) resulted because the API was incorrectly written and did not properly prevent a client from reading another topic's messages even though authorization was in place. The problem was missing input validation that verified the requested message was actually a message for that topic. The fix to CVE-2021-41571 was input validation. 
-
-If there is uncertainty for this section, please submit the PIP and request for feedback on the mailing list.
--->
-
 # Backward & Forward Compatibility
 
-## Revert
+**Old version client and New version Broker**
+Pulsar will create the partitioned topic metadata when calling `pulsarClient.getPartitionsForTopic`.
+- The client does not pass the `create_if_auto_creation_enabled` parameter of `CommandPartitionedTopicMetadata` to the Broker, which defaults to `true` and automatically creates the partitioned topic metadata.
 
-<!--
-Describe a cookbook detailing the steps required to revert pulsar to previous version *without* this feature.
--->
+**New version client and Old version Broker**
+Pulsar will create the partitioned topic metadata when calling `pulsarClient.getPartitionsForTopic`.
+- The client passes the `create_if_auto_creation_enabled` parameter of `CommandPartitionedTopicMetadata` to the Broker; the Broker will discard it and create the partitioned topic metadata automatically.
 
-## Upgrade
-
-<!--
-Specify the list of instructions, if there are such, needed to perform before/after upgrading to Pulsar version containing this feature.
--->
-
-# Alternatives
-
-<!--
-If there are alternatives that were already considered by the authors or, after the discussion, by the community, and were rejected, please list them here along with the reason why they were rejected.
--->
-
-# General Notes
-
-# Links
-
-<!--
-Updated afterwards
--->
-* Mailing List discussion thread:
-* Mailing List voting thread:
+**New version client and New version Broker**
+Pulsar will not create the partitioned topic metadata when calling `pulsarClient.getPartitionsForTopic`.

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -11,11 +11,11 @@
 ### Now `pulsarClient.getPartitionsForTopic`'s behavior.
 | case | broker allow `auto-create` | param allow <br> `create if not exists` | non-partitioned topic | partitioned topic |  current behavior |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `true/false` | `true/false` | `exists: true` | | HTTP API: `partitions: 0`<br> Binary API: `partitions: 0` |
-| 2 | `true/false` | `true/false` | | `exists: true` <br> `partitions: 3` | HTTP API: `partitions: 3`<br> Binary API: `partitions: 3` |
-| 3 | `true` | `true` | | | HTTP API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` <br> Binary API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` <br> |
-| 4 | `true` | `false` | | | HTTP API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> Binary API: <br> &nbsp;&nbsp;not support <br> |
-| 5 | `false` | `true` | | | HTTP API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> Binary API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> |
+| 1 | `true/false` | `true/false` | `exists: true` | | REST API: `partitions: 0`<br> Client API: `partitions: 0` |
+| 2 | `true/false` | `true/false` | | `exists: true` <br> `partitions: 3` | REST API: `partitions: 3`<br> Client API: `partitions: 3` |
+| 3 | `true` | `true` | | | REST API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` <br> Client API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` <br> |
+| 4 | `true` | `false` | | | REST API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> Client API: <br> &nbsp;&nbsp;not support <br> |
+| 5 | `false` | `true` | | | REST API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> Client API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> |
 
 # Motivation
 

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -60,7 +60,7 @@ CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicNam
 **CommandPartitionedTopicMetadata**
 ```
 message CommandPartitionedTopicMetadata {
-  + optional bool create_if_auto_creation_enabled = 6 [default = true];
+  + optional bool metadata_auto_creation_enabled = 6 [default = true];
 }
 ```
 

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -36,6 +36,7 @@ Correct the behaviors of case 4 and case 5.
 ## Public-facing Changes
 
 When you call the public API `pulsarClient.getPartitionsForTopic`, pulsar will not create the partitioned metadata anymore.
+- [flink-connector-pulsar](https://github.com/apache/flink-connector-pulsar/blob/main/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java#L221-L227) is using this API to create partitioned topic metadata.
 
 ### Public API
 **LookupService.java**

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -1,4 +1,4 @@
-# PIP-XXX: PIP-344 Correct the behavior of the public API pulsarClient.getPartitionsForTopic(topicName)
+# PIP-344: Correct the behavior of the public API pulsarClient.getPartitionsForTopic(topicName)
 
 # Background knowledge
 

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -31,6 +31,14 @@ Correct the behaviors of case 4 and case 5.
 - Do not create the partitioned metadata when calling `pulsarClient.getPartitionsForTopic`. The partitioned metadata will only be created when consumers/producers are trying to register.
 - Instead of returning a `0` partitioned metadata, respond to a not found error when calling `pulsarClient.getPartitionsForTopic` if the topic does not exist.
 
+**`pulsarClient.getPartitionsForTopic`'s behavior**
+| case | do `auto-create` | non-partitioned topic | partitioned topic |  current behavior |
+| --- | --- | --- | --- | --- |
+| 1 | `true/false` | `exists: true` | | REST/Client API: `partitions: 0` |
+| 2 | `true/false` | | `exists: true` <br> `partitions: 3` | REST/Client API: `partitions: 3` |
+| 3 | `true` | | | REST/Client API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` |
+| 4 | `false` | | | REST/Client API: <br> &nbsp;&nbsp;- Not found error |
+
 # Detailed Design
 
 ## Public-facing Changes

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -58,13 +58,13 @@ message CommandPartitionedTopicMetadata {
 
 # Backward & Forward Compatibility
 
-**Old version client and New version Broker**
-Pulsar will create the partitioned topic metadata when calling `pulsarClient.getPartitionsForTopic`.
-- The client does not pass the `create_if_auto_creation_enabled` parameter of `CommandPartitionedTopicMetadata` to the Broker, which defaults to `true` and automatically creates the partitioned topic metadata.
+- Old version client and New version Broker
+  - Pulsar will create the partitioned topic metadata when calling `pulsarClient.getPartitionsForTopic`.
+  - The client does not pass the `create_if_auto_creation_enabled` parameter of `CommandPartitionedTopicMetadata` to the Broker, which defaults to `true` and automatically creates the partitioned topic metadata.
 
-**New version client and Old version Broker**
-Pulsar will create the partitioned topic metadata when calling `pulsarClient.getPartitionsForTopic`.
-- The client passes the `create_if_auto_creation_enabled` parameter of `CommandPartitionedTopicMetadata` to the Broker; the Broker will discard it and create the partitioned topic metadata automatically.
+- New version client and Old version Broker
+  - Pulsar will create the partitioned topic metadata when calling `pulsarClient.getPartitionsForTopic`.
+  - The client passes the `create_if_auto_creation_enabled` parameter of `CommandPartitionedTopicMetadata` to the Broker; the Broker will discard it and create the partitioned topic metadata automatically.
 
-**New version client and New version Broker**
-Pulsar will not create the partitioned topic metadata when calling `pulsarClient.getPartitionsForTopic`.
+- New version client and New version Broker
+  - Pulsar will not create the partitioned topic metadata when calling `pulsarClient.getPartitionsForTopic`.

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -14,7 +14,7 @@
 | 1 | `true/false` | `true/false` | `exists: true` | | HTTP API: `partitions: 0`<br> Binary API: `partitions: 0` |
 | 2 | `true/false` | `true/false` | | `exists: true` <br> `partitions: 3` | HTTP API: `partitions: 3`<br> Binary API: `partitions: 3` |
 | 3 | `true` | `true` | | | HTTP API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` <br> Binary API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` <br> |
-| 4 | `true` | `false` | | | HTTP API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> Binary API: not support <br> |
+| 4 | `true` | `false` | | | HTTP API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> Binary API: <br> &nbsp;&nbsp;not support <br> |
 | 5 | `false` | `true` | | | HTTP API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> Binary API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> |
 
 # Motivation

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -47,7 +47,6 @@ CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicNam
 + CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName, boolean createIfAutoCreationEnabled);
 ```
 
-**`LookupService.getPartitionedTopicMetadata`'s behavior**
 | case | do create partitioned metadata | non-partitioned topic | partitioned topic |  current behavior |
 | --- | --- | --- | --- | --- |
 | 1 | `true/false` | `exists: true` | | REST/Client API: `partitions: 0` |

--- a/pip/pip-344.md
+++ b/pip/pip-344.md
@@ -1,0 +1,138 @@
+# PIP-XXX: PIP-344 Correct the behavior of the public API pulsarClient.getPartitionsForTopic(topicName)
+
+# Background knowledge
+
+### Topic auto-creation.
+- The partitioned topic auto-creation is dependent on `pulsarClient.getPartitionsForTopic`
+    - It triggers partitioned metadata creation by `pulsarClient.getPartitionsForTopic`
+    - And triggers the topic partition creation by producers' registration and consumers' registration.
+- When calling `pulsarClient.getPartitionsForTopic(topicName)`, Pulsar will automatically create the partitioned topic metadata if it does not exist, either using `HttpLookupService` or `BinaryProtoLookupService`.
+
+### Now `pulsarClient.getPartitionsForTopic`'s behavior.
+| case | broker allow `auto-create` | param allow <br> `create if not exists` | non-partitioned topic | partitioned topic |  current behavior |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `true/false` | `true/false` | `exists: true` | | HTTP API: `partitions: 0`<br> Binary API: `partitions: 0` |
+| 2 | `true/false` | `true/false` | | `exists: true` <br> `partitions: 3` | HTTP API: `partitions: 3`<br> Binary API: `partitions: 3` |
+| 3 | `true` | `true` | | | HTTP API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` <br> Binary API: <br> &nbsp;&nbsp;- `create new: true` <br> &nbsp;&nbsp;- `partitions: 3` <br> |
+| 4 | `true` | `false` | | | HTTP API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> Binary API: not support <br> |
+| 5 | `false` | `true` | | | HTTP API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> Binary API: <br> &nbsp;&nbsp;- `create new: false` <br> &nbsp;&nbsp;- `partitions: 0` <br> |
+
+# Motivation
+
+- For the case 4 of `pulsarClient.getPartitionsForTopic`'s behavior, it always tries to create the partitioned metadata, but the API name is `getxxx`.
+- For the case 5 of `pulsarClient.getPartitionsForTopic`'s behavior, it returns a `0` partitioned metadata, but the topic not exists. For this behavior, we had discussed [here](https://github.com/apache/pulsar/issues/8813) before.
+
+# Goals
+
+- Do not try to create the partitioned metadata when calling 
+
+
+# High Level Design
+
+<!--
+Describe the design of your solution in *high level*.
+Describe the solution end to end, from a birds-eye view.
+Don't go into implementation details in this section.
+
+I should be able to finish reading from beginning of the PIP to here (including) and understand the feature and 
+how you intend to solve it, end to end.
+
+DON'T
+* Avoid code snippets, unless it's essential to explain your intent.
+-->
+
+# Detailed Design
+
+## Design & Implementation Details
+
+<!--
+This is the section where you dive into the details. It can be:
+* Concrete class names and their roles and responsibility, including methods.
+* Code snippets of existing code.
+* Interface names and its methods.
+* ...
+-->
+
+## Public-facing Changes
+
+<!--
+Describe the additions you plan to make for each public facing component. 
+Remove the sections you are not changing.
+Clearly mark any changes which are BREAKING backward compatability.
+-->
+
+### Public API
+<!--
+When adding a new endpoint to the REST API, please make sure to document the following:
+
+* path
+* query parameters
+* HTTP body parameters, usually as JSON.
+* Response codes, and for each what they mean.
+  For each response code, please include a detailed description of the response body JSON, specifying each field and what it means.
+  This is the place to document the errors.
+-->
+
+### Binary protocol
+
+### Configuration
+
+### CLI
+
+### Metrics
+
+<!--
+For each metric provide:
+* Full name
+* Description
+* Attributes (labels)
+* Unit
+-->
+
+
+# Monitoring
+
+<!-- 
+Describe how the changes you make in this proposal should be monitored. 
+Don't describe the detailed metrics - they should be at "Public-facing Changes" / "Metrics" section.
+Describe how the user will use the metrics to monitor the feature: Which alerts they should set up, which thresholds, ...
+-->
+
+# Security Considerations
+<!--
+A detailed description of the security details that ought to be considered for the PIP. This is most relevant for any new HTTP endpoints, new Pulsar Protocol Commands, and new security features. The goal is to describe details like which role will have permission to perform an action.
+
+An important aspect to consider is also multi-tenancy: Does the feature I'm adding have the permissions / roles set in such a way that prevent one tenant accessing another tenant's data/configuration? For example, the Admin API to read a specific message for a topic only allows a client to read messages for the target topic. However, that was not always the case. CVE-2021-41571 (https://github.com/apache/pulsar/wiki/CVE-2021-41571) resulted because the API was incorrectly written and did not properly prevent a client from reading another topic's messages even though authorization was in place. The problem was missing input validation that verified the requested message was actually a message for that topic. The fix to CVE-2021-41571 was input validation. 
+
+If there is uncertainty for this section, please submit the PIP and request for feedback on the mailing list.
+-->
+
+# Backward & Forward Compatibility
+
+## Revert
+
+<!--
+Describe a cookbook detailing the steps required to revert pulsar to previous version *without* this feature.
+-->
+
+## Upgrade
+
+<!--
+Specify the list of instructions, if there are such, needed to perform before/after upgrading to Pulsar version containing this feature.
+-->
+
+# Alternatives
+
+<!--
+If there are alternatives that were already considered by the authors or, after the discussion, by the community, and were rejected, please list them here along with the reason why they were rejected.
+-->
+
+# General Notes
+
+# Links
+
+<!--
+Updated afterwards
+-->
+* Mailing List discussion thread:
+* Mailing List voting thread:


### PR DESCRIPTION
### Motivation

- [DIscussion](https://lists.apache.org/thread/z693blcxoqk0mj0rzyt1k7nvy72j18t5)
- [Vote](https://lists.apache.org/thread/4x3rgxygt2x8vtd6lnn53bskdhgmvy2v)

### Modifications

<!-- Describe the modifications you've done. -->

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
