### PR TITLE
[fix][sec] Upgrade elasticsearch-java version to avoid CVE-2023-4043

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@ flexible messaging model and an intuitive client API.</description>
     <hdfs-offload-version3>3.3.5</hdfs-offload-version3>
     <json-smart.version>2.4.10</json-smart.version>
     <opensearch.version>1.2.4</opensearch.version>
-    <elasticsearch-java.version>8.5.2</elasticsearch-java.version>
+    <elasticsearch-java.version>8.12.1</elasticsearch-java.version>
     <debezium.version>1.9.7.Final</debezium.version>
     <debezium.postgresql.version>42.5.0</debezium.postgresql.version>
     <debezium.mysql.version>8.0.30</debezium.mysql.version>


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/21783 & 
Could fix some of the vulnerabilities on https://github.com/apache/pulsar/issues/21782

### Motivation
Avoid CVE-2023-4043

### Modifications

Upgrade elasticsearch-java version to 8.12.1
which uses org.eclipse.parsson:parsson@1.0.5 which no longer has the vulnerability.
### Verifying this change

- [X] Make sure that the change passes the CI checks.



### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [X] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->