### PR TITLE
[fix][broker] Fix BufferOverflowException and EOFException bugs in /metrics gzip compression

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -233,7 +233,8 @@ public class PrometheusMetricsGenerator implements AutoCloseable {
             // the completion is checked by the deflater.needsInput() method for buffers that aren't the last buffer
             // for the last buffer, the completion is checked by the deflater.finished() method
             while (!isLast && !deflater.needsInput() || isLast && !deflater.finished()) {
-                // when the previous deflater.deflate() call returns 0, it means that the output buffer is full.
+                // when the previous deflater.deflate() call returns 0 (and needsInput/finished returns false),
+                // it means that the output buffer is full.
                 // append the compressed buffer to the result buffer and allocate a new buffer.
                 if (written == 0) {
                     if (compressBuffer.position() > 0) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -233,7 +233,7 @@ public class PrometheusMetricsGenerator implements AutoCloseable {
             // the completion is checked by the deflater.needsInput() method for buffers that aren't the last buffer
             // for the last buffer, the completion is checked by the deflater.finished() method
             while (!isLast && !deflater.needsInput() || isLast && !deflater.finished()) {
-                // when the previous deflater.deflate() call returns 0 (and needsInput/finished returns false),
+                // when the previous deflater.deflate call returns 0 (and needsInput/finished returns false),
                 // it means that the output buffer is full.
                 // append the compressed buffer to the result buffer and allocate a new buffer.
                 if (written == 0) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -372,7 +372,9 @@ public class PrometheusMetricsGenerator implements AutoCloseable {
         int totalLen = 0;
         while (totalLen < initialBufferSize) {
             totalLen += chunkSize;
-            buf.addComponent(false, byteBufAllocator.directBuffer(chunkSize));
+            // increase the capacity in increments of chunkSize to preallocate the buffers
+            // in the composite buffer
+            buf.capacity(totalLen);
         }
         return buf;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -288,7 +288,7 @@ public class PrometheusMetricsGenerator implements AutoCloseable {
         this.clock = clock;
     }
 
-    private ByteBuf generate0(List<PrometheusRawMetricsProvider> metricsProviders) {
+    protected ByteBuf generateMetrics(List<PrometheusRawMetricsProvider> metricsProviders) {
         ByteBuf buf = allocateMultipartCompositeDirectBuffer();
         boolean exceptionHappens = false;
         //Used in namespace/topic and transaction aggregators as share metric names
@@ -498,7 +498,7 @@ public class PrometheusMetricsGenerator implements AutoCloseable {
                     CompletableFuture<ResponseBuffer> bufferFuture = newMetricsBuffer.getBufferFuture();
                     executor.execute(() -> {
                         try {
-                            bufferFuture.complete(new ResponseBuffer(generate0(metricsProviders)));
+                            bufferFuture.complete(new ResponseBuffer(generateMetrics(metricsProviders)));
                         } catch (Exception e) {
                             bufferFuture.completeExceptionally(e);
                         } finally {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -192,7 +192,7 @@ public class PrometheusMetricsGenerator implements AutoCloseable {
             crc = new CRC32();
             this.bufferSize = Math.max(Math.min(resolveChunkSize(bufAllocator), readableBytes), 8192);
             this.bufAllocator = bufAllocator;
-            this.resultBuffer = bufAllocator.compositeDirectBuffer(readableBytes / bufferSize + 1);
+            this.resultBuffer = bufAllocator.compositeDirectBuffer(readableBytes / bufferSize + 2);
             allocateBuffer();
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -233,15 +233,15 @@ public class PrometheusMetricsGenerator implements AutoCloseable {
             // the completion is checked by the deflater.needsInput() method for buffers that aren't the last buffer
             // for the last buffer, the completion is checked by the deflater.finished() method
             while (!isLast && !deflater.needsInput() || isLast && !deflater.finished()) {
-                // when the previous deflater.deflate() call returns 0, it means the output buffer is full
-                // append the compressed buffer to the result buffer and allocate a new buffer
+                // when the previous deflater.deflate() call returns 0, it means that the output buffer is full.
+                // append the compressed buffer to the result buffer and allocate a new buffer.
                 if (written == 0) {
                     if (compressBuffer.position() > 0) {
                         backingCompressBuffer.setIndex(0, compressBuffer.position());
                         resultBuffer.addComponent(true, backingCompressBuffer);
                         allocateBuffer();
                     } else {
-                        // this is an unexpected case, throw an exception to prevent infinite loop
+                        // this is an unexpected case, throw an exception to prevent an infinite loop
                         throw new IllegalStateException(
                                 "Deflater didn't write any bytes while the compress buffer is empty.");
                     }
@@ -254,7 +254,7 @@ public class PrometheusMetricsGenerator implements AutoCloseable {
                     backingCompressBuffer.setIndex(0, compressBuffer.position());
                     resultBuffer.addComponent(true, backingCompressBuffer);
                 } else {
-                    // release unused empty buffer
+                    // release an unused empty buffer
                     backingCompressBuffer.release();
                 }
                 backingCompressBuffer = null;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats.prometheus;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.time.Clock;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.zip.GZIPInputStream;
+import org.apache.commons.io.IOUtils;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.testng.annotations.Test;
+
+public class PrometheusMetricsGeneratorTest {
+
+    // reproduce issue #22575
+    @Test
+    public void testReproducingBufferOverflowExceptionAndEOFExceptionBugsInGzipCompression()
+            throws ExecutionException, InterruptedException, IOException {
+        PulsarService pulsar = mock(PulsarService.class);
+        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+        when(pulsar.getConfiguration()).thenReturn(serviceConfiguration);
+
+        // generate a random byte buffer which is 8 bytes less than the minimum compress buffer size limit
+        // this will trigger the BufferOverflowException bug in writing the gzip trailer
+        // it will also trigger another bug in finishing the gzip compression stream when the compress buffer is full
+        // which results in EOFException
+        Random random = new Random();
+        byte[] inputBytes = new byte[8192 - 8];
+        random.nextBytes(inputBytes);
+        ByteBuf byteBuf = Unpooled.wrappedBuffer(inputBytes);
+
+        PrometheusMetricsGenerator generator =
+                new PrometheusMetricsGenerator(pulsar, false, false, false, false, Clock.systemUTC()) {
+                    // override the generateMetrics method to return the random byte buffer for gzip compression
+                    // instead of the actual metrics
+                    @Override
+                    protected ByteBuf generateMetrics(List<PrometheusRawMetricsProvider> metricsProviders) {
+                        return byteBuf;
+                    }
+                };
+
+        PrometheusMetricsGenerator.MetricsBuffer metricsBuffer =
+                generator.renderToBuffer(MoreExecutors.directExecutor(), Collections.emptyList());
+        try {
+            PrometheusMetricsGenerator.ResponseBuffer responseBuffer = metricsBuffer.getBufferFuture().get();
+
+            ByteBuf compressed = responseBuffer.getCompressedBuffer(MoreExecutors.directExecutor()).get();
+            byte[] compressedBytes = new byte[compressed.readableBytes()];
+            compressed.readBytes(compressedBytes);
+            try (GZIPInputStream gzipInputStream = new GZIPInputStream(new ByteArrayInputStream(compressedBytes))) {
+                byte[] uncompressedBytes = IOUtils.toByteArray(gzipInputStream);
+                assertEquals(uncompressedBytes, inputBytes);
+            }
+        } finally {
+            metricsBuffer.release();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #22575

### Motivation

See #22575 . This is a bug introduced by #22521. While fixing the bug, another related bug was revealed where it resulted in a EOFException when reading the gzipped content. 

While working on this PR, another unrelated issue in the metrics output buffer pre-allocation was detected. It is also fixed in this PR. The impact of this is about 2x direct memory allocation since the pre-allocated buffers weren't used at all.

### Modifications

- Properly handle boundary conditions where the compression buffer is full. 
  - Properly handle the compression state and usage of java.util.zip.Deflater
- Properly handle writing of the gzip trailer
- Fix unrelated issue in CompositeBuffer pre-allocation. Use the `capacity` method to pre-allocate the buffer.
  - The problem was that `.setIndex(0, chunkSize)` should have been called for the chunk before adding it. This is how the `capacity` method increases the capacity.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->