### PR TITLE
[fix][build][branch-3.1] Fix Pulsar SQL LICENSE file

### DIFF
--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -283,22 +283,22 @@ The Apache Software License, Version 2.0
     - joda-time-2.10.10.jar
     - failsafe-2.4.4.jar
   * Jetty
-    - http2-client-9.4.53.v20231009.jar
-    - http2-common-9.4.53.v20231009.jar
-    - http2-hpack-9.4.53.v20231009.jar
-    - http2-http-client-transport-9.4.53.v20231009.jar
-    - jetty-alpn-client-9.4.53.v20231009.jar
-    - http2-server-9.4.53.v20231009.jar
-    - jetty-alpn-java-client-9.4.53.v20231009.jar
-    - jetty-client-9.4.53.v20231009.jar
-    - jetty-http-9.4.53.v20231009.jar
-    - jetty-io-9.4.53.v20231009.jar
-    - jetty-jmx-9.4.53.v20231009.jar
-    - jetty-security-9.4.53.v20231009.jar
-    - jetty-server-9.4.53.v20231009.jar
-    - jetty-servlet-9.4.53.v20231009.jar
-    - jetty-util-9.4.53.v20231009.jar
-    - jetty-util-ajax-9.4.53.v20231009.jar
+    - http2-client-9.4.54.v20240208.jar
+    - http2-common-9.4.54.v20240208.jar
+    - http2-hpack-9.4.54.v20240208.jar
+    - http2-http-client-transport-9.4.54.v20240208.jar
+    - jetty-alpn-client-9.4.54.v20240208.jar
+    - http2-server-9.4.54.v20240208.jar
+    - jetty-alpn-java-client-9.4.54.v20240208.jar
+    - jetty-client-9.4.54.v20240208.jar
+    - jetty-http-9.4.54.v20240208.jar
+    - jetty-io-9.4.54.v20240208.jar
+    - jetty-jmx-9.4.54.v20240208.jar
+    - jetty-security-9.4.54.v20240208.jar
+    - jetty-server-9.4.54.v20240208.jar
+    - jetty-servlet-9.4.54.v20240208.jar
+    - jetty-util-9.4.54.v20240208.jar
+    - jetty-util-ajax-9.4.54.v20240208.jar
   * Byte Buddy
     - byte-buddy-1.14.12.jar
   * Apache BVal


### PR DESCRIPTION
### Motivation

There are some issues with LICENSE/NOTICE.

```
➜  pulsar git:(branch-3.1) ✗ src/check-binary-license.sh distribution/server/target/apache-pulsar-3.1.3-bin.tar.gz
http2-client-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
http2-common-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
http2-hpack-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
http2-http-client-transport-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
http2-server-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
jetty-alpn-client-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
jetty-alpn-java-client-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
jetty-client-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
jetty-http-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
jetty-http-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
jetty-io-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
jetty-io-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
jetty-jmx-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
jetty-security-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
jetty-security-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
jetty-server-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
jetty-server-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
jetty-servlet-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
jetty-servlet-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
jetty-util-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
jetty-util-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
jetty-util-ajax-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
jetty-util-ajax-9.4.54.v20240208.jar unaccounted for in trino/LICENSE
http2-client-9.4.53.v20231009.jar mentioned in trino/LICENSE, but not bundled
http2-common-9.4.53.v20231009.jar mentioned in trino/LICENSE, but not bundled
http2-hpack-9.4.53.v20231009.jar mentioned in trino/LICENSE, but not bundled
http2-http-client-transport-9.4.53.v20231009.jar mentioned in trino/LICENSE, but not bundled
jetty-alpn-client-9.4.53.v20231009.jar mentioned in trino/LICENSE, but not bundled
http2-server-9.4.53.v20231009.jar mentioned in trino/LICENSE, but not bundled
jetty-alpn-java-client-9.4.53.v20231009.jar mentioned in trino/LICENSE, but not bundled
jetty-client-9.4.53.v20231009.jar mentioned in trino/LICENSE, but not bundled
jetty-http-9.4.53.v20231009.jar mentioned in trino/LICENSE, but not bundled
jetty-io-9.4.53.v20231009.jar mentioned in trino/LICENSE, but not bundled
jetty-jmx-9.4.53.v20231009.jar mentioned in trino/LICENSE, but not bundled
jetty-security-9.4.53.v20231009.jar mentioned in trino/LICENSE, but not bundled
jetty-server-9.4.53.v20231009.jar mentioned in trino/LICENSE, but not bundled
jetty-servlet-9.4.53.v20231009.jar mentioned in trino/LICENSE, but not bundled
jetty-util-9.4.53.v20231009.jar mentioned in trino/LICENSE, but not bundled
jetty-util-ajax-9.4.53.v20231009.jar mentioned in trino/LICENSE, but not bundled

It looks like there are issues with the LICENSE/NOTICE.
```

### Modifications

Fix the Pulsar SQL LICENSE file.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
