### PR TITLE
[improve][pip] PIP-332: peek messages from topic subscription with messagePosition value

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1627,7 +1627,7 @@ public interface Topics {
      * @return a future that can be used to track when the messages are returned
      */
     default CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages) {
-        return peekMessagesAsync (topic, subName,1, numMessages);
+        return peekMessagesAsync (topic, subName, 1, numMessages);
     }
 
     /**

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1592,21 +1592,43 @@ public interface Topics {
     /**
      * Peek messages from a topic subscription.
      *
-     * @param topic
-     *            topic name
-     * @param subName
-     *            Subscription name
-     * @param numMessages
-     *            Number of messages
+     * @param topic       topic name
+     * @param subName     Subscription name
+     * @param numMessages Number of messages
      * @return
-     * @throws NotAuthorizedException
-     *             Don't have admin permission
-     * @throws NotFoundException
-     *             Topic or subscription does not exist
-     * @throws PulsarAdminException
-     *             Unexpected error
+     * @throws NotAuthorizedException Don't have admin permission
+     * @throws NotFoundException      Topic or subscription does not exist
+     * @throws PulsarAdminException   Unexpected error
      */
-    List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages) throws PulsarAdminException;
+    default List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages)
+            throws PulsarAdminException {
+        return peekMessages(topic, subName, 1, numMessages);
+    }
+
+    /**
+     * Peek messages from a topic subscription.
+     * @param topic       topic name
+     * @param subName     Subscription name
+     * @param numMessages Number of messages
+     * @param messagePosition Start index to read messages.
+     * @throws NotAuthorizedException Don't have admin permission
+     * @throws NotFoundException      Topic or subscription does not exist
+     * @throws PulsarAdminException   Unexpected error
+     */
+    List<Message<byte[]>> peekMessages(String topic, String subName, int messagePosition, int numMessages)
+            throws PulsarAdminException;
+
+    /**
+     * Peek messages from a topic subscription asynchronously.
+     *
+     * @param topic       topic name
+     * @param subName     Subscription name
+     * @param numMessages Number of messages
+     * @return a future that can be used to track when the messages are returned
+     */
+    default CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages) {
+        return peekMessagesAsync (topic, subName,1, numMessages);
+    }
 
     /**
      * Peek messages from a topic subscription asynchronously.
@@ -1615,11 +1637,14 @@ public interface Topics {
      *            topic name
      * @param subName
      *            Subscription name
+     * @param messagePosition
+     *            Start index to read messages
      * @param numMessages
      *            Number of messages
      * @return a future that can be used to track when the messages are returned
      */
-    CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages);
+    CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int messagePosition,
+                                                               int numMessages);
 
     /**
      * Get a message by its messageId via a topic subscription.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -885,17 +885,29 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
+    public List<Message<byte[]>> peekMessages(String topic, String subName, int messagePosition, int numMessages)
+            throws PulsarAdminException {
+        return sync(() -> peekMessagesAsync(topic, subName, messagePosition, numMessages));
+    }
+
+    @Override
     public List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages)
             throws PulsarAdminException {
-        return sync(() -> peekMessagesAsync(topic, subName, numMessages));
+        return sync(() -> peekMessagesAsync(topic, subName, 1, numMessages));
+    }
+
+    @Override
+    public CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int messagePosition, int numMessages) {
+        checkArgument(numMessages > 0);
+        CompletableFuture<List<Message<byte[]>>> future = new CompletableFuture<List<Message<byte[]>>>();
+        peekMessagesAsync(topic, subName, numMessages, new ArrayList<>(), future, messagePosition);
+        return future;
     }
 
     @Override
     public CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages) {
         checkArgument(numMessages > 0);
-        CompletableFuture<List<Message<byte[]>>> future = new CompletableFuture<List<Message<byte[]>>>();
-        peekMessagesAsync(topic, subName, numMessages, new ArrayList<>(), future, 1);
-        return future;
+        return peekMessagesAsync(topic, subName, 1, numMessages);
     }
 
     private void peekMessagesAsync(String topic, String subName, int numMessages,


### PR DESCRIPTION


PIP: 332 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

Currently we are able to peek any number of messages of a topic subscription backlog using the Pulsar Java Admin API.
However, we are only able to view these messages starting from the most recent message i.e messagePosition of 1. If we want to view the 100th message, we have to peek all the top 100 messages.
When the number of messages is large, we want to split them by paging them and displaying them on the UI. So, we would like the ability to view any batch of messages instead of all of the top messages. With the messagePosition and numberOfMessages that should be fairly straightforward to do.

### Modifications

The Pulsar Admin API in Java currently provides a way to peek messages using [this](https://pulsar.apache.org/docs/3.1.x/admin-api-topics/#peek-messages)
This function includes a default hardcoded messagePosition value of 1. We want to give the user the option to input a different messagePosition value.
The current peekMessages(String topic, String subName, int numMessages) method will remain the same and use messagePosition of 1.
We will be overloading this method with messagePosition. It will default to 1 if not specified.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

PR for pulsar-site doc updates: [improve][site] Doc changes to support peekMessages with Offset in admin-api-topics pulsar-site#840

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
