### PR TITLE
[fix] [broker] Close dispatchers stuck due to mismatch between dispatcher.consumerList and dispatcher.consumerSet

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -214,7 +214,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         // decrement unack-message count for removed consumer
         addUnAckedMessages(-consumer.getUnackedMessages());
         if (consumerSet.removeAll(consumer) == 1) {
-            consumerList.removeIf(c -> consumer.equals(c));
+            consumerList.remove(consumer);
             log.info("Removed consumer {} with pending {} acks", consumer, consumer.getPendingAcks().size());
             if (consumerList.isEmpty()) {
                 clearComponentsAfterRemovedAllConsumers();
@@ -234,11 +234,16 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
                 readMoreEntries();
             }
         } else {
+            /**
+             * This is not an expected scenario, it will never happen in expected.
+             * Just add a defensive code to avoid the topic can not be unloaded anymore: remove the consumers which
+             * are not mismatch with {@link #consumerSet}. See more detail: https://github.com/apache/pulsar/pull/22270.
+             */
+            log.error("[{}] Trying to remove a non-connected consumer: {}", name, consumer);
             consumerList.removeIf(c -> consumer.equals(c));
             if (consumerList.isEmpty()) {
                 clearComponentsAfterRemovedAllConsumers();
             }
-            log.warn("[{}] Trying to remove a non-connected consumer: {}", name, consumer);
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersTest.java
@@ -59,7 +59,7 @@ public class PersistentDispatcherMultipleConsumersTest extends ProducerConsumerB
 
         Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subscription)
                 .subscriptionType(SubscriptionType.Shared).subscribe();
-        // Make an error that makes "consumerSet" is mismatch with "consumerList".
+        // Make an error that "consumerSet" is mismatch with "consumerList".
         Dispatcher dispatcher = pulsar.getBrokerService()
                 .getTopic(topicName, false).join().get()
                 .getSubscription(subscription).getDispatcher();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service.persistent;
+
+import com.carrotsearch.hppc.ObjectSet;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.service.Dispatcher;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.awaitility.reflect.WhiteboxImpl;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker-api")
+public class PersistentDispatcherMultipleConsumersTest extends ProducerConsumerBase {
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test(timeOut = 30 * 1000)
+    public void testTopicDeleteIfConsumerSetMismatchConsumerList() throws Exception {
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
+        final String subscription = "s1";
+        admin.topics().createNonPartitionedTopic(topicName);
+        admin.topics().createSubscription(topicName, subscription, MessageId.earliest);
+
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subscription)
+                .subscriptionType(SubscriptionType.Shared).subscribe();
+        // Make an error that makes "consumerSet" is mismatch with "consumerList".
+        Dispatcher dispatcher = pulsar.getBrokerService()
+                .getTopic(topicName, false).join().get()
+                .getSubscription(subscription).getDispatcher();
+        ObjectSet<org.apache.pulsar.broker.service.Consumer> consumerSet =
+                WhiteboxImpl.getInternalState(dispatcher, "consumerSet");
+        List<org.apache.pulsar.broker.service.Consumer> consumerList =
+                WhiteboxImpl.getInternalState(dispatcher, "consumerList");
+
+        org.apache.pulsar.broker.service.Consumer serviceConsumer = consumerList.get(0);
+        consumerSet.add(serviceConsumer);
+        consumerList.add(serviceConsumer);
+
+        // Verify: the topic can be deleted successfully.
+        consumer.close();
+        admin.topics().delete(topicName, false);
+    }
+}


### PR DESCRIPTION
### Motivation

```
2024-03-13T07:47:36,071+0000 [pulsar-inactivity-monitor-25-1] INFO  org.apache.pulsar.broker.service.persistent.PersistentTopic - [persistent://{tenat}/{ns}/{topic name}] Global topic inactive for 86400 seconds, closed repl producers
2024-03-13T07:47:36,073+0000 [pulsar-inactivity-monitor-25-1] INFO  org.apache.pulsar.broker.service.Consumer - Disconnecting consumer: Consumer{subscription=PersistentSubscription{topic=persistent://{tenat}/{ns}/{topic name}, name={subscription}}, consumerId=5, consumerName=082c9, address=/127.0.0.6:34293}
2024-03-13T07:47:36,074+0000 [pulsar-inactivity-monitor-25-1] INFO  org.apache.pulsar.broker.service.Consumer - Disconnecting consumer: Consumer{subscription=PersistentSubscription{topic=persistent://{tenat}/{ns}/{topic name}, name={subscription}}, consumerId=10, consumerName=f0c65, address=/127.0.0.6:32911}
2024-03-13T07:47:36,074+0000 [pulsar-inactivity-monitor-25-1] INFO  org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - Removed consumer Consumer{subscription=PersistentSubscription{topic=persistent://{tenat}/{ns}/{topic name}, name={subscription}}, consumerId=5, consumerName=7f82f, address=/127.0.0.6:39763} with pending 0 acks
2024-03-13T07:47:36,074+0000 [pulsar-inactivity-monitor-25-1] INFO  org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://{tenat}/{ns}/{topic name} / {subscription}] Trying to remove a non-connected consumer: Consumer{subscription=PersistentSubscription{topic=persistent://{tenat}/{ns}/{topic name}, name={subscription}}, consumerId=10, consumerName=f0c65, address=/127.0.0.6:32911}
2024-03-13T07:47:36,074+0000 [pulsar-inactivity-monitor-25-1] INFO  org.apache.pulsar.broker.service.Consumer - Disconnecting consumer: Consumer{subscription=PersistentSubscription{topic=persistent://{tenat}/{ns}/{topic name}, name={subscription}}, consumerId=5, consumerName=7f82f, address=/127.0.0.6:39763}
2024-03-13T07:47:36,074+0000 [pulsar-inactivity-monitor-25-1] INFO  org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - Removed consumer Consumer{subscription=PersistentSubscription{topic=persistent://{tenat}/{ns}/{topic name}, name={subscription}}, consumerId=18, consumerName=1aebe, address=/127.0.0.6:33045} with pending 0 acks
2024-03-13T07:47:36,074+0000 [pulsar-inactivity-monitor-25-1] INFO  org.apache.pulsar.broker.service.Consumer - Disconnecting consumer: Consumer{subscription=PersistentSubscription{topic=persistent://{tenat}/{ns}/{topic name}, name={subscription}}, consumerId=18, consumerName=b44be, address=/127.0.0.6:44907}
2024-03-13T07:47:36,074+0000 [pulsar-inactivity-monitor-25-1] INFO  org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://{tenat}/{ns}/{topic name} / {subscription}] Trying to remove a non-connected consumer: Consumer{subscription=PersistentSubscription{topic=persistent://{tenat}/{ns}/{topic name}, name={subscription}}, consumerId=5, consumerName=082c9, address=/127.0.0.6:34293}
2024-03-13T07:47:36,074+0000 [pulsar-inactivity-monitor-25-1] INFO  org.apache.pulsar.broker.service.Consumer - Disconnecting consumer: Consumer{subscription=PersistentSubscription{topic=persistent://{tenat}/{ns}/{topic name}, name={subscription}}, consumerId=10, consumerName=a2fc6, address=/127.0.0.6:54177}
2024-03-13T07:47:36,074+0000 [pulsar-inactivity-monitor-25-1] INFO  org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - [persistent://{tenat}/{ns}/{topic name} / {subscription}] Trying to remove a non-connected consumer: Consumer{subscription=PersistentSubscription{topic=persistent://{tenat}/{ns}/{topic name}, name={subscription}}, consumerId=18, consumerName=b44be, address=/127.0.0.6:44907}
2024-03-13T07:47:36,074+0000 [pulsar-inactivity-monitor-25-1] INFO  org.apache.pulsar.broker.service.Consumer - Disconnecting consumer: Consumer{subscription=PersistentSubscription{topic=persistent://{tenat}/{ns}/{topic name}, name={subscription}}, consumerId=18, consumerName=1aebe, address=/127.0.0.6:33045}
2024-03-13T07:47:36,074+0000 [pulsar-inactivity-monitor-25-1] INFO  org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers - Removed consumer Consumer{subscription=PersistentSubscription{topic=persistent://{tenat}/{ns}/{topic name}, name={subscription}}, consumerId=10, consumerName=a2fc6, address=/127.0.0.6:54177} with pending 0 acks
2024-03-13T07:47:36,186+0000 [pulsar-io-4-22] WARN  org.apache.pulsar.broker.service.persistent.PersistentTopic - [persistent://{tenat}/{ns}/{topic name}] Attempting to subscribe to a fenced topic
```

The logs were printed on our cluster(`2.11.2`)
- The consumer `{clientCnx 127.0.0.6:44907, consumerId: 18}` has been removed twice when calling `dispatcher.disconnectAllConsumers`.<sup>[1]</sup>
- Pulsar printed `Trying to remove a non-connected consumer` when removing the consumer `{clientCnx 127.0.0.6:44907, consumerId: 18}` at the second time, which means this consumer is duplicated in `dispatcher.consumerList`.<sup>[2]</sup>
-  Once the log "Trying to remove a non-connected consumer" is printed, the `closeFuture` of `dispatcher` will never be completed, leading to the process of `topic.delete` being stuck.
- The topic stays in a fenced state.

**[1]:** [dispatcher.disconnectAllConsumers](https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java#L551C5-L561C6)
```java
public synchronized CompletableFuture<Void> disconnectAllConsumers() {
  consumerList.forEach(consumer -> consumer.disconnect(isResetCursor, assignedBrokerLookupData));
}
```

**[2]:** [dispatcher.removeConsumer](https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java#L213C5-L247C6)

```java
public synchronized void removeConsumer(Consumer consumer) throws BrokerServiceException {
    // decrement unack-message count for removed consumer
    addUnAckedMessages(-consumer.getUnackedMessages());
    if (consumerSet.removeAll(consumer) == 1) {
        consumerList.remove(consumer);
        log.info("Removed consumer {} with pending {} acks", consumer, consumer.getPendingAcks().size());
        if (consumerList.isEmpty()) {
            if (closeFuture != null) {
                closeFuture.complete(null); // Once the log "Trying to remove a non-connected consumer" was printed, it means the closeFuture will never be completed.
            }
        } 
    } else {
        log.info("[{}] Trying to remove a non-connected consumer: {}", name, consumer);
    }
}
```

### Modifications

I haven't found the logic of repeating consumer in `dispatcher.consumerList` yet(it may caused by a consumer that has been added twice, and `dispatcher.consumerSet` merged two adding), I just fixed the follow-up issue.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
