### PR TITLE
[fix][build] Switch slf4j scope to provided from compile

### DIFF
--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -133,6 +133,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
     </dependency>

--- a/distribution/shell/pom.xml
+++ b/distribution/shell/pom.xml
@@ -41,6 +41,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
     </dependency>

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -425,6 +425,7 @@ BSD 3-clause "New" or "Revised" License
 MIT License
  * SLF4J -- ../licenses/LICENSE-SLF4J.txt
     - slf4j-api-2.0.13.jar
+    - jcl-over-slf4j-2.0.13.jar
  * The Checker Framework
     - checker-qual-3.33.0.jar
 

--- a/pom.xml
+++ b/pom.xml
@@ -765,18 +765,21 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
+        <scope>provided</scope>
       </dependency>
 
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
         <version>${slf4j.version}</version>
+        <scope>provided</scope>
       </dependency>
 
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
         <version>${slf4j.version}</version>
+        <scope>provided</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
### Motivation

#22391 upgrades the slf4j version to 2.0.13.

When the users upgrade the broker/client library to the latest version, #22391 breaks users who are using slf4j 1.x, and their application is unable to print logs.

Maven has a scope feature, that can help us fix this issue. Import the slf4j dependency with `<scope>provided</scope>` in the pulsar, and then the users use the broker/client library, users can use any version of slf4j.

There is a small issue here, users must include slf4j-api in their projects. The slf4j-api is commonly used anywhere, and I don't think we need to worry about this issue.

### Modifications

- Switch the slf4j scope to `provided` from `compile` in the `pom.xml`, and then the libraries don't include the slf4j.
- Switch the slf4j scope to `compile` from `provided` in the `distribution/server/pom.xml` and `distribution/shell/pom.xml`, and then the tar includes the slf4j.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->