### PR TITLE
[fix][client] GenericProtobufNativeSchema not implement getNativeSchema method.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeSchema.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.impl.schema.generic;
 
 import static org.apache.pulsar.client.impl.schema.generic.MultiVersionGenericProtobufNativeReader.parseProtobufSchema;
 import com.google.protobuf.Descriptors;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.schema.Field;
@@ -66,6 +67,11 @@ public class GenericProtobufNativeSchema extends AbstractGenericSchema {
 
     public Descriptors.Descriptor getProtobufNativeSchema() {
         return descriptor;
+    }
+
+    @Override
+    public Optional<Object> getNativeSchema() {
+        return Optional.of(descriptor);
     }
 
     @Override

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeReaderTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeReaderTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl.schema.generic;
 
+import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.schema.GenericRecord;
@@ -29,6 +30,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 @Slf4j
 public class GenericProtobufNativeReaderTest {
@@ -77,6 +79,12 @@ public class GenericProtobufNativeReaderTest {
         DynamicMessage nativeRecord = (DynamicMessage) record.getNativeObject();
         assertEquals(nativeRecord.getField(nativeRecord.getDescriptorForType().findFieldByName("stringField")), STRING_FIELD_VLUE);
         assertEquals(nativeRecord.getField(nativeRecord.getDescriptorForType().findFieldByName("doubleField")), DOUBLE_FIELD_VLUE);
+    }
+
+    @Test
+    public void testGetNativeSchema() {
+        assertTrue(genericProtobufNativeSchema.getNativeSchema().isPresent());
+        assertTrue(genericProtobufNativeSchema.getNativeSchema().get() instanceof Descriptors.Descriptor);
     }
 
     private static final String STRING_FIELD_VLUE = "stringFieldValue";


### PR DESCRIPTION
### Motivation
GenericProtobufNativeSchema not implement getNativeSchema method.


### Modifications
Add `getNativeSchema` implement for `GenericProtobufNativeSchema`.

### Verifying this change
Add `testGetNativeSchema` to cover it.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
