### PR TITLE
[fix][ml]: subscription props could be lost in case of missing ledger during recovery

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -545,7 +545,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                 log.error("[{}] Error opening metadata ledger {} for cursor {}: {}", ledger.getName(), ledgerId, name,
                         BKException.getMessage(rc));
                 // Rewind to oldest entry available
-                initialize(getRollbackPosition(info), Collections.emptyMap(), Collections.emptyMap(), callback);
+                initialize(getRollbackPosition(info), Collections.emptyMap(), cursorProperties, callback);
                 return;
             } else if (rc != BKException.Code.OK) {
                 log.warn("[{}] Error opening metadata ledger {} for cursor {}: {}", ledger.getName(), ledgerId, name,


### PR DESCRIPTION
### Motivation

During the recovery of the cursor, if the stored position points to a non existent ledger, the cursor is rewinded to the oldest position. In this case the subscription properties won't be stored in the managedcursor info on the metadata store

### Modifications

* Pass the cursorProperties instead of an empty map during recovery

### Verifying this change

- [x] Make sure that the change passes the CI checks.

- [x] `doc-not-needed` 