### PR TITLE
[improve][offload] Apply autoSkipNonRecoverableData configuration to tiered storage

### DIFF
--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
@@ -270,7 +270,7 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
                                   VersionCheck versionCheck,
                                   long ledgerId, int readBufferSize,
                                   LedgerOffloaderStats offloaderStats, String managedLedgerName)
-            throws IOException, BKException.BKNoSuchLedgerExistsOnMetadataServerException {
+            throws IOException, BKException.BKNoSuchLedgerExistsException {
         int retryCount = 3;
         OffloadIndexBlock index = null;
         IOException lastException = null;
@@ -285,7 +285,7 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
             Blob blob = blobStore.getBlob(bucket, indexKey);
             if (blob == null) {
                 log.error("{} not found in container {}", indexKey, bucket);
-                throw new BKException.BKNoSuchLedgerExistsOnMetadataServerException();
+                throw new BKException.BKNoSuchLedgerExistsException();
             }
             offloaderStats.recordReadOffloadIndexLatency(topicName,
                     System.nanoTime() - readIndexStartTime, TimeUnit.NANOSECONDS);

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
@@ -49,6 +49,7 @@ import org.apache.bookkeeper.mledger.offload.jcloud.impl.DataBlockUtils.VersionC
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.naming.TopicName;
 import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.KeyNotFoundException;
 import org.jclouds.blobstore.domain.Blob;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -202,7 +203,11 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
             } catch (Throwable t) {
                 log.error("Failed to read entries {} - {} from the offloader in ledger {}",
                     firstEntry, lastEntry, ledgerId, t);
-                promise.completeExceptionally(t);
+                if (t instanceof KeyNotFoundException) {
+                    promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsException());
+                } else {
+                    promise.completeExceptionally(t);
+                }
                 entries.forEach(LedgerEntry::close);
             }
         });
@@ -265,7 +270,7 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
                                   VersionCheck versionCheck,
                                   long ledgerId, int readBufferSize,
                                   LedgerOffloaderStats offloaderStats, String managedLedgerName)
-            throws IOException {
+            throws IOException, BKException.BKNoSuchLedgerExistsOnMetadataServerException {
         int retryCount = 3;
         OffloadIndexBlock index = null;
         IOException lastException = null;
@@ -278,6 +283,10 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle {
         while (retryCount-- > 0) {
             long readIndexStartTime = System.nanoTime();
             Blob blob = blobStore.getBlob(bucket, indexKey);
+            if (blob == null) {
+                log.error("{} not found in container {}", indexKey, bucket);
+                throw new BKException.BKNoSuchLedgerExistsOnMetadataServerException();
+            }
             offloaderStats.recordReadOffloadIndexLatency(topicName,
                     System.nanoTime() - readIndexStartTime, TimeUnit.NANOSECONDS);
             versionCheck.check(indexKey, blob);

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplV2.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplV2.java
@@ -49,6 +49,7 @@ import org.apache.bookkeeper.mledger.offload.jcloud.impl.DataBlockUtils.VersionC
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.naming.TopicName;
 import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.KeyNotFoundException;
 import org.jclouds.blobstore.domain.Blob;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -224,7 +225,11 @@ public class BlobStoreBackedReadHandleImplV2 implements ReadHandle {
                         }
                     }
                 } catch (Throwable t) {
-                    promise.completeExceptionally(t);
+                    if (t instanceof KeyNotFoundException) {
+                        promise.completeExceptionally(new BKException.BKNoSuchLedgerExistsException());
+                    } else {
+                        promise.completeExceptionally(t);
+                    }
                     entries.forEach(LedgerEntry::close);
                 }
 
@@ -303,7 +308,7 @@ public class BlobStoreBackedReadHandleImplV2 implements ReadHandle {
                                   VersionCheck versionCheck,
                                   long ledgerId, int readBufferSize, LedgerOffloaderStats offloaderStats,
                                   String managedLedgerName)
-            throws IOException {
+            throws IOException, BKException.BKNoSuchLedgerExistsOnMetadataServerException {
         List<BackedInputStream> inputStreams = new LinkedList<>();
         List<OffloadIndexBlockV2> indice = new LinkedList<>();
         String topicName = TopicName.fromPersistenceNamingEncoding(managedLedgerName);
@@ -313,6 +318,10 @@ public class BlobStoreBackedReadHandleImplV2 implements ReadHandle {
             log.debug("open bucket: {} index key: {}", bucket, indexKey);
             long startTime = System.nanoTime();
             Blob blob = blobStore.getBlob(bucket, indexKey);
+            if (blob == null) {
+                log.error("{} not found in container {}", indexKey, bucket);
+                throw new BKException.BKNoSuchLedgerExistsOnMetadataServerException();
+            }
             offloaderStats.recordReadOffloadIndexLatency(topicName,
                     System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
             log.debug("indexKey blob: {} {}", indexKey, blob);

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplV2.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplV2.java
@@ -308,7 +308,7 @@ public class BlobStoreBackedReadHandleImplV2 implements ReadHandle {
                                   VersionCheck versionCheck,
                                   long ledgerId, int readBufferSize, LedgerOffloaderStats offloaderStats,
                                   String managedLedgerName)
-            throws IOException, BKException.BKNoSuchLedgerExistsOnMetadataServerException {
+            throws IOException, BKException.BKNoSuchLedgerExistsException {
         List<BackedInputStream> inputStreams = new LinkedList<>();
         List<OffloadIndexBlockV2> indice = new LinkedList<>();
         String topicName = TopicName.fromPersistenceNamingEncoding(managedLedgerName);
@@ -320,7 +320,7 @@ public class BlobStoreBackedReadHandleImplV2 implements ReadHandle {
             Blob blob = blobStore.getBlob(bucket, indexKey);
             if (blob == null) {
                 log.error("{} not found in container {}", indexKey, bucket);
-                throw new BKException.BKNoSuchLedgerExistsOnMetadataServerException();
+                throw new BKException.BKNoSuchLedgerExistsException();
             }
             offloaderStats.recordReadOffloadIndexLatency(topicName,
                     System.nanoTime() - startTime, TimeUnit.NANOSECONDS);

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/BlobStoreBackedInputStreamTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/BlobStoreBackedInputStreamTest.java
@@ -32,6 +32,7 @@ import java.util.Random;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedInputStreamImpl;
 import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.KeyNotFoundException;
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.io.Payload;
 import org.jclouds.io.Payloads;
@@ -142,8 +143,8 @@ public class BlobStoreBackedInputStreamTest extends BlobStoreTestBase {
         assertStreamsMatchByBytes(toTest, toCompare);
     }
 
-    @Test(expectedExceptions = IOException.class)
-    public void testErrorOnRead() throws Exception {
+    @Test(expectedExceptions = KeyNotFoundException.class)
+    public void testNotFoundOnRead() throws Exception {
         BackedInputStream toTest = new BlobStoreBackedInputStreamImpl(blobStore, BUCKET, "doesn't exist",
                                                                  (key, md) -> {},
                                                                  1234, 1000);

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderStreamingTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderStreamingTest.java
@@ -18,16 +18,19 @@
  */
 package org.apache.bookkeeper.mledger.offload.jcloud.impl;
 
+import static org.apache.bookkeeper.client.api.BKException.Code.NoSuchLedgerExistsException;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.client.api.ReadHandle;
@@ -443,6 +446,57 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
             readHandle.read(0, 20);
             Assert.fail("Shouldn't be able to read anything");
         } catch (Exception e) {
+        }
+    }
+
+    @Test
+    public void testReadNotExistLedger() throws Exception {
+        LedgerOffloader offloader = getOffloader(new HashMap<String, String>() {{
+            put(TieredStorageConfiguration.MAX_OFFLOAD_SEGMENT_SIZE_IN_BYTES, "1000");
+            put(config.getKeys(TieredStorageConfiguration.METADATA_FIELD_MAX_BLOCK_SIZE).get(0), "5242880");
+            put(TieredStorageConfiguration.MAX_OFFLOAD_SEGMENT_ROLLOVER_TIME_SEC, "600");
+        }});
+        ManagedLedger ml = createMockManagedLedger();
+        UUID uuid = UUID.randomUUID();
+        long beginLedger = 0;
+        long beginEntry = 0;
+
+        Map<String, String> driverMeta = new HashMap<String, String>() {{
+            put(TieredStorageConfiguration.METADATA_FIELD_BUCKET, BUCKET);
+        }};
+        OffloadHandle offloadHandle = offloader
+                .streamingOffload(ml, uuid, beginLedger, beginEntry, driverMeta).get();
+
+        // Segment should closed because size in bytes full
+        final LinkedList<Entry> entries = new LinkedList<>();
+        for (int i = 0; i < 10; i++) {
+            final byte[] data = new byte[100];
+            random.nextBytes(data);
+            final EntryImpl entry = EntryImpl.create(0, i, data);
+            offloadHandle.offerEntry(entry);
+            entries.add(entry);
+        }
+
+        final LedgerOffloader.OffloadResult offloadResult = offloadHandle.getOffloadResultAsync().get();
+        assertEquals(offloadResult.endLedger, 0);
+        assertEquals(offloadResult.endEntry, 9);
+        final OffloadContext.Builder contextBuilder = OffloadContext.newBuilder();
+        contextBuilder.addOffloadSegment(
+                MLDataFormats.OffloadSegment.newBuilder()
+                        .setUidLsb(uuid.getLeastSignificantBits())
+                        .setUidMsb(uuid.getMostSignificantBits())
+                        .setComplete(true).setEndEntryId(9).build());
+
+        final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder.build(), driverMeta).get();
+
+        // delete blob(ledger)
+        blobStore.removeBlob(BUCKET, uuid.toString());
+
+        try {
+            readHandle.read(0, 9);
+            fail("Should be read fail");
+        } catch (BKException e) {
+            assertEquals(e.getCode(), NoSuchLedgerExistsException);
         }
     }
 }

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.bookkeeper.mledger.offload.jcloud.impl;
 
+import static org.apache.bookkeeper.client.api.BKException.Code.NoSuchLedgerExistsException;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -26,6 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -599,6 +601,27 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
                 return;
             }
             throw e;
+        }
+    }
+
+    @Test
+    public void testReadNotExistLedger() throws Exception {
+        ReadHandle toWrite = buildReadHandle(DEFAULT_BLOCK_SIZE, 3);
+        LedgerOffloader offloader = getOffloader();
+
+        UUID uuid = UUID.randomUUID();
+        offloader.offload(toWrite, uuid, new HashMap<>()).get();
+        ReadHandle offloadRead = offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get();
+        assertEquals(offloadRead.getLastAddConfirmed(), toWrite.getLastAddConfirmed());
+
+        // delete blob(ledger)
+        blobStore.removeBlob(BUCKET, DataBlockUtils.dataBlockOffloadKey(toWrite.getId(), uuid));
+
+        try {
+            offloadRead.read(0, offloadRead.getLastAddConfirmed());
+            fail("Should be read fail");
+        } catch (BKException e) {
+            assertEquals(e.getCode(), NoSuchLedgerExistsException);
         }
     }
 }


### PR DESCRIPTION
### Motivation
In the implementation of tiered storage, if a `blob` in blob storage is lost unexpectedly, reading it will cause a `NullPointerException`, causing a subscription block.

```
    116 Caused by: java.lang.NullPointerException
    117 2023-08-28T02:35:23,544+0000 [offloader-OrderedScheduler-0-0] WARN  org.apache.bookkeeper.mledger.impl.OpReadEntry - [test/test/persistent/test-partition-1][test-consume] read failed from ledger at position:1358058:0
    118 org.apache.bookkeeper.mledger.ManagedLedgerException: Other exception
    119 Caused by: java.io.IOException: Error reading from BlobStore
    120         at org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedInputStreamImpl.refillBufferIfNeeded(BlobStoreBackedInputStreamImpl.java:91) ~[?:?]
    121         at org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedInputStreamImpl.read(BlobStoreBackedInputStreamImpl.java:99) ~[?:?]
    122         at java.io.DataInputStream.readInt(DataInputStream.java:392) ~[?:?]
    123         at org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedReadHandleImpl.lambda$readAsync$1(BlobStoreBackedReadHandleImpl.java:136) ~[?:?]
    124         at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
    125         at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
    126         at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]
    127         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
    128         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
    129         at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.87.Final.jar:4.1.87.Final]
    130         at java.lang.Thread.run(Thread.java:829) ~[?:?]
    131 Caused by: java.lang.NullPointerException
    132 2023-08-28T02:35:23,545+0000 [broker-topic-workers-OrderedExecutor-5-0] ERROR org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer - [persistent://test/test/test-partition-1 / test-consume -Consumer{subscription=PersistentSubscription{topic=persistent://test/test/test-partition-1, name=test-consume}, consumerId=1, consumerName=07da3, address=/127.0.0.1:39850}] Error reading entries at 1358058:0 : Other exception - Retrying         to read in 27.426 seconds
    133 2023-08-28T02:35:25,999+0000 [offloader-OrderedScheduler-0-0] ERROR org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedReadHandleImpl - Failed to read entries 0 - 0 fro        m the offloader in ledger 1358058
    134 java.io.IOException: Error reading from BlobStore
```

#1046 introduced the `autoSkipNonRecoverableData` configuration to skip BookKeeper ledgers lost unexpectedly. This configuration can be utilized to address the same issue in tiered storage..


BTW: This PR is built upon the enhancements made by #21269. Special thanks to @liangyepianzhou for the initial research.

### Modifications
- In `BackedInputStream`, When [blobStore.getBlob](https://github.com/apache/jclouds/blob/master/blobstore/src/main/java/org/jclouds/blobstore/BlobStore.java#L280C1-L280C77) return null, means a blob not found in container, throw a `KeyNotFoundException` to the caller(**BlobStoreBackedReadHandleImpl.readAsync**).
- In `BlobStoreBackedReadHandleImpl.readAsync` method of the `ReadHandle` interface, if receive a `KeyNotFoundException` exception, will throw a `BKNoSuchLedgerExistsException` that will transfer to `NonRecoverableLedgerException`, which will eventually be handled by the following code.

https://github.com/apache/pulsar/blob/66271e3bf3cf0699789c759d852c24e6f00f90cd/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java#L114-L140


### Verifying this change
- Add testNotFoundOnRead unit test to cover bucket not found.
- Add testReadNotExistLedger unit test to cover ledger not found.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
