### PR TITLE
[fix][storage] ReadonlyManagedLedger initialization does not fill in the properties

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
@@ -19,6 +19,7 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import com.google.common.collect.Range;
+import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +33,7 @@ import org.apache.bookkeeper.mledger.ManagedLedgerException.MetaStoreException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.MetadataNotFoundException;
 import org.apache.bookkeeper.mledger.ReadOnlyCursor;
 import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
 import org.apache.pulsar.metadata.api.Stat;
@@ -56,6 +58,14 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
 
                 for (LedgerInfo ls : mlInfo.getLedgerInfoList()) {
                     ledgers.put(ls.getLedgerId(), ls);
+                }
+
+                if (mlInfo.getPropertiesCount() > 0) {
+                    propertiesMap = new HashMap();
+                    for (int i = 0; i < mlInfo.getPropertiesCount(); i++) {
+                        MLDataFormats.KeyValue property = mlInfo.getProperties(i);
+                        propertiesMap.put(property.getKey(), property.getValue());
+                    }
                 }
 
                 // Last ledger stat may be zeroed, we must update it

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImplTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImplTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+
+import static org.testng.Assert.assertEquals;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
+import org.testng.annotations.Test;
+
+public class ReadOnlyManagedLedgerImplTest extends MockedBookKeeperTestCase {
+    private static final String MANAGED_LEDGER_NAME_NON_PROPERTIES = "ml-non-properties";
+    private static final String MANAGED_LEDGER_NAME_ATTACHED_PROPERTIES = "ml-attached-properties";
+
+
+    @Test
+    public void testReadOnlyManagedLedgerImplAttachProperties()
+            throws ManagedLedgerException, InterruptedException, ExecutionException, TimeoutException {
+        final ManagedLedger ledger = factory.open(MANAGED_LEDGER_NAME_ATTACHED_PROPERTIES,
+                new ManagedLedgerConfig().setRetentionTime(1, TimeUnit.HOURS));
+        final String propertiesKey = "test-key";
+        final String propertiesValue = "test-value";
+
+        ledger.setConfig(new ManagedLedgerConfig());
+        ledger.addEntry("entry-0".getBytes());
+        Map<String, String> properties = new HashMap<>();
+        properties.put(propertiesKey, propertiesValue);
+        ledger.setProperties(Collections.unmodifiableMap(properties));
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        factory.asyncOpenReadOnlyManagedLedger(MANAGED_LEDGER_NAME_ATTACHED_PROPERTIES,
+                new AsyncCallbacks.OpenReadOnlyManagedLedgerCallback() {
+                    @Override
+                    public void openReadOnlyManagedLedgerComplete(ReadOnlyManagedLedgerImpl managedLedger,
+                                                                  Object ctx) {
+                        managedLedger.getProperties().forEach((key, value) -> {
+                            assertEquals(key, propertiesKey);
+                            assertEquals(value, propertiesValue);
+                        });
+                        future.complete(null);
+                    }
+
+                    @Override
+                    public void openReadOnlyManagedLedgerFailed(ManagedLedgerException exception, Object ctx) {
+                        future.completeExceptionally(exception);
+                    }
+                }, new ManagedLedgerConfig(), null);
+
+        future.get(60, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testReadOnlyManagedLedgerImplNoProperties()
+            throws ManagedLedgerException, InterruptedException, ExecutionException, TimeoutException {
+        final ManagedLedger ledger = factory.open(MANAGED_LEDGER_NAME_NON_PROPERTIES,
+                new ManagedLedgerConfig().setRetentionTime(1, TimeUnit.HOURS));
+        ledger.setConfig(new ManagedLedgerConfig());
+        ledger.addEntry("entry-0".getBytes());
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        factory.asyncOpenReadOnlyManagedLedger(MANAGED_LEDGER_NAME_NON_PROPERTIES,
+                new AsyncCallbacks.OpenReadOnlyManagedLedgerCallback() {
+                    @Override
+                    public void openReadOnlyManagedLedgerComplete(ReadOnlyManagedLedgerImpl managedLedger,
+                                                                  Object ctx) {
+                        assertEquals(managedLedger.getProperties().size(), 0);
+                        future.complete(null);
+                    }
+
+                    @Override
+                    public void openReadOnlyManagedLedgerFailed(ManagedLedgerException exception, Object ctx) {
+                        future.completeExceptionally(exception);
+                    }
+                }, new ManagedLedgerConfig(), null);
+
+        future.get(60, TimeUnit.SECONDS);
+    }
+
+}


### PR DESCRIPTION
### Issue
issue: https://github.com/apache/pulsar/issues/22606
ReadonlyManagedLedger initialization does not fill in the properties.

### Modification
### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
