### PR TITLE
[fix][build] Add special handling for pulsar-bom in set-project-version.sh

### DIFF
--- a/src/set-project-version.sh
+++ b/src/set-project-version.sh
@@ -38,6 +38,7 @@ OLD_VERSION=`python3 ${ROOT_DIR}/src/get-project-version.py`
 
 mvn versions:set -DnewVersion=$NEW_VERSION
 mvn versions:set -DnewVersion=$NEW_VERSION -pl buildtools
+mvn versions:set -DnewVersion=$NEW_VERSION -pl pulsar-bom
 # Set terraform ansible deployment pulsar version
 sed -i -e "s/${OLD_VERSION}/${NEW_VERSION}/g" ${TERRAFORM_DIR}/deploy-pulsar.yaml
 


### PR DESCRIPTION
### Motivation

- pulsar-bom didn't get published in 3.2.1 release since the version hadn't been updated in pom.xml

### Modifications

- add special handling for pulsar-bom in set-project-version.sh script

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->