### PR TITLE
[improve][ci] Disable test that causes OOME until the problem has been resolved

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorSubscriptionTest.java
@@ -757,7 +757,8 @@ public class ReplicatorSubscriptionTest extends ReplicatorTestBase {
      *          similar to step 1.
      *  </p>
      */
-    @Test(dataProvider = "isTopicPolicyEnabled")
+    // TODO: this test causes OOME in the CI, need to investigate
+    @Test(dataProvider = "isTopicPolicyEnabled", enabled = false)
     public void testWriteMarkerTaskOfReplicateSubscriptions(boolean isTopicPolicyEnabled) throws Exception {
         // 1. Prepare resource and use proper configuration.
         String namespace = BrokerTestUtil.newUniqueName("pulsar/testReplicateSubBackLog");


### PR DESCRIPTION
### Motivation

Unit test group 1 fails often with OOME. ([example](https://github.com/apache/pulsar/actions/runs/8832004077/job/24248784784?pr=22585))

### Modifications

The issue is most like related to https://github.com/apache/pulsar/pull/21495 and org.apache.pulsar.broker.service.ReplicatorSubscriptionTest#testWriteMarkerTaskOfReplicateSubscriptions .
Disable the test until the problem has been resolved.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->