### PR TITLE
[Fix][Docker] Add execute permission to /pulsar/bin subdirectory to enable running as non-root user

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -40,7 +40,7 @@ COPY scripts/install-pulsar-client.sh /pulsar/bin
 # container when gid=0 is prohibited. In that case, the container must be run with uid 10000 with
 # any group id != 0 (for example 10001).
 # The file permissions are preserved when copying files from this builder image to the target image.
-RUN for SUBDIRECTORY in conf data download logs; do \
+RUN for SUBDIRECTORY in bin conf data download logs; do \
      [ -d /pulsar/$SUBDIRECTORY ] || mkdir /pulsar/$SUBDIRECTORY; \
      chmod -R ug+w /pulsar/$SUBDIRECTORY; \
      chown -R 10000:0 /pulsar/$SUBDIRECTORY; \


### PR DESCRIPTION
Fixes #22440

### Motivation
The pulsar-shell is not getting started on default `pulsar` user (a non-root user). However, it is woking with `root` user.

After exec into the docker container if you try to run the pulsar-shell, you get a permissions error:
```
$ ./bin/pulsar-shell
Exception in thread "main" java.nio.file.AccessDeniedException: /home/pulsar
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:90)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:397)
	at java.base/java.nio.file.Files.createDirectory(Files.java:700)
	at java.base/java.nio.file.Files.createAndCheckIsDirectory(Files.java:807)
	at java.base/java.nio.file.Files.createDirectories(Files.java:793)
	at org.apache.pulsar.shell.PulsarShell.<init>(PulsarShell.java:160)
	at org.apache.pulsar.shell.PulsarShell.<init>(PulsarShell.java:142)
	at org.apache.pulsar.shell.PulsarShell.main(PulsarShell.java:215)
```

This is because the Docker image is running as a non-root user `pulsar` but does not have permissions to execute to the  `./bin/pulsar-shell`

I think this issue is an important concern because it frustrates prospective/new Pulsar users (like me!) with their first impression of trying the pulsar-shell

### Modifications
- Previously the Docker image was adding write permissions (for the root group) to few directories but not to `/pulsar/bin`.
- This PR updates that RUN instruction that creates and sets execute permission on the bin directory:
  - `/pulsar/bin`

### Verifying this change

This change is a rework/code-cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: yes
    - This PR updates the Docker image by creating empty, writeable subdirectories (`data`, `download`, `logs`) inside of `/pulsar` that did not previously exist to enable mounting of volumes that will be writeable by a non-root user at run-time. Potentially this may affect users who were relying on these directories not existing, however I'd contend that the image is broken for new users who are trying out Pulsar for the first time.

### Documentation

Check the box below or label this PR directly.

Need to update docs? 
- [ ] `doc` 
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`