### PR TITLE
[improve][test] Reduce logging overhead in tests

### DIFF
--- a/buildtools/src/main/resources/log4j2.xml
+++ b/buildtools/src/main/resources/log4j2.xml
@@ -22,7 +22,7 @@
 <Configuration status="INFO">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} %-5level [%t{12}] %c{1.}@%L - %msg %X%n" />
+            <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} %-5level [%t{12}] %c{1.} - %msg %X%n" />
         </Console>
     </Appenders>
     <Loggers>

--- a/pulsar-broker/src/test/resources/log4j2.xml
+++ b/pulsar-broker/src/test/resources/log4j2.xml
@@ -24,7 +24,7 @@
                xsi:schemaLocation="http://logging.apache.org/log4j/2.0/config https://logging.apache.org/log4j/2.0/log4j-core.xsd">
   <Appenders>
     <Console name="CONSOLE" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}] - %m%n"/>
+      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m%n"/>
     </Console>
   </Appenders>
   <Loggers>

--- a/pulsar-broker/src/test/resources/log4j2.xml
+++ b/pulsar-broker/src/test/resources/log4j2.xml
@@ -24,7 +24,7 @@
                xsi:schemaLocation="http://logging.apache.org/log4j/2.0/config https://logging.apache.org/log4j/2.0/log4j-core.xsd">
   <Appenders>
     <Console name="CONSOLE" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}] - %m%n"/>
+      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t] - %m%n"/>
     </Console>
   </Appenders>
   <Loggers>

--- a/pulsar-broker/src/test/resources/log4j2.xml
+++ b/pulsar-broker/src/test/resources/log4j2.xml
@@ -24,7 +24,7 @@
                xsi:schemaLocation="http://logging.apache.org/log4j/2.0/config https://logging.apache.org/log4j/2.0/log4j-core.xsd">
   <Appenders>
     <Console name="CONSOLE" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t] - %m%n"/>
+      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}] - %m%n"/>
     </Console>
   </Appenders>
   <Loggers>

--- a/pulsar-broker/src/test/resources/log4j2.xml
+++ b/pulsar-broker/src/test/resources/log4j2.xml
@@ -24,7 +24,7 @@
                xsi:schemaLocation="http://logging.apache.org/log4j/2.0/config https://logging.apache.org/log4j/2.0/log4j-core.xsd">
   <Appenders>
     <Console name="CONSOLE" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}@%L] - %m%n"/>
+      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%C{1}] - %m%n"/>
     </Console>
   </Appenders>
   <Loggers>

--- a/tiered-storage/jcloud/src/test/resources/log4j2-test.yml
+++ b/tiered-storage/jcloud/src/test/resources/log4j2-test.yml
@@ -33,12 +33,12 @@ Configuration:
       name: STDOUT
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t:%C] %-5level %logger{36} - %msg%n"
+        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"
     File:
       name: File
       fileName: ${filename}
       PatternLayout:
-        Pattern: "%d %p %C{1.} [%t] %m%n"
+        Pattern: "%d %p %c{1.} [%t] %m%n"
       Filters:
         ThresholdFilter:
           level: error

--- a/tiered-storage/jcloud/src/test/resources/log4j2-test.yml
+++ b/tiered-storage/jcloud/src/test/resources/log4j2-test.yml
@@ -33,12 +33,12 @@ Configuration:
       name: STDOUT
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t:%C] %-5level %logger{36} - %msg%n"
+        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"
     File:
       name: File
       fileName: ${filename}
       PatternLayout:
-        Pattern: "%d %p %C{1.} [%t] %m%n"
+        Pattern: "%d %p [%t] %m%n"
       Filters:
         ThresholdFilter:
           level: error

--- a/tiered-storage/jcloud/src/test/resources/log4j2-test.yml
+++ b/tiered-storage/jcloud/src/test/resources/log4j2-test.yml
@@ -33,12 +33,12 @@ Configuration:
       name: STDOUT
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"
+        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t:%C] %-5level %logger{36} - %msg%n"
     File:
       name: File
       fileName: ${filename}
       PatternLayout:
-        Pattern: "%d %p [%t] %m%n"
+        Pattern: "%d %p %C{1.} [%t] %m%n"
       Filters:
         ThresholdFilter:
           level: error

--- a/tiered-storage/jcloud/src/test/resources/log4j2-test.yml
+++ b/tiered-storage/jcloud/src/test/resources/log4j2-test.yml
@@ -33,7 +33,7 @@ Configuration:
       name: STDOUT
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t:%C@%L] %-5level %logger{36} - %msg%n"
+        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t:%C] %-5level %logger{36} - %msg%n"
     File:
       name: File
       fileName: ${filename}


### PR DESCRIPTION
### Motivation

- tests use a logging configuration where the location of the log statement is logged. this is very expensive and unnecessary. 
- this was noticed in test profiling (see #22250 for details of how profiling was performed)

### Modifications

- don't log the location where the log was added since this causes a high overhead

### Additional context

- The overhead is explain in https://logging.apache.org/log4j/2.x/manual/layouts.html#location-information

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->