### PR TITLE
[improve][broker] Reduce the duplicated null check for LeaderElectionService

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -540,16 +540,11 @@ public class NamespaceService implements AutoCloseable {
                                           CompletableFuture<Optional<LookupResult>> lookupFuture,
                                           LookupOptions options) {
         String candidateBroker;
-
         LeaderElectionService les = pulsar.getLeaderElectionService();
         if (les == null) {
-            // The leader election service was not initialized yet. This can happen because the broker service is
-            // initialized first, and it might start receiving lookup requests before the leader election service is
-            // fully initialized.
-            LOG.warn("Leader election service isn't initialized yet. "
-                            + "Returning empty result to lookup. NamespaceBundle[{}]",
-                    bundle);
-            lookupFuture.complete(Optional.empty());
+            LOG.warn("The leader election has not yet been completed! NamespaceBundle[{}]", bundle);
+            lookupFuture.completeExceptionally(
+                    new IllegalStateException("The leader election has not yet been completed!"));
             return;
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -539,12 +539,6 @@ public class NamespaceService implements AutoCloseable {
     private void searchForCandidateBroker(NamespaceBundle bundle,
                                           CompletableFuture<Optional<LookupResult>> lookupFuture,
                                           LookupOptions options) {
-        if (null == pulsar.getLeaderElectionService()) {
-            LOG.warn("The leader election has not yet been completed! NamespaceBundle[{}]", bundle);
-            lookupFuture.completeExceptionally(
-                    new IllegalStateException("The leader election has not yet been completed!"));
-            return;
-        }
         String candidateBroker;
 
         LeaderElectionService les = pulsar.getLeaderElectionService();


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/8101 adds the null check for `LeaderElectionService` in `searchForCandidateBroker` to avoid a null leader election service is accessed because the broker service starts before the leader election service. However, https://github.com/apache/pulsar/pull/8273 adds the null check again.

### Modifications

Only retain one null check.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: