### PR TITLE
[fix][sec] Upgrade Zookeeper to 3.9.2 to address CVE-2024-23944

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -495,9 +495,9 @@ The Apache Software License, Version 2.0
     - io.vertx-vertx-web-common-4.3.8.jar
     - io.vertx-vertx-grpc-4.3.5.jar
   * Apache ZooKeeper
-    - org.apache.zookeeper-zookeeper-3.9.1.jar
-    - org.apache.zookeeper-zookeeper-jute-3.9.1.jar
-    - org.apache.zookeeper-zookeeper-prometheus-metrics-3.9.1.jar
+    - org.apache.zookeeper-zookeeper-3.9.2.jar
+    - org.apache.zookeeper-zookeeper-jute-3.9.2.jar
+    - org.apache.zookeeper-zookeeper-prometheus-metrics-3.9.2.jar
   * Snappy Java
     - org.xerial.snappy-snappy-java-1.1.10.5.jar
   * Google HTTP Client

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@ flexible messaging model and an intuitive client API.</description>
     <commons-compress.version>1.26.0</commons-compress.version>
 
     <bookkeeper.version>4.16.4</bookkeeper.version>
-    <zookeeper.version>3.9.1</zookeeper.version>
+    <zookeeper.version>3.9.2</zookeeper.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <commons-text.version>1.10.0</commons-text.version>
     <snappy.version>1.1.10.5</snappy.version> <!-- ZooKeeper server -->


### PR DESCRIPTION
### Motivation

- Address CVE-2024-23944 described in [the announcement email](https://lists.apache.org/thread/96s5nqssj03rznz9hv58txdb2k1lr79k).
- based on the description, this has no direct impact for Pulsar users. 
- it's necessary to make the upgrade so that vulnerability scanning stays clean for Pulsar artifacts.

### Modifications

- upgrade Zookeeper to 3.9.2 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->