### PR TITLE
[improve][misc] Include native epoll library for Netty for arm64

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -309,6 +309,7 @@ The Apache Software License, Version 2.0
     - io.netty-netty-resolver-dns-native-macos-4.1.105.Final-osx-x86_64.jar
     - io.netty-netty-transport-4.1.105.Final.jar
     - io.netty-netty-transport-classes-epoll-4.1.105.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.105.Final-linux-aarch_64.jar
     - io.netty-netty-transport-native-epoll-4.1.105.Final-linux-x86_64.jar
     - io.netty-netty-transport-native-unix-common-4.1.105.Final.jar
     - io.netty-netty-transport-native-unix-common-4.1.105.Final-linux-x86_64.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -360,6 +360,7 @@ The Apache Software License, Version 2.0
     - netty-resolver-dns-4.1.105.Final.jar
     - netty-transport-4.1.105.Final.jar
     - netty-transport-classes-epoll-4.1.105.Final.jar
+    - netty-transport-native-epoll-4.1.105.Final-linux-aarch_64.jar
     - netty-transport-native-epoll-4.1.105.Final-linux-x86_64.jar
     - netty-transport-native-unix-common-4.1.105.Final.jar
     - netty-transport-native-unix-common-4.1.105.Final-linux-x86_64.jar

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -101,6 +101,12 @@
 
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <classifier>linux-aarch_64</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-unix-common</artifactId>
       <classifier>linux-x86_64</classifier>
     </dependency>


### PR DESCRIPTION
### Motivation

When running Pulsar in Docker on MacOS Apple Silicon M3, I get this error message:
```
Caused by: java.io.FileNotFoundException: META-INF/native/libnetty_transport_native_epoll_aarch_64.so
    at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:186) ~[io.netty-netty-common-4.1.100.Final.jar:4.1.100.Final]
    at io.netty.channel.epoll.Native.loadNativeLibrary(Native.java:323) ~[io.netty-netty-transport-classes-epoll-4.1.100.Final.jar:4.1.100.Final]
    at io.netty.channel.epoll.Native.<clinit>(Native.java:85) ~[io.netty-netty-transport-classes-epoll-4.1.100.Final.jar:4.1.100.Final]
    at io.netty.channel.epoll.Epoll.<clinit>(Epoll.java:40) ~[io.netty-netty-transport-classes-epoll-4.1.100.Final.jar:4.1.100.Final]
    at org.apache.pulsar.common.util.netty.EventLoopUtil.newEventLoopGroup(EventLoopUtil.java:59) ~[org.apache.pulsar-pulsar-common-3.0.3.jar:3.0.3]
    at org.apache.pulsar.broker.PulsarService.<init>(PulsarService.java:337) ~[org.apache.pulsar-pulsar-broker-3.0.3.jar:3.0.3]
    at org.apache.pulsar.PulsarBrokerStarter$BrokerStarter.<init>(PulsarBrokerStarter.java:204) ~[org.apache.pulsar-pulsar-broker-3.0.3.jar:3.0.3]
    at org.apache.pulsar.PulsarBrokerStarter.main(PulsarBrokerStarter.java:333) ~[org.apache.pulsar-pulsar-broker-3.0.3.jar:3.0.3]
    Suppressed: java.lang.UnsatisfiedLinkError: no netty_transport_native_epoll_aarch_64 in java.library.path: /usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
        at java.lang.ClassLoader.loadLibrary(ClassLoader.java:2434) ~[?:?]
        at java.lang.Runtime.loadLibrary0(Runtime.java:818) ~[?:?]
        at java.lang.System.loadLibrary(System.java:1993) ~[?:?]
        at io.netty.util.internal.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:38) ~[io.netty-netty-common-4.1.100.Final.jar:4.1.100.Final]
        at io.netty.util.internal.NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:396) ~[io.netty-netty-common-4.1.100.Final.jar:4.1.100.Final]
        at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:161) ~[io.netty-netty-common-4.1.100.Final.jar:4.1.100.Final]
        at io.netty.channel.epoll.Native.loadNativeLibrary(Native.java:323) ~[io.netty-netty-transport-classes-epoll-4.1.100.Final.jar:4.1.100.Final]
        at io.netty.channel.epoll.Native.<clinit>(Native.java:85) ~[io.netty-netty-transport-classes-epoll-4.1.100.Final.jar:4.1.100.Final]
        at io.netty.channel.epoll.Epoll.<clinit>(Epoll.java:40) ~[io.netty-netty-transport-classes-epoll-4.1.100.Final.jar:4.1.100.Final]
        at org.apache.pulsar.common.util.netty.EventLoopUtil.newEventLoopGroup(EventLoopUtil.java:59) ~[org.apache.pulsar-pulsar-common-3.0.3.jar:3.0.3]
        at org.apache.pulsar.broker.PulsarService.<init>(PulsarService.java:337) ~[org.apache.pulsar-pulsar-broker-3.0.3.jar:3.0.3]
        at org.apache.pulsar.PulsarBrokerStarter$BrokerStarter.<init>(PulsarBrokerStarter.java:204) ~[org.apache.pulsar-pulsar-broker-3.0.3.jar:3.0.3]
        at org.apache.pulsar.PulsarBrokerStarter.main(PulsarBrokerStarter.java:333) ~[org.apache.pulsar-pulsar-broker-3.0.3.jar:3.0.3]
        Suppressed: java.lang.UnsatisfiedLinkError: no netty_transport_native_epoll_aarch_64 in java.library.path: /usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
            at java.lang.ClassLoader.loadLibrary(ClassLoader.java:2434) ~[?:?]
            at java.lang.Runtime.loadLibrary0(Runtime.java:818) ~[?:?]
            at java.lang.System.loadLibrary(System.java:1993) ~[?:?]
            at io.netty.util.internal.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:38) ~[io.netty-netty-common-4.1.100.Final.jar:4.1.100.Final]
            at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
            at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
            at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
            at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
            at io.netty.util.internal.NativeLibraryLoader$1.run(NativeLibraryLoader.java:430) ~[io.netty-netty-common-4.1.100.Final.jar:4.1.100.Final]
            at java.security.AccessController.doPrivileged(AccessController.java:318) ~[?:?]
            at io.netty.util.internal.NativeLibraryLoader.loadLibraryByHelper(NativeLibraryLoader.java:422) ~[io.netty-netty-common-4.1.100.Final.jar:4.1.100.Final]
            at io.netty.util.internal.NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:388) ~[io.netty-netty-common-4.1.100.Final.jar:4.1.100.Final]
            at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:161) ~[io.netty-netty-common-4.1.100.Final.jar:4.1.100.Final]
            at io.netty.channel.epoll.Native.loadNativeLibrary(Native.java:323) ~[io.netty-netty-transport-classes-epoll-4.1.100.Final.jar:4.1.100.Final]
            at io.netty.channel.epoll.Native.<clinit>(Native.java:85) ~[io.netty-netty-transport-classes-epoll-4.1.100.Final.jar:4.1.100.Final]
            at io.netty.channel.epoll.Epoll.<clinit>(Epoll.java:40) ~[io.netty-netty-transport-classes-epoll-4.1.100.Final.jar:4.1.100.Final]
            at org.apache.pulsar.common.util.netty.EventLoopUtil.newEventLoopGroup(EventLoopUtil.java:59) ~[org.apache.pulsar-pulsar-common-3.0.3.jar:3.0.3]
            at org.apache.pulsar.broker.PulsarService.<init>(PulsarService.java:337) ~[org.apache.pulsar-pulsar-broker-3.0.3.jar:3.0.3]
            at org.apache.pulsar.PulsarBrokerStarter$BrokerStarter.<init>(PulsarBrokerStarter.java:204) ~[org.apache.pulsar-pulsar-broker-3.0.3.jar:3.0.3]
            at org.apache.pulsar.PulsarBrokerStarter.main(PulsarBrokerStarter.java:333) ~[org.apache.pulsar-pulsar-broker-3.0.3.jar:3.0.3]

```

### Modifications

- include native epoll library for Netty for arm64 (aarch64) platforms

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->