### PR TITLE
[improve][test] Reduce AdvertisedListenersMultiBrokerLeaderElectionTest flakiness

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/MultiBrokerLeaderElectionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/MultiBrokerLeaderElectionTest.java
@@ -108,11 +108,12 @@ public class MultiBrokerLeaderElectionTest extends MultiBrokerTestZKBaseTest {
         List<String> topicNames = IntStream.range(0, 500).mapToObj(i -> topicNameBase + i)
                 .collect(Collectors.toList());
         List<PulsarAdmin> allAdmins = getAllAdmins();
-        @Cleanup("shutdown")
+        @Cleanup("shutdownNow")
         ExecutorService executorService = Executors.newFixedThreadPool(allAdmins.size());
         List<Future<List<String>>> resultFutures = new ArrayList<>();
         // use Phaser to increase the chances of a race condition by triggering all threads once
         // they are waiting just before each lookupTopic call
+        @Cleanup("forceTermination")
         final Phaser phaser = new Phaser(1);
         for (PulsarAdmin brokerAdmin : allAdmins) {
             phaser.register();
@@ -149,11 +150,12 @@ public class MultiBrokerLeaderElectionTest extends MultiBrokerTestZKBaseTest {
         List<String> topicNames = IntStream.range(0, 500).mapToObj(i -> topicNameBase + i)
                 .collect(Collectors.toList());
         List<PulsarClient> allClients = getAllClients();
-        @Cleanup("shutdown")
+        @Cleanup("shutdownNow")
         ExecutorService executorService = Executors.newFixedThreadPool(allClients.size());
         List<Future<List<String>>> resultFutures = new ArrayList<>();
         // use Phaser to increase the chances of a race condition by triggering all threads once
         // they are waiting just before each lookupTopic call
+        @Cleanup("forceTermination")
         final Phaser phaser = new Phaser(1);
         for (PulsarClient brokerClient : allClients) {
             phaser.register();


### PR DESCRIPTION
### Motivation

AdvertisedListenersMultiBrokerLeaderElectionTest is flaky. This change is to reduce issues and this change isn't harmful. 
The thread leak detector reported leaked threads. The way this could help is that when the test fails, cleanup would happen properly and the test retry could pass with better chance. 
There's no guarantee that this would eliminate the flakiness problem, but it's useful for cleanups related to test retries.

### Modifications

- shutdown executors immediately by calling `.shutdownNow()` instead of `.shutdown()`
- ensure that all threads waiting on the phaser instance would terminate by calling `.forceTermination()` on the phaser instance (this could also be taken care by `.shutdownNow()`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->