### PR TITLE
[fix][ci] Don't allow merging PR without successful result

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -1498,12 +1498,16 @@ jobs:
         with:
           action: wait
 
-  # This job is required for pulls to be merged.
+  # This job is required for pulls to be merged. This job is referenced by name in .asf.yaml file in the
+  # protected_branches section for master branch required_status_checks.
   # It depends on all other jobs in this workflow.
-  # It cleans up the binaries in the same job in order to not spin up another runner for basically doing nothing.
+  # This job also cleans up the binaries at the end of the workflow.
   pulsar-ci-checks-completed:
     name: "Pulsar CI checks completed"
-    if: ${{ always() && needs.preconditions.result == 'success' }}
+    # run always, but skip for other repositories than apache/pulsar when a scheduled workflow is cancelled
+    # this is to allow the workflow scheduled jobs to show as cancelled instead of failed since scheduled
+    # jobs are not enabled for other than apache/pulsar repository.
+    if: ${{ always() && !(cancelled() && github.repository != 'apache/pulsar' && github.event_name == 'schedule') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     needs: [
@@ -1521,10 +1525,11 @@ jobs:
     ]
     steps:
       - name: Check that all required jobs were completed successfully
-        if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
+        if: ${{ needs.preconditions.result != 'success' || needs.preconditions.outputs.docs_only != 'true'  }}
         run: |
           if [[ ! ( \
-                   "${{ needs.unit-tests.result }}" == "success" \
+                   "${{ needs.preconditions.result }}" == "success" \
+                && "${{ needs.unit-tests.result }}" == "success" \
                 && "${{ needs.integration-tests.result }}" == "success" \
                 && "${{ needs.system-tests.result }}" == "success" \
                 && "${{ needs.macos-build.result }}" == "success" \


### PR DESCRIPTION
### Motivation

Currently it's possible to merge a PR when it hasn't been approved at all and no tests have run.
The reason for this is that the required job gets skipped in this case.

### Modifications

- Fix the rules for `Pulsar CI checks completed` build step in the workflow.
- Continue to skip the step for cancelled scheduled jobs for other repositories than apache/pulsar.
- Add some comments to explain the logic
- Explicitly require preconditions build step to succeed

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->