### PR TITLE
[fix][build] Upgrade docker-maven-plugin to 0.43.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@ flexible messaging model and an intuitive client API.</description>
     <reflections.version>0.10.2</reflections.version>
     <swagger.version>1.6.2</swagger.version>
     <puppycrawl.checkstyle.version>10.14.2</puppycrawl.checkstyle.version>
-    <docker-maven.version>0.43.3</docker-maven.version>
+    <docker-maven.version>0.44.0</docker-maven.version>
     <docker.verbose>true</docker.verbose>
     <typetools.version>0.5.0</typetools.version>
     <byte-buddy.version>1.14.12</byte-buddy.version>


### PR DESCRIPTION
### Motivation

This plugin doesn't work on the MacOS 14.1.1 (23B81) with intel CPU.

```
Client:
 Cloud integration: v1.0.35+desktop.5
 Version:           24.0.7
 API version:       1.43
 Go version:        go1.20.10
 Git commit:        afdd53b
 Built:             Thu Oct 26 09:04:20 2023
 OS/Arch:           darwin/amd64
 Context:           desktop-linux

Server: Docker Desktop 4.26.1 (131620)
 Engine:
  Version:          24.0.7
  API version:      1.43 (minimum version 1.12)
  Go version:       go1.20.10
  Git commit:       311b9ff
  Built:            Thu Oct 26 09:08:02 2023
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.6.25
  GitCommit:        d8f198a4ed8892c764191ef7b3b06d8a2eeb5c7f
 runc:
  Version:          1.1.10
  GitCommit:        v1.1.10-0-g18a0cb0
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
``` 

Build and Push command:
```
mvn install -DUBUNTU_MIRROR=http://azure.archive.ubuntu.com/ubuntu/ \
    -DskipTests \
    -Dmaven.gitcommitid.nativegit=true \
    -Pmain,docker -Pdocker-push \
    -Ddocker.platforms=linux/arm64 \
    -Ddocker.organization=$YOUR_ORG \
    -pl docker/pulsar
```

Fault log:
```
[INFO] --- docker:0.43.3:build (default) @ pulsar-docker-image ---
[INFO] Building tar: /Users/zixuan/repo/pulsar/docker/pulsar/target/docker/$YOUR_ORG /pulsar/tmp/docker-build.tar
[INFO] DOCKER> [$YOUR_ORG /pulsar:latest]: Created docker-build.tar in 2 seconds 
[INFO] DOCKER> Credentials helper reply for "docker-credential-desktop" is docker-credential-desktop (github.com/docker/docker-credential-helpers) v0.7.0
[INFO] DOCKER> Credentials helper reply for "docker-credential-desktop" is docker-credential-desktop (github.com/docker/docker-credential-helpers) v0.7.0
[INFO] Expanding: /Users/zixuan/repo/pulsar/docker/pulsar/target/docker/$YOUR_ORG /pulsar/tmp/docker-build.tar into /Users/zixuan/repo/pulsar/docker/pulsar/target/docker/$YOUR_ORG /pulsar/tmp/docker-build
[INFO] DOCKER> docker buildx build --progress=plain --builder maven --platform linux/arm64 --tag $YOUR_ORG/pulsar:latest --tag $YOUR_ORG/pulsar:latest --tag $YOUR_ORG/pulsar:3.3.0-SNAPSHOT-e7aecef --build-arg PULSAR_CLIENT_PYTHON_VERSION=3.4.0 --build-arg PULSAR_TARBALL=target/pulsar-server-distribution-3.3.0-SNAPSHOT-bin.tar.gz --file=/Users/zixuan/repo/pulsar/docker/pulsar/target/docker/$YOUR_ORG/pulsar/tmp/docker-build/Dockerfile /Users/zixuan/repo/pulsar/docker/pulsar/target/docker/$YOUR_ORG/pulsar/tmp/docker-build --load
[INFO] DOCKER> ERROR: no builder "maven" found
[ERROR] DOCKER> Error status (1) when building
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE

```

### Modifications

- Upgrade the docker-maven-plugin to 0.43.4 from 0.44.0

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->