### PR TITLE
[fix][misc] Correct the description of patternAutoDiscoveryPeriod

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -464,7 +464,7 @@ public interface ConsumerBuilder<T> extends Cloneable {
     ConsumerBuilder<T> readCompacted(boolean readCompacted);
 
     /**
-     * Sets topic's auto-discovery period when using a pattern for topics consumer.
+     * Sets topic's auto-discovery period when using a pattern for topic's consumer.
      * The period is in minutes, and the default and minimum values are 1 minute.
      *
      * @param periodInMinutes
@@ -476,7 +476,8 @@ public interface ConsumerBuilder<T> extends Cloneable {
 
 
     /**
-     * Sets topic's auto-discovery period when using a pattern for topics consumer.
+     * Sets topic's auto-discovery period when using a pattern for topic's consumer.
+     * The default value of period is 1 minute, with a minimum of 1 second.
      *
      * @param interval
      *            the amount of delay between checks for

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -310,7 +310,7 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
             name = "patternAutoDiscoveryPeriod",
             value = "Topic auto discovery period when using a pattern for topic's consumer.\n"
                     + "\n"
-                    + "The default and minimum value is 1 minute."
+                    + "The default value is 1 minute, with a minimum of 1 second."
     )
     private int patternAutoDiscoveryPeriod = 60;
 


### PR DESCRIPTION
### Motivation

fix comment of patternAutoDiscoveryPeriod in ConsumerConfigurationData class.

### Modifications

`The default and minimum value is 1 minute.` -> `The default value is 1 minute, with a minimum of 1 second.`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->