### PR TITLE
[cleanup][broker] Replace lombok annotations with trivial getters and setters in ServiceConfiguration

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -30,9 +30,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.bookkeeper.util.BookKeeperConstants;
@@ -55,9 +52,8 @@ import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 
 /**
  * Pulsar service configuration object.
+ * Note: Don't use lombok's @Getter and @Setter annotations, which slow the IDE completion speed significantly.
  */
-@Getter
-@Setter
 @ToString
 public class ServiceConfiguration implements PulsarConfiguration {
 
@@ -118,7 +114,6 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "The Zookeeper quorum connection string (as a comma-separated list). Deprecated in favour of "
                 + "metadataStoreUrl"
     )
-    @Getter(AccessLevel.NONE)
     @Deprecated
     private String zookeeperServers;
 
@@ -141,7 +136,6 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Global Zookeeper quorum connection string (as a comma-separated list)."
             + " Deprecated in favor of using `configurationStoreServers`"
     )
-    @Getter(AccessLevel.NONE)
     @Deprecated
     private String globalZookeeperServers;
 
@@ -152,7 +146,6 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Configuration store connection string (as a comma-separated list). Deprecated in favor of "
                 + "`configurationMetadataStoreUrl`"
     )
-    @Getter(AccessLevel.NONE)
     @Deprecated
     private String configurationStoreServers;
 
@@ -1672,7 +1665,6 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Metadata service uri that bookkeeper is used for loading corresponding metadata driver"
             + " and resolving its metadata service location"
     )
-    @Getter(AccessLevel.NONE)
     private String bookkeeperMetadataServiceUri;
 
     @FieldContext(
@@ -3565,5 +3557,3955 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public boolean isSystemTopicAndTopicLevelPoliciesEnabled() {
         return topicLevelPoliciesEnabled && systemTopicEnabled;
+    }
+
+    @Deprecated
+    public void setZookeeperServers(String zookeeperServers) {
+        this.zookeeperServers = zookeeperServers;
+    }
+
+    public void setMetadataStoreUrl(String metadataStoreUrl) {
+        this.metadataStoreUrl = metadataStoreUrl;
+    }
+
+    @Deprecated
+    public void setGlobalZookeeperServers(String globalZookeeperServers) {
+        this.globalZookeeperServers = globalZookeeperServers;
+    }
+
+    public void setConfigurationStoreServers(String configurationStoreServers) {
+        this.configurationStoreServers = configurationStoreServers;
+    }
+
+    public void setConfigurationMetadataStoreUrl(String configurationMetadataStoreUrl) {
+        this.configurationMetadataStoreUrl = configurationMetadataStoreUrl;
+    }
+
+    public Optional<Integer> getBrokerServicePort() {
+        return brokerServicePort;
+    }
+
+    public void setBrokerServicePort(Optional<Integer> brokerServicePort) {
+        this.brokerServicePort = brokerServicePort;
+    }
+
+    public Optional<Integer> getBrokerServicePortTls() {
+        return brokerServicePortTls;
+    }
+
+    public void setBrokerServicePortTls(Optional<Integer> brokerServicePortTls) {
+        this.brokerServicePortTls = brokerServicePortTls;
+    }
+
+    public Optional<Integer> getWebServicePort() {
+        return webServicePort;
+    }
+
+    public void setWebServicePort(Optional<Integer> webServicePort) {
+        this.webServicePort = webServicePort;
+    }
+
+    public Optional<Integer> getWebServicePortTls() {
+        return webServicePortTls;
+    }
+
+    public void setWebServicePortTls(Optional<Integer> webServicePortTls) {
+        this.webServicePortTls = webServicePortTls;
+    }
+
+    public String getWebServiceTlsProvider() {
+        return webServiceTlsProvider;
+    }
+
+    public void setWebServiceTlsProvider(String webServiceTlsProvider) {
+        this.webServiceTlsProvider = webServiceTlsProvider;
+    }
+
+    public Set<String> getWebServiceTlsProtocols() {
+        return webServiceTlsProtocols;
+    }
+
+    public void setWebServiceTlsProtocols(Set<String> webServiceTlsProtocols) {
+        this.webServiceTlsProtocols = webServiceTlsProtocols;
+    }
+
+    public Set<String> getWebServiceTlsCiphers() {
+        return webServiceTlsCiphers;
+    }
+
+    public void setWebServiceTlsCiphers(Set<String> webServiceTlsCiphers) {
+        this.webServiceTlsCiphers = webServiceTlsCiphers;
+    }
+
+    public String getBindAddress() {
+        return bindAddress;
+    }
+
+    public void setBindAddress(String bindAddress) {
+        this.bindAddress = bindAddress;
+    }
+
+    public String getAdvertisedAddress() {
+        return advertisedAddress;
+    }
+
+    public void setAdvertisedAddress(String advertisedAddress) {
+        this.advertisedAddress = advertisedAddress;
+    }
+
+    public String getAdvertisedListeners() {
+        return advertisedListeners;
+    }
+
+    public void setAdvertisedListeners(String advertisedListeners) {
+        this.advertisedListeners = advertisedListeners;
+    }
+
+    public String getInternalListenerName() {
+        return internalListenerName;
+    }
+
+    public void setInternalListenerName(String internalListenerName) {
+        this.internalListenerName = internalListenerName;
+    }
+
+    public String getBindAddresses() {
+        return bindAddresses;
+    }
+
+    public void setBindAddresses(String bindAddresses) {
+        this.bindAddresses = bindAddresses;
+    }
+
+    public boolean isHaProxyProtocolEnabled() {
+        return haProxyProtocolEnabled;
+    }
+
+    public void setHaProxyProtocolEnabled(boolean haProxyProtocolEnabled) {
+        this.haProxyProtocolEnabled = haProxyProtocolEnabled;
+    }
+
+    public int getNumAcceptorThreads() {
+        return numAcceptorThreads;
+    }
+
+    public void setNumAcceptorThreads(int numAcceptorThreads) {
+        this.numAcceptorThreads = numAcceptorThreads;
+    }
+
+    public int getNumIOThreads() {
+        return numIOThreads;
+    }
+
+    public void setNumIOThreads(int numIOThreads) {
+        this.numIOThreads = numIOThreads;
+    }
+
+    public int getNumOrderedExecutorThreads() {
+        return numOrderedExecutorThreads;
+    }
+
+    public void setNumOrderedExecutorThreads(int numOrderedExecutorThreads) {
+        this.numOrderedExecutorThreads = numOrderedExecutorThreads;
+    }
+
+    public int getNumHttpServerThreads() {
+        return numHttpServerThreads;
+    }
+
+    public void setNumHttpServerThreads(int numHttpServerThreads) {
+        this.numHttpServerThreads = numHttpServerThreads;
+    }
+
+    public int getNumExecutorThreadPoolSize() {
+        return numExecutorThreadPoolSize;
+    }
+
+    public void setNumExecutorThreadPoolSize(int numExecutorThreadPoolSize) {
+        this.numExecutorThreadPoolSize = numExecutorThreadPoolSize;
+    }
+
+    @Deprecated
+    public int getNumCacheExecutorThreadPoolSize() {
+        return numCacheExecutorThreadPoolSize;
+    }
+
+    @Deprecated
+    public void setNumCacheExecutorThreadPoolSize(int numCacheExecutorThreadPoolSize) {
+        this.numCacheExecutorThreadPoolSize = numCacheExecutorThreadPoolSize;
+    }
+
+    public boolean isEnableBusyWait() {
+        return enableBusyWait;
+    }
+
+    public void setEnableBusyWait(boolean enableBusyWait) {
+        this.enableBusyWait = enableBusyWait;
+    }
+
+    public int getMaxConcurrentHttpRequests() {
+        return maxConcurrentHttpRequests;
+    }
+
+    public void setMaxConcurrentHttpRequests(int maxConcurrentHttpRequests) {
+        this.maxConcurrentHttpRequests = maxConcurrentHttpRequests;
+    }
+
+    public int getHttpServerThreadPoolQueueSize() {
+        return httpServerThreadPoolQueueSize;
+    }
+
+    public void setHttpServerThreadPoolQueueSize(int httpServerThreadPoolQueueSize) {
+        this.httpServerThreadPoolQueueSize = httpServerThreadPoolQueueSize;
+    }
+
+    public int getHttpServerAcceptQueueSize() {
+        return httpServerAcceptQueueSize;
+    }
+
+    public void setHttpServerAcceptQueueSize(int httpServerAcceptQueueSize) {
+        this.httpServerAcceptQueueSize = httpServerAcceptQueueSize;
+    }
+
+    public int getMaxHttpServerConnections() {
+        return maxHttpServerConnections;
+    }
+
+    public void setMaxHttpServerConnections(int maxHttpServerConnections) {
+        this.maxHttpServerConnections = maxHttpServerConnections;
+    }
+
+    public boolean isDelayedDeliveryEnabled() {
+        return delayedDeliveryEnabled;
+    }
+
+    public void setDelayedDeliveryEnabled(boolean delayedDeliveryEnabled) {
+        this.delayedDeliveryEnabled = delayedDeliveryEnabled;
+    }
+
+    public String getDelayedDeliveryTrackerFactoryClassName() {
+        return delayedDeliveryTrackerFactoryClassName;
+    }
+
+    public void setDelayedDeliveryTrackerFactoryClassName(String delayedDeliveryTrackerFactoryClassName) {
+        this.delayedDeliveryTrackerFactoryClassName = delayedDeliveryTrackerFactoryClassName;
+    }
+
+    public long getDelayedDeliveryTickTimeMillis() {
+        return delayedDeliveryTickTimeMillis;
+    }
+
+    public void setDelayedDeliveryTickTimeMillis(long delayedDeliveryTickTimeMillis) {
+        this.delayedDeliveryTickTimeMillis = delayedDeliveryTickTimeMillis;
+    }
+
+    public boolean isDelayedDeliveryDeliverAtTimeStrict() {
+        return isDelayedDeliveryDeliverAtTimeStrict;
+    }
+
+    public void setDelayedDeliveryDeliverAtTimeStrict(boolean delayedDeliveryDeliverAtTimeStrict) {
+        isDelayedDeliveryDeliverAtTimeStrict = delayedDeliveryDeliverAtTimeStrict;
+    }
+
+    public long getDelayedDeliveryMinIndexCountPerBucket() {
+        return delayedDeliveryMinIndexCountPerBucket;
+    }
+
+    public void setDelayedDeliveryMinIndexCountPerBucket(long delayedDeliveryMinIndexCountPerBucket) {
+        this.delayedDeliveryMinIndexCountPerBucket = delayedDeliveryMinIndexCountPerBucket;
+    }
+
+    public int getDelayedDeliveryMaxTimeStepPerBucketSnapshotSegmentSeconds() {
+        return delayedDeliveryMaxTimeStepPerBucketSnapshotSegmentSeconds;
+    }
+
+    public void setDelayedDeliveryMaxTimeStepPerBucketSnapshotSegmentSeconds(
+            int delayedDeliveryMaxTimeStepPerBucketSnapshotSegmentSeconds) {
+        this.delayedDeliveryMaxTimeStepPerBucketSnapshotSegmentSeconds =
+                delayedDeliveryMaxTimeStepPerBucketSnapshotSegmentSeconds;
+    }
+
+    public int getDelayedDeliveryMaxIndexesPerBucketSnapshotSegment() {
+        return delayedDeliveryMaxIndexesPerBucketSnapshotSegment;
+    }
+
+    public void setDelayedDeliveryMaxIndexesPerBucketSnapshotSegment(
+            int delayedDeliveryMaxIndexesPerBucketSnapshotSegment) {
+        this.delayedDeliveryMaxIndexesPerBucketSnapshotSegment = delayedDeliveryMaxIndexesPerBucketSnapshotSegment;
+    }
+
+    public int getDelayedDeliveryMaxNumBuckets() {
+        return delayedDeliveryMaxNumBuckets;
+    }
+
+    public void setDelayedDeliveryMaxNumBuckets(int delayedDeliveryMaxNumBuckets) {
+        this.delayedDeliveryMaxNumBuckets = delayedDeliveryMaxNumBuckets;
+    }
+
+    public long getDelayedDeliveryFixedDelayDetectionLookahead() {
+        return delayedDeliveryFixedDelayDetectionLookahead;
+    }
+
+    public void setDelayedDeliveryFixedDelayDetectionLookahead(long delayedDeliveryFixedDelayDetectionLookahead) {
+        this.delayedDeliveryFixedDelayDetectionLookahead = delayedDeliveryFixedDelayDetectionLookahead;
+    }
+
+    public long getDelayedDeliveryMaxDelayInMillis() {
+        return delayedDeliveryMaxDelayInMillis;
+    }
+
+    public void setDelayedDeliveryMaxDelayInMillis(long delayedDeliveryMaxDelayInMillis) {
+        this.delayedDeliveryMaxDelayInMillis = delayedDeliveryMaxDelayInMillis;
+    }
+
+    public boolean isAcknowledgmentAtBatchIndexLevelEnabled() {
+        return acknowledgmentAtBatchIndexLevelEnabled;
+    }
+
+    public void setAcknowledgmentAtBatchIndexLevelEnabled(boolean acknowledgmentAtBatchIndexLevelEnabled) {
+        this.acknowledgmentAtBatchIndexLevelEnabled = acknowledgmentAtBatchIndexLevelEnabled;
+    }
+
+    public boolean isWebSocketServiceEnabled() {
+        return webSocketServiceEnabled;
+    }
+
+    public void setWebSocketServiceEnabled(boolean webSocketServiceEnabled) {
+        this.webSocketServiceEnabled = webSocketServiceEnabled;
+    }
+
+    public boolean isRunningStandalone() {
+        return isRunningStandalone;
+    }
+
+    public void setRunningStandalone(boolean runningStandalone) {
+        isRunningStandalone = runningStandalone;
+    }
+
+    public String getClusterName() {
+        return clusterName;
+    }
+
+    public void setClusterName(String clusterName) {
+        this.clusterName = clusterName;
+    }
+
+    public int getMaxTenants() {
+        return maxTenants;
+    }
+
+    public void setMaxTenants(int maxTenants) {
+        this.maxTenants = maxTenants;
+    }
+
+    public boolean isFailureDomainsEnabled() {
+        return failureDomainsEnabled;
+    }
+
+    public void setFailureDomainsEnabled(boolean failureDomainsEnabled) {
+        this.failureDomainsEnabled = failureDomainsEnabled;
+    }
+
+    public void setMetadataStoreSessionTimeoutMillis(long metadataStoreSessionTimeoutMillis) {
+        this.metadataStoreSessionTimeoutMillis = metadataStoreSessionTimeoutMillis;
+    }
+
+    public void setMetadataStoreOperationTimeoutSeconds(int metadataStoreOperationTimeoutSeconds) {
+        this.metadataStoreOperationTimeoutSeconds = metadataStoreOperationTimeoutSeconds;
+    }
+
+    public void setMetadataStoreCacheExpirySeconds(int metadataStoreCacheExpirySeconds) {
+        this.metadataStoreCacheExpirySeconds = metadataStoreCacheExpirySeconds;
+    }
+
+    public void setMetadataStoreAllowReadOnlyOperations(boolean metadataStoreAllowReadOnlyOperations) {
+        this.metadataStoreAllowReadOnlyOperations = metadataStoreAllowReadOnlyOperations;
+    }
+
+    @Deprecated
+    public long getZooKeeperSessionTimeoutMillis() {
+        return zooKeeperSessionTimeoutMillis;
+    }
+
+    @Deprecated
+    public void setZooKeeperSessionTimeoutMillis(long zooKeeperSessionTimeoutMillis) {
+        this.zooKeeperSessionTimeoutMillis = zooKeeperSessionTimeoutMillis;
+    }
+
+    @Deprecated
+    public int getZooKeeperOperationTimeoutSeconds() {
+        return zooKeeperOperationTimeoutSeconds;
+    }
+
+    @Deprecated
+    public void setZooKeeperOperationTimeoutSeconds(int zooKeeperOperationTimeoutSeconds) {
+        this.zooKeeperOperationTimeoutSeconds = zooKeeperOperationTimeoutSeconds;
+    }
+
+    @Deprecated
+    public int getZooKeeperCacheExpirySeconds() {
+        return zooKeeperCacheExpirySeconds;
+    }
+
+    @Deprecated
+    public void setZooKeeperCacheExpirySeconds(int zooKeeperCacheExpirySeconds) {
+        this.zooKeeperCacheExpirySeconds = zooKeeperCacheExpirySeconds;
+    }
+
+    @Deprecated
+    public boolean isZooKeeperAllowReadOnlyOperations() {
+        return zooKeeperAllowReadOnlyOperations;
+    }
+
+    @Deprecated
+    public void setZooKeeperAllowReadOnlyOperations(boolean zooKeeperAllowReadOnlyOperations) {
+        this.zooKeeperAllowReadOnlyOperations = zooKeeperAllowReadOnlyOperations;
+    }
+
+    public long getBrokerShutdownTimeoutMs() {
+        return brokerShutdownTimeoutMs;
+    }
+
+    public void setBrokerShutdownTimeoutMs(long brokerShutdownTimeoutMs) {
+        this.brokerShutdownTimeoutMs = brokerShutdownTimeoutMs;
+    }
+
+    public boolean isSkipBrokerShutdownOnOOM() {
+        return skipBrokerShutdownOnOOM;
+    }
+
+    public void setSkipBrokerShutdownOnOOM(boolean skipBrokerShutdownOnOOM) {
+        this.skipBrokerShutdownOnOOM = skipBrokerShutdownOnOOM;
+    }
+
+    public long getTopicLoadTimeoutSeconds() {
+        return topicLoadTimeoutSeconds;
+    }
+
+    public void setTopicLoadTimeoutSeconds(long topicLoadTimeoutSeconds) {
+        this.topicLoadTimeoutSeconds = topicLoadTimeoutSeconds;
+    }
+
+    public boolean isMetadataStoreBatchingEnabled() {
+        return metadataStoreBatchingEnabled;
+    }
+
+    public void setMetadataStoreBatchingEnabled(boolean metadataStoreBatchingEnabled) {
+        this.metadataStoreBatchingEnabled = metadataStoreBatchingEnabled;
+    }
+
+    public int getMetadataStoreBatchingMaxDelayMillis() {
+        return metadataStoreBatchingMaxDelayMillis;
+    }
+
+    public void setMetadataStoreBatchingMaxDelayMillis(int metadataStoreBatchingMaxDelayMillis) {
+        this.metadataStoreBatchingMaxDelayMillis = metadataStoreBatchingMaxDelayMillis;
+    }
+
+    public int getMetadataStoreBatchingMaxOperations() {
+        return metadataStoreBatchingMaxOperations;
+    }
+
+    public void setMetadataStoreBatchingMaxOperations(int metadataStoreBatchingMaxOperations) {
+        this.metadataStoreBatchingMaxOperations = metadataStoreBatchingMaxOperations;
+    }
+
+    public int getMetadataStoreBatchingMaxSizeKb() {
+        return metadataStoreBatchingMaxSizeKb;
+    }
+
+    public void setMetadataStoreBatchingMaxSizeKb(int metadataStoreBatchingMaxSizeKb) {
+        this.metadataStoreBatchingMaxSizeKb = metadataStoreBatchingMaxSizeKb;
+    }
+
+    public String getMetadataStoreConfigPath() {
+        return metadataStoreConfigPath;
+    }
+
+    public void setMetadataStoreConfigPath(String metadataStoreConfigPath) {
+        this.metadataStoreConfigPath = metadataStoreConfigPath;
+    }
+
+    public String getMetadataSyncEventTopic() {
+        return metadataSyncEventTopic;
+    }
+
+    public void setMetadataSyncEventTopic(String metadataSyncEventTopic) {
+        this.metadataSyncEventTopic = metadataSyncEventTopic;
+    }
+
+    public String getConfigurationMetadataSyncEventTopic() {
+        return configurationMetadataSyncEventTopic;
+    }
+
+    public void setConfigurationMetadataSyncEventTopic(String configurationMetadataSyncEventTopic) {
+        this.configurationMetadataSyncEventTopic = configurationMetadataSyncEventTopic;
+    }
+
+    public String getTopicFactoryClassName() {
+        return topicFactoryClassName;
+    }
+
+    public void setTopicFactoryClassName(String topicFactoryClassName) {
+        this.topicFactoryClassName = topicFactoryClassName;
+    }
+
+    public boolean isBacklogQuotaCheckEnabled() {
+        return backlogQuotaCheckEnabled;
+    }
+
+    public void setBacklogQuotaCheckEnabled(boolean backlogQuotaCheckEnabled) {
+        this.backlogQuotaCheckEnabled = backlogQuotaCheckEnabled;
+    }
+
+    public boolean isPreciseTimeBasedBacklogQuotaCheck() {
+        return preciseTimeBasedBacklogQuotaCheck;
+    }
+
+    public void setPreciseTimeBasedBacklogQuotaCheck(boolean preciseTimeBasedBacklogQuotaCheck) {
+        this.preciseTimeBasedBacklogQuotaCheck = preciseTimeBasedBacklogQuotaCheck;
+    }
+
+    public int getBacklogQuotaCheckIntervalInSeconds() {
+        return backlogQuotaCheckIntervalInSeconds;
+    }
+
+    public void setBacklogQuotaCheckIntervalInSeconds(int backlogQuotaCheckIntervalInSeconds) {
+        this.backlogQuotaCheckIntervalInSeconds = backlogQuotaCheckIntervalInSeconds;
+    }
+
+    @Deprecated
+    public double getBacklogQuotaDefaultLimitGB() {
+        return backlogQuotaDefaultLimitGB;
+    }
+
+    @Deprecated
+    public void setBacklogQuotaDefaultLimitGB(double backlogQuotaDefaultLimitGB) {
+        this.backlogQuotaDefaultLimitGB = backlogQuotaDefaultLimitGB;
+    }
+
+    public long getBacklogQuotaDefaultLimitBytes() {
+        return backlogQuotaDefaultLimitBytes;
+    }
+
+    public void setBacklogQuotaDefaultLimitBytes(long backlogQuotaDefaultLimitBytes) {
+        this.backlogQuotaDefaultLimitBytes = backlogQuotaDefaultLimitBytes;
+    }
+
+    public int getBacklogQuotaDefaultLimitSecond() {
+        return backlogQuotaDefaultLimitSecond;
+    }
+
+    public void setBacklogQuotaDefaultLimitSecond(int backlogQuotaDefaultLimitSecond) {
+        this.backlogQuotaDefaultLimitSecond = backlogQuotaDefaultLimitSecond;
+    }
+
+    public BacklogQuota.RetentionPolicy getBacklogQuotaDefaultRetentionPolicy() {
+        return backlogQuotaDefaultRetentionPolicy;
+    }
+
+    public void setBacklogQuotaDefaultRetentionPolicy(BacklogQuota.RetentionPolicy backlogQuotaDefaultRetentionPolicy) {
+        this.backlogQuotaDefaultRetentionPolicy = backlogQuotaDefaultRetentionPolicy;
+    }
+
+    public int getTtlDurationDefaultInSeconds() {
+        return ttlDurationDefaultInSeconds;
+    }
+
+    public void setTtlDurationDefaultInSeconds(int ttlDurationDefaultInSeconds) {
+        this.ttlDurationDefaultInSeconds = ttlDurationDefaultInSeconds;
+    }
+
+    public boolean isBrokerDeleteInactiveTopicsEnabled() {
+        return brokerDeleteInactiveTopicsEnabled;
+    }
+
+    public void setBrokerDeleteInactiveTopicsEnabled(boolean brokerDeleteInactiveTopicsEnabled) {
+        this.brokerDeleteInactiveTopicsEnabled = brokerDeleteInactiveTopicsEnabled;
+    }
+
+    public boolean isBrokerDeleteInactivePartitionedTopicMetadataEnabled() {
+        return brokerDeleteInactivePartitionedTopicMetadataEnabled;
+    }
+
+    public void setBrokerDeleteInactivePartitionedTopicMetadataEnabled(
+            boolean brokerDeleteInactivePartitionedTopicMetadataEnabled) {
+        this.brokerDeleteInactivePartitionedTopicMetadataEnabled = brokerDeleteInactivePartitionedTopicMetadataEnabled;
+    }
+
+    public int getBrokerDeleteInactiveTopicsFrequencySeconds() {
+        return brokerDeleteInactiveTopicsFrequencySeconds;
+    }
+
+    public void setBrokerDeleteInactiveTopicsFrequencySeconds(int brokerDeleteInactiveTopicsFrequencySeconds) {
+        this.brokerDeleteInactiveTopicsFrequencySeconds = brokerDeleteInactiveTopicsFrequencySeconds;
+    }
+
+    public InactiveTopicDeleteMode getBrokerDeleteInactiveTopicsMode() {
+        return brokerDeleteInactiveTopicsMode;
+    }
+
+    public void setBrokerDeleteInactiveTopicsMode(InactiveTopicDeleteMode brokerDeleteInactiveTopicsMode) {
+        this.brokerDeleteInactiveTopicsMode = brokerDeleteInactiveTopicsMode;
+    }
+
+    public void setBrokerDeleteInactiveTopicsMaxInactiveDurationSeconds(
+            Integer brokerDeleteInactiveTopicsMaxInactiveDurationSeconds) {
+        this.brokerDeleteInactiveTopicsMaxInactiveDurationSeconds =
+                brokerDeleteInactiveTopicsMaxInactiveDurationSeconds;
+    }
+
+    public boolean isForceDeleteTenantAllowed() {
+        return forceDeleteTenantAllowed;
+    }
+
+    public void setForceDeleteTenantAllowed(boolean forceDeleteTenantAllowed) {
+        this.forceDeleteTenantAllowed = forceDeleteTenantAllowed;
+    }
+
+    public boolean isForceDeleteNamespaceAllowed() {
+        return forceDeleteNamespaceAllowed;
+    }
+
+    public void setForceDeleteNamespaceAllowed(boolean forceDeleteNamespaceAllowed) {
+        this.forceDeleteNamespaceAllowed = forceDeleteNamespaceAllowed;
+    }
+
+    public int getMaxPendingPublishRequestsPerConnection() {
+        return maxPendingPublishRequestsPerConnection;
+    }
+
+    public void setMaxPendingPublishRequestsPerConnection(int maxPendingPublishRequestsPerConnection) {
+        this.maxPendingPublishRequestsPerConnection = maxPendingPublishRequestsPerConnection;
+    }
+
+    public int getMessageExpiryCheckIntervalInMinutes() {
+        return messageExpiryCheckIntervalInMinutes;
+    }
+
+    public void setMessageExpiryCheckIntervalInMinutes(int messageExpiryCheckIntervalInMinutes) {
+        this.messageExpiryCheckIntervalInMinutes = messageExpiryCheckIntervalInMinutes;
+    }
+
+    public int getActiveConsumerFailoverDelayTimeMillis() {
+        return activeConsumerFailoverDelayTimeMillis;
+    }
+
+    public void setActiveConsumerFailoverDelayTimeMillis(int activeConsumerFailoverDelayTimeMillis) {
+        this.activeConsumerFailoverDelayTimeMillis = activeConsumerFailoverDelayTimeMillis;
+    }
+
+    public long getSubscriptionBacklogScanMaxTimeMs() {
+        return subscriptionBacklogScanMaxTimeMs;
+    }
+
+    public void setSubscriptionBacklogScanMaxTimeMs(long subscriptionBacklogScanMaxTimeMs) {
+        this.subscriptionBacklogScanMaxTimeMs = subscriptionBacklogScanMaxTimeMs;
+    }
+
+    public long getSubscriptionBacklogScanMaxEntries() {
+        return subscriptionBacklogScanMaxEntries;
+    }
+
+    public void setSubscriptionBacklogScanMaxEntries(long subscriptionBacklogScanMaxEntries) {
+        this.subscriptionBacklogScanMaxEntries = subscriptionBacklogScanMaxEntries;
+    }
+
+    public int getSubscriptionExpirationTimeMinutes() {
+        return subscriptionExpirationTimeMinutes;
+    }
+
+    public void setSubscriptionExpirationTimeMinutes(int subscriptionExpirationTimeMinutes) {
+        this.subscriptionExpirationTimeMinutes = subscriptionExpirationTimeMinutes;
+    }
+
+    public boolean isSubscriptionRedeliveryTrackerEnabled() {
+        return subscriptionRedeliveryTrackerEnabled;
+    }
+
+    public void setSubscriptionRedeliveryTrackerEnabled(boolean subscriptionRedeliveryTrackerEnabled) {
+        this.subscriptionRedeliveryTrackerEnabled = subscriptionRedeliveryTrackerEnabled;
+    }
+
+    public int getSubscriptionExpiryCheckIntervalInMinutes() {
+        return subscriptionExpiryCheckIntervalInMinutes;
+    }
+
+    public void setSubscriptionExpiryCheckIntervalInMinutes(int subscriptionExpiryCheckIntervalInMinutes) {
+        this.subscriptionExpiryCheckIntervalInMinutes = subscriptionExpiryCheckIntervalInMinutes;
+    }
+
+    public Set<String> getSubscriptionTypesEnabled() {
+        return subscriptionTypesEnabled;
+    }
+
+    public void setSubscriptionTypesEnabled(Set<String> subscriptionTypesEnabled) {
+        this.subscriptionTypesEnabled = subscriptionTypesEnabled;
+    }
+
+    @Deprecated
+    public void setSubscriptionKeySharedEnable(boolean subscriptionKeySharedEnable) {
+        this.subscriptionKeySharedEnable = subscriptionKeySharedEnable;
+    }
+
+    public boolean isSubscriptionKeySharedUseConsistentHashing() {
+        return subscriptionKeySharedUseConsistentHashing;
+    }
+
+    public void setSubscriptionKeySharedUseConsistentHashing(boolean subscriptionKeySharedUseConsistentHashing) {
+        this.subscriptionKeySharedUseConsistentHashing = subscriptionKeySharedUseConsistentHashing;
+    }
+
+    public int getSubscriptionKeySharedConsistentHashingReplicaPoints() {
+        return subscriptionKeySharedConsistentHashingReplicaPoints;
+    }
+
+    public void setSubscriptionKeySharedConsistentHashingReplicaPoints(
+            int subscriptionKeySharedConsistentHashingReplicaPoints) {
+        this.subscriptionKeySharedConsistentHashingReplicaPoints = subscriptionKeySharedConsistentHashingReplicaPoints;
+    }
+
+    public boolean isBrokerDeduplicationEnabled() {
+        return brokerDeduplicationEnabled;
+    }
+
+    public void setBrokerDeduplicationEnabled(boolean brokerDeduplicationEnabled) {
+        this.brokerDeduplicationEnabled = brokerDeduplicationEnabled;
+    }
+
+    public int getBrokerDeduplicationMaxNumberOfProducers() {
+        return brokerDeduplicationMaxNumberOfProducers;
+    }
+
+    public void setBrokerDeduplicationMaxNumberOfProducers(int brokerDeduplicationMaxNumberOfProducers) {
+        this.brokerDeduplicationMaxNumberOfProducers = brokerDeduplicationMaxNumberOfProducers;
+    }
+
+    public int getBrokerDeduplicationSnapshotFrequencyInSeconds() {
+        return brokerDeduplicationSnapshotFrequencyInSeconds;
+    }
+
+    public void setBrokerDeduplicationSnapshotFrequencyInSeconds(int brokerDeduplicationSnapshotFrequencyInSeconds) {
+        this.brokerDeduplicationSnapshotFrequencyInSeconds = brokerDeduplicationSnapshotFrequencyInSeconds;
+    }
+
+    public Integer getBrokerDeduplicationSnapshotIntervalSeconds() {
+        return brokerDeduplicationSnapshotIntervalSeconds;
+    }
+
+    public void setBrokerDeduplicationSnapshotIntervalSeconds(Integer brokerDeduplicationSnapshotIntervalSeconds) {
+        this.brokerDeduplicationSnapshotIntervalSeconds = brokerDeduplicationSnapshotIntervalSeconds;
+    }
+
+    public int getBrokerDeduplicationEntriesInterval() {
+        return brokerDeduplicationEntriesInterval;
+    }
+
+    public void setBrokerDeduplicationEntriesInterval(int brokerDeduplicationEntriesInterval) {
+        this.brokerDeduplicationEntriesInterval = brokerDeduplicationEntriesInterval;
+    }
+
+    public int getBrokerDeduplicationProducerInactivityTimeoutMinutes() {
+        return brokerDeduplicationProducerInactivityTimeoutMinutes;
+    }
+
+    public void setBrokerDeduplicationProducerInactivityTimeoutMinutes(
+            int brokerDeduplicationProducerInactivityTimeoutMinutes) {
+        this.brokerDeduplicationProducerInactivityTimeoutMinutes = brokerDeduplicationProducerInactivityTimeoutMinutes;
+    }
+
+    public int getDefaultNumberOfNamespaceBundles() {
+        return defaultNumberOfNamespaceBundles;
+    }
+
+    public void setDefaultNumberOfNamespaceBundles(int defaultNumberOfNamespaceBundles) {
+        this.defaultNumberOfNamespaceBundles = defaultNumberOfNamespaceBundles;
+    }
+
+    public int getMaxNamespacesPerTenant() {
+        return maxNamespacesPerTenant;
+    }
+
+    public void setMaxNamespacesPerTenant(int maxNamespacesPerTenant) {
+        this.maxNamespacesPerTenant = maxNamespacesPerTenant;
+    }
+
+    public int getMaxTopicsPerNamespace() {
+        return maxTopicsPerNamespace;
+    }
+
+    public void setMaxTopicsPerNamespace(int maxTopicsPerNamespace) {
+        this.maxTopicsPerNamespace = maxTopicsPerNamespace;
+    }
+
+    public int getBrokerMaxConnections() {
+        return brokerMaxConnections;
+    }
+
+    public void setBrokerMaxConnections(int brokerMaxConnections) {
+        this.brokerMaxConnections = brokerMaxConnections;
+    }
+
+    public int getBrokerMaxConnectionsPerIp() {
+        return brokerMaxConnectionsPerIp;
+    }
+
+    public void setBrokerMaxConnectionsPerIp(int brokerMaxConnectionsPerIp) {
+        this.brokerMaxConnectionsPerIp = brokerMaxConnectionsPerIp;
+    }
+
+    public boolean isAllowAutoUpdateSchemaEnabled() {
+        return isAllowAutoUpdateSchemaEnabled;
+    }
+
+    public void setAllowAutoUpdateSchemaEnabled(boolean allowAutoUpdateSchemaEnabled) {
+        isAllowAutoUpdateSchemaEnabled = allowAutoUpdateSchemaEnabled;
+    }
+
+    public boolean isAutoShrinkForConsumerPendingAcksMap() {
+        return autoShrinkForConsumerPendingAcksMap;
+    }
+
+    public void setAutoShrinkForConsumerPendingAcksMap(boolean autoShrinkForConsumerPendingAcksMap) {
+        this.autoShrinkForConsumerPendingAcksMap = autoShrinkForConsumerPendingAcksMap;
+    }
+
+    public boolean isClientLibraryVersionCheckEnabled() {
+        return clientLibraryVersionCheckEnabled;
+    }
+
+    public void setClientLibraryVersionCheckEnabled(boolean clientLibraryVersionCheckEnabled) {
+        this.clientLibraryVersionCheckEnabled = clientLibraryVersionCheckEnabled;
+    }
+
+    public String getStatusFilePath() {
+        return statusFilePath;
+    }
+
+    public void setStatusFilePath(String statusFilePath) {
+        this.statusFilePath = statusFilePath;
+    }
+
+    public int getMaxUnackedMessagesPerConsumer() {
+        return maxUnackedMessagesPerConsumer;
+    }
+
+    public void setMaxUnackedMessagesPerConsumer(int maxUnackedMessagesPerConsumer) {
+        this.maxUnackedMessagesPerConsumer = maxUnackedMessagesPerConsumer;
+    }
+
+    public int getMaxUnackedMessagesPerSubscription() {
+        return maxUnackedMessagesPerSubscription;
+    }
+
+    public void setMaxUnackedMessagesPerSubscription(int maxUnackedMessagesPerSubscription) {
+        this.maxUnackedMessagesPerSubscription = maxUnackedMessagesPerSubscription;
+    }
+
+    public int getMaxUnackedMessagesPerBroker() {
+        return maxUnackedMessagesPerBroker;
+    }
+
+    public void setMaxUnackedMessagesPerBroker(int maxUnackedMessagesPerBroker) {
+        this.maxUnackedMessagesPerBroker = maxUnackedMessagesPerBroker;
+    }
+
+    public double getMaxUnackedMessagesPerSubscriptionOnBrokerBlocked() {
+        return maxUnackedMessagesPerSubscriptionOnBrokerBlocked;
+    }
+
+    public void setMaxUnackedMessagesPerSubscriptionOnBrokerBlocked(
+            double maxUnackedMessagesPerSubscriptionOnBrokerBlocked) {
+        this.maxUnackedMessagesPerSubscriptionOnBrokerBlocked = maxUnackedMessagesPerSubscriptionOnBrokerBlocked;
+    }
+
+    public int getMaxConsumerMetadataSize() {
+        return maxConsumerMetadataSize;
+    }
+
+    public void setMaxConsumerMetadataSize(int maxConsumerMetadataSize) {
+        this.maxConsumerMetadataSize = maxConsumerMetadataSize;
+    }
+
+    public boolean isUnblockStuckSubscriptionEnabled() {
+        return unblockStuckSubscriptionEnabled;
+    }
+
+    public void setUnblockStuckSubscriptionEnabled(boolean unblockStuckSubscriptionEnabled) {
+        this.unblockStuckSubscriptionEnabled = unblockStuckSubscriptionEnabled;
+    }
+
+    public int getTopicPublisherThrottlingTickTimeMillis() {
+        return topicPublisherThrottlingTickTimeMillis;
+    }
+
+    public void setTopicPublisherThrottlingTickTimeMillis(int topicPublisherThrottlingTickTimeMillis) {
+        this.topicPublisherThrottlingTickTimeMillis = topicPublisherThrottlingTickTimeMillis;
+    }
+
+    public boolean isPreciseTopicPublishRateLimiterEnable() {
+        return preciseTopicPublishRateLimiterEnable;
+    }
+
+    public void setPreciseTopicPublishRateLimiterEnable(boolean preciseTopicPublishRateLimiterEnable) {
+        this.preciseTopicPublishRateLimiterEnable = preciseTopicPublishRateLimiterEnable;
+    }
+
+    public int getBrokerPublisherThrottlingTickTimeMillis() {
+        return brokerPublisherThrottlingTickTimeMillis;
+    }
+
+    public void setBrokerPublisherThrottlingTickTimeMillis(int brokerPublisherThrottlingTickTimeMillis) {
+        this.brokerPublisherThrottlingTickTimeMillis = brokerPublisherThrottlingTickTimeMillis;
+    }
+
+    public int getBrokerPublisherThrottlingMaxMessageRate() {
+        return brokerPublisherThrottlingMaxMessageRate;
+    }
+
+    public void setBrokerPublisherThrottlingMaxMessageRate(int brokerPublisherThrottlingMaxMessageRate) {
+        this.brokerPublisherThrottlingMaxMessageRate = brokerPublisherThrottlingMaxMessageRate;
+    }
+
+    public long getBrokerPublisherThrottlingMaxByteRate() {
+        return brokerPublisherThrottlingMaxByteRate;
+    }
+
+    public void setBrokerPublisherThrottlingMaxByteRate(long brokerPublisherThrottlingMaxByteRate) {
+        this.brokerPublisherThrottlingMaxByteRate = brokerPublisherThrottlingMaxByteRate;
+    }
+
+    public int getDispatchThrottlingRateInMsg() {
+        return dispatchThrottlingRateInMsg;
+    }
+
+    public void setDispatchThrottlingRateInMsg(int dispatchThrottlingRateInMsg) {
+        this.dispatchThrottlingRateInMsg = dispatchThrottlingRateInMsg;
+    }
+
+    public long getDispatchThrottlingRateInByte() {
+        return dispatchThrottlingRateInByte;
+    }
+
+    public void setDispatchThrottlingRateInByte(long dispatchThrottlingRateInByte) {
+        this.dispatchThrottlingRateInByte = dispatchThrottlingRateInByte;
+    }
+
+    public int getMaxPublishRatePerTopicInMessages() {
+        return maxPublishRatePerTopicInMessages;
+    }
+
+    public void setMaxPublishRatePerTopicInMessages(int maxPublishRatePerTopicInMessages) {
+        this.maxPublishRatePerTopicInMessages = maxPublishRatePerTopicInMessages;
+    }
+
+    public long getMaxPublishRatePerTopicInBytes() {
+        return maxPublishRatePerTopicInBytes;
+    }
+
+    public void setMaxPublishRatePerTopicInBytes(long maxPublishRatePerTopicInBytes) {
+        this.maxPublishRatePerTopicInBytes = maxPublishRatePerTopicInBytes;
+    }
+
+    public int getSubscribeThrottlingRatePerConsumer() {
+        return subscribeThrottlingRatePerConsumer;
+    }
+
+    public void setSubscribeThrottlingRatePerConsumer(int subscribeThrottlingRatePerConsumer) {
+        this.subscribeThrottlingRatePerConsumer = subscribeThrottlingRatePerConsumer;
+    }
+
+    public int getSubscribeRatePeriodPerConsumerInSecond() {
+        return subscribeRatePeriodPerConsumerInSecond;
+    }
+
+    public void setSubscribeRatePeriodPerConsumerInSecond(int subscribeRatePeriodPerConsumerInSecond) {
+        this.subscribeRatePeriodPerConsumerInSecond = subscribeRatePeriodPerConsumerInSecond;
+    }
+
+    public int getDispatchThrottlingRatePerTopicInMsg() {
+        return dispatchThrottlingRatePerTopicInMsg;
+    }
+
+    public void setDispatchThrottlingRatePerTopicInMsg(int dispatchThrottlingRatePerTopicInMsg) {
+        this.dispatchThrottlingRatePerTopicInMsg = dispatchThrottlingRatePerTopicInMsg;
+    }
+
+    public long getDispatchThrottlingRatePerTopicInByte() {
+        return dispatchThrottlingRatePerTopicInByte;
+    }
+
+    public void setDispatchThrottlingRatePerTopicInByte(long dispatchThrottlingRatePerTopicInByte) {
+        this.dispatchThrottlingRatePerTopicInByte = dispatchThrottlingRatePerTopicInByte;
+    }
+
+    public boolean isDispatchThrottlingOnBatchMessageEnabled() {
+        return dispatchThrottlingOnBatchMessageEnabled;
+    }
+
+    public void setDispatchThrottlingOnBatchMessageEnabled(boolean dispatchThrottlingOnBatchMessageEnabled) {
+        this.dispatchThrottlingOnBatchMessageEnabled = dispatchThrottlingOnBatchMessageEnabled;
+    }
+
+    public int getDispatchThrottlingRatePerSubscriptionInMsg() {
+        return dispatchThrottlingRatePerSubscriptionInMsg;
+    }
+
+    public void setDispatchThrottlingRatePerSubscriptionInMsg(int dispatchThrottlingRatePerSubscriptionInMsg) {
+        this.dispatchThrottlingRatePerSubscriptionInMsg = dispatchThrottlingRatePerSubscriptionInMsg;
+    }
+
+    public long getDispatchThrottlingRatePerSubscriptionInByte() {
+        return dispatchThrottlingRatePerSubscriptionInByte;
+    }
+
+    public void setDispatchThrottlingRatePerSubscriptionInByte(long dispatchThrottlingRatePerSubscriptionInByte) {
+        this.dispatchThrottlingRatePerSubscriptionInByte = dispatchThrottlingRatePerSubscriptionInByte;
+    }
+
+    public int getDispatchThrottlingRatePerReplicatorInMsg() {
+        return dispatchThrottlingRatePerReplicatorInMsg;
+    }
+
+    public void setDispatchThrottlingRatePerReplicatorInMsg(int dispatchThrottlingRatePerReplicatorInMsg) {
+        this.dispatchThrottlingRatePerReplicatorInMsg = dispatchThrottlingRatePerReplicatorInMsg;
+    }
+
+    public long getDispatchThrottlingRatePerReplicatorInByte() {
+        return dispatchThrottlingRatePerReplicatorInByte;
+    }
+
+    public void setDispatchThrottlingRatePerReplicatorInByte(long dispatchThrottlingRatePerReplicatorInByte) {
+        this.dispatchThrottlingRatePerReplicatorInByte = dispatchThrottlingRatePerReplicatorInByte;
+    }
+
+    public boolean isDispatchThrottlingRateRelativeToPublishRate() {
+        return dispatchThrottlingRateRelativeToPublishRate;
+    }
+
+    public void setDispatchThrottlingRateRelativeToPublishRate(boolean dispatchThrottlingRateRelativeToPublishRate) {
+        this.dispatchThrottlingRateRelativeToPublishRate = dispatchThrottlingRateRelativeToPublishRate;
+    }
+
+    public boolean isDispatchThrottlingOnNonBacklogConsumerEnabled() {
+        return dispatchThrottlingOnNonBacklogConsumerEnabled;
+    }
+
+    public void setDispatchThrottlingOnNonBacklogConsumerEnabled(
+            boolean dispatchThrottlingOnNonBacklogConsumerEnabled) {
+        this.dispatchThrottlingOnNonBacklogConsumerEnabled = dispatchThrottlingOnNonBacklogConsumerEnabled;
+    }
+
+    public String getResourceUsageTransportClassName() {
+        return resourceUsageTransportClassName;
+    }
+
+    public void setResourceUsageTransportClassName(String resourceUsageTransportClassName) {
+        this.resourceUsageTransportClassName = resourceUsageTransportClassName;
+    }
+
+    public int getResourceUsageTransportPublishIntervalInSecs() {
+        return resourceUsageTransportPublishIntervalInSecs;
+    }
+
+    public void setResourceUsageTransportPublishIntervalInSecs(int resourceUsageTransportPublishIntervalInSecs) {
+        this.resourceUsageTransportPublishIntervalInSecs = resourceUsageTransportPublishIntervalInSecs;
+    }
+
+    public boolean isEnableBrokerSideSubscriptionPatternEvaluation() {
+        return enableBrokerSideSubscriptionPatternEvaluation;
+    }
+
+    public void setEnableBrokerSideSubscriptionPatternEvaluation(
+            boolean enableBrokerSideSubscriptionPatternEvaluation) {
+        this.enableBrokerSideSubscriptionPatternEvaluation = enableBrokerSideSubscriptionPatternEvaluation;
+    }
+
+    public int getSubscriptionPatternMaxLength() {
+        return subscriptionPatternMaxLength;
+    }
+
+    public void setSubscriptionPatternMaxLength(int subscriptionPatternMaxLength) {
+        this.subscriptionPatternMaxLength = subscriptionPatternMaxLength;
+    }
+
+    public int getDispatcherMaxReadBatchSize() {
+        return dispatcherMaxReadBatchSize;
+    }
+
+    public void setDispatcherMaxReadBatchSize(int dispatcherMaxReadBatchSize) {
+        this.dispatcherMaxReadBatchSize = dispatcherMaxReadBatchSize;
+    }
+
+    public boolean isDispatcherDispatchMessagesInSubscriptionThread() {
+        return dispatcherDispatchMessagesInSubscriptionThread;
+    }
+
+    public void setDispatcherDispatchMessagesInSubscriptionThread(
+            boolean dispatcherDispatchMessagesInSubscriptionThread) {
+        this.dispatcherDispatchMessagesInSubscriptionThread = dispatcherDispatchMessagesInSubscriptionThread;
+    }
+
+    public boolean isDispatchThrottlingForFilteredEntriesEnabled() {
+        return dispatchThrottlingForFilteredEntriesEnabled;
+    }
+
+    public void setDispatchThrottlingForFilteredEntriesEnabled(
+            boolean dispatchThrottlingForFilteredEntriesEnabled) {
+        this.dispatchThrottlingForFilteredEntriesEnabled = dispatchThrottlingForFilteredEntriesEnabled;
+    }
+
+    public int getDispatcherMaxReadSizeBytes() {
+        return dispatcherMaxReadSizeBytes;
+    }
+
+    public void setDispatcherMaxReadSizeBytes(int dispatcherMaxReadSizeBytes) {
+        this.dispatcherMaxReadSizeBytes = dispatcherMaxReadSizeBytes;
+    }
+
+    public int getDispatcherMinReadBatchSize() {
+        return dispatcherMinReadBatchSize;
+    }
+
+    public void setDispatcherMinReadBatchSize(int dispatcherMinReadBatchSize) {
+        this.dispatcherMinReadBatchSize = dispatcherMinReadBatchSize;
+    }
+
+    public int getDispatcherReadFailureBackoffInitialTimeInMs() {
+        return dispatcherReadFailureBackoffInitialTimeInMs;
+    }
+
+    public void setDispatcherReadFailureBackoffInitialTimeInMs(int dispatcherReadFailureBackoffInitialTimeInMs) {
+        this.dispatcherReadFailureBackoffInitialTimeInMs = dispatcherReadFailureBackoffInitialTimeInMs;
+    }
+
+    public int getDispatcherReadFailureBackoffMaxTimeInMs() {
+        return dispatcherReadFailureBackoffMaxTimeInMs;
+    }
+
+    public void setDispatcherReadFailureBackoffMaxTimeInMs(int dispatcherReadFailureBackoffMaxTimeInMs) {
+        this.dispatcherReadFailureBackoffMaxTimeInMs = dispatcherReadFailureBackoffMaxTimeInMs;
+    }
+
+    public int getDispatcherReadFailureBackoffMandatoryStopTimeInMs() {
+        return dispatcherReadFailureBackoffMandatoryStopTimeInMs;
+    }
+
+    public void setDispatcherReadFailureBackoffMandatoryStopTimeInMs(
+            int dispatcherReadFailureBackoffMandatoryStopTimeInMs) {
+        this.dispatcherReadFailureBackoffMandatoryStopTimeInMs = dispatcherReadFailureBackoffMandatoryStopTimeInMs;
+    }
+
+    public int getDispatcherEntryFilterRescheduledMessageDelay() {
+        return dispatcherEntryFilterRescheduledMessageDelay;
+    }
+
+    public void setDispatcherEntryFilterRescheduledMessageDelay(int dispatcherEntryFilterRescheduledMessageDelay) {
+        this.dispatcherEntryFilterRescheduledMessageDelay = dispatcherEntryFilterRescheduledMessageDelay;
+    }
+
+    public int getDispatcherMaxRoundRobinBatchSize() {
+        return dispatcherMaxRoundRobinBatchSize;
+    }
+
+    public void setDispatcherMaxRoundRobinBatchSize(int dispatcherMaxRoundRobinBatchSize) {
+        this.dispatcherMaxRoundRobinBatchSize = dispatcherMaxRoundRobinBatchSize;
+    }
+
+    public boolean isPreciseDispatcherFlowControl() {
+        return preciseDispatcherFlowControl;
+    }
+
+    public void setPreciseDispatcherFlowControl(boolean preciseDispatcherFlowControl) {
+        this.preciseDispatcherFlowControl = preciseDispatcherFlowControl;
+    }
+
+    public List<String> getEntryFilterNames() {
+        return entryFilterNames;
+    }
+
+    public void setEntryFilterNames(List<String> entryFilterNames) {
+        this.entryFilterNames = entryFilterNames;
+    }
+
+    public String getEntryFiltersDirectory() {
+        return entryFiltersDirectory;
+    }
+
+    public void setEntryFiltersDirectory(String entryFiltersDirectory) {
+        this.entryFiltersDirectory = entryFiltersDirectory;
+    }
+
+    public boolean isAllowOverrideEntryFilters() {
+        return allowOverrideEntryFilters;
+    }
+
+    public void setAllowOverrideEntryFilters(boolean allowOverrideEntryFilters) {
+        this.allowOverrideEntryFilters = allowOverrideEntryFilters;
+    }
+
+    public int getMaxConcurrentLookupRequest() {
+        return maxConcurrentLookupRequest;
+    }
+
+    public void setMaxConcurrentLookupRequest(int maxConcurrentLookupRequest) {
+        this.maxConcurrentLookupRequest = maxConcurrentLookupRequest;
+    }
+
+    public int getMaxConcurrentTopicLoadRequest() {
+        return maxConcurrentTopicLoadRequest;
+    }
+
+    public void setMaxConcurrentTopicLoadRequest(int maxConcurrentTopicLoadRequest) {
+        this.maxConcurrentTopicLoadRequest = maxConcurrentTopicLoadRequest;
+    }
+
+    public int getMaxConcurrentNonPersistentMessagePerConnection() {
+        return maxConcurrentNonPersistentMessagePerConnection;
+    }
+
+    public void setMaxConcurrentNonPersistentMessagePerConnection(int maxConcurrentNonPersistentMessagePerConnection) {
+        this.maxConcurrentNonPersistentMessagePerConnection = maxConcurrentNonPersistentMessagePerConnection;
+    }
+
+    @Deprecated
+    public int getNumWorkerThreadsForNonPersistentTopic() {
+        return numWorkerThreadsForNonPersistentTopic;
+    }
+
+    @Deprecated
+    public void setNumWorkerThreadsForNonPersistentTopic(int numWorkerThreadsForNonPersistentTopic) {
+        this.numWorkerThreadsForNonPersistentTopic = numWorkerThreadsForNonPersistentTopic;
+    }
+
+    public void setTopicOrderedExecutorThreadNum(int topicOrderedExecutorThreadNum) {
+        this.topicOrderedExecutorThreadNum = topicOrderedExecutorThreadNum;
+    }
+
+    public boolean isEnablePersistentTopics() {
+        return enablePersistentTopics;
+    }
+
+    public void setEnablePersistentTopics(boolean enablePersistentTopics) {
+        this.enablePersistentTopics = enablePersistentTopics;
+    }
+
+    public boolean isEnableNonPersistentTopics() {
+        return enableNonPersistentTopics;
+    }
+
+    public void setEnableNonPersistentTopics(boolean enableNonPersistentTopics) {
+        this.enableNonPersistentTopics = enableNonPersistentTopics;
+    }
+
+    public boolean isEnableRunBookieTogether() {
+        return enableRunBookieTogether;
+    }
+
+    public void setEnableRunBookieTogether(boolean enableRunBookieTogether) {
+        this.enableRunBookieTogether = enableRunBookieTogether;
+    }
+
+    public boolean isEnableRunBookieAutoRecoveryTogether() {
+        return enableRunBookieAutoRecoveryTogether;
+    }
+
+    public void setEnableRunBookieAutoRecoveryTogether(boolean enableRunBookieAutoRecoveryTogether) {
+        this.enableRunBookieAutoRecoveryTogether = enableRunBookieAutoRecoveryTogether;
+    }
+
+    public int getMaxProducersPerTopic() {
+        return maxProducersPerTopic;
+    }
+
+    public void setMaxProducersPerTopic(int maxProducersPerTopic) {
+        this.maxProducersPerTopic = maxProducersPerTopic;
+    }
+
+    public int getMaxSameAddressProducersPerTopic() {
+        return maxSameAddressProducersPerTopic;
+    }
+
+    public void setMaxSameAddressProducersPerTopic(int maxSameAddressProducersPerTopic) {
+        this.maxSameAddressProducersPerTopic = maxSameAddressProducersPerTopic;
+    }
+
+    public boolean isEncryptionRequireOnProducer() {
+        return encryptionRequireOnProducer;
+    }
+
+    public void setEncryptionRequireOnProducer(boolean encryptionRequireOnProducer) {
+        this.encryptionRequireOnProducer = encryptionRequireOnProducer;
+    }
+
+    public int getMaxConsumersPerTopic() {
+        return maxConsumersPerTopic;
+    }
+
+    public void setMaxConsumersPerTopic(int maxConsumersPerTopic) {
+        this.maxConsumersPerTopic = maxConsumersPerTopic;
+    }
+
+    public int getMaxSameAddressConsumersPerTopic() {
+        return maxSameAddressConsumersPerTopic;
+    }
+
+    public void setMaxSameAddressConsumersPerTopic(int maxSameAddressConsumersPerTopic) {
+        this.maxSameAddressConsumersPerTopic = maxSameAddressConsumersPerTopic;
+    }
+
+    public int getMaxSubscriptionsPerTopic() {
+        return maxSubscriptionsPerTopic;
+    }
+
+    public void setMaxSubscriptionsPerTopic(int maxSubscriptionsPerTopic) {
+        this.maxSubscriptionsPerTopic = maxSubscriptionsPerTopic;
+    }
+
+    public int getMaxConsumersPerSubscription() {
+        return maxConsumersPerSubscription;
+    }
+
+    public void setMaxConsumersPerSubscription(int maxConsumersPerSubscription) {
+        this.maxConsumersPerSubscription = maxConsumersPerSubscription;
+    }
+
+    public int getMaxMessageSize() {
+        return maxMessageSize;
+    }
+
+    public void setMaxMessageSize(int maxMessageSize) {
+        this.maxMessageSize = maxMessageSize;
+    }
+
+    public boolean isEnableReplicatedSubscriptions() {
+        return enableReplicatedSubscriptions;
+    }
+
+    public void setEnableReplicatedSubscriptions(boolean enableReplicatedSubscriptions) {
+        this.enableReplicatedSubscriptions = enableReplicatedSubscriptions;
+    }
+
+    public int getReplicatedSubscriptionsSnapshotFrequencyMillis() {
+        return replicatedSubscriptionsSnapshotFrequencyMillis;
+    }
+
+    public void setReplicatedSubscriptionsSnapshotFrequencyMillis(int replicatedSubscriptionsSnapshotFrequencyMillis) {
+        this.replicatedSubscriptionsSnapshotFrequencyMillis = replicatedSubscriptionsSnapshotFrequencyMillis;
+    }
+
+    public int getReplicatedSubscriptionsSnapshotTimeoutSeconds() {
+        return replicatedSubscriptionsSnapshotTimeoutSeconds;
+    }
+
+    public void setReplicatedSubscriptionsSnapshotTimeoutSeconds(int replicatedSubscriptionsSnapshotTimeoutSeconds) {
+        this.replicatedSubscriptionsSnapshotTimeoutSeconds = replicatedSubscriptionsSnapshotTimeoutSeconds;
+    }
+
+    public int getReplicatedSubscriptionsSnapshotMaxCachedPerSubscription() {
+        return replicatedSubscriptionsSnapshotMaxCachedPerSubscription;
+    }
+
+    public void setReplicatedSubscriptionsSnapshotMaxCachedPerSubscription(
+            int replicatedSubscriptionsSnapshotMaxCachedPerSubscription) {
+        this.replicatedSubscriptionsSnapshotMaxCachedPerSubscription =
+                replicatedSubscriptionsSnapshotMaxCachedPerSubscription;
+    }
+
+    public int getMaxMessagePublishBufferSizeInMB() {
+        return maxMessagePublishBufferSizeInMB;
+    }
+
+    public void setMaxMessagePublishBufferSizeInMB(int maxMessagePublishBufferSizeInMB) {
+        this.maxMessagePublishBufferSizeInMB = maxMessagePublishBufferSizeInMB;
+    }
+
+    public int getMessagePublishBufferCheckIntervalInMillis() {
+        return messagePublishBufferCheckIntervalInMillis;
+    }
+
+    public void setMessagePublishBufferCheckIntervalInMillis(int messagePublishBufferCheckIntervalInMillis) {
+        this.messagePublishBufferCheckIntervalInMillis = messagePublishBufferCheckIntervalInMillis;
+    }
+
+    public boolean isLazyCursorRecovery() {
+        return lazyCursorRecovery;
+    }
+
+    public void setLazyCursorRecovery(boolean lazyCursorRecovery) {
+        this.lazyCursorRecovery = lazyCursorRecovery;
+    }
+
+    public int getRetentionCheckIntervalInSeconds() {
+        return retentionCheckIntervalInSeconds;
+    }
+
+    public void setRetentionCheckIntervalInSeconds(int retentionCheckIntervalInSeconds) {
+        this.retentionCheckIntervalInSeconds = retentionCheckIntervalInSeconds;
+    }
+
+    public int getMaxNumPartitionsPerPartitionedTopic() {
+        return maxNumPartitionsPerPartitionedTopic;
+    }
+
+    public void setMaxNumPartitionsPerPartitionedTopic(int maxNumPartitionsPerPartitionedTopic) {
+        this.maxNumPartitionsPerPartitionedTopic = maxNumPartitionsPerPartitionedTopic;
+    }
+
+    public String getBrokerInterceptorsDirectory() {
+        return brokerInterceptorsDirectory;
+    }
+
+    public void setBrokerInterceptorsDirectory(String brokerInterceptorsDirectory) {
+        this.brokerInterceptorsDirectory = brokerInterceptorsDirectory;
+    }
+
+    public Set<String> getBrokerInterceptors() {
+        return brokerInterceptors;
+    }
+
+    public void setBrokerInterceptors(Set<String> brokerInterceptors) {
+        this.brokerInterceptors = brokerInterceptors;
+    }
+
+    public Set<String> getBrokerEntryPayloadProcessors() {
+        return brokerEntryPayloadProcessors;
+    }
+
+    public void setBrokerEntryPayloadProcessors(Set<String> brokerEntryPayloadProcessors) {
+        this.brokerEntryPayloadProcessors = brokerEntryPayloadProcessors;
+    }
+
+    public MetadataSessionExpiredPolicy getZookeeperSessionExpiredPolicy() {
+        return zookeeperSessionExpiredPolicy;
+    }
+
+    public void setZookeeperSessionExpiredPolicy(MetadataSessionExpiredPolicy zookeeperSessionExpiredPolicy) {
+        this.zookeeperSessionExpiredPolicy = zookeeperSessionExpiredPolicy;
+    }
+
+    public int getTopicFencingTimeoutSeconds() {
+        return topicFencingTimeoutSeconds;
+    }
+
+    public void setTopicFencingTimeoutSeconds(int topicFencingTimeoutSeconds) {
+        this.topicFencingTimeoutSeconds = topicFencingTimeoutSeconds;
+    }
+
+    public String getProtocolHandlerDirectory() {
+        return protocolHandlerDirectory;
+    }
+
+    public void setProtocolHandlerDirectory(String protocolHandlerDirectory) {
+        this.protocolHandlerDirectory = protocolHandlerDirectory;
+    }
+
+    public boolean isUseSeparateThreadPoolForProtocolHandlers() {
+        return useSeparateThreadPoolForProtocolHandlers;
+    }
+
+    public void setUseSeparateThreadPoolForProtocolHandlers(boolean useSeparateThreadPoolForProtocolHandlers) {
+        this.useSeparateThreadPoolForProtocolHandlers = useSeparateThreadPoolForProtocolHandlers;
+    }
+
+    public Set<String> getMessagingProtocols() {
+        return messagingProtocols;
+    }
+
+    public void setMessagingProtocols(Set<String> messagingProtocols) {
+        this.messagingProtocols = messagingProtocols;
+    }
+
+    public boolean isSystemTopicEnabled() {
+        return systemTopicEnabled;
+    }
+
+    public void setSystemTopicEnabled(boolean systemTopicEnabled) {
+        this.systemTopicEnabled = systemTopicEnabled;
+    }
+
+    public boolean isStrictTopicNameEnabled() {
+        return strictTopicNameEnabled;
+    }
+
+    public void setStrictTopicNameEnabled(boolean strictTopicNameEnabled) {
+        this.strictTopicNameEnabled = strictTopicNameEnabled;
+    }
+
+    public SchemaCompatibilityStrategy getSystemTopicSchemaCompatibilityStrategy() {
+        return systemTopicSchemaCompatibilityStrategy;
+    }
+
+    public void setSystemTopicSchemaCompatibilityStrategy(
+            SchemaCompatibilityStrategy systemTopicSchemaCompatibilityStrategy) {
+        this.systemTopicSchemaCompatibilityStrategy = systemTopicSchemaCompatibilityStrategy;
+    }
+
+    public boolean isTopicLevelPoliciesEnabled() {
+        return topicLevelPoliciesEnabled;
+    }
+
+    public void setTopicLevelPoliciesEnabled(boolean topicLevelPoliciesEnabled) {
+        this.topicLevelPoliciesEnabled = topicLevelPoliciesEnabled;
+    }
+
+    public Set<String> getBrokerEntryMetadataInterceptors() {
+        return brokerEntryMetadataInterceptors;
+    }
+
+    public void setBrokerEntryMetadataInterceptors(Set<String> brokerEntryMetadataInterceptors) {
+        this.brokerEntryMetadataInterceptors = brokerEntryMetadataInterceptors;
+    }
+
+    public boolean isExposingBrokerEntryMetadataToClientEnabled() {
+        return exposingBrokerEntryMetadataToClientEnabled;
+    }
+
+    public void setExposingBrokerEntryMetadataToClientEnabled(boolean exposingBrokerEntryMetadataToClientEnabled) {
+        this.exposingBrokerEntryMetadataToClientEnabled = exposingBrokerEntryMetadataToClientEnabled;
+    }
+
+    public boolean isEnableNamespaceIsolationUpdateOnTime() {
+        return enableNamespaceIsolationUpdateOnTime;
+    }
+
+    public void setEnableNamespaceIsolationUpdateOnTime(boolean enableNamespaceIsolationUpdateOnTime) {
+        this.enableNamespaceIsolationUpdateOnTime = enableNamespaceIsolationUpdateOnTime;
+    }
+
+    public boolean isStrictBookieAffinityEnabled() {
+        return strictBookieAffinityEnabled;
+    }
+
+    public void setStrictBookieAffinityEnabled(boolean strictBookieAffinityEnabled) {
+        this.strictBookieAffinityEnabled = strictBookieAffinityEnabled;
+    }
+
+    @Deprecated
+    public boolean isTlsEnabled() {
+        return tlsEnabled;
+    }
+
+    @Deprecated
+    public void setTlsEnabled(boolean tlsEnabled) {
+        this.tlsEnabled = tlsEnabled;
+    }
+
+    public long getTlsCertRefreshCheckDurationSec() {
+        return tlsCertRefreshCheckDurationSec;
+    }
+
+    public void setTlsCertRefreshCheckDurationSec(long tlsCertRefreshCheckDurationSec) {
+        this.tlsCertRefreshCheckDurationSec = tlsCertRefreshCheckDurationSec;
+    }
+
+    public String getTlsCertificateFilePath() {
+        return tlsCertificateFilePath;
+    }
+
+    public void setTlsCertificateFilePath(String tlsCertificateFilePath) {
+        this.tlsCertificateFilePath = tlsCertificateFilePath;
+    }
+
+    public String getTlsKeyFilePath() {
+        return tlsKeyFilePath;
+    }
+
+    public void setTlsKeyFilePath(String tlsKeyFilePath) {
+        this.tlsKeyFilePath = tlsKeyFilePath;
+    }
+
+    public String getTlsTrustCertsFilePath() {
+        return tlsTrustCertsFilePath;
+    }
+
+    public void setTlsTrustCertsFilePath(String tlsTrustCertsFilePath) {
+        this.tlsTrustCertsFilePath = tlsTrustCertsFilePath;
+    }
+
+    public boolean isTlsAllowInsecureConnection() {
+        return tlsAllowInsecureConnection;
+    }
+
+    public void setTlsAllowInsecureConnection(boolean tlsAllowInsecureConnection) {
+        this.tlsAllowInsecureConnection = tlsAllowInsecureConnection;
+    }
+
+    public boolean isTlsHostnameVerificationEnabled() {
+        return tlsHostnameVerificationEnabled;
+    }
+
+    public void setTlsHostnameVerificationEnabled(boolean tlsHostnameVerificationEnabled) {
+        this.tlsHostnameVerificationEnabled = tlsHostnameVerificationEnabled;
+    }
+
+    public Set<String> getTlsProtocols() {
+        return tlsProtocols;
+    }
+
+    public void setTlsProtocols(Set<String> tlsProtocols) {
+        this.tlsProtocols = tlsProtocols;
+    }
+
+    public Set<String> getTlsCiphers() {
+        return tlsCiphers;
+    }
+
+    public void setTlsCiphers(Set<String> tlsCiphers) {
+        this.tlsCiphers = tlsCiphers;
+    }
+
+    public boolean isTlsRequireTrustedClientCertOnConnect() {
+        return tlsRequireTrustedClientCertOnConnect;
+    }
+
+    public void setTlsRequireTrustedClientCertOnConnect(boolean tlsRequireTrustedClientCertOnConnect) {
+        this.tlsRequireTrustedClientCertOnConnect = tlsRequireTrustedClientCertOnConnect;
+    }
+
+    public boolean isAuthenticationEnabled() {
+        return authenticationEnabled;
+    }
+
+    public void setAuthenticationEnabled(boolean authenticationEnabled) {
+        this.authenticationEnabled = authenticationEnabled;
+    }
+
+    public Set<String> getAuthenticationProviders() {
+        return authenticationProviders;
+    }
+
+    public void setAuthenticationProviders(Set<String> authenticationProviders) {
+        this.authenticationProviders = authenticationProviders;
+    }
+
+    public int getAuthenticationRefreshCheckSeconds() {
+        return authenticationRefreshCheckSeconds;
+    }
+
+    public void setAuthenticationRefreshCheckSeconds(int authenticationRefreshCheckSeconds) {
+        this.authenticationRefreshCheckSeconds = authenticationRefreshCheckSeconds;
+    }
+
+    public boolean isAuthorizationEnabled() {
+        return authorizationEnabled;
+    }
+
+    public void setAuthorizationEnabled(boolean authorizationEnabled) {
+        this.authorizationEnabled = authorizationEnabled;
+    }
+
+    public String getAuthorizationProvider() {
+        return authorizationProvider;
+    }
+
+    public void setAuthorizationProvider(String authorizationProvider) {
+        this.authorizationProvider = authorizationProvider;
+    }
+
+    public Set<String> getSuperUserRoles() {
+        return superUserRoles;
+    }
+
+    public void setSuperUserRoles(Set<String> superUserRoles) {
+        this.superUserRoles = superUserRoles;
+    }
+
+    public Set<String> getProxyRoles() {
+        return proxyRoles;
+    }
+
+    public void setProxyRoles(Set<String> proxyRoles) {
+        this.proxyRoles = proxyRoles;
+    }
+
+    public boolean isAuthenticateOriginalAuthData() {
+        return authenticateOriginalAuthData;
+    }
+
+    public void setAuthenticateOriginalAuthData(boolean authenticateOriginalAuthData) {
+        this.authenticateOriginalAuthData = authenticateOriginalAuthData;
+    }
+
+    public boolean isAuthorizationAllowWildcardsMatching() {
+        return authorizationAllowWildcardsMatching;
+    }
+
+    public void setAuthorizationAllowWildcardsMatching(boolean authorizationAllowWildcardsMatching) {
+        this.authorizationAllowWildcardsMatching = authorizationAllowWildcardsMatching;
+    }
+
+    public String getAnonymousUserRole() {
+        return anonymousUserRole;
+    }
+
+    public void setAnonymousUserRole(String anonymousUserRole) {
+        this.anonymousUserRole = anonymousUserRole;
+    }
+
+    public long getHttpMaxRequestSize() {
+        return httpMaxRequestSize;
+    }
+
+    public void setHttpMaxRequestSize(long httpMaxRequestSize) {
+        this.httpMaxRequestSize = httpMaxRequestSize;
+    }
+
+    public int getHttpMaxRequestHeaderSize() {
+        return httpMaxRequestHeaderSize;
+    }
+
+    public void setHttpMaxRequestHeaderSize(int httpMaxRequestHeaderSize) {
+        this.httpMaxRequestHeaderSize = httpMaxRequestHeaderSize;
+    }
+
+    public boolean isDisableHttpDebugMethods() {
+        return disableHttpDebugMethods;
+    }
+
+    public void setDisableHttpDebugMethods(boolean disableHttpDebugMethods) {
+        this.disableHttpDebugMethods = disableHttpDebugMethods;
+    }
+
+    public boolean isHttpRequestsLimitEnabled() {
+        return httpRequestsLimitEnabled;
+    }
+
+    public void setHttpRequestsLimitEnabled(boolean httpRequestsLimitEnabled) {
+        this.httpRequestsLimitEnabled = httpRequestsLimitEnabled;
+    }
+
+    public double getHttpRequestsMaxPerSecond() {
+        return httpRequestsMaxPerSecond;
+    }
+
+    public void setHttpRequestsMaxPerSecond(double httpRequestsMaxPerSecond) {
+        this.httpRequestsMaxPerSecond = httpRequestsMaxPerSecond;
+    }
+
+    public boolean isHttpRequestsFailOnUnknownPropertiesEnabled() {
+        return httpRequestsFailOnUnknownPropertiesEnabled;
+    }
+
+    public void setHttpRequestsFailOnUnknownPropertiesEnabled(boolean httpRequestsFailOnUnknownPropertiesEnabled) {
+        this.httpRequestsFailOnUnknownPropertiesEnabled = httpRequestsFailOnUnknownPropertiesEnabled;
+    }
+
+    public String getSaslJaasClientAllowedIds() {
+        return saslJaasClientAllowedIds;
+    }
+
+    public void setSaslJaasClientAllowedIds(String saslJaasClientAllowedIds) {
+        this.saslJaasClientAllowedIds = saslJaasClientAllowedIds;
+    }
+
+    public String getSaslJaasServerSectionName() {
+        return saslJaasServerSectionName;
+    }
+
+    public void setSaslJaasServerSectionName(String saslJaasServerSectionName) {
+        this.saslJaasServerSectionName = saslJaasServerSectionName;
+    }
+
+    public String getSaslJaasServerRoleTokenSignerSecretPath() {
+        return saslJaasServerRoleTokenSignerSecretPath;
+    }
+
+    public void setSaslJaasServerRoleTokenSignerSecretPath(String saslJaasServerRoleTokenSignerSecretPath) {
+        this.saslJaasServerRoleTokenSignerSecretPath = saslJaasServerRoleTokenSignerSecretPath;
+    }
+
+    public String getKinitCommand() {
+        return kinitCommand;
+    }
+
+    public void setKinitCommand(String kinitCommand) {
+        this.kinitCommand = kinitCommand;
+    }
+
+    public long getInflightSaslContextExpiryMs() {
+        return inflightSaslContextExpiryMs;
+    }
+
+    public void setInflightSaslContextExpiryMs(long inflightSaslContextExpiryMs) {
+        this.inflightSaslContextExpiryMs = inflightSaslContextExpiryMs;
+    }
+
+    public long getMaxInflightSaslContext() {
+        return maxInflightSaslContext;
+    }
+
+    public void setMaxInflightSaslContext(long maxInflightSaslContext) {
+        this.maxInflightSaslContext = maxInflightSaslContext;
+    }
+
+    public void setBookkeeperMetadataServiceUri(String bookkeeperMetadataServiceUri) {
+        this.bookkeeperMetadataServiceUri = bookkeeperMetadataServiceUri;
+    }
+
+    public String getBookkeeperClientAuthenticationPlugin() {
+        return bookkeeperClientAuthenticationPlugin;
+    }
+
+    public void setBookkeeperClientAuthenticationPlugin(String bookkeeperClientAuthenticationPlugin) {
+        this.bookkeeperClientAuthenticationPlugin = bookkeeperClientAuthenticationPlugin;
+    }
+
+    public String getBookkeeperClientAuthenticationParametersName() {
+        return bookkeeperClientAuthenticationParametersName;
+    }
+
+    public void setBookkeeperClientAuthenticationParametersName(String bookkeeperClientAuthenticationParametersName) {
+        this.bookkeeperClientAuthenticationParametersName = bookkeeperClientAuthenticationParametersName;
+    }
+
+    public String getBookkeeperClientAuthenticationParameters() {
+        return bookkeeperClientAuthenticationParameters;
+    }
+
+    public void setBookkeeperClientAuthenticationParameters(String bookkeeperClientAuthenticationParameters) {
+        this.bookkeeperClientAuthenticationParameters = bookkeeperClientAuthenticationParameters;
+    }
+
+    public long getBookkeeperClientTimeoutInSeconds() {
+        return bookkeeperClientTimeoutInSeconds;
+    }
+
+    public void setBookkeeperClientTimeoutInSeconds(long bookkeeperClientTimeoutInSeconds) {
+        this.bookkeeperClientTimeoutInSeconds = bookkeeperClientTimeoutInSeconds;
+    }
+
+    public int getBookkeeperClientSpeculativeReadTimeoutInMillis() {
+        return bookkeeperClientSpeculativeReadTimeoutInMillis;
+    }
+
+    public void setBookkeeperClientSpeculativeReadTimeoutInMillis(int bookkeeperClientSpeculativeReadTimeoutInMillis) {
+        this.bookkeeperClientSpeculativeReadTimeoutInMillis = bookkeeperClientSpeculativeReadTimeoutInMillis;
+    }
+
+    public int getBookkeeperNumberOfChannelsPerBookie() {
+        return bookkeeperNumberOfChannelsPerBookie;
+    }
+
+    public void setBookkeeperNumberOfChannelsPerBookie(int bookkeeperNumberOfChannelsPerBookie) {
+        this.bookkeeperNumberOfChannelsPerBookie = bookkeeperNumberOfChannelsPerBookie;
+    }
+
+    public boolean isBookkeeperUseV2WireProtocol() {
+        return bookkeeperUseV2WireProtocol;
+    }
+
+    public void setBookkeeperUseV2WireProtocol(boolean bookkeeperUseV2WireProtocol) {
+        this.bookkeeperUseV2WireProtocol = bookkeeperUseV2WireProtocol;
+    }
+
+    public boolean isBookkeeperClientHealthCheckEnabled() {
+        return bookkeeperClientHealthCheckEnabled;
+    }
+
+    public void setBookkeeperClientHealthCheckEnabled(boolean bookkeeperClientHealthCheckEnabled) {
+        this.bookkeeperClientHealthCheckEnabled = bookkeeperClientHealthCheckEnabled;
+    }
+
+    public long getBookkeeperClientHealthCheckIntervalSeconds() {
+        return bookkeeperClientHealthCheckIntervalSeconds;
+    }
+
+    public void setBookkeeperClientHealthCheckIntervalSeconds(long bookkeeperClientHealthCheckIntervalSeconds) {
+        this.bookkeeperClientHealthCheckIntervalSeconds = bookkeeperClientHealthCheckIntervalSeconds;
+    }
+
+    public long getBookkeeperClientHealthCheckErrorThresholdPerInterval() {
+        return bookkeeperClientHealthCheckErrorThresholdPerInterval;
+    }
+
+    public void setBookkeeperClientHealthCheckErrorThresholdPerInterval(
+            long bookkeeperClientHealthCheckErrorThresholdPerInterval) {
+        this.bookkeeperClientHealthCheckErrorThresholdPerInterval =
+                bookkeeperClientHealthCheckErrorThresholdPerInterval;
+    }
+
+    public long getBookkeeperClientHealthCheckQuarantineTimeInSeconds() {
+        return bookkeeperClientHealthCheckQuarantineTimeInSeconds;
+    }
+
+    public void setBookkeeperClientHealthCheckQuarantineTimeInSeconds(
+            long bookkeeperClientHealthCheckQuarantineTimeInSeconds) {
+        this.bookkeeperClientHealthCheckQuarantineTimeInSeconds = bookkeeperClientHealthCheckQuarantineTimeInSeconds;
+    }
+
+    public double getBookkeeperClientQuarantineRatio() {
+        return bookkeeperClientQuarantineRatio;
+    }
+
+    public void setBookkeeperClientQuarantineRatio(double bookkeeperClientQuarantineRatio) {
+        this.bookkeeperClientQuarantineRatio = bookkeeperClientQuarantineRatio;
+    }
+
+    public boolean isBookkeeperClientRackawarePolicyEnabled() {
+        return bookkeeperClientRackawarePolicyEnabled;
+    }
+
+    public void setBookkeeperClientRackawarePolicyEnabled(boolean bookkeeperClientRackawarePolicyEnabled) {
+        this.bookkeeperClientRackawarePolicyEnabled = bookkeeperClientRackawarePolicyEnabled;
+    }
+
+    public boolean isBookkeeperClientRegionawarePolicyEnabled() {
+        return bookkeeperClientRegionawarePolicyEnabled;
+    }
+
+    public void setBookkeeperClientRegionawarePolicyEnabled(boolean bookkeeperClientRegionawarePolicyEnabled) {
+        this.bookkeeperClientRegionawarePolicyEnabled = bookkeeperClientRegionawarePolicyEnabled;
+    }
+
+    public int getBookkeeperClientMinNumRacksPerWriteQuorum() {
+        return bookkeeperClientMinNumRacksPerWriteQuorum;
+    }
+
+    public void setBookkeeperClientMinNumRacksPerWriteQuorum(int bookkeeperClientMinNumRacksPerWriteQuorum) {
+        this.bookkeeperClientMinNumRacksPerWriteQuorum = bookkeeperClientMinNumRacksPerWriteQuorum;
+    }
+
+    public boolean isBookkeeperClientEnforceMinNumRacksPerWriteQuorum() {
+        return bookkeeperClientEnforceMinNumRacksPerWriteQuorum;
+    }
+
+    public void setBookkeeperClientEnforceMinNumRacksPerWriteQuorum(
+            boolean bookkeeperClientEnforceMinNumRacksPerWriteQuorum) {
+        this.bookkeeperClientEnforceMinNumRacksPerWriteQuorum = bookkeeperClientEnforceMinNumRacksPerWriteQuorum;
+    }
+
+    public boolean isBookkeeperClientReorderReadSequenceEnabled() {
+        return bookkeeperClientReorderReadSequenceEnabled;
+    }
+
+    public void setBookkeeperClientReorderReadSequenceEnabled(boolean bookkeeperClientReorderReadSequenceEnabled) {
+        this.bookkeeperClientReorderReadSequenceEnabled = bookkeeperClientReorderReadSequenceEnabled;
+    }
+
+    public String getBookkeeperClientIsolationGroups() {
+        return bookkeeperClientIsolationGroups;
+    }
+
+    public void setBookkeeperClientIsolationGroups(String bookkeeperClientIsolationGroups) {
+        this.bookkeeperClientIsolationGroups = bookkeeperClientIsolationGroups;
+    }
+
+    public String getBookkeeperClientSecondaryIsolationGroups() {
+        return bookkeeperClientSecondaryIsolationGroups;
+    }
+
+    public void setBookkeeperClientSecondaryIsolationGroups(String bookkeeperClientSecondaryIsolationGroups) {
+        this.bookkeeperClientSecondaryIsolationGroups = bookkeeperClientSecondaryIsolationGroups;
+    }
+
+    public int getBookkeeperClientGetBookieInfoIntervalSeconds() {
+        return bookkeeperClientGetBookieInfoIntervalSeconds;
+    }
+
+    public void setBookkeeperClientGetBookieInfoIntervalSeconds(int bookkeeperClientGetBookieInfoIntervalSeconds) {
+        this.bookkeeperClientGetBookieInfoIntervalSeconds = bookkeeperClientGetBookieInfoIntervalSeconds;
+    }
+
+    public int getBookkeeperClientGetBookieInfoRetryIntervalSeconds() {
+        return bookkeeperClientGetBookieInfoRetryIntervalSeconds;
+    }
+
+    public void setBookkeeperClientGetBookieInfoRetryIntervalSeconds(
+            int bookkeeperClientGetBookieInfoRetryIntervalSeconds) {
+        this.bookkeeperClientGetBookieInfoRetryIntervalSeconds = bookkeeperClientGetBookieInfoRetryIntervalSeconds;
+    }
+
+    public boolean isBookkeeperEnableStickyReads() {
+        return bookkeeperEnableStickyReads;
+    }
+
+    public void setBookkeeperEnableStickyReads(boolean bookkeeperEnableStickyReads) {
+        this.bookkeeperEnableStickyReads = bookkeeperEnableStickyReads;
+    }
+
+    public String getBookkeeperTLSProviderFactoryClass() {
+        return bookkeeperTLSProviderFactoryClass;
+    }
+
+    public void setBookkeeperTLSProviderFactoryClass(String bookkeeperTLSProviderFactoryClass) {
+        this.bookkeeperTLSProviderFactoryClass = bookkeeperTLSProviderFactoryClass;
+    }
+
+    public boolean isBookkeeperTLSClientAuthentication() {
+        return bookkeeperTLSClientAuthentication;
+    }
+
+    public void setBookkeeperTLSClientAuthentication(boolean bookkeeperTLSClientAuthentication) {
+        this.bookkeeperTLSClientAuthentication = bookkeeperTLSClientAuthentication;
+    }
+
+    public String getBookkeeperTLSKeyFileType() {
+        return bookkeeperTLSKeyFileType;
+    }
+
+    public void setBookkeeperTLSKeyFileType(String bookkeeperTLSKeyFileType) {
+        this.bookkeeperTLSKeyFileType = bookkeeperTLSKeyFileType;
+    }
+
+    public String getBookkeeperTLSTrustCertTypes() {
+        return bookkeeperTLSTrustCertTypes;
+    }
+
+    public void setBookkeeperTLSTrustCertTypes(String bookkeeperTLSTrustCertTypes) {
+        this.bookkeeperTLSTrustCertTypes = bookkeeperTLSTrustCertTypes;
+    }
+
+    public String getBookkeeperTLSKeyStorePasswordPath() {
+        return bookkeeperTLSKeyStorePasswordPath;
+    }
+
+    public void setBookkeeperTLSKeyStorePasswordPath(String bookkeeperTLSKeyStorePasswordPath) {
+        this.bookkeeperTLSKeyStorePasswordPath = bookkeeperTLSKeyStorePasswordPath;
+    }
+
+    public String getBookkeeperTLSTrustStorePasswordPath() {
+        return bookkeeperTLSTrustStorePasswordPath;
+    }
+
+    public void setBookkeeperTLSTrustStorePasswordPath(String bookkeeperTLSTrustStorePasswordPath) {
+        this.bookkeeperTLSTrustStorePasswordPath = bookkeeperTLSTrustStorePasswordPath;
+    }
+
+    public String getBookkeeperTLSKeyFilePath() {
+        return bookkeeperTLSKeyFilePath;
+    }
+
+    public void setBookkeeperTLSKeyFilePath(String bookkeeperTLSKeyFilePath) {
+        this.bookkeeperTLSKeyFilePath = bookkeeperTLSKeyFilePath;
+    }
+
+    public String getBookkeeperTLSCertificateFilePath() {
+        return bookkeeperTLSCertificateFilePath;
+    }
+
+    public void setBookkeeperTLSCertificateFilePath(String bookkeeperTLSCertificateFilePath) {
+        this.bookkeeperTLSCertificateFilePath = bookkeeperTLSCertificateFilePath;
+    }
+
+    public String getBookkeeperTLSTrustCertsFilePath() {
+        return bookkeeperTLSTrustCertsFilePath;
+    }
+
+    public void setBookkeeperTLSTrustCertsFilePath(String bookkeeperTLSTrustCertsFilePath) {
+        this.bookkeeperTLSTrustCertsFilePath = bookkeeperTLSTrustCertsFilePath;
+    }
+
+    public int getBookkeeperTlsCertFilesRefreshDurationSeconds() {
+        return bookkeeperTlsCertFilesRefreshDurationSeconds;
+    }
+
+    public void setBookkeeperTlsCertFilesRefreshDurationSeconds(int bookkeeperTlsCertFilesRefreshDurationSeconds) {
+        this.bookkeeperTlsCertFilesRefreshDurationSeconds = bookkeeperTlsCertFilesRefreshDurationSeconds;
+    }
+
+    public boolean isBookkeeperDiskWeightBasedPlacementEnabled() {
+        return bookkeeperDiskWeightBasedPlacementEnabled;
+    }
+
+    public void setBookkeeperDiskWeightBasedPlacementEnabled(boolean bookkeeperDiskWeightBasedPlacementEnabled) {
+        this.bookkeeperDiskWeightBasedPlacementEnabled = bookkeeperDiskWeightBasedPlacementEnabled;
+    }
+
+    public int getBookkeeperExplicitLacIntervalInMills() {
+        return bookkeeperExplicitLacIntervalInMills;
+    }
+
+    public void setBookkeeperExplicitLacIntervalInMills(int bookkeeperExplicitLacIntervalInMills) {
+        this.bookkeeperExplicitLacIntervalInMills = bookkeeperExplicitLacIntervalInMills;
+    }
+
+    public boolean isBookkeeperClientExposeStatsToPrometheus() {
+        return bookkeeperClientExposeStatsToPrometheus;
+    }
+
+    public void setBookkeeperClientExposeStatsToPrometheus(boolean bookkeeperClientExposeStatsToPrometheus) {
+        this.bookkeeperClientExposeStatsToPrometheus = bookkeeperClientExposeStatsToPrometheus;
+    }
+
+    public boolean isBookkeeperClientLimitStatsLogging() {
+        return bookkeeperClientLimitStatsLogging;
+    }
+
+    public void setBookkeeperClientLimitStatsLogging(boolean bookkeeperClientLimitStatsLogging) {
+        this.bookkeeperClientLimitStatsLogging = bookkeeperClientLimitStatsLogging;
+    }
+
+    public int getBookkeeperClientThrottleValue() {
+        return bookkeeperClientThrottleValue;
+    }
+
+    public void setBookkeeperClientThrottleValue(int bookkeeperClientThrottleValue) {
+        this.bookkeeperClientThrottleValue = bookkeeperClientThrottleValue;
+    }
+
+    public int getBookkeeperClientNumWorkerThreads() {
+        return bookkeeperClientNumWorkerThreads;
+    }
+
+    public void setBookkeeperClientNumWorkerThreads(int bookkeeperClientNumWorkerThreads) {
+        this.bookkeeperClientNumWorkerThreads = bookkeeperClientNumWorkerThreads;
+    }
+
+    public int getBookkeeperClientNumIoThreads() {
+        return bookkeeperClientNumIoThreads;
+    }
+
+    public void setBookkeeperClientNumIoThreads(int bookkeeperClientNumIoThreads) {
+        this.bookkeeperClientNumIoThreads = bookkeeperClientNumIoThreads;
+    }
+
+    public boolean isBookkeeperClientSeparatedIoThreadsEnabled() {
+        return bookkeeperClientSeparatedIoThreadsEnabled;
+    }
+
+    public void setBookkeeperClientSeparatedIoThreadsEnabled(boolean bookkeeperClientSeparatedIoThreadsEnabled) {
+        this.bookkeeperClientSeparatedIoThreadsEnabled = bookkeeperClientSeparatedIoThreadsEnabled;
+    }
+
+    public int getManagedLedgerDefaultEnsembleSize() {
+        return managedLedgerDefaultEnsembleSize;
+    }
+
+    public void setManagedLedgerDefaultEnsembleSize(int managedLedgerDefaultEnsembleSize) {
+        this.managedLedgerDefaultEnsembleSize = managedLedgerDefaultEnsembleSize;
+    }
+
+    public int getManagedLedgerDefaultWriteQuorum() {
+        return managedLedgerDefaultWriteQuorum;
+    }
+
+    public void setManagedLedgerDefaultWriteQuorum(int managedLedgerDefaultWriteQuorum) {
+        this.managedLedgerDefaultWriteQuorum = managedLedgerDefaultWriteQuorum;
+    }
+
+    public int getManagedLedgerDefaultAckQuorum() {
+        return managedLedgerDefaultAckQuorum;
+    }
+
+    public void setManagedLedgerDefaultAckQuorum(int managedLedgerDefaultAckQuorum) {
+        this.managedLedgerDefaultAckQuorum = managedLedgerDefaultAckQuorum;
+    }
+
+    public int getManagedLedgerCursorPositionFlushSeconds() {
+        return managedLedgerCursorPositionFlushSeconds;
+    }
+
+    public void setManagedLedgerCursorPositionFlushSeconds(int managedLedgerCursorPositionFlushSeconds) {
+        this.managedLedgerCursorPositionFlushSeconds = managedLedgerCursorPositionFlushSeconds;
+    }
+
+    public int getManagedLedgerStatsPeriodSeconds() {
+        return managedLedgerStatsPeriodSeconds;
+    }
+
+    public void setManagedLedgerStatsPeriodSeconds(int managedLedgerStatsPeriodSeconds) {
+        this.managedLedgerStatsPeriodSeconds = managedLedgerStatsPeriodSeconds;
+    }
+
+    public DigestType getManagedLedgerDigestType() {
+        return managedLedgerDigestType;
+    }
+
+    public void setManagedLedgerDigestType(DigestType managedLedgerDigestType) {
+        this.managedLedgerDigestType = managedLedgerDigestType;
+    }
+
+    public String getManagedLedgerPassword() {
+        return managedLedgerPassword;
+    }
+
+    public void setManagedLedgerPassword(String managedLedgerPassword) {
+        this.managedLedgerPassword = managedLedgerPassword;
+    }
+
+    public int getManagedLedgerMaxEnsembleSize() {
+        return managedLedgerMaxEnsembleSize;
+    }
+
+    public void setManagedLedgerMaxEnsembleSize(int managedLedgerMaxEnsembleSize) {
+        this.managedLedgerMaxEnsembleSize = managedLedgerMaxEnsembleSize;
+    }
+
+    public int getManagedLedgerMaxWriteQuorum() {
+        return managedLedgerMaxWriteQuorum;
+    }
+
+    public void setManagedLedgerMaxWriteQuorum(int managedLedgerMaxWriteQuorum) {
+        this.managedLedgerMaxWriteQuorum = managedLedgerMaxWriteQuorum;
+    }
+
+    public int getManagedLedgerMaxAckQuorum() {
+        return managedLedgerMaxAckQuorum;
+    }
+
+    public void setManagedLedgerMaxAckQuorum(int managedLedgerMaxAckQuorum) {
+        this.managedLedgerMaxAckQuorum = managedLedgerMaxAckQuorum;
+    }
+
+    public int getManagedLedgerCacheSizeMB() {
+        return managedLedgerCacheSizeMB;
+    }
+
+    public void setManagedLedgerCacheSizeMB(int managedLedgerCacheSizeMB) {
+        this.managedLedgerCacheSizeMB = managedLedgerCacheSizeMB;
+    }
+
+    public boolean isManagedLedgerCacheCopyEntries() {
+        return managedLedgerCacheCopyEntries;
+    }
+
+    public void setManagedLedgerCacheCopyEntries(boolean managedLedgerCacheCopyEntries) {
+        this.managedLedgerCacheCopyEntries = managedLedgerCacheCopyEntries;
+    }
+
+    public long getManagedLedgerMaxReadsInFlightSizeInMB() {
+        return managedLedgerMaxReadsInFlightSizeInMB;
+    }
+
+    public void setManagedLedgerMaxReadsInFlightSizeInMB(long managedLedgerMaxReadsInFlightSizeInMB) {
+        this.managedLedgerMaxReadsInFlightSizeInMB = managedLedgerMaxReadsInFlightSizeInMB;
+    }
+
+    public double getManagedLedgerCacheEvictionWatermark() {
+        return managedLedgerCacheEvictionWatermark;
+    }
+
+    public void setManagedLedgerCacheEvictionWatermark(double managedLedgerCacheEvictionWatermark) {
+        this.managedLedgerCacheEvictionWatermark = managedLedgerCacheEvictionWatermark;
+    }
+
+    @Deprecated
+    public double getManagedLedgerCacheEvictionFrequency() {
+        return managedLedgerCacheEvictionFrequency;
+    }
+
+    @Deprecated
+    public void setManagedLedgerCacheEvictionFrequency(double managedLedgerCacheEvictionFrequency) {
+        this.managedLedgerCacheEvictionFrequency = managedLedgerCacheEvictionFrequency;
+    }
+
+    public void setManagedLedgerCacheEvictionIntervalMs(long managedLedgerCacheEvictionIntervalMs) {
+        this.managedLedgerCacheEvictionIntervalMs = managedLedgerCacheEvictionIntervalMs;
+    }
+
+    public long getManagedLedgerCacheEvictionTimeThresholdMillis() {
+        return managedLedgerCacheEvictionTimeThresholdMillis;
+    }
+
+    public void setManagedLedgerCacheEvictionTimeThresholdMillis(long managedLedgerCacheEvictionTimeThresholdMillis) {
+        this.managedLedgerCacheEvictionTimeThresholdMillis = managedLedgerCacheEvictionTimeThresholdMillis;
+    }
+
+    public long getManagedLedgerCursorBackloggedThreshold() {
+        return managedLedgerCursorBackloggedThreshold;
+    }
+
+    public void setManagedLedgerCursorBackloggedThreshold(long managedLedgerCursorBackloggedThreshold) {
+        this.managedLedgerCursorBackloggedThreshold = managedLedgerCursorBackloggedThreshold;
+    }
+
+    public double getManagedLedgerDefaultMarkDeleteRateLimit() {
+        return managedLedgerDefaultMarkDeleteRateLimit;
+    }
+
+    public void setManagedLedgerDefaultMarkDeleteRateLimit(double managedLedgerDefaultMarkDeleteRateLimit) {
+        this.managedLedgerDefaultMarkDeleteRateLimit = managedLedgerDefaultMarkDeleteRateLimit;
+    }
+
+    public boolean isAllowAutoTopicCreation() {
+        return allowAutoTopicCreation;
+    }
+
+    public void setAllowAutoTopicCreation(boolean allowAutoTopicCreation) {
+        this.allowAutoTopicCreation = allowAutoTopicCreation;
+    }
+
+    public TopicType getAllowAutoTopicCreationType() {
+        return allowAutoTopicCreationType;
+    }
+
+    public void setAllowAutoTopicCreationType(TopicType allowAutoTopicCreationType) {
+        this.allowAutoTopicCreationType = allowAutoTopicCreationType;
+    }
+
+    public boolean isAllowAutoSubscriptionCreation() {
+        return allowAutoSubscriptionCreation;
+    }
+
+    public void setAllowAutoSubscriptionCreation(boolean allowAutoSubscriptionCreation) {
+        this.allowAutoSubscriptionCreation = allowAutoSubscriptionCreation;
+    }
+
+    public int getDefaultNumPartitions() {
+        return defaultNumPartitions;
+    }
+
+    public void setDefaultNumPartitions(int defaultNumPartitions) {
+        this.defaultNumPartitions = defaultNumPartitions;
+    }
+
+    public String getManagedLedgerStorageClassName() {
+        return managedLedgerStorageClassName;
+    }
+
+    public void setManagedLedgerStorageClassName(String managedLedgerStorageClassName) {
+        this.managedLedgerStorageClassName = managedLedgerStorageClassName;
+    }
+
+    public int getManagedLedgerNumSchedulerThreads() {
+        return managedLedgerNumSchedulerThreads;
+    }
+
+    public void setManagedLedgerNumSchedulerThreads(int managedLedgerNumSchedulerThreads) {
+        this.managedLedgerNumSchedulerThreads = managedLedgerNumSchedulerThreads;
+    }
+
+    public int getManagedLedgerMaxEntriesPerLedger() {
+        return managedLedgerMaxEntriesPerLedger;
+    }
+
+    public void setManagedLedgerMaxEntriesPerLedger(int managedLedgerMaxEntriesPerLedger) {
+        this.managedLedgerMaxEntriesPerLedger = managedLedgerMaxEntriesPerLedger;
+    }
+
+    public int getManagedLedgerMinLedgerRolloverTimeMinutes() {
+        return managedLedgerMinLedgerRolloverTimeMinutes;
+    }
+
+    public void setManagedLedgerMinLedgerRolloverTimeMinutes(int managedLedgerMinLedgerRolloverTimeMinutes) {
+        this.managedLedgerMinLedgerRolloverTimeMinutes = managedLedgerMinLedgerRolloverTimeMinutes;
+    }
+
+    public int getManagedLedgerMaxLedgerRolloverTimeMinutes() {
+        return managedLedgerMaxLedgerRolloverTimeMinutes;
+    }
+
+    public void setManagedLedgerMaxLedgerRolloverTimeMinutes(int managedLedgerMaxLedgerRolloverTimeMinutes) {
+        this.managedLedgerMaxLedgerRolloverTimeMinutes = managedLedgerMaxLedgerRolloverTimeMinutes;
+    }
+
+    public int getManagedLedgerMaxSizePerLedgerMbytes() {
+        return managedLedgerMaxSizePerLedgerMbytes;
+    }
+
+    public void setManagedLedgerMaxSizePerLedgerMbytes(int managedLedgerMaxSizePerLedgerMbytes) {
+        this.managedLedgerMaxSizePerLedgerMbytes = managedLedgerMaxSizePerLedgerMbytes;
+    }
+
+    public long getManagedLedgerOffloadDeletionLagMs() {
+        return managedLedgerOffloadDeletionLagMs;
+    }
+
+    public void setManagedLedgerOffloadDeletionLagMs(long managedLedgerOffloadDeletionLagMs) {
+        this.managedLedgerOffloadDeletionLagMs = managedLedgerOffloadDeletionLagMs;
+    }
+
+    public long getManagedLedgerOffloadAutoTriggerSizeThresholdBytes() {
+        return managedLedgerOffloadAutoTriggerSizeThresholdBytes;
+    }
+
+    public void setManagedLedgerOffloadAutoTriggerSizeThresholdBytes(
+            long managedLedgerOffloadAutoTriggerSizeThresholdBytes) {
+        this.managedLedgerOffloadAutoTriggerSizeThresholdBytes = managedLedgerOffloadAutoTriggerSizeThresholdBytes;
+    }
+
+    public long getManagedLedgerOffloadThresholdInSeconds() {
+        return managedLedgerOffloadThresholdInSeconds;
+    }
+
+    public void setManagedLedgerOffloadThresholdInSeconds(long managedLedgerOffloadThresholdInSeconds) {
+        this.managedLedgerOffloadThresholdInSeconds = managedLedgerOffloadThresholdInSeconds;
+    }
+
+    public int getManagedLedgerCursorMaxEntriesPerLedger() {
+        return managedLedgerCursorMaxEntriesPerLedger;
+    }
+
+    public void setManagedLedgerCursorMaxEntriesPerLedger(int managedLedgerCursorMaxEntriesPerLedger) {
+        this.managedLedgerCursorMaxEntriesPerLedger = managedLedgerCursorMaxEntriesPerLedger;
+    }
+
+    public int getManagedLedgerCursorRolloverTimeInSeconds() {
+        return managedLedgerCursorRolloverTimeInSeconds;
+    }
+
+    public void setManagedLedgerCursorRolloverTimeInSeconds(int managedLedgerCursorRolloverTimeInSeconds) {
+        this.managedLedgerCursorRolloverTimeInSeconds = managedLedgerCursorRolloverTimeInSeconds;
+    }
+
+    public int getManagedLedgerMaxUnackedRangesToPersist() {
+        return managedLedgerMaxUnackedRangesToPersist;
+    }
+
+    public void setManagedLedgerMaxUnackedRangesToPersist(int managedLedgerMaxUnackedRangesToPersist) {
+        this.managedLedgerMaxUnackedRangesToPersist = managedLedgerMaxUnackedRangesToPersist;
+    }
+
+    public boolean isPersistentUnackedRangesWithMultipleEntriesEnabled() {
+        return persistentUnackedRangesWithMultipleEntriesEnabled;
+    }
+
+    public void setPersistentUnackedRangesWithMultipleEntriesEnabled(
+            boolean persistentUnackedRangesWithMultipleEntriesEnabled) {
+        this.persistentUnackedRangesWithMultipleEntriesEnabled = persistentUnackedRangesWithMultipleEntriesEnabled;
+    }
+
+    @Deprecated
+    public int getManagedLedgerMaxUnackedRangesToPersistInZooKeeper() {
+        return managedLedgerMaxUnackedRangesToPersistInZooKeeper;
+    }
+
+    @Deprecated
+    public void setManagedLedgerMaxUnackedRangesToPersistInZooKeeper(
+            int managedLedgerMaxUnackedRangesToPersistInZooKeeper) {
+        this.managedLedgerMaxUnackedRangesToPersistInZooKeeper = managedLedgerMaxUnackedRangesToPersistInZooKeeper;
+    }
+
+    public void setManagedLedgerMaxUnackedRangesToPersistInMetadataStore(
+            int managedLedgerMaxUnackedRangesToPersistInMetadataStore) {
+        this.managedLedgerMaxUnackedRangesToPersistInMetadataStore =
+                managedLedgerMaxUnackedRangesToPersistInMetadataStore;
+    }
+
+    public boolean isManagedLedgerUnackedRangesOpenCacheSetEnabled() {
+        return managedLedgerUnackedRangesOpenCacheSetEnabled;
+    }
+
+    public void setManagedLedgerUnackedRangesOpenCacheSetEnabled(
+            boolean managedLedgerUnackedRangesOpenCacheSetEnabled) {
+        this.managedLedgerUnackedRangesOpenCacheSetEnabled = managedLedgerUnackedRangesOpenCacheSetEnabled;
+    }
+
+    public boolean isDispatcherPauseOnAckStatePersistentEnabled() {
+        return dispatcherPauseOnAckStatePersistentEnabled;
+    }
+
+    public void setDispatcherPauseOnAckStatePersistentEnabled(boolean dispatcherPauseOnAckStatePersistentEnabled) {
+        this.dispatcherPauseOnAckStatePersistentEnabled = dispatcherPauseOnAckStatePersistentEnabled;
+    }
+
+    public boolean isAutoSkipNonRecoverableData() {
+        return autoSkipNonRecoverableData;
+    }
+
+    public void setAutoSkipNonRecoverableData(boolean autoSkipNonRecoverableData) {
+        this.autoSkipNonRecoverableData = autoSkipNonRecoverableData;
+    }
+
+    public long getManagedLedgerMetadataOperationsTimeoutSeconds() {
+        return managedLedgerMetadataOperationsTimeoutSeconds;
+    }
+
+    public void setManagedLedgerMetadataOperationsTimeoutSeconds(long managedLedgerMetadataOperationsTimeoutSeconds) {
+        this.managedLedgerMetadataOperationsTimeoutSeconds = managedLedgerMetadataOperationsTimeoutSeconds;
+    }
+
+    public long getManagedLedgerReadEntryTimeoutSeconds() {
+        return managedLedgerReadEntryTimeoutSeconds;
+    }
+
+    public void setManagedLedgerReadEntryTimeoutSeconds(long managedLedgerReadEntryTimeoutSeconds) {
+        this.managedLedgerReadEntryTimeoutSeconds = managedLedgerReadEntryTimeoutSeconds;
+    }
+
+    public long getManagedLedgerAddEntryTimeoutSeconds() {
+        return managedLedgerAddEntryTimeoutSeconds;
+    }
+
+    public void setManagedLedgerAddEntryTimeoutSeconds(long managedLedgerAddEntryTimeoutSeconds) {
+        this.managedLedgerAddEntryTimeoutSeconds = managedLedgerAddEntryTimeoutSeconds;
+    }
+
+    public int getManagedLedgerPrometheusStatsLatencyRolloverSeconds() {
+        return managedLedgerPrometheusStatsLatencyRolloverSeconds;
+    }
+
+    public void setManagedLedgerPrometheusStatsLatencyRolloverSeconds(
+            int managedLedgerPrometheusStatsLatencyRolloverSeconds) {
+        this.managedLedgerPrometheusStatsLatencyRolloverSeconds = managedLedgerPrometheusStatsLatencyRolloverSeconds;
+    }
+
+    public boolean isManagedLedgerTraceTaskExecution() {
+        return managedLedgerTraceTaskExecution;
+    }
+
+    public void setManagedLedgerTraceTaskExecution(boolean managedLedgerTraceTaskExecution) {
+        this.managedLedgerTraceTaskExecution = managedLedgerTraceTaskExecution;
+    }
+
+    public int getManagedLedgerNewEntriesCheckDelayInMillis() {
+        return managedLedgerNewEntriesCheckDelayInMillis;
+    }
+
+    public void setManagedLedgerNewEntriesCheckDelayInMillis(int managedLedgerNewEntriesCheckDelayInMillis) {
+        this.managedLedgerNewEntriesCheckDelayInMillis = managedLedgerNewEntriesCheckDelayInMillis;
+    }
+
+    public String getManagedLedgerDataReadPriority() {
+        return managedLedgerDataReadPriority;
+    }
+
+    public void setManagedLedgerDataReadPriority(String managedLedgerDataReadPriority) {
+        this.managedLedgerDataReadPriority = managedLedgerDataReadPriority;
+    }
+
+    public String getManagedLedgerInfoCompressionType() {
+        return managedLedgerInfoCompressionType;
+    }
+
+    public void setManagedLedgerInfoCompressionType(String managedLedgerInfoCompressionType) {
+        this.managedLedgerInfoCompressionType = managedLedgerInfoCompressionType;
+    }
+
+    public long getManagedLedgerInfoCompressionThresholdInBytes() {
+        return managedLedgerInfoCompressionThresholdInBytes;
+    }
+
+    public void setManagedLedgerInfoCompressionThresholdInBytes(long managedLedgerInfoCompressionThresholdInBytes) {
+        this.managedLedgerInfoCompressionThresholdInBytes = managedLedgerInfoCompressionThresholdInBytes;
+    }
+
+    public String getManagedCursorInfoCompressionType() {
+        return managedCursorInfoCompressionType;
+    }
+
+    public void setManagedCursorInfoCompressionType(String managedCursorInfoCompressionType) {
+        this.managedCursorInfoCompressionType = managedCursorInfoCompressionType;
+    }
+
+    public long getManagedCursorInfoCompressionThresholdInBytes() {
+        return managedCursorInfoCompressionThresholdInBytes;
+    }
+
+    public void setManagedCursorInfoCompressionThresholdInBytes(long managedCursorInfoCompressionThresholdInBytes) {
+        this.managedCursorInfoCompressionThresholdInBytes = managedCursorInfoCompressionThresholdInBytes;
+    }
+
+    public int getManagedLedgerMinimumBacklogCursorsForCaching() {
+        return managedLedgerMinimumBacklogCursorsForCaching;
+    }
+
+    public void setManagedLedgerMinimumBacklogCursorsForCaching(int managedLedgerMinimumBacklogCursorsForCaching) {
+        this.managedLedgerMinimumBacklogCursorsForCaching = managedLedgerMinimumBacklogCursorsForCaching;
+    }
+
+    public int getManagedLedgerMinimumBacklogEntriesForCaching() {
+        return managedLedgerMinimumBacklogEntriesForCaching;
+    }
+
+    public void setManagedLedgerMinimumBacklogEntriesForCaching(int managedLedgerMinimumBacklogEntriesForCaching) {
+        this.managedLedgerMinimumBacklogEntriesForCaching = managedLedgerMinimumBacklogEntriesForCaching;
+    }
+
+    public int getManagedLedgerMaxBacklogBetweenCursorsForCaching() {
+        return managedLedgerMaxBacklogBetweenCursorsForCaching;
+    }
+
+    public void setManagedLedgerMaxBacklogBetweenCursorsForCaching(
+            int managedLedgerMaxBacklogBetweenCursorsForCaching) {
+        this.managedLedgerMaxBacklogBetweenCursorsForCaching = managedLedgerMaxBacklogBetweenCursorsForCaching;
+    }
+
+    public boolean isLoadBalancerEnabled() {
+        return loadBalancerEnabled;
+    }
+
+    public void setLoadBalancerEnabled(boolean loadBalancerEnabled) {
+        this.loadBalancerEnabled = loadBalancerEnabled;
+    }
+
+    @Deprecated
+    public String getLoadBalancerPlacementStrategy() {
+        return loadBalancerPlacementStrategy;
+    }
+
+    @Deprecated
+    public void setLoadBalancerPlacementStrategy(String loadBalancerPlacementStrategy) {
+        this.loadBalancerPlacementStrategy = loadBalancerPlacementStrategy;
+    }
+
+    public String getLoadBalancerLoadSheddingStrategy() {
+        return loadBalancerLoadSheddingStrategy;
+    }
+
+    public void setLoadBalancerLoadSheddingStrategy(String loadBalancerLoadSheddingStrategy) {
+        this.loadBalancerLoadSheddingStrategy = loadBalancerLoadSheddingStrategy;
+    }
+
+    public boolean isLowerBoundarySheddingEnabled() {
+        return lowerBoundarySheddingEnabled;
+    }
+
+    public void setLowerBoundarySheddingEnabled(boolean lowerBoundarySheddingEnabled) {
+        this.lowerBoundarySheddingEnabled = lowerBoundarySheddingEnabled;
+    }
+
+    public String getLoadBalancerLoadPlacementStrategy() {
+        return loadBalancerLoadPlacementStrategy;
+    }
+
+    public void setLoadBalancerLoadPlacementStrategy(String loadBalancerLoadPlacementStrategy) {
+        this.loadBalancerLoadPlacementStrategy = loadBalancerLoadPlacementStrategy;
+    }
+
+    public int getLoadBalancerReportUpdateThresholdPercentage() {
+        return loadBalancerReportUpdateThresholdPercentage;
+    }
+
+    public void setLoadBalancerReportUpdateThresholdPercentage(int loadBalancerReportUpdateThresholdPercentage) {
+        this.loadBalancerReportUpdateThresholdPercentage = loadBalancerReportUpdateThresholdPercentage;
+    }
+
+    public int getLoadBalancerReportUpdateMinIntervalMillis() {
+        return loadBalancerReportUpdateMinIntervalMillis;
+    }
+
+    public void setLoadBalancerReportUpdateMinIntervalMillis(int loadBalancerReportUpdateMinIntervalMillis) {
+        this.loadBalancerReportUpdateMinIntervalMillis = loadBalancerReportUpdateMinIntervalMillis;
+    }
+
+    public int getLoadBalancerReportUpdateMaxIntervalMinutes() {
+        return loadBalancerReportUpdateMaxIntervalMinutes;
+    }
+
+    public void setLoadBalancerReportUpdateMaxIntervalMinutes(int loadBalancerReportUpdateMaxIntervalMinutes) {
+        this.loadBalancerReportUpdateMaxIntervalMinutes = loadBalancerReportUpdateMaxIntervalMinutes;
+    }
+
+    public int getLoadBalancerHostUsageCheckIntervalMinutes() {
+        return loadBalancerHostUsageCheckIntervalMinutes;
+    }
+
+    public void setLoadBalancerHostUsageCheckIntervalMinutes(int loadBalancerHostUsageCheckIntervalMinutes) {
+        this.loadBalancerHostUsageCheckIntervalMinutes = loadBalancerHostUsageCheckIntervalMinutes;
+    }
+
+    public boolean isLoadBalancerSheddingEnabled() {
+        return loadBalancerSheddingEnabled;
+    }
+
+    public void setLoadBalancerSheddingEnabled(boolean loadBalancerSheddingEnabled) {
+        this.loadBalancerSheddingEnabled = loadBalancerSheddingEnabled;
+    }
+
+    public int getLoadBalancerSheddingIntervalMinutes() {
+        return loadBalancerSheddingIntervalMinutes;
+    }
+
+    public void setLoadBalancerSheddingIntervalMinutes(int loadBalancerSheddingIntervalMinutes) {
+        this.loadBalancerSheddingIntervalMinutes = loadBalancerSheddingIntervalMinutes;
+    }
+
+    public boolean isLoadBalancerDistributeBundlesEvenlyEnabled() {
+        return loadBalancerDistributeBundlesEvenlyEnabled;
+    }
+
+    public void setLoadBalancerDistributeBundlesEvenlyEnabled(boolean loadBalancerDistributeBundlesEvenlyEnabled) {
+        this.loadBalancerDistributeBundlesEvenlyEnabled = loadBalancerDistributeBundlesEvenlyEnabled;
+    }
+
+    public long getLoadBalancerSheddingGracePeriodMinutes() {
+        return loadBalancerSheddingGracePeriodMinutes;
+    }
+
+    public void setLoadBalancerSheddingGracePeriodMinutes(long loadBalancerSheddingGracePeriodMinutes) {
+        this.loadBalancerSheddingGracePeriodMinutes = loadBalancerSheddingGracePeriodMinutes;
+    }
+
+    @Deprecated
+    public int getLoadBalancerBrokerUnderloadedThresholdPercentage() {
+        return loadBalancerBrokerUnderloadedThresholdPercentage;
+    }
+
+    @Deprecated
+    public void setLoadBalancerBrokerUnderloadedThresholdPercentage(
+            int loadBalancerBrokerUnderloadedThresholdPercentage) {
+        this.loadBalancerBrokerUnderloadedThresholdPercentage = loadBalancerBrokerUnderloadedThresholdPercentage;
+    }
+
+    public int getLoadBalancerBrokerMaxTopics() {
+        return loadBalancerBrokerMaxTopics;
+    }
+
+    public void setLoadBalancerBrokerMaxTopics(int loadBalancerBrokerMaxTopics) {
+        this.loadBalancerBrokerMaxTopics = loadBalancerBrokerMaxTopics;
+    }
+
+    public int getLoadBalancerBrokerOverloadedThresholdPercentage() {
+        return loadBalancerBrokerOverloadedThresholdPercentage;
+    }
+
+    public void setLoadBalancerBrokerOverloadedThresholdPercentage(
+            int loadBalancerBrokerOverloadedThresholdPercentage) {
+        this.loadBalancerBrokerOverloadedThresholdPercentage = loadBalancerBrokerOverloadedThresholdPercentage;
+    }
+
+    public int getLoadBalancerBrokerThresholdShedderPercentage() {
+        return loadBalancerBrokerThresholdShedderPercentage;
+    }
+
+    public void setLoadBalancerBrokerThresholdShedderPercentage(int loadBalancerBrokerThresholdShedderPercentage) {
+        this.loadBalancerBrokerThresholdShedderPercentage = loadBalancerBrokerThresholdShedderPercentage;
+    }
+
+    public int getLoadBalancerAverageResourceUsageDifferenceThresholdPercentage() {
+        return loadBalancerAverageResourceUsageDifferenceThresholdPercentage;
+    }
+
+    public void setLoadBalancerAverageResourceUsageDifferenceThresholdPercentage(
+            int loadBalancerAverageResourceUsageDifferenceThresholdPercentage) {
+        this.loadBalancerAverageResourceUsageDifferenceThresholdPercentage =
+                loadBalancerAverageResourceUsageDifferenceThresholdPercentage;
+    }
+
+    public int getFlowOrQpsDifferenceThresholdPercentage() {
+        return flowOrQpsDifferenceThresholdPercentage;
+    }
+
+    public void setFlowOrQpsDifferenceThresholdPercentage(int flowOrQpsDifferenceThresholdPercentage) {
+        this.flowOrQpsDifferenceThresholdPercentage = flowOrQpsDifferenceThresholdPercentage;
+    }
+
+    public int getMinUnloadMessage() {
+        return minUnloadMessage;
+    }
+
+    public void setMinUnloadMessage(int minUnloadMessage) {
+        this.minUnloadMessage = minUnloadMessage;
+    }
+
+    public int getMinUnloadMessageThroughput() {
+        return minUnloadMessageThroughput;
+    }
+
+    public void setMinUnloadMessageThroughput(int minUnloadMessageThroughput) {
+        this.minUnloadMessageThroughput = minUnloadMessageThroughput;
+    }
+
+    public double getMaxUnloadPercentage() {
+        return maxUnloadPercentage;
+    }
+
+    public void setMaxUnloadPercentage(double maxUnloadPercentage) {
+        this.maxUnloadPercentage = maxUnloadPercentage;
+    }
+
+    public double getLoadBalancerMsgRateDifferenceShedderThreshold() {
+        return loadBalancerMsgRateDifferenceShedderThreshold;
+    }
+
+    public void setLoadBalancerMsgRateDifferenceShedderThreshold(double loadBalancerMsgRateDifferenceShedderThreshold) {
+        this.loadBalancerMsgRateDifferenceShedderThreshold = loadBalancerMsgRateDifferenceShedderThreshold;
+    }
+
+    public double getLoadBalancerMsgThroughputMultiplierDifferenceShedderThreshold() {
+        return loadBalancerMsgThroughputMultiplierDifferenceShedderThreshold;
+    }
+
+    public void setLoadBalancerMsgThroughputMultiplierDifferenceShedderThreshold(
+            double loadBalancerMsgThroughputMultiplierDifferenceShedderThreshold) {
+        this.loadBalancerMsgThroughputMultiplierDifferenceShedderThreshold =
+                loadBalancerMsgThroughputMultiplierDifferenceShedderThreshold;
+    }
+
+    public int getMaxUnloadBundleNumPerShedding() {
+        return maxUnloadBundleNumPerShedding;
+    }
+
+    public void setMaxUnloadBundleNumPerShedding(int maxUnloadBundleNumPerShedding) {
+        this.maxUnloadBundleNumPerShedding = maxUnloadBundleNumPerShedding;
+    }
+
+    public double getLoadBalancerHistoryResourcePercentage() {
+        return loadBalancerHistoryResourcePercentage;
+    }
+
+    public void setLoadBalancerHistoryResourcePercentage(double loadBalancerHistoryResourcePercentage) {
+        this.loadBalancerHistoryResourcePercentage = loadBalancerHistoryResourcePercentage;
+    }
+
+    public double getLoadBalancerBandwithInResourceWeight() {
+        return loadBalancerBandwithInResourceWeight;
+    }
+
+    public void setLoadBalancerBandwithInResourceWeight(double loadBalancerBandwithInResourceWeight) {
+        this.loadBalancerBandwithInResourceWeight = loadBalancerBandwithInResourceWeight;
+    }
+
+    public double getLoadBalancerBandwithOutResourceWeight() {
+        return loadBalancerBandwithOutResourceWeight;
+    }
+
+    public void setLoadBalancerBandwithOutResourceWeight(double loadBalancerBandwithOutResourceWeight) {
+        this.loadBalancerBandwithOutResourceWeight = loadBalancerBandwithOutResourceWeight;
+    }
+
+    public double getLoadBalancerCPUResourceWeight() {
+        return loadBalancerCPUResourceWeight;
+    }
+
+    public void setLoadBalancerCPUResourceWeight(double loadBalancerCPUResourceWeight) {
+        this.loadBalancerCPUResourceWeight = loadBalancerCPUResourceWeight;
+    }
+
+    @Deprecated(since = "3.0.0")
+    public double getLoadBalancerMemoryResourceWeight() {
+        return loadBalancerMemoryResourceWeight;
+    }
+
+    @Deprecated(since = "3.0.0")
+    public void setLoadBalancerMemoryResourceWeight(double loadBalancerMemoryResourceWeight) {
+        this.loadBalancerMemoryResourceWeight = loadBalancerMemoryResourceWeight;
+    }
+
+    public double getLoadBalancerDirectMemoryResourceWeight() {
+        return loadBalancerDirectMemoryResourceWeight;
+    }
+
+    public void setLoadBalancerDirectMemoryResourceWeight(double loadBalancerDirectMemoryResourceWeight) {
+        this.loadBalancerDirectMemoryResourceWeight = loadBalancerDirectMemoryResourceWeight;
+    }
+
+    public double getLoadBalancerBundleUnloadMinThroughputThreshold() {
+        return loadBalancerBundleUnloadMinThroughputThreshold;
+    }
+
+    public void setLoadBalancerBundleUnloadMinThroughputThreshold(
+            double loadBalancerBundleUnloadMinThroughputThreshold) {
+        this.loadBalancerBundleUnloadMinThroughputThreshold = loadBalancerBundleUnloadMinThroughputThreshold;
+    }
+
+    public int getLoadBalancerResourceQuotaUpdateIntervalMinutes() {
+        return loadBalancerResourceQuotaUpdateIntervalMinutes;
+    }
+
+    public void setLoadBalancerResourceQuotaUpdateIntervalMinutes(
+            int loadBalancerResourceQuotaUpdateIntervalMinutes) {
+        this.loadBalancerResourceQuotaUpdateIntervalMinutes = loadBalancerResourceQuotaUpdateIntervalMinutes;
+    }
+
+    @Deprecated
+    public int getLoadBalancerBrokerComfortLoadLevelPercentage() {
+        return loadBalancerBrokerComfortLoadLevelPercentage;
+    }
+
+    @Deprecated
+    public void setLoadBalancerBrokerComfortLoadLevelPercentage(int loadBalancerBrokerComfortLoadLevelPercentage) {
+        this.loadBalancerBrokerComfortLoadLevelPercentage = loadBalancerBrokerComfortLoadLevelPercentage;
+    }
+
+    public boolean isLoadBalancerAutoBundleSplitEnabled() {
+        return loadBalancerAutoBundleSplitEnabled;
+    }
+
+    public void setLoadBalancerAutoBundleSplitEnabled(boolean loadBalancerAutoBundleSplitEnabled) {
+        this.loadBalancerAutoBundleSplitEnabled = loadBalancerAutoBundleSplitEnabled;
+    }
+
+    public boolean isLoadBalancerAutoUnloadSplitBundlesEnabled() {
+        return loadBalancerAutoUnloadSplitBundlesEnabled;
+    }
+
+    public void setLoadBalancerAutoUnloadSplitBundlesEnabled(boolean loadBalancerAutoUnloadSplitBundlesEnabled) {
+        this.loadBalancerAutoUnloadSplitBundlesEnabled = loadBalancerAutoUnloadSplitBundlesEnabled;
+    }
+
+    public int getLoadBalancerNamespaceBundleMaxTopics() {
+        return loadBalancerNamespaceBundleMaxTopics;
+    }
+
+    public void setLoadBalancerNamespaceBundleMaxTopics(int loadBalancerNamespaceBundleMaxTopics) {
+        this.loadBalancerNamespaceBundleMaxTopics = loadBalancerNamespaceBundleMaxTopics;
+    }
+
+    public int getLoadBalancerNamespaceBundleMaxSessions() {
+        return loadBalancerNamespaceBundleMaxSessions;
+    }
+
+    public void setLoadBalancerNamespaceBundleMaxSessions(int loadBalancerNamespaceBundleMaxSessions) {
+        this.loadBalancerNamespaceBundleMaxSessions = loadBalancerNamespaceBundleMaxSessions;
+    }
+
+    public int getLoadBalancerNamespaceBundleMaxMsgRate() {
+        return loadBalancerNamespaceBundleMaxMsgRate;
+    }
+
+    public void setLoadBalancerNamespaceBundleMaxMsgRate(int loadBalancerNamespaceBundleMaxMsgRate) {
+        this.loadBalancerNamespaceBundleMaxMsgRate = loadBalancerNamespaceBundleMaxMsgRate;
+    }
+
+    public int getLoadBalancerNamespaceBundleMaxBandwidthMbytes() {
+        return loadBalancerNamespaceBundleMaxBandwidthMbytes;
+    }
+
+    public void setLoadBalancerNamespaceBundleMaxBandwidthMbytes(int loadBalancerNamespaceBundleMaxBandwidthMbytes) {
+        this.loadBalancerNamespaceBundleMaxBandwidthMbytes = loadBalancerNamespaceBundleMaxBandwidthMbytes;
+    }
+
+    public int getLoadBalancerNamespaceMaximumBundles() {
+        return loadBalancerNamespaceMaximumBundles;
+    }
+
+    public void setLoadBalancerNamespaceMaximumBundles(int loadBalancerNamespaceMaximumBundles) {
+        this.loadBalancerNamespaceMaximumBundles = loadBalancerNamespaceMaximumBundles;
+    }
+
+    public String getLoadManagerClassName() {
+        return loadManagerClassName;
+    }
+
+    public void setLoadManagerClassName(String loadManagerClassName) {
+        this.loadManagerClassName = loadManagerClassName;
+    }
+
+    public String getTopicBundleAssignmentStrategy() {
+        return topicBundleAssignmentStrategy;
+    }
+
+    public void setTopicBundleAssignmentStrategy(String topicBundleAssignmentStrategy) {
+        this.topicBundleAssignmentStrategy = topicBundleAssignmentStrategy;
+    }
+
+    public List<String> getSupportedNamespaceBundleSplitAlgorithms() {
+        return supportedNamespaceBundleSplitAlgorithms;
+    }
+
+    public void setSupportedNamespaceBundleSplitAlgorithms(List<String> supportedNamespaceBundleSplitAlgorithms) {
+        this.supportedNamespaceBundleSplitAlgorithms = supportedNamespaceBundleSplitAlgorithms;
+    }
+
+    public String getDefaultNamespaceBundleSplitAlgorithm() {
+        return defaultNamespaceBundleSplitAlgorithm;
+    }
+
+    public void setDefaultNamespaceBundleSplitAlgorithm(String defaultNamespaceBundleSplitAlgorithm) {
+        this.defaultNamespaceBundleSplitAlgorithm = defaultNamespaceBundleSplitAlgorithm;
+    }
+
+    public Optional<Double> getLoadBalancerOverrideBrokerNicSpeedGbps() {
+        return loadBalancerOverrideBrokerNicSpeedGbps;
+    }
+
+    public void setLoadBalancerOverrideBrokerNicSpeedGbps(Optional<Double> loadBalancerOverrideBrokerNicSpeedGbps) {
+        this.loadBalancerOverrideBrokerNicSpeedGbps = loadBalancerOverrideBrokerNicSpeedGbps;
+    }
+
+    public long getNamespaceBundleUnloadingTimeoutMs() {
+        return namespaceBundleUnloadingTimeoutMs;
+    }
+
+    public void setNamespaceBundleUnloadingTimeoutMs(long namespaceBundleUnloadingTimeoutMs) {
+        this.namespaceBundleUnloadingTimeoutMs = namespaceBundleUnloadingTimeoutMs;
+    }
+
+    public boolean isLoadBalancerDebugModeEnabled() {
+        return loadBalancerDebugModeEnabled;
+    }
+
+    public void setLoadBalancerDebugModeEnabled(boolean loadBalancerDebugModeEnabled) {
+        this.loadBalancerDebugModeEnabled = loadBalancerDebugModeEnabled;
+    }
+
+    public double getLoadBalancerBrokerLoadTargetStd() {
+        return loadBalancerBrokerLoadTargetStd;
+    }
+
+    public void setLoadBalancerBrokerLoadTargetStd(double loadBalancerBrokerLoadTargetStd) {
+        this.loadBalancerBrokerLoadTargetStd = loadBalancerBrokerLoadTargetStd;
+    }
+
+    public int getLoadBalancerSheddingConditionHitCountThreshold() {
+        return loadBalancerSheddingConditionHitCountThreshold;
+    }
+
+    public void setLoadBalancerSheddingConditionHitCountThreshold(int loadBalancerSheddingConditionHitCountThreshold) {
+        this.loadBalancerSheddingConditionHitCountThreshold = loadBalancerSheddingConditionHitCountThreshold;
+    }
+
+    public boolean isLoadBalancerTransferEnabled() {
+        return loadBalancerTransferEnabled;
+    }
+
+    public void setLoadBalancerTransferEnabled(boolean loadBalancerTransferEnabled) {
+        this.loadBalancerTransferEnabled = loadBalancerTransferEnabled;
+    }
+
+    public int getLoadBalancerMaxNumberOfBrokerSheddingPerCycle() {
+        return loadBalancerMaxNumberOfBrokerSheddingPerCycle;
+    }
+
+    public void setLoadBalancerMaxNumberOfBrokerSheddingPerCycle(int loadBalancerMaxNumberOfBrokerSheddingPerCycle) {
+        this.loadBalancerMaxNumberOfBrokerSheddingPerCycle = loadBalancerMaxNumberOfBrokerSheddingPerCycle;
+    }
+
+    public long getLoadBalanceSheddingDelayInSeconds() {
+        return loadBalanceSheddingDelayInSeconds;
+    }
+
+    public void setLoadBalanceSheddingDelayInSeconds(long loadBalanceSheddingDelayInSeconds) {
+        this.loadBalanceSheddingDelayInSeconds = loadBalanceSheddingDelayInSeconds;
+    }
+
+    public long getLoadBalancerBrokerLoadDataTTLInSeconds() {
+        return loadBalancerBrokerLoadDataTTLInSeconds;
+    }
+
+    public void setLoadBalancerBrokerLoadDataTTLInSeconds(long loadBalancerBrokerLoadDataTTLInSeconds) {
+        this.loadBalancerBrokerLoadDataTTLInSeconds = loadBalancerBrokerLoadDataTTLInSeconds;
+    }
+
+    public int getLoadBalancerMaxNumberOfBundlesInBundleLoadReport() {
+        return loadBalancerMaxNumberOfBundlesInBundleLoadReport;
+    }
+
+    public void setLoadBalancerMaxNumberOfBundlesInBundleLoadReport(
+            int loadBalancerMaxNumberOfBundlesInBundleLoadReport) {
+        this.loadBalancerMaxNumberOfBundlesInBundleLoadReport = loadBalancerMaxNumberOfBundlesInBundleLoadReport;
+    }
+
+    public int getLoadBalancerSplitIntervalMinutes() {
+        return loadBalancerSplitIntervalMinutes;
+    }
+
+    public void setLoadBalancerSplitIntervalMinutes(int loadBalancerSplitIntervalMinutes) {
+        this.loadBalancerSplitIntervalMinutes = loadBalancerSplitIntervalMinutes;
+    }
+
+    public int getLoadBalancerMaxNumberOfBundlesToSplitPerCycle() {
+        return loadBalancerMaxNumberOfBundlesToSplitPerCycle;
+    }
+
+    public void setLoadBalancerMaxNumberOfBundlesToSplitPerCycle(int loadBalancerMaxNumberOfBundlesToSplitPerCycle) {
+        this.loadBalancerMaxNumberOfBundlesToSplitPerCycle = loadBalancerMaxNumberOfBundlesToSplitPerCycle;
+    }
+
+    public int getLoadBalancerNamespaceBundleSplitConditionHitCountThreshold() {
+        return loadBalancerNamespaceBundleSplitConditionHitCountThreshold;
+    }
+
+    public void setLoadBalancerNamespaceBundleSplitConditionHitCountThreshold(
+            int loadBalancerNamespaceBundleSplitConditionHitCountThreshold) {
+        this.loadBalancerNamespaceBundleSplitConditionHitCountThreshold =
+                loadBalancerNamespaceBundleSplitConditionHitCountThreshold;
+    }
+
+    public long getLoadBalancerServiceUnitStateTombstoneDelayTimeInSeconds() {
+        return loadBalancerServiceUnitStateTombstoneDelayTimeInSeconds;
+    }
+
+    public void setLoadBalancerServiceUnitStateTombstoneDelayTimeInSeconds(
+            long loadBalancerServiceUnitStateTombstoneDelayTimeInSeconds) {
+        this.loadBalancerServiceUnitStateTombstoneDelayTimeInSeconds =
+                loadBalancerServiceUnitStateTombstoneDelayTimeInSeconds;
+    }
+
+    public boolean isLoadBalancerSheddingBundlesWithPoliciesEnabled() {
+        return loadBalancerSheddingBundlesWithPoliciesEnabled;
+    }
+
+    public void setLoadBalancerSheddingBundlesWithPoliciesEnabled(
+            boolean loadBalancerSheddingBundlesWithPoliciesEnabled) {
+        this.loadBalancerSheddingBundlesWithPoliciesEnabled = loadBalancerSheddingBundlesWithPoliciesEnabled;
+    }
+
+    public long getLoadBalancerInFlightServiceUnitStateWaitingTimeInMillis() {
+        return loadBalancerInFlightServiceUnitStateWaitingTimeInMillis;
+    }
+
+    public void setLoadBalancerInFlightServiceUnitStateWaitingTimeInMillis(
+            long loadBalancerInFlightServiceUnitStateWaitingTimeInMillis) {
+        this.loadBalancerInFlightServiceUnitStateWaitingTimeInMillis =
+                loadBalancerInFlightServiceUnitStateWaitingTimeInMillis;
+    }
+
+    public long getLoadBalancerServiceUnitStateMonitorIntervalInSeconds() {
+        return loadBalancerServiceUnitStateMonitorIntervalInSeconds;
+    }
+
+    public void setLoadBalancerServiceUnitStateMonitorIntervalInSeconds(
+            long loadBalancerServiceUnitStateMonitorIntervalInSeconds) {
+        this.loadBalancerServiceUnitStateMonitorIntervalInSeconds =
+                loadBalancerServiceUnitStateMonitorIntervalInSeconds;
+    }
+
+    public boolean isLoadBalancerMultiPhaseBundleUnload() {
+        return loadBalancerMultiPhaseBundleUnload;
+    }
+
+    public void setLoadBalancerMultiPhaseBundleUnload(boolean loadBalancerMultiPhaseBundleUnload) {
+        this.loadBalancerMultiPhaseBundleUnload = loadBalancerMultiPhaseBundleUnload;
+    }
+
+    public boolean isReplicationMetricsEnabled() {
+        return replicationMetricsEnabled;
+    }
+
+    public void setReplicationMetricsEnabled(boolean replicationMetricsEnabled) {
+        this.replicationMetricsEnabled = replicationMetricsEnabled;
+    }
+
+    public int getReplicationConnectionsPerBroker() {
+        return replicationConnectionsPerBroker;
+    }
+
+    public void setReplicationConnectionsPerBroker(int replicationConnectionsPerBroker) {
+        this.replicationConnectionsPerBroker = replicationConnectionsPerBroker;
+    }
+
+    public String getReplicatorPrefix() {
+        return replicatorPrefix;
+    }
+
+    public void setReplicatorPrefix(String replicatorPrefix) {
+        this.replicatorPrefix = replicatorPrefix;
+    }
+
+    public int getReplicationProducerQueueSize() {
+        return replicationProducerQueueSize;
+    }
+
+    public void setReplicationProducerQueueSize(int replicationProducerQueueSize) {
+        this.replicationProducerQueueSize = replicationProducerQueueSize;
+    }
+
+    public int getReplicationPolicyCheckDurationSeconds() {
+        return replicationPolicyCheckDurationSeconds;
+    }
+
+    public void setReplicationPolicyCheckDurationSeconds(int replicationPolicyCheckDurationSeconds) {
+        this.replicationPolicyCheckDurationSeconds = replicationPolicyCheckDurationSeconds;
+    }
+
+    @Deprecated
+    public boolean isReplicationTlsEnabled() {
+        return replicationTlsEnabled;
+    }
+
+    @Deprecated
+    public void setReplicationTlsEnabled(boolean replicationTlsEnabled) {
+        this.replicationTlsEnabled = replicationTlsEnabled;
+    }
+
+    public int getDefaultRetentionTimeInMinutes() {
+        return defaultRetentionTimeInMinutes;
+    }
+
+    public void setDefaultRetentionTimeInMinutes(int defaultRetentionTimeInMinutes) {
+        this.defaultRetentionTimeInMinutes = defaultRetentionTimeInMinutes;
+    }
+
+    public int getDefaultRetentionSizeInMB() {
+        return defaultRetentionSizeInMB;
+    }
+
+    public void setDefaultRetentionSizeInMB(int defaultRetentionSizeInMB) {
+        this.defaultRetentionSizeInMB = defaultRetentionSizeInMB;
+    }
+
+    public int getKeepAliveIntervalSeconds() {
+        return keepAliveIntervalSeconds;
+    }
+
+    public void setKeepAliveIntervalSeconds(int keepAliveIntervalSeconds) {
+        this.keepAliveIntervalSeconds = keepAliveIntervalSeconds;
+    }
+
+    public long getConnectionLivenessCheckTimeoutMillis() {
+        return connectionLivenessCheckTimeoutMillis;
+    }
+
+    public void setConnectionLivenessCheckTimeoutMillis(long connectionLivenessCheckTimeoutMillis) {
+        this.connectionLivenessCheckTimeoutMillis = connectionLivenessCheckTimeoutMillis;
+    }
+
+    @Deprecated
+    public int getBrokerServicePurgeInactiveFrequencyInSeconds() {
+        return brokerServicePurgeInactiveFrequencyInSeconds;
+    }
+
+    @Deprecated
+    public void setBrokerServicePurgeInactiveFrequencyInSeconds(int brokerServicePurgeInactiveFrequencyInSeconds) {
+        this.brokerServicePurgeInactiveFrequencyInSeconds = brokerServicePurgeInactiveFrequencyInSeconds;
+    }
+
+    public List<String> getBootstrapNamespaces() {
+        return bootstrapNamespaces;
+    }
+
+    public void setBootstrapNamespaces(List<String> bootstrapNamespaces) {
+        this.bootstrapNamespaces = bootstrapNamespaces;
+    }
+
+    public boolean isPreferLaterVersions() {
+        return preferLaterVersions;
+    }
+
+    public void setPreferLaterVersions(boolean preferLaterVersions) {
+        this.preferLaterVersions = preferLaterVersions;
+    }
+
+    public int getBrokerServiceCompactionMonitorIntervalInSeconds() {
+        return brokerServiceCompactionMonitorIntervalInSeconds;
+    }
+
+    public void setBrokerServiceCompactionMonitorIntervalInSeconds(
+            int brokerServiceCompactionMonitorIntervalInSeconds) {
+        this.brokerServiceCompactionMonitorIntervalInSeconds = brokerServiceCompactionMonitorIntervalInSeconds;
+    }
+
+    public long getBrokerServiceCompactionThresholdInBytes() {
+        return brokerServiceCompactionThresholdInBytes;
+    }
+
+    public void setBrokerServiceCompactionThresholdInBytes(long brokerServiceCompactionThresholdInBytes) {
+        this.brokerServiceCompactionThresholdInBytes = brokerServiceCompactionThresholdInBytes;
+    }
+
+    public long getBrokerServiceCompactionPhaseOneLoopTimeInSeconds() {
+        return brokerServiceCompactionPhaseOneLoopTimeInSeconds;
+    }
+
+    public void setBrokerServiceCompactionPhaseOneLoopTimeInSeconds(
+            long brokerServiceCompactionPhaseOneLoopTimeInSeconds) {
+        this.brokerServiceCompactionPhaseOneLoopTimeInSeconds = brokerServiceCompactionPhaseOneLoopTimeInSeconds;
+    }
+
+    public boolean isTopicCompactionRetainNullKey() {
+        return topicCompactionRetainNullKey;
+    }
+
+    public void setTopicCompactionRetainNullKey(boolean topicCompactionRetainNullKey) {
+        this.topicCompactionRetainNullKey = topicCompactionRetainNullKey;
+    }
+
+    public int getClusterMigrationCheckDurationSeconds() {
+        return clusterMigrationCheckDurationSeconds;
+    }
+
+    public void setClusterMigrationCheckDurationSeconds(int clusterMigrationCheckDurationSeconds) {
+        this.clusterMigrationCheckDurationSeconds = clusterMigrationCheckDurationSeconds;
+    }
+
+    public boolean isClusterMigrationAutoResourceCreation() {
+        return clusterMigrationAutoResourceCreation;
+    }
+
+    public void setClusterMigrationAutoResourceCreation(boolean clusterMigrationAutoResourceCreation) {
+        this.clusterMigrationAutoResourceCreation = clusterMigrationAutoResourceCreation;
+    }
+
+    public boolean isSchemaValidationEnforced() {
+        return isSchemaValidationEnforced;
+    }
+
+    public void setSchemaValidationEnforced(boolean schemaValidationEnforced) {
+        isSchemaValidationEnforced = schemaValidationEnforced;
+    }
+
+    public String getSchemaRegistryStorageClassName() {
+        return schemaRegistryStorageClassName;
+    }
+
+    public void setSchemaRegistryStorageClassName(String schemaRegistryStorageClassName) {
+        this.schemaRegistryStorageClassName = schemaRegistryStorageClassName;
+    }
+
+    public Set<String> getSchemaRegistryCompatibilityCheckers() {
+        return schemaRegistryCompatibilityCheckers;
+    }
+
+    public void setSchemaRegistryCompatibilityCheckers(Set<String> schemaRegistryCompatibilityCheckers) {
+        this.schemaRegistryCompatibilityCheckers = schemaRegistryCompatibilityCheckers;
+    }
+
+    public void setSchemaCompatibilityStrategy(SchemaCompatibilityStrategy schemaCompatibilityStrategy) {
+        this.schemaCompatibilityStrategy = schemaCompatibilityStrategy;
+    }
+
+    public int getWebSocketNumIoThreads() {
+        return webSocketNumIoThreads;
+    }
+
+    public void setWebSocketNumIoThreads(int webSocketNumIoThreads) {
+        this.webSocketNumIoThreads = webSocketNumIoThreads;
+    }
+
+    public int getWebSocketNumServiceThreads() {
+        return webSocketNumServiceThreads;
+    }
+
+    public void setWebSocketNumServiceThreads(int webSocketNumServiceThreads) {
+        this.webSocketNumServiceThreads = webSocketNumServiceThreads;
+    }
+
+    public int getWebSocketConnectionsPerBroker() {
+        return webSocketConnectionsPerBroker;
+    }
+
+    public void setWebSocketConnectionsPerBroker(int webSocketConnectionsPerBroker) {
+        this.webSocketConnectionsPerBroker = webSocketConnectionsPerBroker;
+    }
+
+    public int getWebSocketSessionIdleTimeoutMillis() {
+        return webSocketSessionIdleTimeoutMillis;
+    }
+
+    public void setWebSocketSessionIdleTimeoutMillis(int webSocketSessionIdleTimeoutMillis) {
+        this.webSocketSessionIdleTimeoutMillis = webSocketSessionIdleTimeoutMillis;
+    }
+
+    public int getWebSocketPingDurationSeconds() {
+        return webSocketPingDurationSeconds;
+    }
+
+    public void setWebSocketPingDurationSeconds(int webSocketPingDurationSeconds) {
+        this.webSocketPingDurationSeconds = webSocketPingDurationSeconds;
+    }
+
+    public int getWebSocketMaxTextFrameSize() {
+        return webSocketMaxTextFrameSize;
+    }
+
+    public void setWebSocketMaxTextFrameSize(int webSocketMaxTextFrameSize) {
+        this.webSocketMaxTextFrameSize = webSocketMaxTextFrameSize;
+    }
+
+    public boolean isAuthenticateMetricsEndpoint() {
+        return authenticateMetricsEndpoint;
+    }
+
+    public void setAuthenticateMetricsEndpoint(boolean authenticateMetricsEndpoint) {
+        this.authenticateMetricsEndpoint = authenticateMetricsEndpoint;
+    }
+
+    public boolean isExposeTopicLevelMetricsInPrometheus() {
+        return exposeTopicLevelMetricsInPrometheus;
+    }
+
+    public void setExposeTopicLevelMetricsInPrometheus(boolean exposeTopicLevelMetricsInPrometheus) {
+        this.exposeTopicLevelMetricsInPrometheus = exposeTopicLevelMetricsInPrometheus;
+    }
+
+    public boolean isMetricsBufferResponse() {
+        return metricsBufferResponse;
+    }
+
+    public void setMetricsBufferResponse(boolean metricsBufferResponse) {
+        this.metricsBufferResponse = metricsBufferResponse;
+    }
+
+    public boolean isExposeConsumerLevelMetricsInPrometheus() {
+        return exposeConsumerLevelMetricsInPrometheus;
+    }
+
+    public void setExposeConsumerLevelMetricsInPrometheus(boolean exposeConsumerLevelMetricsInPrometheus) {
+        this.exposeConsumerLevelMetricsInPrometheus = exposeConsumerLevelMetricsInPrometheus;
+    }
+
+    public boolean isExposeProducerLevelMetricsInPrometheus() {
+        return exposeProducerLevelMetricsInPrometheus;
+    }
+
+    public void setExposeProducerLevelMetricsInPrometheus(boolean exposeProducerLevelMetricsInPrometheus) {
+        this.exposeProducerLevelMetricsInPrometheus = exposeProducerLevelMetricsInPrometheus;
+    }
+
+    public boolean isExposeManagedLedgerMetricsInPrometheus() {
+        return exposeManagedLedgerMetricsInPrometheus;
+    }
+
+    public void setExposeManagedLedgerMetricsInPrometheus(boolean exposeManagedLedgerMetricsInPrometheus) {
+        this.exposeManagedLedgerMetricsInPrometheus = exposeManagedLedgerMetricsInPrometheus;
+    }
+
+    public boolean isExposeManagedCursorMetricsInPrometheus() {
+        return exposeManagedCursorMetricsInPrometheus;
+    }
+
+    public void setExposeManagedCursorMetricsInPrometheus(boolean exposeManagedCursorMetricsInPrometheus) {
+        this.exposeManagedCursorMetricsInPrometheus = exposeManagedCursorMetricsInPrometheus;
+    }
+
+    public String getJvmGCMetricsLoggerClassName() {
+        return jvmGCMetricsLoggerClassName;
+    }
+
+    public void setJvmGCMetricsLoggerClassName(String jvmGCMetricsLoggerClassName) {
+        this.jvmGCMetricsLoggerClassName = jvmGCMetricsLoggerClassName;
+    }
+
+    public boolean isExposePreciseBacklogInPrometheus() {
+        return exposePreciseBacklogInPrometheus;
+    }
+
+    public void setExposePreciseBacklogInPrometheus(boolean exposePreciseBacklogInPrometheus) {
+        this.exposePreciseBacklogInPrometheus = exposePreciseBacklogInPrometheus;
+    }
+
+    public long getMetricsServletTimeoutMs() {
+        return metricsServletTimeoutMs;
+    }
+
+    public void setMetricsServletTimeoutMs(long metricsServletTimeoutMs) {
+        this.metricsServletTimeoutMs = metricsServletTimeoutMs;
+    }
+
+    public boolean isExposeSubscriptionBacklogSizeInPrometheus() {
+        return exposeSubscriptionBacklogSizeInPrometheus;
+    }
+
+    public void setExposeSubscriptionBacklogSizeInPrometheus(boolean exposeSubscriptionBacklogSizeInPrometheus) {
+        this.exposeSubscriptionBacklogSizeInPrometheus = exposeSubscriptionBacklogSizeInPrometheus;
+    }
+
+    public boolean isSplitTopicAndPartitionLabelInPrometheus() {
+        return splitTopicAndPartitionLabelInPrometheus;
+    }
+
+    public void setSplitTopicAndPartitionLabelInPrometheus(boolean splitTopicAndPartitionLabelInPrometheus) {
+        this.splitTopicAndPartitionLabelInPrometheus = splitTopicAndPartitionLabelInPrometheus;
+    }
+
+    public boolean isExposeBundlesMetricsInPrometheus() {
+        return exposeBundlesMetricsInPrometheus;
+    }
+
+    public void setExposeBundlesMetricsInPrometheus(boolean exposeBundlesMetricsInPrometheus) {
+        this.exposeBundlesMetricsInPrometheus = exposeBundlesMetricsInPrometheus;
+    }
+
+    public boolean isFunctionsWorkerEnabled() {
+        return functionsWorkerEnabled;
+    }
+
+    public void setFunctionsWorkerEnabled(boolean functionsWorkerEnabled) {
+        this.functionsWorkerEnabled = functionsWorkerEnabled;
+    }
+
+    public String getFunctionsWorkerServiceNarPackage() {
+        return functionsWorkerServiceNarPackage;
+    }
+
+    public void setFunctionsWorkerServiceNarPackage(String functionsWorkerServiceNarPackage) {
+        this.functionsWorkerServiceNarPackage = functionsWorkerServiceNarPackage;
+    }
+
+    public boolean isFunctionsWorkerEnablePackageManagement() {
+        return functionsWorkerEnablePackageManagement;
+    }
+
+    public void setFunctionsWorkerEnablePackageManagement(boolean functionsWorkerEnablePackageManagement) {
+        this.functionsWorkerEnablePackageManagement = functionsWorkerEnablePackageManagement;
+    }
+
+    public boolean isExposePublisherStats() {
+        return exposePublisherStats;
+    }
+
+    public void setExposePublisherStats(boolean exposePublisherStats) {
+        this.exposePublisherStats = exposePublisherStats;
+    }
+
+    public int getStatsUpdateFrequencyInSecs() {
+        return statsUpdateFrequencyInSecs;
+    }
+
+    public void setStatsUpdateFrequencyInSecs(int statsUpdateFrequencyInSecs) {
+        this.statsUpdateFrequencyInSecs = statsUpdateFrequencyInSecs;
+    }
+
+    public int getStatsUpdateInitialDelayInSecs() {
+        return statsUpdateInitialDelayInSecs;
+    }
+
+    public void setStatsUpdateInitialDelayInSecs(int statsUpdateInitialDelayInSecs) {
+        this.statsUpdateInitialDelayInSecs = statsUpdateInitialDelayInSecs;
+    }
+
+    public boolean isAggregatePublisherStatsByProducerName() {
+        return aggregatePublisherStatsByProducerName;
+    }
+
+    public void setAggregatePublisherStatsByProducerName(boolean aggregatePublisherStatsByProducerName) {
+        this.aggregatePublisherStatsByProducerName = aggregatePublisherStatsByProducerName;
+    }
+
+    public String getOffloadersDirectory() {
+        return offloadersDirectory;
+    }
+
+    public void setOffloadersDirectory(String offloadersDirectory) {
+        this.offloadersDirectory = offloadersDirectory;
+    }
+
+    public String getManagedLedgerOffloadDriver() {
+        return managedLedgerOffloadDriver;
+    }
+
+    public void setManagedLedgerOffloadDriver(String managedLedgerOffloadDriver) {
+        this.managedLedgerOffloadDriver = managedLedgerOffloadDriver;
+    }
+
+    public int getManagedLedgerOffloadMaxThreads() {
+        return managedLedgerOffloadMaxThreads;
+    }
+
+    public void setManagedLedgerOffloadMaxThreads(int managedLedgerOffloadMaxThreads) {
+        this.managedLedgerOffloadMaxThreads = managedLedgerOffloadMaxThreads;
+    }
+
+    public String getNarExtractionDirectory() {
+        return narExtractionDirectory;
+    }
+
+    public void setNarExtractionDirectory(String narExtractionDirectory) {
+        this.narExtractionDirectory = narExtractionDirectory;
+    }
+
+    public int getManagedLedgerOffloadPrefetchRounds() {
+        return managedLedgerOffloadPrefetchRounds;
+    }
+
+    public void setManagedLedgerOffloadPrefetchRounds(int managedLedgerOffloadPrefetchRounds) {
+        this.managedLedgerOffloadPrefetchRounds = managedLedgerOffloadPrefetchRounds;
+    }
+
+    public int getManagedLedgerInactiveLedgerRolloverTimeSeconds() {
+        return managedLedgerInactiveLedgerRolloverTimeSeconds;
+    }
+
+    public void setManagedLedgerInactiveLedgerRolloverTimeSeconds(int managedLedgerInactiveLedgerRolloverTimeSeconds) {
+        this.managedLedgerInactiveLedgerRolloverTimeSeconds = managedLedgerInactiveLedgerRolloverTimeSeconds;
+    }
+
+    public boolean isCacheEvictionByMarkDeletedPosition() {
+        return cacheEvictionByMarkDeletedPosition;
+    }
+
+    public void setCacheEvictionByMarkDeletedPosition(boolean cacheEvictionByMarkDeletedPosition) {
+        this.cacheEvictionByMarkDeletedPosition = cacheEvictionByMarkDeletedPosition;
+    }
+
+    public boolean isTransactionCoordinatorEnabled() {
+        return transactionCoordinatorEnabled;
+    }
+
+    public void setTransactionCoordinatorEnabled(boolean transactionCoordinatorEnabled) {
+        this.transactionCoordinatorEnabled = transactionCoordinatorEnabled;
+    }
+
+    public String getTransactionMetadataStoreProviderClassName() {
+        return transactionMetadataStoreProviderClassName;
+    }
+
+    public void setTransactionMetadataStoreProviderClassName(String transactionMetadataStoreProviderClassName) {
+        this.transactionMetadataStoreProviderClassName = transactionMetadataStoreProviderClassName;
+    }
+
+    public String getTransactionBufferProviderClassName() {
+        return transactionBufferProviderClassName;
+    }
+
+    public void setTransactionBufferProviderClassName(String transactionBufferProviderClassName) {
+        this.transactionBufferProviderClassName = transactionBufferProviderClassName;
+    }
+
+    public String getTransactionPendingAckStoreProviderClassName() {
+        return transactionPendingAckStoreProviderClassName;
+    }
+
+    public void setTransactionPendingAckStoreProviderClassName(String transactionPendingAckStoreProviderClassName) {
+        this.transactionPendingAckStoreProviderClassName = transactionPendingAckStoreProviderClassName;
+    }
+
+    public int getNumTransactionReplayThreadPoolSize() {
+        return numTransactionReplayThreadPoolSize;
+    }
+
+    public void setNumTransactionReplayThreadPoolSize(int numTransactionReplayThreadPoolSize) {
+        this.numTransactionReplayThreadPoolSize = numTransactionReplayThreadPoolSize;
+    }
+
+    public int getTransactionBufferSnapshotMaxTransactionCount() {
+        return transactionBufferSnapshotMaxTransactionCount;
+    }
+
+    public void setTransactionBufferSnapshotMaxTransactionCount(int transactionBufferSnapshotMaxTransactionCount) {
+        this.transactionBufferSnapshotMaxTransactionCount = transactionBufferSnapshotMaxTransactionCount;
+    }
+
+    public int getTransactionBufferSnapshotMinTimeInMillis() {
+        return transactionBufferSnapshotMinTimeInMillis;
+    }
+
+    public void setTransactionBufferSnapshotMinTimeInMillis(int transactionBufferSnapshotMinTimeInMillis) {
+        this.transactionBufferSnapshotMinTimeInMillis = transactionBufferSnapshotMinTimeInMillis;
+    }
+
+    public int getTransactionBufferSnapshotSegmentSize() {
+        return transactionBufferSnapshotSegmentSize;
+    }
+
+    public void setTransactionBufferSnapshotSegmentSize(int transactionBufferSnapshotSegmentSize) {
+        this.transactionBufferSnapshotSegmentSize = transactionBufferSnapshotSegmentSize;
+    }
+
+    public boolean isTransactionBufferSegmentedSnapshotEnabled() {
+        return transactionBufferSegmentedSnapshotEnabled;
+    }
+
+    public void setTransactionBufferSegmentedSnapshotEnabled(boolean transactionBufferSegmentedSnapshotEnabled) {
+        this.transactionBufferSegmentedSnapshotEnabled = transactionBufferSegmentedSnapshotEnabled;
+    }
+
+    public int getTransactionBufferClientMaxConcurrentRequests() {
+        return transactionBufferClientMaxConcurrentRequests;
+    }
+
+    public void setTransactionBufferClientMaxConcurrentRequests(int transactionBufferClientMaxConcurrentRequests) {
+        this.transactionBufferClientMaxConcurrentRequests = transactionBufferClientMaxConcurrentRequests;
+    }
+
+    public long getTransactionBufferClientOperationTimeoutInMills() {
+        return transactionBufferClientOperationTimeoutInMills;
+    }
+
+    public void setTransactionBufferClientOperationTimeoutInMills(long transactionBufferClientOperationTimeoutInMills) {
+        this.transactionBufferClientOperationTimeoutInMills = transactionBufferClientOperationTimeoutInMills;
+    }
+
+    public long getMaxActiveTransactionsPerCoordinator() {
+        return maxActiveTransactionsPerCoordinator;
+    }
+
+    public void setMaxActiveTransactionsPerCoordinator(long maxActiveTransactionsPerCoordinator) {
+        this.maxActiveTransactionsPerCoordinator = maxActiveTransactionsPerCoordinator;
+    }
+
+    public long getTransactionPendingAckLogIndexMinLag() {
+        return transactionPendingAckLogIndexMinLag;
+    }
+
+    public void setTransactionPendingAckLogIndexMinLag(long transactionPendingAckLogIndexMinLag) {
+        this.transactionPendingAckLogIndexMinLag = transactionPendingAckLogIndexMinLag;
+    }
+
+    public boolean isTransactionLogBatchedWriteEnabled() {
+        return transactionLogBatchedWriteEnabled;
+    }
+
+    public void setTransactionLogBatchedWriteEnabled(boolean transactionLogBatchedWriteEnabled) {
+        this.transactionLogBatchedWriteEnabled = transactionLogBatchedWriteEnabled;
+    }
+
+    public int getTransactionLogBatchedWriteMaxRecords() {
+        return transactionLogBatchedWriteMaxRecords;
+    }
+
+    public void setTransactionLogBatchedWriteMaxRecords(int transactionLogBatchedWriteMaxRecords) {
+        this.transactionLogBatchedWriteMaxRecords = transactionLogBatchedWriteMaxRecords;
+    }
+
+    public int getTransactionLogBatchedWriteMaxSize() {
+        return transactionLogBatchedWriteMaxSize;
+    }
+
+    public void setTransactionLogBatchedWriteMaxSize(int transactionLogBatchedWriteMaxSize) {
+        this.transactionLogBatchedWriteMaxSize = transactionLogBatchedWriteMaxSize;
+    }
+
+    public int getTransactionLogBatchedWriteMaxDelayInMillis() {
+        return transactionLogBatchedWriteMaxDelayInMillis;
+    }
+
+    public void setTransactionLogBatchedWriteMaxDelayInMillis(int transactionLogBatchedWriteMaxDelayInMillis) {
+        this.transactionLogBatchedWriteMaxDelayInMillis = transactionLogBatchedWriteMaxDelayInMillis;
+    }
+
+    public boolean isTransactionPendingAckBatchedWriteEnabled() {
+        return transactionPendingAckBatchedWriteEnabled;
+    }
+
+    public void setTransactionPendingAckBatchedWriteEnabled(boolean transactionPendingAckBatchedWriteEnabled) {
+        this.transactionPendingAckBatchedWriteEnabled = transactionPendingAckBatchedWriteEnabled;
+    }
+
+    public int getTransactionPendingAckBatchedWriteMaxRecords() {
+        return transactionPendingAckBatchedWriteMaxRecords;
+    }
+
+    public void setTransactionPendingAckBatchedWriteMaxRecords(int transactionPendingAckBatchedWriteMaxRecords) {
+        this.transactionPendingAckBatchedWriteMaxRecords = transactionPendingAckBatchedWriteMaxRecords;
+    }
+
+    public int getTransactionPendingAckBatchedWriteMaxSize() {
+        return transactionPendingAckBatchedWriteMaxSize;
+    }
+
+    public void setTransactionPendingAckBatchedWriteMaxSize(int transactionPendingAckBatchedWriteMaxSize) {
+        this.transactionPendingAckBatchedWriteMaxSize = transactionPendingAckBatchedWriteMaxSize;
+    }
+
+    public int getTransactionPendingAckBatchedWriteMaxDelayInMillis() {
+        return transactionPendingAckBatchedWriteMaxDelayInMillis;
+    }
+
+    public void setTransactionPendingAckBatchedWriteMaxDelayInMillis(
+            int transactionPendingAckBatchedWriteMaxDelayInMillis) {
+        this.transactionPendingAckBatchedWriteMaxDelayInMillis = transactionPendingAckBatchedWriteMaxDelayInMillis;
+    }
+
+    public String getCompactionServiceFactoryClassName() {
+        return compactionServiceFactoryClassName;
+    }
+
+    public void setCompactionServiceFactoryClassName(String compactionServiceFactoryClassName) {
+        this.compactionServiceFactoryClassName = compactionServiceFactoryClassName;
+    }
+
+    public boolean isTlsEnabledWithKeyStore() {
+        return tlsEnabledWithKeyStore;
+    }
+
+    public void setTlsEnabledWithKeyStore(boolean tlsEnabledWithKeyStore) {
+        this.tlsEnabledWithKeyStore = tlsEnabledWithKeyStore;
+    }
+
+    public String getTlsProvider() {
+        return tlsProvider;
+    }
+
+    public void setTlsProvider(String tlsProvider) {
+        this.tlsProvider = tlsProvider;
+    }
+
+    public String getTlsKeyStoreType() {
+        return tlsKeyStoreType;
+    }
+
+    public void setTlsKeyStoreType(String tlsKeyStoreType) {
+        this.tlsKeyStoreType = tlsKeyStoreType;
+    }
+
+    public String getTlsKeyStore() {
+        return tlsKeyStore;
+    }
+
+    public void setTlsKeyStore(String tlsKeyStore) {
+        this.tlsKeyStore = tlsKeyStore;
+    }
+
+    public String getTlsKeyStorePassword() {
+        return tlsKeyStorePassword;
+    }
+
+    public void setTlsKeyStorePassword(String tlsKeyStorePassword) {
+        this.tlsKeyStorePassword = tlsKeyStorePassword;
+    }
+
+    public String getTlsTrustStoreType() {
+        return tlsTrustStoreType;
+    }
+
+    public void setTlsTrustStoreType(String tlsTrustStoreType) {
+        this.tlsTrustStoreType = tlsTrustStoreType;
+    }
+
+    public String getTlsTrustStore() {
+        return tlsTrustStore;
+    }
+
+    public void setTlsTrustStore(String tlsTrustStore) {
+        this.tlsTrustStore = tlsTrustStore;
+    }
+
+    public String getTlsTrustStorePassword() {
+        return tlsTrustStorePassword;
+    }
+
+    public void setTlsTrustStorePassword(String tlsTrustStorePassword) {
+        this.tlsTrustStorePassword = tlsTrustStorePassword;
+    }
+
+    public String getBrokerClientAuthenticationPlugin() {
+        return brokerClientAuthenticationPlugin;
+    }
+
+    public void setBrokerClientAuthenticationPlugin(String brokerClientAuthenticationPlugin) {
+        this.brokerClientAuthenticationPlugin = brokerClientAuthenticationPlugin;
+    }
+
+    public String getBrokerClientAuthenticationParameters() {
+        return brokerClientAuthenticationParameters;
+    }
+
+    public void setBrokerClientAuthenticationParameters(String brokerClientAuthenticationParameters) {
+        this.brokerClientAuthenticationParameters = brokerClientAuthenticationParameters;
+    }
+
+    public boolean isBrokerClientTlsEnabled() {
+        return brokerClientTlsEnabled;
+    }
+
+    public void setBrokerClientTlsEnabled(boolean brokerClientTlsEnabled) {
+        this.brokerClientTlsEnabled = brokerClientTlsEnabled;
+    }
+
+    public boolean isBrokerClientTlsEnabledWithKeyStore() {
+        return brokerClientTlsEnabledWithKeyStore;
+    }
+
+    public void setBrokerClientTlsEnabledWithKeyStore(boolean brokerClientTlsEnabledWithKeyStore) {
+        this.brokerClientTlsEnabledWithKeyStore = brokerClientTlsEnabledWithKeyStore;
+    }
+
+    public String getBrokerClientSslProvider() {
+        return brokerClientSslProvider;
+    }
+
+    public void setBrokerClientSslProvider(String brokerClientSslProvider) {
+        this.brokerClientSslProvider = brokerClientSslProvider;
+    }
+
+    public String getBrokerClientTrustCertsFilePath() {
+        return brokerClientTrustCertsFilePath;
+    }
+
+    public void setBrokerClientTrustCertsFilePath(String brokerClientTrustCertsFilePath) {
+        this.brokerClientTrustCertsFilePath = brokerClientTrustCertsFilePath;
+    }
+
+    public String getBrokerClientKeyFilePath() {
+        return brokerClientKeyFilePath;
+    }
+
+    public void setBrokerClientKeyFilePath(String brokerClientKeyFilePath) {
+        this.brokerClientKeyFilePath = brokerClientKeyFilePath;
+    }
+
+    public String getBrokerClientCertificateFilePath() {
+        return brokerClientCertificateFilePath;
+    }
+
+    public void setBrokerClientCertificateFilePath(String brokerClientCertificateFilePath) {
+        this.brokerClientCertificateFilePath = brokerClientCertificateFilePath;
+    }
+
+    public String getBrokerClientTlsTrustStoreType() {
+        return brokerClientTlsTrustStoreType;
+    }
+
+    public void setBrokerClientTlsTrustStoreType(String brokerClientTlsTrustStoreType) {
+        this.brokerClientTlsTrustStoreType = brokerClientTlsTrustStoreType;
+    }
+
+    public String getBrokerClientTlsTrustStore() {
+        return brokerClientTlsTrustStore;
+    }
+
+    public void setBrokerClientTlsTrustStore(String brokerClientTlsTrustStore) {
+        this.brokerClientTlsTrustStore = brokerClientTlsTrustStore;
+    }
+
+    public String getBrokerClientTlsTrustStorePassword() {
+        return brokerClientTlsTrustStorePassword;
+    }
+
+    public void setBrokerClientTlsTrustStorePassword(String brokerClientTlsTrustStorePassword) {
+        this.brokerClientTlsTrustStorePassword = brokerClientTlsTrustStorePassword;
+    }
+
+    public String getBrokerClientTlsKeyStoreType() {
+        return brokerClientTlsKeyStoreType;
+    }
+
+    public void setBrokerClientTlsKeyStoreType(String brokerClientTlsKeyStoreType) {
+        this.brokerClientTlsKeyStoreType = brokerClientTlsKeyStoreType;
+    }
+
+    public String getBrokerClientTlsKeyStore() {
+        return brokerClientTlsKeyStore;
+    }
+
+    public void setBrokerClientTlsKeyStore(String brokerClientTlsKeyStore) {
+        this.brokerClientTlsKeyStore = brokerClientTlsKeyStore;
+    }
+
+    public String getBrokerClientTlsKeyStorePassword() {
+        return brokerClientTlsKeyStorePassword;
+    }
+
+    public void setBrokerClientTlsKeyStorePassword(String brokerClientTlsKeyStorePassword) {
+        this.brokerClientTlsKeyStorePassword = brokerClientTlsKeyStorePassword;
+    }
+
+    public Set<String> getBrokerClientTlsCiphers() {
+        return brokerClientTlsCiphers;
+    }
+
+    public void setBrokerClientTlsCiphers(Set<String> brokerClientTlsCiphers) {
+        this.brokerClientTlsCiphers = brokerClientTlsCiphers;
+    }
+
+    public Set<String> getBrokerClientTlsProtocols() {
+        return brokerClientTlsProtocols;
+    }
+
+    public void setBrokerClientTlsProtocols(Set<String> brokerClientTlsProtocols) {
+        this.brokerClientTlsProtocols = brokerClientTlsProtocols;
+    }
+
+    public boolean isEnablePackagesManagement() {
+        return enablePackagesManagement;
+    }
+
+    public void setEnablePackagesManagement(boolean enablePackagesManagement) {
+        this.enablePackagesManagement = enablePackagesManagement;
+    }
+
+    public String getPackagesManagementStorageProvider() {
+        return packagesManagementStorageProvider;
+    }
+
+    public void setPackagesManagementStorageProvider(String packagesManagementStorageProvider) {
+        this.packagesManagementStorageProvider = packagesManagementStorageProvider;
+    }
+
+    public int getPackagesReplicas() {
+        return packagesReplicas;
+    }
+
+    public void setPackagesReplicas(int packagesReplicas) {
+        this.packagesReplicas = packagesReplicas;
+    }
+
+    public String getPackagesManagementLedgerRootPath() {
+        return packagesManagementLedgerRootPath;
+    }
+
+    public void setPackagesManagementLedgerRootPath(String packagesManagementLedgerRootPath) {
+        this.packagesManagementLedgerRootPath = packagesManagementLedgerRootPath;
+    }
+
+    public String getAdditionalServletDirectory() {
+        return additionalServletDirectory;
+    }
+
+    public void setAdditionalServletDirectory(String additionalServletDirectory) {
+        this.additionalServletDirectory = additionalServletDirectory;
+    }
+
+    public Set<String> getAdditionalServlets() {
+        return additionalServlets;
+    }
+
+    public void setAdditionalServlets(Set<String> additionalServlets) {
+        this.additionalServlets = additionalServlets;
     }
 }


### PR DESCRIPTION
### Motivation

There are about 500 fields in `ServiceConfiguration`, which is decorated with the `@Getter` and `@Setter` lombok annotations. It makes IDE code completion extremely slow and harms the develop experience.

### Modifications

Replace these annotations with trivial getters and setters generated from Intellj Idea. After this change, the code completion time when I typed `.` on a `ServiceConfiguration` object reduces from about 10 seconds to less than 2 seconds.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: