### PR TITLE
[improve][broker] Deprecate unused enableNamespaceIsolationUpdateOnTime config

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1453,11 +1453,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
             doc = "Enable or disable exposing broker entry metadata to client.")
     private boolean exposingBrokerEntryMetadataToClientEnabled = false;
 
+    @Deprecated
     @FieldContext(
         category = CATEGORY_SERVER,
-        doc = "Enable namespaceIsolation policy update take effect ontime or not,"
-                + " if set to ture, then the related namespaces will be unloaded after reset policy to make it "
-                + "take effect."
+        doc = "This config never takes effect and will be removed in the next release"
     )
     private boolean enableNamespaceIsolationUpdateOnTime = false;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -199,7 +199,6 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
     void configureDefaults(ServiceConfiguration conf) {
         conf.setForceDeleteNamespaceAllowed(true);
         conf.setLoadBalancerEnabled(true);
-        conf.setEnableNamespaceIsolationUpdateOnTime(true);
         conf.setAllowOverrideEntryFilters(true);
         conf.setEntryFilterNames(List.of());
         conf.setMaxNumPartitionsPerPartitionedTopic(0);
@@ -1394,6 +1393,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
 
         try {
             admin.lookups().lookupTopic(ns1Name + "/topic3");
+            fail();
         } catch (Exception e) {
             // expected lookup fail, because no brokers matched the policy.
             log.info(" 2 expected fail lookup");
@@ -1401,6 +1401,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
 
         try {
             admin.lookups().lookupTopic(ns1Name + "/topic1");
+            fail();
         } catch (Exception e) {
             // expected lookup fail, because no brokers matched the policy.
             log.info(" 22 expected fail lookup");


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/8976 introduced an `enableNamespaceIsolationUpdateOnTime` config, which is useless after https://github.com/apache/pulsar/pull/15527. This config actually does not make sense because it should always be true, while it's false by default just to keep the meaningless compatibility.

### Motivation

Deprecate this config and strength the
`brokerNamespaceIsolationPoliciesUpdateOnTime` test.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [x] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: