### PR TITLE
[fix][sec] Upgrade Debezium oracle connector version to avoid CVE-2023-4586

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,7 @@ flexible messaging model and an intuitive client API.</description>
     <opensearch.version>1.2.4</opensearch.version>
     <elasticsearch-java.version>8.5.2</elasticsearch-java.version>
     <debezium.version>1.9.7.Final</debezium.version>
+    <debezium.oracle.version>2.2.0.Final</debezium.oracle.version>
     <debezium.postgresql.version>42.5.0</debezium.postgresql.version>
     <debezium.mysql.version>8.0.30</debezium.mysql.version>
     <!-- Override version that brings CVE-2022-3143 with debezium -->

--- a/pulsar-io/debezium/oracle/pom.xml
+++ b/pulsar-io/debezium/oracle/pom.xml
@@ -48,7 +48,8 @@
     <dependency>
       <groupId>io.debezium</groupId>
       <artifactId>debezium-connector-oracle</artifactId>
-      <version>${debezium.version}</version>
+      <version>${debezium.oracle.version}</version>
+      <scope>runtime</scope>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/22626

### Motivation
Avoid CVE-2023-4586

### Modifications

Upgrade debezium-oracle-connector version to 2.2.0.Final
which avoids `org.infinispan:infinispan-client-hotrod@14.0.4.Final` which has the vulnerability and uses `org.infinispan:infinispan-client-hotrod-jakarta@14.0.4.Final` instead, which has no vulnerabilities.

### Verifying this change

- [X] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [X] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->