### PR TITLE
[fix][io] Fix es index creation

### DIFF
--- a/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/elastic/ElasticSearchJavaRestClient.java
+++ b/pulsar-io/elastic-search/src/main/java/org/apache/pulsar/io/elasticsearch/client/elastic/ElasticSearchJavaRestClient.java
@@ -144,7 +144,7 @@ public class ElasticSearchJavaRestClient extends RestClient {
     public boolean deleteDocument(String index, String documentId) throws IOException {
         final DeleteRequest req = new
                 DeleteRequest.Builder()
-                .index(config.getIndexName())
+                .index(index)
                 .id(documentId)
                 .build();
 
@@ -156,7 +156,7 @@ public class ElasticSearchJavaRestClient extends RestClient {
     public boolean indexDocument(String index, String documentId, String documentSource) throws IOException {
         final Map mapped = objectMapper.readValue(documentSource, Map.class);
         final IndexRequest<Object> indexRequest = new IndexRequest.Builder<>()
-                .index(config.getIndexName())
+                .index(index)
                 .document(mapped)
                 .id(documentId)
                 .build();

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
@@ -154,7 +154,7 @@ public abstract class ElasticSearchSinkTests extends ElasticSearchTestBase {
         });
 
         when(mockRecord.getSchema()).thenAnswer((Answer<Schema<KeyValue<String, UserProfile>>>) invocation -> kvSchema);
-        when(mockRecord.getEventTime()).thenAnswer(invocation -> System.currentTimeMillis());
+        when(mockRecord.getEventTime()).thenAnswer(invocation -> Optional.of(System.currentTimeMillis()));
     }
 
     @AfterMethod(alwaysRun = true)
@@ -218,7 +218,7 @@ public abstract class ElasticSearchSinkTests extends ElasticSearchTestBase {
         sink.open(map, mockSinkContext);
         send(1);
         verify(mockRecord, times(1)).ack();
-        String value = getHitIdAtIndex("test-formatted-index-", 0);
+        String value = getHitIdAtIndex("test-formatted-index-*", 0);
         assertTrue(StringUtils.isNotBlank(value));
     }
 

--- a/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
+++ b/pulsar-io/elastic-search/src/test/java/org/apache/pulsar/io/elasticsearch/ElasticSearchSinkTests.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import co.elastic.clients.transport.ElasticsearchTransport;
 import com.fasterxml.jackson.core.JsonParseException;
@@ -43,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericObject;
@@ -152,6 +154,7 @@ public abstract class ElasticSearchSinkTests extends ElasticSearchTestBase {
         });
 
         when(mockRecord.getSchema()).thenAnswer((Answer<Schema<KeyValue<String, UserProfile>>>) invocation -> kvSchema);
+        when(mockRecord.getEventTime()).thenAnswer(invocation -> System.currentTimeMillis());
     }
 
     @AfterMethod(alwaysRun = true)
@@ -207,6 +210,16 @@ public abstract class ElasticSearchSinkTests extends ElasticSearchTestBase {
         sink.open(map, mockSinkContext);
         send(100);
         verify(mockRecord, times(100)).ack();
+    }
+
+    @Test
+    public final void send1WithFormattedIndexTest() throws Exception {
+        map.put("indexName", "test-formatted-index-%{+yyyy-MM-dd}");
+        sink.open(map, mockSinkContext);
+        send(1);
+        verify(mockRecord, times(1)).ack();
+        String value = getHitIdAtIndex("test-formatted-index-", 0);
+        assertTrue(StringUtils.isNotBlank(value));
     }
 
     @Test


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/14383 introduces the event-time-based index name, it works fine. 

This behavior has been broken by https://github.com/apache/pulsar/pull/14805. 

Elasticsearch sink yaml:

```yml
configs:
    elasticSearchUrl: "http://localhost:9200"
    indexName: "test-index-%{+yyyy-MM-dd}"
    createIndexIfNeeded: true
    compatibilityMode: ELASTICSEARCH
```

When the index name equals to the `test-index-%{+yyyy-MM-dd}`, the es index creation fails:
```
co.elastic.clients.elasticsearch._types.ElasticsearchException: [es/index] failed: [invalid_index_name_exception] Invalid index name [test-index-%{+yyyy-MM-dd}], must be lowercase
	at co.elastic.clients.transport.ElasticsearchTransportBase.getApiResponse(ElasticsearchTransportBase.java:345) ~[elasticsearch-java-8.12.1.jar:?]
	at co.elastic.clients.transport.ElasticsearchTransportBase.performRequest(ElasticsearchTransportBase.java:147) ~[elasticsearch-java-8.12.1.jar:?]
	at co.elastic.clients.elasticsearch.ElasticsearchClient.index(ElasticsearchClient.java:1141) ~[elasticsearch-java-8.12.1.jar:?]
	at org.apache.pulsar.io.elasticsearch.client.elastic.ElasticSearchJavaRestClient.indexDocument(ElasticSearchJavaRestClient.java:163) ~[gurFS0VR_Lh-tuSoWDLguA/:?]
	at org.apache.pulsar.io.elasticsearch.ElasticSearchClient.indexDocument(ElasticSearchClient.java:190) [gurFS0VR_Lh-tuSoWDLguA/:?]
	at org.apache.pulsar.io.elasticsearch.ElasticSearchSink.write(ElasticSearchSink.java:139) [gurFS0VR_Lh-tuSoWDLguA/:?]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.sendOutputMessage(JavaInstanceRunnable.java:469) [pulsar-functions-instance.jar:3.3.0-SNAPSHOT]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.handleResult(JavaInstanceRunnable.java:431) [pulsar-functions-instance.jar:3.3.0-SNAPSHOT]
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:352) [pulsar-functions-instance.jar:3.3.0-SNAPSHOT]
	at java.base/java.lang.Thread.run(Thread.java:840) [?:?]
```

The expected index name should be equal to `test-1-2024-05-06`(eventTime: `System.currentTimeMillis()`).

### Modifications

- Use the index passed in instead of reading the index from config. 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->