### PR TITLE
[improve][misc] Upgrade slf4j to 2.0.13

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -41,7 +41,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <surefire.version>3.1.0</surefire.version>
     <log4j2.version>2.23.1</log4j2.version>
-    <slf4j.version>1.7.32</slf4j.version>
+    <slf4j.version>2.0.13</slf4j.version>
     <testng.version>7.7.1</testng.version>
     <commons-lang3.version>3.11</commons-lang3.version>
     <license-maven-plugin.version>4.1</license-maven-plugin.version>
@@ -100,6 +100,12 @@
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <version>${testng.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -111,7 +117,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -180,7 +180,7 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
 
     <dependency>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -350,7 +350,7 @@ The Apache Software License, Version 2.0
  * Log4J
     - org.apache.logging.log4j-log4j-api-2.23.1.jar
     - org.apache.logging.log4j-log4j-core-2.23.1.jar
-    - org.apache.logging.log4j-log4j-slf4j-impl-2.23.1.jar
+    - org.apache.logging.log4j-log4j-slf4j2-impl-2.23.1.jar
     - org.apache.logging.log4j-log4j-web-2.23.1.jar
  * Java Native Access JNA
     - net.java.dev.jna-jna-jpms-5.12.1.jar
@@ -563,8 +563,8 @@ BSD 2-Clause License
 MIT License
  * Java SemVer -- com.github.zafarkhaja-java-semver-0.9.0.jar -- ../licenses/LICENSE-SemVer.txt
  * SLF4J -- ../licenses/LICENSE-SLF4J.txt
-    - org.slf4j-slf4j-api-1.7.32.jar
-    - org.slf4j-jcl-over-slf4j-1.7.32.jar
+    - org.slf4j-slf4j-api-2.0.13.jar
+    - org.slf4j-jcl-over-slf4j-2.0.13.jar
  * The Checker Framework
     - org.checkerframework-checker-qual-3.33.0.jar
  * oshi

--- a/distribution/shell/pom.xml
+++ b/distribution/shell/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
 
     <dependency>

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -385,7 +385,7 @@ The Apache Software License, Version 2.0
  * Log4J
     - log4j-api-2.23.1.jar
     - log4j-core-2.23.1.jar
-    - log4j-slf4j-impl-2.23.1.jar
+    - log4j-slf4j2-impl-2.23.1.jar
     - log4j-web-2.23.1.jar
  * OpenTelemetry
     - opentelemetry-api-1.34.1.jar
@@ -423,7 +423,7 @@ BSD 3-clause "New" or "Revised" License
 
 MIT License
  * SLF4J -- ../licenses/LICENSE-SLF4J.txt
-    - slf4j-api-1.7.32.jar
+    - slf4j-api-2.0.13.jar
  * The Checker Framework
     - checker-qual-3.33.0.jar
 

--- a/pom.xml
+++ b/pom.xml
@@ -2713,5 +2713,13 @@ flexible messaging model and an intuitive client API.</description>
         <enabled>false</enabled>
       </snapshots>
     </repository>
+    <!-- For the BDB JE dependency -->
+    <repository>
+      <id>oracle.releases</id>
+      <url>https://download.oracle.com/maven</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
   </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@ flexible messaging model and an intuitive client API.</description>
     <prometheus.version>0.16.0</prometheus.version>
     <vertx.version>4.3.8</vertx.version>
     <rocksdb.version>7.9.2</rocksdb.version>
-    <slf4j.version>1.7.32</slf4j.version>
+    <slf4j.version>2.0.13</slf4j.version>
     <commons.collections4.version>4.4</commons.collections4.version>
     <log4j2.version>2.23.1</log4j2.version>
     <bouncycastle.version>1.78</bouncycastle.version>
@@ -352,6 +352,10 @@ flexible messaging model and an intuitive client API.</description>
                 <groupId>org.yaml</groupId>
                 <artifactId>*</artifactId>
             </exclusion>
+            <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>*</artifactId>
+            </exclusion>
         </exclusions>
       </dependency>
 
@@ -459,6 +463,10 @@ flexible messaging model and an intuitive client API.</description>
           <exclusion>
             <groupId>org.bouncycastle</groupId>
             <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
           </exclusion>
           <exclusion>
             <artifactId>slf4j-log4j12</artifactId>
@@ -1581,6 +1589,10 @@ flexible messaging model and an intuitive client API.</description>
         <exclusion>
           <groupId>org.apache.zookeeper</groupId>
           <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <artifactId>log4j-slf4j-impl</artifactId>
+          <groupId>org.apache.logging.log4j</groupId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -66,7 +66,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pulsar-functions/instance/pom.xml
+++ b/pulsar-functions/instance/pom.xml
@@ -36,7 +36,7 @@
     <!-- logging -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/pulsar-functions/localrun/pom.xml
+++ b/pulsar-functions/localrun/pom.xml
@@ -43,7 +43,7 @@
         <!-- logging -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/pulsar-functions/runtime-all/pom.xml
+++ b/pulsar-functions/runtime-all/pom.xml
@@ -105,7 +105,7 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
 
     <dependency>

--- a/pulsar-io/alluxio/pom.xml
+++ b/pulsar-io/alluxio/pom.xml
@@ -57,6 +57,12 @@
             <groupId>org.alluxio</groupId>
             <artifactId>alluxio-core-client-fs</artifactId>
             <version>${alluxio.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -68,6 +74,10 @@
                 <exclusion>
                     <groupId>org.glassfish</groupId>
                     <artifactId>javax.el</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pulsar-io/hdfs2/pom.xml
+++ b/pulsar-io/hdfs2/pom.xml
@@ -61,7 +61,7 @@
           </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>*</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.apache.avro</groupId>

--- a/pulsar-io/hdfs3/pom.xml
+++ b/pulsar-io/hdfs3/pom.xml
@@ -65,7 +65,7 @@
           </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>*</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.apache.avro</groupId>

--- a/pulsar-io/rabbitmq/pom.xml
+++ b/pulsar-io/rabbitmq/pom.xml
@@ -85,13 +85,6 @@
       <artifactId>qpid-broker</artifactId>
       <version>9.2.0</version>
       <scope>test</scope>
-      <exclusions>
-        <!-- com.sleepycat:je:7.4.5 in the Oracle Maven Repository, not Maven Central -->
-        <exclusion>
-          <groupId>org.apache.qpid</groupId>
-          <artifactId>qpid-bdbstore</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>

--- a/pulsar-io/rabbitmq/pom.xml
+++ b/pulsar-io/rabbitmq/pom.xml
@@ -85,6 +85,13 @@
       <artifactId>qpid-broker</artifactId>
       <version>9.2.0</version>
       <scope>test</scope>
+      <exclusions>
+        <!-- com.sleepycat:je:7.4.5 in the Oracle Maven Repository, not Maven Central -->
+        <exclusion>
+          <groupId>org.apache.qpid</groupId>
+          <artifactId>qpid-bdbstore</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>

--- a/pulsar-io/rabbitmq/pom.xml
+++ b/pulsar-io/rabbitmq/pom.xml
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.apache.qpid</groupId>
       <artifactId>qpid-broker</artifactId>
-      <version>6.1.6</version>
+      <version>9.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pulsar-io/rabbitmq/pom.xml
+++ b/pulsar-io/rabbitmq/pom.xml
@@ -49,7 +49,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-slf4j-impl</artifactId>
+          <artifactId>log4j-slf4j2-impl</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/RabbitMQBrokerManager.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/RabbitMQBrokerManager.java
@@ -18,28 +18,29 @@
  */
 package org.apache.pulsar.io.rabbitmq;
 
-import org.apache.qpid.server.Broker;
-import org.apache.qpid.server.BrokerOptions;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.qpid.server.SystemLauncher;
+import org.apache.qpid.server.model.SystemConfig;
 
 public class RabbitMQBrokerManager {
 
-    private final Broker broker = new Broker();
+    private final SystemLauncher systemLauncher = new SystemLauncher();
 
     public void startBroker(String port) throws Exception {
-        BrokerOptions brokerOptions = getBrokerOptions(port);
-        broker.startup(brokerOptions);
+        Map<String, Object> brokerOptions = getBrokerOptions(port);
+        systemLauncher.startup(brokerOptions);
     }
 
     public void stopBroker() {
-        broker.shutdown();
+        systemLauncher.shutdown();
     }
 
-    BrokerOptions getBrokerOptions(String port) throws Exception {
+    Map<String, Object> getBrokerOptions(String port) throws Exception {
         Path tmpFolder = Files.createTempDirectory("qpidWork");
         Path homeFolder = Files.createTempDirectory("qpidHome");
         File etc = new File(homeFolder.toFile(), "etc");
@@ -48,15 +49,17 @@ public class RabbitMQBrokerManager {
         fos.write("guest:guest\n".getBytes());
         fos.close();
 
-        BrokerOptions brokerOptions = new BrokerOptions();
-
-        brokerOptions.setConfigProperty("qpid.work_dir", tmpFolder.toAbsolutePath().toString());
-        brokerOptions.setConfigProperty("qpid.amqp_port", port);
-        brokerOptions.setConfigProperty("qpid.home_dir", homeFolder.toAbsolutePath().toString());
+        Map<String, Object> config = new HashMap<>();
+        config.put("qpid.work_dir", tmpFolder.toAbsolutePath().toString());
+        config.put("qpid.amqp_port", port);
+        config.put("qpid.home_dir", homeFolder.toAbsolutePath().toString());
         String configPath = getFile("qpid.json").getAbsolutePath();
-        brokerOptions.setInitialConfigurationLocation(configPath);
 
-        return brokerOptions;
+        Map<String, Object> context = new HashMap<>();
+        context.put(SystemConfig.INITIAL_CONFIGURATION_LOCATION, configPath);
+        context.put(SystemConfig.TYPE, "Memory");
+        context.put(SystemConfig.CONTEXT, config);
+        return context;
     }
 
     private File getFile(String name) {

--- a/pulsar-io/solr/pom.xml
+++ b/pulsar-io/solr/pom.xml
@@ -70,6 +70,10 @@
                     <artifactId>jose4j</artifactId>
                     <groupId>org.bitbucket.b_c</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
             </exclusions>
             <scope>test</scope>
         </dependency>

--- a/structured-event-log/pom.xml
+++ b/structured-event-log/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tiered-storage/file-system/pom.xml
+++ b/tiered-storage/file-system/pom.xml
@@ -48,7 +48,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -116,6 +116,10 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>


### PR DESCRIPTION
### Motivation

Keep up-to-date, and this version supports [fluent logging api](https://www.slf4j.org/manual.html#fluent).

### Modifications

- Upgrade slf4j from 1.7.32 to 2.0.13
- Upgrade qpid-server to adapt the slf4j 2
- Use log4j-slf4j2-impl instead log4j-slf4j-impl
- Exclude the log4j-slf4j-impl and slf4j from some library

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->