### PR TITLE
[fix] [client] Unclear error message when creating a consumer with two same topics

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiTopicsConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiTopicsConsumerTest.java
@@ -26,9 +26,11 @@ import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -42,6 +44,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.Cleanup;
+import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.impl.ClientBuilderImpl;
 import org.apache.pulsar.client.impl.ConsumerImpl;
@@ -50,6 +53,7 @@ import org.apache.pulsar.client.impl.MultiTopicsConsumerImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.awaitility.Awaitility;
 import org.mockito.AdditionalAnswers;
 import org.mockito.Mockito;
@@ -370,6 +374,28 @@ public class MultiTopicsConsumerTest extends ProducerConsumerBase {
                 .subscriptionName("sub").subscribe();
         assertTrue(consumer instanceof MultiTopicsConsumerImpl);
         assertTrue(consumer.isConnected());
+    }
+
+    @Test
+    public void testSameTopics() throws Exception {
+        final String topic1 = BrokerTestUtil.newUniqueName("public/default/tp");
+        final String topic2 = "persistent://" + topic1;
+        admin.topics().createNonPartitionedTopic(topic2);
+        // Create consumer with two same topics.
+        try {
+            pulsarClient.newConsumer(Schema.INT32).topics(Arrays.asList(topic1, topic2))
+                    .subscriptionName("s1").subscribe();
+            fail("Do not allow use two same topics.");
+        } catch (Exception e) {
+            if (e instanceof PulsarClientException && e.getCause() != null) {
+                e = (Exception) e.getCause();
+            }
+            Throwable unwrapEx = FutureUtil.unwrapCompletionException(e);
+            assertTrue(unwrapEx instanceof IllegalArgumentException);
+            assertTrue(e.getMessage().contains( "The param [topics] is invalid"));
+        }
+        // cleanup.
+        admin.topics().delete(topic2);
     }
 
     @Test(timeOut = 30000)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiTopicsConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiTopicsConsumerTest.java
@@ -392,7 +392,8 @@ public class MultiTopicsConsumerTest extends ProducerConsumerBase {
             }
             Throwable unwrapEx = FutureUtil.unwrapCompletionException(e);
             assertTrue(unwrapEx instanceof IllegalArgumentException);
-            assertTrue(e.getMessage().contains( "The param [topics] is invalid"));
+            assertTrue(e.getMessage().contains( "Subscription topics include duplicate items"
+                    + " or invalid names"));
         }
         // cleanup.
         admin.topics().delete(topic2);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -165,7 +165,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             return;
         }
 
-        checkArgument(topicNamesValid(conf.getTopicNames()), "The param [topics] is invalid.");
+        checkArgument(topicNamesValid(conf.getTopicNames()), "Subscription topics include duplicate items"
+                + " or invalid names.");
 
         List<CompletableFuture<Void>> futures = conf.getTopicNames().stream()
                 .map(t -> subscribeAsync(t, createTopicIfDoesNotExist))

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -165,7 +165,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             return;
         }
 
-        checkArgument(topicNamesValid(conf.getTopicNames()), "Topics is invalid.");
+        checkArgument(topicNamesValid(conf.getTopicNames()), "The param [topics] is invalid.");
 
         List<CompletableFuture<Void>> futures = conf.getTopicNames().stream()
                 .map(t -> subscribeAsync(t, createTopicIfDoesNotExist))
@@ -202,21 +202,21 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         checkState(topics != null && topics.size() >= 1,
             "topics should contain more than 1 topic");
 
-        Optional<String> result = topics.stream()
-                .filter(topic -> !TopicName.isValid(topic))
-                .findFirst();
+        Set<TopicName> topicNames = new HashSet<>();
 
-        if (result.isPresent()) {
-            log.warn("Received invalid topic name: {}", result.get());
-            return false;
+        for (String topic : topics) {
+            if (!TopicName.isValid(topic)) {
+                log.warn("Received invalid topic name: {}", topic);
+                return false;
+            }
+            topicNames.add(TopicName.get(topic));
         }
 
         // check topic names are unique
-        HashSet<String> set = new HashSet<>(topics);
-        if (set.size() == topics.size()) {
+        if (topicNames.size() == topics.size()) {
             return true;
         } else {
-            log.warn("Topic names not unique. unique/all : {}/{}", set.size(), topics.size());
+            log.warn("Topic names not unique. unique/all : {}/{}", topicNames.size(), topics.size());
             return false;
         }
     }


### PR DESCRIPTION
### Motivation

When I create a MultiTopicsConsumer using the two same topics, I get a warning log `Topic is already being subscribed for in another thread`, which is not clear.
- `persistent://public/default/tp`
- `public/default/tp`

```
2024-03-13T00:27:42,785 - INFO  - [pulsar-client-io-35-2:ConsumerImpl@938] - [persistent://public/default/tp-8446b215-9f1d-470f-af07-eb9be8b15415][s1] Subscribed to topic on localhost/127.0.0.1:49225 -- consumer: 0
2024-03-13T00:27:42,785 - WARN  - [pulsar-client-io-35-2:MultiTopicsConsumerImpl@186] - [MultiTopicsConsumer-2d576] Failed to subscribe topics: org.apache.pulsar.client.api.PulsarClientException: [MultiTopicsConsumer-2d576] Failed to subscribe for topic [persistent://public/default/tp-8446b215-9f1d-470f-af07-eb9be8b15415] in topics consumer. Topic is already being subscribed for in other thread., closing consumer
2024-03-13T00:27:42,787 - INFO  - [pulsar-client-io-35-2:MultiTopicsConsumerImpl@1135] - [MultiTopicsConsumer-2d576] [s1] Success subscribe new topic persistent://public/default/tp-8446b215-9f1d-470f-af07-eb9be8b15415 in topics consumer, partitions: 0, allTopicPartitionsNumber: 2
2024-03-13T00:27:42,788 - INFO  - [pulsar-io-8-4:ServerCnx@2108] - [/127.0.0.1:49232] Closing consumer: consumerId=0
2024-03-13T00:27:42,788 - INFO  - [pulsar-io-8-4:AbstractDispatcherSingleActiveConsumer@227] - Removing consumer Consumer{subscription=PersistentSubscription{topic=persistent://public/default/tp-8446b215-9f1d-470f-af07-eb9be8b15415, name=s1}, consumerId=0, consumerName=c1651, address=/127.0.0.1:49232}
2024-03-13T00:27:42,789 - INFO  - [pulsar-io-8-4:ServerCnx@2144] - [/127.0.0.1:49232] Closed consumer, consumerId=0
```

### Modifications

Correct the param check: `MultiTopicsConsumer.topics`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
