### PR TITLE
[fix][cli] Fix help option

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
@@ -99,7 +99,7 @@ public class PulsarBrokerStarter {
         @Option(names = {"-fwc", "--functions-worker-conf"}, description = "Configuration file for Functions Worker")
         private String fnWorkerConfigFile = "conf/functions_worker.yml";
 
-        @Option(names = {"-h", "--help"}, description = "Show this help message")
+        @Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this help message")
         private boolean help = false;
 
         @Option(names = {"-g", "--generate-docs"}, description = "Generate docs")

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
@@ -161,7 +161,7 @@ public class PulsarClusterMetadataSetup {
                 "--proxy-url"}, description = "Proxy-server URL to which to connect.", required = false)
         private String clusterProxyUrl;
 
-        @Option(names = {"-h", "--help"}, description = "Show this help message")
+        @Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this help message")
         private boolean help = false;
 
         @Option(names = {"-g", "--generate-docs"}, description = "Generate docs")

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarVersionStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarVersionStarter.java
@@ -31,7 +31,7 @@ public class PulsarVersionStarter {
 
     @Command(name = "version", showDefaultValues = true, scope = ScopeType.INHERIT)
     private static class Arguments {
-        @Option(names = {"-h", "--help"}, description = "Show this help message")
+        @Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this help message")
         private boolean help = false;
 
         @Option(names = {"-g", "--generate-docs"}, description = "Generate docs")

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
@@ -61,7 +61,7 @@ public class CompactorTool {
         @Option(names = {"-t", "--topic"}, description = "Topic to compact", required = true)
         private String topic;
 
-        @Option(names = {"-h", "--help"}, description = "Show this help message")
+        @Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this help message")
         private boolean help = false;
 
         @Option(names = {"-g", "--generate-docs"}, description = "Generate docs")

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionWorkerStarter.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionWorkerStarter.java
@@ -40,7 +40,7 @@ public class FunctionWorkerStarter {
             description = "Configuration File for Function Worker")
         private String configFile;
 
-        @Option(names = {"-h", "--help"}, description = "Show this help message")
+        @Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this help message")
         private boolean help = false;
 
         @Option(names = {"-g", "--generate-docs"}, description = "Generate docs")

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketServiceStarter.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketServiceStarter.java
@@ -47,7 +47,7 @@ public class WebSocketServiceStarter {
         @Parameters(description = "config file", arity = "0..1")
         private String configFile = "";
 
-        @Option(names = {"-h", "--help"}, description = "Show this help message")
+        @Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this help message")
         private boolean help = false;
 
         @Option(names = {"-g", "--generate-docs"}, description = "Generate docs")


### PR DESCRIPTION
### Motivation

Right now, the command with `-h` doesn't work:
```
❯ ./bin/pulsar initialize-cluster-metadata -h                                                    
picocli.CommandLine$MissingParameterException: Missing required options: '--cluster=<cluster>', '--web-service-url=<clusterWebServiceUrl>'
Exception in thread "main" picocli.CommandLine$MissingParameterException: Missing required options: '--cluster=<cluster>', '--web-service-url=<clusterWebServiceUrl>'
        at picocli.CommandLine$MissingParameterException.create(CommandLine.java:18661)
        at picocli.CommandLine$MissingParameterException.access$21200(CommandLine.java:18649)
        at picocli.CommandLine$Interpreter.validateConstraints(CommandLine.java:13651)
        at picocli.CommandLine$Interpreter.parse(CommandLine.java:13614)
        at picocli.CommandLine$Interpreter.parse(CommandLine.java:13559)
        at picocli.CommandLine$Interpreter.parse(CommandLine.java:13454)
        at picocli.CommandLine.parseArgs(CommandLine.java:1552)
        at org.apache.pulsar.PulsarClusterMetadataSetup.main(PulsarClusterMetadataSetup.java:205)
```

Fixed version:
```
❯ ./bin/pulsar initialize-cluster-metadata -h                                                    
Usage: initialize-cluster-metadata [-gh]
                                   [-bn=<numberOfDefaultNamespaceBundles>]
                                   -c=<cluster>
                                   [-cms=<configurationMetadataStore>]
                                   [--existing-bk-metadata-service-uri=<existing
                                   BkMetadataServiceUri>]
                                   [--initial-num-stream-storage-containers=<num
                                   StreamStorageContainers>]
                                   [--initial-num-transaction-coordinators=<numT
                                   ransactionCoordinators>]
                                   [-md=<metadataStoreUrl>]
                                   [-pp=<clusterProxyProtocol>]
                                   [-pu=<clusterProxyUrl>]
                                   [-tb=<clusterBrokerServiceUrlTls>]
                                   [-tw=<clusterWebServiceUrlTls>]
                                   [-ub=<clusterBrokerServiceUrl>]
                                   -uw=<clusterWebServiceUrl>
                                   [--zookeeper-session-timeout-ms=<zkSessionTim
                                   eoutMillis>]
      -bn, --default-namespace-bundle-number=<numberOfDefaultNamespaceBundles>
                            The bundle numbers for the default namespaces
                              (public/default), default is 16
                              Default: 0
  -c, --cluster=<cluster>   Cluster name
      -cms, --configuration-metadata-store=<configurationMetadataStore>
                            Configuration Metadata Store connection string
      --existing-bk-metadata-service-uri=<existingBkMetadataServiceUri>
                            The metadata service URI of the existing BookKeeper
                              cluster that you want to use
  -g, --generate-docs       Generate docs
  -h, --help                Show this help message
      --initial-num-stream-storage-containers=<numStreamStorageContainers>
                            Num storage containers of BookKeeper stream storage
                              Default: 16
      --initial-num-transaction-coordinators=<numTransactionCoordinators>
                            Num transaction coordinators will assigned in
                              cluster
                              Default: 16
      -md, --metadata-store=<metadataStoreUrl>
                            Metadata Store service url. eg: zk:my-zk:2181
      -pp, --proxy-protocol=<clusterProxyProtocol>
                            Proxy protocol to select type of routing at proxy.
                              Possible Values: [SNI]
      -pu, --proxy-url=<clusterProxyUrl>
                            Proxy-server URL to which to connect.
      -tb, --broker-service-url-tls=<clusterBrokerServiceUrlTls>
                            Broker-service URL for new cluster with TLS
                              encryption
      -tw, --web-service-url-tls=<clusterWebServiceUrlTls>
                            Web-service URL for new cluster with TLS encryption
      -ub, --broker-service-url=<clusterBrokerServiceUrl>
                            Broker-service URL for new cluster
      -uw, --web-service-url=<clusterWebServiceUrl>
                            Web-service URL for new cluster
      --zookeeper-session-timeout-ms=<zkSessionTimeoutMillis>
                            Local zookeeper session timeout ms
                              Default: 30000

```





### Modifications

- Add `usageHelp=true` to the `-h, --help` option to print the help info.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->