### PR TITLE
[improve] [broker] Avoid repeated Read-and-discard when using Key_Shared mode

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
@@ -95,6 +95,14 @@ public class MessageRedeliveryController {
         }
     }
 
+    public Long getHash(long ledgerId, long entryId) {
+        LongPair value = hashesToBeBlocked.get(ledgerId, entryId);
+        if (value == null) {
+            return null;
+        }
+        return value.first;
+    }
+
     public void removeAllUpTo(long markDeleteLedgerId, long markDeleteEntryId) {
         if (!allowOutOfOrderDelivery) {
             List<LongPair> keysToRemove = new ArrayList<>();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -334,34 +334,25 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
             }
 
             NavigableSet<PositionImpl> messagesToReplayNow = getMessagesToReplayNow(messagesToRead);
-
-            if (!messagesToReplayNow.isEmpty()) {
-                // In Key_Shared mode: It is possible that all resend messages will be discarded:
-                // - Partly because the target consumer does not have enough permits
-                // - Partly because of mechanism “recentJoinedConsumers”.
-                NavigableSet<PositionImpl> messagesToReplayNowFiltered =
-                        filterOutMessagesWillBeDiscarded(messagesToReplayNow);
-                if (messagesToReplayNowFiltered.isEmpty()) {
-                    // No messages can be delivery now.
-                    return;
-                }
+            NavigableSet<PositionImpl> messagesToReplayFiltered = filterOutEntriesWillBeDiscarded(messagesToReplayNow);
+            if (!messagesToReplayFiltered.isEmpty()) {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Schedule replay of {} messages for {} consumers", name,
-                            messagesToReplayNowFiltered.size(), consumerList.size());
+                            messagesToReplayFiltered.size(), consumerList.size());
                 }
 
                 havePendingReplayRead = true;
                 minReplayedPosition = messagesToReplayNow.first();
                 Set<? extends Position> deletedMessages = topic.isDelayedDeliveryEnabled()
-                        ? asyncReplayEntriesInOrder(messagesToReplayNowFiltered)
-                        : asyncReplayEntries(messagesToReplayNowFiltered);
+                        ? asyncReplayEntriesInOrder(messagesToReplayFiltered)
+                        : asyncReplayEntries(messagesToReplayFiltered);
                 // clear already acked positions from replay bucket
 
                 deletedMessages.forEach(position -> redeliveryMessages.remove(((PositionImpl) position).getLedgerId(),
                         ((PositionImpl) position).getEntryId()));
                 // if all the entries are acked-entries and cleared up from redeliveryMessages, try to read
                 // next entries as readCompletedEntries-callback was never called
-                if ((messagesToReplayNowFiltered.size() - deletedMessages.size()) == 0) {
+                if ((messagesToReplayFiltered.size() - deletedMessages.size()) == 0) {
                     havePendingReplayRead = false;
                     readMoreEntriesAsync();
                 }
@@ -370,7 +361,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
                     log.debug("[{}] Dispatcher read is blocked due to unackMessages {} reached to max {}", name,
                             totalUnackedMessages, topic.getMaxUnackedMessagesOnSubscription());
                 }
-            } else if (!havePendingRead) {
+            } else if (!havePendingRead && hasConsumersNeededNormalRead()) {
                 if (shouldPauseOnAckStatePersist(ReadType.Normal)) {
                     if (log.isDebugEnabled()) {
                         log.debug("[{}] [{}] Skipping read for the topic, Due to blocked on ack state persistent.",
@@ -406,7 +397,16 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
                             topic.getMaxReadPosition());
                 }
             } else {
-                log.debug("[{}] Cannot schedule next read until previous one is done", name);
+                if (log.isDebugEnabled()) {
+                    if (!messagesToReplayNow.isEmpty()) {
+                        log.debug("[{}] [{}] Skipping read for the topic: because all entries in replay queue were"
+                                + " filtered out due to the mechanism of Key_Shared mode, and the left consumers have"
+                                + " no permits now",
+                                topic.getName(), getSubscriptionName());
+                    } else {
+                        log.debug("[{}] Cannot schedule next read until previous one is done", name);
+                    }
+                }
             }
         } else {
             if (log.isDebugEnabled()) {
@@ -1190,13 +1190,24 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
     }
 
     /**
+     * This is a mode method designed for Key_Shared mode.
+     * Filter out the entries that will be discarded due to the order guarantee mechanism of Key_Shared mode.
      * This method is in order to avoid the scenario below:
-     * - Read entries from the Replay queue.
-     * - The Key_Shared anti-ordering mechanism filtered out all of the entries.
+     * - Get positions from the Replay queue.
+     * - Read entries from BK.
+     * - The order guarantee mechanism of Key_Shared mode filtered out all the entries.
      * - Delivery non entry to the client, but we did a BK read.
      */
-    protected NavigableSet<PositionImpl> filterOutMessagesWillBeDiscarded(NavigableSet<PositionImpl> src) {
+    protected NavigableSet<PositionImpl> filterOutEntriesWillBeDiscarded(NavigableSet<PositionImpl> src) {
         return src;
+    }
+
+    /**
+     * This is a mode method designed for Key_Shared mode, to avoid unnecessary stuck.
+     * See detail {@link PersistentStickyKeyDispatcherMultipleConsumers#hasConsumersNeededNormalRead}.
+     */
+    protected boolean hasConsumersNeededNormalRead() {
+        return true;
     }
 
     protected synchronized boolean shouldPauseDeliveryForDelayTracker() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -481,13 +481,13 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
                 res.add(pos);
             }
             Consumer c = selector.select(stickyKeyHash.intValue());
+            if (c == null) {
+                continue;
+            }
             if (getAvailablePermits(c) == 0) {
                 continue;
             }
             PositionImpl currentMaxReadPosition = recentlyJoinedConsumers.get(c);
-            if (c == null) {
-                continue;
-            }
             if (currentMaxReadPosition == null) {
                 res.add(pos);
             } else if (pos.compareTo(firstMaxReadPos) < 0 && pos.compareTo(currentMaxReadPosition) < 0) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -410,6 +410,9 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
     }
 
     private boolean removeConsumersFromRecentJoinedConsumers() {
+        if (MapUtils.isEmpty(recentlyJoinedConsumers)) {
+            return false;
+        }
         Iterator<Map.Entry<Consumer, PositionImpl>> itr = recentlyJoinedConsumers.entrySet().iterator();
         boolean hasConsumerRemovedFromTheRecentJoinedConsumers = false;
         PositionImpl mdp = (PositionImpl) cursor.getMarkDeletedPosition();
@@ -479,6 +482,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             Long stickyKeyHash = redeliveryMessages.getHash(pos.getLedgerId(), pos.getEntryId());
             if (stickyKeyHash == null) {
                 res.add(pos);
+                continue;
             }
             Consumer c = selector.select(stickyKeyHash.intValue());
             if (c == null) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -482,6 +482,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             }
             Consumer c = selector.select(stickyKeyHash.intValue());
             if (c == null) {
+                // Maybe using HashRangeExclusiveStickyKeyConsumerSelector.
                 continue;
             }
             if (getAvailablePermits(c) == 0) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -472,7 +472,6 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             // Avoid error due to concurrent modifying.
             return src;
         }
-        // Group by key_hash.
         NavigableSet<PositionImpl> res = new TreeSet<>();
         final Map<Consumer, List<PositionImpl>> groupedEntries = localGroupedPositions.get();
         groupedEntries.clear();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -485,8 +485,8 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             }
             int posCountToRead = getRestrictedMaxEntriesForConsumer(item.getKey(), item.getValue(), availablePermits,
                     ReadType.Replay, null);
-            for (int i = 0; i < posCountToRead; i++) {
-                res.add(item.getValue().get(i));
+            if (posCountToRead > 0) {
+                res.addAll(item.getValue().subList(0, posCountToRead));
             }
         }
         return res;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -1721,7 +1721,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         Consumer<Integer> consumer3 = pulsarClient.newConsumer(Schema.INT32)
                 .topic(topic)
                 .subscriptionName(subName)
-                .receiverQueueSize(10)
+                .receiverQueueSize(1000)
                 .subscriptionType(SubscriptionType.Key_Shared)
                 .subscribe();
         redeliverConsumer.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -1681,7 +1681,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                     .key(String.valueOf(random.nextInt(NUMBER_OF_KEYS)))
                     .value(100 + i)
                     .send();
-            log.info("Published delayed message :{}", messageId);
+            log.info("Published message :{}", messageId);
         }
         producer.close();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerConsumerBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerConsumerBase.java
@@ -21,9 +21,14 @@ package org.apache.pulsar.client.api;
 import com.google.common.collect.Sets;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
@@ -69,4 +74,65 @@ public abstract class ProducerConsumerBase extends MockedPulsarServiceBaseTest {
         return "my-property/my-ns/topic-" + Long.toHexString(random.nextLong());
     }
 
+    protected <T> ReceivedMessages<T> receiveAndAckMessages(
+            BiFunction<MessageId, T, Boolean> ackPredicate,
+            Consumer<T>...consumers) throws Exception {
+        ReceivedMessages receivedMessages = new ReceivedMessages();
+        while (true) {
+            int receivedMsgCount = 0;
+            for (int i = 0; i < consumers.length; i++) {
+                Consumer<T> consumer = consumers[i];
+                while (true) {
+                    Message<T> msg = consumer.receive(2, TimeUnit.SECONDS);
+                    if (msg != null) {
+                        receivedMsgCount++;
+                        T v = msg.getValue();
+                        MessageId messageId = msg.getMessageId();
+                        receivedMessages.messagesReceived.add(Pair.of(msg.getMessageId(), v));
+                        if (ackPredicate.apply(messageId, v)) {
+                            consumer.acknowledge(msg);
+                            receivedMessages.messagesAcked.add(Pair.of(msg.getMessageId(), v));
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            }
+            // Because of the possibility of consumers getting stuck with each other, only jump out of the loop if all
+            // consumers could not receive messages.
+            if (receivedMsgCount == 0) {
+                break;
+            }
+        }
+        return receivedMessages;
+    }
+
+    protected <T> ReceivedMessages<T> ackAllMessages(Consumer<T>...consumers) throws Exception {
+        return receiveAndAckMessages((msgId, msgV) -> true, consumers);
+    }
+
+    protected static class ReceivedMessages<T> {
+
+        List<Pair<MessageId, T>> messagesReceived = new ArrayList<>();
+
+        List<Pair<MessageId, T>> messagesAcked = new ArrayList<>();
+
+        public boolean hasReceivedMessage(T v) {
+            for (Pair<MessageId, T> pair : messagesReceived) {
+                if (pair.getRight().equals(v)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public boolean hasAckedMessage(T v) {
+            for (Pair<MessageId, T> pair : messagesAcked) {
+                if (pair.getRight().equals(v)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionPauseOnAckStatPersistTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionPauseOnAckStatPersistTest.java
@@ -21,13 +21,10 @@ package org.apache.pulsar.client.api;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Position;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.service.Dispatcher;
 import org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService;
@@ -148,69 +145,8 @@ public class SubscriptionPauseOnAckStatPersistTest extends ProducerConsumerBase 
         RESET_CURSOR;
     }
 
-    private ReceivedMessages receiveAndAckMessages(BiFunction<MessageId, String, Boolean> ackPredicate,
-                                                Consumer<String>...consumers) throws Exception {
-        ReceivedMessages receivedMessages = new ReceivedMessages();
-        while (true) {
-            int receivedMsgCount = 0;
-            for (int i = 0; i < consumers.length; i++) {
-                Consumer<String> consumer = consumers[i];
-                while (true) {
-                    Message<String> msg = consumer.receive(2, TimeUnit.SECONDS);
-                    if (msg != null) {
-                        receivedMsgCount++;
-                        String v = msg.getValue();
-                        MessageId messageId = msg.getMessageId();
-                        receivedMessages.messagesReceived.add(Pair.of(msg.getMessageId(), v));
-                        if (ackPredicate.apply(messageId, v)) {
-                            consumer.acknowledge(msg);
-                            receivedMessages.messagesAcked.add(Pair.of(msg.getMessageId(), v));
-                        }
-                    } else {
-                        break;
-                    }
-                }
-            }
-            // Because of the possibility of consumers getting stuck with each other, only jump out of the loop if all
-            // consumers could not receive messages.
-            if (receivedMsgCount == 0) {
-                break;
-            }
-        }
-        return receivedMessages;
-    }
-
-    private ReceivedMessages ackAllMessages(Consumer<String>...consumers) throws Exception {
-        return receiveAndAckMessages((msgId, msgV) -> true, consumers);
-    }
-
-    private ReceivedMessages ackOddMessagesOnly(Consumer<String>...consumers) throws Exception {
+    private ReceivedMessages<String> ackOddMessagesOnly(Consumer<String>...consumers) throws Exception {
         return receiveAndAckMessages((msgId, msgV) -> Integer.valueOf(msgV) % 2 == 1, consumers);
-    }
-
-    private static class ReceivedMessages {
-
-        List<Pair<MessageId,String>> messagesReceived = new ArrayList<>();
-
-        List<Pair<MessageId,String>> messagesAcked = new ArrayList<>();
-
-        public boolean hasReceivedMessage(String v) {
-            for (Pair<MessageId,String> pair : messagesReceived) {
-                if (pair.getRight().equals(v)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        public boolean hasAckedMessage(String v) {
-            for (Pair<MessageId,String> pair : messagesAcked) {
-                if (pair.getRight().equals(v)) {
-                    return true;
-                }
-            }
-            return false;
-        }
     }
 
     @DataProvider(name = "typesOfSetDispatcherPauseOnAckStatePersistent")
@@ -367,7 +303,7 @@ public class SubscriptionPauseOnAckStatPersistTest extends ProducerConsumerBase 
 
         // Verify: after ack messages, will unpause the dispatcher.
         c1.acknowledge(messageIdsSent);
-        ReceivedMessages receivedMessagesAfterPause = ackAllMessages(c1);
+        ReceivedMessages<String> receivedMessagesAfterPause = ackAllMessages(c1);
         Assert.assertTrue(receivedMessagesAfterPause.hasReceivedMessage(specifiedMessage));
         Assert.assertTrue(receivedMessagesAfterPause.hasAckedMessage(specifiedMessage));
 
@@ -417,7 +353,7 @@ public class SubscriptionPauseOnAckStatPersistTest extends ProducerConsumerBase 
         final String specifiedMessage2 = "9876543211";
         p1.send(specifiedMessage2);
 
-        ReceivedMessages receivedMessagesAfterPause = ackAllMessages(c1);
+        ReceivedMessages<String> receivedMessagesAfterPause = ackAllMessages(c1);
         Assert.assertTrue(receivedMessagesAfterPause.hasReceivedMessage(specifiedMessage2));
         Assert.assertTrue(receivedMessagesAfterPause.hasAckedMessage(specifiedMessage2));
 
@@ -520,7 +456,7 @@ public class SubscriptionPauseOnAckStatPersistTest extends ProducerConsumerBase 
             messageIdsSent.add(messageId);
         }
         // Make ack holes.
-        ReceivedMessages receivedMessagesC1 = ackOddMessagesOnly(c1);
+        ReceivedMessages<String> receivedMessagesC1 = ackOddMessagesOnly(c1);
         verifyAckHolesIsMuchThanLimit(tpName, subscription);
 
         cancelPendingRead(tpName, subscription);
@@ -540,7 +476,7 @@ public class SubscriptionPauseOnAckStatPersistTest extends ProducerConsumerBase 
 
         // Verify: close the previous consumer, the new one could receive all messages.
         c1.close();
-        ReceivedMessages receivedMessagesC2 = ackAllMessages(c2);
+        ReceivedMessages<String> receivedMessagesC2 = ackAllMessages(c2);
         int messageCountAckedByC1 = receivedMessagesC1.messagesAcked.size();
         int messageCountAckedByC2 = receivedMessagesC2.messagesAcked.size();
         Assert.assertEquals(messageCountAckedByC2, msgSendCount - messageCountAckedByC1 + specifiedMessageCount);
@@ -577,7 +513,7 @@ public class SubscriptionPauseOnAckStatPersistTest extends ProducerConsumerBase 
             messageIdsSent.add(messageId);
         }
         // Make ack holes.
-        ReceivedMessages receivedMessagesC1AndC2 = ackOddMessagesOnly(c1, c2);
+        ReceivedMessages<String> receivedMessagesC1AndC2 = ackOddMessagesOnly(c1, c2);
         verifyAckHolesIsMuchThanLimit(tpName, subscription);
 
         cancelPendingRead(tpName, subscription);
@@ -601,7 +537,7 @@ public class SubscriptionPauseOnAckStatPersistTest extends ProducerConsumerBase 
         // Verify: close the previous consumer, the new one could receive all messages.
         c1.close();
         c2.close();
-        ReceivedMessages receivedMessagesC3AndC4 = ackAllMessages(c3, c4);
+        ReceivedMessages<String> receivedMessagesC3AndC4 = ackAllMessages(c3, c4);
         int messageCountAckedByC1AndC2 = receivedMessagesC1AndC2.messagesAcked.size();
         int messageCountAckedByC3AndC4 = receivedMessagesC3AndC4.messagesAcked.size();
         Assert.assertEquals(messageCountAckedByC3AndC4,


### PR DESCRIPTION
### Motivation

When using `Key_Shared` subscription, the broker may discard a part of the result reading from BK to avoid breaking the order of consumption, but this may cause repeated Read-and-discard, which wastes a lot of BK traffic.
- Read entries from the Replay queue.
- The entries can not be sent to the consumer due to they are larger than `consumer.maxReadPosition`
- Nothing was delivered to the client, but the Broker did more and more BK readings.

You can reproduce the issue by `testNoRepeatedReadAndDiscard `

### Modifications
Before reading the BK, filter out the positions that will be discarded.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x