### PR TITLE
[fix][test] fix flaky test shouldProvideConsistentAnswerToTopicLookupsUsingAdminApi

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/MultiBrokerLeaderElectionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/MultiBrokerLeaderElectionTest.java
@@ -99,7 +99,7 @@ public class MultiBrokerLeaderElectionTest extends MultiBrokerTestZKBaseTest {
         });
     }
 
-    @Test(timeOut = 60000L)
+    @Test(timeOut = 120000L)
     public void shouldProvideConsistentAnswerToTopicLookupsUsingAdminApi()
             throws PulsarAdminException, ExecutionException, InterruptedException {
         String namespace = "public/ns" + UUID.randomUUID();


### PR DESCRIPTION
Fixes #22239

### Motivation
The test shouldProvideConsistentAnswerToTopicLookupsUsingAdminApi failed too many times in the GitHub CI because of too many topics and too little runtime.
https://github.com/apache/pulsar/actions/runs/8245776074/job/22550815658?pr=22034
https://github.com/apache/pulsar/actions/runs/8234998047/job/22547427391?pr=22243
```log
org.apache.pulsar.broker.loadbalance.AdvertisedListenersMultiBrokerLeaderElectionTest.shouldProvideConsistentAnswerToTopicLookupsUsingAdminApi  Time elapsed: 60.005 s  <<< FAILURE!
  org.testng.internal.thread.ThreadTimeoutException: Method org.apache.pulsar.broker.loadbalance.MultiBrokerLeaderElectionTest.shouldProvideConsistentAnswerToTopicLookupsUsingAdminApi() didn't finish within the time-out 60000
  	at java.base@17.0.10/jdk.internal.misc.Unsafe.park(Native Method)
  	at java.base@17.0.10/java.util.concurrent.locks.LockSupport.park(LockSupport.java:211)
  	at java.base@17.0.10/java.util.concurrent.FutureTask.awaitDone(FutureTask.java:447)
  	at java.base@17.0.10/java.util.concurrent.FutureTask.get(FutureTask.java:190)
  	at 
```
### Modifications

Increase the runtime of the shouldProvideConsistentAnswerToTopicLookupsUsingAdminApi
### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
