### PR TITLE
[improve] [broker] Add additionalSystemCursorNames ignore list for TTL check

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -180,7 +180,8 @@ backlogQuotaDefaultRetentionPolicy=producer_request_hold
 # Default ttl for namespaces if ttl is not already configured at namespace policies. (disable default-ttl with value 0)
 ttlDurationDefaultInSeconds=0
 
-# Additional system subscriptions that will be ignored by ttl check. Default is empty.
+# Additional system subscriptions that will be ignored by ttl check. The cursor names are comma separated.
+# Default is empty.
 # additionalSystemCursorNames=
 
 # Enable topic auto creation if new producer or consumer connected (disable auto creation with value false)

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -180,6 +180,9 @@ backlogQuotaDefaultRetentionPolicy=producer_request_hold
 # Default ttl for namespaces if ttl is not already configured at namespace policies. (disable default-ttl with value 0)
 ttlDurationDefaultInSeconds=0
 
+# System subscriptions that will be ignored by ttl check. Default is __compaction.
+# systemCursorNames=__compaction
+
 # Enable topic auto creation if new producer or consumer connected (disable auto creation with value false)
 allowAutoTopicCreation=true
 

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -181,7 +181,7 @@ backlogQuotaDefaultRetentionPolicy=producer_request_hold
 ttlDurationDefaultInSeconds=0
 
 # Additional system subscriptions that will be ignored by ttl check. Default is empty.
-# systemCursorNames=
+# additionalSystemCursorNames=
 
 # Enable topic auto creation if new producer or consumer connected (disable auto creation with value false)
 allowAutoTopicCreation=true

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -180,8 +180,8 @@ backlogQuotaDefaultRetentionPolicy=producer_request_hold
 # Default ttl for namespaces if ttl is not already configured at namespace policies. (disable default-ttl with value 0)
 ttlDurationDefaultInSeconds=0
 
-# System subscriptions that will be ignored by ttl check. Default is __compaction.
-# systemCursorNames=__compaction
+# Additional system subscriptions that will be ignored by ttl check. Default is empty.
+# systemCursorNames=
 
 # Enable topic auto creation if new producer or consumer connected (disable auto creation with value false)
 allowAutoTopicCreation=true

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -121,6 +121,9 @@ backlogQuotaDefaultLimitSecond=-1
 # Default ttl for namespaces if ttl is not already configured at namespace policies. (disable default-ttl with value 0)
 ttlDurationDefaultInSeconds=0
 
+# System subscriptions that will be ignored by ttl check. Default is __compaction.
+# systemCursorNames=__compaction
+
 # Enable the deletion of inactive topics. This parameter need to cooperate with the allowAutoTopicCreation parameter.
 # If brokerDeleteInactiveTopicsEnabled is set to true, we should ensure that allowAutoTopicCreation is also set to true.
 brokerDeleteInactiveTopicsEnabled=true

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -121,7 +121,8 @@ backlogQuotaDefaultLimitSecond=-1
 # Default ttl for namespaces if ttl is not already configured at namespace policies. (disable default-ttl with value 0)
 ttlDurationDefaultInSeconds=0
 
-# Additional system subscriptions that will be ignored by ttl check. Default is empty.
+# Additional system subscriptions that will be ignored by ttl check.  The cursor names are comma separated.
+# Default is empty.
 # additionalSystemCursorNames=
 
 # Enable the deletion of inactive topics. This parameter need to cooperate with the allowAutoTopicCreation parameter.

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -121,8 +121,8 @@ backlogQuotaDefaultLimitSecond=-1
 # Default ttl for namespaces if ttl is not already configured at namespace policies. (disable default-ttl with value 0)
 ttlDurationDefaultInSeconds=0
 
-# System subscriptions that will be ignored by ttl check. Default is __compaction.
-# systemCursorNames=__compaction
+# Additional system subscriptions that will be ignored by ttl check. Default is empty.
+# systemCursorNames=
 
 # Enable the deletion of inactive topics. This parameter need to cooperate with the allowAutoTopicCreation parameter.
 # If brokerDeleteInactiveTopicsEnabled is set to true, we should ensure that allowAutoTopicCreation is also set to true.

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -122,7 +122,7 @@ backlogQuotaDefaultLimitSecond=-1
 ttlDurationDefaultInSeconds=0
 
 # Additional system subscriptions that will be ignored by ttl check. Default is empty.
-# systemCursorNames=
+# additionalSystemCursorNames=
 
 # Enable the deletion of inactive topics. This parameter need to cooperate with the allowAutoTopicCreation parameter.
 # If brokerDeleteInactiveTopicsEnabled is set to true, we should ensure that allowAutoTopicCreation is also set to true.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -654,7 +654,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_POLICIES,
-        doc = "Additional system subscriptions that will be ignored by ttl check. Default is empty."
+        doc = "Additional system subscriptions that will be ignored by ttl check. "
+                + "The cursor names are comma separated. Default is empty."
     )
     private Set<String> additionalSystemCursorNames = new TreeSet<>();
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -656,7 +656,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         category = CATEGORY_POLICIES,
         doc = "Subscriptions that will be ignored by ttl check. Default is empty."
     )
-    private Set<String> SubscriptionsIgnoredByTtl = new TreeSet<>();
+    private Set<String> subscriptionsIgnoredByTtl = new TreeSet<>();
 
     @FieldContext(
         category = CATEGORY_POLICIES,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -654,6 +654,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_POLICIES,
+        doc = "Default auto-creation of namespace bundles if auto-creation is not already configured at namespace policies."
+    )
+    private Set<String> SubscriptionsIgnoredByTtl = new TreeSet<>();
+
+    @FieldContext(
+        category = CATEGORY_POLICIES,
         dynamic = true,
         doc = "Enable the deletion of inactive topics.\n"
         + "If only enable this option, will not clean the metadata of partitioned topic."

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -654,7 +654,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_POLICIES,
-        doc = "System subscriptions that will be ignored by ttl check. Default is empty."
+        doc = "System subscriptions that will be ignored by ttl check. Default is __compaction."
     )
     private Set<String> systemCursorNames = Set.of("__compaction");
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -654,9 +654,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_POLICIES,
-        doc = "System subscriptions that will be ignored by ttl check. Default is __compaction."
+        doc = "Additional system subscriptions that will be ignored by ttl check. Default is empty."
     )
-    private Set<String> systemCursorNames = Set.of("__compaction");
+    private Set<String> additionalSystemCursorNames = new TreeSet<>();
 
     @FieldContext(
         category = CATEGORY_POLICIES,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -654,7 +654,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_POLICIES,
-        doc = "Default auto-creation of namespace bundles if auto-creation is not already configured at namespace policies."
+        doc = "Subscriptions that will be ignored by ttl check. Default is empty."
     )
     private Set<String> SubscriptionsIgnoredByTtl = new TreeSet<>();
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -654,9 +654,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_POLICIES,
-        doc = "Subscriptions that will be ignored by ttl check. Default is empty."
+        doc = "System subscriptions that will be ignored by ttl check. Default is empty."
     )
-    private Set<String> subscriptionsIgnoredByTtl = new TreeSet<>();
+    private Set<String> systemCursorNames = Set.of("__compaction");
 
     @FieldContext(
         category = CATEGORY_POLICIES,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1936,7 +1936,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         int messageTtlInSeconds = topicPolicies.getMessageTTLInSeconds().get();
         if (messageTtlInSeconds != 0) {
             subscriptions.forEach((__, sub) -> {
-                if (systemCursorNames.contains(sub.getName())) {
+                if (!systemCursorNames.contains(sub.getName())) {
                    sub.expireMessages(messageTtlInSeconds);
                 }
             });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -279,7 +279,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     private final ExecutorService orderedExecutor;
 
     private volatile CloseFutures closeFutures;
-    private Set<String> subscriptionsIgnoredByTtl = new TreeSet<>();
+    private Set<String> systemCursorNames = new TreeSet<>();
 
     @Getter
     private final PersistentTopicMetrics persistentTopicMetrics = new PersistentTopicMetrics();
@@ -415,7 +415,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         } else {
             shadowSourceTopic = null;
         }
-        subscriptionsIgnoredByTtl = brokerService.pulsar().getConfiguration().getSubscriptionsIgnoredByTtl();
+        systemCursorNames = brokerService.pulsar().getConfiguration().getSystemCursorNames();
     }
 
     @Override
@@ -1936,9 +1936,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         int messageTtlInSeconds = topicPolicies.getMessageTTLInSeconds().get();
         if (messageTtlInSeconds != 0) {
             subscriptions.forEach((__, sub) -> {
-                if (!isCompactionSubscription(sub.getName())
-                        && (subscriptionsIgnoredByTtl.isEmpty()
-                            || !subscriptionsIgnoredByTtl.contains(sub.getName()))) {
+                if (systemCursorNames.contains(sub.getName())) {
                    sub.expireMessages(messageTtlInSeconds);
                 }
             });

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessageTTLTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessageTTLTest.java
@@ -23,15 +23,23 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.CursorStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
@@ -138,4 +146,92 @@ public class MessageTTLTest extends BrokerTestBase {
         topicRefMock.onUpdate(topicPolicies);
         verify(topicRefMock, times(2)).checkMessageExpiry();
     }
+
+    @Test
+    public void testTtlFilteredByIgnoreSubscriptions() throws Exception {
+        String topicName = "persistent://prop/ns-abc/testTTLFilteredByIgnoreSubscriptions";
+        String subName = "__SUB_FILTER";
+        cleanup();
+        Set<String> ignoredSubscriptions = new HashSet<>();
+        ignoredSubscriptions.add(subName);
+        int defaultTtl = 5;
+        conf.setSubscriptionsIgnoredByTtl(ignoredSubscriptions);
+        conf.setTtlDurationDefaultInSeconds(defaultTtl);
+        super.baseSetup();
+
+        pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subName)
+                .subscribe().close();
+
+        @Cleanup
+        org.apache.pulsar.client.api.Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .enableBatching(false).topic(topicName).create();
+
+        final int messages = 10;
+
+        for (int i = 0; i < messages; i++) {
+            String message = "my-message-" + i;
+            producer.send(message);
+        }
+        producer.close();
+
+        Optional<Topic> topic = pulsar.getBrokerService().getTopicReference(topicName);
+        assertTrue(topic.isPresent());
+        PersistentSubscription subscription = (PersistentSubscription) topic.get().getSubscription(subName);
+
+        Thread.sleep((defaultTtl - 1) * 1000);
+        topic.get().checkMessageExpiry();
+        // Wait the message expire task done and make sure the message does not expire early.
+        Thread.sleep(1000);
+        assertEquals(subscription.getNumberOfEntriesInBacklog(false), 10);
+        Thread.sleep(2000);
+        topic.get().checkMessageExpiry();
+        // Wait the message expire task done.
+        retryStrategically((test) -> subscription.getNumberOfEntriesInBacklog(false) == 0, 5, 200);
+        // The message should not expire because the subscription is ignored.
+        assertEquals(subscription.getNumberOfEntriesInBacklog(false), 10);
+
+        conf.setSubscriptionsIgnoredByTtl(new TreeSet<>());
+    }
+
+    @Test
+    public void testTtlWithoutIgnoreSubscriptions() throws Exception {
+        String topicName = "persistent://prop/ns-abc/testTTLWithoutIgnoreSubscriptions";
+        String subName = "__SUB_FILTER";
+        cleanup();
+        int defaultTtl = 5;
+        conf.setTtlDurationDefaultInSeconds(defaultTtl);
+        conf.setBrokerDeleteInactiveTopicsEnabled(false);
+        super.baseSetup();
+
+        pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subName)
+                .subscribe().close();
+
+        @Cleanup
+        org.apache.pulsar.client.api.Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .enableBatching(false).topic(topicName).create();
+
+        final int messages = 10;
+
+        for (int i = 0; i < messages; i++) {
+            String message = "my-message-" + i;
+            producer.send(message);
+        }
+        producer.close();
+
+        Optional<Topic> topic = pulsar.getBrokerService().getTopicReference(topicName);
+        assertTrue(topic.isPresent());
+        PersistentSubscription subscription = (PersistentSubscription) topic.get().getSubscription(subName);
+
+        Thread.sleep((defaultTtl - 1) * 1000);
+        topic.get().checkMessageExpiry();
+        // Wait the message expire task done and make sure the message does not expire early.
+        Thread.sleep(1000);
+        assertEquals(subscription.getNumberOfEntriesInBacklog(false), 10);
+        Thread.sleep(2000);
+        topic.get().checkMessageExpiry();
+        // Wait the message expire task done and make sure the message expired.
+        retryStrategically((test) -> subscription.getNumberOfEntriesInBacklog(false) == 0, 5, 200);
+        assertEquals(subscription.getNumberOfEntriesInBacklog(false), 0);
+    }
+
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessageTTLTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessageTTLTest.java
@@ -155,7 +155,7 @@ public class MessageTTLTest extends BrokerTestBase {
         Set<String> ignoredSubscriptions = new HashSet<>();
         ignoredSubscriptions.add(subName);
         int defaultTtl = 5;
-        conf.setSystemCursorNames(ignoredSubscriptions);
+        conf.setAdditionalSystemCursorNames(ignoredSubscriptions);
         conf.setTtlDurationDefaultInSeconds(defaultTtl);
         super.baseSetup();
 
@@ -190,7 +190,7 @@ public class MessageTTLTest extends BrokerTestBase {
         // The message should not expire because the subscription is ignored.
         assertEquals(subscription.getNumberOfEntriesInBacklog(false), 10);
 
-        conf.setSystemCursorNames(new TreeSet<>());
+        conf.setAdditionalSystemCursorNames(new TreeSet<>());
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessageTTLTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessageTTLTest.java
@@ -155,7 +155,7 @@ public class MessageTTLTest extends BrokerTestBase {
         Set<String> ignoredSubscriptions = new HashSet<>();
         ignoredSubscriptions.add(subName);
         int defaultTtl = 5;
-        conf.setSubscriptionsIgnoredByTtl(ignoredSubscriptions);
+        conf.setSystemCursorNames(ignoredSubscriptions);
         conf.setTtlDurationDefaultInSeconds(defaultTtl);
         super.baseSetup();
 
@@ -190,7 +190,7 @@ public class MessageTTLTest extends BrokerTestBase {
         // The message should not expire because the subscription is ignored.
         assertEquals(subscription.getNumberOfEntriesInBacklog(false), 10);
 
-        conf.setSubscriptionsIgnoredByTtl(new TreeSet<>());
+        conf.setSystemCursorNames(new TreeSet<>());
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -2321,5 +2321,4 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         verify(topic, times(0)).publishTxnMessage(any(), any(), any());
     }
 
-
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -2321,4 +2321,5 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         verify(topic, times(0)).publishTxnMessage(any(), any(), any());
     }
 
+
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
Message TTL will move the cursors based on the configured `ttlDurationDefaultInSeconds`. However, for those system topics' cursors, such as compaction service cursor, transaction system topic cursor, and even some third-party plugins cursors, should not or don't want to be impacted by the TTL. 

We have one PR https://github.com/apache/pulsar/pull/21865 to filter the compaction service cursors for TTL check, but doesn't cover other system topics cursors. To provide a general solution and support third-party plugin cursors not impacted by TTL, I proposed to add a systemCursorNames ignore list  to filter the TTL check.



### Modifications

Add a configuration in `conf/broker.conf` to support filter subscriptions for TTL check.
<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
