### PR TITLE
[improve][test] Clear fields in AuthZTest classes at cleanup

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AuthZTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AuthZTest.java
@@ -47,6 +47,21 @@ public class AuthZTest extends MockedPulsarStandalone {
     protected static final String TENANT_ADMIN_TOKEN = Jwts.builder()
             .claim("sub", TENANT_ADMIN_SUBJECT).signWith(SECRET_KEY).compact();
 
+    @Override
+    public void close() throws Exception {
+        if (superUserAdmin != null) {
+            superUserAdmin.close();
+            superUserAdmin = null;
+        }
+        if (tenantManagerAdmin != null) {
+            tenantManagerAdmin.close();
+            tenantManagerAdmin = null;
+        }
+        authorizationService = null;
+        orignalAuthorizationService = null;
+        super.close();
+    }
+
     @BeforeMethod(alwaysRun = true)
     public void before() throws IllegalAccessException {
         orignalAuthorizationService = getPulsarService().getBrokerService().getAuthorizationService();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespaceAuthZTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespaceAuthZTest.java
@@ -129,10 +129,14 @@ public class NamespaceAuthZTest extends MockedPulsarStandalone {
     public void cleanup() {
         if (superUserAdmin != null) {
             superUserAdmin.close();
+            superUserAdmin = null;
         }
         if (tenantManagerAdmin != null) {
             tenantManagerAdmin.close();
+            tenantManagerAdmin = null;
         }
+        pulsarClient = null;
+        authorizationService = null;
         close();
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAuthZTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAuthZTest.java
@@ -19,9 +19,19 @@
 
 package org.apache.pulsar.broker.admin;
 
+import static org.mockito.Mockito.doReturn;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.jsonwebtoken.Jwts;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Cleanup;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -45,6 +55,7 @@ import org.apache.pulsar.common.policies.data.DelayedDeliveryPolicies;
 import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.EntryFilters;
 import org.apache.pulsar.common.policies.data.InactiveTopicPolicies;
+import org.apache.pulsar.common.policies.data.NamespaceOperation;
 import org.apache.pulsar.common.policies.data.OffloadPolicies;
 import org.apache.pulsar.common.policies.data.PersistencePolicies;
 import org.apache.pulsar.common.policies.data.PolicyName;
@@ -53,24 +64,13 @@ import org.apache.pulsar.common.policies.data.PublishRate;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.common.policies.data.TopicOperation;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.pulsar.common.policies.data.NamespaceOperation;
-import org.apache.pulsar.common.policies.data.TopicOperation;
-import org.mockito.Mockito;
-import static org.mockito.Mockito.doReturn;
 
 @Test(groups = "broker-admin")
 public class TopicAuthZTest extends AuthZTest {
@@ -98,12 +98,6 @@ public class TopicAuthZTest extends AuthZTest {
     @SneakyThrows
     @AfterClass(alwaysRun = true)
     public void cleanup() {
-        if (superUserAdmin != null) {
-            superUserAdmin.close();
-        }
-        if (tenantManagerAdmin != null) {
-            tenantManagerAdmin.close();
-        }
         close();
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesAuthZTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesAuthZTest.java
@@ -74,9 +74,11 @@ public final class TopicPoliciesAuthZTest extends MockedPulsarStandalone {
     public void after() {
         if (superUserAdmin != null) {
             superUserAdmin.close();
+            superUserAdmin = null;
         }
         if (tenantManagerAdmin != null) {
             tenantManagerAdmin.close();
+            tenantManagerAdmin = null;
         }
         close();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TransactionAndSchemaAuthZTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TransactionAndSchemaAuthZTest.java
@@ -19,6 +19,10 @@
 package org.apache.pulsar.broker.admin;
 
 import io.jsonwebtoken.Jwts;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.Cleanup;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -47,10 +51,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 @Test(groups = "broker-admin")
 public class TransactionAndSchemaAuthZTest extends AuthZTest {
@@ -82,12 +82,6 @@ public class TransactionAndSchemaAuthZTest extends AuthZTest {
     @SneakyThrows
     @AfterClass(alwaysRun = true)
     public void cleanup() {
-        if (superUserAdmin != null) {
-            superUserAdmin.close();
-        }
-        if (tenantManagerAdmin != null) {
-            tenantManagerAdmin.close();
-        }
         close();
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/security/MockedPulsarStandalone.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/security/MockedPulsarStandalone.java
@@ -193,7 +193,10 @@ public abstract class MockedPulsarStandalone implements AutoCloseable {
     public void close() throws Exception {
         if (pulsarTestContext != null) {
             pulsarTestContext.close();
+            pulsarTestContext = null;
         }
+        pulsarService = null;
+        serviceInternalAdmin = null;
     }
 
     // Utils


### PR DESCRIPTION
### Motivation

Follow up on #22583. TestNG keeps strong references to test class instances for the duration of the test run. (https://github.com/testng-team/testng/issues/1461) This causes a memory leak in test runtime.
The way to workaround this is to clear fields at cleanup. 

### Modifications

Clear fields for AuthZTest classes

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->