### PR TITLE
[fix][client] Fix client side memory leak when call MessageImpl.create and fix imprecise client-side metrics: pendingMessagesUpDownCounter, pendingBytesUpDownCounter, latencyHistogram

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/DefaultSendMessageCallback.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/DefaultSendMessageCallback.java
@@ -1,4 +1,0 @@
-package org.apache.pulsar.client.impl;
-
-public class DefaultSendMessageCallback {
-}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/DefaultSendMessageCallback.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/DefaultSendMessageCallback.java
@@ -1,0 +1,4 @@
+package org.apache.pulsar.client.impl;
+
+public class DefaultSendMessageCallback {
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -378,79 +378,93 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         pendingMessagesUpDownCounter.increment();
         pendingBytesUpDownCounter.add(msgSize);
 
-        sendAsync(interceptorMessage, new SendCallback() {
-            SendCallback nextCallback = null;
-            MessageImpl<?> nextMsg = null;
-            long createdAt = System.nanoTime();
-
-            @Override
-            public CompletableFuture<MessageId> getFuture() {
-                return future;
-            }
-
-            @Override
-            public SendCallback getNextSendCallback() {
-                return nextCallback;
-            }
-
-            @Override
-            public MessageImpl<?> getNextMessage() {
-                return nextMsg;
-            }
-
-            @Override
-            public void sendComplete(Exception e) {
-                SendCallback loopingCallback = this;
-                MessageImpl<?> loopingMsg = interceptorMessage;
-                while (loopingCallback != null) {
-                    onSendComplete(e, loopingCallback, loopingMsg);
-                    loopingMsg = loopingCallback.getNextMessage();
-                    loopingCallback = loopingCallback.getNextSendCallback();
-                }
-            }
-
-            private void onSendComplete(Exception e, SendCallback sendCallback, MessageImpl<?> msg) {
-                long latencyNanos = System.nanoTime() - createdAt;
-                pendingMessagesUpDownCounter.decrement();
-                pendingBytesUpDownCounter.subtract(msgSize);
-                ByteBuf payload = msg.getDataBuffer();
-                if (e != null) {
-                    latencyHistogram.recordFailure(latencyNanos);
-                    stats.incrementSendFailed();
-                    try {
-                        onSendAcknowledgement(msg, null, e);
-                        sendCallback.getFuture().completeExceptionally(e);
-                    } finally {
-                        if (payload == null) {
-                            log.error("[{}] [{}] Payload is null when calling a failed onSendComplete, which is not"
-                                            + " expected.", topic, producerName);
-                        }
-                        ReferenceCountUtil.safeRelease(payload);
-                    }
-                } else {
-                    latencyHistogram.recordSuccess(latencyNanos);
-                    publishedBytesCounter.add(msgSize);
-                    stats.incrementNumAcksReceived(latencyNanos);
-                    try {
-                        onSendAcknowledgement(msg, msg.getMessageId(), null);
-                        sendCallback.getFuture().complete(msg.getMessageId());
-                    } finally {
-                        if (payload == null) {
-                            log.error("[{}] [{}] Payload is null when calling onSendComplete, which is not expected.",
-                                    topic, producerName);
-                        }
-                        ReferenceCountUtil.safeRelease(payload);
-                    }
-                }
-            }
-
-            @Override
-            public void addCallback(MessageImpl<?> msg, SendCallback scb) {
-                nextMsg = msg;
-                nextCallback = scb;
-            }
-        });
+        sendAsync(interceptorMessage, new DefaultSendMessageCallback(future, interceptorMessage, msgSize));
         return future;
+    }
+
+    private class DefaultSendMessageCallback implements SendCallback {
+
+        CompletableFuture<MessageId> sendFuture;
+        MessageImpl<?> currentMsg;
+        int msgSize;
+        long createdAt = System.nanoTime();
+        SendCallback nextCallback = null;
+        MessageImpl<?> nextMsg = null;
+
+        DefaultSendMessageCallback(CompletableFuture<MessageId> sendFuture, MessageImpl<?> currentMsg, int msgSize) {
+            this.sendFuture = sendFuture;
+            this.currentMsg = currentMsg;
+            this.msgSize = msgSize;
+        }
+
+        @Override
+        public CompletableFuture<MessageId> getFuture() {
+            return sendFuture;
+        }
+
+        @Override
+        public SendCallback getNextSendCallback() {
+            return nextCallback;
+        }
+
+        @Override
+        public MessageImpl<?> getNextMessage() {
+            return nextMsg;
+        }
+
+        @Override
+        public void sendComplete(Exception e) {
+            SendCallback loopingCallback = this;
+            MessageImpl<?> loopingMsg = currentMsg;
+            while (loopingCallback != null) {
+                onSendComplete(e, loopingCallback, loopingMsg);
+                loopingMsg = loopingCallback.getNextMessage();
+                loopingCallback = loopingCallback.getNextSendCallback();
+            }
+        }
+
+        private void onSendComplete(Exception e, SendCallback sendCallback, MessageImpl<?> msg) {
+            long createdAt = (sendCallback instanceof ProducerImpl.DefaultSendMessageCallback) ?
+                    ((DefaultSendMessageCallback) sendCallback).createdAt : this.createdAt;
+            long latencyNanos = System.nanoTime() - createdAt;
+            pendingMessagesUpDownCounter.decrement();
+            pendingBytesUpDownCounter.subtract(msgSize);
+            ByteBuf payload = msg.getDataBuffer();
+            if (e != null) {
+                latencyHistogram.recordFailure(latencyNanos);
+                stats.incrementSendFailed();
+                try {
+                    onSendAcknowledgement(msg, null, e);
+                    sendCallback.getFuture().completeExceptionally(e);
+                } finally {
+                    if (payload == null) {
+                        log.error("[{}] [{}] Payload is null when calling a failed onSendComplete, which is not"
+                                + " expected.", topic, producerName);
+                    }
+                    ReferenceCountUtil.safeRelease(payload);
+                }
+            } else {
+                latencyHistogram.recordSuccess(latencyNanos);
+                publishedBytesCounter.add(msgSize);
+                stats.incrementNumAcksReceived(latencyNanos);
+                try {
+                    onSendAcknowledgement(msg, msg.getMessageId(), null);
+                    sendCallback.getFuture().complete(msg.getMessageId());
+                } finally {
+                    if (payload == null) {
+                        log.error("[{}] [{}] Payload is null when calling onSendComplete, which is not expected.",
+                                topic, producerName);
+                    }
+                    ReferenceCountUtil.safeRelease(payload);
+                }
+            }
+        }
+
+        @Override
+        public void addCallback(MessageImpl<?> msg, SendCallback scb) {
+            nextMsg = msg;
+            nextCallback = scb;
+        }
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -424,8 +424,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         }
 
         private void onSendComplete(Exception e, SendCallback sendCallback, MessageImpl<?> msg) {
-            long createdAt = (sendCallback instanceof ProducerImpl.DefaultSendMessageCallback) ?
-                    ((DefaultSendMessageCallback) sendCallback).createdAt : this.createdAt;
+            long createdAt = (sendCallback instanceof ProducerImpl.DefaultSendMessageCallback)
+                    ? ((DefaultSendMessageCallback) sendCallback).createdAt : this.createdAt;
             long latencyNanos = System.nanoTime() - createdAt;
             pendingMessagesUpDownCounter.decrement();
             pendingBytesUpDownCounter.subtract(msgSize);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -425,10 +425,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 while (nextCallback != null) {
                     SendCallback sendCallback = nextCallback;
                     MessageImpl<?> msg = nextMsg;
-                    // Retain the buffer used by interceptors callback to get message. Buffer will release after
-                    // complete interceptors.
                     ByteBuf payloadInNextMsg = msg.getDataBuffer();
-                    payloadInNextMsg.retain();
                     try {
                         if (e != null) {
                             stats.incrementSendFailed();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -440,6 +440,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     if (payload == null) {
                         log.error("[{}] [{}] Payload is null when calling a failed onSendComplete, which is not"
                                 + " expected.", topic, producerName);
+                        return;
                     }
                     ReferenceCountUtil.safeRelease(payload);
                 }
@@ -454,6 +455,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     if (payload == null) {
                         log.error("[{}] [{}] Payload is null when calling onSendComplete, which is not expected.",
                                 topic, producerName);
+                        return;
                     }
                     ReferenceCountUtil.safeRelease(payload);
                 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -419,7 +419,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                         stats.incrementNumAcksReceived(latencyNanos);
                     }
                 } finally {
-                    payloadInCurrentMsg.release();
+                    ReferenceCountUtil.safeRelease(payloadInCurrentMsg);
                 }
 
                 while (nextCallback != null) {


### PR DESCRIPTION
### Motivation

**Issue 1:** logs is below<sup>[1]</sup>
- create a Message manually.
- call `ProducerBase.sendAsync(Message)`
- release the message that was created manually after the send is completed.
  - (Highlight)  the variable `Message.payload` is `null` after calling `Message.release`.
  - Pulsar client will get an NPE at this line https://github.com/apache/pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java#L421, and leads a client-side memory leak, eventually get an OOM error.

**Issue 2:**
- create a Message manually.
- call `ProducerBase.sendAsync(msg1)`
- call `ProducerBase.sendAsync(msg2)`
- release the message that was created manually after the send is completed.
  - (Highlight) `msg2.payload` was retained again when calling `interceptor.onSendAcknowledgement`, leading to this payload not being released. This retention is unnecessary. See https://github.com/apache/pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java#L430

**[1]**:
```
2024-04-02T14:37:27,801 - WARN  - [pulsar-client-io-35-4:ProducerImpl] - [persistent://my-property/my-ns/tp-7c4d35f4-0c0b-4415-b565-e88722b4879a] [test-0-0] Got exception while completing the callback for msg 1:
java.lang.NullPointerException: Cannot invoke "io.netty.buffer.ByteBuf.release()" because the return value of "org.apache.pulsar.client.impl.MessageImpl.getDataBuffer()" is null
	at org.apache.pulsar.client.impl.ProducerImpl$1.sendComplete(ProducerImpl.java:421) ~[classes/:?]
	at org.apache.pulsar.client.impl.ProducerImpl$OpSendMsg.sendComplete(ProducerImpl.java:1594) ~[classes/:?]
	at org.apache.pulsar.client.impl.ProducerImpl.ackReceived(ProducerImpl.java:1277) ~[classes/:?]
	at org.apache.pulsar.client.impl.ClientCnx.handleSendReceipt(ClientCnx.java:485) ~[classes/:?]
	at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:236) ~[classes/:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346) ~[netty-codec-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318) ~[netty-codec-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.handler.flush.FlushConsolidationHandler.channelRead(FlushConsolidationHandler.java:152) ~[netty-handler-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

### The scope that the issue affects
Regarding issue-2 that was described in Motivation, it will happen if batch sending is enabled(without calling the API `ProducerBase.sendAsync(Message)`).  But it will not cause an OOM because all the message payload created by the public API will be built this way: 
- `ByteBuffer jdkBuffer = ByteBuffer.wrap( byte[] )`
- `ByteBuf nettyByteBuf = Unpooled.wrappedBuffer(jdkBuffer)`

So there is no memory leak because the UnpooledByteBuf will not cause issues even if it is eventually not being released.

Note: If someone builds messages by `public static MessageImpl<T> create(ByteBuf payload)` and enables batch-send, they will encounter issue 2, but we did not provide an API to send a message typed `org.apache.pulsar.client.api.Message`, so no worry about this. (Highlight)It only affects the users who use `ProducerImpl` or `ProducerBase`

### Modifications

- Fix the memory leak
  - which is caused by issue 1.
  - which is caused by issue 1.
- Fix the inaccurate metrics:
  - `pendingMessagesUpDownCounter`
  - `pendingBytesUpDownCounter`
  - `latencyHistogram` 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x