### PR TITLE
[fix][broker] Disable system topic message deduplication

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -213,6 +213,16 @@ public interface Topic {
 
     void checkCursorsToCacheEntries();
 
+    /**
+     * Indicate if the current topic enabled server side deduplication.
+     * This is a dynamic configuration, user may update it by namespace/topic policies.
+     *
+     * @return whether enabled server side deduplication
+     */
+    default boolean isDeduplicationEnabled() {
+        return false;
+    }
+
     void checkDeduplicationSnapshot();
 
     void checkMessageExpiry();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -473,7 +473,7 @@ public class MessageDeduplication {
     }
 
     private boolean isDeduplicationEnabled() {
-        return topic.getHierarchyTopicPolicies().getDeduplicationEnabled().get();
+        return topic.isDeduplicationEnabled();
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -217,7 +217,7 @@ public class MessageDeduplication {
      * returning a future to track the completion of the task
      */
     public CompletableFuture<Void> checkStatus() {
-        boolean shouldBeEnabled = isDeduplicationEnabled();
+        boolean shouldBeEnabled = topic.isDeduplicationEnabled();
         synchronized (this) {
             if (status == Status.Recovering || status == Status.Removing) {
                 // If there's already a transition happening, check later for status
@@ -470,10 +470,6 @@ public class MessageDeduplication {
                 snapshotTaking.set(false);
             }
         }, null);
-    }
-
-    private boolean isDeduplicationEnabled() {
-        return topic.isDeduplicationEnabled();
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2040,10 +2040,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return future;
     }
 
-    public boolean isDeduplicationEnabled() {
-        return messageDeduplication.isEnabled();
-    }
-
     @Override
     public int getNumberOfConsumers() {
         int count = 0;
@@ -4109,6 +4105,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return ledger.isMigrated();
     }
 
+    public boolean isDeduplicationEnabled() {
+        return getHierarchyTopicPolicies().getDeduplicationEnabled().get();
+    }
+
     public TransactionInPendingAckStats getTransactionInPendingAckStats(TxnID txnID, String subName) {
         return this.subscriptions.get(subName).getTransactionInPendingAckStats(txnID);
     }
@@ -4143,4 +4143,5 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }
         return false;
     }
+
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SystemTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SystemTopic.java
@@ -81,6 +81,22 @@ public class SystemTopic extends PersistentTopic {
     }
 
     @Override
+    public boolean isDeduplicationEnabled() {
+        /*
+            Disable deduplication on system topic to avoid recovering deduplication WAL
+            (especially from offloaded topic).
+            Because the system topic usually is a precondition of other topics. therefore,
+            we should pay attention on topic loading time.
+
+            Note: If the system topic loading timeout may cause dependent topics to fail to run.
+
+            Dependency diagram: normal topic --rely on--> system topic --rely on--> deduplication recover
+                                --may rely on--> (tiered storage)
+         */
+        return false;
+    }
+
+    @Override
     public boolean isEncryptionRequired() {
         // System topics are only written by the broker that can't know the encryption context.
         return false;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
@@ -33,16 +33,13 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
-
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.EventLoopGroup;
 import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.*;
-
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;


### PR DESCRIPTION
### Motivation

Disable deduplication on system topic to avoid recovering deduplication WAL (especially from offloaded topic). Because the system topic usually is a precondition to other topics. Therefore, we should pay attention to topic loading time.

Note: If the system topic loading timeout may cause dependent topics to fail to run.
Dependency diagram: normal topic --rely on--> system topic --rely on--> deduplication recover --may rely on--> (tiered storage)

### Modifications

- MessageDeduplication use `Topic#isDeduplicationEnabled` to judge if we should enable deduplication.
- System topic overrides the `Topic#isDeduplicationEnabled` to return `false`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
