### PR TITLE
[fix][build] Fix ps command

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -97,7 +97,8 @@ RUN apk add --no-cache \
             python3 \
             py3-pip \
             gcompat \
-            ca-certificates
+            ca-certificates \
+            procps
 
 # Install GLibc compatibility library
 COPY --from=glibc /root/packages /root/packages
@@ -105,6 +106,9 @@ RUN apk add --allow-untrusted --force-overwrite /root/packages/glibc-*.apk
 
 COPY --from=jvm /opt/jvm /opt/jvm
 ENV JAVA_HOME=/opt/jvm
+
+# The default is /pulsat/bin and cannot be written.
+ENV PULSAR_PID_DIR=/pulsar/logs
 
 # Copy Python depedencies from the other stage
 COPY --from=python-deps /usr/lib/python3.11/site-packages /usr/lib/python3.11/site-packages


### PR DESCRIPTION
### Motivation

```
58a588ac742d:/pulsar# ./bin/pulsar-daemon start zookeeper
doing start zookeeper ...
starting zookeeper, logging to /pulsar/logs/pulsar-zookeeper-58a588ac742d.log
Note: Set immediateFlush to true in conf/log4j2.yaml will guarantee the logging event is flushing to disk immediately. The default behavior is switched off due to performance considerations.
ps: unrecognized option: p
BusyBox v1.36.1 (2023-11-07 18:53:09 UTC) multi-call binary.

Usage: ps [-o COL1,COL2=HEADER] [-T]

Show list of processes

	-o COL1,COL2=HEADER	Select columns for display
	-T
```

ps command doesn't include `-p` option.

### Modifications

- Add `procps` package to fix the ps command
- Set the `PULSAR_PID_DIR` environment variable, and default to `/pulsar/logs` in the docker environment.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->