### PR TITLE
[improve][build] Upgrade OWASP Dependency check version to 9.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@ flexible messaging model and an intuitive client API.</description>
     <errorprone-slf4j.version>0.1.21</errorprone-slf4j.version>
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
-    <dependency-check-maven.version>9.0.7</dependency-check-maven.version>
+    <dependency-check-maven.version>9.1.0</dependency-check-maven.version>
     <roaringbitmap.version>0.9.44</roaringbitmap.version>
     <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
     <oshi.version>6.4.0</oshi.version>


### PR DESCRIPTION
### Motivation

- keep version up-to-date
  - newer versions typically fix bugs in reporting such as false positives
- changelog: https://github.com/jeremylong/DependencyCheck/blob/main/CHANGELOG.md#change-log

### Modifications

- Upgrade dependency-check-maven.version to 9.1.0

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->