### PR TITLE
[fix][ci] Fix labeler GitHub Actions workflow, adapt to v5 configuration format

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,4 +16,5 @@
 # under the License.
 
 PIP:
-- 'pip/**'
+  - changed-files:
+      - any-glob-to-any-file: 'pip/**'


### PR DESCRIPTION
### Motivation

[labeler action](https://github.com/actions/labeler) was upgraded from v4 to v5 in #22620. The configuration format has changed in v5.

### Modifications

adapt to v5 configuration format

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->