### PR TITLE
[fix][broker] Fix typos in PersistentTopic class

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2753,7 +2753,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     ledger.asyncMigrate();
                 }
                 if (log.isDebugEnabled()) {
-                    log.debug("{} has replication backlog and applied migraiton", topic);
+                    log.debug("{} has replication backlog and applied migration", topic);
                 }
                 return CompletableFuture.completedFuture(null);
             }


### PR DESCRIPTION
### Motivation

Fix typos in PersistentTopic class


### Modifications

fix typos: `migraiton` => `migration`


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->