### PR TITLE
[improve][broker] Add fine-grain authorization to ns/topic management endpoints

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -597,6 +597,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                             case COMPACT:
                             case OFFLOAD:
                             case UNLOAD:
+                            case TRIM_TOPIC:
                             case DELETE_METADATA:
                             case UPDATE_METADATA:
                             case ADD_BUNDLE_RANGE:

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -62,8 +62,6 @@ import org.apache.pulsar.common.policies.data.NamespaceOperation;
 import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
 import org.apache.pulsar.common.policies.data.PersistencePolicies;
 import org.apache.pulsar.common.policies.data.Policies;
-import org.apache.pulsar.common.policies.data.PolicyName;
-import org.apache.pulsar.common.policies.data.PolicyOperation;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.SubscribeRate;
@@ -714,10 +712,7 @@ public abstract class AdminResource extends PulsarWebResource {
     }
 
     protected CompletableFuture<SchemaCompatibilityStrategy> getSchemaCompatibilityStrategyAsync() {
-        return validateTopicPolicyOperationAsync(topicName,
-                PolicyName.SCHEMA_COMPATIBILITY_STRATEGY,
-                PolicyOperation.READ)
-                .thenCompose((__) -> getSchemaCompatibilityStrategyAsyncWithoutAuth()).whenComplete((__, ex) -> {
+        return getSchemaCompatibilityStrategyAsyncWithoutAuth().whenComplete((__, ex) -> {
                     if (ex != null) {
                         log.error("[{}] Failed to get schema compatibility strategy of topic {} {}",
                                 clientAppId(), topicName, ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -2339,102 +2339,110 @@ public abstract class NamespacesBase extends AdminResource {
    }
 
    protected void internalSetProperty(String key, String value, AsyncResponse asyncResponse) {
-       validatePoliciesReadOnlyAccess();
-       updatePoliciesAsync(namespaceName, policies -> {
-           policies.properties.put(key, value);
-           return policies;
-       }).thenAccept(v -> {
-           log.info("[{}] Successfully set property for key {} on namespace {}", clientAppId(), key,
-                   namespaceName);
-           asyncResponse.resume(Response.noContent().build());
-       }).exceptionally(ex -> {
-           Throwable cause = ex.getCause();
-           log.error("[{}] Failed to set property for key {} on namespace {}", clientAppId(), key,
-                   namespaceName, cause);
-           asyncResponse.resume(cause);
-           return null;
-       });
+       validateTenantOperationAsync(namespaceName.getTenant(), TenantOperation.CREATE_NAMESPACE)
+               .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
+               .thenCompose(__ -> updatePoliciesAsync(namespaceName, policies -> {
+                   policies.properties.put(key, value);
+                   return policies;
+               }))
+               .thenAccept(v -> {
+                   log.info("[{}] Successfully set property for key {} on namespace {}", clientAppId(), key,
+                           namespaceName);
+                   asyncResponse.resume(Response.noContent().build());
+               }).exceptionally(ex -> {
+                   Throwable cause = ex.getCause();
+                   log.error("[{}] Failed to set property for key {} on namespace {}", clientAppId(), key,
+                           namespaceName, cause);
+                   asyncResponse.resume(cause);
+                   return null;
+               });
    }
 
    protected void internalSetProperties(Map<String, String> properties, AsyncResponse asyncResponse) {
-       validatePoliciesReadOnlyAccess();
-       updatePoliciesAsync(namespaceName, policies -> {
-           policies.properties.putAll(properties);
-           return policies;
-       }).thenAccept(v -> {
-           log.info("[{}] Successfully set {} properties on namespace {}", clientAppId(), properties.size(),
-                   namespaceName);
-           asyncResponse.resume(Response.noContent().build());
-       }).exceptionally(ex -> {
-           Throwable cause = ex.getCause();
-           log.error("[{}] Failed to set {} properties on namespace {}", clientAppId(), properties.size(),
-                   namespaceName, cause);
-           asyncResponse.resume(cause);
-           return null;
-       });
+       validateTenantOperationAsync(namespaceName.getTenant(), TenantOperation.CREATE_NAMESPACE)
+               .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
+               .thenCompose(__ -> updatePoliciesAsync(namespaceName, policies -> {
+                   policies.properties.putAll(properties);
+                   return policies;
+               }))
+               .thenAccept(v -> {
+                   log.info("[{}] Successfully set {} properties on namespace {}", clientAppId(), properties.size(),
+                           namespaceName);
+                   asyncResponse.resume(Response.noContent().build());
+               }).exceptionally(ex -> {
+                   Throwable cause = ex.getCause();
+                   log.error("[{}] Failed to set {} properties on namespace {}", clientAppId(), properties.size(),
+                           namespaceName, cause);
+                   asyncResponse.resume(cause);
+                   return null;
+               });
    }
 
    protected void internalGetProperty(String key, AsyncResponse asyncResponse) {
-        getNamespacePoliciesAsync(namespaceName).thenAccept(policies -> {
-            asyncResponse.resume(policies.properties.get(key));
-        }).exceptionally(ex -> {
-            Throwable cause = ex.getCause();
-            log.error("[{}] Failed to get property for key {} of namespace {}", clientAppId(), key,
-                    namespaceName, cause);
-            asyncResponse.resume(cause);
-            return null;
-        });
+       validateTenantOperationAsync(namespaceName.getTenant(), TenantOperation.CREATE_NAMESPACE)
+               .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
+               .thenAccept(policies -> asyncResponse.resume(policies.properties.get(key)))
+               .exceptionally(ex -> {
+                   Throwable cause = ex.getCause();
+                   log.error("[{}] Failed to get property for key {} of namespace {}", clientAppId(), key,
+                           namespaceName, cause);
+                   asyncResponse.resume(cause);
+                   return null;
+               });
    }
 
    protected void internalGetProperties(AsyncResponse asyncResponse) {
-       getNamespacePoliciesAsync(namespaceName).thenAccept(policies -> {
-           asyncResponse.resume(policies.properties);
-       }).exceptionally(ex -> {
-           Throwable cause = ex.getCause();
-           log.error("[{}] Failed to get properties of namespace {}", clientAppId(), namespaceName, cause);
-           asyncResponse.resume(cause);
-           return null;
-       });
+       validateTenantOperationAsync(namespaceName.getTenant(), TenantOperation.CREATE_NAMESPACE)
+               .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
+               .thenAccept(policies -> asyncResponse.resume(policies.properties))
+               .exceptionally(ex -> {
+                   Throwable cause = ex.getCause();
+                   log.error("[{}] Failed to get properties of namespace {}", clientAppId(), namespaceName, cause);
+                   asyncResponse.resume(cause);
+                   return null;
+               });
    }
 
    protected void internalRemoveProperty(String key, AsyncResponse asyncResponse) {
-       validatePoliciesReadOnlyAccess();
-
        AtomicReference<String> oldVal = new AtomicReference<>(null);
-       updatePoliciesAsync(namespaceName, policies -> {
-           oldVal.set(policies.properties.remove(key));
-           return policies;
-       }).thenAccept(v -> {
-           asyncResponse.resume(oldVal.get());
-           log.info("[{}] Successfully remove property for key {} on namespace {}", clientAppId(), key,
-                   namespaceName);
-       }).exceptionally(ex -> {
-           Throwable cause = ex.getCause();
-           log.error("[{}] Failed to remove property for key {} on namespace {}", clientAppId(), key,
-                   namespaceName, cause);
-           asyncResponse.resume(cause);
-          return null;
-       });
+       validateTenantOperationAsync(namespaceName.getTenant(), TenantOperation.CREATE_NAMESPACE)
+               .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
+               .thenCompose(__ -> updatePoliciesAsync(namespaceName, policies -> {
+                   oldVal.set(policies.properties.remove(key));
+                   return policies;
+               })).thenAccept(v -> {
+                   asyncResponse.resume(oldVal.get());
+                   log.info("[{}] Successfully remove property for key {} on namespace {}", clientAppId(), key,
+                           namespaceName);
+               }).exceptionally(ex -> {
+                   Throwable cause = ex.getCause();
+                   log.error("[{}] Failed to remove property for key {} on namespace {}", clientAppId(), key,
+                           namespaceName, cause);
+                   asyncResponse.resume(cause);
+                   return null;
+               });
    }
 
    protected void internalClearProperties(AsyncResponse asyncResponse) {
-       validatePoliciesReadOnlyAccess();
        AtomicReference<Integer> clearedCount = new AtomicReference<>(0);
-       updatePoliciesAsync(namespaceName, policies -> {
-           clearedCount.set(policies.properties.size());
-           policies.properties.clear();
-           return policies;
-       }).thenAccept(v -> {
-           asyncResponse.resume(Response.noContent().build());
-           log.info("[{}] Successfully clear {} properties on namespace {}", clientAppId(), clearedCount.get(),
-                   namespaceName);
-       }).exceptionally(ex -> {
-           Throwable cause = ex.getCause();
-           log.error("[{}] Failed to clear {} properties on namespace {}", clientAppId(), clearedCount.get(),
-                   namespaceName, cause);
-           asyncResponse.resume(cause);
-           return null;
-       });
+       validateTenantOperationAsync(namespaceName.getTenant(), TenantOperation.CREATE_NAMESPACE)
+               .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
+               .thenCompose(__ -> updatePoliciesAsync(namespaceName, policies -> {
+                   clearedCount.set(policies.properties.size());
+                   policies.properties.clear();
+                   return policies;
+               }))
+               .thenAccept(v -> {
+                   asyncResponse.resume(Response.noContent().build());
+                   log.info("[{}] Successfully clear {} properties on namespace {}", clientAppId(), clearedCount.get(),
+                           namespaceName);
+               }).exceptionally(ex -> {
+                   Throwable cause = ex.getCause();
+                   log.error("[{}] Failed to clear {} properties on namespace {}", clientAppId(), clearedCount.get(),
+                           namespaceName, cause);
+                   asyncResponse.resume(cause);
+                   return null;
+               });
    }
 
    private CompletableFuture<Void> updatePoliciesAsync(NamespaceName ns, Function<Policies, Policies> updateFunction) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -2339,7 +2339,7 @@ public abstract class NamespacesBase extends AdminResource {
    }
 
    protected void internalSetProperty(String key, String value, AsyncResponse asyncResponse) {
-       validateTenantOperationAsync(namespaceName.getTenant(), TenantOperation.CREATE_NAMESPACE)
+       validateAdminAccessForTenantAsync(namespaceName.getTenant())
                .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
                .thenCompose(__ -> updatePoliciesAsync(namespaceName, policies -> {
                    policies.properties.put(key, value);
@@ -2359,7 +2359,7 @@ public abstract class NamespacesBase extends AdminResource {
    }
 
    protected void internalSetProperties(Map<String, String> properties, AsyncResponse asyncResponse) {
-       validateTenantOperationAsync(namespaceName.getTenant(), TenantOperation.CREATE_NAMESPACE)
+       validateAdminAccessForTenantAsync(namespaceName.getTenant())
                .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
                .thenCompose(__ -> updatePoliciesAsync(namespaceName, policies -> {
                    policies.properties.putAll(properties);
@@ -2379,7 +2379,7 @@ public abstract class NamespacesBase extends AdminResource {
    }
 
    protected void internalGetProperty(String key, AsyncResponse asyncResponse) {
-       validateTenantOperationAsync(namespaceName.getTenant(), TenantOperation.CREATE_NAMESPACE)
+       validateAdminAccessForTenantAsync(namespaceName.getTenant())
                .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                .thenAccept(policies -> asyncResponse.resume(policies.properties.get(key)))
                .exceptionally(ex -> {
@@ -2392,7 +2392,7 @@ public abstract class NamespacesBase extends AdminResource {
    }
 
    protected void internalGetProperties(AsyncResponse asyncResponse) {
-       validateTenantOperationAsync(namespaceName.getTenant(), TenantOperation.CREATE_NAMESPACE)
+       validateAdminAccessForTenantAsync(namespaceName.getTenant())
                .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                .thenAccept(policies -> asyncResponse.resume(policies.properties))
                .exceptionally(ex -> {
@@ -2405,7 +2405,7 @@ public abstract class NamespacesBase extends AdminResource {
 
    protected void internalRemoveProperty(String key, AsyncResponse asyncResponse) {
        AtomicReference<String> oldVal = new AtomicReference<>(null);
-       validateTenantOperationAsync(namespaceName.getTenant(), TenantOperation.CREATE_NAMESPACE)
+       validateAdminAccessForTenantAsync(namespaceName.getTenant())
                .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
                .thenCompose(__ -> updatePoliciesAsync(namespaceName, policies -> {
                    oldVal.set(policies.properties.remove(key));
@@ -2425,7 +2425,7 @@ public abstract class NamespacesBase extends AdminResource {
 
    protected void internalClearProperties(AsyncResponse asyncResponse) {
        AtomicReference<Integer> clearedCount = new AtomicReference<>(0);
-       validateTenantOperationAsync(namespaceName.getTenant(), TenantOperation.CREATE_NAMESPACE)
+       validateAdminAccessForTenantAsync(namespaceName.getTenant())
                .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
                .thenCompose(__ -> updatePoliciesAsync(namespaceName, policies -> {
                    clearedCount.set(policies.properties.size());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2410,7 +2410,7 @@ public class PersistentTopicsBase extends AdminResource {
     protected void internalUpdateSubscriptionProperties(AsyncResponse asyncResponse, String subName,
                                                         Map<String, String> subscriptionProperties,
                                                         boolean authoritative) {
-        CompletableFuture<Void> future = validateTopicOperationAsync(topicName, TopicOperation.CONSUME, subName);
+        CompletableFuture<Void> future = validateTopicOperationAsync(topicName, TopicOperation.SUBSCRIBE, subName);
         future.thenCompose(__ -> {
             if (topicName.isGlobal()) {
                 return validateGlobalNamespaceOwnershipAsync(namespaceName);
@@ -2488,7 +2488,7 @@ public class PersistentTopicsBase extends AdminResource {
     protected void internalAnalyzeSubscriptionBacklog(AsyncResponse asyncResponse, String subName,
                                                       Optional<Position> position,
                                                       boolean authoritative) {
-        CompletableFuture<Void> future = validateTopicOperationAsync(topicName, TopicOperation.CONSUME, subName);
+        CompletableFuture<Void> future = validateTopicOperationAsync(topicName, TopicOperation.GET_STATS, subName);
         future.thenCompose(__ -> {
             if (topicName.isGlobal()) {
                 return validateGlobalNamespaceOwnershipAsync(namespaceName);
@@ -2526,7 +2526,7 @@ public class PersistentTopicsBase extends AdminResource {
 
     protected void internalGetSubscriptionProperties(AsyncResponse asyncResponse, String subName,
                                                         boolean authoritative) {
-        CompletableFuture<Void> future = validateTopicOperationAsync(topicName, TopicOperation.CONSUME, subName);
+        CompletableFuture<Void> future = validateTopicOperationAsync(topicName, TopicOperation.GET_METADATA, subName);
         future.thenCompose(__ -> {
             if (topicName.isGlobal()) {
                 return validateGlobalNamespaceOwnershipAsync(namespaceName);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -5338,7 +5338,7 @@ public class PersistentTopicsBase extends AdminResource {
         CompletableFuture<Void> future = validateTopicPolicyOperationAsync(topicName,
                 PolicyName.SCHEMA_COMPATIBILITY_STRATEGY, PolicyOperation.READ);
         if (applied) {
-            return getSchemaCompatibilityStrategyAsync();
+            return future.thenCompose(__ -> getSchemaCompatibilityStrategyAsync());
         }
         return future
                 .thenCompose(n -> getTopicPoliciesAsyncWithRetry(topicName).thenApply(op -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1068,8 +1068,10 @@ public class PersistentTopicsBase extends AdminResource {
 
     private void internalUnloadTransactionCoordinatorAsync(AsyncResponse asyncResponse, boolean authoritative) {
         validateTopicOwnershipAsync(topicName, authoritative)
-                .thenCompose(v -> pulsar().getTransactionMetadataStoreService().removeTransactionMetadataStore(
-                                        TransactionCoordinatorID.get(topicName.getPartitionIndex())))
+                .thenCompose(v -> pulsar()
+                        .getTransactionMetadataStoreService()
+                        .removeTransactionMetadataStore(
+                                TransactionCoordinatorID.get(topicName.getPartitionIndex())))
                 .thenRun(() -> {
                     log.info("[{}] Successfully unloaded tc {}", clientAppId(), topicName.getPartitionIndex());
                     asyncResponse.resume(Response.noContent().build());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -2490,7 +2490,7 @@ public class PersistentTopicsBase extends AdminResource {
     protected void internalAnalyzeSubscriptionBacklog(AsyncResponse asyncResponse, String subName,
                                                       Optional<Position> position,
                                                       boolean authoritative) {
-        CompletableFuture<Void> future = validateTopicOperationAsync(topicName, TopicOperation.GET_STATS, subName);
+        CompletableFuture<Void> future = validateTopicOperationAsync(topicName, TopicOperation.CONSUME, subName);
         future.thenCompose(__ -> {
             if (topicName.isGlobal()) {
                 return validateGlobalNamespaceOwnershipAsync(namespaceName);
@@ -2528,7 +2528,7 @@ public class PersistentTopicsBase extends AdminResource {
 
     protected void internalGetSubscriptionProperties(AsyncResponse asyncResponse, String subName,
                                                         boolean authoritative) {
-        CompletableFuture<Void> future = validateTopicOperationAsync(topicName, TopicOperation.GET_METADATA, subName);
+        CompletableFuture<Void> future = validateTopicOperationAsync(topicName, TopicOperation.CONSUME, subName);
         future.thenCompose(__ -> {
             if (topicName.isGlobal()) {
                 return validateGlobalNamespaceOwnershipAsync(namespaceName);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -488,7 +488,9 @@ public class PersistentTopicsBase extends AdminResource {
     protected void internalCreateMissedPartitions(AsyncResponse asyncResponse) {
         getPartitionedTopicMetadataAsync(topicName, false, false).thenAccept(metadata -> {
             if (metadata != null) {
-                tryCreatePartitionsAsync(metadata.partitions).thenAccept(v -> {
+                CompletableFuture<Void> future = validateNamespaceOperationAsync(topicName.getNamespaceObject(),
+                        NamespaceOperation.CREATE_TOPIC);
+                future.thenCompose(__ -> tryCreatePartitionsAsync(metadata.partitions)).thenAccept(v -> {
                     asyncResponse.resume(Response.noContent().build());
                 }).exceptionally(e -> {
                     log.error("[{}] Failed to create partitions for topic {}", clientAppId(), topicName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespaceAuthZTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespaceAuthZTest.java
@@ -113,47 +113,24 @@ public class NamespaceAuthZTest extends MockedPulsarStandalone {
         tenantManagerAdmin.namespaces().clearProperties(namespace);
 
         // test nobody
-        try {
-            subAdmin.namespaces().setProperties(namespace, properties);
-            Assert.fail("unexpected behaviour");
-        } catch (PulsarAdminException ex) {
-            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-        }
+        Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                () -> subAdmin.namespaces().setProperties(namespace, properties));
 
-        try {
+        Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                () -> subAdmin.namespaces().setProperty(namespace, "key2", "value2"));
 
-            subAdmin.namespaces().setProperty(namespace, "key2", "value2");
-            Assert.fail("unexpected behaviour");
-        } catch (PulsarAdminException ex) {
-            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-        }
+        Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                () -> subAdmin.namespaces().getProperties(namespace));
 
-        try {
-            subAdmin.namespaces().getProperties(namespace);
-            Assert.fail("unexpected behaviour");
-        } catch (PulsarAdminException ex) {
-            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-        }
+        Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                () -> subAdmin.namespaces().getProperty(namespace, "key2"));
 
-        try {
-            subAdmin.namespaces().getProperty(namespace, "key2");
-            Assert.fail("unexpected behaviour");
-        } catch (PulsarAdminException ex) {
-            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-        }
 
-        try {
-            subAdmin.namespaces().removeProperty(namespace, "key2");
-            Assert.fail("unexpected behaviour");
-        } catch (PulsarAdminException ex) {
-            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-        }
+        Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                () -> subAdmin.namespaces().removeProperty(namespace, "key2"));
 
-        try {
-            subAdmin.namespaces().clearProperties(namespace);
-            Assert.fail("unexpected behaviour");
-        } catch (PulsarAdminException ex) {
-            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-        }
+        Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                () -> subAdmin.namespaces().clearProperties(namespace));
+
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespaceAuthZTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespaceAuthZTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.broker.admin;
+
+import io.jsonwebtoken.Jwts;
+import lombok.Cleanup;
+import lombok.SneakyThrows;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.impl.auth.AuthenticationToken;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.security.MockedPulsarStandalone;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class NamespaceAuthZTest extends MockedPulsarStandalone {
+
+    private PulsarAdmin superUserAdmin;
+
+    private PulsarAdmin tenantManagerAdmin;
+
+    private static final String TENANT_ADMIN_SUBJECT =  UUID.randomUUID().toString();
+    private static final String TENANT_ADMIN_TOKEN = Jwts.builder()
+            .claim("sub", TENANT_ADMIN_SUBJECT).signWith(SECRET_KEY).compact();
+
+    @SneakyThrows
+    @BeforeClass
+    public void before() {
+        configureTokenAuthentication();
+        configureDefaultAuthorization();
+        start();
+        this.superUserAdmin =PulsarAdmin.builder()
+                .serviceHttpUrl(getPulsarService().getWebServiceAddress())
+                .authentication(new AuthenticationToken(SUPER_USER_TOKEN))
+                .build();
+        final TenantInfo tenantInfo = superUserAdmin.tenants().getTenantInfo("public");
+        tenantInfo.getAdminRoles().add(TENANT_ADMIN_SUBJECT);
+        superUserAdmin.tenants().updateTenant("public", tenantInfo);
+        this.tenantManagerAdmin = PulsarAdmin.builder()
+                .serviceHttpUrl(getPulsarService().getWebServiceAddress())
+                .authentication(new AuthenticationToken(TENANT_ADMIN_TOKEN))
+                .build();
+    }
+
+
+    @SneakyThrows
+    @AfterClass
+    public void after() {
+        if (superUserAdmin != null) {
+            superUserAdmin.close();
+        }
+        if (tenantManagerAdmin != null) {
+            tenantManagerAdmin.close();
+        }
+        close();
+    }
+
+
+    @SneakyThrows
+    @Test
+    public void testProperties() {
+        final String random = UUID.randomUUID().toString();
+        final String namespace = "public/default";
+        final String topic = "persistent://public/default/" + random;
+        final String subject =  UUID.randomUUID().toString();
+        final String token = Jwts.builder()
+                .claim("sub", subject).signWith(SECRET_KEY).compact();
+        superUserAdmin.topics().createNonPartitionedTopic(topic);
+
+        @Cleanup
+        final PulsarAdmin subAdmin = PulsarAdmin.builder()
+                .serviceHttpUrl(getPulsarService().getWebServiceAddress())
+                .authentication(new AuthenticationToken(token))
+                .build();
+        // test superuser
+        Map<String, String> properties = new HashMap<>();
+        properties.put("key1", "value1");
+        superUserAdmin.namespaces().setProperties(namespace, properties);
+        superUserAdmin.namespaces().setProperty(namespace, "key2", "value2");
+        superUserAdmin.namespaces().getProperties(namespace);
+        superUserAdmin.namespaces().getProperty(namespace, "key2");
+        superUserAdmin.namespaces().removeProperty(namespace, "key2");
+        superUserAdmin.namespaces().clearProperties(namespace);
+
+        // test tenant manager
+        tenantManagerAdmin.namespaces().setProperties(namespace, properties);
+        tenantManagerAdmin.namespaces().setProperty(namespace, "key2", "value2");
+        tenantManagerAdmin.namespaces().getProperties(namespace);
+        tenantManagerAdmin.namespaces().getProperty(namespace, "key2");
+        tenantManagerAdmin.namespaces().removeProperty(namespace, "key2");
+        tenantManagerAdmin.namespaces().clearProperties(namespace);
+
+        // test nobody
+        try {
+            subAdmin.namespaces().setProperties(namespace, properties);
+            Assert.fail("unexpected behaviour");
+        } catch (PulsarAdminException ex) {
+            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+        }
+
+        try {
+
+            subAdmin.namespaces().setProperty(namespace, "key2", "value2");
+            Assert.fail("unexpected behaviour");
+        } catch (PulsarAdminException ex) {
+            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+        }
+
+        try {
+            subAdmin.namespaces().getProperties(namespace);
+            Assert.fail("unexpected behaviour");
+        } catch (PulsarAdminException ex) {
+            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+        }
+
+        try {
+            subAdmin.namespaces().getProperty(namespace, "key2");
+            Assert.fail("unexpected behaviour");
+        } catch (PulsarAdminException ex) {
+            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+        }
+
+        try {
+            subAdmin.namespaces().removeProperty(namespace, "key2");
+            Assert.fail("unexpected behaviour");
+        } catch (PulsarAdminException ex) {
+            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+        }
+
+        try {
+            subAdmin.namespaces().clearProperties(namespace);
+            Assert.fail("unexpected behaviour");
+        } catch (PulsarAdminException ex) {
+            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAuthZTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAuthZTest.java
@@ -1,0 +1,387 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.broker.admin;
+
+import io.jsonwebtoken.Jwts;
+import lombok.Cleanup;
+import lombok.SneakyThrows;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.impl.auth.AuthenticationToken;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.security.MockedPulsarStandalone;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TopicAuthZTest extends MockedPulsarStandalone {
+
+    private PulsarAdmin superUserAdmin;
+
+    private PulsarAdmin tenantManagerAdmin;
+
+    private static final String TENANT_ADMIN_SUBJECT =  UUID.randomUUID().toString();
+    private static final String TENANT_ADMIN_TOKEN = Jwts.builder()
+            .claim("sub", TENANT_ADMIN_SUBJECT).signWith(SECRET_KEY).compact();
+
+    @SneakyThrows
+    @BeforeClass
+    public void before() {
+        configureTokenAuthentication();
+        configureDefaultAuthorization();
+        start();
+        this.superUserAdmin =PulsarAdmin.builder()
+                .serviceHttpUrl(getPulsarService().getWebServiceAddress())
+                .authentication(new AuthenticationToken(SUPER_USER_TOKEN))
+                .build();
+        final TenantInfo tenantInfo = superUserAdmin.tenants().getTenantInfo("public");
+        tenantInfo.getAdminRoles().add(TENANT_ADMIN_SUBJECT);
+        superUserAdmin.tenants().updateTenant("public", tenantInfo);
+        this.tenantManagerAdmin = PulsarAdmin.builder()
+                .serviceHttpUrl(getPulsarService().getWebServiceAddress())
+                .authentication(new AuthenticationToken(TENANT_ADMIN_TOKEN))
+                .build();
+    }
+
+
+    @SneakyThrows
+    @AfterClass
+    public void after() {
+        if (superUserAdmin != null) {
+            superUserAdmin.close();
+        }
+        if (tenantManagerAdmin != null) {
+            tenantManagerAdmin.close();
+        }
+        close();
+    }
+
+
+    @SneakyThrows
+    @Test
+    public void testUnloadAndCompactAndTrim() {
+        final String random = UUID.randomUUID().toString();
+        final String topic = "persistent://public/default/" + random;
+        final String subject =  UUID.randomUUID().toString();
+        final String token = Jwts.builder()
+                .claim("sub", subject).signWith(SECRET_KEY).compact();
+        superUserAdmin.topics().createPartitionedTopic(topic, 2);
+
+        @Cleanup
+        final PulsarAdmin subAdmin = PulsarAdmin.builder()
+                .serviceHttpUrl(getPulsarService().getWebServiceAddress())
+                .authentication(new AuthenticationToken(token))
+                .build();
+        // test superuser
+        superUserAdmin.topics().unload(topic);
+        superUserAdmin.topics().triggerCompaction(topic);
+        superUserAdmin.topics().trimTopic(TopicName.get(topic).getPartition(0).getLocalName());
+        superUserAdmin.topicPolicies().getSchemaCompatibilityStrategy(topic, false);
+
+        // test tenant manager
+        tenantManagerAdmin.topics().unload(topic);
+        tenantManagerAdmin.topics().triggerCompaction(topic);
+        tenantManagerAdmin.topics().trimTopic(TopicName.get(topic).getPartition(0).getLocalName());
+        tenantManagerAdmin.topicPolicies().getSchemaCompatibilityStrategy(topic, false);
+
+        // test nobody
+        try {
+            subAdmin.topics().unload(topic);
+            Assert.fail("unexpected behaviour");
+        } catch (PulsarAdminException ex) {
+            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+        }
+        try {
+            subAdmin.topics().triggerCompaction(topic);
+            Assert.fail("unexpected behaviour");
+        } catch (PulsarAdminException ex) {
+            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+        }
+        try {
+            subAdmin.topics().trimTopic(TopicName.get(topic).getPartition(0).getLocalName());
+            Assert.fail("unexpected behaviour");
+        } catch (PulsarAdminException ex) {
+            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+        }
+        try {
+            subAdmin.topicPolicies().getSchemaCompatibilityStrategy(topic, false);
+            Assert.fail("unexpected behaviour");
+        } catch (PulsarAdminException ex) {
+            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+        }
+
+        for (AuthAction action : AuthAction.values()) {
+            superUserAdmin.topics().grantPermission(topic, subject, Set.of(action));
+            try {
+                subAdmin.topics().unload(topic);
+                Assert.fail("unexpected behaviour");
+            } catch (PulsarAdminException ex) {
+                Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+            }
+            try {
+                subAdmin.topics().triggerCompaction(topic);
+                Assert.fail("unexpected behaviour");
+            } catch (PulsarAdminException ex) {
+                Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+            }
+            try {
+                subAdmin.topics().trimTopic(topic);
+                Assert.fail("unexpected behaviour");
+            } catch (PulsarAdminException ex) {
+                Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+            }
+            try {
+                subAdmin.topicPolicies().getSchemaCompatibilityStrategy(topic, false);
+                Assert.fail("unexpected behaviour");
+            } catch (PulsarAdminException ex) {
+                Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+            }
+            superUserAdmin.topics().revokePermissions(topic, subject);
+        }
+        superUserAdmin.topics().deletePartitionedTopic(topic, true);
+    }
+
+    @Test
+    @SneakyThrows
+    public void testGetManagedLedgerInfo() {
+        final String random = UUID.randomUUID().toString();
+        final String topic = "persistent://public/default/" + random;
+        final String subject =  UUID.randomUUID().toString();
+        final String token = Jwts.builder()
+                .claim("sub", subject).signWith(SECRET_KEY).compact();
+        superUserAdmin.topics().createPartitionedTopic(topic, 2);
+
+        @Cleanup
+        final PulsarAdmin subAdmin = PulsarAdmin.builder()
+                .serviceHttpUrl(getPulsarService().getWebServiceAddress())
+                .authentication(new AuthenticationToken(token))
+                .build();
+        // test superuser
+        superUserAdmin.topics().getInternalInfo(topic);
+
+        // test tenant manager
+        tenantManagerAdmin.topics().getInternalInfo(topic);
+
+        // test nobody
+        try {
+            subAdmin.topics().getInternalInfo(topic);
+            Assert.fail("unexpected behaviour");
+        } catch (PulsarAdminException ex) {
+            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+        }
+
+        for (AuthAction action : AuthAction.values()) {
+            superUserAdmin.topics().grantPermission(topic, subject, Set.of(action));
+            if (action == AuthAction.produce || action == AuthAction.consume) {
+                subAdmin.topics().getInternalInfo(topic);
+            } else {
+                try {
+                    subAdmin.topics().getInternalInfo(topic);
+                    Assert.fail("unexpected behaviour");
+                } catch (PulsarAdminException ex) {
+                    Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+                }
+            }
+            superUserAdmin.topics().revokePermissions(topic, subject);
+        }
+        superUserAdmin.topics().deletePartitionedTopic(topic, true);
+    }
+
+    @Test
+    @SneakyThrows
+    public void testGetPartitionedStatsAndInternalStats() {
+        final String random = UUID.randomUUID().toString();
+        final String topic = "persistent://public/default/" + random;
+        final String subject =  UUID.randomUUID().toString();
+        final String token = Jwts.builder()
+                .claim("sub", subject).signWith(SECRET_KEY).compact();
+        superUserAdmin.topics().createPartitionedTopic(topic, 2);
+
+        @Cleanup
+        final PulsarAdmin subAdmin = PulsarAdmin.builder()
+                .serviceHttpUrl(getPulsarService().getWebServiceAddress())
+                .authentication(new AuthenticationToken(token))
+                .build();
+        // test superuser
+        superUserAdmin.topics().getPartitionedStats(topic, false);
+        superUserAdmin.topics().getPartitionedInternalStats(topic);
+
+        // test tenant manager
+        tenantManagerAdmin.topics().getPartitionedStats(topic, false);
+        tenantManagerAdmin.topics().getPartitionedInternalStats(topic);
+
+        // test nobody
+        try {
+            subAdmin.topics().getPartitionedStats(topic, false);
+            Assert.fail("unexpected behaviour");
+        } catch (PulsarAdminException ex) {
+            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+        }
+
+        try {
+            subAdmin.topics().getPartitionedInternalStats(topic);
+            Assert.fail("unexpected behaviour");
+        } catch (PulsarAdminException ex) {
+            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+        }
+
+        for (AuthAction action : AuthAction.values()) {
+            superUserAdmin.topics().grantPermission(topic, subject, Set.of(action));
+            if (action == AuthAction.produce || action == AuthAction.consume) {
+                subAdmin.topics().getPartitionedStats(topic, false);
+                subAdmin.topics().getPartitionedInternalStats(topic);
+            } else {
+                try {
+                    subAdmin.topics().getPartitionedStats(topic, false);
+                    Assert.fail("unexpected behaviour");
+                } catch (PulsarAdminException ex) {
+                    Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+                }
+                try {
+                    subAdmin.topics().getPartitionedInternalStats(topic);
+                    Assert.fail("unexpected behaviour");
+                } catch (PulsarAdminException ex) {
+                    Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+                }
+            }
+            superUserAdmin.topics().revokePermissions(topic, subject);
+        }
+        superUserAdmin.topics().deletePartitionedTopic(topic, true);
+    }
+
+    @Test
+    @SneakyThrows
+    public void testCreateSubscriptionAndUpdateSubscriptionProperties() {
+        final String random = UUID.randomUUID().toString();
+        final String topic = "persistent://public/default/" + random;
+        final String subject =  UUID.randomUUID().toString();
+        final String token = Jwts.builder()
+                .claim("sub", subject).signWith(SECRET_KEY).compact();
+        superUserAdmin.topics().createPartitionedTopic(topic, 2);
+        AtomicInteger suffix = new AtomicInteger(1);
+        @Cleanup
+        final PulsarAdmin subAdmin = PulsarAdmin.builder()
+                .serviceHttpUrl(getPulsarService().getWebServiceAddress())
+                .authentication(new AuthenticationToken(token))
+                .build();
+        //
+        superUserAdmin.topics().createSubscription(topic, "test-sub" + suffix.incrementAndGet(), MessageId.earliest);
+
+        // test tenant manager
+        tenantManagerAdmin.topics().createSubscription(topic, "test-sub" + suffix.incrementAndGet(), MessageId.earliest);
+
+        // test nobody
+        try {
+            subAdmin.topics().createSubscription(topic, "test-sub" + suffix.incrementAndGet(), MessageId.earliest);
+            Assert.fail("unexpected behaviour");
+        } catch (PulsarAdminException ex) {
+            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+        }
+
+
+        for (AuthAction action : AuthAction.values()) {
+            superUserAdmin.topics().grantPermission(topic, subject, Set.of(action));
+            if (action == AuthAction.consume) {
+                subAdmin.topics().createSubscription(topic, "test-sub" + suffix.incrementAndGet(), MessageId.earliest);
+            } else {
+                try {
+                    subAdmin.topics().createSubscription(topic, "test-sub" + suffix.incrementAndGet(), MessageId.earliest);
+                    Assert.fail("unexpected behaviour");
+                } catch (PulsarAdminException ex) {
+                    Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+                }
+            }
+            superUserAdmin.topics().revokePermissions(topic, subject);
+        }
+        // test UpdateSubscriptionProperties
+        Map<String, String> properties = new HashMap<>();
+        superUserAdmin.topics().createSubscription(topic, "test-sub", MessageId.earliest);
+        // test superuser
+        superUserAdmin.topics().updateSubscriptionProperties(topic, "test-sub" , properties);
+        superUserAdmin.topics().getSubscriptionProperties(topic, "test-sub");
+        superUserAdmin.topics().analyzeSubscriptionBacklog(TopicName.get(topic).getPartition(0).getLocalName(), "test-sub", Optional.empty());
+
+        // test tenant manager
+        tenantManagerAdmin.topics().updateSubscriptionProperties(topic, "test-sub" , properties);
+        tenantManagerAdmin.topics().getSubscriptionProperties(topic, "test-sub");
+        tenantManagerAdmin.topics().analyzeSubscriptionBacklog(TopicName.get(topic).getPartition(0).getLocalName(), "test-sub", Optional.empty());
+
+        // test nobody
+        try {
+            subAdmin.topics().updateSubscriptionProperties(topic, "test-sub", properties);
+            Assert.fail("unexpected behaviour");
+        } catch (PulsarAdminException ex) {
+            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+        }
+        try {
+            subAdmin.topics().getSubscriptionProperties(topic, "test-sub");
+            Assert.fail("unexpected behaviour");
+        } catch (PulsarAdminException ex) {
+            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+        }
+        try {
+            subAdmin.topics().analyzeSubscriptionBacklog(TopicName.get(topic).getPartition(0).getLocalName(), "test-sub", Optional.empty());
+            Assert.fail("unexpected behaviour");
+        } catch (PulsarAdminException ex) {
+            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+        }
+
+
+        for (AuthAction action : AuthAction.values()) {
+            superUserAdmin.topics().grantPermission(topic, subject, Set.of(action));
+            if (action == AuthAction.consume) {
+                subAdmin.topics().updateSubscriptionProperties(topic, "test-sub", properties);
+                subAdmin.topics().getSubscriptionProperties(topic, "test-sub");
+                subAdmin.topics().analyzeSubscriptionBacklog(TopicName.get(topic).getPartition(0).getLocalName(), "test-sub", Optional.empty());
+            } else {
+                try {
+                    subAdmin.topics().updateSubscriptionProperties(topic, "test-sub", properties);
+                    Assert.fail("unexpected behaviour");
+                } catch (PulsarAdminException ex) {
+                    Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+                }
+                try {
+                    subAdmin.topics().getSubscriptionProperties(topic, "test-sub");
+                    Assert.fail("unexpected behaviour");
+                } catch (PulsarAdminException ex) {
+                    Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+                }
+                try {
+                    subAdmin.topics().analyzeSubscriptionBacklog(TopicName.get(topic).getPartition(0).getLocalName(), "test-sub", Optional.empty());
+                    Assert.fail("unexpected behaviour");
+                } catch (PulsarAdminException ex) {
+                    Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+                }
+            }
+            superUserAdmin.topics().revokePermissions(topic, subject);
+        }
+        superUserAdmin.topics().deletePartitionedTopic(topic, true);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAuthZTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAuthZTest.java
@@ -112,57 +112,34 @@ public class TopicAuthZTest extends MockedPulsarStandalone {
         tenantManagerAdmin.topicPolicies().getSchemaCompatibilityStrategy(topic, false);
 
         // test nobody
-        try {
-            subAdmin.topics().unload(topic);
-            Assert.fail("unexpected behaviour");
-        } catch (PulsarAdminException ex) {
-            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-        }
-        try {
-            subAdmin.topics().triggerCompaction(topic);
-            Assert.fail("unexpected behaviour");
-        } catch (PulsarAdminException ex) {
-            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-        }
-        try {
-            subAdmin.topics().trimTopic(TopicName.get(topic).getPartition(0).getLocalName());
-            Assert.fail("unexpected behaviour");
-        } catch (PulsarAdminException ex) {
-            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-        }
-        try {
-            subAdmin.topicPolicies().getSchemaCompatibilityStrategy(topic, false);
-            Assert.fail("unexpected behaviour");
-        } catch (PulsarAdminException ex) {
-            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-        }
+        Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                () -> subAdmin.topics().unload(topic));
 
+        Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                () -> subAdmin.topics().triggerCompaction(topic));
+
+        Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                () -> subAdmin.topics().trimTopic(TopicName.get(topic).getPartition(0).getLocalName()));
+
+        Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                () -> subAdmin.topicPolicies().getSchemaCompatibilityStrategy(topic, false));
+
+        // Test only super/admin can do the operation, other auth are not permitted.
         for (AuthAction action : AuthAction.values()) {
             superUserAdmin.topics().grantPermission(topic, subject, Set.of(action));
-            try {
-                subAdmin.topics().unload(topic);
-                Assert.fail("unexpected behaviour");
-            } catch (PulsarAdminException ex) {
-                Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-            }
-            try {
-                subAdmin.topics().triggerCompaction(topic);
-                Assert.fail("unexpected behaviour");
-            } catch (PulsarAdminException ex) {
-                Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-            }
-            try {
-                subAdmin.topics().trimTopic(topic);
-                Assert.fail("unexpected behaviour");
-            } catch (PulsarAdminException ex) {
-                Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-            }
-            try {
-                subAdmin.topicPolicies().getSchemaCompatibilityStrategy(topic, false);
-                Assert.fail("unexpected behaviour");
-            } catch (PulsarAdminException ex) {
-                Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-            }
+
+            Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                    () -> subAdmin.topics().unload(topic));
+
+            Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                    () -> subAdmin.topics().triggerCompaction(topic));
+
+            Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                    () -> subAdmin.topics().trimTopic(topic));
+
+            Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                    () -> subAdmin.topicPolicies().getSchemaCompatibilityStrategy(topic, false));
+
             superUserAdmin.topics().revokePermissions(topic, subject);
         }
         superUserAdmin.topics().deletePartitionedTopic(topic, true);
@@ -190,24 +167,16 @@ public class TopicAuthZTest extends MockedPulsarStandalone {
         tenantManagerAdmin.topics().getInternalInfo(topic);
 
         // test nobody
-        try {
-            subAdmin.topics().getInternalInfo(topic);
-            Assert.fail("unexpected behaviour");
-        } catch (PulsarAdminException ex) {
-            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-        }
+        Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                () -> subAdmin.topics().getInternalInfo(topic));
 
         for (AuthAction action : AuthAction.values()) {
             superUserAdmin.topics().grantPermission(topic, subject, Set.of(action));
             if (action == AuthAction.produce || action == AuthAction.consume) {
                 subAdmin.topics().getInternalInfo(topic);
             } else {
-                try {
-                    subAdmin.topics().getInternalInfo(topic);
-                    Assert.fail("unexpected behaviour");
-                } catch (PulsarAdminException ex) {
-                    Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-                }
+                Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                        () -> subAdmin.topics().getInternalInfo(topic));
             }
             superUserAdmin.topics().revokePermissions(topic, subject);
         }
@@ -238,19 +207,11 @@ public class TopicAuthZTest extends MockedPulsarStandalone {
         tenantManagerAdmin.topics().getPartitionedInternalStats(topic);
 
         // test nobody
-        try {
-            subAdmin.topics().getPartitionedStats(topic, false);
-            Assert.fail("unexpected behaviour");
-        } catch (PulsarAdminException ex) {
-            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-        }
+        Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                () -> subAdmin.topics().getPartitionedStats(topic, false));
 
-        try {
-            subAdmin.topics().getPartitionedInternalStats(topic);
-            Assert.fail("unexpected behaviour");
-        } catch (PulsarAdminException ex) {
-            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-        }
+        Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                () -> subAdmin.topics().getPartitionedInternalStats(topic));
 
         for (AuthAction action : AuthAction.values()) {
             superUserAdmin.topics().grantPermission(topic, subject, Set.of(action));
@@ -258,18 +219,11 @@ public class TopicAuthZTest extends MockedPulsarStandalone {
                 subAdmin.topics().getPartitionedStats(topic, false);
                 subAdmin.topics().getPartitionedInternalStats(topic);
             } else {
-                try {
-                    subAdmin.topics().getPartitionedStats(topic, false);
-                    Assert.fail("unexpected behaviour");
-                } catch (PulsarAdminException ex) {
-                    Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-                }
-                try {
-                    subAdmin.topics().getPartitionedInternalStats(topic);
-                    Assert.fail("unexpected behaviour");
-                } catch (PulsarAdminException ex) {
-                    Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-                }
+                Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                        () -> subAdmin.topics().getPartitionedStats(topic, false));
+
+                Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                        () -> subAdmin.topics().getPartitionedInternalStats(topic));
             }
             superUserAdmin.topics().revokePermissions(topic, subject);
         }
@@ -298,25 +252,16 @@ public class TopicAuthZTest extends MockedPulsarStandalone {
         tenantManagerAdmin.topics().createSubscription(topic, "test-sub" + suffix.incrementAndGet(), MessageId.earliest);
 
         // test nobody
-        try {
-            subAdmin.topics().createSubscription(topic, "test-sub" + suffix.incrementAndGet(), MessageId.earliest);
-            Assert.fail("unexpected behaviour");
-        } catch (PulsarAdminException ex) {
-            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-        }
-
+        Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                () -> subAdmin.topics().createSubscription(topic, "test-sub" + suffix.incrementAndGet(), MessageId.earliest));
 
         for (AuthAction action : AuthAction.values()) {
             superUserAdmin.topics().grantPermission(topic, subject, Set.of(action));
             if (action == AuthAction.consume) {
                 subAdmin.topics().createSubscription(topic, "test-sub" + suffix.incrementAndGet(), MessageId.earliest);
             } else {
-                try {
-                    subAdmin.topics().createSubscription(topic, "test-sub" + suffix.incrementAndGet(), MessageId.earliest);
-                    Assert.fail("unexpected behaviour");
-                } catch (PulsarAdminException ex) {
-                    Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-                }
+                Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                        () -> subAdmin.topics().createSubscription(topic, "test-sub" + suffix.incrementAndGet(), MessageId.earliest));
             }
             superUserAdmin.topics().revokePermissions(topic, subject);
         }
@@ -334,25 +279,14 @@ public class TopicAuthZTest extends MockedPulsarStandalone {
         tenantManagerAdmin.topics().analyzeSubscriptionBacklog(TopicName.get(topic).getPartition(0).getLocalName(), "test-sub", Optional.empty());
 
         // test nobody
-        try {
-            subAdmin.topics().updateSubscriptionProperties(topic, "test-sub", properties);
-            Assert.fail("unexpected behaviour");
-        } catch (PulsarAdminException ex) {
-            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-        }
-        try {
-            subAdmin.topics().getSubscriptionProperties(topic, "test-sub");
-            Assert.fail("unexpected behaviour");
-        } catch (PulsarAdminException ex) {
-            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-        }
-        try {
-            subAdmin.topics().analyzeSubscriptionBacklog(TopicName.get(topic).getPartition(0).getLocalName(), "test-sub", Optional.empty());
-            Assert.fail("unexpected behaviour");
-        } catch (PulsarAdminException ex) {
-            Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-        }
+        Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                () -> subAdmin.topics().updateSubscriptionProperties(topic, "test-sub", properties));
 
+        Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                () -> subAdmin.topics().getSubscriptionProperties(topic, "test-sub"));
+
+        Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                () -> subAdmin.topics().analyzeSubscriptionBacklog(TopicName.get(topic).getPartition(0).getLocalName(), "test-sub", Optional.empty()));
 
         for (AuthAction action : AuthAction.values()) {
             superUserAdmin.topics().grantPermission(topic, subject, Set.of(action));
@@ -361,24 +295,14 @@ public class TopicAuthZTest extends MockedPulsarStandalone {
                 subAdmin.topics().getSubscriptionProperties(topic, "test-sub");
                 subAdmin.topics().analyzeSubscriptionBacklog(TopicName.get(topic).getPartition(0).getLocalName(), "test-sub", Optional.empty());
             } else {
-                try {
-                    subAdmin.topics().updateSubscriptionProperties(topic, "test-sub", properties);
-                    Assert.fail("unexpected behaviour");
-                } catch (PulsarAdminException ex) {
-                    Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-                }
-                try {
-                    subAdmin.topics().getSubscriptionProperties(topic, "test-sub");
-                    Assert.fail("unexpected behaviour");
-                } catch (PulsarAdminException ex) {
-                    Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-                }
-                try {
-                    subAdmin.topics().analyzeSubscriptionBacklog(TopicName.get(topic).getPartition(0).getLocalName(), "test-sub", Optional.empty());
-                    Assert.fail("unexpected behaviour");
-                } catch (PulsarAdminException ex) {
-                    Assert.assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
-                }
+                Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                        () -> subAdmin.topics().updateSubscriptionProperties(topic, "test-sub", properties));
+
+                Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                        () -> subAdmin.topics().getSubscriptionProperties(topic, "test-sub"));
+
+                Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                        () -> subAdmin.topics().analyzeSubscriptionBacklog(TopicName.get(topic).getPartition(0).getLocalName(), "test-sub", Optional.empty()));
             }
             superUserAdmin.topics().revokePermissions(topic, subject);
         }


### PR DESCRIPTION
### Motivation
Add fine-grain authorization to ns/topic management endpoints so that it can be controlled at a more fine-grain level.

### Modification
- `TRIM_TOPIC` was missing, this would cause the normal user throw `IllegalStateException` not NotAuthorizedException.
- adding fine-grain authorization to `internalSetProperty`, `internalSetProperties`, `internalGetProperty`, `internalGetProperties`, `internalRemoveProperty`, `internalClearProperties`, `internalUnloadTopic`,`internalGetManagedLedgerInfo`, `internalGetPartitionedStats`, `internalGetPartitionedStatsInternal`, `internalCreateSubscription`, `internalUpdateSubscriptionProperties`, `internalAnalyzeSubscriptionBacklog`, `internalGetSubscriptionProperties`, `internalCreateMissedPartitions`

### Verifying this change
- Add fine-grain authorization test coverage to `NamespaceAuthZTest` and `TopicAuthZTest`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

