### PR TITLE
[improve][broker] Support X-Forwarded-For and HA Proxy Protocol for resolving original client IP of http/https requests

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -94,6 +94,10 @@ webServiceHaProxyProtocolEnabled=false
 # Trust X-Forwarded-For header for resolving the client IP for http/https requests. Default is false.
 webServiceTrustXForwardedFor=false
 
+# Add detailed client/remote and server/local addresses and ports to http/https request logging.
+# Defaults to true when either webServiceHaProxyProtocolEnabled or webServiceTrustXForwardedFor is enabled.
+webServiceLogDetailedAddresses=
+
 # Number of threads to config Netty Acceptor. Default is 1
 numAcceptorThreads=
 

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -88,6 +88,12 @@ advertisedAddress=
 # If true, the real IP addresses of consumers and producers can be obtained when getting topic statistics data.
 haProxyProtocolEnabled=false
 
+# Enable or disable the use of HA proxy protocol for resolving the client IP for http/https requests.
+webServiceHaProxyProtocolEnabled=false
+
+# Trust X-Forwarded-For header for resolving the client IP for http/https requests. Default is false.
+webServiceTrustXForwardedFor=false
+
 # Number of threads to config Netty Acceptor. Default is 1
 numAcceptorThreads=
 

--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -27,6 +27,16 @@ workerHostname: localhost
 workerPort: 6750
 workerPortTls: 6751
 
+# Enable or disable the use of HA proxy protocol for resolving the client IP for http/https requests.
+webServiceHaProxyProtocolEnabled: false
+
+# Trust X-Forwarded-For header for resolving the client IP for http/https requests. Default is false.
+webServiceTrustXForwardedFor: false
+
+# Add detailed client/remote and server/local addresses and ports to http/https request logging.
+# Defaults to true when either webServiceHaProxyProtocolEnabled or webServiceTrustXForwardedFor is enabled.
+webServiceLogDetailedAddresses: null
+
 # The Configuration metadata store url
 # Examples:
 # * zk:my-zk-1:2181,my-zk-2:2181,my-zk-3:2181

--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -63,6 +63,12 @@ advertisedAddress=
 # If true, the real IP addresses of consumers and producers can be obtained when getting topic statistics data.
 haProxyProtocolEnabled=false
 
+# Enable or disable the use of HA proxy protocol for resolving the client IP for http/https requests.
+webServiceHaProxyProtocolEnabled=false
+
+# Trust X-Forwarded-For header for resolving the client IP for http/https requests. Default is false.
+webServiceTrustXForwardedFor=false
+
 # Enables zero-copy transport of data across network interfaces using the splice system call.
 # Zero copy mode cannot be used when TLS is enabled or when proxyLogLevel is > 0.
 proxyZeroCopyModeEnabled=true

--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -69,6 +69,10 @@ webServiceHaProxyProtocolEnabled=false
 # Trust X-Forwarded-For header for resolving the client IP for http/https requests. Default is false.
 webServiceTrustXForwardedFor=false
 
+# Add detailed client/remote and server/local addresses and ports to http/https request logging.
+# Defaults to true when either webServiceHaProxyProtocolEnabled or webServiceTrustXForwardedFor is enabled.
+webServiceLogDetailedAddresses=
+
 # Enables zero-copy transport of data across network interfaces using the splice system call.
 # Zero copy mode cannot be used when TLS is enabled or when proxyLogLevel is > 0.
 proxyZeroCopyModeEnabled=true

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -51,6 +51,12 @@ advertisedAddress=
 # If true, the real IP addresses of consumers and producers can be obtained when getting topic statistics data.
 haProxyProtocolEnabled=false
 
+# Enable or disable the use of HA proxy protocol for resolving the client IP for http/https requests.
+webServiceHaProxyProtocolEnabled=false
+
+# Trust X-Forwarded-For header for resolving the client IP for http/https requests. Default is false.
+webServiceTrustXForwardedFor=false
+
 # Number of threads to use for Netty IO. Default is set to 2 * Runtime.getRuntime().availableProcessors()
 numIOThreads=
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -57,6 +57,10 @@ webServiceHaProxyProtocolEnabled=false
 # Trust X-Forwarded-For header for resolving the client IP for http/https requests. Default is false.
 webServiceTrustXForwardedFor=false
 
+# Add detailed client/remote and server/local addresses and ports to http/https request logging.
+# Defaults to true when either webServiceHaProxyProtocolEnabled or webServiceTrustXForwardedFor is enabled.
+webServiceLogDetailedAddresses=
+
 # Number of threads to use for Netty IO. Default is set to 2 * Runtime.getRuntime().availableProcessors()
 numIOThreads=
 

--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -46,6 +46,16 @@ statusFilePath=
 # Hostname or IP address the service binds on, default is 0.0.0.0.
 bindAddress=0.0.0.0
 
+# Enable or disable the use of HA proxy protocol for resolving the client IP for http/https requests.
+webServiceHaProxyProtocolEnabled=false
+
+# Trust X-Forwarded-For header for resolving the client IP for http/https requests. Default is false.
+webServiceTrustXForwardedFor=false
+
+# Add detailed client/remote and server/local addresses and ports to http/https request logging.
+# Defaults to true when either webServiceHaProxyProtocolEnabled or webServiceTrustXForwardedFor is enabled.
+webServiceLogDetailedAddresses=
+
 # Name of the pulsar cluster to connect to
 clusterName=
 

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,7 @@ flexible messaging model and an intuitive client API.</description>
     <jettison.version>1.5.4</jettison.version>
     <woodstox.version>5.4.0</woodstox.version>
     <wiremock.version>2.33.2</wiremock.version>
+    <consolecaptor.version>1.0.3</consolecaptor.version>
 
     <!-- Plugin dependencies -->
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -260,6 +260,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
                     + "Default is false.")
     private boolean webServiceTrustXForwardedFor = false;
 
+    @FieldContext(category = CATEGORY_SERVER, doc =
+            "Add detailed client/remote and server/local addresses and ports to http/https request logging.\n"
+                    + "Defaults to true when either webServiceHaProxyProtocolEnabled or webServiceTrustXForwardedFor "
+                    + "is enabled.")
+    private Boolean webServiceLogDetailedAddresses;
+
     @FieldContext(
             category = CATEGORY_SERVER,
             doc = "Number of threads to use for Netty Acceptor."

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -250,6 +250,16 @@ public class ServiceConfiguration implements PulsarConfiguration {
                     + " when getting topic statistics data.")
     private boolean haProxyProtocolEnabled;
 
+    @FieldContext(category = CATEGORY_SERVER,
+            doc = "Enable or disable the use of HA proxy protocol for resolving the client IP for http/https "
+                    + "requests. Default is false.")
+    private boolean webServiceHaProxyProtocolEnabled = false;
+
+    @FieldContext(category = CATEGORY_SERVER, doc =
+            "Trust X-Forwarded-For header for resolving the client IP for http/https requests.\n"
+                    + "Default is false.")
+    private boolean webServiceTrustXForwardedFor = false;
+
     @FieldContext(
             category = CATEGORY_SERVER,
             doc = "Number of threads to use for Netty Acceptor."

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/JettyRequestLogFactory.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/JettyRequestLogFactory.java
@@ -18,9 +18,23 @@
  */
 package org.apache.pulsar.broker.web;
 
+import java.net.InetSocketAddress;
 import java.util.TimeZone;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.CustomRequestLog;
+import org.eclipse.jetty.server.ProxyConnectionFactory;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.RequestLog;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.Slf4jRequestLogWriter;
+import org.eclipse.jetty.util.HostPort;
+import org.eclipse.jetty.util.component.ContainerLifeCycle;
 
 /**
  * Class to standardize initialization of a Jetty request logger for all pulsar components.
@@ -58,7 +72,184 @@ public class JettyRequestLogFactory {
      * Build a new Jetty request logger using the format defined in this class.
      * @return a request logger
      */
-    public static CustomRequestLog createRequestLogger() {
-        return new CustomRequestLog(new Slf4jRequestLogWriter(), LOG_FORMAT);
+    public static RequestLog createRequestLogger() {
+        return createRequestLogger(false, null);
+    }
+
+    /**
+     * Build a new Jetty request logger using the format defined in this class.
+     * @param showDetailedAddresses whether to show detailed addresses and ports in logs
+     * @return a request logger
+     */
+    public static RequestLog createRequestLogger(boolean showDetailedAddresses, Server server) {
+        if (!showDetailedAddresses) {
+            return new CustomRequestLog(new Slf4jRequestLogWriter(), LOG_FORMAT);
+        } else {
+            return new OriginalClientIPRequestLog(server);
+        }
+    }
+
+    /**
+     * Logs the original and real remote (client) and local (server) IP addresses
+     * when detailed addresses are enabled.
+     * Tracks the real addresses of remote and local using a registered Connection.Listener
+     * when detailed addresses are enabled.
+     * This is necessary when Proxy Protocol is used to pass the original client IP.
+     */
+    @Slf4j
+    private static class OriginalClientIPRequestLog extends ContainerLifeCycle implements RequestLog {
+        private final ThreadLocal<StringBuilder> requestLogStringBuilder = ThreadLocal.withInitial(StringBuilder::new);
+        private final CustomRequestLog delegate;
+        private final Slf4jRequestLogWriter delegateLogWriter;
+
+        OriginalClientIPRequestLog(Server server) {
+            delegate = new CustomRequestLog(this::write, LOG_FORMAT);
+            addBean(delegate);
+            delegateLogWriter = new Slf4jRequestLogWriter();
+            addBean(delegateLogWriter);
+            if (server != null) {
+                for (Connector connector : server.getConnectors()) {
+                    // adding the listener is only necessary for connectors that use ProxyConnectionFactory
+                    if (connector.getDefaultConnectionFactory() instanceof ProxyConnectionFactory) {
+                        connector.addBean(proxyProtocolOriginalEndpointListener);
+                    }
+                }
+            }
+        }
+
+        void write(String requestEntry) {
+            StringBuilder sb = requestLogStringBuilder.get();
+            sb.setLength(0);
+            sb.append(requestEntry);
+        }
+
+        @Override
+        public void log(Request request, Response response) {
+            delegate.log(request, response);
+            StringBuilder sb = requestLogStringBuilder.get();
+            sb.append(" [R:");
+            sb.append(request.getRemoteHost());
+            sb.append(':');
+            sb.append(request.getRemotePort());
+            InetSocketAddress realRemoteAddress = lookupRealAddress(request.getHttpChannel().getRemoteAddress());
+            if (realRemoteAddress != null) {
+                String realRemoteHost = HostPort.normalizeHost(realRemoteAddress.getHostString());
+                int realRemotePort = realRemoteAddress.getPort();
+                if (!realRemoteHost.equals(request.getRemoteHost()) || realRemotePort != request.getRemotePort()) {
+                    sb.append(" via ");
+                    sb.append(realRemoteHost);
+                    sb.append(':');
+                    sb.append(realRemotePort);
+                }
+            }
+            sb.append("]->[L:");
+            InetSocketAddress realLocalAddress = lookupRealAddress(request.getHttpChannel().getLocalAddress());
+            if (realLocalAddress != null) {
+                String realLocalHost = HostPort.normalizeHost(realLocalAddress.getHostString());
+                int realLocalPort = realLocalAddress.getPort();
+                sb.append(realLocalHost);
+                sb.append(':');
+                sb.append(realLocalPort);
+                if (!realLocalHost.equals(request.getLocalAddr()) || realLocalPort != request.getLocalPort()) {
+                    sb.append(" dst ");
+                    sb.append(request.getLocalAddr());
+                    sb.append(':');
+                    sb.append(request.getLocalPort());
+                }
+            } else {
+                sb.append(request.getLocalAddr());
+                sb.append(':');
+                sb.append(request.getLocalPort());
+            }
+            sb.append(']');
+            try {
+                delegateLogWriter.write(sb.toString());
+            } catch (Exception e) {
+                log.warn("Failed to write request log", e);
+            }
+        }
+
+        private InetSocketAddress lookupRealAddress(InetSocketAddress socketAddress) {
+            if (socketAddress == null) {
+                return null;
+            }
+            if (proxyProtocolRealAddressMapping.isEmpty()) {
+                return socketAddress;
+            }
+            AddressEntry entry = proxyProtocolRealAddressMapping.get(new AddressKey(socketAddress.getHostString(),
+                    socketAddress.getPort()));
+            if (entry != null) {
+                return entry.realAddress;
+            } else {
+                return socketAddress;
+            }
+        }
+
+        private final Connection.Listener proxyProtocolOriginalEndpointListener =
+                new ProxyProtocolOriginalEndpointListener();
+
+        private final ConcurrentHashMap<AddressKey, AddressEntry> proxyProtocolRealAddressMapping =
+                new ConcurrentHashMap<>();
+
+        // Use a record as key since InetSocketAddress hash code changes if the address gets resolved
+        record AddressKey(String hostString, int port) {
+
+        }
+
+        record AddressEntry(InetSocketAddress realAddress, AtomicInteger referenceCount) {
+
+        }
+
+        // Tracks the real addresses of remote and local when detailed addresses are enabled.
+        // This is necessary when Proxy Protocol is used to pass the original client IP.
+        // The Proxy Protocol implementation in Jetty wraps the original endpoint with a ProxyEndPoint
+        // and the real endpoint information isn't available in the request object.
+        // This listener is added to all connectors to track the real addresses of the client and server.
+        class ProxyProtocolOriginalEndpointListener implements Connection.Listener {
+            @Override
+            public void onOpened(Connection connection) {
+                handleConnection(connection, true);
+            }
+
+            @Override
+            public void onClosed(Connection connection) {
+                handleConnection(connection, false);
+            }
+
+            private void handleConnection(Connection connection, boolean increment) {
+                if (connection.getEndPoint() instanceof ProxyConnectionFactory.ProxyEndPoint) {
+                    ProxyConnectionFactory.ProxyEndPoint proxyEndPoint =
+                            (ProxyConnectionFactory.ProxyEndPoint) connection.getEndPoint();
+                    EndPoint originalEndpoint = proxyEndPoint.unwrap();
+                    mapAddress(proxyEndPoint.getLocalAddress(), originalEndpoint.getLocalAddress(), increment);
+                    mapAddress(proxyEndPoint.getRemoteAddress(), originalEndpoint.getRemoteAddress(), increment);
+                }
+            }
+
+            private void mapAddress(InetSocketAddress current, InetSocketAddress real, boolean increment) {
+                // don't add the mapping if the current address is the same as the real address
+                if (real != null && current != null && current.equals(real)) {
+                    return;
+                }
+                AddressKey key = new AddressKey(current.getHostString(), current.getPort());
+                proxyProtocolRealAddressMapping.compute(key, (__, entry) -> {
+                    if (entry == null) {
+                        if (increment) {
+                            entry = new AddressEntry(real, new AtomicInteger(1));
+                        }
+                    } else {
+                        if (increment) {
+                            entry.referenceCount.incrementAndGet();
+                        } else {
+                            if (entry.referenceCount.decrementAndGet() == 0) {
+                                // remove the entry if the reference count drops to 0
+                                entry = null;
+                            }
+                        }
+                    }
+                    return entry;
+                });
+            }
+        }
     }
 }

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -177,6 +177,13 @@
     </dependency>
 
     <dependency>
+      <groupId>io.github.hakky54</groupId>
+      <artifactId>consolecaptor</artifactId>
+      <version>${consolecaptor.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.streamnative.oxia</groupId>
       <artifactId>oxia-testcontainers</artifactId>
       <scope>test</scope>

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -38,6 +38,7 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.ProxyConnectionFactory;
+import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
@@ -309,7 +310,12 @@ public class WebService implements AutoCloseable {
     public void start() throws PulsarServerException {
         try {
             RequestLogHandler requestLogHandler = new RequestLogHandler();
-            requestLogHandler.setRequestLog(JettyRequestLogFactory.createRequestLogger());
+            boolean showDetailedAddresses = pulsar.getConfiguration().getWebServiceLogDetailedAddresses() != null
+                    ? pulsar.getConfiguration().getWebServiceLogDetailedAddresses() :
+                    (pulsar.getConfiguration().isWebServiceHaProxyProtocolEnabled()
+                            || pulsar.getConfiguration().isWebServiceTrustXForwardedFor());
+            RequestLog requestLogger = JettyRequestLogFactory.createRequestLogger(showDetailedAddresses, server);
+            requestLogHandler.setRequestLog(requestLogger);
             handlers.add(0, new ContextHandlerCollection());
             handlers.add(requestLogHandler);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -38,6 +38,7 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.ProxyConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
@@ -163,6 +164,11 @@ public class WebService implements AutoCloseable {
                 }
                 connectionFactories.add(new SslConnectionFactory(sslCtxFactory, httpConnectionFactory.getProtocol()));
                 connectionFactories.add(httpConnectionFactory);
+                // org.eclipse.jetty.server.AbstractConnectionFactory.getFactories contains similar logic
+                // this is needed for TLS authentication
+                if (httpConfig.getCustomizer(SecureRequestCustomizer.class) == null) {
+                    httpConfig.addCustomizer(new SecureRequestCustomizer());
+                }
                 httpsConnector = new ServerConnector(server, connectionFactories.toArray(new ConnectionFactory[0]));
                 httpsConnector.setPort(tlsPort.get());
                 httpsConnector.setHost(pulsar.getBindAddress());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceOriginalClientIPTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceOriginalClientIPTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.web;
+
+import static org.testng.Assert.assertTrue;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import nl.altindag.console.ConsoleCaptor;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.awaitility.Awaitility;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.ProxyProtocolClientConnectionFactory.V2;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker")
+public class WebServiceOriginalClientIPTest extends MockedPulsarServiceBaseTest {
+    HttpClient httpClient;
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        httpClient = new HttpClient(new SslContextFactory(true));
+        httpClient.start();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+        if (httpClient != null) {
+            httpClient.stop();
+        }
+    }
+
+    @Override
+    protected void doInitConf() throws Exception {
+        super.doInitConf();
+        conf.setWebServiceTrustXForwardedFor(true);
+        conf.setWebServiceHaProxyProtocolEnabled(true);
+        conf.setWebServicePortTls(Optional.of(0));
+        conf.setTlsCertificateFilePath(BROKER_CERT_FILE_PATH);
+        conf.setTlsKeyFilePath(BROKER_KEY_FILE_PATH);
+        conf.setTlsTrustCertsFilePath(CA_CERT_FILE_PATH);
+    }
+
+    @DataProvider(name = "tlsEnabled")
+    public Object[][] tlsEnabled() {
+        return new Object[][] { { true }, { false } };
+    }
+
+    @Test(dataProvider = "tlsEnabled")
+    public void testClientIPIsPickedFromXForwardedForHeaderAndLogged(boolean tlsEnabled) throws Exception {
+        String metricsUrl =
+                (tlsEnabled ? pulsar.getWebServiceAddressTls() : pulsar.getWebServiceAddress()) + "/metrics/";
+        ConsoleCaptor consoleCaptor = new ConsoleCaptor();
+        try {
+            Awaitility.await().untilAsserted(() -> {
+                consoleCaptor.clearOutput();
+
+                // Send a GET request to the metrics URL
+                ContentResponse response = httpClient.newRequest(metricsUrl)
+                        .header("X-Forwarded-For", "11.22.33.44")
+                        .send();
+
+                // Validate the response
+                assertTrue(response.getContentAsString().contains("process_cpu_seconds_total"));
+
+                // Validate that the client IP passed in HA Proxy protocol is logged
+                assertTrue(consoleCaptor.getStandardOutput().stream()
+                        .anyMatch(line -> line.contains("RequestLog") && line.contains("- 11.22.33.44")));
+            });
+        } finally {
+            consoleCaptor.close();
+        }
+    }
+
+
+    @Test(dataProvider = "tlsEnabled")
+    public void testClientIPIsPickedFromHAProxyProtocolAndLogged(boolean tlsEnabled) throws Exception {
+        String metricsUrl = (tlsEnabled ? pulsar.getWebServiceAddressTls() : pulsar.getWebServiceAddress()) + "/metrics/";
+        ConsoleCaptor consoleCaptor = new ConsoleCaptor();
+        try {
+            Awaitility.await().untilAsserted(() -> {
+                consoleCaptor.clearOutput();
+
+                // Send a GET request to the metrics URL
+                ContentResponse response = httpClient.newRequest(metricsUrl)
+                        // Jetty client will add HA Proxy protocol header with the given IP to the request
+                        .tag(new V2.Tag("99.22.33.44", 1234))
+                        .send();
+
+                // Validate the response
+                assertTrue(response.getContentAsString().contains("process_cpu_seconds_total"));
+
+                // Validate that the client IP passed in HA Proxy protocol is logged
+                assertTrue(consoleCaptor.getStandardOutput().stream()
+                        .anyMatch(line -> line.contains("RequestLog") && line.contains("- 99.22.33.44")));
+            });
+        } finally {
+            consoleCaptor.close();
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceOriginalClientIPTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceOriginalClientIPTest.java
@@ -88,7 +88,7 @@ public class WebServiceOriginalClientIPTest extends MockedPulsarServiceBaseTest 
                 // Validate the response
                 assertTrue(response.getContentAsString().contains("process_cpu_seconds_total"));
 
-                // Validate that the client IP passed in HA Proxy protocol is logged
+                // Validate that the client IP passed in X-Forwarded-For is logged
                 assertTrue(consoleCaptor.getStandardOutput().stream()
                         .anyMatch(line -> line.contains("RequestLog") && line.contains("- 11.22.33.44")));
             });

--- a/pulsar-broker/src/test/resources/log4j2.xml
+++ b/pulsar-broker/src/test/resources/log4j2.xml
@@ -23,7 +23,8 @@
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xsi:schemaLocation="http://logging.apache.org/log4j/2.0/config https://logging.apache.org/log4j/2.0/log4j-core.xsd">
   <Appenders>
-    <Console name="CONSOLE" target="SYSTEM_OUT">
+    <!-- setting follow="true" is required for using ConsoleCaptor to validate log messages -->
+    <Console name="CONSOLE" target="SYSTEM_OUT" follow="true">
       <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m%n"/>
     </Console>
   </Appenders>

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -163,6 +163,22 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
             + "(0 to disable limiting)")
     private int maxHttpServerConnections = 2048;
 
+    @FieldContext(category = CATEGORY_WORKER,
+            doc = "Enable or disable the use of HA proxy protocol for resolving the client IP for http/https "
+                    + "requests. Default is false.")
+    private boolean webServiceHaProxyProtocolEnabled = false;
+
+    @FieldContext(category = CATEGORY_WORKER, doc =
+            "Trust X-Forwarded-For header for resolving the client IP for http/https requests.\n"
+                    + "Default is false.")
+    private boolean webServiceTrustXForwardedFor = false;
+
+    @FieldContext(category = CATEGORY_WORKER, doc =
+            "Add detailed client/remote and server/local addresses and ports to http/https request logging.\n"
+                    + "Defaults to true when either webServiceHaProxyProtocolEnabled or webServiceTrustXForwardedFor "
+                    + "is enabled.")
+    private Boolean webServiceLogDetailedAddresses;
+
     @FieldContext(
             category = CATEGORY_WORKER,
             required = false,

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
@@ -35,10 +35,17 @@ import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.rest.api.v2.WorkerApiV2Resource;
 import org.apache.pulsar.functions.worker.rest.api.v2.WorkerStatsApiV2Resource;
 import org.apache.pulsar.jetty.tls.JettySslContextFactory;
+import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.ConnectionLimit;
+import org.eclipse.jetty.server.ForwardedRequestCustomizer;
 import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.ProxyConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
@@ -88,10 +95,21 @@ public class WorkerServer {
             server.addBean(new ConnectionLimit(workerConfig.getMaxHttpServerConnections(), server));
         }
 
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        if (workerConfig.isWebServiceTrustXForwardedFor()) {
+            httpConfig.addCustomizer(new ForwardedRequestCustomizer());
+        }
+        HttpConnectionFactory httpConnectionFactory = new HttpConnectionFactory(httpConfig);
+
         List<ServerConnector> connectors = new ArrayList<>();
         if (this.workerConfig.getWorkerPort() != null) {
             log.info("Configuring http server on port={}", this.workerConfig.getWorkerPort());
-            httpConnector = new ServerConnector(server);
+            List<ConnectionFactory> connectionFactories = new ArrayList<>();
+            if (workerConfig.isWebServiceHaProxyProtocolEnabled()) {
+                connectionFactories.add(new ProxyConnectionFactory());
+            }
+            connectionFactories.add(httpConnectionFactory);
+            httpConnector = new ServerConnector(server, connectionFactories.toArray(new ConnectionFactory[0]));
             httpConnector.setPort(this.workerConfig.getWorkerPort());
             connectors.add(httpConnector);
         }
@@ -109,7 +127,10 @@ public class WorkerServer {
             workerConfig.isAuthenticateMetricsEndpoint(), filterInitializer));
 
         RequestLogHandler requestLogHandler = new RequestLogHandler();
-        requestLogHandler.setRequestLog(JettyRequestLogFactory.createRequestLogger());
+        boolean showDetailedAddresses = workerConfig.getWebServiceLogDetailedAddresses() != null
+                ? workerConfig.getWebServiceLogDetailedAddresses() :
+                (workerConfig.isWebServiceHaProxyProtocolEnabled() || workerConfig.isWebServiceTrustXForwardedFor());
+        requestLogHandler.setRequestLog(JettyRequestLogFactory.createRequestLogger(showDetailedAddresses, server));
         handlers.add(0, new ContextHandlerCollection());
         handlers.add(requestLogHandler);
 
@@ -161,7 +182,18 @@ public class WorkerServer {
                             workerConfig.getTlsCertRefreshCheckDurationSec()
                     );
                 }
-                httpsConnector = new ServerConnector(server, sslCtxFactory);
+                List<ConnectionFactory> connectionFactories = new ArrayList<>();
+                if (workerConfig.isWebServiceHaProxyProtocolEnabled()) {
+                    connectionFactories.add(new ProxyConnectionFactory());
+                }
+                connectionFactories.add(new SslConnectionFactory(sslCtxFactory, httpConnectionFactory.getProtocol()));
+                connectionFactories.add(httpConnectionFactory);
+                // org.eclipse.jetty.server.AbstractConnectionFactory.getFactories contains similar logic
+                // this is needed for TLS authentication
+                if (httpConfig.getCustomizer(SecureRequestCustomizer.class) == null) {
+                    httpConfig.addCustomizer(new SecureRequestCustomizer());
+                }
+                httpsConnector = new ServerConnector(server, connectionFactories.toArray(new ConnectionFactory[0]));
                 httpsConnector.setPort(this.workerConfig.getWorkerPortTls());
                 connectors.add(httpsConnector);
             } catch (Exception e) {

--- a/pulsar-proxy/pom.xml
+++ b/pulsar-proxy/pom.xml
@@ -209,6 +209,12 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.github.hakky54</groupId>
+      <artifactId>consolecaptor</artifactId>
+      <version>${consolecaptor.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -278,6 +278,12 @@ public class ProxyConfiguration implements PulsarConfiguration {
                     + "Default is false.")
     private boolean webServiceTrustXForwardedFor = false;
 
+    @FieldContext(category = CATEGORY_SERVER, doc =
+            "Add detailed client/remote and server/local addresses and ports to http/https request logging.\n"
+                    + "Defaults to true when either webServiceHaProxyProtocolEnabled or webServiceTrustXForwardedFor "
+                    + "is enabled.")
+    private Boolean webServiceLogDetailedAddresses;
+
     @FieldContext(category = CATEGORY_SERVER,
             doc = "Enables zero-copy transport of data across network interfaces using the spice. "
                     + "Zero copy mode cannot be used when TLS is enabled or when proxyLogLevel is > 0.")

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -269,6 +269,16 @@ public class ProxyConfiguration implements PulsarConfiguration {
     private boolean haProxyProtocolEnabled;
 
     @FieldContext(category = CATEGORY_SERVER,
+            doc = "Enable or disable the use of HA proxy protocol for resolving the client IP for http/https "
+                    + "requests. Default is false.")
+    private boolean webServiceHaProxyProtocolEnabled = false;
+
+    @FieldContext(category = CATEGORY_SERVER, doc =
+            "Trust X-Forwarded-For header for resolving the client IP for http/https requests.\n"
+                    + "Default is false.")
+    private boolean webServiceTrustXForwardedFor = false;
+
+    @FieldContext(category = CATEGORY_SERVER,
             doc = "Enables zero-copy transport of data across network interfaces using the spice. "
                     + "Zero copy mode cannot be used when TLS is enabled or when proxyLogLevel is > 0.")
     private boolean proxyZeroCopyModeEnabled = true;

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
@@ -35,6 +35,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import lombok.Getter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
@@ -109,8 +110,15 @@ public class ProxyServiceStarter {
     private WebServer server;
     private WebSocketService webSocketService;
     private static boolean metricsInitialized;
+    private boolean embeddedMode;
 
     public ProxyServiceStarter(String[] args) throws Exception {
+        this(args, null, false);
+    }
+
+    public ProxyServiceStarter(String[] args, Consumer<ProxyConfiguration> proxyConfigurationCustomizer,
+                               boolean embeddedMode) throws Exception {
+        this.embeddedMode = embeddedMode;
         try {
             DateFormat dateFormat = new SimpleDateFormat(
                 FixedDateFormat.FixedFormat.ISO8601_OFFSET_DATE_TIME_HHMM.getPattern());
@@ -132,15 +140,26 @@ public class ProxyServiceStarter {
                     CmdGenerateDocs cmd = new CmdGenerateDocs("pulsar");
                     cmd.addCommand("proxy", commander);
                     cmd.run(null);
-                    System.exit(0);
+                    if (embeddedMode) {
+                        return;
+                    } else {
+                        System.exit(0);
+                    }
                 }
             } catch (Exception e) {
                 commander.getErr().println(e);
-                System.exit(1);
+                if (embeddedMode) {
+                    return;
+                } else {
+                    System.exit(1);
+                }
             }
 
             // load config file
             config = PulsarConfigurationLoader.create(configFile, ProxyConfiguration.class);
+            if (proxyConfigurationCustomizer != null) {
+                proxyConfigurationCustomizer.accept(config);
+            }
 
             if (!isBlank(zookeeperServers)) {
                 // Use zookeeperServers from command line
@@ -230,7 +249,9 @@ public class ProxyServiceStarter {
         // create a web-service
         server = new WebServer(config, authenticationService);
 
-        Runtime.getRuntime().addShutdownHook(new Thread(this::close));
+        if (!embeddedMode) {
+            Runtime.getRuntime().addShutdownHook(new Thread(this::close));
+        }
 
         proxyService.start();
 
@@ -293,7 +314,9 @@ public class ProxyServiceStarter {
         } catch (Exception e) {
             log.warn("server couldn't stop gracefully {}", e.getMessage(), e);
         } finally {
-            LogManager.shutdown();
+            if (!embeddedMode) {
+                LogManager.shutdown();
+            }
         }
     }
 

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
@@ -37,13 +37,17 @@ import org.apache.pulsar.broker.web.JsonMapperProvider;
 import org.apache.pulsar.broker.web.RateLimitingFilter;
 import org.apache.pulsar.broker.web.WebExecutorThreadPool;
 import org.apache.pulsar.jetty.tls.JettySslContextFactory;
+import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.ConnectionLimit;
 import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.ForwardedRequestCustomizer;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.ProxyConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
@@ -93,12 +97,21 @@ public class WebServer {
         List<ServerConnector> connectors = new ArrayList<>();
 
         HttpConfiguration httpConfig = new HttpConfiguration();
+        if (config.isWebServiceTrustXForwardedFor()) {
+            httpConfig.addCustomizer(new ForwardedRequestCustomizer());
+        }
         httpConfig.setOutputBufferSize(config.getHttpOutputBufferSize());
         httpConfig.setRequestHeaderSize(config.getHttpMaxRequestHeaderSize());
 
+        HttpConnectionFactory httpConnectionFactory = new HttpConnectionFactory(httpConfig);
         if (config.getWebServicePort().isPresent()) {
             this.externalServicePort = config.getWebServicePort().get();
-            connector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));
+            List<ConnectionFactory> connectionFactories = new ArrayList<>();
+            if (config.isWebServiceHaProxyProtocolEnabled()) {
+                connectionFactories.add(new ProxyConnectionFactory());
+            }
+            connectionFactories.add(httpConnectionFactory);
+            connector = new ServerConnector(server, connectionFactories.toArray(new ConnectionFactory[0]));
             connector.setHost(config.getBindAddress());
             connector.setPort(externalServicePort);
             connectors.add(connector);
@@ -133,7 +146,13 @@ public class WebServer {
                             config.getWebServiceTlsProtocols(),
                             config.getTlsCertRefreshCheckDurationSec());
                 }
-                connectorTls = new ServerConnector(server, sslCtxFactory, new HttpConnectionFactory(httpConfig));
+                List<ConnectionFactory> connectionFactories = new ArrayList<>();
+                if (config.isWebServiceHaProxyProtocolEnabled()) {
+                    connectionFactories.add(new ProxyConnectionFactory());
+                }
+                connectionFactories.add(new SslConnectionFactory(sslCtxFactory, httpConnectionFactory.getProtocol()));
+                connectionFactories.add(httpConnectionFactory);
+                connectorTls = new ServerConnector(server, connectionFactories.toArray(new ConnectionFactory[0]));
                 connectorTls.setPort(config.getWebServicePortTls().get());
                 connectorTls.setHost(config.getBindAddress());
                 connectors.add(connectorTls);

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
@@ -306,7 +306,10 @@ public class WebServer {
 
     public void start() throws Exception {
         RequestLogHandler requestLogHandler = new RequestLogHandler();
-        requestLogHandler.setRequestLog(JettyRequestLogFactory.createRequestLogger());
+        boolean showDetailedAddresses = config.getWebServiceLogDetailedAddresses() != null
+                ? config.getWebServiceLogDetailedAddresses() :
+                (config.isWebServiceHaProxyProtocolEnabled() || config.isWebServiceTrustXForwardedFor());
+        requestLogHandler.setRequestLog(JettyRequestLogFactory.createRequestLogger(showDetailedAddresses, server));
         handlers.add(0, new ContextHandlerCollection());
         handlers.add(requestLogHandler);
 

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
@@ -45,6 +45,7 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.ProxyConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
@@ -152,6 +153,11 @@ public class WebServer {
                 }
                 connectionFactories.add(new SslConnectionFactory(sslCtxFactory, httpConnectionFactory.getProtocol()));
                 connectionFactories.add(httpConnectionFactory);
+                // org.eclipse.jetty.server.AbstractConnectionFactory.getFactories contains similar logic
+                // this is needed for TLS authentication
+                if (httpConfig.getCustomizer(SecureRequestCustomizer.class) == null) {
+                    httpConfig.addCustomizer(new SecureRequestCustomizer());
+                }
                 connectorTls = new ServerConnector(server, connectionFactories.toArray(new ConnectionFactory[0]));
                 connectorTls.setPort(config.getWebServicePortTls().get());
                 connectorTls.setHost(config.getBindAddress());

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyOriginalClientIPTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyOriginalClientIPTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.proxy.server;
+
+import static org.testng.Assert.assertTrue;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import nl.altindag.console.ConsoleCaptor;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.awaitility.Awaitility;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.ProxyProtocolClientConnectionFactory.V2;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker")
+public class ProxyOriginalClientIPTest extends MockedPulsarServiceBaseTest {
+    static final String[] ARGS = new String[]{"-c", "./src/test/resources/proxy.conf"};
+    HttpClient httpClient;
+    ProxyServiceStarter serviceStarter;
+    String webServiceUrl;
+    String webServiceUrlTls;
+
+    @Override
+    @BeforeClass
+    protected void setup() throws Exception {
+        internalSetup();
+        serviceStarter = new ProxyServiceStarter(ARGS, proxyConfig -> {
+            proxyConfig.setBrokerServiceURL(pulsar.getBrokerServiceUrl());
+            proxyConfig.setBrokerWebServiceURL(pulsar.getWebServiceAddress());
+            proxyConfig.setWebServicePort(Optional.of(0));
+            proxyConfig.setWebServicePortTls(Optional.of(0));
+            proxyConfig.setTlsEnabledWithBroker(false);
+            proxyConfig.setTlsCertificateFilePath(PROXY_CERT_FILE_PATH);
+            proxyConfig.setTlsKeyFilePath(PROXY_KEY_FILE_PATH);
+            proxyConfig.setServicePort(Optional.of(0));
+            proxyConfig.setWebSocketServiceEnabled(true);
+            proxyConfig.setBrokerProxyAllowedTargetPorts("*");
+            proxyConfig.setClusterName(configClusterName);
+            proxyConfig.setWebServiceTrustXForwardedFor(true);
+            proxyConfig.setWebServiceHaProxyProtocolEnabled(true);
+        }, true);
+        serviceStarter.start();
+        webServiceUrl = "http://localhost:" + serviceStarter.getServer().getListenPortHTTP().get();
+        webServiceUrlTls = "https://localhost:" + serviceStarter.getServer().getListenPortHTTPS().get();
+        httpClient = new HttpClient(new SslContextFactory(true));
+        httpClient.start();
+    }
+
+    @Override
+    @AfterClass(alwaysRun = true)
+    protected void cleanup() throws Exception {
+        internalCleanup();
+        if (serviceStarter != null) {
+            serviceStarter.close();
+        }
+        if (httpClient != null) {
+            httpClient.stop();
+        }
+    }
+
+    @Override
+    protected void doInitConf() throws Exception {
+        super.doInitConf();
+        conf.setWebServiceTrustXForwardedFor(true);
+    }
+
+    @DataProvider(name = "tlsEnabled")
+    public Object[][] tlsEnabled() {
+        return new Object[][] { { true }, { false } };
+    }
+
+    @Test(dataProvider = "tlsEnabled")
+    public void testClientIPIsPickedFromXForwardedForHeaderAndLogged(boolean tlsEnabled) throws Exception {
+        String metricsUrl = (tlsEnabled ? webServiceUrlTls : webServiceUrl) + "/metrics/";
+        ConsoleCaptor consoleCaptor = new ConsoleCaptor();
+        try {
+            Awaitility.await().untilAsserted(() -> {
+                consoleCaptor.clearOutput();
+
+                // Send a GET request to the metrics URL
+                ContentResponse response = httpClient.newRequest(metricsUrl)
+                        .header("X-Forwarded-For", "11.22.33.44")
+                        .send();
+
+                // Validate the response
+                assertTrue(response.getContentAsString().contains("process_cpu_seconds_total"));
+
+                // Validate that the client IP passed in HA Proxy protocol is logged
+                assertTrue(consoleCaptor.getStandardOutput().stream()
+                        .anyMatch(line -> line.contains("RequestLog") && line.contains("- 11.22.33.44")));
+            });
+        } finally {
+            consoleCaptor.close();
+        }
+    }
+
+
+    @Test(dataProvider = "tlsEnabled")
+    public void testClientIPIsPickedFromHAProxyProtocolAndLogged(boolean tlsEnabled) throws Exception {
+        String metricsUrl = (tlsEnabled ? webServiceUrlTls : webServiceUrl) + "/metrics/";
+        ConsoleCaptor consoleCaptor = new ConsoleCaptor();
+        try {
+            Awaitility.await().untilAsserted(() -> {
+                consoleCaptor.clearOutput();
+
+                // Send a GET request to the metrics URL
+                ContentResponse response = httpClient.newRequest(metricsUrl)
+                        // Jetty client will add HA Proxy protocol header with the given IP to the request
+                        .tag(new V2.Tag("99.22.33.44", 1234))
+                        .send();
+
+                // Validate the response
+                assertTrue(response.getContentAsString().contains("process_cpu_seconds_total"));
+
+                // Validate that the client IP passed in HA Proxy protocol is logged
+                assertTrue(consoleCaptor.getStandardOutput().stream()
+                        .anyMatch(line -> line.contains("RequestLog") && line.contains("- 99.22.33.44")));
+            });
+        } finally {
+            consoleCaptor.close();
+        }
+    }
+}

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyServiceStarterDisableZeroCopyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyServiceStarterDisableZeroCopyTest.java
@@ -27,7 +27,7 @@ public class ProxyServiceStarterDisableZeroCopyTest extends ProxyServiceStarterT
     @BeforeClass
     protected void setup() throws Exception {
         internalSetup();
-        serviceStarter = new ProxyServiceStarter(ARGS);
+        serviceStarter = new ProxyServiceStarter(ARGS, null, true);
         serviceStarter.getConfig().setBrokerServiceURL(pulsar.getBrokerServiceUrl());
         serviceStarter.getConfig().setBrokerWebServiceURL(pulsar.getWebServiceAddress());
         serviceStarter.getConfig().setWebServicePort(Optional.of(0));

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyServiceStarterTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyServiceStarterTest.java
@@ -54,7 +54,7 @@ public class ProxyServiceStarterTest extends MockedPulsarServiceBaseTest {
     @BeforeClass
     protected void setup() throws Exception {
         internalSetup();
-        serviceStarter = new ProxyServiceStarter(ARGS);
+        serviceStarter = new ProxyServiceStarter(ARGS, null, true);
         serviceStarter.getConfig().setBrokerServiceURL(pulsar.getBrokerServiceUrl());
         serviceStarter.getConfig().setBrokerWebServiceURL(pulsar.getWebServiceAddress());
         serviceStarter.getConfig().setWebServicePort(Optional.of(0));

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyServiceTlsStarterTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyServiceTlsStarterTest.java
@@ -55,7 +55,7 @@ public class ProxyServiceTlsStarterTest extends MockedPulsarServiceBaseTest {
     @BeforeClass
     protected void setup() throws Exception {
         internalSetup();
-        serviceStarter = new ProxyServiceStarter(ARGS);
+        serviceStarter = new ProxyServiceStarter(ARGS, null, true);
         serviceStarter.getConfig().setBrokerServiceURL(pulsar.getBrokerServiceUrl());
         serviceStarter.getConfig().setBrokerServiceURLTLS(pulsar.getBrokerServiceUrlTls());
         serviceStarter.getConfig().setBrokerWebServiceURL(pulsar.getWebServiceAddress());

--- a/pulsar-proxy/src/test/resources/log4j2.xml
+++ b/pulsar-proxy/src/test/resources/log4j2.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<Configuration xmlns="http://logging.apache.org/log4j/2.0/config"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://logging.apache.org/log4j/2.0/config https://logging.apache.org/log4j/2.0/log4j-core.xsd">
+  <Appenders>
+    <!-- setting follow="true" is required for using ConsoleCaptor to validate log messages -->
+    <Console name="CONSOLE" target="SYSTEM_OUT" follow="true">
+      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="INFO">
+      <AppenderRef ref="CONSOLE"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -96,6 +96,20 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     @FieldContext(doc = "Hostname or IP address the service binds on, default is 0.0.0.0.")
     private String bindAddress = "0.0.0.0";
 
+    @FieldContext(doc = "Enable or disable the use of HA proxy protocol for resolving the client IP for http/https "
+                    + "requests. Default is false.")
+    private boolean webServiceHaProxyProtocolEnabled = false;
+
+    @FieldContext(doc = "Trust X-Forwarded-For header for resolving the client IP for http/https requests.\n"
+                    + "Default is false.")
+    private boolean webServiceTrustXForwardedFor = false;
+
+    @FieldContext(doc =
+            "Add detailed client/remote and server/local addresses and ports to http/https request logging.\n"
+                    + "Defaults to true when either webServiceHaProxyProtocolEnabled or webServiceTrustXForwardedFor "
+                    + "is enabled.")
+    private Boolean webServiceLogDetailedAddresses;
+
     @FieldContext(doc = "Maximum size of a text message during parsing in WebSocket proxy")
     private int webSocketMaxTextFrameSize = 1024 * 1024;
     // --- Authentication ---


### PR DESCRIPTION
Fixes #22512

### Motivation

See #22512. In some environments, there's a HTTP reverse proxy in front of Pulsar Proxy or Pulsar Broker and there's a desire to log the actual client IP addresses instead of the reverse proxy's IP address. For this purpose, it's now possible to configure the broker or proxy to trust the value of the X-Forwarded-For header. 

X-Forwarded-For support is also useful when Pulsar Proxy is in front of Pulsar Broker. Pulsar Proxy already adds the X-Forwarded-For headers to the request. This change will allow propagating the original client IP from the Pulsar Proxy to the Pulsar Broker as well.

For supporting Layer 4 (TCP) proxies, this PR also includes[ HA Proxy Protocol v1 and v2 support](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) for resolving the original client IP of http/https requests. This is added to ensure that client IP propagation can be configured in all types of configurations.

In the cloud, HA Proxy Protocol is used in Layer 4 (TCP) proxies such as AWS Classic LB or AWS NLB. X-Forwarded-For/Forwarded headers are used in Layer 7 (http reverse proxy) proxies such as AWS ALB.

### Security implications

Enabling `webServiceTrustXForwardedFor=true` or `webServiceHaProxyProtocolEnabled=true` should be only done in environments where only a trusted proxy and trusted clients that can connect to the server with http/https. In other words, network perimeter security should be in place. The reason for this is that any client can set the `X-Forwarded-For` header or the Proxy Protocol prefix and that value would be logged as the client IP.

### Modifications

- Configure [ForwardedRequestCustomizer](https://eclipse.dev/jetty/javadoc/jetty-12/org/eclipse/jetty/server/ForwardedRequestCustomizer.html) for jetty [httpConfiguration](https://github.com/apache/pulsar/blob/20915d1c438783c05778d98a3b77ec485b79d79d/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java#L105) to handle the `X-Forwarded-For` header when `webServiceTrustXForwardedFor=true`.
- Configure [ProxyConnectionFactory](https://eclipse.dev/jetty/javadoc/jetty-12/org/eclipse/jetty/server/ProxyConnectionFactory.html) to handle the [HA Proxy Protocol v1 and v2](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) prefix when `webServiceHaProxyProtocolEnabled=true`.
- Add configuration `webServiceLogDetailedAddresses` to enable logging detailed remote addresses (original and real) and local addresses (real and original destination).
  - example: `[R:99.22.33.44:1234 via 127.0.0.1:56873]->[L:127.0.0.1:56871 dst 5.4.3.1:4321]` is appended to the log entry, such as: `2024-04-19T14:59:15,896 - INFO  - [prometheus-stats-32-1:RequestLog] - 99.22.33.44 - - [19/Apr/2024:14:59:15 +0300] "GET /metrics/ HTTP/1.1" 200 5061 "-" "Jetty/9.4.54.v20240208" 6 [R:99.22.33.44:1234 via 127.0.0.1:56873]->[L:127.0.0.1:56871 dst 5.4.3.1:4321]`
- Add support for all webservers in Pulsar: broker, proxy, function worker and websocket proxy

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->