### PR TITLE
[improve][misc] Upgrade to Netty 4.1.108 and tcnative 2.0.65

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -292,34 +292,34 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-lang3-3.11.jar
     - org.apache.commons-commons-text-1.10.0.jar
  * Netty
-    - io.netty-netty-buffer-4.1.105.Final.jar
-    - io.netty-netty-codec-4.1.105.Final.jar
-    - io.netty-netty-codec-dns-4.1.105.Final.jar
-    - io.netty-netty-codec-http-4.1.105.Final.jar
-    - io.netty-netty-codec-http2-4.1.105.Final.jar
-    - io.netty-netty-codec-socks-4.1.105.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.105.Final.jar
-    - io.netty-netty-common-4.1.105.Final.jar
-    - io.netty-netty-handler-4.1.105.Final.jar
-    - io.netty-netty-handler-proxy-4.1.105.Final.jar
-    - io.netty-netty-resolver-4.1.105.Final.jar
-    - io.netty-netty-resolver-dns-4.1.105.Final.jar
-    - io.netty-netty-resolver-dns-classes-macos-4.1.105.Final.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.105.Final-osx-aarch_64.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.105.Final-osx-x86_64.jar
-    - io.netty-netty-transport-4.1.105.Final.jar
-    - io.netty-netty-transport-classes-epoll-4.1.105.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.105.Final-linux-aarch_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.105.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-unix-common-4.1.105.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.105.Final-linux-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.61.Final.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar
-    - io.netty-netty-tcnative-classes-2.0.61.Final.jar
+    - io.netty-netty-buffer-4.1.108.Final.jar
+    - io.netty-netty-codec-4.1.108.Final.jar
+    - io.netty-netty-codec-dns-4.1.108.Final.jar
+    - io.netty-netty-codec-http-4.1.108.Final.jar
+    - io.netty-netty-codec-http2-4.1.108.Final.jar
+    - io.netty-netty-codec-socks-4.1.108.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.108.Final.jar
+    - io.netty-netty-common-4.1.108.Final.jar
+    - io.netty-netty-handler-4.1.108.Final.jar
+    - io.netty-netty-handler-proxy-4.1.108.Final.jar
+    - io.netty-netty-resolver-4.1.108.Final.jar
+    - io.netty-netty-resolver-dns-4.1.108.Final.jar
+    - io.netty-netty-resolver-dns-classes-macos-4.1.108.Final.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.108.Final-osx-aarch_64.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.108.Final-osx-x86_64.jar
+    - io.netty-netty-transport-4.1.108.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.108.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.108.Final-linux-aarch_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.108.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-unix-common-4.1.108.Final.jar
+    - io.netty-netty-transport-native-unix-common-4.1.108.Final-linux-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.65.Final.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.65.Final-linux-aarch_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.65.Final-linux-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.65.Final-osx-aarch_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.65.Final-osx-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.65.Final-windows-x86_64.jar
+    - io.netty-netty-tcnative-classes-2.0.65.Final.jar
     - io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.24.Final.jar
     - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
     - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -346,36 +346,36 @@ The Apache Software License, Version 2.0
     - commons-text-1.10.0.jar
     - commons-compress-1.26.0.jar
  * Netty
-    - netty-buffer-4.1.105.Final.jar
-    - netty-codec-4.1.105.Final.jar
-    - netty-codec-dns-4.1.105.Final.jar
-    - netty-codec-http-4.1.105.Final.jar
-    - netty-codec-socks-4.1.105.Final.jar
-    - netty-codec-haproxy-4.1.105.Final.jar
-    - netty-common-4.1.105.Final.jar
-    - netty-handler-4.1.105.Final.jar
-    - netty-handler-proxy-4.1.105.Final.jar
-    - netty-resolver-4.1.105.Final.jar
-    - netty-resolver-dns-4.1.105.Final.jar
-    - netty-transport-4.1.105.Final.jar
-    - netty-transport-classes-epoll-4.1.105.Final.jar
-    - netty-transport-native-epoll-4.1.105.Final-linux-aarch_64.jar
-    - netty-transport-native-epoll-4.1.105.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.105.Final.jar
-    - netty-transport-native-unix-common-4.1.105.Final-linux-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.61.Final.jar
-    - netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar
-    - netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar
-    - netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar
-    - netty-tcnative-classes-2.0.61.Final.jar
+    - netty-buffer-4.1.108.Final.jar
+    - netty-codec-4.1.108.Final.jar
+    - netty-codec-dns-4.1.108.Final.jar
+    - netty-codec-http-4.1.108.Final.jar
+    - netty-codec-socks-4.1.108.Final.jar
+    - netty-codec-haproxy-4.1.108.Final.jar
+    - netty-common-4.1.108.Final.jar
+    - netty-handler-4.1.108.Final.jar
+    - netty-handler-proxy-4.1.108.Final.jar
+    - netty-resolver-4.1.108.Final.jar
+    - netty-resolver-dns-4.1.108.Final.jar
+    - netty-transport-4.1.108.Final.jar
+    - netty-transport-classes-epoll-4.1.108.Final.jar
+    - netty-transport-native-epoll-4.1.108.Final-linux-aarch_64.jar
+    - netty-transport-native-epoll-4.1.108.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.108.Final.jar
+    - netty-transport-native-unix-common-4.1.108.Final-linux-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.65.Final.jar
+    - netty-tcnative-boringssl-static-2.0.65.Final-linux-aarch_64.jar
+    - netty-tcnative-boringssl-static-2.0.65.Final-linux-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.65.Final-osx-aarch_64.jar
+    - netty-tcnative-boringssl-static-2.0.65.Final-osx-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.65.Final-windows-x86_64.jar
+    - netty-tcnative-classes-2.0.65.Final.jar
     - netty-incubator-transport-classes-io_uring-0.0.24.Final.jar
     - netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar
     - netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
-    - netty-resolver-dns-classes-macos-4.1.105.Final.jar
-    - netty-resolver-dns-native-macos-4.1.105.Final-osx-aarch_64.jar
-    - netty-resolver-dns-native-macos-4.1.105.Final-osx-x86_64.jar
+    - netty-resolver-dns-classes-macos-4.1.108.Final.jar
+    - netty-resolver-dns-native-macos-4.1.108.Final-osx-aarch_64.jar
+    - netty-resolver-dns-native-macos-4.1.108.Final-osx-x86_64.jar
  * Prometheus client
     - simpleclient-0.16.0.jar
     - simpleclient_log4j2-0.16.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.10.5</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.1.0</curator.version>
-    <netty.version>4.1.105.Final</netty.version>
+    <netty.version>4.1.108.Final</netty.version>
     <netty-iouring.version>0.0.24.Final</netty-iouring.version>
     <jetty.version>9.4.54.v20240208</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>


### PR DESCRIPTION
### Motivation

- keep Netty and tcnative updated so that we catch possible regressions early and so that we get bug fixes
- release notes:
  - https://netty.io/news/2024/03/21/4-1-108-Final.html
  - https://netty.io/news/2024/02/13/4-1-107-Final.html
  - https://netty.io/news/2024/01/19/4-1-106-Final.html
  - https://github.com/netty/netty-tcnative/compare/netty-tcnative-parent-2.0.61.Final...netty-tcnative-parent-2.0.65.Final
- contains a fix https://github.com/netty/netty/pull/13848 to issue https://github.com/netty/netty/issues/13831 reported by @nodece to address #22015

### Modifications

- upgrade Netty to 4.1.108.Final
  - This pulls in Netty tcnative version 2.0.65.Final

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->