### PR TITLE
[improve][test] Don't configure Mockito spying for MultiBrokerTestZKBaseTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerTestZKBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerTestZKBaseTest.java
@@ -65,6 +65,7 @@ public abstract class MultiBrokerTestZKBaseTest extends MultiBrokerBaseTest {
     @Override
     protected PulsarTestContext.Builder createPulsarTestContextBuilder(ServiceConfiguration conf) {
         return super.createPulsarTestContextBuilder(conf)
+                .spyNoneByDefault()
                 .localMetadataStore(createMetadataStore(MetadataStoreConfig.METADATA_STORE))
                 .configurationMetadataStore(createMetadataStore(MetadataStoreConfig.CONFIGURATION_METADATA_STORE));
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
@@ -331,7 +331,17 @@ public class PulsarTestContext implements AutoCloseable {
          * @return the builder
          */
         public Builder spyByDefault() {
-            spyConfigBuilder = SpyConfig.builder(SpyConfig.SpyType.SPY);
+            spyConfigDefault(SpyConfig.SpyType.SPY);
+            return this;
+        }
+
+        public Builder spyNoneByDefault() {
+            spyConfigDefault(SpyConfig.SpyType.NONE);
+            return this;
+        }
+
+        public Builder spyConfigDefault(SpyConfig.SpyType spyType) {
+            spyConfigBuilder = SpyConfig.builder(spyType);
             return this;
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/SpyConfig.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/SpyConfig.java
@@ -129,6 +129,11 @@ public class SpyConfig {
      */
     public static Builder builder(SpyType defaultSpyType) {
         Builder spyConfigBuilder = new Builder();
+        configureDefaults(spyConfigBuilder, defaultSpyType);
+        return spyConfigBuilder;
+    }
+
+    public static void configureDefaults(Builder spyConfigBuilder, SpyType defaultSpyType) {
         spyConfigBuilder.pulsarService(defaultSpyType);
         spyConfigBuilder.pulsarResources(defaultSpyType);
         spyConfigBuilder.brokerService(defaultSpyType);
@@ -136,6 +141,5 @@ public class SpyConfig {
         spyConfigBuilder.compactor(defaultSpyType);
         spyConfigBuilder.compactedServiceFactory(defaultSpyType);
         spyConfigBuilder.namespaceService(defaultSpyType);
-        return spyConfigBuilder;
     }
 }


### PR DESCRIPTION
Fixes #22239 

### Motivation

The AdvertisedListenersMultiBrokerLeaderElectionTest test is flaky since it times out.
I profiled the test with Async Profiler on Linux by adding this to pom.xml in `<test.additional.args>`
```
    <test.additional.args>
      -agentpath:/home/lari/tools/async-profiler-3.0-linux-x64/lib/libasyncProfiler.so=start,event=cpu,jfr,file=/tmp/profile${maven.build.timestamp}_${surefire.forkNumber}.jfr
```
and converting the `.jfr` file to `.html` with `java -jar tools/async-profiler-3.0-macos/lib/converter.jar jfr2flame profile2024-03-12T10:44:25Z_1.jfr output.html` and `java -jar tools/async-profiler-3.0-macos/lib/converter.jar jfr2flame --threads profile2024-03-12T10:44:25Z_1.jfr output_threads.html`. 
In the profile, I could see that Mockito was causing a lot of overhead to the execution.

### Modifications

- add `.spyNoneByDefault()` to `PulsarTestContext.Builder`
- use this in MultiBrokerTestZKBaseTest

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->