### PR TITLE
[fix][test] Fix flaky ManagedLedgerErrorsTest.recoverAfterZnodeVersionError

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerErrorsTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerErrorsTest.java
@@ -381,7 +381,6 @@ public class ManagedLedgerErrorsTest extends MockedBookKeeperTestCase {
             ledger.addEntry("entry".getBytes());
             fail("should fail");
         } catch (ManagedLedgerFencedException e) {
-            assertEquals(e.getCause().getClass(), ManagedLedgerException.BadVersionException.class);
             // ok
         }
 


### PR DESCRIPTION
Fixes #22348 

### Motivation

ManagedLedgerErrorsTest.recoverAfterZnodeVersionError is flaky. The problem can be reproduced consistently by adding a short delay (such as 1000ms) after the first add in the test case.

### Modifications

- remove extra condition since this is flaky due to a race condition
  - this depends on having a pending add so that the exception gets propagated to the addEntry operation when the asyncUpdateLedgerIds gets executed

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->