### PR TITLE
[fix][broker] Fix NPE causing dispatching to stop when using Key_Shared mode and allowOutOfOrderDelivery=true

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -501,6 +501,9 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
      */
     @Override
     protected boolean hasConsumersNeededNormalRead() {
+        if (MapUtils.isEmpty(recentlyJoinedConsumers)) {
+            return getFirstAvailableConsumerPermits() > 0;
+        }
         for (Consumer consumer : consumerList) {
             if (consumer == null || consumer.isBlocked()) {
                 continue;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -457,6 +457,11 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
 
     @Override
     protected synchronized NavigableSet<PositionImpl> filterOutEntriesWillBeDiscarded(NavigableSet<PositionImpl> src) {
+        // The variable "hashesToBeBlocked" and "recentlyJoinedConsumers" will be null if "isAllowOutOfOrderDelivery()",
+        // So skip this filter out.
+        if (!isAllowOutOfOrderDelivery()) {
+            return src;
+        }
         if (src.isEmpty()) {
             return src;
         }
@@ -501,8 +506,10 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
      */
     @Override
     protected boolean hasConsumersNeededNormalRead() {
-        if (MapUtils.isEmpty(recentlyJoinedConsumers)) {
-            return getFirstAvailableConsumerPermits() > 0;
+        // The variable "hashesToBeBlocked" and "recentlyJoinedConsumers" will be null if "isAllowOutOfOrderDelivery()",
+        // So the method "filterOutEntriesWillBeDiscarded" will filter out nothing, just return "true" here.
+        if (!isAllowOutOfOrderDelivery()) {
+            return true;
         }
         for (Consumer consumer : consumerList) {
             if (consumer == null || consumer.isBlocked()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -459,7 +459,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
     protected synchronized NavigableSet<PositionImpl> filterOutEntriesWillBeDiscarded(NavigableSet<PositionImpl> src) {
         // The variable "hashesToBeBlocked" and "recentlyJoinedConsumers" will be null if "isAllowOutOfOrderDelivery()",
         // So skip this filter out.
-        if (!isAllowOutOfOrderDelivery()) {
+        if (isAllowOutOfOrderDelivery()) {
             return src;
         }
         if (src.isEmpty()) {
@@ -508,7 +508,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
     protected boolean hasConsumersNeededNormalRead() {
         // The variable "hashesToBeBlocked" and "recentlyJoinedConsumers" will be null if "isAllowOutOfOrderDelivery()",
         // So the method "filterOutEntriesWillBeDiscarded" will filter out nothing, just return "true" here.
-        if (!isAllowOutOfOrderDelivery()) {
+        if (isAllowOutOfOrderDelivery()) {
             return true;
         }
         for (Consumer consumer : consumerList) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -61,7 +61,6 @@ import org.apache.pulsar.broker.service.persistent.PersistentStickyKeyDispatcher
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.impl.ConsumerImpl;
-import org.apache.pulsar.common.api.proto.KeySharedMeta;
 import org.apache.pulsar.common.api.proto.KeySharedMode;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -61,6 +61,7 @@ import org.apache.pulsar.broker.service.persistent.PersistentStickyKeyDispatcher
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.impl.ConsumerImpl;
+import org.apache.pulsar.common.api.proto.KeySharedMeta;
 import org.apache.pulsar.common.api.proto.KeySharedMode;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
@@ -1741,6 +1742,14 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         admin.topics().delete(topic, false);
     }
 
+    @DataProvider(name = "allowKeySharedOutOfOrder")
+    public Object[][] allowKeySharedOutOfOrder() {
+        return new Object[][]{
+                {true},
+                {false}
+        };
+    }
+
     /**
      * This test is in order to guarantee the feature added by https://github.com/apache/pulsar/pull/7105.
      * 1. Start 3 consumers:
@@ -1755,8 +1764,8 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
      *   - no repeated Read-and-discard.
      *   - at last, all messages will be received.
      */
-    @Test(timeOut = 180 * 1000) // the test will be finished in 60s.
-    public void testRecentJoinedPosWillNotStuckOtherConsumer() throws Exception {
+    @Test(timeOut = 180 * 1000, dataProvider = "allowKeySharedOutOfOrder") // the test will be finished in 60s.
+    public void testRecentJoinedPosWillNotStuckOtherConsumer(boolean allowKeySharedOutOfOrder) throws Exception {
         final int messagesSentPerTime = 100;
         final Set<Integer> totalReceivedMessages = new TreeSet<>();
         final String topic = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
@@ -1775,6 +1784,8 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
             log.info("Published message :{}", messageId);
         }
 
+        KeySharedPolicy keySharedPolicy = KeySharedPolicy.autoSplitHashRange()
+                .setAllowOutOfOrderDelivery(allowKeySharedOutOfOrder);
         // 1. Start 3 consumers and make ack holes.
         //   - one consumer will be closed and trigger a messages redeliver.
         //   - one consumer will not ack any messages to make the new consumer joined late will be stuck due to the
@@ -1785,18 +1796,21 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                 .subscriptionName(subName)
                 .receiverQueueSize(10)
                 .subscriptionType(SubscriptionType.Key_Shared)
+                .keySharedPolicy(keySharedPolicy)
                 .subscribe();
         Consumer<Integer> consumer2 = pulsarClient.newConsumer(Schema.INT32)
                 .topic(topic)
                 .subscriptionName(subName)
                 .receiverQueueSize(10)
                 .subscriptionType(SubscriptionType.Key_Shared)
+                .keySharedPolicy(keySharedPolicy)
                 .subscribe();
         Consumer<Integer> consumer3 = pulsarClient.newConsumer(Schema.INT32)
                 .topic(topic)
                 .subscriptionName(subName)
                 .receiverQueueSize(10)
                 .subscriptionType(SubscriptionType.Key_Shared)
+                .keySharedPolicy(keySharedPolicy)
                 .subscribe();
         List<Message> msgList1 = new ArrayList<>();
         List<Message> msgList2 = new ArrayList<>();
@@ -1845,6 +1859,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                 .subscriptionName(subName)
                 .receiverQueueSize(1000)
                 .subscriptionType(SubscriptionType.Key_Shared)
+                .keySharedPolicy(keySharedPolicy)
                 .subscribe();
         consumerWillBeClose.close();
 


### PR DESCRIPTION
### Motivation

In Key_Shared mode, the variable `recentlyJoinedConsumers` of `PersistentStickyKeyDispatcherMultipleConsumers` will always be null when enabling the config below.  #22245 introduced a NPE if set `allowOutOfOrderDelivery` to true, which will lead dispatching stuck.
```
// The default value is false.
pulsarClient.newConsumer().keySharedPolicy(KeySharedPolicy.setAllowOutOfOrderDelivery(true))
```

**error logs**

```
--- An unexpected error occurred in the server ---

Message: org.apache.bookkeeper.mledger.ManagedLedgerException: Other exception

Stacktrace:

org.apache.pulsar.broker.service.BrokerServiceException: org.apache.bookkeeper.mledger.ManagedLedgerException: Other exception
	at org.apache.pulsar.broker.service.persistent.PersistentSubscription$6.findEntryFailed(PersistentSubscription.java:761)
	at org.apache.pulsar.broker.service.persistent.PersistentMessageFinder.findEntryFailed(PersistentMessageFinder.java:113)
	at org.apache.bookkeeper.mledger.impl.OpFindNewest.readEntryFailed(OpFindNewest.java:141)
	at org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImpl.lambda$asyncReadEntry0$1(RangeEntryCacheImpl.java:274)
	at java.base/java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:990)
	at java.base/java.util.concurrent.CompletableFuture$UniExceptionally.tryFire(CompletableFuture.java:974)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
	at java.base/java.util.concurrent.CompletableFuture.postFire(CompletableFuture.java:614)
	at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:726)
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482)
	at org.apache.bookkeeper.common.util.SingleThreadExecutor.safeRunTask(SingleThreadExecutor.java:128)
	at org.apache.bookkeeper.common.util.SingleThreadExecutor.run(SingleThreadExecutor.java:99)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: org.apache.bookkeeper.mledger.ManagedLedgerException: Other exception
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.LinkedHashMap.containsKey(Object)" because "this.recentlyJoinedConsumers" is null
	at org.apache.pulsar.broker.service.persistent.PersistentStickyKeyDispatcherMultipleConsumers.hasConsumersNeededNormalRead(PersistentStickyKeyDispatcherMultipleConsumers.java:508)
	at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.readMoreEntries(PersistentDispatcherMultipleConsumers.java:344)
	at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.removeConsumer(PersistentDispatcherMultipleConsumers.java:228)
	at org.apache.pulsar.broker.service.persistent.PersistentStickyKeyDispatcherMultipleConsumers.removeConsumer(PersistentStickyKeyDispatcherMultipleConsumers.java:151)
	at org.apache.pulsar.broker.service.persistent.PersistentSubscription.removeConsumer(PersistentSubscription.java:301)
	at org.apache.pulsar.broker.service.Consumer.close(Consumer.java:402)
	at org.apache.pulsar.broker.service.Consumer.disconnect(Consumer.java:418)
	at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.lambda$disconnectAllConsumers$7(PersistentDispatcherMultipleConsumers.java:548)
	at java.base/java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:807)
	at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.disconnectAllConsumers(PersistentDispatcherMultipleConsumers.java:548)
	at org.apache.pulsar.broker.service.Dispatcher.disconnectAllConsumers(Dispatcher.java:73)
	at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.disconnectActiveConsumers(PersistentDispatcherMultipleConsumers.java:563)
	at org.apache.pulsar.broker.service.persistent.PersistentSubscription.resetCursor(PersistentSubscription.java:787)
	at org.apache.pulsar.broker.service.persistent.PersistentSubscription$6.findEntryComplete(PersistentSubscription.java:751)
	at org.apache.pulsar.broker.service.persistent.PersistentMessageFinder.findEntryComplete(PersistentMessageFinder.java:101)
	at org.apache.bookkeeper.mledger.impl.OpFindNewest.readEntryComplete(OpFindNewest.java:131)
	at org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImpl.lambda$asyncReadEntry0$0(RangeEntryCacheImpl.java:262)
	at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:718)
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482)
	at org.apache.bookkeeper.common.util.SingleThreadExecutor.safeRunTask(SingleThreadExecutor.java:128)
	at org.apache.bookkeeper.common.util.SingleThreadExecutor.run(SingleThreadExecutor.java:99)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:840)
```


### Modifications

Fix the NPE.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
