### PR TITLE
[fix][build] Fix networkaddress.cache.negative.ttl config

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -79,7 +79,7 @@ RUN mkdir -p /etc/apt/keyrings \
      && apt-get -y install temurin-17-jdk \
      && export ARCH=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1') \
      && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$ARCH/conf/security/java.security \
-     && echo networkaddress.cache.negative.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$ARCH/conf/security/java.security \
+     && echo networkaddress.cache.negative.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$ARCH/conf/security/java.security
 
 # Cleanup apt
 RUN apt-get -y --purge autoremove \


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/21207 introduces the `networkaddress.cache.negative.ttl config` config, which also introduces a bug that appends the "\\" at the end:

```
2024-04-02T15:00:10,494+0000 [pulsar-perf-producer-exec-1-1] INFO  org.apache.pulsar.testclient.PerformanceProducer - Started performance test thread 0
2024-04-02T15:00:10,671+0000 [pulsar-perf-producer-exec-1-1] WARN  org.apache.pulsar.common.util.netty.DnsResolverUtil - Cannot get DNS TTL settings
java.lang.NumberFormatException: For input string: "1 RUN apt-get -y --purge autoremove"
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:67) ~[?:?]
        at java.lang.Integer.parseInt(Integer.java:668) ~[?:?]
        at java.lang.Integer.valueOf(Integer.java:973) ~[?:?]
        at java.lang.Integer.decode(Integer.java:1458) ~[?:?]
        at java.util.Optional.map(Optional.java:260) ~[?:?]
        at org.apache.pulsar.common.util.netty.DnsResolverUtil.<clinit>(DnsResolverUtil.java:71) ~[org.apache.pulsar-pulsar-common-3.2.2.jar:3.2.2]
        at org.apache.pulsar.client.impl.ConnectionPool.createAddressResolver(ConnectionPool.java:164) ~[org.apache.pulsar-pulsar-client-original-3.2.2.jar:3.2.2]
        at org.apache.pulsar.client.impl.ConnectionPool.lambda$new$1(ConnectionPool.java:127) ~[org.apache.pulsar-pulsar-client-original-3.2.2.jar:3.2.2]
        at java.util.Optional.orElseGet(Optional.java:364) ~[?:?]
        at org.apache.pulsar.client.impl.ConnectionPool.<init>(ConnectionPool.java:127) ~[org.apache.pulsar-pulsar-client-original-3.2.2.jar:3.2.2]
        at org.apache.pulsar.client.impl.ConnectionPool.<init>(ConnectionPool.java:96) ~[org.apache.pulsar-pulsar-client-original-3.2.2.jar:3.2.2]
        at org.apache.pulsar.client.impl.ConnectionPool.<init>(ConnectionPool.java:91) ~[org.apache.pulsar-pulsar-client-original-3.2.2.jar:3.2.2]
        at org.apache.pulsar.client.impl.PulsarClientImpl.<init>(PulsarClientImpl.java:199) ~[org.apache.pulsar-pulsar-client-original-3.2.2.jar:3.2.2]
        at org.apache.pulsar.client.impl.PulsarClientImpl.<init>(PulsarClientImpl.java:156) ~[org.apache.pulsar-pulsar-client-original-3.2.2.jar:3.2.2]
        at org.apache.pulsar.client.impl.ClientBuilderImpl.build(ClientBuilderImpl.java:65) ~[org.apache.pulsar-pulsar-client-original-3.2.2.jar:3.2.2]
        at org.apache.pulsar.testclient.PerformanceProducer.runProducer(PerformanceProducer.java:519) ~[org.apache.pulsar-pulsar-testclient-3.2.2.jar:3.2.2]
        at org.apache.pulsar.testclient.PerformanceProducer.lambda$main$1(PerformanceProducer.java:351) ~[org.apache.pulsar-pulsar-testclient-3.2.2.jar:3.2.2]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.105.Final.jar:4.1.105.Final]
        at java.lang.Thread.run(Thread.java:840) ~[?:?]
2024-04-02T15:00:10,763+0000 [pulsar-perf-producer-exec-1-1] INFO  org.apache.pulsar.testclient.PerformanceProducer - Adding 1 publishers on topic my-tenant/my-namespace/rg-test-1
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->