### PR TITLE
[improve][broker] Add class name and line number output to the log.

### DIFF
--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -56,7 +56,7 @@ Configuration:
       name: Console
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"
+        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} (%F:%L) - %msg%n"
 
     # Rolling file appender configuration
     RollingFile:
@@ -65,7 +65,7 @@ Configuration:
       filePattern: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}-%d{MM-dd-yyyy}-%i.log.gz"
       immediateFlush: ${sys:pulsar.log.immediateFlush}
       PatternLayout:
-        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"
+        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} (%F:%L) - %msg%n"
       Policies:
         TimeBasedTriggeringPolicy:
           interval: 1


### PR DESCRIPTION
### Motivation

The current log file does not output the class name and line number. In some cases, it is difficult to quickly locate specific lines of code based on the log content.


Before optimization, we could only see the name of the logger, but we didn’t know which line of log output was of which class.
The log example is as follows:
![image](https://github.com/apache/pulsar/assets/16524922/48ab4483-6da3-489b-9564-333b9ac069a3)


After optimization, we print out the class name and line number, so we can quickly locate the specific line of code.
The log example is as follows:
![image](https://github.com/apache/pulsar/assets/16524922/b27ac620-2120-46e1-8b24-7ec6d4f46204)


### Modifications
Add java class file name and line number output to the log.
`"%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} **(%F:%L)** - %msg%n"`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->