### PR TITLE
[fix][broker] Fix the applying of namespace policies

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -318,6 +318,9 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
 
         topicPolicies.getDispatcherPauseOnAckStatePersistentEnabled().updateNamespaceValue(
                 namespacePolicies.dispatcherPauseOnAckStatePersistentEnabled);
+        topicPolicies.getResourceGroup().updateNamespaceValue(namespacePolicies.resource_group_name);
+        topicPolicies.getEncryptionRequired().updateNamespaceValue(namespacePolicies.encryption_required);
+        topicPolicies.getAllowAutoUpdateSchema().updateNamespaceValue(namespacePolicies.is_allow_auto_update_schema);
 
         updateEntryFilters();
     }
@@ -1107,7 +1110,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
     /**
      * @deprecated Avoid using the deprecated method
      * #{@link org.apache.pulsar.broker.resources.NamespaceResources#getPoliciesIfCached(NamespaceName)} and we can use
-     * #{@link AbstractTopic#updateResourceGroupLimiter(Policies)} to instead of it.
+     * #{@link AbstractTopic#updateResourceGroupLimiter()} to instead of it.
      */
     @Deprecated
     public void updateResourceGroupLimiter(Optional<Policies> optPolicies) {
@@ -1123,13 +1126,24 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
             log.warn("[{}] Error getting policies {} and publish throttling will be disabled", topic, e.getMessage());
             policies = new Policies();
         }
-        updateResourceGroupLimiter(policies);
+        updateResourceGroupLimiter(policies.resource_group_name);
     }
 
+    /**
+     * @deprecated Use {@link #updateResourceGroupLimiter()} instead.
+     */
+    @Deprecated
     public void updateResourceGroupLimiter(@Nonnull Policies namespacePolicies) {
         requireNonNull(namespacePolicies);
+        updateResourceGroupLimiter(namespacePolicies.resource_group_name);
+    }
+
+    protected void updateResourceGroupLimiter() {
+        updateResourceGroupLimiter(this.topicPolicies.getResourceGroup().get());
+    }
+
+    private void updateResourceGroupLimiter(String rgName) {
         // attach the resource-group level rate limiters, if set
-        String rgName = namespacePolicies.resource_group_name;
         if (rgName != null) {
             final ResourceGroup resourceGroup =
                     brokerService.getPulsar().getResourceGroupServiceManager().resourceGroupGet(rgName);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3310,8 +3310,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         Boolean encryptionRequired = topicPolicies.getEncryptionRequired().get();
         isEncryptionRequired = encryptionRequired != null ? encryptionRequired : false;
-        Boolean allowAutoUpdateSchema = topicPolicies.getAllowAutoUpdateSchema().get();
-        isAllowAutoUpdateSchema = allowAutoUpdateSchema != null ? allowAutoUpdateSchema : false;
+        isAllowAutoUpdateSchema = topicPolicies.getAllowAutoUpdateSchema().get();
 
         // Client permission check.
         subscriptions.forEach((subName, sub) -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -1742,6 +1742,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
                                 brokerService.pulsar().getPulsarResources().getClusterResources()
                                         .getCluster(remoteCluster))));
         replicatorMap.put(remoteReplicatorName, replicator);
+        String cursorName = PersistentReplicator.getReplicatorName(topic.getReplicatorPrefix(), remoteReplicatorName);
 
         // step-1 remove replicator : it will disconnect the producer but it will wait for callback to be completed
         Method removeMethod = PersistentTopic.class.getDeclaredMethod("removeReplicator", String.class);
@@ -1757,7 +1758,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
 
         // step-3 : complete the callback to remove replicator from the list
         ArgumentCaptor<DeleteCursorCallback> captor = ArgumentCaptor.forClass(DeleteCursorCallback.class);
-        Mockito.verify(ledgerMock).asyncDeleteCursor(any(), captor.capture(), any());
+        Mockito.verify(ledgerMock).asyncDeleteCursor(eq(cursorName), captor.capture(), any());
         DeleteCursorCallback callback = captor.getValue();
         callback.deleteCursorComplete(null);
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/HierarchyTopicPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/HierarchyTopicPolicies.java
@@ -61,6 +61,9 @@ public class HierarchyTopicPolicies {
 
     final PolicyHierarchyValue<Boolean> schemaValidationEnforced;
     final PolicyHierarchyValue<EntryFilters> entryFilters;
+    final PolicyHierarchyValue<String> resourceGroup;
+    final PolicyHierarchyValue<Boolean> encryptionRequired;
+    final PolicyHierarchyValue<Boolean> allowAutoUpdateSchema;
 
     public HierarchyTopicPolicies() {
         replicationClusters = new PolicyHierarchyValue<>();
@@ -94,5 +97,8 @@ public class HierarchyTopicPolicies {
         dispatchRate = new PolicyHierarchyValue<>();
         schemaValidationEnforced = new PolicyHierarchyValue<>();
         entryFilters = new PolicyHierarchyValue<>();
+        resourceGroup = new PolicyHierarchyValue<>();
+        encryptionRequired = new PolicyHierarchyValue<>();
+        allowAutoUpdateSchema = new PolicyHierarchyValue<>();
     }
 }


### PR DESCRIPTION
### Motivation

I'm using the rate limiter on the replicator, when an existing topic is initializing, and the replicator's cursor exists, the topic will create the replicator, and then load and apply the namespace and topic policies to the topic(which includes the replicator), but I found the rate limiter doesn't work.

The namespace policies will not be applied to the replicator after the broker restart.

When will this happen:

- The topic policies are disabled.
- The topic policies are enabled, and there are no policies.

### Modifications

- Loading the compaction service and replicator after the namespace and topic policies are loaded
- When there are no topic policies, apply the namespace policies to the topic
- Add `resourceGroup`, `encryptionRequired`, and `allowAutoUpdateSchema` to the `HierarchyTopicPolicies` to unify the policies

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->