### PR TITLE
[improve][ci] revisit tune-runner-vm action,  drop tuning for docker

### DIFF
--- a/.github/actions/tune-runner-vm/action.yml
+++ b/.github/actions/tune-runner-vm/action.yml
@@ -77,12 +77,6 @@ runs:
             # stop Azure Linux agent to save RAM
             sudo systemctl stop walinuxagent.service || true
           
-            # enable docker experimental mode which is
-            # required for using "docker build --squash" / "-Ddocker.squash=true"
-            daemon_json="$(sudo cat /etc/docker/daemon.json  | jq '.experimental = true')"
-            echo "$daemon_json" | sudo tee /etc/docker/daemon.json
-            # restart docker daemon
-            sudo systemctl restart docker
             echo '::endgroup::'
 
             # show memory

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -512,8 +512,8 @@ jobs:
       - name: Build java-test-image docker image
         run: |
           # build docker image
-          mvn -B -am -pl docker/pulsar,tests/docker-images/java-test-image install -Pcore-modules,-main,integrationTests,docker \
-          -Dmaven.test.skip=true -Ddocker.squash=true -DskipSourceReleaseAssembly=true \
+          DOCKER_CLI_EXPERIMENTAL=enabled mvn -B -am -pl docker/pulsar,tests/docker-images/java-test-image install -Pcore-modules,-main,integrationTests,docker \
+          -Dmaven.test.skip=true -DskipSourceReleaseAssembly=true \
           -Dspotbugs.skip=true  -Dlicense.skip=true -Dcheckstyle.skip=true -Drat.skip=true
 
       - name: save docker image apachepulsar/java-test-image:latest to Github artifact cache
@@ -868,8 +868,8 @@ jobs:
         run: |
           # build docker image
           # include building of Connectors, Offloaders and server distros
-          mvn -B -am -pl distribution/io,distribution/offloaders,distribution/server,distribution/shell,tests/docker-images/latest-version-image install \
-          -Pmain,docker -Dmaven.test.skip=true -Ddocker.squash=true \
+          DOCKER_CLI_EXPERIMENTAL=enabled mvn -B -am -pl distribution/io,distribution/offloaders,distribution/server,distribution/shell,tests/docker-images/latest-version-image install \
+          -Pmain,docker -Dmaven.test.skip=true \
           -Dspotbugs.skip=true -Dlicense.skip=true -Dcheckstyle.skip=true -Drat.skip=true
 
       # check full build artifacts licenses

--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ Check https://pulsar.apache.org for documentation and examples.
 
 ## Build custom docker images
 
+The commands used in the Apache Pulsar release process can be found in the [release process documentation](https://pulsar.apache.org/contribute/release-process/#stage-docker-images).
+
+Here are some general instructions for building custom docker images:
+
 * Docker images must be built with Java 8 for `branch-2.7` or previous branches because of [ISSUE-8445](https://github.com/apache/pulsar/issues/8445).
 * Java 11 is the recommended JDK version in `branch-2.8`, `branch-2.9` and `branch-2.10`.
 * Java 17 is the recommended JDK version in `master`.
@@ -200,6 +204,8 @@ The following command builds the docker images `apachepulsar/pulsar-all:latest` 
 
 ```bash
 mvn clean install -DskipTests
+# setting DOCKER_CLI_EXPERIMENTAL=enabled is required in some environments with older docker versions
+export DOCKER_CLI_EXPERIMENTAL=enabled
 mvn package -Pdocker,-main -am -pl docker/pulsar-all -DskipTests
 ```
 

--- a/build/build_java_test_image.sh
+++ b/build/build_java_test_image.sh
@@ -20,12 +20,6 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$SCRIPT_DIR/.."
-SQUASH_PARAM=""
-# check if docker experimental mode is enabled which is required for
-# using "docker build --squash" for squashing all intermediate layers of the build to a single layer
-if [[ "$(docker version -f '{{.Server.Experimental}}' 2>/dev/null)" == "true" ]]; then
-  SQUASH_PARAM="-Ddocker.squash=true"
-fi
 mvn -am -pl tests/docker-images/java-test-image -Pcore-modules,-main,integrationTests,docker \
-  -Dmaven.test.skip=true -DskipSourceReleaseAssembly=true -Dspotbugs.skip=true -Dlicense.skip=true $SQUASH_PARAM \
+  -Dmaven.test.skip=true -DskipSourceReleaseAssembly=true -Dspotbugs.skip=true -Dlicense.skip=true \
   "$@" install

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@ flexible messaging model and an intuitive client API.</description>
     <reflections.version>0.10.2</reflections.version>
     <swagger.version>1.6.2</swagger.version>
     <puppycrawl.checkstyle.version>10.14.2</puppycrawl.checkstyle.version>
-    <docker-maven.version>0.44.0</docker-maven.version>
+    <docker-maven.version>0.43.3</docker-maven.version>
     <docker.verbose>true</docker.verbose>
     <typetools.version>0.5.0</typetools.version>
     <byte-buddy.version>1.14.12</byte-buddy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@ flexible messaging model and an intuitive client API.</description>
     <reflections.version>0.10.2</reflections.version>
     <swagger.version>1.6.2</swagger.version>
     <puppycrawl.checkstyle.version>10.14.2</puppycrawl.checkstyle.version>
-    <docker-maven.version>0.43.3</docker-maven.version>
+    <docker-maven.version>0.44.0</docker-maven.version>
     <docker.verbose>true</docker.verbose>
     <typetools.version>0.5.0</typetools.version>
     <byte-buddy.version>1.14.12</byte-buddy.version>


### PR DESCRIPTION
### Motivation & Modifications

- drop tuning for docker since it's no longer needed
  - image squashing is deprecated and it's no longer used in the build to build the docker image
  - sometimes builds have been failing due to the docker service not restarting

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->