### PR TITLE
[improve][client] add physicalAddress as part of connection pool key

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
@@ -93,9 +93,9 @@ public class ConnectionPool implements AutoCloseable {
 
     @Value
     private static class Key {
-        private final InetSocketAddress logicalAddress;
-        private final InetSocketAddress physicalAddress;
-        private final int randomKey;
+        InetSocketAddress logicalAddress;
+        InetSocketAddress physicalAddress;
+        int randomKey;
     }
 
     public ConnectionPool(ClientConfigurationData conf, EventLoopGroup eventLoopGroup) throws PulsarClientException {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
@@ -470,8 +470,7 @@ public class ConnectionPool implements AutoCloseable {
             return;
         }
         List<Runnable> releaseIdleConnectionTaskList = new ArrayList<>();
-        for (Map.Entry<Key,  CompletableFuture<ClientCnx>> entry :
-                pool.entrySet()){
+        for (Map.Entry<Key,  CompletableFuture<ClientCnx>> entry : pool.entrySet()) {
                 CompletableFuture<ClientCnx> future = entry.getValue();
                 // Ensure connection has been connected.
                 if (!future.isDone()) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
@@ -233,8 +233,7 @@ public class ConnectionPool implements AutoCloseable {
             return createConnection(new Key(logicalAddress, physicalAddress, -1));
         }
         Key key = new Key(logicalAddress, physicalAddress, randomKey);
-        CompletableFuture<ClientCnx> completableFuture = pool
-                .computeIfAbsent(key, k -> createConnection(key));
+        CompletableFuture<ClientCnx> completableFuture = pool.computeIfAbsent(key, k -> createConnection(key));
         if (completableFuture.isCompletedExceptionally()) {
             // we cannot cache a failed connection, so we remove it from the pool
             // there is a race condition in which
@@ -248,8 +247,7 @@ public class ConnectionPool implements AutoCloseable {
             // If connection already release, create a new one.
             if (clientCnx.getIdleState().isReleased()) {
                 pool.remove(key, completableFuture);
-                return pool
-                        .computeIfAbsent(key, k -> createConnection(key));
+                return pool.computeIfAbsent(key, k -> createConnection(key));
             }
             // Try use exists connection.
             if (clientCnx.getIdleState().tryMarkUsingAndClearIdleTime()) {
@@ -257,8 +255,7 @@ public class ConnectionPool implements AutoCloseable {
             } else {
                 // If connection already release, create a new one.
                 pool.remove(key, completableFuture);
-                return pool
-                        .computeIfAbsent(key, k -> createConnection(key));
+                return pool.computeIfAbsent(key, k -> createConnection(key));
             }
         });
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
@@ -209,10 +209,6 @@ public class ConnectionPool implements AutoCloseable {
             }
         });
     }
-
-    private Key getKey(InetSocketAddress logicalAddress, InetSocketAddress physicalAddress, final int randomKey) {
-        return new Key(logicalAddress, physicalAddress, randomKey);
-    }
             /**
      * Get a connection from the pool.
      * <p>
@@ -234,9 +230,9 @@ public class ConnectionPool implements AutoCloseable {
             InetSocketAddress physicalAddress, final int randomKey) {
         if (maxConnectionsPerHosts == 0) {
             // Disable pooling
-            return createConnection(getKey(logicalAddress, physicalAddress, -1));
+            return createConnection(new Key(logicalAddress, physicalAddress, -1));
         }
-        Key key = getKey(logicalAddress, physicalAddress, randomKey);
+        Key key = new Key(logicalAddress, physicalAddress, randomKey);
         CompletableFuture<ClientCnx> completableFuture = pool
                 .computeIfAbsent(key, k -> createConnection(key));
         if (completableFuture.isCompletedExceptionally()) {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->



<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Context: https://github.com/apache/pulsar/pull/22085/files#r1497008116

Currently, the connection pool key does not include physicalAddress (currently logicalAddress + keySuffix). This can be a problem when the same logicalAddresses are in the migrated(green) cluster. (the connection pool will return the connection to the old(blue) cluster)

### Modifications

Add physicalAddress as part of the connection pool key

### Verifying this change

- [x] Make sure that the change passes the CI checks.
### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
