### PR TITLE
[improve][build] Upgrade OTel library versions

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -338,12 +338,12 @@ The Apache Software License, Version 2.0
     - io.prometheus-simpleclient_tracer_otel-0.16.0.jar
     - io.prometheus-simpleclient_tracer_otel_agent-0.16.0.jar
  * Prometheus exporter
-    - io.prometheus-prometheus-metrics-config-1.1.0.jar
-    - io.prometheus-prometheus-metrics-exporter-common-1.1.0.jar
-    - io.prometheus-prometheus-metrics-exporter-httpserver-1.1.0.jar
-    - io.prometheus-prometheus-metrics-exposition-formats-1.1.0.jar
-    - io.prometheus-prometheus-metrics-model-1.1.0.jar
-    - io.prometheus-prometheus-metrics-shaded-protobuf-1.1.0.jar
+    - io.prometheus-prometheus-metrics-config-1.2.1.jar
+    - io.prometheus-prometheus-metrics-exporter-common-1.2.1.jar
+    - io.prometheus-prometheus-metrics-exporter-httpserver-1.2.1.jar
+    - io.prometheus-prometheus-metrics-exposition-formats-1.2.1.jar
+    - io.prometheus-prometheus-metrics-model-1.2.1.jar
+    - io.prometheus-prometheus-metrics-shaded-protobuf-1.2.1.jar
  * Jakarta Bean Validation API
     - jakarta.validation-jakarta.validation-api-2.0.2.jar
     - javax.validation-validation-api-1.1.0.Final.jar
@@ -524,26 +524,25 @@ The Apache Software License, Version 2.0
     - org.roaringbitmap-RoaringBitmap-0.9.44.jar
     - org.roaringbitmap-shims-0.9.44.jar
   * OpenTelemetry
-    - io.opentelemetry-opentelemetry-api-1.34.1.jar
-    - io.opentelemetry-opentelemetry-api-events-1.34.1-alpha.jar
-    - io.opentelemetry-opentelemetry-context-1.34.1.jar
-    - io.opentelemetry-opentelemetry-exporter-common-1.34.1.jar
-    - io.opentelemetry-opentelemetry-exporter-otlp-1.34.1.jar
-    - io.opentelemetry-opentelemetry-exporter-otlp-common-1.34.1.jar
-    - io.opentelemetry-opentelemetry-exporter-prometheus-1.34.1-alpha.jar
-    - io.opentelemetry-opentelemetry-exporter-sender-okhttp-1.34.1.jar
-    - io.opentelemetry-opentelemetry-extension-incubator-1.34.1-alpha.jar
-    - io.opentelemetry-opentelemetry-sdk-1.34.1.jar
-    - io.opentelemetry-opentelemetry-sdk-common-1.34.1.jar
-    - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-1.34.1.jar
-    - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-spi-1.34.1.jar
-    - io.opentelemetry-opentelemetry-sdk-logs-1.34.1.jar
-    - io.opentelemetry-opentelemetry-sdk-metrics-1.34.1.jar
-    - io.opentelemetry-opentelemetry-sdk-trace-1.34.1.jar
-    - io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-1.32.1.jar
-    - io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-semconv-1.32.1-alpha.jar
-    - io.opentelemetry.instrumentation-opentelemetry-resources-1.32.1-alpha.jar
-    - io.opentelemetry.semconv-opentelemetry-semconv-1.23.1-alpha.jar
+    - io.opentelemetry-opentelemetry-api-1.37.0.jar
+    - io.opentelemetry-opentelemetry-api-incubator-1.37.0-alpha.jar
+    - io.opentelemetry-opentelemetry-context-1.37.0.jar
+    - io.opentelemetry-opentelemetry-exporter-common-1.37.0.jar
+    - io.opentelemetry-opentelemetry-exporter-otlp-1.37.0.jar
+    - io.opentelemetry-opentelemetry-exporter-otlp-common-1.37.0.jar
+    - io.opentelemetry-opentelemetry-exporter-prometheus-1.37.0-alpha.jar
+    - io.opentelemetry-opentelemetry-exporter-sender-okhttp-1.37.0.jar
+    - io.opentelemetry-opentelemetry-sdk-1.37.0.jar
+    - io.opentelemetry-opentelemetry-sdk-common-1.37.0.jar
+    - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-1.37.0.jar
+    - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-spi-1.37.0.jar
+    - io.opentelemetry-opentelemetry-sdk-logs-1.37.0.jar
+    - io.opentelemetry-opentelemetry-sdk-metrics-1.37.0.jar
+    - io.opentelemetry-opentelemetry-sdk-trace-1.37.0.jar
+    - io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-1.33.2.jar
+    - io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-semconv-1.33.2-alpha.jar
+    - io.opentelemetry.instrumentation-opentelemetry-resources-1.33.2-alpha.jar
+    - io.opentelemetry.semconv-opentelemetry-semconv-1.25.0-alpha.jar
 
 BSD 3-clause "New" or "Revised" License
  * Google auth library

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -389,9 +389,9 @@ The Apache Software License, Version 2.0
     - log4j-slf4j2-impl-2.23.1.jar
     - log4j-web-2.23.1.jar
  * OpenTelemetry
-    - opentelemetry-api-1.34.1.jar
-    - opentelemetry-context-1.34.1.jar
-    - opentelemetry-extension-incubator-1.34.1-alpha.jar
+    - opentelemetry-api-1.37.0.jar
+    - opentelemetry-api-incubator-1.37.0-alpha.jar
+    - opentelemetry-context-1.37.0.jar
 
  * BookKeeper
     - bookkeeper-common-allocator-4.17.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -256,10 +256,11 @@ flexible messaging model and an intuitive client API.</description>
     <disruptor.version>3.4.3</disruptor.version>
     <zstd-jni.version>1.5.2-3</zstd-jni.version>
     <netty-reactive-streams.version>2.0.6</netty-reactive-streams.version>
-    <opentelemetry.version>1.34.1</opentelemetry.version>
-    <opentelemetry.alpha.version>1.34.1-alpha</opentelemetry.alpha.version>
-    <opentelemetry.instrumentation.version>1.32.1-alpha</opentelemetry.instrumentation.version>
-    <opentelemetry.semconv.version>1.23.1-alpha</opentelemetry.semconv.version>
+    <opentelemetry.version>1.37.0</opentelemetry.version>
+    <opentelemetry.alpha.version>${opentelemetry.version}-alpha</opentelemetry.alpha.version>
+    <opentelemetry.instrumentation.version>1.33.2</opentelemetry.instrumentation.version>
+    <opentelemetry.instrumentation.alpha.version>${opentelemetry.instrumentation.version}-alpha</opentelemetry.instrumentation.alpha.version>
+    <opentelemetry.semconv.version>1.25.0-alpha</opentelemetry.semconv.version>
     <picocli.version>4.7.5</picocli.version>
 
     <!-- test dependencies -->
@@ -1497,8 +1498,17 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
       <dependency>
         <groupId>io.opentelemetry.instrumentation</groupId>
-        <artifactId>opentelemetry-resources</artifactId>
+        <artifactId>opentelemetry-instrumentation-bom</artifactId>
         <version>${opentelemetry.instrumentation.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.opentelemetry.instrumentation</groupId>
+        <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
+        <version>${opentelemetry.instrumentation.alpha.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.opentelemetry.semconv</groupId>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -496,12 +496,6 @@
       <artifactId>pulsar-package-filesystem-storage</artifactId>
       <version>${project.version}</version>
     </dependency>
-
-    <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-sdk-testing</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -59,7 +59,7 @@
 
     <dependency>
       <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-extension-incubator</artifactId>
+      <artifactId>opentelemetry-api-incubator</artifactId>
     </dependency>
 
     <dependency>

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/metrics/Counter.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/metrics/Counter.java
@@ -21,10 +21,10 @@ package org.apache.pulsar.client.impl.metrics;
 import static org.apache.pulsar.client.impl.metrics.MetricsUtil.getDefaultAggregationLabels;
 import static org.apache.pulsar.client.impl.metrics.MetricsUtil.getTopicAttributes;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.incubator.metrics.ExtendedLongCounterBuilder;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongCounterBuilder;
 import io.opentelemetry.api.metrics.Meter;
-import io.opentelemetry.extension.incubator.metrics.ExtendedLongCounterBuilder;
 
 public class Counter {
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/metrics/LatencyHistogram.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/metrics/LatencyHistogram.java
@@ -23,10 +23,10 @@ import static org.apache.pulsar.client.impl.metrics.MetricsUtil.getDefaultAggreg
 import static org.apache.pulsar.client.impl.metrics.MetricsUtil.getTopicAttributes;
 import com.google.common.collect.Lists;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.incubator.metrics.ExtendedDoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.Meter;
-import io.opentelemetry.extension.incubator.metrics.ExtendedDoubleHistogramBuilder;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/metrics/UpDownCounter.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/metrics/UpDownCounter.java
@@ -22,10 +22,10 @@ package org.apache.pulsar.client.impl.metrics;
 import static org.apache.pulsar.client.impl.metrics.MetricsUtil.getDefaultAggregationLabels;
 import static org.apache.pulsar.client.impl.metrics.MetricsUtil.getTopicAttributes;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.incubator.metrics.ExtendedLongUpDownCounterBuilder;
 import io.opentelemetry.api.metrics.LongUpDownCounter;
 import io.opentelemetry.api.metrics.LongUpDownCounterBuilder;
 import io.opentelemetry.api.metrics.Meter;
-import io.opentelemetry.extension.incubator.metrics.ExtendedLongUpDownCounterBuilder;
 
 public class UpDownCounter {
 


### PR DESCRIPTION
### Motivation

In Pulsar, a long waited improvement to Otel, metric exporter REUSABLE_DATA memory mode, contributed by @asafm, has been released in [1.37.0 version](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.37.0).
In addition, it's a good practice to stay updated with the experimental API changes within OTel. 
For example, in 1.37.0, the opentelemetry-extension-incubator got renamed to opentelemetry-api-incubator and the package name also changed. This impacts the Pulsar client OTel support (PIP-342, #22179).

### Modifications

- upgrades
  - opentelemetry.version: 1.34.1 -> 1.37.0
  - opentelemetry.instrumentation.version: 1.32.1-alpha -> 1.33.2
  - opentelemetry.semconv.version: 1.23.1-alpha -> 1.25.0-alpha
- start using opentelemetry-instrumentation-bom / opentelemetry-instrumentation-bom-alpha
- adapt to breaking changes

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->