### PR TITLE
[improve][fn] Expose `RuntimeFlags` as CLI option for Pulsar Functions and Connectors

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
@@ -165,7 +165,8 @@ public class CmdFunctionsTest {
             "--className", DummyFunction.class.getName(),
             "--dead-letter-topic", "test-dead-letter-topic",
             "--custom-runtime-options", "custom-runtime-options",
-            "--user-config", "{\"key\": [\"value1\", \"value2\"]}"
+            "--user-config", "{\"key\": [\"value1\", \"value2\"]}",
+            "--runtime-flags", "--add-opens java.base/java.lang=ALL-UNNAMED"
         });
 
         CreateFunction creater = cmd.getCreater();
@@ -175,6 +176,7 @@ public class CmdFunctionsTest {
         assertEquals(Boolean.FALSE, creater.getAutoAck());
         assertEquals("test-dead-letter-topic", creater.getDeadLetterTopic());
         assertEquals("custom-runtime-options", creater.getCustomRuntimeOptions());
+        assertEquals("--add-opens java.base/java.lang=ALL-UNNAMED", creater.getRuntimeFlags());
 
         verify(functions, times(1)).createFunction(any(FunctionConfig.class), anyString());
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -377,6 +377,9 @@ public class CmdFunctions extends CmdBase {
         @Option(names = "--dead-letter-topic",
                 description = "The topic where messages that are not processed successfully are sent to #Java")
         protected String deadLetterTopic;
+        @Option(names = "--runtime-flags", description = "Any flags that you want to pass to a runtime"
+                + " (for process & Kubernetes runtime only).")
+        protected String runtimeFlags;
         protected FunctionConfig functionConfig;
         protected String userCodeFile;
 
@@ -674,6 +677,10 @@ public class CmdFunctions extends CmdBase {
                 userCodeFile = functionConfig.getPy();
             } else if (functionConfig.getGo() != null) {
                 userCodeFile = functionConfig.getGo();
+            }
+
+            if (null != runtimeFlags) {
+                functionConfig.setRuntimeFlags(runtimeFlags);
             }
 
             // check if configs are valid

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -404,6 +404,9 @@ public class CmdSinks extends CmdBase {
         protected String transformFunctionConfig;
         @Option(names = "--log-topic", description = "The topic to which the logs of a Pulsar Sink are produced")
         protected String logTopic;
+        @Option(names = "--runtime-flags", description = "Any flags that you want to pass to a runtime"
+                + " (for process & Kubernetes runtime only).")
+        protected String runtimeFlags;
 
         protected SinkConfig sinkConfig;
 
@@ -601,6 +604,9 @@ public class CmdSinks extends CmdBase {
             }
             if (null != logTopic) {
                 sinkConfig.setLogTopic(logTopic);
+            }
+            if (null != runtimeFlags) {
+                sinkConfig.setRuntimeFlags(runtimeFlags);
             }
 
             // check if configs are valid

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -359,6 +359,9 @@ public class CmdSources extends CmdBase {
         protected String secretsString;
         @Option(names = "--log-topic", description = "The topic to which the logs of a Pulsar Sink are produced")
         protected String logTopic;
+        @Option(names = "--runtime-flags", description = "Any flags that you want to pass to a runtime"
+                + " (for process & Kubernetes runtime only).")
+        protected String runtimeFlags;
 
         protected SourceConfig sourceConfig;
 
@@ -496,6 +499,9 @@ public class CmdSources extends CmdBase {
             }
             if (null != logTopic) {
                 sourceConfig.setLogTopic(logTopic);
+            }
+            if (null != runtimeFlags) {
+                sourceConfig.setRuntimeFlags(runtimeFlags);
             }
 
             // check if source configs are valid


### PR DESCRIPTION

### Motivation

The `runtimeFlags` is been used to allow user to customize the java options for both Kubernetes Runtime & Process runtime, the config can be passed by YAML or JSON via pulsar-admin, but not been exposed as any option in CLI.


### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [x] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
