### PR TITLE
[improve][ci] Skip detecting changed files in fork repositories

### DIFF
--- a/.github/workflows/ci-go-functions.yaml
+++ b/.github/workflows/ci-go-functions.yaml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Detect changed files
+        if: ${{ github.event_name == 'pull_request' && github.repository == 'apache/pulsar' }}
         id: changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
@@ -52,6 +53,7 @@ jobs:
           list-files: csv
 
       - name: Check changed files
+        if: ${{ github.event_name == 'pull_request' && github.repository == 'apache/pulsar' }}
         id: check_changes
         run: |
           if [[ "${GITHUB_EVENT_NAME}" != "schedule" ]]; then

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -108,7 +108,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Detect changed files
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' && github.repository == 'apache/pulsar' }}
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
@@ -116,7 +116,7 @@ jobs:
           list-files: csv
 
       - name: Check changed files
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' && github.repository == 'apache/pulsar' }}
         id: check_changes
         run: |
           if [[ "${GITHUB_EVENT_NAME}" != "schedule" && "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ]]; then
@@ -126,6 +126,7 @@ jobs:
           fi
 
       - name: Check if coverage should be collected
+        if: ${{ github.repository == 'apache/pulsar' }}
         id: check_coverage
         run: |
           echo "collect_coverage=${{ 

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -108,7 +108,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Detect changed files
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' && github.repository == 'apache/pulsar' }}
         id:   changes
         uses: apache/pulsar-test-infra/paths-filter@master
         with:
@@ -116,7 +116,7 @@ jobs:
           list-files: csv
 
       - name: Check changed files
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' && github.repository == 'apache/pulsar' }}
         id: check_changes
         run: |
           if [[ "${GITHUB_EVENT_NAME}" != "schedule" && "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ]]; then
@@ -126,6 +126,7 @@ jobs:
           fi
 
       - name: Check if coverage should be collected
+        if: ${{ github.repository == 'apache/pulsar' }}
         id: check_coverage
         run: |
           echo "collect_coverage=${{ 


### PR DESCRIPTION
### Motivation

In a private fork repository, the precondition workflow of a PR will always fail due to the lack of the permission to fetch the content of that PR.

```
Fetching list of changed files for PR#208 from Github API
  Invoking listFiles(pull_number: 208, per_page: 100)
Error: Resource not accessible by integration
```

### Modifications

Only run the "Detect changed files" step and steps that depend on that step in the Apache repo.

### Verifying this change

After applying this patch, the precondition workflows succeeded and the tests were executed.

<img width="829" alt="image" src="https://github.com/apache/pulsar/assets/18204803/c5388604-c0fe-4f33-8566-412c02c7e2f9">

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
