### PR TITLE
[fix][test] Fix NPE in BookKeeperClusterTestCase tearDown

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -86,7 +86,7 @@ public abstract class BookKeeperClusterTestCase {
 
     protected String testName;
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void handleTestMethodName(Method method) {
         testName = method.getName();
     }
@@ -148,7 +148,7 @@ public abstract class BookKeeperClusterTestCase {
         }
     }
 
-    @BeforeTest
+    @BeforeTest(alwaysRun = true)
     public void setUp() throws Exception {
         setUp(getLedgersRootPath());
     }
@@ -222,7 +222,9 @@ public abstract class BookKeeperClusterTestCase {
             tearDownException = e;
         }
 
-        executor.shutdownNow();
+        if (executor != null) {
+            executor.shutdownNow();
+        }
 
         LOG.info("Tearing down test {} in {} ms.", testName, sw.elapsed(TimeUnit.MILLISECONDS));
         if (tearDownException != null) {


### PR DESCRIPTION
### Motivation

- impacts ManagedLedgerBkTest.tearDown and ManagedLedgerFactoryChangeLedgerPathTest.tearDown

```
  Error:  Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.278 s <<< FAILURE! - in org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryChangeLedgerPathTest
  Error:  org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryChangeLedgerPathTest.tearDown  Time elapsed: 0.186 s  <<< FAILURE!
  java.lang.NullPointerException: Cannot invoke "java.util.concurrent.ExecutorService.shutdownNow()" because "this.executor" is null
  	at org.apache.bookkeeper.test.BookKeeperClusterTestCase.tearDown(BookKeeperClusterTestCase.java:225)
```

and 

```
  Error:  Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.573 s <<< FAILURE! - in org.apache.bookkeeper.mledger.impl.ManagedLedgerBkTest
  Error:  org.apache.bookkeeper.mledger.impl.ManagedLedgerBkTest.tearDown  Time elapsed: 0.446 s  <<< FAILURE!
  java.lang.NullPointerException: Cannot invoke "java.util.concurrent.ExecutorService.shutdownNow()" because "this.executor" is null
  	at org.apache.bookkeeper.test.BookKeeperClusterTestCase.tearDown(BookKeeperClusterTestCase.java:225)
```

### Modifications

- add null check
- add `alwaysRun=true` to Before* methods

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->