### PR TITLE
[improve][broker] Optimize web interface deleteDynamicConfiguration return error message

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -526,7 +526,7 @@ public class BrokersBase extends AdminResource {
 
     private CompletableFuture<Void> internalDeleteDynamicConfigurationOnMetadataAsync(String configName) {
         if (!pulsar().getBrokerService().isDynamicConfiguration(configName)) {
-            throw new RestException(Status.PRECONDITION_FAILED, " Can't update non-dynamic configuration");
+            throw new RestException(Status.PRECONDITION_FAILED, " Can't delete non-dynamic configuration");
         } else {
             return dynamicConfigurationResources().setDynamicConfigurationAsync(old -> {
                 if (old != null) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -526,7 +526,7 @@ public class BrokersBase extends AdminResource {
 
     private CompletableFuture<Void> internalDeleteDynamicConfigurationOnMetadataAsync(String configName) {
         if (!pulsar().getBrokerService().isDynamicConfiguration(configName)) {
-            throw new RestException(Status.PRECONDITION_FAILED, " Can't delete non-dynamic configuration");
+            throw new RestException(Status.PRECONDITION_FAILED, "Can't delete non-dynamic configuration");
         } else {
             return dynamicConfigurationResources().setDynamicConfigurationAsync(old -> {
                 if (old != null) {


### PR DESCRIPTION
### Motivation

When executing the method `internalDeleteDynamicConfigurationOnMetadataAsync`. If the `configName` is not a dynamic configuration, the returned exception information is inaccurate.

<img width="1469" alt="image" src="https://github.com/apache/pulsar/assets/16524922/5a24b370-6556-400c-9397-af8abfdb0183">


### Modifications
Modify error message from ` Can't update non-dynamic configuration` to `Can't delete non-dynamic configuration`.

<img width="1483" alt="image" src="https://github.com/apache/pulsar/assets/16524922/8005c14f-5de2-4bdf-8a98-1a0193753af3">



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->