### PR TITLE
[improve][cli]Support for pulsar-shell persistent modes

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
@@ -137,22 +137,22 @@ public class PulsarShell {
         CONFIG("config"),
         DEFAULT("");
 
+        private static final Map<String, ShellMode> COMMAND_MAP = new HashMap<>();
+
+        static {
+            for (ShellMode shellMode: values()) {
+                COMMAND_MAP.put(shellMode.command, shellMode);
+            }
+        }
+
         final String command;
 
         ShellMode(String command) {
             this.command = command;
         }
 
-        private static final Map<String, ShellMode> commandMap = new HashMap<>();
-
-        static {
-            for (ShellMode shellMode: values()) {
-                commandMap.put(shellMode.command, shellMode);
-            }
-        }
-
         public static ShellMode valueOfCommand(String command) {
-            return commandMap.get(command);
+            return COMMAND_MAP.get(command);
         }
     }
     private Properties properties;


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes [21194](https://github.com/apache/pulsar/issues/21194) of apache/pulsar

### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
Pulsar shell doesn't support persistent mode for admin, client, config. If we need to run a lot of admin commands for example, we would need to prefix admin each time. This will provide an alternative approach.

### Modifications

<!-- Describe the modifications you've done. -->
Modified so that `admin`, `client`, `config` commands individually will launch their own mode and prompt message also gets updated. `exit` or `quit` command will exit from the mode to the default mode.
In the admin mode, we can run command `topics` instead of `admin topics`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is already covered by existing tests, such as *(please describe tests)*.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
https://github.com/cognitree/pulsar/pull/6
<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
