### PR TITLE
[fix] [broker] [branch-2.10] Remove the unnecessary HTTP response header: Content-Encoding when calling getSchema

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
@@ -29,7 +29,6 @@ import java.time.Clock;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.ws.rs.container.AsyncResponse;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.service.schema.SchemaRegistry.SchemaAndMetadata;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
@@ -258,7 +258,7 @@ public class SchemasResourceBase extends AdminResource {
                 response.resume(Response.status(
                         Response.Status.NOT_FOUND.getStatusCode(), "Schema is deleted").build());
             } else {
-                response.resume(Response.ok().encoding(MediaType.APPLICATION_JSON)
+                response.resume(Response.ok()
                         .entity(convertSchemaAndMetadataToGetSchemaResponse(schema)).build());
             }
         } else {
@@ -275,7 +275,7 @@ public class SchemasResourceBase extends AdminResource {
                 response.resume(Response.status(
                         Response.Status.NOT_FOUND.getStatusCode(), "Schemas not found").build());
             } else {
-                response.resume(Response.ok().encoding(MediaType.APPLICATION_JSON)
+                response.resume(Response.ok()
                         .entity(GetAllVersionsSchemaResponse.builder()
                                 .getSchemaResponses(schemas.stream()
                                         .map(SchemasResourceBase::convertSchemaAndMetadataToGetSchemaResponse)


### PR DESCRIPTION
### Motivation

```
curl -X GET https://127.0.0.1:443/admin/v2/schemas/public/default/tp1/schema 

Response:

HTTP/1.1 200 OK
Content-Encoding: application/json
Content-Type: application/json
Server: Jetty(9.4.51.v20230217)
Content-Length: 403
```

The HTTP response header `Content-Encoding` is wrong and unnecessary. The other branches have been fixed by https://github.com/apache/pulsar/pull/16018 and can not cherry-pick into `branch-2.10`, see detail [here](https://github.com/apache/pulsar/pull/16018#issuecomment-1820357348)

### Modifications

Remove the unnecessary HTTP response header: Content-Encoding

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x