### PR TITLE
[fix][misc] Rename all shaded Netty native libraries

### DIFF
--- a/src/rename-netty-native-libs.cmd
+++ b/src/rename-netty-native-libs.cmd
@@ -42,11 +42,27 @@ call %UNZIP_CMD%
 cd /d %TMP_DIR%/%FILE_PREFIX%
 
 :: Loop through the number of groups
-SET Obj_Length=2
+SET Obj_Length=10
 SET Obj[0].FROM=libnetty_transport_native_epoll_x86_64.so
 SET Obj[0].TO=liborg_apache_pulsar_shade_netty_transport_native_epoll_x86_64.so
-SET Obj[1].FROM=libnetty_tcnative_linux_x86_64.so
-SET Obj[1].TO=liborg_apache_pulsar_shade_netty_tcnative_linux_x86_64.so
+SET Obj[1].FROM=libnetty_transport_native_epoll_aarch_64.so
+SET Obj[1].TO=liborg_apache_pulsar_shade_netty_transport_native_epoll_aarch_64.so
+SET Obj[2].FROM=libnetty_tcnative_linux_x86_64.so
+SET Obj[2].TO=liborg_apache_pulsar_shade_netty_tcnative_linux_x86_64.so
+SET Obj[3].FROM=libnetty_tcnative_linux_aarch_64.so
+SET Obj[3].TO=liborg_apache_pulsar_shade_netty_tcnative_linux_aarch_64.so
+SET Obj[4].FROM=libnetty_tcnative_osx_x86_64.jnilib
+SET Obj[4].TO=liborg_apache_pulsar_shade_netty_tcnative_osx_x86_64.jnilib
+SET Obj[5].FROM=libnetty_tcnative_osx_aarch_64.jnilib
+SET Obj[5].TO=liborg_apache_pulsar_shade_netty_tcnative_osx_aarch_64.jnilib
+SET Obj[6].FROM=libnetty_transport_native_io_uring_x86_64.so
+SET Obj[6].TO=liborg_apache_pulsar_shade_netty_transport_native_io_uring_x86_64.so
+SET Obj[7].FROM=libnetty_transport_native_io_uring_aarch_64.so
+SET Obj[7].TO=liborg_apache_pulsar_shade_netty_transport_native_io_uring_aarch_64.so
+SET Obj[8].FROM=libnetty_resolver_dns_native_macos_aarch_64.jnilib
+SET Obj[8].TO=liborg_apache_pulsar_shade_netty_resolver_dns_native_macos_aarch_64.jnilib
+SET Obj[9].FROM=libnetty_resolver_dns_native_macos_x86_64.jnilib
+SET Obj[9].TO=liborg_apache_pulsar_shade_netty_resolver_dns_native_macos_x86_64.jnilibSET Obj_Index=0
 SET Obj_Index=0
 
 :LoopStart

--- a/src/rename-netty-native-libs.sh
+++ b/src/rename-netty-native-libs.sh
@@ -27,7 +27,13 @@ FILE_PREFIX='META-INF/native'
 
 FILES_TO_RENAME=(
     'libnetty_transport_native_epoll_x86_64.so liborg_apache_pulsar_shade_netty_transport_native_epoll_x86_64.so'
+    'libnetty_transport_native_epoll_aarch_64.so liborg_apache_pulsar_shade_netty_transport_native_epoll_aarch_64.so'
     'libnetty_tcnative_linux_x86_64.so liborg_apache_pulsar_shade_netty_tcnative_linux_x86_64.so'
+    'libnetty_tcnative_linux_aarch_64.so liborg_apache_pulsar_shade_netty_tcnative_linux_aarch_64.so'
+    'libnetty_tcnative_osx_x86_64.jnilib liborg_apache_pulsar_shade_netty_tcnative_osx_x86_64.jnilib'
+    'libnetty_tcnative_osx_aarch_64.jnilib liborg_apache_pulsar_shade_netty_tcnative_osx_aarch_64.jnilib'
+    'libnetty_transport_native_io_uring_x86_64.so liborg_apache_pulsar_shade_netty_transport_native_io_uring_x86_64.so'
+    'libnetty_transport_native_io_uring_aarch_64.so liborg_apache_pulsar_shade_netty_transport_native_io_uring_aarch_64.so'
     'libnetty_resolver_dns_native_macos_aarch_64.jnilib liborg_apache_pulsar_shade_netty_resolver_dns_native_macos_aarch_64.jnilib'
     'libnetty_resolver_dns_native_macos_x86_64.jnilib liborg_apache_pulsar_shade_netty_resolver_dns_native_macos_x86_64.jnilib'
 )


### PR DESCRIPTION
### Motivation

- some Netty native libraries weren't renamed as part of the shading

### Modifications

- add missing libraries to renaming
- keep the Powershell script in sync with the bash script

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->