### PR TITLE
[fix][test] Fix thread leak in TopicPoliciesAuthZTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesAuthZTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesAuthZTest.java
@@ -72,6 +72,12 @@ public final class TopicPoliciesAuthZTest extends MockedPulsarStandalone {
     @SneakyThrows
     @AfterClass
     public void after() {
+        if (superUserAdmin != null) {
+            superUserAdmin.close();
+        }
+        if (tenantManagerAdmin != null) {
+            tenantManagerAdmin.close();
+        }
         close();
     }
 


### PR DESCRIPTION
### Motivation

```
Summary: Tests in class org.apache.pulsar.broker.admin.TopicPoliciesAuthZTest created 24 new threads. There are now 34 threads in total.
```

### Modifications

Close the resource that have been created in the test.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->