### PR TITLE
[fix][test] Fix the flaky tests of ManagedLedgerImplUtilsTest

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/util/ManagedLedgerImplUtilsTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/util/ManagedLedgerImplUtilsTest.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.mledger.util;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
@@ -41,6 +42,8 @@ public class ManagedLedgerImplUtilsTest extends MockedBookKeeperTestCase {
 
         ManagedLedgerConfig managedLedgerConfig = new ManagedLedgerConfig();
         managedLedgerConfig.setMaxEntriesPerLedger(maxEntriesPerLedger);
+        managedLedgerConfig.setRetentionSizeInMB(10);
+        managedLedgerConfig.setRetentionTime(5, TimeUnit.MINUTES);
         ManagedLedger ledger = factory.open("testReverseFindPositionOneByOne", managedLedgerConfig);
 
         String matchEntry = "match-entry";


### PR DESCRIPTION
### Motivation

If the trim ledger happened before get the `ManagedLedgerImplUtils.asyncGetLastValidPosition()`, the returned message ID will not be the message ID returned to the writer because messages are deleted by the trimming task.

```
2024-04-29T09:29:18,911 - INFO  - [test-OrderedScheduler-0-0:PulsarMockBookKeeper@123] - Creating ledger 4
2024-04-29T09:29:18,911 - INFO  - [test-OrderedScheduler-0-0:ManagedLedgerImpl@1529] - [testReverseFindPositionOneByOne] Created new ledger 4
2024-04-29T09:29:18,919 - INFO  - [test-OrderedScheduler-1-0:OpAddEntry@231] - [testReverseFindPositionOneByOne] Closing ledger 4 for being full
2024-04-29T09:29:18,920 - INFO  - [bookkeeper-ml-scheduler-OrderedScheduler-1-0:ManagedLedgerImpl$17@2686] - [testReverseFindPositionOneByOne] End TrimConsumedLedgers. ledgers=1 totalSize=65
2024-04-29T09:29:18,921 - INFO  - [bookkeeper-ml-scheduler-OrderedScheduler-1-0:ManagedLedgerImpl$17@2693] - [testReverseFindPositionOneByOne] Removing ledger 3 - size: 55

java.lang.AssertionError:
Expected :3:4
Actual   :4:-1
<Click to see difference>


	at org.testng.Assert.fail(Assert.java:99)
	at org.testng.Assert.failNotEquals(Assert.java:1037)
	at org.testng.Assert.assertEqualsImpl(Assert.java:140)
	at org.testng.Assert.assertEquals(Assert.java:122)
	at org.testng.Assert.assertEquals(Assert.java:617)
	at org.apache.bookkeeper.mledger.util.ManagedLedgerImplUtilsTest.testGetLastValidPosition(ManagedLedgerImplUtilsTest.java:69)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
	at org.testng.internal.TestInvoker.invokeMethod(TestInvoker.java:599)
	at org.testng.internal.TestInvoker.invokeTestMethod(TestInvoker.java:174)
	at org.testng.internal.MethodRunner.runInSequence(MethodRunner.java:46)
	at org.testng.internal.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:822)
	at org.testng.internal.TestInvoker.invokeTestMethods(TestInvoker.java:147)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:146)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:128)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.testng.TestRunner.privateRun(TestRunner.java:764)
	at org.testng.TestRunner.run(TestRunner.java:585)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:384)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:378)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:337)
	at org.testng.SuiteRunner.run(SuiteRunner.java:286)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:53)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:96)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1218)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1140)
	at org.testng.TestNG.runSuites(TestNG.java:1069)
	at org.testng.TestNG.run(TestNG.java:1037)
	at com.intellij.rt.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:65)
	at com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:105)
```

### Modifications

Set retention policy to the managed ledger to avoid the data deletion before the verification of the test. Otherwise, the test will not cover the newly added method.

### Verifying this change

It's a test change

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
