### PR TITLE
[improve][misc] Specify valid home dir for the default user in the Ubuntu based docker image

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -110,5 +110,5 @@ RUN chmod +x /pulsar/bin/install-pulsar-client.sh
 RUN /pulsar/bin/install-pulsar-client.sh
 
 # The UID must be non-zero. Otherwise, it is arbitrary. No logic should rely on its specific value.
-RUN useradd ${DEFAULT_USERNAME} -u 10000 -g 0
+RUN useradd ${DEFAULT_USERNAME} -u 10000 -g 0 --no-create-home --home-dir /pulsar/data
 USER 10000


### PR DESCRIPTION
### Motivation

A default user was added to the docker image #21695. The problem is that the home directory for the user is invalid.
This causes issues such as #22440 .

The home directory for the `pulsar` user is `/home/pulsar`, which is invalid.

```
❯ docker run --rm -it apachepulsar/pulsar:3.0.4 bash -c "cat /etc/passwd|grep pulsar"
pulsar:x:10000:0::/home/pulsar:/bin/sh
```

### Modifications

Make the home directory `/pulsar/data` for the `pulsar` user.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->