### PR TITLE
[fix][sec] Upgrade Vertx to 4.5.7 to address CVE-2024-1300

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -489,11 +489,11 @@ The Apache Software License, Version 2.0
   * JCTools - Java Concurrency Tools for the JVM
     - org.jctools-jctools-core-2.1.2.jar
   * Vertx
-    - io.vertx-vertx-auth-common-4.3.8.jar
-    - io.vertx-vertx-bridge-common-4.3.8.jar
-    - io.vertx-vertx-core-4.3.8.jar
-    - io.vertx-vertx-web-4.3.8.jar
-    - io.vertx-vertx-web-common-4.3.8.jar
+    - io.vertx-vertx-auth-common-4.5.7.jar
+    - io.vertx-vertx-bridge-common-4.5.7.jar
+    - io.vertx-vertx-core-4.5.7.jar
+    - io.vertx-vertx-web-4.5.7.jar
+    - io.vertx-vertx-web-common-4.5.7.jar
     - io.vertx-vertx-grpc-4.3.5.jar
   * Apache ZooKeeper
     - org.apache.zookeeper-zookeeper-3.9.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@ flexible messaging model and an intuitive client API.</description>
     <jersey.version>2.41</jersey.version>
     <athenz.version>1.10.50</athenz.version>
     <prometheus.version>0.16.0</prometheus.version>
-    <vertx.version>4.3.8</vertx.version>
+    <vertx.version>4.5.7</vertx.version>
     <rocksdb.version>7.9.2</rocksdb.version>
     <slf4j.version>1.7.32</slf4j.version>
     <commons.collections4.version>4.4</commons.collections4.version>


### PR DESCRIPTION
### Motivation

- address CVE-2024-1300

### Modifications

- upgrade Vertx to 4.5.7 (this requires Netty 4.1.108.Final, failures will be at runtime with BK Vertx usage for HTTP admin API unless Netty 4.1.108.Final is used)

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->