### PR TITLE
[improve][admin] Align the auth and check it at the first place for topic related API 

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -480,9 +480,9 @@ public abstract class AdminResource extends PulsarWebResource {
         // validates global-namespace contains local/peer cluster: if peer/local cluster present then lookup can
         // serve/redirect request else fail partitioned-metadata-request so, client fails while creating
         // producer/consumer
-        return validateClusterOwnershipAsync(topicName.getCluster())
+        return validateTopicOperationAsync(topicName, TopicOperation.LOOKUP)
+                .thenCompose(__ -> validateClusterOwnershipAsync(topicName.getCluster()))
                 .thenCompose(__ -> validateGlobalNamespaceOwnershipAsync(topicName.getNamespaceObject()))
-                .thenCompose(__ -> validateTopicOperationAsync(topicName, TopicOperation.LOOKUP))
                 .thenCompose(__ -> {
                     if (checkAllowAutoCreation) {
                         return pulsar().getBrokerService()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1946,8 +1946,7 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiParam(value = "Whether leader broker redirected this call to this broker. For internal use.")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         validateTopicName(tenant, namespace, encodedTopic);
-        validateTopicOperationAsync(topicName, TopicOperation.PEEK_MESSAGES)
-            .thenCompose(__ -> internalExamineMessageAsync(initialPosition, messagePosition, authoritative))
+        internalExamineMessageAsync(initialPosition, messagePosition, authoritative)
             .thenAccept(asyncResponse::resume)
             .exceptionally(ex -> {
                 if (isNot307And404Exception(ex)) {


### PR DESCRIPTION
### Motivation

The main thing is to align the auth operation and put the auth checking operation at the first position.

### Modifications

- `getPartitionedTopicMetadat`, `internalGetPropertiesAsync`, `internalUpdatePropertiesAsync `, `internalRemovePropertiesAsync`, `internalDeletePartitionedTopic`, `internalGetSubscriptions`, 
`internalGetStatsAsync`, `internalSkipMessages`, `internalSkipAllMessages`, `internalPeekNthMessageAsync`, `internalExamineMessageAsync`, `internalExpireMessagesByPosition`, `internalResetCursorAsync`, `internalResetCursorOnPosition`, `internalGetMessageById`,
`internalExpireMessagesByTimestamp`

And add related auth test.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


