### PR TITLE
[fix][sec] Dismiss warning about MD5 since it's sufficient for these use cases

### DIFF
--- a/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
+++ b/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
@@ -148,7 +148,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
             cipher = Cipher.getInstance(AESGCM, BouncyCastleProvider.PROVIDER_NAME);
             // If keygen is not needed(e.g: consumer), data key will be decrypted from the message
             if (!keyGenNeeded) {
-
+                // codeql[java/weak-cryptographic-algorithm] - md5 is sufficient for this use case
                 digest = MessageDigest.getInstance("MD5");
 
                 dataKey = null;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarUnpacker.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarUnpacker.java
@@ -168,6 +168,7 @@ public class NarUnpacker {
      */
     private static byte[] calculateMd5sum(final File file) throws IOException {
         try (final FileInputStream inputStream = new FileInputStream(file)) {
+            // codeql[java/weak-cryptographic-algorithm] - md5 is sufficient for this use case
             final MessageDigest md5 = MessageDigest.getInstance("md5");
 
             final byte[] buffer = new byte[1024];


### PR DESCRIPTION
### Motivation

- CodeQL warns about using MD5 in 2 locations in the Pulsar code base

### Modifications

- Dismiss warning about MD5 since it's sufficient for these use cases

### Additional context

- Dismissing warnings is mentioned [in CodeQL changelog](https://github.com/github/codeql/blob/main/java/ql/src/CHANGELOG.md#minor-analysis-improvements-14).
- CodeQL Java support's test case contains [examples of supported syntax](https://github.com/github/codeql/blob/daee22d38cdfedb110ff3e807df83d6149c904c9/java/ql/test/query-tests/AlertSuppression/Test.java).

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->