### PR TITLE
[improve][misc] Specify /pulsar/data as the home dir for the user in the Alpine based image

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -118,5 +118,5 @@ ENV PATH=$PATH:$JAVA_HOME/bin:/pulsar/bin
 
 # The UID must be non-zero. Otherwise, it is arbitrary. No logic should rely on its specific value.
 ARG DEFAULT_USERNAME=pulsar
-RUN adduser ${DEFAULT_USERNAME} -u 10000 -G root -D
+RUN adduser ${DEFAULT_USERNAME} -u 10000 -G root -D -H -h /pulsar/data
 USER 10000


### PR DESCRIPTION
### Motivation

In #22446, the home directory for the default user `pulsar` is set to `/pulsar/data` in the Ubuntu based image. For consistency, it makes sense to use the same directory in the Alpine based image.

In the Alpine image `adduser` seems to create the `/home/pulsar` directory so the directory is valid and the problem is different than with the Ubuntu image used in the maintenance branches.

### Modifications

Specify /pulsar/data as the home dir for the created default user.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->