### PR TITLE
[fix][broker] Continue closing even when executor is shut down

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -45,6 +45,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -1429,7 +1430,14 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 }
                 FutureUtil.waitForAll(futures).thenRunAsync(() -> {
                     closeClientFuture.complete(null);
-                }, getOrderedExecutor()).exceptionally(ex -> {
+                }, command -> {
+                    try {
+                        getOrderedExecutor().execute(command);
+                    } catch (RejectedExecutionException e) {
+                        // executor has been shut down, execute in current thread
+                        command.run();
+                    }
+                }).exceptionally(ex -> {
                     log.error("[{}] Error closing clients", topic, ex);
                     unfenceTopicToResume();
                     closeClientFuture.completeExceptionally(ex);


### PR DESCRIPTION
### Motivation

```
2024-04-26T09:36:28,397 - ERROR - [ForkJoinPool.commonPool-worker-10:PersistentTopic] - [persistent://pulsar/global/removeClusterTest/__change_events] Error closing clients
java.util.concurrent.CompletionException: java.util.concurrent.RejectedExecutionException: Executor is shutting down
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.uniRunNow(CompletableFuture.java:823) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.uniRunStage(CompletableFuture.java:803) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.thenRunAsync(CompletableFuture.java:2204) ~[?:?]
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.lambda$delete$44(PersistentTopic.java:1430) ~[classes/:?]
	at org.apache.pulsar.broker.resources.NamespaceResources$PartitionedTopicResources.lambda$runWithMarkDeleteAsync$9(NamespaceResources.java:359) ~[pulsar-broker-common-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863) [?:?]
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841) [?:?]
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:483) [?:?]
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373) [?:?]
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182) [?:?]
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655) [?:?]
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622) [?:?]
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165) [?:?]
Caused by: java.util.concurrent.RejectedExecutionException: Executor is shutting down
	at org.apache.bookkeeper.common.util.SingleThreadExecutor.execute(SingleThreadExecutor.java:208) ~[bookkeeper-common-4.17.0.jar:4.17.0]
	at java.base/java.util.concurrent.CompletableFuture.uniRunNow(CompletableFuture.java:817) ~[?:?]
	... 12 more
```

### Modifications

- provide custom Executor that catches RejectedExecutionException and runs in current thread in that case.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->