### PR TITLE
[improve][misc] Upgrade log4j2 to 2.23.1

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -40,7 +40,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <surefire.version>3.1.0</surefire.version>
-    <log4j2.version>2.18.0</log4j2.version>
+    <log4j2.version>2.23.1</log4j2.version>
     <slf4j.version>1.7.32</slf4j.version>
     <testng.version>7.7.1</testng.version>
     <commons-lang3.version>3.11</commons-lang3.version>

--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -19,7 +19,7 @@
 
 
 Configuration:
-  status: INFO
+  status: ERROR
   monitorInterval: 30
   name: pulsar
   packages: io.prometheus.client.log4j2

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -348,10 +348,10 @@ The Apache Software License, Version 2.0
     - jakarta.validation-jakarta.validation-api-2.0.2.jar
     - javax.validation-validation-api-1.1.0.Final.jar
  * Log4J
-    - org.apache.logging.log4j-log4j-api-2.18.0.jar
-    - org.apache.logging.log4j-log4j-core-2.18.0.jar
-    - org.apache.logging.log4j-log4j-slf4j-impl-2.18.0.jar
-    - org.apache.logging.log4j-log4j-web-2.18.0.jar
+    - org.apache.logging.log4j-log4j-api-2.23.1.jar
+    - org.apache.logging.log4j-log4j-core-2.23.1.jar
+    - org.apache.logging.log4j-log4j-slf4j-impl-2.23.1.jar
+    - org.apache.logging.log4j-log4j-web-2.23.1.jar
  * Java Native Access JNA
     - net.java.dev.jna-jna-jpms-5.12.1.jar
     - net.java.dev.jna-jna-platform-jpms-5.12.1.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -383,10 +383,10 @@ The Apache Software License, Version 2.0
     - simpleclient_tracer_otel-0.16.0.jar
     - simpleclient_tracer_otel_agent-0.16.0.jar
  * Log4J
-    - log4j-api-2.18.0.jar
-    - log4j-core-2.18.0.jar
-    - log4j-slf4j-impl-2.18.0.jar
-    - log4j-web-2.18.0.jar
+    - log4j-api-2.23.1.jar
+    - log4j-core-2.23.1.jar
+    - log4j-slf4j-impl-2.23.1.jar
+    - log4j-web-2.23.1.jar
  * OpenTelemetry
     - opentelemetry-api-1.34.1.jar
     - opentelemetry-context-1.34.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@ flexible messaging model and an intuitive client API.</description>
     <rocksdb.version>7.9.2</rocksdb.version>
     <slf4j.version>1.7.32</slf4j.version>
     <commons.collections4.version>4.4</commons.collections4.version>
-    <log4j2.version>2.18.0</log4j2.version>
+    <log4j2.version>2.23.1</log4j2.version>
     <bouncycastle.version>1.75</bouncycastle.version>
     <bouncycastle.bcpkix-fips.version>1.0.6</bouncycastle.bcpkix-fips.version>
     <bouncycastle.bc-fips.version>1.0.2.4</bouncycastle.bc-fips.version>


### PR DESCRIPTION
### Motivation

Keep up-to-date, and then upgrade the slf4j to 2.x.

Release notes: https://logging.apache.org/log4j/2.x/release-notes.html

### Modifications

- Upgrade log4j2 from 2.18.0 to 2.23.1
- `Configuration.status` from `INFO` to `ERROR` in the `log4j2.yaml`
   - Because `Configuration.packages` has been deprecated, the log4j2 prints the warn log, this breaks our test.
   - The `simpleclient_log4j2` is no longer updated and doesn't provide `Log4j2Plugins.dat`, we can only suppress this warn log.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
