### PR TITLE
[improve][broker] Remove the atomicity on active consumer of a dispatcher

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
@@ -30,7 +30,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
@@ -47,9 +46,6 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBaseDispatcher {
 
     protected final String topicName;
-    protected static final AtomicReferenceFieldUpdater<AbstractDispatcherSingleActiveConsumer, Consumer>
-            ACTIVE_CONSUMER_UPDATER = AtomicReferenceFieldUpdater.newUpdater(
-            AbstractDispatcherSingleActiveConsumer.class, Consumer.class, "activeConsumer");
     private volatile Consumer activeConsumer = null;
     protected final CopyOnWriteArrayList<Consumer> consumers;
     protected StickyKeyConsumerSelector stickyKeyConsumerSelector;
@@ -78,11 +74,16 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
         this.partitionIndex = partitionIndex;
         this.subscriptionType = subscriptionType;
         this.cursor = cursor;
-        ACTIVE_CONSUMER_UPDATER.set(this, null);
     }
 
+    /**
+     * @apiNote this method does not need to be thread safe
+     */
     protected abstract void scheduleReadOnActiveConsumer();
 
+    /**
+     * @apiNote this method does not need to be thread safe
+     */
     protected abstract void cancelPendingRead();
 
     protected void notifyActiveConsumerChanged(Consumer activeConsumer) {
@@ -99,6 +100,7 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
      * distributed partitions evenly across consumers with highest priority level.
      *
      * @return the true consumer if the consumer is changed, otherwise false.
+     * @apiNote this method is not thread safe
      */
     protected boolean pickAndScheduleActiveConsumer() {
         checkArgument(!consumers.isEmpty());
@@ -128,14 +130,14 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
                 ? partitionIndex % consumersSize
                 : peekConsumerIndexFromHashRing(makeHashRing(consumersSize));
 
-        Consumer prevConsumer = ACTIVE_CONSUMER_UPDATER.getAndSet(this, consumers.get(index));
+        Consumer selectedConsumer = consumers.get(index);
 
-        Consumer activeConsumer = ACTIVE_CONSUMER_UPDATER.get(this);
-        if (prevConsumer == activeConsumer) {
+        if (selectedConsumer == activeConsumer) {
             // Active consumer did not change. Do nothing at this point
             return false;
         } else {
             // If the active consumer is changed, send notification.
+            activeConsumer = selectedConsumer;
             scheduleReadOnActiveConsumer();
             return true;
         }
@@ -167,7 +169,7 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
         }
 
         if (subscriptionType == SubType.Exclusive && !consumers.isEmpty()) {
-            Consumer actConsumer = ACTIVE_CONSUMER_UPDATER.get(this);
+            Consumer actConsumer = getActiveConsumer();
             if (actConsumer != null) {
                 return actConsumer.cnx().checkConnectionLiveness().thenCompose(actConsumerStillAlive -> {
                     if (actConsumerStillAlive.isEmpty() || actConsumerStillAlive.get()) {
@@ -210,7 +212,7 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
 
         if (!pickAndScheduleActiveConsumer()) {
             // the active consumer is not changed
-            Consumer currentActiveConsumer = ACTIVE_CONSUMER_UPDATER.get(this);
+            Consumer currentActiveConsumer = getActiveConsumer();
             if (null == currentActiveConsumer) {
                 if (log.isDebugEnabled()) {
                     log.debug("Current active consumer disappears while adding consumer {}", consumer);
@@ -230,7 +232,7 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
         }
 
         if (consumers.isEmpty()) {
-            ACTIVE_CONSUMER_UPDATER.set(this, null);
+            activeConsumer = null;
         }
 
         if (closeFuture == null && !consumers.isEmpty()) {
@@ -255,7 +257,7 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
      *            Calling consumer object
      */
     public synchronized boolean canUnsubscribe(Consumer consumer) {
-        return (consumers.size() == 1) && Objects.equals(consumer, ACTIVE_CONSUMER_UPDATER.get(this));
+        return (consumers.size() == 1) && Objects.equals(consumer, activeConsumer);
     }
 
     @Override
@@ -322,7 +324,7 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
     }
 
     public Consumer getActiveConsumer() {
-        return ACTIVE_CONSUMER_UPDATER.get(this);
+        return activeConsumer;
     }
 
     @Override
@@ -331,7 +333,7 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
     }
 
     public boolean isConsumerConnected() {
-        return ACTIVE_CONSUMER_UPDATER.get(this) != null;
+        return activeConsumer != null;
     }
 
     private static final Logger log = LoggerFactory.getLogger(AbstractDispatcherSingleActiveConsumer.class);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
@@ -53,7 +53,7 @@ public final class NonPersistentDispatcherSingleActiveConsumer extends AbstractD
 
     @Override
     public void sendMessages(List<Entry> entries) {
-        Consumer currentConsumer = ACTIVE_CONSUMER_UPDATER.get(this);
+        Consumer currentConsumer = getActiveConsumer();
         if (currentConsumer != null && currentConsumer.getAvailablePermits() > 0 && currentConsumer.isWritable()) {
             SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
             EntryBatchSizes batchSizes = EntryBatchSizes.get(entries.size());
@@ -83,7 +83,7 @@ public final class NonPersistentDispatcherSingleActiveConsumer extends AbstractD
 
     @Override
     public boolean hasPermits() {
-        return ACTIVE_CONSUMER_UPDATER.get(this) != null && ACTIVE_CONSUMER_UPDATER.get(this).getAvailablePermits() > 0;
+        return getActiveConsumer() != null && getActiveConsumer().getAvailablePermits() > 0;
     }
 
     @Override


### PR DESCRIPTION
### Motivation

The modifications on
`AbstractDispatcherSingleActiveConsumer#activeConsumer` only happen on `pickAndScheduleActiveConsumer`, which is only called in `addConsumer` and `removeConsumer`. However, both `addConsumer` and `removeConsumer` are synchronized methods so that we don't have to perform an atomic operation on `activeConsumer`.

The composite operations on `activeConsumer` also happen on synchronized methods like `disconnectActiveConsumers`. The only access to `activeConsumer` that is not synchronized is the read on `activeConsumer` like `getActiveConsumer()` and `isConsumerConnected()`.

### Modifications

Remove the `ACTIVE_CONSUMER_UPDATER` and note some methods are not thread safe or there is no need to make them thread safe.

Besides, since `pickAndScheduleActiveConsumer` is never called concurrently, we don't need a double-checked locking on `readOnActiveConsumerTask`. Instead, just synchronize the modification in the scheduled task.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: