### PR TITLE
[fix][broker] Avoid execute prepareInitPoliciesCacheAsync if namespace is deleted

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -351,11 +351,13 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                                         });
                                 initFuture.exceptionally(ex -> {
                                     try {
-                                        log.error("[{}] Failed to create reader on __change_events topic", namespace, ex);
+                                        log.error("[{}] Failed to create reader on __change_events topic",
+                                                namespace, ex);
                                         cleanCacheAndCloseReader(namespace, false);
                                     } catch (Throwable cleanupEx) {
                                         // Adding this catch to avoid break callback chain
-                                        log.error("[{}] Failed to cleanup reader on __change_events topic", namespace, cleanupEx);
+                                        log.error("[{}] Failed to cleanup reader on __change_events topic",
+                                                namespace, cleanupEx);
                                     }
                                     return null;
                                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -329,7 +329,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         requireNonNull(namespace);
         return pulsarService.getPulsarResources().getNamespaceResources().getPoliciesAsync(namespace)
                         .thenCompose(namespacePolicies -> {
-                            if (namespacePolicies.isPresent() && namespacePolicies.get().deleted) {
+                            if (namespacePolicies.isEmpty() || namespacePolicies.get().deleted) {
                                 log.info("[{}] skip prepare init policies cache since the namespace is deleted",
                                         namespace);
                                 return CompletableFuture.completedFuture(null);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -462,7 +462,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         });
     }
 
-    void cleanCacheAndCloseReader(@Nonnull NamespaceName namespace, boolean cleanOwnedBundlesCount) {
+    private void cleanCacheAndCloseReader(@Nonnull NamespaceName namespace, boolean cleanOwnedBundlesCount) {
         cleanCacheAndCloseReader(namespace, cleanOwnedBundlesCount, false);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -324,7 +324,8 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         }
     }
 
-    private @Nonnull CompletableFuture<Void> prepareInitPoliciesCacheAsync(@Nonnull NamespaceName namespace) {
+    @VisibleForTesting
+    @Nonnull CompletableFuture<Void> prepareInitPoliciesCacheAsync(@Nonnull NamespaceName namespace) {
         requireNonNull(namespace);
         return pulsarService.getPulsarResources().getNamespaceResources().getPoliciesAsync(namespace)
                         .thenCompose(namespacePolicies -> {
@@ -332,8 +333,6 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                                 log.info("[{}] skip prepare init policies cache since the namespace is deleted",
                                         namespace);
                                 return CompletableFuture.completedFuture(null);
-
-
                             }
 
                             return policyCacheInitMap.computeIfAbsent(namespace, (k) -> {
@@ -463,7 +462,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         });
     }
 
-    private void cleanCacheAndCloseReader(@Nonnull NamespaceName namespace, boolean cleanOwnedBundlesCount) {
+    void cleanCacheAndCloseReader(@Nonnull NamespaceName namespace, boolean cleanOwnedBundlesCount) {
         cleanCacheAndCloseReader(namespace, cleanOwnedBundlesCount, false);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
@@ -473,13 +473,15 @@ public class SystemTopicBasedTopicPoliciesServiceTest extends MockedPulsarServic
         SystemTopicBasedTopicPoliciesService service = (SystemTopicBasedTopicPoliciesService) pulsar.getTopicPoliciesService();
         admin.namespaces().createNamespace(NAMESPACE5);
 
-        pulsar.getPulsarResources().getNamespaceResources().setPolicies(NamespaceName.get(NAMESPACE5),
+        NamespaceName namespaceName = NamespaceName.get(NAMESPACE5);
+        pulsar.getPulsarResources().getNamespaceResources().setPolicies(namespaceName,
                 old -> {
                     old.deleted = true;
                     return old;
                 });
 
-        service.prepareInitPoliciesCacheAsync(NamespaceName.get(NAMESPACE5)).get();
+        assertNull(service.getPoliciesCacheInit(namespaceName));
+        service.prepareInitPoliciesCacheAsync(namespaceName).get();
         admin.namespaces().deleteNamespace(NAMESPACE5);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
@@ -71,6 +71,8 @@ public class SystemTopicBasedTopicPoliciesServiceTest extends MockedPulsarServic
 
     private static final String NAMESPACE4 = "system-topic/namespace-4";
 
+    private static final String NAMESPACE5 = "system-topic/namespace-5";
+
     private static final TopicName TOPIC1 = TopicName.get("persistent", NamespaceName.get(NAMESPACE1), "topic-1");
     private static final TopicName TOPIC2 = TopicName.get("persistent", NamespaceName.get(NAMESPACE1), "topic-2");
     private static final TopicName TOPIC3 = TopicName.get("persistent", NamespaceName.get(NAMESPACE2), "topic-1");
@@ -464,5 +466,20 @@ public class SystemTopicBasedTopicPoliciesServiceTest extends MockedPulsarServic
         }
         admin.namespaces().deleteNamespace(NAMESPACE4);
         Assert.assertNull(service.getWriterCaches().synchronous().getIfPresent(NamespaceName.get(NAMESPACE4)));
+    }
+
+    @Test
+    public void testPrepareInitPoliciesCacheAsyncWhenNamespaceBeingDeleted() throws Exception {
+        SystemTopicBasedTopicPoliciesService service = (SystemTopicBasedTopicPoliciesService) pulsar.getTopicPoliciesService();
+        admin.namespaces().createNamespace(NAMESPACE5);
+
+        pulsar.getPulsarResources().getNamespaceResources().setPolicies(NamespaceName.get(NAMESPACE5),
+                old -> {
+                    old.deleted = true;
+                    return old;
+                });
+
+        service.prepareInitPoliciesCacheAsync(NamespaceName.get(NAMESPACE5)).get();
+        admin.namespaces().deleteNamespace(NAMESPACE5);
     }
 }


### PR DESCRIPTION
### Motivation
If the namespace has been deleted,` prepareInitPoliciesCacheAsync` should not be executed.

**More detailed description:**
When the namespace is forcibly deleted, if a topic exists and the own bundle of the topic is not loaded into the memory, deleting the namespace will trigger the loading of the bundle, which will trigger the execution of `prepareInitPoliciesCacheAsync`(load topic policies). However, at this time, due to the namespace is already in a deleted state, so execution will print the following exception log.

**Minimal reproduce step:**
1.Start a single broker node and create a tenant `test-tenant`

2.Create a new namespace and a  new partitioned topic.
sh bin/pulsar-admin namespaces create test-tenant/test-ns
sh bin/pulsar-admin topics create-partitioned-topic test-tenant/test-ns/test-topic -p 1

3.Delete namespace force.
sh bin/pulsar-admin namespaces delete -f test-tenant/test-ns

We will see the following log:
![image](https://github.com/apache/pulsar/assets/16524922/7168b65d-a627-43c5-aa59-9c022514ac38)



### Modifications

Skip prepare init policies cache if the namespace has been deleted.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->