### PR TITLE
[improve][broker][WIP] Add brokerId to lookup results and load manager data

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/NoopLoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/NoopLoadManager.java
@@ -60,7 +60,7 @@ public class NoopLoadManager implements LoadManager {
         brokerId = pulsar.getBrokerId();
         localResourceUnit = new SimpleResourceUnit(brokerId, new PulsarResourceDescription());
 
-        LocalBrokerData localData = new LocalBrokerData(pulsar.getWebServiceAddress(),
+        LocalBrokerData localData = new LocalBrokerData(brokerId, pulsar.getWebServiceAddress(),
                 pulsar.getWebServiceAddressTls(),
                 pulsar.getBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls(), pulsar.getAdvertisedListeners());
         localData.setProtocols(pulsar.getProtocolDataToAdvertise());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryImpl.java
@@ -84,6 +84,7 @@ public class BrokerRegistryImpl implements BrokerRegistry {
         this.listeners = new ArrayList<>();
         this.brokerId = pulsar.getBrokerId();
         this.brokerLookupData = new BrokerLookupData(
+                pulsar.getBrokerId(),
                 pulsar.getWebServiceAddress(),
                 pulsar.getWebServiceAddressTls(),
                 pulsar.getBrokerServiceUrl(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupData.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupData.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.broker.loadbalance.extensions.data;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
@@ -31,7 +33,8 @@ import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
 /**
  * Defines the information required to broker lookup.
  */
-public record BrokerLookupData (String webServiceUrl,
+public record BrokerLookupData (@JsonProperty("name") String brokerId,
+                                String webServiceUrl,
                                 String webServiceUrlTls,
                                 String pulsarServiceUrl,
                                 String pulsarServiceUrlTls,
@@ -42,6 +45,12 @@ public record BrokerLookupData (String webServiceUrl,
                                 String loadManagerClassName,
                                 long startTimestamp,
                                 String brokerVersion) implements ServiceLookupData {
+    @JsonGetter("name")
+    @Override
+    public String getBrokerId() {
+        return this.brokerId;
+    }
+
     @Override
     public String getWebServiceUrl() {
         return this.webServiceUrl();
@@ -91,16 +100,16 @@ public record BrokerLookupData (String webServiceUrl,
             }
             URI url = listener.getBrokerServiceUrl();
             URI urlTls = listener.getBrokerServiceUrlTls();
-            return new LookupResult(webServiceUrl, webServiceUrlTls,
+            return new LookupResult(getBrokerId(), webServiceUrl, webServiceUrlTls,
                     url == null ? null : url.toString(),
                     urlTls == null ? null : urlTls.toString(), LookupResult.Type.BrokerUrl, false);
         }
-        return new LookupResult(webServiceUrl, webServiceUrlTls, pulsarServiceUrl, pulsarServiceUrlTls,
+        return new LookupResult(getBrokerId(), webServiceUrl, webServiceUrlTls, pulsarServiceUrl, pulsarServiceUrlTls,
                 LookupResult.Type.BrokerUrl, false);
     }
 
     public NamespaceEphemeralData toNamespaceEphemeralData() {
-        return new NamespaceEphemeralData(pulsarServiceUrl, pulsarServiceUrlTls, webServiceUrl, webServiceUrlTls,
-                false, advertisedListeners);
+        return new NamespaceEphemeralData(getBrokerId(), pulsarServiceUrl, pulsarServiceUrlTls, webServiceUrl,
+                webServiceUrlTls, false, advertisedListeners);
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/manager/RedirectManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/manager/RedirectManager.java
@@ -114,7 +114,7 @@ public class RedirectManager {
             });
             var selectedBroker = candidateBrokers.get((int) (Math.random() * candidateBrokers.size()));
 
-            return Optional.of(new LookupResult(selectedBroker.getWebServiceUrl(),
+            return Optional.of(new LookupResult(selectedBroker.getBrokerId(), selectedBroker.getWebServiceUrl(),
                     selectedBroker.getWebServiceUrlTls(),
                     selectedBroker.getPulsarServiceUrl(),
                     selectedBroker.getPulsarServiceUrlTls(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -961,14 +961,16 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
             // At this point, the ports will be updated with the real port number that the server was assigned
             Map<String, String> protocolData = pulsar.getProtocolDataToAdvertise();
 
-            lastData = new LocalBrokerData(pulsar.getWebServiceAddress(), pulsar.getWebServiceAddressTls(),
+            lastData = new LocalBrokerData(pulsar.getBrokerId(), pulsar.getWebServiceAddress(),
+                    pulsar.getWebServiceAddressTls(),
                     pulsar.getBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls(), pulsar.getAdvertisedListeners());
             lastData.setProtocols(protocolData);
             // configure broker-topic mode
             lastData.setPersistentTopicsEnabled(pulsar.getConfiguration().isEnablePersistentTopics());
             lastData.setNonPersistentTopicsEnabled(pulsar.getConfiguration().isEnableNonPersistentTopics());
 
-            localData = new LocalBrokerData(pulsar.getWebServiceAddress(), pulsar.getWebServiceAddressTls(),
+            localData = new LocalBrokerData(pulsar.getBrokerId(), pulsar.getWebServiceAddress(),
+                    pulsar.getWebServiceAddressTls(),
                     pulsar.getBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls(), pulsar.getAdvertisedListeners());
             localData.setProtocols(protocolData);
             localData.setBrokerVersionString(pulsar.getBrokerVersion());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/PulsarLoadReportImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/PulsarLoadReportImpl.java
@@ -55,7 +55,7 @@ public class PulsarLoadReportImpl implements LoadReport {
             org.apache.pulsar.policies.data.loadbalancer.LoadReport report =
                     LOAD_REPORT_READER.readValue(loadReportJson);
             SystemResourceUsage sru = report.getSystemResourceUsage();
-            String resourceUnitName = report.getName();
+            String resourceUnitName = report.getBrokerId();
             pulsarLoadReport.resourceDescription = new PulsarResourceDescription();
             if (sru.bandwidthIn != null) {
                 pulsarLoadReport.resourceDescription.put("bandwidthIn", sru.bandwidthIn);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -1003,7 +1003,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                     try {
                         String key = String.format("%s/%s", LOADBALANCE_BROKERS_ROOT, broker);
                         LoadReport lr = loadReports.readLock(key).join().get();
-                        ResourceUnit ru = new SimpleResourceUnit(lr.getName(), fromLoadReport(lr));
+                        ResourceUnit ru = new SimpleResourceUnit(lr.getBrokerId(), fromLoadReport(lr));
                         this.currentLoadReports.put(ru, lr);
                     } catch (Exception e) {
                         log.warn("Error reading load report from Cache for broker - [{}], [{}]", broker, e);
@@ -1075,7 +1075,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                 loadReport.setProtocols(pulsar.getProtocolDataToAdvertise());
                 loadReport.setNonPersistentTopicsEnabled(pulsar.getConfiguration().isEnableNonPersistentTopics());
                 loadReport.setPersistentTopicsEnabled(pulsar.getConfiguration().isEnablePersistentTopics());
-                loadReport.setName(pulsar.getBrokerId());
+                loadReport.setBrokerId(pulsar.getBrokerId());
                 loadReport.setBrokerVersionString(pulsar.getBrokerVersion());
 
                 SystemResourceUsage systemResourceUsage = this.getSystemResourceUsage();
@@ -1119,7 +1119,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                 loadReport.setAllocatedMsgRateOut(allocatedQuota.getMsgRateOut());
 
                 final ResourceUnit resourceUnit =
-                        new SimpleResourceUnit(loadReport.getName(), fromLoadReport(loadReport));
+                        new SimpleResourceUnit(loadReport.getBrokerId(), fromLoadReport(loadReport));
                 Set<String> preAllocatedBundles;
                 if (resourceUnitRankings.containsKey(resourceUnit)) {
                     preAllocatedBundles = resourceUnitRankings.get(resourceUnit).getPreAllocatedBundles();
@@ -1328,7 +1328,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                     ResourceType bottleneckResourceType = lr.getBottleneckResourceType();
                     Map<String, NamespaceBundleStats> bundleStats = lr.getSortedBundleStats(bottleneckResourceType);
                     if (bundleStats == null) {
-                        log.warn("Null bundle stats for bundle {}", lr.getName());
+                        log.warn("Null bundle stats for bundle {}", lr.getBrokerId());
                         continue;
 
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/LookupResult.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/LookupResult.java
@@ -39,32 +39,32 @@ public class LookupResult {
     public LookupResult(NamespaceEphemeralData namespaceEphemeralData) {
         this.type = Type.BrokerUrl;
         this.authoritativeRedirect = false;
-        this.lookupData = new LookupData(namespaceEphemeralData.getNativeUrl(),
+        this.lookupData = new LookupData(namespaceEphemeralData.getBrokerId(), namespaceEphemeralData.getNativeUrl(),
                 namespaceEphemeralData.getNativeUrlTls(), namespaceEphemeralData.getHttpUrl(),
                 namespaceEphemeralData.getHttpUrlTls());
     }
 
-    public LookupResult(String httpUrl, String httpUrlTls, String brokerServiceUrl, String brokerServiceUrlTls,
-            boolean authoritativeRedirect) {
+    public LookupResult(String brokerId, String httpUrl, String httpUrlTls, String brokerServiceUrl,
+                        String brokerServiceUrlTls, boolean authoritativeRedirect) {
         this.type = Type.RedirectUrl; // type = redirect => as current broker is
                                       // not owner and prepares LookupResult
                                       // with other broker's urls
         this.authoritativeRedirect = authoritativeRedirect;
-        this.lookupData = new LookupData(brokerServiceUrl, brokerServiceUrlTls, httpUrl, httpUrlTls);
+        this.lookupData = new LookupData(brokerId, brokerServiceUrl, brokerServiceUrlTls, httpUrl, httpUrlTls);
     }
 
-    public LookupResult(String httpUrl, String httpUrlTls, String nativeUrl, String nativeUrlTls, Type type,
-            boolean authoritativeRedirect) {
+    public LookupResult(String brokerId, String httpUrl, String httpUrlTls, String nativeUrl, String nativeUrlTls,
+                        Type type, boolean authoritativeRedirect) {
         this.type = type;
         this.authoritativeRedirect = authoritativeRedirect;
-        this.lookupData = new LookupData(nativeUrl, nativeUrlTls, httpUrl, httpUrlTls);
+        this.lookupData = new LookupData(brokerId, nativeUrl, nativeUrlTls, httpUrl, httpUrlTls);
     }
 
     public LookupResult(NamespaceEphemeralData namespaceEphemeralData, String nativeUrl, String nativeUrlTls) {
         this.type = Type.BrokerUrl;
         this.authoritativeRedirect = false;
-        this.lookupData = new LookupData(nativeUrl, nativeUrlTls, namespaceEphemeralData.getHttpUrl(),
-                namespaceEphemeralData.getHttpUrlTls());
+        this.lookupData = new LookupData(namespaceEphemeralData.getBrokerId(), nativeUrl, nativeUrlTls,
+                namespaceEphemeralData.getHttpUrl(), namespaceEphemeralData.getHttpUrlTls());
     }
 
     public boolean isBrokerUrl() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -217,7 +217,7 @@ public class TopicLookupBase extends PulsarWebResource {
                             differentClusterData.getBrokerServiceUrl(), differentClusterData.getBrokerServiceUrlTls(),
                             cluster);
                 }
-                validationFuture.complete(newLookupResponse(differentClusterData.getBrokerServiceUrl(),
+                validationFuture.complete(newLookupResponse(null, differentClusterData.getBrokerServiceUrl(),
                         differentClusterData.getBrokerServiceUrlTls(), true, LookupType.Redirect,
                         requestId, false));
             } else {
@@ -245,10 +245,11 @@ public class TopicLookupBase extends PulsarWebResource {
                                                 requestId));
                                         return;
                                     }
-                                    validationFuture.complete(newLookupResponse(peerClusterData.getBrokerServiceUrl(),
-                                            peerClusterData.getBrokerServiceUrlTls(), true,
-                                            LookupType.Redirect, requestId,
-                                            false));
+                                    validationFuture.complete(
+                                            newLookupResponse(null, peerClusterData.getBrokerServiceUrl(),
+                                                    peerClusterData.getBrokerServiceUrlTls(), true,
+                                                    LookupType.Redirect, requestId,
+                                                    false));
                         }).exceptionally(ex -> {
                             Throwable throwable = FutureUtil.unwrapCompletionException(ex);
                             if (throwable instanceof RestException restException){
@@ -311,13 +312,16 @@ public class TopicLookupBase extends PulsarWebResource {
                             if (lookupResult.get().isRedirect()) {
                                 boolean newAuthoritative = lookupResult.get().isAuthoritativeRedirect();
                                 lookupfuture.complete(
-                                        newLookupResponse(lookupData.getBrokerUrl(), lookupData.getBrokerUrlTls(),
-                                                newAuthoritative, LookupType.Redirect, requestId, false));
+                                        newLookupResponse(lookupData.getBrokerId(), lookupData.getBrokerUrl(),
+                                                lookupData.getBrokerUrlTls(), newAuthoritative, LookupType.Redirect,
+                                                requestId, false));
                             } else {
                                 ServiceConfiguration conf = pulsarService.getConfiguration();
-                                lookupfuture.complete(newLookupResponse(lookupData.getBrokerUrl(),
-                                        lookupData.getBrokerUrlTls(), true /* authoritative */, LookupType.Connect,
-                                        requestId, shouldRedirectThroughServiceUrl(conf, lookupData)));
+                                lookupfuture.complete(
+                                        newLookupResponse(lookupData.getBrokerId(), lookupData.getBrokerUrl(),
+                                                lookupData.getBrokerUrlTls(), true /* authoritative */,
+                                                LookupType.Connect, requestId,
+                                                shouldRedirectThroughServiceUrl(conf, lookupData)));
                             }
                         }).exceptionally(ex -> {
                             handleLookupError(lookupfuture, topicName.toString(), clientAppId, requestId, ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceEphemeralData.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceEphemeralData.java
@@ -24,11 +24,13 @@ import java.util.Map;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
 
 @Data
 @NoArgsConstructor
 public class NamespaceEphemeralData {
+    private String brokerId;
     private String nativeUrl;
     private String nativeUrlTls;
     private String httpUrl;
@@ -36,13 +38,15 @@ public class NamespaceEphemeralData {
     private boolean disabled;
     private Map<String, AdvertisedListener> advertisedListeners;
 
-    public NamespaceEphemeralData(String brokerUrl, String brokerUrlTls, String httpUrl, String httpUrlTls,
-            boolean disabled) {
-        this(brokerUrl, brokerUrlTls, httpUrl, httpUrlTls, disabled, null);
+    public NamespaceEphemeralData(String brokerId, String brokerUrl, String brokerUrlTls, String httpUrl,
+                                  String httpUrlTls, boolean disabled) {
+        this(brokerId, brokerUrl, brokerUrlTls, httpUrl, httpUrlTls, disabled, null);
     }
 
-    public NamespaceEphemeralData(String brokerUrl, String brokerUrlTls, String httpUrl, String httpUrlTls,
-                                  boolean disabled, Map<String, AdvertisedListener> advertisedListeners) {
+    public NamespaceEphemeralData(String brokerId, String brokerUrl, String brokerUrlTls, String httpUrl,
+                                  String httpUrlTls, boolean disabled,
+                                  Map<String, AdvertisedListener> advertisedListeners) {
+        this.brokerId = brokerId;
         this.nativeUrl = brokerUrl;
         this.nativeUrlTls = brokerUrlTls;
         this.httpUrl = httpUrl;
@@ -53,6 +57,12 @@ public class NamespaceEphemeralData {
         } else {
             this.advertisedListeners = new HashMap<>(advertisedListeners);
         }
+    }
+
+    public static NamespaceEphemeralData create(PulsarService pulsar, boolean disabled) {
+        return new NamespaceEphemeralData(pulsar.getBrokerId(), pulsar.getBrokerServiceUrl(),
+                pulsar.getBrokerServiceUrlTls(), pulsar.getWebServiceAddress(), pulsar.getWebServiceAddressTls(),
+                disabled, pulsar.getAdvertisedListeners());
     }
 
     @NotNull

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -730,12 +730,13 @@ public class NamespaceService implements AutoCloseable {
                         } else {
                             URI url = listener.getBrokerServiceUrl();
                             URI urlTls = listener.getBrokerServiceUrlTls();
-                            lookupFuture.complete(new LookupResult(lookupData.getWebServiceUrl(),
-                                    lookupData.getWebServiceUrlTls(), url == null ? null : url.toString(),
-                                    urlTls == null ? null : urlTls.toString(), authoritativeRedirect));
+                            lookupFuture.complete(
+                                    new LookupResult(lookupData.getBrokerId(), lookupData.getWebServiceUrl(),
+                                            lookupData.getWebServiceUrlTls(), url == null ? null : url.toString(),
+                                            urlTls == null ? null : urlTls.toString(), authoritativeRedirect));
                         }
                     } else {
-                        lookupFuture.complete(new LookupResult(lookupData.getWebServiceUrl(),
+                        lookupFuture.complete(new LookupResult(lookupData.getBrokerId(), lookupData.getWebServiceUrl(),
                                 lookupData.getWebServiceUrlTls(), lookupData.getPulsarServiceUrl(),
                                 lookupData.getPulsarServiceUrlTls(), authoritativeRedirect));
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSender.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSender.java
@@ -64,7 +64,7 @@ public interface PulsarCommandSender {
 
     void sendConnectedResponse(int clientProtocolVersion, int maxMessageSize, boolean supportsTopicWatchers);
 
-    void sendLookupResponse(String brokerServiceUrl, String brokerServiceUrlTls, boolean authoritative,
+    void sendLookupResponse(String brokerId, String brokerServiceUrl, String brokerServiceUrlTls, boolean authoritative,
                             CommandLookupTopicResponse.LookupType response, long requestId,
                             boolean proxyThroughServiceUrl);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
@@ -172,10 +172,10 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
     }
 
     @Override
-    public void sendLookupResponse(String brokerServiceUrl, String brokerServiceUrlTls, boolean authoritative,
-                                   CommandLookupTopicResponse.LookupType response,
+    public void sendLookupResponse(String brokerId, String brokerServiceUrl, String brokerServiceUrlTls,
+                                   boolean authoritative, CommandLookupTopicResponse.LookupType response,
                                    long requestId, boolean proxyThroughServiceUrl) {
-        BaseCommand command = Commands.newLookupResponseCommand(brokerServiceUrl, brokerServiceUrlTls,
+        BaseCommand command = Commands.newLookupResponseCommand(brokerId, brokerServiceUrl, brokerServiceUrlTls,
                 authoritative, response, requestId, proxyThroughServiceUrl);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -3129,9 +3129,11 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     private void closeProducer(long producerId, long epoch, Optional<BrokerLookupData> assignedBrokerLookupData) {
         if (getRemoteEndpointProtocolVersion() >= v5.getValue()) {
             if (assignedBrokerLookupData.isPresent()) {
+                BrokerLookupData brokerLookupData = assignedBrokerLookupData.get();
                 writeAndFlush(Commands.newCloseProducer(producerId, -1L,
-                        assignedBrokerLookupData.get().pulsarServiceUrl(),
-                        assignedBrokerLookupData.get().pulsarServiceUrlTls()));
+                        brokerLookupData.brokerId(),
+                        brokerLookupData.pulsarServiceUrl(),
+                        brokerLookupData.pulsarServiceUrlTls()));
             } else {
                 writeAndFlush(Commands.newCloseProducer(producerId, -1L));
             }
@@ -3161,6 +3163,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     private void closeConsumer(long consumerId, Optional<BrokerLookupData> assignedBrokerLookupData) {
         if (getRemoteEndpointProtocolVersion() >= v5.getValue()) {
             writeAndFlush(newCloseConsumer(consumerId, -1L,
+                    assignedBrokerLookupData.map(BrokerLookupData::brokerId).orElse(null),
                     assignedBrokerLookupData.map(BrokerLookupData::pulsarServiceUrl).orElse(null),
                     assignedBrokerLookupData.map(BrokerLookupData::pulsarServiceUrlTls).orElse(null)));
         } else {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAutoCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAutoCreationTest.java
@@ -138,7 +138,8 @@ public class TopicAutoCreationTest extends ProducerConsumerBase {
             when(mockLookup.getBroker(any())).thenAnswer(ignored -> {
                 InetSocketAddress brokerAddress =
                         new InetSocketAddress(pulsar.getAdvertisedAddress(), pulsar.getBrokerListenPort().get());
-                return CompletableFuture.completedFuture(new LookupTopicResult(brokerAddress, brokerAddress, false));
+                return CompletableFuture.completedFuture(
+                        new LookupTopicResult(pulsar.getBrokerId(), brokerAddress, brokerAddress, false));
             });
             final String topicPoliciesServiceInitException
                     = "Topic creation encountered an exception by initialize topic policies service";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -198,7 +198,7 @@ public class LoadBalancerTest {
             log.info("LoadReport {}, {}", lookupAddresses[i], new String(loadReportData));
 
             LoadReport loadReport = ObjectMapperFactory.getMapper().reader().readValue(loadReportData, LoadReport.class);
-            assertEquals(loadReport.getName(), lookupAddresses[i]);
+            assertEquals(loadReport.getBrokerId(), lookupAddresses[i]);
 
             // Check Initial Ranking is populated in both the brokers
             Field ranking = ((SimpleLoadManagerImpl) pulsarServices[i].getLoadManager().get()).getClass()
@@ -229,7 +229,7 @@ public class LoadBalancerTest {
     public void testUpdateLoadReportAndCheckUpdatedRanking() throws Exception {
         for (int i = 0; i < BROKER_COUNT; i++) {
             LoadReport lr = new LoadReport();
-            lr.setName(lookupAddresses[i]);
+            lr.setBrokerId(lookupAddresses[i]);
             SystemResourceUsage sru = new SystemResourceUsage();
             sru.setBandwidthIn(new ResourceUsage(256, 1024000));
             sru.setBandwidthOut(new ResourceUsage(250, 1024000));
@@ -308,7 +308,7 @@ public class LoadBalancerTest {
     public void testBrokerRanking() throws Exception {
         for (int i = 0; i < BROKER_COUNT; i++) {
             LoadReport lr = new LoadReport();
-            lr.setName(lookupAddresses[i]);
+            lr.setBrokerId(lookupAddresses[i]);
             SystemResourceUsage sru = new SystemResourceUsage();
             sru.setBandwidthIn(new ResourceUsage(0, 1024000));
             sru.setBandwidthOut(new ResourceUsage(0, 1024000));
@@ -361,7 +361,7 @@ public class LoadBalancerTest {
             pulsarServices[i].getBrokerService().getBundlesQuotas().setDefaultResourceQuota(defaultQuota).join();
 
             LoadReport lr = new LoadReport();
-            lr.setName(lookupAddresses[i]);
+            lr.setBrokerId(lookupAddresses[i]);
             SystemResourceUsage sru = new SystemResourceUsage();
             sru.setBandwidthIn(new ResourceUsage(0, 1024000));
             sru.setBandwidthOut(new ResourceUsage(0, 1024000));
@@ -444,7 +444,7 @@ public class LoadBalancerTest {
     private void writeLoadReportsForDynamicQuota(long timestamp) throws Exception {
         for (int i = 0; i < BROKER_COUNT; i++) {
             LoadReport lr = new LoadReport();
-            lr.setName(lookupAddresses[i]);
+            lr.setBrokerId(lookupAddresses[i]);
             lr.setTimestamp(timestamp);
             SystemResourceUsage sru = new SystemResourceUsage();
             sru.setBandwidthIn(new ResourceUsage(5000 * (10 + i * 5), 1024000));
@@ -603,7 +603,7 @@ public class LoadBalancerTest {
         // namespace 01~09 need to be split
         // namespace 08~10 don't need or cannot be split
         LoadReport lr = new LoadReport();
-        lr.setName(lookupAddresses[0]);
+        lr.setBrokerId(lookupAddresses[0]);
         lr.setSystemResourceUsage(new SystemResourceUsage());
 
         Map<String, NamespaceBundleStats> bundleStats = new HashMap<String, NamespaceBundleStats>();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleLoadManagerImplTest.java
@@ -352,7 +352,7 @@ public class SimpleLoadManagerImplTest {
 
         ObjectMapper mapper = ObjectMapperFactory.create();
         org.apache.pulsar.policies.data.loadbalancer.LoadReport reportData = new org.apache.pulsar.policies.data.loadbalancer.LoadReport();
-        reportData.setName("b1");
+        reportData.setBrokerId("b1");
         SystemResourceUsage resource = new SystemResourceUsage();
         ResourceUsage resourceUsage = new ResourceUsage();
         resource.setBandwidthIn(resourceUsage);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupDataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupDataTest.java
@@ -39,8 +39,9 @@ public class BrokerLookupDataTest {
 
     @Test
     public void testConstructors() throws PulsarServerException, URISyntaxException {
+        String brokerId = "localhost:8081";
         String webServiceUrl = "http://localhost:8080";
-        String webServiceUrlTls = "https://localhoss:8081";
+        String webServiceUrlTls = "https://localhost:8081";
         String pulsarServiceUrl = "pulsar://localhost:6650";
         String pulsarServiceUrlTls = "pulsar+ssl://localhost:6651";
         final String listenerUrl = "pulsar://gateway:7000";
@@ -55,10 +56,11 @@ public class BrokerLookupDataTest {
         Map<String, String> protocols = new HashMap<>(){{
             put("kafka", "9092");
         }};
-        BrokerLookupData lookupData = new BrokerLookupData(
+        BrokerLookupData lookupData = new BrokerLookupData(brokerId,
                 webServiceUrl, webServiceUrlTls, pulsarServiceUrl,
                 pulsarServiceUrlTls, advertisedListeners, protocols, true, true,
                 ExtensibleLoadManagerImpl.class.getName(), System.currentTimeMillis(),"3.0");
+        assertEquals(brokerId, lookupData.getBrokerId());
         assertEquals(webServiceUrl, lookupData.webServiceUrl());
         assertEquals(webServiceUrlTls, lookupData.webServiceUrlTls());
         assertEquals(pulsarServiceUrl, lookupData.pulsarServiceUrl());
@@ -68,7 +70,6 @@ public class BrokerLookupDataTest {
         assertTrue(lookupData.persistentTopicsEnabled());
         assertTrue(lookupData.nonPersistentTopicsEnabled());
         assertEquals("3.0", lookupData.brokerVersion());
-
 
         LookupResult lookupResult = lookupData.toLookupResult(LookupOptions.builder().build());
         assertEquals(webServiceUrl, lookupResult.getLookupData().getHttpUrl());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerFilterTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerFilterTestBase.java
@@ -125,15 +125,16 @@ public class BrokerFilterTestBase {
     }
 
     public BrokerLookupData getLookupData(String version, String loadManagerClassName) {
+        String brokerId = "localhost:8081";
         String webServiceUrl = "http://localhost:8080";
-        String webServiceUrlTls = "https://localhoss:8081";
+        String webServiceUrlTls = "https://localhost:8081";
         String pulsarServiceUrl = "pulsar://localhost:6650";
         String pulsarServiceUrlTls = "pulsar+ssl://localhost:6651";
         Map<String, AdvertisedListener> advertisedListeners = new HashMap<>();
         Map<String, String> protocols = new HashMap<>(){{
             put("kafka", "9092");
         }};
-        return new BrokerLookupData(
+        return new BrokerLookupData(brokerId,
                 webServiceUrl, webServiceUrlTls, pulsarServiceUrl,
                 pulsarServiceUrlTls, advertisedListeners, protocols, true, true,
                 loadManagerClassName, -1, version);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerIsolationPoliciesFilterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerIsolationPoliciesFilterTest.java
@@ -206,15 +206,16 @@ public class BrokerIsolationPoliciesFilterTest {
 
     public BrokerLookupData getLookupData(boolean persistentTopicsEnabled,
                                           boolean nonPersistentTopicsEnabled) {
+        String brokerId = "localhost:8081";
         String webServiceUrl = "http://localhost:8080";
-        String webServiceUrlTls = "https://localhoss:8081";
+        String webServiceUrlTls = "https://localhost:8081";
         String pulsarServiceUrl = "pulsar://localhost:6650";
         String pulsarServiceUrlTls = "pulsar+ssl://localhost:6651";
         Map<String, AdvertisedListener> advertisedListeners = new HashMap<>();
         Map<String, String> protocols = new HashMap<>(){{
             put("kafka", "9092");
         }};
-        return new BrokerLookupData(
+        return new BrokerLookupData(brokerId,
                 webServiceUrl, webServiceUrlTls, pulsarServiceUrl,
                 pulsarServiceUrlTls, advertisedListeners, protocols,
                 persistentTopicsEnabled, nonPersistentTopicsEnabled,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/manager/RedirectManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/manager/RedirectManagerTest.java
@@ -95,6 +95,7 @@ public class RedirectManagerTest {
 
 
     public BrokerLookupData getLookupData(String broker, String loadManagerClassName, long startTimeStamp) {
+        String brokerId = "broker:8081";
         String webServiceUrl = "http://" + broker + ":8080";
         String webServiceUrlTls = "https://" + broker + ":8081";
         String pulsarServiceUrl = "pulsar://" + broker + ":6650";
@@ -103,7 +104,7 @@ public class RedirectManagerTest {
         Map<String, String> protocols = new HashMap<>(){{
             put("kafka", "9092");
         }};
-        return new BrokerLookupData(
+        return new BrokerLookupData(brokerId,
                 webServiceUrl, webServiceUrlTls, pulsarServiceUrl,
                 pulsarServiceUrlTls, advertisedListeners, protocols, true, true,
                 loadManagerClassName, startTimeStamp, "3.0.0");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedderTest.java
@@ -685,15 +685,16 @@ public class TransferShedderTest {
     }
 
     public BrokerLookupData getLookupData() {
+        String brokerId = "localhost:8081";
         String webServiceUrl = "http://localhost:8080";
-        String webServiceUrlTls = "https://localhoss:8081";
+        String webServiceUrlTls = "https://localhost:8081";
         String pulsarServiceUrl = "pulsar://localhost:6650";
         String pulsarServiceUrlTls = "pulsar+ssl://localhost:6651";
         Map<String, AdvertisedListener> advertisedListeners = new HashMap<>();
         Map<String, String> protocols = new HashMap<>(){{
             put("kafka", "9092");
         }};
-        return new BrokerLookupData(
+        return new BrokerLookupData(brokerId,
                 webServiceUrl, webServiceUrlTls, pulsarServiceUrl,
                 pulsarServiceUrlTls, advertisedListeners, protocols,
                 true, true,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -358,7 +358,8 @@ public class NamespaceServiceTest extends BrokerTestBase {
         final String candidateBroker2 = "localhost:3000";
         String broker2Url = "pulsar://localhost:6660";
         LoadReport lr = new LoadReport("http://" + candidateBroker1, null, broker1Url, null);
-        LocalBrokerData ld = new LocalBrokerData("http://" + candidateBroker2, null, broker2Url, null);
+        lr.setBrokerId(candidateBroker1);
+        LocalBrokerData ld = new LocalBrokerData(candidateBroker2, "http://" + candidateBroker2, null, broker2Url, null);
         String path1 = String.format("%s/%s", LoadManager.LOADBALANCE_BROKERS_ROOT, candidateBroker1);
         String path2 = String.format("%s/%s", LoadManager.LOADBALANCE_BROKERS_ROOT, candidateBroker2);
 
@@ -394,7 +395,8 @@ public class NamespaceServiceTest extends BrokerTestBase {
         final String listener = "listenerName";
         Map<String, AdvertisedListener> advertisedListeners = new HashMap<>();
         advertisedListeners.put(listener, AdvertisedListener.builder().brokerServiceUrl(new URI(listenerUrl)).brokerServiceUrlTls(new URI(listenerUrlTls)).build());
-        LocalBrokerData ld = new LocalBrokerData("http://" + candidateBroker, null, brokerUrl, null, advertisedListeners);
+        LocalBrokerData ld = new LocalBrokerData(candidateBroker, "http://" + candidateBroker, null, brokerUrl, null,
+                advertisedListeners);
         String path = String.format("%s/%s", LoadManager.LOADBALANCE_BROKERS_ROOT, candidateBroker);
 
         pulsar.getLocalMetadataStore().put(path,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnershipCacheTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnershipCacheTest.java
@@ -169,7 +169,7 @@ public class OwnershipCacheTest {
                 MetadataStoreConfig.builder().sessionTimeoutMillis(5000).build());
         otherStore.put(ServiceUnitUtils.path(testFullBundle),
                 ObjectMapperFactory.getMapper().writer().writeValueAsBytes(
-                        new NamespaceEphemeralData("pulsar://otherhost:8881",
+                        new NamespaceEphemeralData("localhost:4443", "pulsar://otherhost:8881",
                                 "pulsar://otherhost:8884",
                                 "http://localhost:8080",
                                 "https://localhost:4443", false)),
@@ -204,7 +204,7 @@ public class OwnershipCacheTest {
                 MetadataStoreConfig.builder().sessionTimeoutMillis(5000).build());
         otherStore.put(ServiceUnitUtils.path(testBundle),
                 ObjectMapperFactory.getMapper().writer().writeValueAsBytes(
-                        new NamespaceEphemeralData("pulsar://otherhost:8881",
+                        new NamespaceEphemeralData("localhost:4443", "pulsar://otherhost:8881",
                                 "pulsar://otherhost:8884",
                                 "http://localhost:8080",
                                 "https://localhost:4443", false)),
@@ -255,7 +255,7 @@ public class OwnershipCacheTest {
         // case 2: someone else owns the namespace
         otherStore.put(ServiceUnitUtils.path(testBundle),
                 ObjectMapperFactory.getMapper().writer().writeValueAsBytes(
-                        new NamespaceEphemeralData("pulsar://otherhost:8881",
+                        new NamespaceEphemeralData("localhost:4443", "pulsar://otherhost:8881",
                                 "pulsar://otherhost:8884",
                                 "http://localhost:8080",
                                 "https://localhost:4443", false)),
@@ -311,7 +311,7 @@ public class OwnershipCacheTest {
         // case 2: someone else owns the namespace
         otherStore.put(ServiceUnitUtils.path(testBundle),
                 ObjectMapperFactory.getMapper().writer().writeValueAsBytes(
-                        new NamespaceEphemeralData("pulsar://otherhost:8881",
+                        new NamespaceEphemeralData("localhost:4443", "pulsar://otherhost:8881",
                                 "pulsar://otherhost:8884",
                                 "http://otherhost:8080",
                                 "https://otherhost:4443", false)),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -2415,7 +2415,7 @@ public class ServerCnxTest {
         channel.writeInbound(subscribe1);
 
         ByteBuf closeConsumer = Commands.newCloseConsumer(1 /* consumer id */, 2 /* request id */,
-                null /* assignedBrokerServiceUrl */, null /* assignedBrokerServiceUrlTls */);
+                null /* assignedBrokerId */, null /* assignedBrokerServiceUrl */, null /* assignedBrokerServiceUrlTls */);
         channel.writeInbound(closeConsumer);
 
         ByteBuf subscribe2 = Commands.newSubscribe(successTopicName, //

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
@@ -146,7 +146,7 @@ public class TopicOwnerTest {
             if (pulsarService == null) {
                 return (CompletableFuture<Optional<LookupResult>>) invocation.callRealMethod();
             }
-            LookupResult lookupResult = new LookupResult(
+            LookupResult lookupResult = new LookupResult(pulsarService.getBrokerId(),
                     pulsarService.getWebServiceAddress(),
                     pulsarService.getWebServiceAddressTls(),
                     pulsarService.getBrokerServiceUrl(),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
@@ -270,7 +270,7 @@ public class ClientErrorsTest {
             if (subscribeCount == 1) {
                 ctx.writeAndFlush(Commands.newSuccess(subscribe.getRequestId()));
                 // Trigger reconnect
-                ctx.writeAndFlush(Commands.newCloseConsumer(subscribe.getConsumerId(), -1, null, null));
+                ctx.writeAndFlush(Commands.newCloseConsumer(subscribe.getConsumerId(), -1, null, null, null));
             } else if (subscribeCount != 2) {
                 // Respond to subsequent requests to prevent timeouts
                 ctx.writeAndFlush(Commands.newSuccess(subscribe.getRequestId()));
@@ -408,7 +408,8 @@ public class ClientErrorsTest {
                 return;
             }
             ctx.writeAndFlush(
-                    Commands.newLookupResponse(mockBrokerService.getBrokerAddress(), null, true, LookupType.Connect,
+                    Commands.newLookupResponse(mockBrokerService.getBrokerId(), mockBrokerService.getBrokerAddress(),
+                            null, true, LookupType.Connect,
                             lookup.getRequestId(), false));
         });
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MockBrokerService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MockBrokerService.java
@@ -30,6 +30,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 
+import io.netty.util.NetUtil;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.ThreadFactory;
@@ -166,7 +167,7 @@ public class MockBrokerService {
                 return;
             }
             // default
-            ctx.writeAndFlush(Commands.newLookupResponse(getBrokerAddress(), null, true,
+            ctx.writeAndFlush(Commands.newLookupResponse(getBrokerId(), getBrokerAddress(), null, true,
                     LookupType.Connect, lookup.getRequestId(), false));
         }
 
@@ -307,7 +308,7 @@ public class MockBrokerService {
             startMockBrokerService();
             log.info("Started mock Pulsar service on {}", getBrokerAddress());
 
-            lookupData = new LookupData(getBrokerAddress(), null,
+            lookupData = new LookupData(getBrokerId(), getBrokerAddress(), null,
                     getHttpAddress(), null);
         } catch (Exception e) {
             log.error("Error starting mock service", e);
@@ -447,6 +448,10 @@ public class MockBrokerService {
 
     public String getBrokerAddress() {
         return String.format("pulsar://localhost:%d", ((InetSocketAddress) listenChannel.localAddress()).getPort());
+    }
+
+    public String getBrokerId() {
+        return NetUtil.toSocketAddressString((InetSocketAddress) listenChannel.localAddress());
     }
 
     private static final Logger log = LoggerFactory.getLogger(MockBrokerService.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
@@ -176,13 +176,14 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
         HttpLookupService lookupService = new HttpLookupService(InstrumentProvider.NOOP, conf, eventExecutors);
         NamespaceService namespaceService = pulsar.getNamespaceService();
 
-        LookupResult lookupResult = new LookupResult(pulsar.getWebServiceAddress(), null,
+        LookupResult lookupResult = new LookupResult(pulsar.getBrokerId(), pulsar.getWebServiceAddress(), null,
                 pulsar.getBrokerServiceUrl(), null, true);
         Optional<LookupResult> optional = Optional.of(lookupResult);
         InetSocketAddress address = InetSocketAddress.createUnresolved("192.168.0.1", 8080);
         NamespaceEphemeralData namespaceEphemeralData =
-                new NamespaceEphemeralData("pulsar://" + address.getHostName() + ":" + address.getPort(),
-                null, "http://192.168.0.1:8081", null, false);
+                new NamespaceEphemeralData("192.168.0.1:8081",
+                        "pulsar://" + address.getHostName() + ":" + address.getPort(),
+                        null, "http://192.168.0.1:8081", null, false);
         LookupResult lookupResult2 = new LookupResult(namespaceEphemeralData);
         Optional<LookupResult> optional2 = Optional.of(lookupResult2);
         doReturn(CompletableFuture.completedFuture(optional), CompletableFuture.completedFuture(optional2))

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/LookupServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/LookupServiceTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.testng.Assert.assertEquals;
+import com.google.common.collect.Sets;
+import java.util.concurrent.ExecutionException;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+public class LookupServiceTest extends MockedPulsarServiceBaseTest {
+    @DataProvider(name = "isTcpLookup")
+    public static Object[][] booleanProvider() {
+        return new Object[][] { { Boolean.TRUE }, { Boolean.FALSE } };
+    }
+
+    @Factory(dataProvider = "isTcpLookup")
+    public LookupServiceTest(boolean isTcpLookup) {
+        this.isTcpLookup = isTcpLookup;
+    }
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+
+        admin.clusters().createCluster("test",
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.tenants().createTenant("public",
+                new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
+        admin.namespaces().createNamespace("public/default", Sets.newHashSet("test"));
+    }
+
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testLookupReturnsBrokerId() throws PulsarClientException, ExecutionException, InterruptedException {
+        String topicName = BrokerTestUtil.newUniqueName("my-topic");
+        pulsarClient.newConsumer(Schema.STRING).topic(topicName);
+        try(Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName).create()) {
+            producer.newMessage().value("Hello").send();
+        }
+        LookupService lookupService = ((PulsarClientImpl) pulsarClient).getLookup();
+        LookupTopicResult lookupTopicResult = lookupService.getBroker(TopicName.get(topicName)).get();
+        assertEquals(lookupTopicResult.getBrokerId(), pulsar.getBrokerId());
+    }
+
+}

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/policies/data/loadbalancer/ServiceLookupData.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/policies/data/loadbalancer/ServiceLookupData.java
@@ -25,6 +25,8 @@ import java.util.Optional;
  * For backwards compatibility purposes.
  */
 public interface ServiceLookupData {
+    String getBrokerId();
+
     String getWebServiceUrl();
 
     String getWebServiceUrlTls();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
@@ -221,11 +221,12 @@ public class BinaryProtoLookupService implements LookupService {
                             if (r.proxyThroughServiceUrl) {
                                 // Connect through proxy
                                 addressFuture.complete(
-                                        new LookupTopicResult(responseBrokerAddress, socketAddress, true));
+                                        new LookupTopicResult(r.brokerId, responseBrokerAddress, socketAddress, true));
                             } else {
                                 // Normal result with direct connection to broker
                                 addressFuture.complete(
-                                        new LookupTopicResult(responseBrokerAddress, responseBrokerAddress, false));
+                                        new LookupTopicResult(r.brokerId, responseBrokerAddress, responseBrokerAddress,
+                                                false));
                             }
                         }
 
@@ -415,7 +416,7 @@ public class BinaryProtoLookupService implements LookupService {
     }
 
     public static class LookupDataResult {
-
+        public final String brokerId;
         public final String brokerUrl;
         public final String brokerUrlTls;
         public final int partitions;
@@ -424,6 +425,7 @@ public class BinaryProtoLookupService implements LookupService {
         public final boolean redirect;
 
         public LookupDataResult(CommandLookupTopicResponse result) {
+            this.brokerId = result.hasBrokerId() ? result.getBrokerId() : null;
             this.brokerUrl = result.hasBrokerServiceUrl() ? result.getBrokerServiceUrl() : null;
             this.brokerUrlTls = result.hasBrokerServiceUrlTls() ? result.getBrokerServiceUrlTls() : null;
             this.authoritative = result.isAuthoritative();
@@ -435,6 +437,7 @@ public class BinaryProtoLookupService implements LookupService {
         public LookupDataResult(int partitions) {
             super();
             this.partitions = partitions;
+            this.brokerId = null;
             this.brokerUrl = null;
             this.brokerUrlTls = null;
             this.authoritative = false;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -819,8 +819,10 @@ public class ClientCnx extends PulsarHandler {
     @Override
     protected void handleCloseProducer(CommandCloseProducer closeProducer) {
         final long producerId = closeProducer.getProducerId();
-        log.info("[{}] Broker notification of closed producer: {}, assignedBrokerUrl: {}, assignedBrokerUrlTls: {}",
+        log.info("[{}] Broker notification of closed producer: {}, assignedBrokerId: {}, assignedBrokerUrl: {}, "
+                        + "assignedBrokerUrlTls: {}",
                 remoteAddress, producerId,
+                closeProducer.hasAssignedBrokerId() ? closeProducer.getAssignedBrokerId() : null,
                 closeProducer.hasAssignedBrokerServiceUrl() ? closeProducer.getAssignedBrokerServiceUrl() : null,
                 closeProducer.hasAssignedBrokerServiceUrlTls() ? closeProducer.getAssignedBrokerServiceUrlTls() : null);
         ProducerImpl<?> producer = producers.remove(producerId);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -940,7 +940,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                     // in case it was indeed created, otherwise it might prevent new create consumer operation,
                     // since we are not necessarily closing the connection.
                     long closeRequestId = client.newRequestId();
-                    ByteBuf cmd = Commands.newCloseConsumer(consumerId, closeRequestId, null, null);
+                    ByteBuf cmd = Commands.newCloseConsumer(consumerId, closeRequestId, null, null, null);
                     cnx.sendRequestWithId(cmd, closeRequestId);
                 }
 
@@ -1119,7 +1119,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         if (null == cnx) {
             cleanupAtClose(closeFuture, null);
         } else {
-            ByteBuf cmd = Commands.newCloseConsumer(consumerId, requestId, null, null);
+            ByteBuf cmd = Commands.newCloseConsumer(consumerId, requestId, null, null, null);
             cnx.sendRequestWithId(cmd, requestId).handle((v, exception) -> {
                 final ChannelHandlerContext ctx = cnx.ctx();
                 boolean ignoreException = ctx == null || !ctx.channel().isActive();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpLookupService.java
@@ -128,8 +128,9 @@ public class HttpLookupService implements LookupService {
                 }
 
                 InetSocketAddress brokerAddress = InetSocketAddress.createUnresolved(uri.getHost(), uri.getPort());
-                return CompletableFuture.completedFuture(new LookupTopicResult(brokerAddress, brokerAddress,
-                        false /* HTTP lookups never use the proxy */));
+                return CompletableFuture.completedFuture(
+                        new LookupTopicResult(lookupData.getBrokerId(), brokerAddress, brokerAddress,
+                                false /* HTTP lookups never use the proxy */));
             } catch (Exception e) {
                 // Failed to parse url
                 log.warn("[{}] Lookup Failed due to invalid url {}, {}", topicName, uri, e.getMessage());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/LookupTopicResult.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/LookupTopicResult.java
@@ -29,6 +29,7 @@ import lombok.ToString;
 @AllArgsConstructor
 @ToString
 public class LookupTopicResult {
+    private final String brokerId;
     private final InetSocketAddress logicalAddress;
     private final InetSocketAddress physicalAddress;
     private final boolean isUseProxy;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
@@ -110,7 +110,7 @@ public class PulsarClientImplTest {
         when(lookup.getPartitionedTopicMetadata(any(TopicName.class)))
                 .thenReturn(CompletableFuture.completedFuture(new PartitionedTopicMetadata()));
         when(lookup.getBroker(any()))
-                .thenReturn(CompletableFuture.completedFuture(new LookupTopicResult(
+                .thenReturn(CompletableFuture.completedFuture(new LookupTopicResult(null,
                         mock(InetSocketAddress.class), mock(InetSocketAddress.class), false)));
         ConnectionPool pool = mock(ConnectionPool.class);
         ClientCnx cnx = mock(ClientCnx.class);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/lookup/data/LookupData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/lookup/data/LookupData.java
@@ -24,6 +24,7 @@ import com.google.common.base.MoreObjects;
  * This class encapsulates lookup data.
  */
 public class LookupData {
+    private String brokerId;
     private String brokerUrl;
     private String brokerUrlTls;
     private String httpUrl; // Web service HTTP address
@@ -33,12 +34,17 @@ public class LookupData {
     public LookupData() {
     }
 
-    public LookupData(String brokerUrl, String brokerUrlTls, String httpUrl, String httpUrlTls) {
+    public LookupData(String brokerId, String brokerUrl, String brokerUrlTls, String httpUrl, String httpUrlTls) {
+        this.brokerId = brokerId;
         this.brokerUrl = brokerUrl;
         this.brokerUrlTls = brokerUrlTls;
         this.httpUrl = httpUrl;
         this.httpUrlTls = httpUrlTls;
         this.nativeUrl = brokerUrl;
+    }
+
+    public String getBrokerId() {
+        return brokerId;
     }
 
     public String getBrokerUrl() {
@@ -82,7 +88,7 @@ public class LookupData {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("brokerUrl", brokerUrl).add("brokerUrlTls", brokerUrlTls)
-                .add("httpUrl", httpUrl).add("httpUrlTls", httpUrlTls).toString();
+        return MoreObjects.toStringHelper(this).add("brokerId", brokerId).add("brokerUrl", brokerUrl)
+                .add("brokerUrlTls", brokerUrlTls).add("httpUrl", httpUrl).add("httpUrlTls", httpUrlTls).toString();
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -740,11 +740,16 @@ public class Commands {
     }
 
     public static ByteBuf newCloseConsumer(
-            long consumerId, long requestId, String assignedBrokerUrl, String assignedBrokerUrlTls) {
+            long consumerId, long requestId, String assignedBrokerId, String assignedBrokerUrl,
+            String assignedBrokerUrlTls) {
         BaseCommand cmd = localCmd(Type.CLOSE_CONSUMER);
         CommandCloseConsumer commandCloseConsumer = cmd.setCloseConsumer()
             .setConsumerId(consumerId)
             .setRequestId(requestId);
+
+        if (assignedBrokerId != null) {
+            commandCloseConsumer.setAssignedBrokerId(assignedBrokerId);
+        }
 
         if (assignedBrokerUrl != null) {
             commandCloseConsumer.setAssignedBrokerServiceUrl(assignedBrokerUrl);
@@ -776,15 +781,21 @@ public class Commands {
 
     public static ByteBuf newCloseProducer(
             long producerId, long requestId) {
-        return newCloseProducer(producerId, requestId, null, null);
+        return newCloseProducer(producerId, requestId, null, null, null);
     }
 
     public static ByteBuf newCloseProducer(
-            long producerId, long requestId, String assignedBrokerUrl, String assignedBrokerUrlTls) {
+            long producerId, long requestId, String assignedBrokerId, String assignedBrokerUrl,
+            String assignedBrokerUrlTls) {
         BaseCommand cmd = localCmd(Type.CLOSE_PRODUCER);
         CommandCloseProducer commandCloseProducer = cmd.setCloseProducer()
                 .setProducerId(producerId)
                 .setRequestId(requestId);
+
+        if (assignedBrokerId != null) {
+            commandCloseProducer
+                    .setAssignedBrokerId(assignedBrokerId);
+        }
 
         if (assignedBrokerUrl != null) {
             commandCloseProducer
@@ -947,10 +958,13 @@ public class Commands {
         return serializeWithSize(cmd);
     }
 
-    public static BaseCommand newLookupResponseCommand(String brokerServiceUrl, String brokerServiceUrlTls,
-        boolean authoritative, LookupType lookupType, long requestId, boolean proxyThroughServiceUrl) {
+    public static BaseCommand newLookupResponseCommand(String brokerId, String brokerServiceUrl,
+                                                       String brokerServiceUrlTls, boolean authoritative,
+                                                       LookupType lookupType, long requestId,
+                                                       boolean proxyThroughServiceUrl) {
         BaseCommand cmd = localCmd(Type.LOOKUP_RESPONSE);
         CommandLookupTopicResponse response = cmd.setLookupTopicResponse()
+                .setBrokerId(brokerId)
                 .setResponse(lookupType)
                 .setRequestId(requestId)
                 .setAuthoritative(authoritative)
@@ -965,10 +979,12 @@ public class Commands {
         return cmd;
     }
 
-    public static ByteBuf newLookupResponse(String brokerServiceUrl, String brokerServiceUrlTls, boolean authoritative,
-            LookupType lookupType, long requestId, boolean proxyThroughServiceUrl) {
-        return serializeWithSize(newLookupResponseCommand(brokerServiceUrl, brokerServiceUrlTls, authoritative,
-                lookupType, requestId, proxyThroughServiceUrl));
+    public static ByteBuf newLookupResponse(String brokerId, String brokerServiceUrl, String brokerServiceUrlTls,
+                                            boolean authoritative,
+                                            LookupType lookupType, long requestId, boolean proxyThroughServiceUrl) {
+        return serializeWithSize(
+                newLookupResponseCommand(brokerId, brokerServiceUrl, brokerServiceUrlTls, authoritative,
+                        lookupType, requestId, proxyThroughServiceUrl));
     }
 
     public static BaseCommand newLookupErrorResponseCommand(ServerError error, String errorMsg, long requestId) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LoadReport.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LoadReport.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pulsar.policies.data.loadbalancer;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -35,7 +37,7 @@ import org.apache.pulsar.policies.data.loadbalancer.SystemResourceUsage.Resource
  */
 @JsonDeserialize(as = LoadReport.class)
 public class LoadReport implements LoadManagerReport {
-    private String name;
+    private String brokerId;
     private String brokerVersionString;
 
     private final String webServiceUrl;
@@ -118,12 +120,15 @@ public class LoadReport implements LoadManagerReport {
         return bundleStats;
     }
 
-    public String getName() {
-        return name;
+    @JsonGetter("name")
+    @Override
+    public String getBrokerId() {
+        return brokerId;
     }
 
-    public void setName(String brokerName) {
-        this.name = brokerName;
+    @JsonSetter("name")
+    public void setBrokerId(String brokerId) {
+        this.brokerId = brokerId;
     }
 
     public SystemResourceUsage getSystemResourceUsage() {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -464,6 +464,8 @@ message CommandLookupTopicResponse {
     // always connect through the service url after the
     // lookup has been completed.
     optional bool proxy_through_service_url = 8 [default = false];
+
+    optional string brokerId = 9;
 }
 
 /// Create a new Producer on a topic, assigning the given producer_id,
@@ -635,7 +637,8 @@ message CommandTopicMigrated {
     required ResourceType resource_type = 2;
     optional string brokerServiceUrl      = 3;
     optional string brokerServiceUrlTls   = 4;
-    
+    optional string brokerId = 5;
+
 }
 
 
@@ -644,6 +647,7 @@ message CommandCloseProducer {
     required uint64 request_id = 2;
     optional string assignedBrokerServiceUrl = 3;
     optional string assignedBrokerServiceUrlTls = 4;
+    optional string assignedBrokerId = 5;
 }
 
 message CommandCloseConsumer {
@@ -651,6 +655,7 @@ message CommandCloseConsumer {
     required uint64 request_id = 2;
     optional string assignedBrokerServiceUrl = 3;
     optional string assignedBrokerServiceUrlTls = 4;
+    optional string assignedBrokerId = 5;
 }
 
 message CommandRedeliverUnacknowledgedMessages {
@@ -1130,6 +1135,6 @@ message BaseCommand {
     optional CommandWatchTopicListSuccess watchTopicListSuccess = 65;
     optional CommandWatchTopicUpdate watchTopicUpdate = 66;
     optional CommandWatchTopicListClose watchTopicListClose = 67;
-    
+
     optional CommandTopicMigrated topicMigrated = 68;
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/lookup/data/LookupDataTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/lookup/data/LookupDataTest.java
@@ -38,17 +38,18 @@ public class LookupDataTest {
 
     @Test
     public void withConstructor() {
-        LookupData data = new LookupData("pulsar://localhost:8888", "pulsar://localhost:8884", "http://localhost:8080",
-                                         "http://localhost:8081");
+        LookupData data = new LookupData("localhost:8081", "pulsar://localhost:8888", "pulsar://localhost:8884",
+                "http://localhost:8080", "http://localhost:8081");
         assertEquals(data.getBrokerUrl(), "pulsar://localhost:8888");
         assertEquals(data.getHttpUrl(), "http://localhost:8080");
+        assertEquals(data.getBrokerId(), "localhost:8081");
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void serializeToJsonTest() throws Exception {
-        LookupData data = new LookupData("pulsar://localhost:8888", "pulsar://localhost:8884", "http://localhost:8080",
-                                         "http://localhost:8081");
+        LookupData data = new LookupData("localhost:8081", "pulsar://localhost:8888", "pulsar://localhost:8884",
+                "http://localhost:8080", "http://localhost:8081");
         ObjectMapper mapper = ObjectMapperFactory.getMapper().getObjectMapper();
         String json = mapper.writeValueAsString(data);
 
@@ -60,6 +61,7 @@ public class LookupDataTest {
         assertEquals(jsonMap.get("nativeUrl"), "pulsar://localhost:8888");
         assertEquals(jsonMap.get("httpUrl"), "http://localhost:8080");
         assertEquals(jsonMap.get("httpUrlTls"), "http://localhost:8081");
+        assertEquals(jsonMap.get("brokerId"), "localhost:8081");
     }
 
     @Test
@@ -94,7 +96,7 @@ public class LookupDataTest {
 
         assertEquals(simpleLoadReport.getWebServiceUrl(), simpleLmBrokerUrl);
         assertTrue(simpleLoadReport instanceof LoadReport);
-        assertEquals(((LoadReport) simpleLoadReport).getName(), simpleLmReportName);
+        assertEquals(((LoadReport) simpleLoadReport).getBrokerId(), simpleLmReportName);
         assertEquals(((LoadReport) simpleLoadReport).getSystemResourceUsage().bandwidthIn.usage, usage);
 
         assertEquals(modularLoadReport.getWebServiceUrl(), modularLmBrokerUrl);
@@ -106,13 +108,13 @@ public class LookupDataTest {
     private LoadReport getSimpleLoadManagerLoadReport(String brokerUrl, String reportName,
             SystemResourceUsage systemResourceUsage) {
         LoadReport report = new LoadReport(brokerUrl, null, null, null);
-        report.setName(reportName);
+        report.setBrokerId(reportName);
         report.setSystemResourceUsage(systemResourceUsage);
         return report;
     }
 
     private LocalBrokerData getModularLoadManagerLoadReport(String brokerUrl, ResourceUsage bandwidthIn) {
-        LocalBrokerData report = new LocalBrokerData(brokerUrl, null, null, null);
+        LocalBrokerData report = new LocalBrokerData(null, brokerUrl, null, null, null);
         report.setBandwidthIn(bandwidthIn);
         return report;
     }

--- a/pulsar-common/src/test/java/org/apache/pulsar/policies/data/loadbalancer/LocalBrokerDataTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/policies/data/loadbalancer/LocalBrokerDataTest.java
@@ -18,25 +18,45 @@
  */
 package org.apache.pulsar.policies.data.loadbalancer;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.Gson;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class LocalBrokerDataTest {
 
     @Test
-    public void testLocalBrokerDataDeserialization() {
-        String data = "{\"webServiceUrl\":\"http://10.244.2.23:8080\",\"webServiceUrlTls\":\"https://10.244.2.23:8081\",\"pulsarServiceUrlTls\":\"pulsar+ssl://10.244.2.23:6651\",\"persistentTopicsEnabled\":true,\"nonPersistentTopicsEnabled\":false,\"cpu\":{\"usage\":3.1577712104798255,\"limit\":100.0},\"memory\":{\"usage\":614.0,\"limit\":1228.0},\"directMemory\":{\"usage\":32.0,\"limit\":1228.0},\"bandwidthIn\":{\"usage\":0.0,\"limit\":0.0},\"bandwidthOut\":{\"usage\":0.0,\"limit\":0.0},\"msgThroughputIn\":0.0,\"msgThroughputOut\":0.0,\"msgRateIn\":0.0,\"msgRateOut\":0.0,\"lastUpdate\":1650886425227,\"lastStats\":{\"pulsar/pulsar/10.244.2.23:8080/0x00000000_0xffffffff\":{\"msgRateIn\":0.0,\"msgThroughputIn\":0.0,\"msgRateOut\":0.0,\"msgThroughputOut\":0.0,\"consumerCount\":0,\"producerCount\":0,\"topics\":1,\"cacheSize\":0}},\"numTopics\":1,\"numBundles\":1,\"numConsumers\":0,\"numProducers\":0,\"bundles\":[\"pulsar/pulsar/10.244.2.23:8080/0x00000000_0xffffffff\"],\"lastBundleGains\":[],\"lastBundleLosses\":[],\"brokerVersionString\":\"2.11.0-hw-0.0.4-SNAPSHOT\",\"protocols\":{},\"advertisedListeners\":{},\"bundleStats\":{\"pulsar/pulsar/10.244.2.23:8080/0x00000000_0xffffffff\":{\"msgRateIn\":0.0,\"msgThroughputIn\":0.0,\"msgRateOut\":0.0,\"msgThroughputOut\":0.0,\"consumerCount\":0,\"producerCount\":0,\"topics\":1,\"cacheSize\":0}},\"maxResourceUsage\":0.49645519256591797,\"loadReportType\":\"LocalBrokerData\"}";
-        Gson gson = new Gson();
-        LocalBrokerData localBrokerData = gson.fromJson(data, LocalBrokerData.class);
+    public void testLocalBrokerDataDeserialization() throws JsonProcessingException {
+        String data = "{\"name\":\"10.244.2.23:8081\",\"webServiceUrl\":\"http://10.244.2.23:8080\","
+                        + "\"webServiceUrlTls\":\"https://10.244.2.23:8081\","
+                        + "\"pulsarServiceUrlTls\":\"pulsar+ssl://10.244.2.23:6651\","
+                        + "\"persistentTopicsEnabled\":true,\"nonPersistentTopicsEnabled\":false,\"cpu\":{\"usage\":3"
+                        + ".1577712104798255,\"limit\":100.0},\"memory\":{\"usage\":614.0,\"limit\":1228.0},"
+                        + "\"directMemory\":{\"usage\":32.0,\"limit\":1228.0},\"bandwidthIn\":{\"usage\":0.0,"
+                        + "\"limit\":0.0},\"bandwidthOut\":{\"usage\":0.0,\"limit\":0.0},\"msgThroughputIn\":0.0,"
+                        + "\"msgThroughputOut\":0.0,\"msgRateIn\":0.0,\"msgRateOut\":0.0,"
+                        + "\"lastUpdate\":1650886425227,\"lastStats\":{\"pulsar/pulsar/10.244.2"
+                        + ".23:8080/0x00000000_0xffffffff\":{\"msgRateIn\":0.0,\"msgThroughputIn\":0.0,"
+                        + "\"msgRateOut\":0.0,\"msgThroughputOut\":0.0,\"consumerCount\":0,\"producerCount\":0,"
+                        + "\"topics\":1,\"cacheSize\":0}},\"numTopics\":1,\"numBundles\":1,\"numConsumers\":0,"
+                        + "\"numProducers\":0,\"bundles\":[\"pulsar/pulsar/10.244.2.23:8080/0x00000000_0xffffffff\"],"
+                        + "\"lastBundleGains\":[],\"lastBundleLosses\":[],\"brokerVersionString\":\"2.11.0-hw-0.0"
+                        + ".4-SNAPSHOT\",\"protocols\":{},\"advertisedListeners\":{},"
+                        + "\"bundleStats\":{\"pulsar/pulsar/10.244.2.23:8080/0x00000000_0xffffffff\":{\"msgRateIn\":0"
+                        + ".0,\"msgThroughputIn\":0.0,\"msgRateOut\":0.0,\"msgThroughputOut\":0.0,"
+                        + "\"consumerCount\":0,\"producerCount\":0,\"topics\":1,\"cacheSize\":0}},"
+                        + "\"maxResourceUsage\":0.49645519256591797,\"loadReportType\":\"LocalBrokerData\"}";
+        ObjectMapper objectMapper = ObjectMapperFactory.getMapper().getObjectMapper();
+        LocalBrokerData localBrokerData = objectMapper.readValue(data, LocalBrokerData.class);
         Assert.assertEquals(localBrokerData.getMemory().limit, 1228.0d, 0.0001f);
         Assert.assertEquals(localBrokerData.getMemory().usage, 614.0d, 0.0001f);
-        Assert.assertEquals(localBrokerData.getMemory().percentUsage(), ((float) localBrokerData.getMemory().usage) / ((float) localBrokerData.getMemory().limit) * 100, 0.0001f);
+        Assert.assertEquals(localBrokerData.getMemory().percentUsage(),
+                ((float) localBrokerData.getMemory().usage) / ((float) localBrokerData.getMemory().limit) * 100,
+                0.0001f);
+        Assert.assertEquals(localBrokerData.getBrokerId(), "10.244.2.23:8081");
     }
 
     @Test

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/LookupProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/LookupProxyHandler.java
@@ -157,6 +157,7 @@ public class LookupProxyHandler {
                         Commands.newLookupErrorResponse(getServerError(t), t.getMessage(), clientRequestId));
                 } else {
                     String brokerUrl = resolveBrokerUrlFromLookupDataResult(r);
+                    String brokerId = r.brokerId;
                     if (r.redirect) {
                         // Need to try the lookup again on a different broker
                         performLookup(clientRequestId, topic, brokerUrl, r.authoritative, numberOfRetries - 1);
@@ -170,10 +171,10 @@ public class LookupProxyHandler {
                         // will connect back.
                         if (log.isDebugEnabled()) {
                             log.debug("Successfully perform lookup '{}' for topic '{}'"
-                                            + " with clientReq Id '{}' and lookup-broker {}",
-                                    addr, topic, clientRequestId, brokerUrl);
+                                            + " with clientReq Id '{}' and lookup-broker id '{}'",
+                                    addr, topic, clientRequestId, brokerId);
                         }
-                        writeAndFlush(Commands.newLookupResponse(brokerUrl, brokerUrl, true,
+                        writeAndFlush(Commands.newLookupResponse(brokerId, brokerUrl, brokerUrl, true,
                             LookupType.Connect, clientRequestId, true /* this is coming from proxy */));
                     }
                 }


### PR DESCRIPTION
WIP: This PR most likely requires a PIP and that will follow.

### Motivation

In the past brokers didn't have a stable unique identifier. In PR #21894, the "lookupServiceAddress" was renamed to be "brokerId" so that there would be a single unique identifier for a broker in a cluster.

This PR continues making brokerId a first class identifier for a broker. The long term benefit is having consistency across the APIs. One reason to add this information to the topic lookup result is to be able to use the APIs in a way where you lookup a topic and receive that broker id. With this broker id, you could then lookup more details about the broker in the Admin API with the broker id.

### Modifications

- add brokerId to lookup results
- add brokerId to load manager data
  - brokerId already was contained in LoadReport with the field name `name` instead of `brokerId`. Keep the name `name` for backwards compatibility
- add client test to ensure that lookup result includes the broker id for both binary and http lookup results   

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->