### PR TITLE
[improve][broker] Recover susbcription creation on the broken schema ledger topic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -26,6 +26,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.unsafeGetPartitionedTopicMetadataAsync;
 import static org.apache.pulsar.broker.lookup.TopicLookupBase.lookupTopicAsync;
 import static org.apache.pulsar.broker.service.persistent.PersistentTopic.getMigratedClusterUrl;
+import static org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage.ignoreUnrecoverableBKException;
 import static org.apache.pulsar.common.api.proto.ProtocolVersion.v5;
 import static org.apache.pulsar.common.protocol.Commands.DEFAULT_CONSUMER_EPOCH;
 import static org.apache.pulsar.common.protocol.Commands.newCloseConsumer;
@@ -1291,7 +1292,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                                 .schemaType(schema == null ? null : schema.getType())
                                                 .build();
                                         if (schema != null && schema.getType() != SchemaType.AUTO_CONSUME) {
-                                            return topic.addSchemaIfIdleOrCheckCompatible(schema)
+                                            return ignoreUnrecoverableBKException
+                                                    (topic.addSchemaIfIdleOrCheckCompatible(schema))
                                                     .thenCompose(v -> topic.subscribe(option));
                                         } else {
                                             return topic.subscribe(option);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
@@ -52,6 +52,7 @@ import org.apache.bookkeeper.mledger.impl.LedgerMetadataUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException;
 import org.apache.pulsar.broker.service.schema.exceptions.SchemaException;
 import org.apache.pulsar.common.protocol.schema.SchemaStorage;
 import org.apache.pulsar.common.protocol.schema.SchemaVersion;
@@ -716,6 +717,7 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
         return source.exceptionally(t -> {
             if (t.getCause() != null
                     && (t.getCause() instanceof SchemaException)
+                    && !(t.getCause() instanceof IncompatibleSchemaException)
                     && !((SchemaException) t.getCause()).isRecoverable()) {
                 // Meeting NoSuchLedgerExistsException, NoSuchEntryException or
                 // NoSuchLedgerExistsOnMetadataServerException when reading schemas in


### PR DESCRIPTION
### Motivation

Right now, broker failed to create schema-consumer if the topic's schema ledger is already deleted and broker is not able to recover that ledger. In that case, client will keep receiving below error message and will never be able to consumer on that topic.
```
2024-04-09T23:17:00,140 - INFO  - [pulsar-client-io-35-3:ConsumerImpl] - [persistent://my-prop/ns1/t1][test] Subscribing to topic on cnx [id: 0x59ed6366, L:/127.0.0.1:60336 - R:localhost/127.0.0.1:60330], consumerId 1
2024-04-09T23:17:00,141 - INFO  - [pulsar-io-8-1:ServerCnx] - [[id: 0x92bca72e, L:/127.0.0.1:60330 - R:/127.0.0.1:60336]] Subscribing on topic persistent://my-prop/ns1/t1 / test. consumerId: 1
2024-04-09T23:17:00,142 - WARN  - [PulsarTestContext-executor-OrderedExecutor-0-0:ServerCnx] - [/127.0.0.1:60336][persistent://my-prop/ns1/t1][test] Failed to create consumer: consumerId=1, No such ledger exists on Bookies -  ledger=6 - operation=Failed to open ledger
2024-04-09T23:17:00,143 - WARN  - [pulsar-client-io-35-3:ClientCnx] - [id: 0x59ed6366, L:/127.0.0.1:60336 - R:localhost/127.0.0.1:60330] Received error from server: No such ledger exists on Bookies -  ledger=6 - operation=Failed to open ledger
2024-04-09T23:17:00,143 - WARN  - [pulsar-client-io-35-3:ConsumerImpl] - [persistent://my-prop/ns1/t1][test] Failed to subscribe to topic on localhost/127.0.0.1:60330
2024-04-09T23:17:00,143 - WARN  - [pulsar-client-io-35-3:ConnectionHandler] - [persistent://my-prop/ns1/t1] [test] Error connecting to broker: org.apache.pulsar.client.api.PulsarClientException: {"errorMsg":"No such ledger exists on Bookies -  ledger=6 - operation=Failed to open ledger","reqId":1815857183629359419, "remote":"localhost/127.0.0.1:60330", "local":"/127.0.0.1:60336"}
2024-04-09T23:17:00,143 - WARN  - [pulsar-client-io-35-3:ConnectionHandler] - [persistent://my-prop/ns1/t1] [test] Could not get connection to broker: org.apache.pulsar.client.api.PulsarClientException: {"errorMsg":"No such ledger exists on Bookies -  ledger=6 - operation=Failed to open ledger","reqId":1815857183629359419, "remote":"localhost/127.0.0.1:60330", "local":"/127.0.0.1:60336"} -- Will try again in 1.583 s
2024-04-09T23:17:01,727 - INFO  - [pulsar-timer-84-1:ConnectionHandler] - [persistent://my-prop/ns1/t1] [test] Reconnecting after connection was closed
```

### Modifications

Schema should be recovered if schema ledger is failing to open due to non-recoverable ledger error.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
