### PR TITLE
[improve][broker] Close TopicPoliciesService to allow Pulsar broker graceful shutdown

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -562,6 +562,11 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 transactionBufferClient.close();
             }
 
+            if (topicPoliciesService != null) {
+                topicPoliciesService.close();
+                topicPoliciesService = null;
+            }
+
             if (client != null) {
                 client.close();
                 client = null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -23,7 +23,6 @@ import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -113,7 +112,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                 .removalListener((namespaceName, writer, cause) -> {
                     try {
                         ((SystemTopicClient.Writer) writer).close();
-                    } catch (IOException e) {
+                    } catch (Exception e) {
                         log.error("[{}] Close writer error.", namespaceName, e);
                     }
                 })
@@ -752,7 +751,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                 future.thenAccept(reader -> {
                     try {
                         reader.close();
-                    } catch (IOException e) {
+                    } catch (Exception e) {
                         log.error("Failed to close reader.", e);
                     }
                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang3.concurrent.ConcurrentInitializer;
@@ -72,6 +73,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
     private final PulsarService pulsarService;
     private final HashSet localCluster;
     private final String clusterName;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
 
     private final ConcurrentInitializer<NamespaceEventsSystemTopicFactory>
             namespaceEventsSystemTopicFactoryLazyInitializer = new LazyInitializer<>() {
@@ -118,6 +120,10 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                 })
                 .executor(pulsarService.getExecutor())
                 .buildAsync((namespaceName, executor) -> {
+                    if (closed.get()) {
+                        return CompletableFuture.failedFuture(
+                                new BrokerServiceException(getClass().getName() + " is closed."));
+                    }
                     SystemTopicClient<PulsarEvent> systemTopicClient = getNamespaceEventsSystemTopicFactory()
                             .createTopicPoliciesSystemTopicClient(namespaceName);
                     return systemTopicClient.newWriterAsync();
@@ -384,6 +390,10 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
 
     protected CompletableFuture<SystemTopicClient.Reader<PulsarEvent>> createSystemTopicClient(
             NamespaceName namespace) {
+        if (closed.get()) {
+            return CompletableFuture.failedFuture(
+                    new BrokerServiceException(getClass().getName() + " is closed."));
+        }
         try {
             createSystemTopicFactoryIfNeeded();
         } catch (PulsarServerException ex) {
@@ -432,6 +442,11 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
     }
 
     private void initPolicesCache(SystemTopicClient.Reader<PulsarEvent> reader, CompletableFuture<Void> future) {
+        if (closed.get()) {
+            future.completeExceptionally(new BrokerServiceException(getClass().getName() + " is closed."));
+            cleanCacheAndCloseReader(reader.getSystemTopic().getTopicName().getNamespaceObject(), false);
+            return;
+        }
         reader.hasMoreEventsAsync().whenComplete((hasMore, ex) -> {
             if (ex != null) {
                 log.error("[{}] Failed to check the move events for the system topic",
@@ -513,6 +528,10 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
      * #{@link SystemTopicBasedTopicPoliciesService#getTopicPoliciesAsync(TopicName)} method to block loading topic.
      */
     private void readMorePoliciesAsync(SystemTopicClient.Reader<PulsarEvent> reader) {
+        if (closed.get()) {
+            cleanCacheAndCloseReader(reader.getSystemTopic().getTopicName().getNamespaceObject(), false);
+            return;
+        }
         reader.readNextAsync()
                 .thenAccept(msg -> {
                     refreshTopicPoliciesCache(msg);
@@ -630,11 +649,20 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
     private void fetchTopicPoliciesAsyncAndCloseReader(SystemTopicClient.Reader<PulsarEvent> reader,
                                                        TopicName topicName, TopicPolicies policies,
                                                        CompletableFuture<TopicPolicies> future) {
+        if (closed.get()) {
+            future.completeExceptionally(new BrokerServiceException(getClass().getName() + " is closed."));
+            reader.closeAsync().whenComplete((v, e) -> {
+                if (e != null) {
+                    log.error("[{}] Close reader error.", topicName, e);
+                }
+            });
+            return;
+        }
         reader.hasMoreEventsAsync().whenComplete((hasMore, ex) -> {
             if (ex != null) {
                 future.completeExceptionally(ex);
             }
-            if (hasMore) {
+            if (hasMore != null && hasMore) {
                 reader.readNextAsync().whenComplete((msg, e) -> {
                     if (e != null) {
                         future.completeExceptionally(e);
@@ -658,7 +686,9 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                     }
                 });
             } else {
-                future.complete(policies);
+                if (!future.isDone()) {
+                    future.complete(policies);
+                }
                 reader.closeAsync().whenComplete((v, e) -> {
                     if (e != null) {
                         log.error("[{}] Close reader error.", topicName, e);
@@ -745,18 +775,20 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
 
     @Override
     public void close() throws Exception {
-        writerCaches.synchronous().invalidateAll();
-        readerCaches.values().forEach(future -> {
-            if (future != null && !future.isCompletedExceptionally()) {
-                future.thenAccept(reader -> {
-                    try {
-                        reader.close();
-                    } catch (Exception e) {
-                        log.error("Failed to close reader.", e);
-                    }
-                });
-            }
-        });
-        readerCaches.clear();
+        if (closed.compareAndSet(false, true)) {
+            writerCaches.synchronous().invalidateAll();
+            readerCaches.values().forEach(future -> {
+                if (future != null && !future.isCompletedExceptionally()) {
+                    future.thenAccept(reader -> {
+                        try {
+                            reader.close();
+                        } catch (Exception e) {
+                            log.error("Failed to close reader.", e);
+                        }
+                    });
+                }
+            });
+            readerCaches.clear();
+        }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicTxnBufferSnapshotService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicTxnBufferSnapshotService.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.service;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -156,7 +155,7 @@ public class SystemTopicTxnBufferSnapshotService<T> {
                 future.thenAccept(writer -> {
                     try {
                         writer.close();
-                    } catch (IOException e) {
+                    } catch (Exception e) {
                         log.error("Failed to close writer for namespace {}", entry.getKey(), e);
                     }
                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPoliciesService.java
@@ -38,7 +38,7 @@ import org.jetbrains.annotations.NotNull;
  * Topic policies service.
  */
 @InterfaceStability.Evolving
-public interface TopicPoliciesService {
+public interface TopicPoliciesService extends AutoCloseable {
 
     TopicPoliciesService DISABLED = new TopicPoliciesServiceDisabled();
     long DEFAULT_GET_TOPIC_POLICY_TIMEOUT = 30_000;
@@ -237,6 +237,11 @@ public interface TopicPoliciesService {
 
         @Override
         public void unregisterListener(TopicName topicName, TopicPolicyListener<TopicPolicies> listener) {
+            //No-op
+        }
+
+        @Override
+        public void close() {
             //No-op
         }
     }


### PR DESCRIPTION
### Motivation

There doesn't seem to be a proper handling for TopicPoliciesService shutdown.
This would be needed to allow the Pulsar broker to shutdown gracefully.
This also prevents memory leaks in tests. This problem was detected during the investigation of test OOMEs.
See #22588 for details.

### Modifications

- Add close method to TopicPoliciesService and implement it
- Prevent creating new cached writers or readers after the service has been closed
- Use Pulsar's executor for the AsyncLoader in TopicPoliciesService
- make shutdown synchronous
- Improve the close method of SystemTopicTxnBufferSnapshotService

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->