### PR TITLE
[fix][ci] Fix labels for flaky test GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky-test.yml
+++ b/.github/ISSUE_TEMPLATE/flaky-test.yml
@@ -18,7 +18,7 @@
 name: Flaky test
 title: "Flaky-test: test_class.test_method"
 description: Report a flaky test failure
-labels: [ "component/test", "flaky-tests" ]
+labels: [ "area/test", "type/flaky-tests" ]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
### Motivation

The labels in the flaky test issue template are invalid.

### Modifications

Use the correct labels in the template.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->