### PR TITLE
[improve][broker] Make BrokerSelectionStrategy pluggable

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -85,6 +85,7 @@ import org.apache.pulsar.broker.loadbalance.extensions.store.LoadDataStore;
 import org.apache.pulsar.broker.loadbalance.extensions.store.LoadDataStoreException;
 import org.apache.pulsar.broker.loadbalance.extensions.store.LoadDataStoreFactory;
 import org.apache.pulsar.broker.loadbalance.extensions.strategy.BrokerSelectionStrategy;
+import org.apache.pulsar.broker.loadbalance.extensions.strategy.BrokerSelectionStrategyFactory;
 import org.apache.pulsar.broker.loadbalance.extensions.strategy.LeastResourceUsageWithWeight;
 import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared;
 import org.apache.pulsar.broker.loadbalance.impl.SimpleResourceAllocationPolicies;
@@ -103,7 +104,7 @@ import org.apache.pulsar.metadata.api.coordination.LeaderElectionState;
 import org.slf4j.Logger;
 
 @Slf4j
-public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
+public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerSelectionStrategyFactory {
 
     public static final String BROKER_LOAD_DATA_STORE_TOPIC = TopicName.get(
             TopicDomain.non_persistent.value(),
@@ -251,6 +252,11 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
         return ownedServiceUnits;
     }
 
+    @Override
+    public BrokerSelectionStrategy createBrokerSelectionStrategy() {
+        return new LeastResourceUsageWithWeight();
+    }
+
     public enum Role {
         Leader,
         Follower
@@ -266,8 +272,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
         this.brokerFilterPipeline.add(new BrokerLoadManagerClassFilter());
         this.brokerFilterPipeline.add(new BrokerMaxTopicCountFilter());
         this.brokerFilterPipeline.add(new BrokerVersionFilter());
-        // TODO: Make brokerSelectionStrategy configurable.
-        this.brokerSelectionStrategy = new LeastResourceUsageWithWeight();
+        this.brokerSelectionStrategy = createBrokerSelectionStrategy();
     }
 
     public static boolean isLoadManagerExtensionEnabled(PulsarService pulsar) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/BrokerSelectionStrategyFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/BrokerSelectionStrategyFactory.java
@@ -18,28 +18,10 @@
  */
 package org.apache.pulsar.broker.loadbalance.extensions.strategy;
 
-import java.util.Optional;
-import java.util.Set;
-import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
 import org.apache.pulsar.common.classification.InterfaceStability;
-import org.apache.pulsar.common.naming.ServiceUnitId;
 
-/**
- * The broker selection strategy is designed to select the broker according to different implementations.
- */
-@InterfaceStability.Evolving
-public interface BrokerSelectionStrategy {
+@InterfaceStability.Stable
+public interface BrokerSelectionStrategyFactory {
 
-    /**
-     * Choose an appropriate broker according to different load balancing implementations.
-     *
-     * @param brokers
-     *               The candidate brokers list.
-     * @param bundle
-     *               The input bundle to select the owner broker
-     * @param context
-     *               The context contains information needed for selection (load data, config, and etc).
-     */
-    Optional<String> select(Set<String> brokers, ServiceUnitId bundle, LoadManagerContext context);
-
+    BrokerSelectionStrategy createBrokerSelectionStrategy();
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/CustomBrokerSelectionStrategyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/CustomBrokerSelectionStrategyTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.extensions.strategy;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.Cleanup;
+import org.apache.pulsar.broker.MultiBrokerBaseTest;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
+import org.apache.pulsar.client.impl.PartitionedProducerImpl;
+import org.apache.pulsar.client.impl.ProducerImpl;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class CustomBrokerSelectionStrategyTest extends MultiBrokerBaseTest {
+
+    @Override
+    protected void startBroker() throws Exception {
+        addCustomConfigs(conf);
+        super.startBroker();
+    }
+
+    @Override
+    protected ServiceConfiguration createConfForAdditionalBroker(int additionalBrokerIndex) {
+        return addCustomConfigs(getDefaultConf());
+    }
+
+    private static ServiceConfiguration addCustomConfigs(ServiceConfiguration conf) {
+        conf.setLoadManagerClassName(CustomExtensibleLoadManager.class.getName());
+        conf.setLoadBalancerAutoBundleSplitEnabled(false);
+        conf.setDefaultNumberOfNamespaceBundles(8);
+        // Don't consider broker's load so the broker will be selected randomly with the default strategy
+        conf.setLoadBalancerAverageResourceUsageDifferenceThresholdPercentage(100);
+        return conf;
+    }
+
+    @Test
+    public void testSingleBrokerSelected() throws Exception {
+        final var topic = "test-single-broker-selected";
+        getAllAdmins().get(0).topics().createPartitionedTopic(topic, 16);
+        @Cleanup final var producer = (PartitionedProducerImpl<byte[]>) getAllClients().get(0).newProducer()
+                .topic(topic).create();
+        Assert.assertNotNull(producer);
+        final var connections = producer.getProducers().stream().map(ProducerImpl::getClientCnx)
+                .collect(Collectors.toSet());
+        Assert.assertEquals(connections.size(), 1);
+        final var port = Integer.parseInt(connections.stream().findFirst().orElseThrow().ctx().channel()
+                .remoteAddress().toString().replaceAll(".*:", ""));
+        final var sortedPorts = Stream.concat(Stream.of(pulsar), additionalBrokers.stream())
+                .map(PulsarService::getBrokerListenPort).map(Optional::orElseThrow).sorted().toList();
+        Assert.assertEquals(port, sortedPorts.get(0).intValue());
+    }
+
+    public static class CustomExtensibleLoadManager extends ExtensibleLoadManagerImpl {
+
+        @Override
+        public BrokerSelectionStrategy createBrokerSelectionStrategy() {
+            // The smallest port will always be selected because the host parts are all "localhost"
+            return (brokers, __, ___) -> brokers.stream().sorted().findFirst();
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

When users want to extend the `ExtensibleLoadManagerImpl`, the `BrokerSelectionStrategy` cannot be customized, so users have to write much duplicated code for a customized broker selection strategy.

### Modifications

Add a stable interface `BrokerSelectionStrategyFactory` and implements this interface in `ExtensibleLoadManagerImpl` with the default implementation that returns a `LeastResourceUsageWithWeight` instance by default. Add `CustomBrokerSelectionStrategyTest` to show how to customize the broker selection strategy and verify it works.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
