### PR TITLE
[improve][broker] Apply loadBalancerDebugModeEnabled in LeastResourceUsageWithWeight

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/LeastResourceUsageWithWeight.java
@@ -96,8 +96,7 @@ public class LeastResourceUsageWithWeight implements BrokerSelectionStrategy {
         // select one of them at the end.
         double totalUsage = 0.0d;
 
-        // TODO: use loadBalancerDebugModeEnabled too.
-        boolean debugMode = log.isDebugEnabled();
+        boolean debugMode = log.isDebugEnabled() || conf.isLoadBalancerDebugModeEnabled();
         for (String broker : candidates) {
             var brokerLoadDataOptional = context.brokerLoadDataStore().get(broker);
             if (brokerLoadDataOptional.isEmpty()) {


### PR DESCRIPTION
### Motivation

Info logs are not printed in `LeastResourceUsageWithWeight` even if `loadBalancerDebugModeEnabled` is true.

### Modifications

Fix the TODO in `LeastResourceUsageWithWeight`.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
