### PR TITLE
[improve][test] Replace usage of curl in Java test and fix stream leaks

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
@@ -23,18 +23,17 @@ import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
-
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.io.CharStreams;
 import com.google.common.io.Closeables;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.security.KeyStore;
 import java.security.PrivateKey;
@@ -361,68 +360,66 @@ public class WebServiceTest {
 
     @Test
     public void testCompressOutputMetricsInPrometheus() throws Exception {
-
         setupEnv(true, false, false, false, -1, false);
 
         String metricsUrl = pulsar.getWebServiceAddress() + "/metrics/";
 
-        String[] command = {"curl", "-H", "Accept-Encoding: gzip", metricsUrl};
+        URL url = new URL(metricsUrl);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("GET");
+        connection.setRequestProperty("Accept-Encoding", "gzip");
 
-        ProcessBuilder processBuilder = new ProcessBuilder(command);
-        Process process = processBuilder.start();
+        StringBuilder content = new StringBuilder();
 
-        InputStream inputStream = process.getInputStream();
-
-        try {
-            GZIPInputStream gzipInputStream = new GZIPInputStream(inputStream);
-
-            // Process the decompressed content
-            StringBuilder content = new StringBuilder();
-            int data;
-            while ((data = gzipInputStream.read()) != -1) {
-                content.append((char) data);
+        try (InputStream inputStream = connection.getInputStream()) {
+            try (GZIPInputStream gzipInputStream = new GZIPInputStream(inputStream)) {
+                // Process the decompressed content
+                int data;
+                while ((data = gzipInputStream.read()) != -1) {
+                    content.append((char) data);
+                }
             }
-            log.info("Response Content: {}", content);
 
-            process.waitFor();
+            log.info("Response Content: {}", content);
             assertTrue(content.toString().contains("process_cpu_seconds_total"));
         } catch (IOException e) {
             log.error("Failed to decompress the content, likely the content is not compressed ", e);
             fail();
+        } finally {
+            connection.disconnect();
         }
     }
 
     @Test
     public void testUnCompressOutputMetricsInPrometheus() throws Exception {
-
         setupEnv(true, false, false, false, -1, false);
 
         String metricsUrl = pulsar.getWebServiceAddress() + "/metrics/";
 
-        String[] command = {"curl", metricsUrl};
+        URL url = new URL(metricsUrl);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("GET");
 
-        ProcessBuilder processBuilder = new ProcessBuilder(command);
-        Process process = processBuilder.start();
-
-        InputStream inputStream = process.getInputStream();
-        try {
-            GZIPInputStream gzipInputStream = new GZIPInputStream(inputStream);
-            fail();
-        } catch (IOException e) {
-            log.error("Failed to decompress the content, likely the content is not compressed ", e);
-            assertTrue(e instanceof ZipException);
-        }
-
-        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
         StringBuilder content = new StringBuilder();
-        String line;
-        while ((line = reader.readLine()) != null) {
-            content.append(line + "\n");
+
+        try (InputStream inputStream = connection.getInputStream()) {
+            try (GZIPInputStream gzipInputStream = new GZIPInputStream(inputStream)) {
+                fail();
+            } catch (IOException e) {
+                assertTrue(e instanceof ZipException);
+            }
+
+            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+            String line;
+            while ((line = reader.readLine()) != null) {
+                content.append(line + "\n");
+            }
+        } finally {
+            connection.disconnect();
         }
 
         log.info("Response Content: {}", content);
 
-        process.waitFor();
         assertTrue(content.toString().contains("process_cpu_seconds_total"));
     }
 


### PR DESCRIPTION
### Motivation

- it's not a good practice to use curl in Java tests
- the previous tests leaked some InputStream instances

### Modification

- replace `curl` usage with Java's built-in `HttpURLConnection` http client
- use try-finally blocks for closing InputStreams

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->