### PR TITLE
[improve] Make the config `metricsBufferResponse` description more effective

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2916,7 +2916,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
             category = CATEGORY_METRICS,
             doc = "Set to true to enable the broker to cache the metrics response, default is false. "
-                    + "For scraping metrics more than once per scrape period, the broker generates metrics at the first "
+                    + "For scraping metrics more than once per scrape period(defined by " +
+                    "`managedLedgerStatsPeriodSeconds`, please make sure `managedLedgerStatsPeriodSeconds`" +
+                    " same with your time series DB scrape interval.), the broker generates metrics at the first "
                     + "scrape and returns the same response for the rest of the scrape period. "
     )
     private boolean metricsBufferResponse = false;

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2916,9 +2916,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
             category = CATEGORY_METRICS,
             doc = "Set to true to enable the broker to cache the metrics response, default is false. "
-                    + "For scraping metrics more than once per scrape period(defined by " +
-                    "`managedLedgerStatsPeriodSeconds`, please make sure `managedLedgerStatsPeriodSeconds`" +
-                    " same with your time series DB scrape interval.), the broker generates metrics at the first "
+                    + "For scraping metrics more than once per scrape period(defined by "
+                    + "`managedLedgerStatsPeriodSeconds`, please make sure `managedLedgerStatsPeriodSeconds`"
+                    + " same with your time series DB scrape interval.), the broker generates metrics at the first "
                     + "scrape and returns the same response for the rest of the scrape period. "
     )
     private boolean metricsBufferResponse = false;

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2915,12 +2915,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private boolean exposeTopicLevelMetricsInPrometheus = true;
     @FieldContext(
             category = CATEGORY_METRICS,
-            doc = "Set to true to enable the broker to cache the metrics response, default is false. "
-                    + "For scraping metrics more than once per scrape period(defined by "
-                    + "`managedLedgerStatsPeriodSeconds`, please make sure `managedLedgerStatsPeriodSeconds`"
-                    + " same with your time series DB scrape interval.), the broker generates metrics at the first "
-                    + "scrape and returns the same response for the rest of the scrape period. "
-    )
+            doc = "Set to true to enable the broker to cache the metrics response; the default is false. "
+                    + "The caching period is defined by `managedLedgerStatsPeriodSeconds`. "
+                    + "The broker returns the same response for subsequent requests within the same period. "
+                    + "Ensure that the scrape interval of your monitoring system matches the caching period.")
     private boolean metricsBufferResponse = false;
     @FieldContext(
         category = CATEGORY_METRICS,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2915,7 +2915,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private boolean exposeTopicLevelMetricsInPrometheus = true;
     @FieldContext(
             category = CATEGORY_METRICS,
-            doc = "If true, export buffered metrics"
+            doc = "Set to true to enable the broker to cache the metrics response, default is false. "
+                    + "For scraping metrics more than once per scrape period, the broker generates metrics at the first "
+                    + "scrape and returns the same response for the rest of the scrape period. "
     )
     private boolean metricsBufferResponse = false;
     @FieldContext(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -2902,8 +2902,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
             Producer<byte[]> producer1 = pulsarClient.newProducer().topic(topic).create();
             fail("should fail");
         } catch (PulsarClientException e) {
-            String expectMsg = "Topic '" + topic + "' reached max producers limit";
-            assertTrue(e.getMessage().contains(expectMsg));
+            assertTrue(e.getMessage().contains("Topic reached max producers limit"));
         }
 
         //clean up

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -2902,7 +2902,8 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
             Producer<byte[]> producer1 = pulsarClient.newProducer().topic(topic).create();
             fail("should fail");
         } catch (PulsarClientException e) {
-            assertTrue(e.getMessage().contains("Topic reached max producers limit"));
+            String expectMsg = "Topic '" + topic + "' reached max producers limit";
+            assertTrue(e.getMessage().contains(expectMsg));
         }
 
         //clean up


### PR DESCRIPTION
### Motivation

Referring to: https://github.com/apache/pulsar/issues/22477#issuecomment-2050141202

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
