### PR TITLE
[fix] [test] Fix flaky test ManagedLedgerTest.testGetNumberOfEntriesInStorage

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -2642,10 +2642,10 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
             managedLedger.addEntry(("entry-" + i).getBytes(Encoding));
         }
 
-        //trigger ledger rollover and wait for the new ledger created
-        Field stateUpdater = ManagedLedgerImpl.class.getDeclaredField("state");
-        stateUpdater.setAccessible(true);
-        stateUpdater.set(managedLedger, ManagedLedgerImpl.State.LedgerOpened);
+        // trigger ledger rollover and wait for the new ledger created
+        Awaitility.await().untilAsserted(() -> {
+           assertEquals("LedgerOpened", WhiteboxImpl.getInternalState(managedLedger, "state").toString());
+        });
         managedLedger.rollCurrentLedgerIfFull();
         Awaitility.await().untilAsserted(() -> {
             assertEquals(managedLedger.getLedgersInfo().size(), 3);


### PR DESCRIPTION
### Motivation
**Flaky test logs**
https://github.com/apache/pulsar/actions/runs/8416664128/job/23064867159?pr=22283

**Issue**
- After https://github.com/apache/pulsar/pull/22034, Managedledger will always create a new ledger after the previous closed
- The test `testGetNumberOfEntriesInStorage` force set `ML.state` to `LedgerOpened,` which breaks the mechanism to guarantee no concurrent ledger switching. This leads to an unexpected empty `ledgerInfo` in the ledger list. 
  - In expected, the ledgers should be `[{id: 1, entries: 5}, {id: 2, entries: 5}, {id: 3, entries:0}]` 
  - Current behavior: `[{id: 1, entries: 5}, {id: 2, entries: 5}, {id: 3, entries:0}, {id: 4, entries:0}]` 

**Reproduce**
You can reproduce the flaky test by running it about 10 times.

### Modifications

Remove the unnecessary ledger switching.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
