### PR TITLE
[improve][io]: Add validation for JDBC sink not supporting primitive schema

### DIFF
--- a/pulsar-io/jdbc/core/pom.xml
+++ b/pulsar-io/jdbc/core/pom.xml
@@ -71,6 +71,13 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-client-original</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/BaseJdbcAutoSchemaSink.java
+++ b/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/BaseJdbcAutoSchemaSink.java
@@ -34,6 +34,7 @@ import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.KeyValueSchema;
 import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.jdbc.JdbcUtils.ColumnId;
 
@@ -137,6 +138,10 @@ public abstract class BaseJdbcAutoSchemaSink extends JdbcAbstractSink<GenericObj
             }
             recordValueGetter = (k) -> data.get(k);
         } else {
+            SchemaType schemaType = message.getSchema().getSchemaInfo().getType();
+            if (schemaType.isPrimitive()) {
+                throw new UnsupportedOperationException("Primitive schema is not supported: " + schemaType);
+            }
             recordValueGetter = (key) -> ((GenericRecord) record).getField(key);
         }
         String action = message.getProperties().get(ACTION_PROPERTY);

--- a/pulsar-io/jdbc/core/src/test/java/org/apache/pulsar/io/jdbc/BaseJdbcAutoSchemaSinkTest.java
+++ b/pulsar-io/jdbc/core/src/test/java/org/apache/pulsar/io/jdbc/BaseJdbcAutoSchemaSinkTest.java
@@ -22,6 +22,10 @@ import java.util.function.Function;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.util.Utf8;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.functions.api.Record;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -141,6 +145,27 @@ public class BaseJdbcAutoSchemaSinkTest {
         final SchemaBuilder.FieldAssembler<Schema> record = SchemaBuilder.record("record")
                 .fields();
         return consumer.apply(record).endRecord().getFields().get(0).schema();
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class,
+            expectedExceptionsMessageRegExp = "Primitive schema is not supported.*")
+    @SuppressWarnings("unchecked")
+    public void testNotSupportPrimitiveSchema() {
+        BaseJdbcAutoSchemaSink baseJdbcAutoSchemaSink = new BaseJdbcAutoSchemaSink() {};
+        AutoConsumeSchema autoConsumeSchema = new AutoConsumeSchema();
+        autoConsumeSchema.setSchema(org.apache.pulsar.client.api.Schema.STRING);
+        Record<? extends GenericObject> record = new Record<GenericRecord>() {
+            @Override
+            public org.apache.pulsar.client.api.Schema<GenericRecord> getSchema() {
+                return autoConsumeSchema;
+            }
+
+            @Override
+            public GenericRecord getValue() {
+                return null;
+            }
+        };
+        baseJdbcAutoSchemaSink.createMutation((Record<GenericObject>) record);
     }
 
 


### PR DESCRIPTION
### Motivation
Currently implemented for `JdbcAutoSchemaSink` connector,  It utilizes `GenericRecord.getField` to find fields with the same table column names. 

https://github.com/apache/pulsar/blob/849cbf3a46cc7e85fca6500c08ab6efb8697f12e/pulsar-io/jdbc/core/src/main/java/org/apache/pulsar/io/jdbc/BaseJdbcAutoSchemaSink.java#L140

However, the return value of the [primitive type](https://github.com/apache/pulsar/blob/82237d3684fe506bcb6426b3b23f413422e6e4fb/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/GenericObjectWrapper.java#L63-L65) schema is always null. This results in null data being inserted into the table, thereby causing errors.

### Modifications
- For the primitive type of schema, throw a clear exception to inform the user that it is not supported.

### Verifying this change
- Add `testNotSupportPrimitiveSchema ` to cover it.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
