### PR TITLE
[fix][test] Clear MockedPulsarServiceBaseTest fields to prevent test runtime memory leak

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -277,15 +277,22 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         }
         if (brokerGateway != null) {
             brokerGateway.close();
+            brokerGateway = null;
         }
         if (pulsarTestContext != null) {
             pulsarTestContext.close();
             pulsarTestContext = null;
         }
+
         resetConfig();
         callCloseables(closeables);
         closeables.clear();
         onCleanup();
+
+        // clear fields to avoid test runtime memory leak, pulsarTestContext already handles closing of these instances
+        pulsar = null;
+        mockZooKeeper = null;
+        mockZooKeeperGlobal = null;
     }
 
     protected void closeAdmin() {


### PR DESCRIPTION
### Motivation

Follow up on #22583. TestNG keeps strong references to test class instances for the duration of the test run. (https://github.com/testng-team/testng/issues/1461)
This causes OOM issues. 

### Modifications

Clear remaining fields in MockedPulsarServiceBaseTest to prevent test runtime memory leak.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->