### PR TITLE
[improve][fn] Pass FunctionDetails to Go instance

### DIFF
--- a/pulsar-function-go/conf/conf.go
+++ b/pulsar-function-go/conf/conf.go
@@ -91,6 +91,8 @@ type Conf struct {
 	UserConfig                  string `json:"userConfig" yaml:"userConfig"`
 	//metrics config
 	MetricsPort int `json:"metricsPort" yaml:"metricsPort"`
+	// FunctionDetails
+	FunctionDetails string `json:"functionDetails" yaml:"functionDetails"`
 }
 
 var (

--- a/pulsar-function-go/pf/instanceConf.go
+++ b/pulsar-function-go/pf/instanceConf.go
@@ -20,6 +20,7 @@
 package pf
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -66,7 +67,7 @@ func newInstanceConfWithConf(cfg *conf.Conf) *instanceConf {
 	}
 	for topic, value := range cfg.SourceInputSpecs {
 		spec := &pb.ConsumerSpec{}
-		if err := protojson.Unmarshal([]byte(value), spec); err != nil {
+		if err := json.Unmarshal([]byte(value), spec); err != nil {
 			panic(fmt.Sprintf("Failed to unmarshal consume specs: %v", err))
 		}
 		inputSpecs[topic] = spec

--- a/pulsar-function-go/pf/instanceConf_test.go
+++ b/pulsar-function-go/pf/instanceConf_test.go
@@ -113,3 +113,182 @@ func TestInstanceConf_Fail(t *testing.T) {
 		newInstanceConfWithConf(&cfg.Conf{ProcessingGuarantees: 3})
 	}, "Should have a panic")
 }
+
+func TestInstanceConf_WithDetails(t *testing.T) {
+	cfg := &cfg.Conf{
+		FunctionDetails: `{"tenant":"public","namespace":"default","name":"test-function","className":"process","logTopic":"test-logs","userConfig":"{\"key1\":\"value1\"}","runtime":"GO","autoAck":true,"parallelism":1,"source":{"configs":"{\"username\":\"admin\"}","typeClassName":"string","timeoutMs":"15000","subscriptionName":"test-subscription","inputSpecs":{"input":{"schemaType":"avro","receiverQueueSize":{"value":1000},"schemaProperties":{"schema_prop1":"schema1"},"consumerProperties":{"consumer_prop1":"consumer1"},"cryptoSpec":{"cryptoKeyReaderClassName":"key-reader","producerCryptoFailureAction":"SEND","consumerCryptoFailureAction":"CONSUME"}}},"negativeAckRedeliveryDelayMs":"15000"},"sink":{"configs":"{\"password\":\"admin\"}","topic":"test-output","typeClassName":"string","schemaType":"avro","producerSpec":{"maxPendingMessages":2000,"useThreadLocalProducers":true,"cryptoSpec":{"cryptoKeyReaderClassName":"key-reader","producerCryptoFailureAction":"DISCARD"},"batchBuilder":"DEFAULT"}},"resources":{"cpu":2.0,"ram":"1024","disk":"1024"},"packageUrl":"/path/to/package","retryDetails":{"maxMessageRetries":3,"deadLetterTopic":"test-dead-letter-topic"},"secretsMap":"{\"secret1\":\"secret-value1\"}","runtimeFlags":"flags","componentType":"FUNCTION","customRuntimeOptions":"options","retainOrdering":true,"retainKeyOrdering":true,"subscriptionPosition":"EARLIEST"}`,
+	}
+	instanceConf := newInstanceConfWithConf(cfg)
+	assert.Equal(t, "public", instanceConf.funcDetails.Tenant)
+	assert.Equal(t, "default", instanceConf.funcDetails.Namespace)
+	assert.Equal(t, "test-function", instanceConf.funcDetails.Name)
+	assert.Equal(t, "process", instanceConf.funcDetails.ClassName)
+	assert.Equal(t, "test-logs", instanceConf.funcDetails.LogTopic)
+	assert.Equal(t, pb.ProcessingGuarantees_ATLEAST_ONCE, instanceConf.funcDetails.ProcessingGuarantees)
+	assert.Equal(t, `{"key1":"value1"}`, instanceConf.funcDetails.UserConfig)
+	assert.Equal(t, `{"secret1":"secret-value1"}`, instanceConf.funcDetails.SecretsMap)
+	assert.Equal(t, pb.FunctionDetails_GO, instanceConf.funcDetails.Runtime)
+
+	assert.Equal(t, true, instanceConf.funcDetails.AutoAck)
+	assert.Equal(t, int32(1), instanceConf.funcDetails.Parallelism)
+
+	sourceSpec := pb.SourceSpec{
+		TypeClassName:                "string",
+		TimeoutMs:                    15000,
+		Configs:                      `{"username":"admin"}`,
+		SubscriptionName:             "test-subscription",
+		SubscriptionType:             pb.SubscriptionType_SHARED,
+		NegativeAckRedeliveryDelayMs: 15000,
+		InputSpecs: map[string]*pb.ConsumerSpec{
+			"input": {
+				SchemaType: "avro",
+				SchemaProperties: map[string]string{
+					"schema_prop1": "schema1",
+				},
+				ConsumerProperties: map[string]string{
+					"consumer_prop1": "consumer1",
+				},
+				ReceiverQueueSize: &pb.ConsumerSpec_ReceiverQueueSize{
+					Value: 1000,
+				},
+				CryptoSpec: &pb.CryptoSpec{
+					CryptoKeyReaderClassName:    "key-reader",
+					ProducerCryptoFailureAction: pb.CryptoSpec_SEND,
+					ConsumerCryptoFailureAction: pb.CryptoSpec_CONSUME,
+				},
+			},
+		},
+	}
+	assert.Equal(t, sourceSpec.String(), instanceConf.funcDetails.Source.String())
+
+	sinkSpec := pb.SinkSpec{
+		TypeClassName: "string",
+		Topic:         "test-output",
+		Configs:       `{"password":"admin"}`,
+		SchemaType:    "avro",
+		ProducerSpec: &pb.ProducerSpec{
+			MaxPendingMessages:      2000,
+			UseThreadLocalProducers: true,
+			CryptoSpec: &pb.CryptoSpec{
+				CryptoKeyReaderClassName:    "key-reader",
+				ProducerCryptoFailureAction: pb.CryptoSpec_DISCARD,
+				ConsumerCryptoFailureAction: pb.CryptoSpec_FAIL,
+			},
+			BatchBuilder: "DEFAULT",
+		},
+	}
+	assert.Equal(t, sinkSpec.String(), instanceConf.funcDetails.Sink.String())
+
+	resource := pb.Resources{
+		Cpu:  2.0,
+		Ram:  1024,
+		Disk: 1024,
+	}
+	assert.Equal(t, resource.String(), instanceConf.funcDetails.Resources.String())
+	assert.Equal(t, "/path/to/package", instanceConf.funcDetails.PackageUrl)
+
+	retryDetails := pb.RetryDetails{
+		MaxMessageRetries: 3,
+		DeadLetterTopic:   "test-dead-letter-topic",
+	}
+	assert.Equal(t, retryDetails.String(), instanceConf.funcDetails.RetryDetails.String())
+
+	assert.Equal(t, "flags", instanceConf.funcDetails.RuntimeFlags)
+	assert.Equal(t, pb.FunctionDetails_FUNCTION, instanceConf.funcDetails.ComponentType)
+	assert.Equal(t, "options", instanceConf.funcDetails.CustomRuntimeOptions)
+	assert.Equal(t, "", instanceConf.funcDetails.Builtin)
+	assert.Equal(t, true, instanceConf.funcDetails.RetainOrdering)
+	assert.Equal(t, true, instanceConf.funcDetails.RetainKeyOrdering)
+	assert.Equal(t, pb.SubscriptionPosition_EARLIEST, instanceConf.funcDetails.SubscriptionPosition)
+}
+
+func TestInstanceConf_WithoutDetails(t *testing.T) {
+	cfg := &cfg.Conf{
+		FunctionDetails:      "",
+		Tenant:               "public",
+		NameSpace:            "default",
+		Name:                 "test-function",
+		LogTopic:             "test-logs",
+		ProcessingGuarantees: 0,
+		UserConfig:           `{"key1":"value1"}`,
+		SecretsMap:           `{"secret1":"secret-value1"}`,
+		Runtime:              3,
+		AutoACK:              true,
+		Parallelism:          1,
+		SubscriptionType:     1,
+		TimeoutMs:            15000,
+		SubscriptionName:     "test-subscription",
+		CleanupSubscription:  false,
+		SubscriptionPosition: 0,
+		SinkSpecTopic:        "test-output",
+		SinkSchemaType:       "avro",
+		Cpu:                  2.0,
+		Ram:                  1024,
+		Disk:                 1024,
+		MaxMessageRetries:    3,
+		DeadLetterTopic:      "test-dead-letter-topic",
+		SourceInputSpecs: map[string]string{
+			"input": `{"schemaType":"avro","receiverQueueSize":{"value":1000},"schemaProperties":{"schema_prop1":"schema1"},"consumerProperties":{"consumer_prop1":"consumer1"},"cryptoSpec":{"cryptoKeyReaderClassName":"key-reader","producerCryptoFailureAction":"SEND","consumerCryptoFailureAction":"CONSUME"}}`,
+		},
+	}
+	instanceConf := newInstanceConfWithConf(cfg)
+
+	assert.Equal(t, "public", instanceConf.funcDetails.Tenant)
+	assert.Equal(t, "default", instanceConf.funcDetails.Namespace)
+	assert.Equal(t, "test-function", instanceConf.funcDetails.Name)
+	assert.Equal(t, "test-logs", instanceConf.funcDetails.LogTopic)
+	assert.Equal(t, pb.ProcessingGuarantees_ATLEAST_ONCE, instanceConf.funcDetails.ProcessingGuarantees)
+	assert.Equal(t, `{"key1":"value1"}`, instanceConf.funcDetails.UserConfig)
+	assert.Equal(t, `{"secret1":"secret-value1"}`, instanceConf.funcDetails.SecretsMap)
+	assert.Equal(t, pb.FunctionDetails_GO, instanceConf.funcDetails.Runtime)
+
+	assert.Equal(t, true, instanceConf.funcDetails.AutoAck)
+	assert.Equal(t, int32(1), instanceConf.funcDetails.Parallelism)
+
+	sourceSpec := pb.SourceSpec{
+		SubscriptionType:     pb.SubscriptionType_FAILOVER,
+		TimeoutMs:            15000,
+		SubscriptionName:     "test-subscription",
+		CleanupSubscription:  false,
+		SubscriptionPosition: pb.SubscriptionPosition_LATEST,
+		InputSpecs: map[string]*pb.ConsumerSpec{
+			"input": {
+				SchemaType: "avro",
+				SchemaProperties: map[string]string{
+					"schema_prop1": "schema1",
+				},
+				ConsumerProperties: map[string]string{
+					"consumer_prop1": "consumer1",
+				},
+				ReceiverQueueSize: &pb.ConsumerSpec_ReceiverQueueSize{
+					Value: 1000,
+				},
+				CryptoSpec: &pb.CryptoSpec{
+					CryptoKeyReaderClassName:    "key-reader",
+					ProducerCryptoFailureAction: pb.CryptoSpec_SEND,
+					ConsumerCryptoFailureAction: pb.CryptoSpec_CONSUME,
+				},
+			},
+		},
+	}
+	assert.Equal(t, sourceSpec.String(), instanceConf.funcDetails.Source.String())
+
+	sinkSpec := pb.SinkSpec{
+		Topic:      "test-output",
+		SchemaType: "avro",
+	}
+	assert.Equal(t, sinkSpec.String(), instanceConf.funcDetails.Sink.String())
+
+	resource := pb.Resources{
+		Cpu:  2.0,
+		Ram:  1024,
+		Disk: 1024,
+	}
+	assert.Equal(t, resource.String(), instanceConf.funcDetails.Resources.String())
+
+	retryDetails := pb.RetryDetails{
+		MaxMessageRetries: 3,
+		DeadLetterTopic:   "test-dead-letter-topic",
+	}
+	assert.Equal(t, retryDetails.String(), instanceConf.funcDetails.RetryDetails.String())
+}

--- a/pulsar-function-go/pf/instanceConf_test.go
+++ b/pulsar-function-go/pf/instanceConf_test.go
@@ -259,8 +259,7 @@ func TestInstanceConf_WithEmptyOrInvalidDetails(t *testing.T) {
 				DeadLetterTopic:      "test-dead-letter-topic",
 				SourceInputSpecs: map[string]string{
 					"input": `{"schemaType":"avro","receiverQueueSize":{"value":1000},"schemaProperties":
-{"schema_prop1":"schema1"},"consumerProperties":{"consumer_prop1":"consumer1"},"cryptoSpec":{"cryptoKeyReaderClassName":
-"key-reader","producerCryptoFailureAction":"SEND","consumerCryptoFailureAction":"CONSUME"}}`,
+{"schema_prop1":"schema1"},"consumerProperties":{"consumer_prop1":"consumer1"}}`,
 				},
 			}
 			instanceConf := newInstanceConfWithConf(cfg)
@@ -294,11 +293,6 @@ func TestInstanceConf_WithEmptyOrInvalidDetails(t *testing.T) {
 						},
 						ReceiverQueueSize: &pb.ConsumerSpec_ReceiverQueueSize{
 							Value: 1000,
-						},
-						CryptoSpec: &pb.CryptoSpec{
-							CryptoKeyReaderClassName:    "key-reader",
-							ProducerCryptoFailureAction: pb.CryptoSpec_SEND,
-							ConsumerCryptoFailureAction: pb.CryptoSpec_CONSUME,
 						},
 					},
 				},

--- a/pulsar-function-go/pf/instanceConf_test.go
+++ b/pulsar-function-go/pf/instanceConf_test.go
@@ -117,7 +117,19 @@ func TestInstanceConf_Fail(t *testing.T) {
 
 func TestInstanceConf_WithDetails(t *testing.T) {
 	cfg := &cfg.Conf{
-		FunctionDetails: `{"tenant":"public","namespace":"default","name":"test-function","className":"process","logTopic":"test-logs","userConfig":"{\"key1\":\"value1\"}","runtime":"GO","autoAck":true,"parallelism":1,"source":{"configs":"{\"username\":\"admin\"}","typeClassName":"string","timeoutMs":"15000","subscriptionName":"test-subscription","inputSpecs":{"input":{"schemaType":"avro","receiverQueueSize":{"value":1000},"schemaProperties":{"schema_prop1":"schema1"},"consumerProperties":{"consumer_prop1":"consumer1"},"cryptoSpec":{"cryptoKeyReaderClassName":"key-reader","producerCryptoFailureAction":"SEND","consumerCryptoFailureAction":"CONSUME"}}},"negativeAckRedeliveryDelayMs":"15000"},"sink":{"configs":"{\"password\":\"admin\"}","topic":"test-output","typeClassName":"string","schemaType":"avro","producerSpec":{"maxPendingMessages":2000,"useThreadLocalProducers":true,"cryptoSpec":{"cryptoKeyReaderClassName":"key-reader","producerCryptoFailureAction":"DISCARD"},"batchBuilder":"DEFAULT"}},"resources":{"cpu":2.0,"ram":"1024","disk":"1024"},"packageUrl":"/path/to/package","retryDetails":{"maxMessageRetries":3,"deadLetterTopic":"test-dead-letter-topic"},"secretsMap":"{\"secret1\":\"secret-value1\"}","runtimeFlags":"flags","componentType":"FUNCTION","customRuntimeOptions":"options","retainOrdering":true,"retainKeyOrdering":true,"subscriptionPosition":"EARLIEST"}`,
+		FunctionDetails: `{"tenant":"public","namespace":"default","name":"test-function","className":"process",
+"logTopic":"test-logs","userConfig":"{\"key1\":\"value1\"}","runtime":"GO","autoAck":true,"parallelism":1,
+"source":{"configs":"{\"username\":\"admin\"}","typeClassName":"string","timeoutMs":"15000",
+"subscriptionName":"test-subscription","inputSpecs":{"input":{"schemaType":"avro","receiverQueueSize":{"value":1000},
+"schemaProperties":{"schema_prop1":"schema1"},"consumerProperties":{"consumer_prop1":"consumer1"},"cryptoSpec":
+{"cryptoKeyReaderClassName":"key-reader","producerCryptoFailureAction":"SEND","consumerCryptoFailureAction":"CONSUME"}}}
+,"negativeAckRedeliveryDelayMs":"15000"},"sink":{"configs":"{\"password\":\"admin\"}","topic":"test-output",
+"typeClassName":"string","schemaType":"avro","producerSpec":{"maxPendingMessages":2000,"useThreadLocalProducers":true,
+"cryptoSpec":{"cryptoKeyReaderClassName":"key-reader","producerCryptoFailureAction":"DISCARD"},
+"batchBuilder":"DEFAULT"}},"resources":{"cpu":2.0,"ram":"1024","disk":"1024"},"packageUrl":"/path/to/package",
+"retryDetails":{"maxMessageRetries":3,"deadLetterTopic":"test-dead-letter-topic"},"secretsMap":
+"{\"secret1\":\"secret-value1\"}","runtimeFlags":"flags","componentType":"FUNCTION","customRuntimeOptions":"options",
+"retainOrdering":true,"retainKeyOrdering":true,"subscriptionPosition":"EARLIEST"}`,
 	}
 	instanceConf := newInstanceConfWithConf(cfg)
 	assert.Equal(t, "public", instanceConf.funcDetails.Tenant)
@@ -246,7 +258,9 @@ func TestInstanceConf_WithEmptyOrInvalidDetails(t *testing.T) {
 				MaxMessageRetries:    3,
 				DeadLetterTopic:      "test-dead-letter-topic",
 				SourceInputSpecs: map[string]string{
-					"input": `{"schemaType":"avro","receiverQueueSize":{"value":1000},"schemaProperties":{"schema_prop1":"schema1"},"consumerProperties":{"consumer_prop1":"consumer1"},"cryptoSpec":{"cryptoKeyReaderClassName":"key-reader","producerCryptoFailureAction":"SEND","consumerCryptoFailureAction":"CONSUME"}}`,
+					"input": `{"schemaType":"avro","receiverQueueSize":{"value":1000},"schemaProperties":
+{"schema_prop1":"schema1"},"consumerProperties":{"consumer_prop1":"consumer1"},"cryptoSpec":{"cryptoKeyReaderClassName":
+"key-reader","producerCryptoFailureAction":"SEND","consumerCryptoFailureAction":"CONSUME"}}`,
 				},
 			}
 			instanceConf := newInstanceConfWithConf(cfg)

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/go/GoInstanceConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/go/GoInstanceConfig.java
@@ -83,4 +83,6 @@ public class GoInstanceConfig {
     private String deadLetterTopic = "";
 
     private int metricsPort;
+
+    private String functionDetails = "";
 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -142,8 +142,7 @@ public class RuntimeUtils {
         // pass the raw functino details directly so that we don't need to assemble the `instanceConf.funcDetails`
         // manually in Go instance
         String functionDetails =
-                "'" + JsonFormat.printer().omittingInsignificantWhitespace().print(instanceConfig.getFunctionDetails())
-                        + "'";
+                JsonFormat.printer().omittingInsignificantWhitespace().print(instanceConfig.getFunctionDetails());
         goInstanceConfig.setFunctionDetails(functionDetails);
 
         if (instanceConfig.getClusterName() != null) {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -139,8 +139,11 @@ public class RuntimeUtils {
         final List<String> args = new LinkedList<>();
         GoInstanceConfig goInstanceConfig = new GoInstanceConfig();
 
-        // pass the raw functino details directly so that we don't need to assemble the `instanceConf.funcDetails` manually in Go instance
-        String functionDetails = "'" + JsonFormat.printer().omittingInsignificantWhitespace().print(instanceConfig.getFunctionDetails()) + "'";
+        // pass the raw functino details directly so that we don't need to assemble the `instanceConf.funcDetails`
+        // manually in Go instance
+        String functionDetails =
+                "'" + JsonFormat.printer().omittingInsignificantWhitespace().print(instanceConfig.getFunctionDetails())
+                        + "'";
         goInstanceConfig.setFunctionDetails(functionDetails);
 
         if (instanceConfig.getClusterName() != null) {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -139,6 +139,10 @@ public class RuntimeUtils {
         final List<String> args = new LinkedList<>();
         GoInstanceConfig goInstanceConfig = new GoInstanceConfig();
 
+        // pass the raw functino details directly so that we don't need to assemble the `instanceConf.funcDetails` manually in Go instance
+        String functionDetails = "'" + JsonFormat.printer().omittingInsignificantWhitespace().print(instanceConfig.getFunctionDetails()) + "'";
+        goInstanceConfig.setFunctionDetails(functionDetails);
+
         if (instanceConfig.getClusterName() != null) {
             goInstanceConfig.setClusterName(instanceConfig.getClusterName());
         }

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
@@ -1006,6 +1006,14 @@ public class KubernetesRuntimeTest {
         assertEquals(goInstanceConfig.get("expectedHealthCheckInterval"), 0);
         assertEquals(goInstanceConfig.get("deadLetterTopic"), "");
         assertEquals(goInstanceConfig.get("metricsPort"), 4331);
+        assertEquals(goInstanceConfig.get("functionDetails"), "{\"tenant\":\"tenant\",\"namespace\":\"namespace\","
+                + "\"name\":\"container\",\"className\":\"org.apache.pulsar.functions.utils.functioncache"
+                + ".AddFunction\",\"logTopic\":\"container-log\",\"runtime\":\"GO\",\"source\":{\"className\":\"org"
+                + ".pulsar.pulsar.TestSource\",\"subscriptionType\":\"FAILOVER\",\"typeClassName\":\"java.lang"
+                + ".String\",\"inputSpecs\":{\"test_src\":{}}},\"sink\":{\"className\":\"org.pulsar.pulsar"
+                + ".TestSink\",\"topic\":\"container-output\",\"serDeClassName\":\"org.apache.pulsar.functions"
+                + ".runtime.serde.Utf8Serializer\",\"typeClassName\":\"java.lang.String\"},\"resources\":{\"cpu\":1"
+                + ".0,\"ram\":\"1000\",\"disk\":\"10000\"}}");
 
         // check padding and xmx
         V1Container containerSpec = container.getFunctionContainer(Collections.emptyList(), RESOURCES);


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #22349 

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

The Go instance doesn't get the full `FunctionDetails`, which makes it missing many features like Java and Python

### Modifications

Pass the `FunctionDetails` string directly to Go and unmarshal it to the `FunctionDetails` struct

### Verifying this change

- [x] Make sure that the change passes the CI checks.

- [x] This change is already covered by existing tests, such as *(please describe tests)*.
    - *org.apache.pulsar.tests.integration.functions.go.PulsarFunctionsGoProcessTest*
    - *org.apache.pulsar.tests.integration.functions.go.PulsarFunctionsGoThreadTest*
    - *org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeTest*

- [x] This change added tests and can be verified as follows:
  - *Added unit test for config with valid, invalid, and empty "FunctionDetails"*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/jiangpengcheng/pulsar/pull/31

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
