### PR TITLE
[fix][misc] Make ConcurrentBitSet thread safe

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentBitSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentBitSet.java
@@ -114,42 +114,66 @@ public class ConcurrentBitSet extends BitSet {
 
     @Override
     public int nextSetBit(int fromIndex) {
-        long stamp = rwLock.writeLock();
-        try {
-            return super.nextSetBit(fromIndex);
-        } finally {
-            rwLock.unlockWrite(stamp);
+        long stamp = rwLock.tryOptimisticRead();
+        int nextSetBit = super.nextSetBit(fromIndex);
+        if (!rwLock.validate(stamp)) {
+            // Fallback to read lock
+            stamp = rwLock.readLock();
+            try {
+                nextSetBit = super.nextSetBit(fromIndex);
+            } finally {
+                rwLock.unlockRead(stamp);
+            }
         }
+        return nextSetBit;
     }
 
     @Override
     public int nextClearBit(int fromIndex) {
-        long stamp = rwLock.writeLock();
-        try {
-            return super.nextClearBit(fromIndex);
-        } finally {
-            rwLock.unlockWrite(stamp);
+        long stamp = rwLock.tryOptimisticRead();
+        int nextClearBit = super.nextClearBit(fromIndex);
+        if (!rwLock.validate(stamp)) {
+            // Fallback to read lock
+            stamp = rwLock.readLock();
+            try {
+                nextClearBit = super.nextClearBit(fromIndex);
+            } finally {
+                rwLock.unlockRead(stamp);
+            }
         }
+        return nextClearBit;
     }
 
     @Override
     public int previousSetBit(int fromIndex) {
-        long stamp = rwLock.writeLock();
-        try {
-            return super.previousSetBit(fromIndex);
-        } finally {
-            rwLock.unlockWrite(stamp);
+        long stamp = rwLock.tryOptimisticRead();
+        int previousSetBit = super.previousSetBit(fromIndex);
+        if (!rwLock.validate(stamp)) {
+            // Fallback to read lock
+            stamp = rwLock.readLock();
+            try {
+                previousSetBit = super.previousSetBit(fromIndex);
+            } finally {
+                rwLock.unlockRead(stamp);
+            }
         }
+        return previousSetBit;
     }
 
     @Override
     public int previousClearBit(int fromIndex) {
-        long stamp = rwLock.writeLock();
-        try {
-            return super.previousClearBit(fromIndex);
-        } finally {
-            rwLock.unlockWrite(stamp);
+        long stamp = rwLock.tryOptimisticRead();
+        int previousClearBit = super.previousClearBit(fromIndex);
+        if (!rwLock.validate(stamp)) {
+            // Fallback to read lock
+            stamp = rwLock.readLock();
+            try {
+                previousClearBit = super.previousClearBit(fromIndex);
+            } finally {
+                rwLock.unlockRead(stamp);
+            }
         }
+        return previousClearBit;
     }
 
     @Override

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentBitSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentBitSet.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.common.util.collections;
 
 import java.util.BitSet;
 import java.util.concurrent.locks.StampedLock;
+import java.util.stream.IntStream;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -65,90 +66,92 @@ public class ConcurrentBitSet extends BitSet {
 
     @Override
     public void set(int bitIndex) {
-        long stamp = rwLock.tryOptimisticRead();
-        super.set(bitIndex);
-        if (!rwLock.validate(stamp)) {
-            stamp = rwLock.readLock();
-            try {
-                super.set(bitIndex);
-            } finally {
-                rwLock.unlockRead(stamp);
-            }
+        long stamp = rwLock.writeLock();
+        try {
+            super.set(bitIndex);
+        } finally {
+            rwLock.unlockWrite(stamp);
+        }
+    }
+
+    @Override
+    public void clear(int bitIndex) {
+        long stamp = rwLock.writeLock();
+        try {
+            super.clear(bitIndex);
+        } finally {
+            rwLock.unlockWrite(stamp);
         }
     }
 
     @Override
     public void set(int fromIndex, int toIndex) {
-        long stamp = rwLock.tryOptimisticRead();
-        super.set(fromIndex, toIndex);
-        if (!rwLock.validate(stamp)) {
-            stamp = rwLock.readLock();
-            try {
-                super.set(fromIndex, toIndex);
-            } finally {
-                rwLock.unlockRead(stamp);
-            }
+        long stamp = rwLock.writeLock();
+        try {
+            super.set(fromIndex, toIndex);
+        } finally {
+            rwLock.unlockWrite(stamp);
+        }
+    }
+
+    @Override
+    public void clear(int fromIndex, int toIndex) {
+        long stamp = rwLock.writeLock();
+        try {
+            super.clear(fromIndex, toIndex);
+        } finally {
+            rwLock.unlockWrite(stamp);
+        }
+    }
+
+    @Override
+    public void clear() {
+        long stamp = rwLock.writeLock();
+        try {
+            super.clear();
+        } finally {
+            rwLock.unlockWrite(stamp);
         }
     }
 
     @Override
     public int nextSetBit(int fromIndex) {
-        long stamp = rwLock.tryOptimisticRead();
-        int bit = super.nextSetBit(fromIndex);
-        if (!rwLock.validate(stamp)) {
-            stamp = rwLock.readLock();
-            try {
-                bit = super.nextSetBit(fromIndex);
-            } finally {
-                rwLock.unlockRead(stamp);
-            }
+        long stamp = rwLock.writeLock();
+        try {
+            return super.nextSetBit(fromIndex);
+        } finally {
+            rwLock.unlockWrite(stamp);
         }
-        return bit;
     }
 
     @Override
     public int nextClearBit(int fromIndex) {
-        long stamp = rwLock.tryOptimisticRead();
-        int bit = super.nextClearBit(fromIndex);
-        if (!rwLock.validate(stamp)) {
-            stamp = rwLock.readLock();
-            try {
-                bit = super.nextClearBit(fromIndex);
-            } finally {
-                rwLock.unlockRead(stamp);
-            }
+        long stamp = rwLock.writeLock();
+        try {
+            return super.nextClearBit(fromIndex);
+        } finally {
+            rwLock.unlockWrite(stamp);
         }
-        return bit;
     }
 
     @Override
     public int previousSetBit(int fromIndex) {
-        long stamp = rwLock.tryOptimisticRead();
-        int bit = super.previousSetBit(fromIndex);
-        if (!rwLock.validate(stamp)) {
-            stamp = rwLock.readLock();
-            try {
-                bit = super.previousSetBit(fromIndex);
-            } finally {
-                rwLock.unlockRead(stamp);
-            }
+        long stamp = rwLock.writeLock();
+        try {
+            return super.previousSetBit(fromIndex);
+        } finally {
+            rwLock.unlockWrite(stamp);
         }
-        return bit;
     }
 
     @Override
     public int previousClearBit(int fromIndex) {
-        long stamp = rwLock.tryOptimisticRead();
-        int bit = super.previousClearBit(fromIndex);
-        if (!rwLock.validate(stamp)) {
-            stamp = rwLock.readLock();
-            try {
-                bit = super.previousClearBit(fromIndex);
-            } finally {
-                rwLock.unlockRead(stamp);
-            }
+        long stamp = rwLock.writeLock();
+        try {
+            return super.previousClearBit(fromIndex);
+        } finally {
+            rwLock.unlockWrite(stamp);
         }
-        return bit;
     }
 
     @Override
@@ -165,5 +168,237 @@ public class ConcurrentBitSet extends BitSet {
             }
         }
         return isEmpty;
+    }
+
+    @Override
+    public int cardinality() {
+        long stamp = rwLock.tryOptimisticRead();
+        int cardinality = super.cardinality();
+        if (!rwLock.validate(stamp)) {
+            // Fallback to read lock
+            stamp = rwLock.readLock();
+            try {
+                cardinality = super.cardinality();
+            } finally {
+                rwLock.unlockRead(stamp);
+            }
+        }
+        return cardinality;
+    }
+
+    @Override
+    public int size() {
+        long stamp = rwLock.tryOptimisticRead();
+        int size = super.size();
+        if (!rwLock.validate(stamp)) {
+            // Fallback to read lock
+            stamp = rwLock.readLock();
+            try {
+                size = super.size();
+            } finally {
+                rwLock.unlockRead(stamp);
+            }
+        }
+        return size;
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        long stamp = rwLock.tryOptimisticRead();
+        byte[] byteArray = super.toByteArray();
+        if (!rwLock.validate(stamp)) {
+            // Fallback to read lock
+            stamp = rwLock.readLock();
+            try {
+                byteArray = super.toByteArray();
+            } finally {
+                rwLock.unlockRead(stamp);
+            }
+        }
+        return byteArray;
+    }
+
+    @Override
+    public long[] toLongArray() {
+        long stamp = rwLock.tryOptimisticRead();
+        long[] longArray = super.toLongArray();
+        if (!rwLock.validate(stamp)) {
+            // Fallback to read lock
+            stamp = rwLock.readLock();
+            try {
+                longArray = super.toLongArray();
+            } finally {
+                rwLock.unlockRead(stamp);
+            }
+        }
+        return longArray;
+    }
+
+    @Override
+    public void flip(int bitIndex) {
+        long stamp = rwLock.writeLock();
+        try {
+            super.flip(bitIndex);
+        } finally {
+            rwLock.unlockWrite(stamp);
+        }
+    }
+
+    @Override
+    public void flip(int fromIndex, int toIndex) {
+        long stamp = rwLock.writeLock();
+        try {
+            super.flip(fromIndex, toIndex);
+        } finally {
+            rwLock.unlockWrite(stamp);
+        }
+    }
+
+    @Override
+    public void set(int bitIndex, boolean value) {
+        long stamp = rwLock.writeLock();
+        try {
+            super.set(bitIndex, value);
+        } finally {
+            rwLock.unlockWrite(stamp);
+        }
+    }
+
+    @Override
+    public void set(int fromIndex, int toIndex, boolean value) {
+        long stamp = rwLock.writeLock();
+        try {
+            super.set(fromIndex, toIndex, value);
+        } finally {
+            rwLock.unlockWrite(stamp);
+        }
+    }
+
+    @Override
+    public BitSet get(int fromIndex, int toIndex) {
+        long stamp = rwLock.tryOptimisticRead();
+        BitSet bitSet = super.get(fromIndex, toIndex);
+        if (!rwLock.validate(stamp)) {
+            // Fallback to read lock
+            stamp = rwLock.readLock();
+            try {
+                bitSet = super.get(fromIndex, toIndex);
+            } finally {
+                rwLock.unlockRead(stamp);
+            }
+        }
+        return bitSet;
+    }
+
+    @Override
+    public int length() {
+        long stamp = rwLock.tryOptimisticRead();
+        int length = super.length();
+        if (!rwLock.validate(stamp)) {
+            // Fallback to read lock
+            stamp = rwLock.readLock();
+            try {
+                length = super.length();
+            } finally {
+                rwLock.unlockRead(stamp);
+            }
+        }
+        return length;
+    }
+
+    @Override
+    public boolean intersects(BitSet set) {
+        long stamp = rwLock.writeLock();
+        try {
+            return super.intersects(set);
+        } finally {
+            rwLock.unlockWrite(stamp);
+        }
+    }
+
+    @Override
+    public void and(BitSet set) {
+        long stamp = rwLock.writeLock();
+        try {
+            super.and(set);
+        } finally {
+            rwLock.unlockWrite(stamp);
+        }
+    }
+
+    @Override
+    public void or(BitSet set) {
+        long stamp = rwLock.writeLock();
+        try {
+            super.or(set);
+        } finally {
+            rwLock.unlockWrite(stamp);
+        }
+    }
+
+    @Override
+    public void xor(BitSet set) {
+        long stamp = rwLock.writeLock();
+        try {
+            super.xor(set);
+        } finally {
+            rwLock.unlockWrite(stamp);
+        }
+    }
+
+    @Override
+    public void andNot(BitSet set) {
+        long stamp = rwLock.writeLock();
+        try {
+            super.andNot(set);
+        } finally {
+            rwLock.unlockWrite(stamp);
+        }
+    }
+
+    /**
+     * Returns the clone of the internal wrapped {@code BitSet}.
+     * This won't be a clone of the {@code ConcurrentBitSet} object.
+     *
+     * @return a clone of the internal wrapped {@code BitSet}
+     */
+    @Override
+    public Object clone() {
+        long stamp = rwLock.tryOptimisticRead();
+        BitSet clonedBitSet = (BitSet) super.clone();
+        if (!rwLock.validate(stamp)) {
+            // Fallback to read lock
+            stamp = rwLock.readLock();
+            try {
+                clonedBitSet = (BitSet) super.clone();
+            } finally {
+                rwLock.unlockRead(stamp);
+            }
+        }
+        return clonedBitSet;
+    }
+
+    @Override
+    public String toString() {
+        long stamp = rwLock.tryOptimisticRead();
+        String str = super.toString();
+        if (!rwLock.validate(stamp)) {
+            // Fallback to read lock
+            stamp = rwLock.readLock();
+            try {
+                str = super.toString();
+            } finally {
+                rwLock.unlockRead(stamp);
+            }
+        }
+        return str;
+    }
+
+    /**
+     * This operation is not supported on {@code ConcurrentBitSet}.
+     */
+    @Override
+    public IntStream stream() {
+        throw new UnsupportedOperationException("stream is not supported");
     }
 }


### PR DESCRIPTION
Fixes #22360

### Motivation

ConcurrentBitSet isn't thread safe although it claims this in the javadoc. This is causing concurrency issues in Pulsar. See #22360 for examples.

### Modifications

- Fix usage of StampedLock in ConcurrentBitSet
  - modifications must use the write lock
  - read operations must use the read lock

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->