### PR TITLE
[improve][broker] Propagate cause exception in TopicBusyException when applicable

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
@@ -146,6 +146,10 @@ public class BrokerServiceException extends Exception {
         public TopicBusyException(String msg) {
             super(msg);
         }
+
+        public TopicBusyException(String msg, Throwable t) {
+            super(msg, t);
+        }
     }
 
     public static class TopicNotFoundException extends BrokerServiceException {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -477,7 +477,8 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                 }
             }).exceptionally(ex -> {
                 deleteFuture.completeExceptionally(
-                        new TopicBusyException("Failed to close clients before deleting topic."));
+                        new TopicBusyException("Failed to close clients before deleting topic.",
+                                FutureUtil.unwrapCompletionException(ex)));
                 return null;
             });
         } finally {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1506,7 +1506,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 }).exceptionally(ex->{
                     unfenceTopicToResume();
                     deleteFuture.completeExceptionally(
-                            new TopicBusyException("Failed to close clients before deleting topic."));
+                            new TopicBusyException("Failed to close clients before deleting topic.",
+                                    FutureUtil.unwrapCompletionException(ex)));
                     return null;
                 });
 


### PR DESCRIPTION
### Motivation

When topic is closing and throws an exception, the exception isn't logged and it's swallowed.
It's better to propagate the cause in TopicBusyException in these cases.

### Modifications

- Add support for cause exception to TopicBusyException
- Propagate the cause when closing throws an exception

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->