### PR TITLE
[improve][broker] PIP-226: Add JWKS support for AuthenticationProviderToken

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -880,6 +880,12 @@ tokenSecretKey=
 # tokenPublicKey=file:///my/public.key    ( Note: key file must be DER-encoded )
 tokenPublicKey=
 
+# JSON Web Key Set
+# This content is the response for jwks_uri, where jwks_uri is from https://ODIC_PORIVDER/.well-known/openid-configuration
+# tokenKeySetKey=data:;base64,xxxxxxxxx
+# tokenKeySetKey=file://my/jwks.json
+tokenKeySetKey=
+
 # The token "claim" that will be interpreted as the authentication "role" or "principal" by AuthenticationProviderToken (defaults to "sub" if blank)
 tokenAuthClaim=
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -565,6 +565,11 @@ tokenSecretKey=
 # tokenPublicKey=file:///my/public.key    ( Note: key file must be DER-encoded )
 tokenPublicKey=
 
+# JSON Web Key Set
+# This content is the response for jwks_uri, where jwks_uri is from https://ODIC_PORIVDER/.well-known/openid-configuration
+# tokenKeySetKey=data:;base64,xxxxxxxxx
+# tokenKeySetKey=file://my/jwks.json
+tokenKeySetKey=
 
 # The token "claim" that will be interpreted as the authentication "role" or "principal" by AuthenticationProviderToken (defaults to "sub" if blank)
 tokenAuthClaim=

--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,7 @@ flexible messaging model and an intuitive client API.</description>
     <opentelemetry.alpha.version>1.34.1-alpha</opentelemetry.alpha.version>
     <opentelemetry.instrumentation.version>1.32.1-alpha</opentelemetry.instrumentation.version>
     <opentelemetry.semconv.version>1.23.1-alpha</opentelemetry.semconv.version>
+    <jwks-rsa.version>0.22.0</jwks-rsa.version>
 
     <!-- test dependencies -->
     <testcontainers.version>1.18.3</testcontainers.version>
@@ -1492,6 +1493,11 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>io.opentelemetry.semconv</groupId>
         <artifactId>opentelemetry-semconv</artifactId>
         <version>${opentelemetry.semconv.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.auth0</groupId>
+        <artifactId>jwks-rsa</artifactId>
+        <version>${jwks-rsa.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pulsar-broker-common/pom.xml
+++ b/pulsar-broker-common/pom.xml
@@ -69,6 +69,11 @@
       <artifactId>jjwt-jackson</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.auth0</groupId>
+      <artifactId>jwks-rsa</artifactId>
+    </dependency>
+
     <!-- test -->
     <dependency>
       <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
PIP: #18798 

### Motivation

This PIP was agreed upon a long time ago, but because the OIDC provider supports this feature, it was turned off.

Community users need this feature, but do not want to use the OIDC provider, please see #8152

This PIP doesn't support rotating public keys, we only load the public key once at startup, we can improve here by cache.

### Modifications

- Add tokenKeySet config to provide the JWKS support

### Verifying this change

- Added RSA test
- Added EC test

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->