### PR TITLE
[improve][client] Add a warn log for calling reconsumeLater for a no-shared subscription

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -461,9 +461,9 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         }
         if (conf.getSubscriptionType() != SubscriptionType.Shared
                 && conf.getSubscriptionType() != SubscriptionType.Key_Shared) {
-            log.warn("[{}] Message {} will be reconsumed after delay {} {}. This isn't recommended for "
-                            + "subscription {} with type {}.", this.topic, message, delayTime, unit.toString(),
-                    this.subscription, conf.getSubscriptionType());
+            log.warn("[{}] Message {} will be reconsumed without delayed delivery. reconsumeLater isn't supported for "
+                            + "subscription {} with type {}.", this.topic, message, this.subscription,
+                    conf.getSubscriptionType());
         }
         try {
             reconsumeLaterAsync(message, customProperties, delayTime, unit).get();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -459,6 +459,12 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         if (!conf.isRetryEnable()) {
             throw new PulsarClientException(RECONSUME_LATER_ERROR_MSG);
         }
+        if (conf.getSubscriptionType() != SubscriptionType.Shared
+                && conf.getSubscriptionType() != SubscriptionType.Key_Shared) {
+            log.warn("[{}] Reconsume the message {} later for a no-shared subscription {} {} "
+                            + "that will caused message out of order.",
+                    this.topic, message, this.subscription, conf.getSubscriptionType());
+        }
         try {
             reconsumeLaterAsync(message, customProperties, delayTime, unit).get();
         } catch (InterruptedException e) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -461,9 +461,9 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         }
         if (conf.getSubscriptionType() != SubscriptionType.Shared
                 && conf.getSubscriptionType() != SubscriptionType.Key_Shared) {
-            log.warn("[{}] Reconsume the message {} later for a no-shared subscription {} {} "
-                            + "that will caused message out of order.",
-                    this.topic, message, this.subscription, conf.getSubscriptionType());
+            log.warn("[{}] Message {} will be reconsumed after delay {} {}. This isn't recommended for "
+                            + "subscription {} with type {}.", this.topic, message, delayTime, unit.toString(),
+                    this.subscription, conf.getSubscriptionType());
         }
         try {
             reconsumeLaterAsync(message, customProperties, delayTime, unit).get();


### PR DESCRIPTION
### Motivation

Since delayed delivery is only supported for `shared` and `key_shared` subscription types, it is necessary to add a log to notify the users when they use `reconsumeLater` for the `exclusive` subscription and `failover` subscription.

### Modifications
Add a warning log to notify the users of the potential message out of order issue.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
