### PR TITLE
[improve][broker] Add logs to `getInternalStats` for quickly locate problem when schema ledger is lost

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2516,6 +2516,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                     stats.schemaLedgers.add(schemaLedgerInfo);
                                     completableFuture.complete(null);
                                 }).exceptionally(e -> {
+                                    log.info("[{}] Failed to get ledger metadata for the schema ledger {}",
+                                            topic, ledgerId, e);
                                     completableFuture.completeExceptionally(e);
                                     return null;
                                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2516,7 +2516,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                     stats.schemaLedgers.add(schemaLedgerInfo);
                                     completableFuture.complete(null);
                                 }).exceptionally(e -> {
-                                    log.info("[{}] Failed to get ledger metadata for the schema ledger {}",
+                                    log.error("[{}] Failed to get ledger metadata for the schema ledger {}",
                                             topic, ledgerId, e);
                                     completableFuture.completeExceptionally(e);
                                     return null;


### PR DESCRIPTION
### Motivation

If schema ledger is lost, when we call the admin interface "topics stats-internal", the server only has the following error log:
<img width="2401" alt="image" src="https://github.com/apache/pulsar/assets/16524922/1cdabeac-6dc7-466e-9e1d-33c3d01a459d">

However, this log does not clearly indicate which ledger is lost. We don’t even know whether the ledger of topic, cursor or schema is lost. Therefore, it brings challenges to quickly locate the problem.


### Modifications

When failed to get ledger metadata for the schema ledger, add logs to quickly locate problem:
` log.info("[{}] Failed to get ledger metadata for the schema ledger {}", topic, ledgerId, e);`

At this time, we can see the following log, and we can quickly and clearly know that the problem is caused by schema ledger is lost.
<img width="1379" alt="image" src="https://github.com/apache/pulsar/assets/16524922/40b17eb0-5cd0-4345-afee-e26edc7a8f6c">


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->