### PR TITLE
[improve] Removed unnecessary native libraries from Docker images

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -18,13 +18,18 @@
 #
 
 # First create a stage with just the Pulsar tarball and scripts
-FROM busybox as pulsar
+FROM alpine as pulsar
+
+RUN apk add zip
 
 ARG PULSAR_TARBALL
 
 ADD ${PULSAR_TARBALL} /
 RUN mv /apache-pulsar-* /pulsar
 RUN rm -rf /pulsar/bin/*.cmd
+
+COPY build-scripts /build-scripts/
+RUN /build-scripts/remove-unnecessary-native-binaries.sh
 
 COPY scripts/* /pulsar/bin/
 

--- a/docker/pulsar/build-scripts/remove-unnecessary-native-binaries.sh
+++ b/docker/pulsar/build-scripts/remove-unnecessary-native-binaries.sh
@@ -25,7 +25,13 @@ set -e
 ARCH=$(uname -m)
 
 # Remove extra binaries for Netty TCNative
-ls /pulsar/lib/io.netty-netty-tcnative-boringssl-static*Final-*.jar | grep -v linux-$ARCH | xargs rm
+if [ "$ARCH" = "aarch64" ]
+then
+  TC_NATIVE_TO_KEEP=linux-aarch_64
+else
+  TC_NATIVE_TO_KEEP=linux-$ARCH
+fi
+ls /pulsar/lib/io.netty-netty-tcnative-boringssl-static*Final-*.jar | grep -v $TC_NATIVE_TO_KEEP | xargs rm
 
 # Prune extra libs from RocksDB JAR
 mkdir /tmp/rocksdb
@@ -33,6 +39,13 @@ cd /tmp/rocksdb
 ROCKSDB_JAR=$(ls /pulsar/lib/org.rocksdb-rocksdbjni-*.jar)
 unzip $ROCKSDB_JAR > /dev/null
 
-ls librocksdbjni-* | grep -v librocksdbjni-linux-$ARCH-musl.so | xargs rm
+if [ "$ARCH" = "x86_64" ]
+then
+  ROCKSDB_TO_KEEP=linux64-musl
+else
+  ROCKSDB_TO_KEEP=linux-$ARCH-musl
+fi
+
+ls librocksdbjni-* | grep -v librocksdbjni-${ROCKSDB_TO_KEEP}.so | xargs rm
 rm $ROCKSDB_JAR
 zip -r -9 $ROCKSDB_JAR * > /dev/null

--- a/docker/pulsar/build-scripts/remove-unnecessary-native-binaries.sh
+++ b/docker/pulsar/build-scripts/remove-unnecessary-native-binaries.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -e
+
+# Retain only native libraries for the architecture of this
+# image
+ARCH=$(uname -m)
+
+# Remove extra binaries for Netty TCNative
+ls /pulsar/lib/io.netty-netty-tcnative-boringssl-static*Final-*.jar | grep -v linux-$ARCH | xargs rm
+
+# Prune extra libs from RocksDB JAR
+mkdir /tmp/rocksdb
+cd /tmp/rocksdb
+ROCKSDB_JAR=$(ls /pulsar/lib/org.rocksdb-rocksdbjni-*.jar)
+unzip $ROCKSDB_JAR > /dev/null
+
+ls librocksdbjni-* | grep -v librocksdbjni-linux-$ARCH-musl.so | xargs rm
+rm $ROCKSDB_JAR
+zip -r -9 $ROCKSDB_JAR * > /dev/null


### PR DESCRIPTION
### Motivation

The RocksDB jar that we are including in our Docker image is ~55 MB in size because it includes native library of RocksDB compiled for many different platforms. 

In reality, our Docker image is going to be used exactly on one single platorm, either `linux/x86-64` or `linux/arm64`. 

Therefore we can remove all the other RocksDB compiled libraries from the image. The resulting RocksDB jar is shrunk to 4.6 MB.

Similarly, we can remove Netty TC natives jar that are not relevant for the container.

### Modifications

Added a script to remove the unnecessary libraries.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
