### PR TITLE
[fix][fn] Fix eventTime filling in RecordFunction

### DIFF
--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/RecordFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/RecordFunction.java
@@ -38,6 +38,7 @@ public class RecordFunction implements Function<String, Record<String>> {
         return context.newOutputRecordBuilder(Schema.STRING)
                 .destinationTopic(publishTopic)
                 .value(output)
+                .eventTime(context.getCurrentRecord().getEventTime().orElse(null))
                 .properties(properties)
                 .build();
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -1960,8 +1960,11 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
                     .newProducer(Schema.STRING)
                     .topic(inputTopic)
                     .create();
+            List<Long> timestamps = new ArrayList<>();
             for (int i = 0; i < numMessages; i++) {
-                producer.send("message" + i);
+                long timeMillis = System.currentTimeMillis();
+                timestamps.add(timeMillis);
+                producer.newMessage().eventTime(timeMillis).value("message" + i).send();
             }
 
             getFunctionInfoSuccess(functionName);
@@ -1972,6 +1975,7 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
                 Message<String> msg = consumer.receive(30, TimeUnit.SECONDS);
                 log.info("Received: {}", msg.getValue());
                 assertEquals(msg.getValue(), "message" + i + "!");
+                assertEquals(msg.getEventTime(), timestamps.get(i));
                 assertEquals(msg.getProperty("input_topic"), "persistent://" + inputTopic);
             }
         } finally {


### PR DESCRIPTION
### Motivation

When a message with event time has been processed by `org.apache.pulsar.functions.api.Context#newOutputRecordBuilder`, which didn't fill the event time.


### Modifications

- Fill the `eventTime` in the `org.apache.pulsar.functions.api.examples.RecordFunction#process`.

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->