### PR TITLE
[fix][test] Move ExtensibleLoadManagerImplTest to flaky tests

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -142,7 +142,7 @@ import org.testng.annotations.Test;
  * Unit test for {@link ExtensibleLoadManagerImpl}.
  */
 @Slf4j
-@Test(groups = "broker")
+@Test(groups = "flaky")
 @SuppressWarnings("unchecked")
 public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBaseTest {
 


### PR DESCRIPTION
### Motivation

- this test is flaky, let's categorize it as flaky until it is stable
- logs for [most recent case](https://github.com/apache/pulsar/actions/runs/8664728390/job/23762246664?pr=22494#step:11:716): https://gist.github.com/lhotari/25d618984841eae4b7fd51ae3908e5d7

### Modifications

- Move ExtensibleLoadManagerImplTest to flaky tests

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->