### PR TITLE
[fix][misc] NPE during standalone shutdown

### DIFF
--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -1141,7 +1141,7 @@ defaultNumPartitions=1
 
 ### --- Transaction config variables --- ###
 # Enable transaction coordinator in broker
-transactionCoordinatorEnabled=true
+transactionCoordinatorEnabled=false
 transactionMetadataStoreProviderClassName=org.apache.pulsar.transaction.coordinator.impl.MLTransactionMetadataStoreProvider
 
 # Transaction buffer takes a snapshot after the number of transaction operations reaches this value.

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -1141,7 +1141,7 @@ defaultNumPartitions=1
 
 ### --- Transaction config variables --- ###
 # Enable transaction coordinator in broker
-transactionCoordinatorEnabled=false
+transactionCoordinatorEnabled=true
 transactionMetadataStoreProviderClassName=org.apache.pulsar.transaction.coordinator.impl.MLTransactionMetadataStoreProvider
 
 # Transaction buffer takes a snapshot after the number of transaction operations reaches this value.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -498,7 +498,9 @@ public class LocalBookkeeperEnsemble {
         LOG.debug("Local ZK/BK stopping ...");
         for (LifecycleComponent bookie : bookieComponents) {
             try {
-                bookie.close();
+                if (bookie != null) {
+                    bookie.close();
+                }
             } catch (Exception e) {
                 LOG.warn("failed to shutdown bookie", e);
             }


### PR DESCRIPTION
### Motivation

```
java.lang.NullPointerException: Cannot invoke "org.apache.bookkeeper.common.component.LifecycleComponent.close()" because "bookie" is null
	at org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble.stop(LocalBookkeeperEnsemble.java:501) ~[pulsar-broker-3.2.2.jar:3.2.2]
	at org.apache.pulsar.PulsarStandaloneStarter.lambda$new$0(PulsarStandaloneStarter.java:123) ~[pulsar-broker-3.2.2.jar:3.2.2]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]
```

### Modifications
- Fix NPE while closing pulsar standalone and bookies are not completed initialized yet

- [x] `doc-not-needed`
