### PR TITLE
[improve][client] Client add permits metric

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/metrics/ClientMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/metrics/ClientMetricsTest.java
@@ -333,4 +333,59 @@ public class ClientMetricsTest extends ProducerConsumerBase {
         assertCounterValue(metrics, "pulsar.client.consumer.closed", 1, nsAttrs);
         assertCounterValue(metrics, "pulsar.client.connection.closed", 1, Attributes.empty());
     }
+    @Test
+    public void testConsumerAvailablePermitsMetrics() throws Exception {
+        String topic = newTopicName();
+        final int recvQueueSize = 100;
+
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl(pulsar.getBrokerServiceUrl())
+                .openTelemetry(otel)
+                .build();
+
+        @Cleanup
+        Producer<String> producer = client.newProducer(Schema.STRING)
+                .topic(topic)
+                .create();
+
+        Consumer<String> consumer = client.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName("my-sub")
+                .ackTimeout(1, TimeUnit.SECONDS)
+                .subscriptionType(SubscriptionType.Shared)
+                .receiverQueueSize(recvQueueSize)
+                .subscribe();
+
+        for (int i = 0; i < recvQueueSize; i++) {
+            producer.send("Hello");
+        }
+
+        Thread.sleep(1000);
+
+        Attributes nsAttrs = Attributes.builder()
+                .put("pulsar.tenant", "my-property")
+                .put("pulsar.namespace", "my-property/my-ns")
+                .put("pulsar.subscription", "my-sub")
+                .build();
+        var metrics = collectMetrics();
+
+        assertCounterValue(metrics, "pulsar.client.consumer.available_permits.count", 0, nsAttrs);
+
+        Message<String> msg1 = consumer.receive();
+        metrics = collectMetrics();
+        consumer.acknowledge(msg1);
+        assertCounterValue(metrics, "pulsar.client.consumer.available_permits.count", 1, nsAttrs);
+
+        // clear the queue
+        while (true) {
+            Message<String> msg = consumer.receive(1, TimeUnit.SECONDS);
+            if (msg == null) {
+                break;
+            }
+        }
+        metrics = collectMetrics();
+        assertCounterValue(metrics, "pulsar.client.consumer.available_permits.count", 0, nsAttrs);
+
+        client.close();
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -420,8 +420,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 "The number of messages currently sitting in the consumer receive queue", topic, attrs);
         bytesPrefetchedGauge = ip.newUpDownCounter("pulsar.client.consumer.receive_queue.size", Unit.Bytes,
                 "The total size in bytes of messages currently sitting in the consumer receive queue", topic, attrs);
-        messageAvailablePermitsGauge = ip.newUpDownCounter("pulsar.client.consumer.available_permits.count", Unit.Messages,
-                "The number of consumer available permits", topic, attrs);
+        messageAvailablePermitsGauge = ip.newUpDownCounter("pulsar.client.consumer.available_permits.count",
+                Unit.Messages, "The number of consumer available permits", topic, attrs);
 
         consumerAcksCounter = ip.newCounter("pulsar.client.consumer.message.ack", Unit.Messages,
                 "The number of acknowledged messages", topic, attrs);


### PR DESCRIPTION

### Motivation

Added a new dimensional metric to help better monitor clients.

### Modifications

Add `pulsar.client.consumer.available_permits.count` metric.

### Verifying this change

- [x] Make sure that the change passes the CI checks.



### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/crossoverJie/pulsar/pull/23
