### PR TITLE
[improve][meta] Log a warning when ZK batch fails with connectionloss

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -192,7 +192,20 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
                     Code code = Code.get(rc);
                     if (code == Code.CONNECTIONLOSS) {
                         // There is the chance that we caused a connection reset by sending or requesting a batch
-                        // that passed the max ZK limit. Retry with the individual operations
+                        // that passed the max ZK limit.
+
+                        // Build the log warning message
+                        // summarize the operations by type
+                        String countsByType = ops.stream().collect(
+                                        Collectors.groupingBy(MetadataOp::getType, Collectors.summingInt(op -> 1)))
+                                .entrySet().stream().map(e -> e.getValue() + " " + e.getKey().name() + " entries")
+                                .collect(Collectors.joining(", "));
+                        Long totalSize = ops.stream().collect(Collectors.summingLong(MetadataOp::size));
+                        log.warn("Connection loss while executing batch operation of {} "
+                                + "of total data size of {}. "
+                                + "Retrying individual operations one-by-one.", countsByType, totalSize);
+
+                        // Retry with the individual operations
                         executor.schedule(() -> {
                             ops.forEach(o -> batchOperation(Collections.singletonList(o)));
                         }, 100, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
### Motivation

A batch operation might cause a  connection to break which is a severe issue. It's better to log a warning whenever this happens instead of silently ignoring it.

### Modifications

- Log a warning when a batch operation fails with connectionloss.
- Add summary information to the log message.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->