### PR TITLE
[improve][build] Upgrade Lombok to 1.18.32 for Java 22 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@ flexible messaging model and an intuitive client API.</description>
     <hppc.version>0.9.1</hppc.version>
     <spark-streaming_2.10.version>2.1.0</spark-streaming_2.10.version>
     <assertj-core.version>3.24.2</assertj-core.version>
-    <lombok.version>1.18.30</lombok.version>
+    <lombok.version>1.18.32</lombok.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <jaxb-api>2.3.1</jaxb-api>
     <javax.activation.version>1.2.0</javax.activation.version>


### PR DESCRIPTION
### Motivation

Java 22 has been released. Lombok 1.18.32 comes with Java 22 support.
Lombok changelog: https://projectlombok.org/changelog

### Modifications

Upgrade Lombok to 1.18.32

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->