### PR TITLE
[fix][broker] Add the missed opentelemetry-sdk-testing dependency to tests of pulsar-broker-auth-sasl

### DIFF
--- a/pulsar-broker-auth-sasl/pom.xml
+++ b/pulsar-broker-auth-sasl/pom.xml
@@ -42,6 +42,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.kerby</groupId>
       <artifactId>kerby-config</artifactId>
       <version>${kerby.version}</version>


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/22664

After importing the dependency, tests of pulsar-broker-auth-sasl can run now.

<img width="1330" alt="image" src="https://github.com/apache/pulsar/assets/18204803/28c0dc31-fc49-4634-9ec3-9e7fbda4d21a">

```bash
$ mvn test -pl pulsar-broker-auth-sasl -Dtest='ProxySaslAuthenticationTest'
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 13.28 s - in org.apache.pulsar.broker.authentication.ProxySaslAuthenticationTest
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: