### PR TITLE
[improve][ws] Add memory limit configuration for Pulsar client used in Websocket proxy

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1544,6 +1544,9 @@ webSocketNumServiceThreads=
 # Number of connections per Broker in Pulsar Client used in WebSocket proxy
 webSocketConnectionsPerBroker=
 
+# Memory limit in MBs for direct memory in Pulsar Client used in WebSocket proxy
+webSocketPulsarClientMemoryLimitInMB=0
+
 # Time in milliseconds that idle WebSocket session times out
 webSocketSessionIdleTimeoutMillis=300000
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -967,6 +967,9 @@ webSocketNumIoThreads=8
 # Number of connections per Broker in Pulsar Client used in WebSocket proxy
 webSocketConnectionsPerBroker=8
 
+# Memory limit in MBs for direct memory in Pulsar Client used in WebSocket proxy
+webSocketPulsarClientMemoryLimitInMB=0
+
 # Time in milliseconds that idle WebSocket session times out
 webSocketSessionIdleTimeoutMillis=300000
 

--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -71,6 +71,9 @@ numHttpServerThreads=
 # Number of connections per Broker in Pulsar Client used in WebSocket proxy
 webSocketConnectionsPerBroker=
 
+# Memory limit in MBs for direct memory in Pulsar Client used in WebSocket proxy
+webSocketPulsarClientMemoryLimitInMB=0
+
 # Time in milliseconds that idle WebSocket session times out
 webSocketSessionIdleTimeoutMillis=300000
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2912,6 +2912,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Number of connections per Broker in Pulsar Client used in WebSocket proxy"
     )
     private int webSocketConnectionsPerBroker = Runtime.getRuntime().availableProcessors();
+
+    @FieldContext(
+            category = CATEGORY_WEBSOCKET,
+            doc = "Memory limit in MBs for direct memory in Pulsar Client used in WebSocket proxy"
+    )
+    private int webSocketPulsarClientMemoryLimitInMB = 0;
+
     @FieldContext(
         category = CATEGORY_WEBSOCKET,
         doc = "Time in milliseconds that idle WebSocket session times out"

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
@@ -195,7 +195,8 @@ public class WebSocketService implements Closeable {
 
     private PulsarClient createClientInstance(ClusterData clusterData) throws IOException {
         ClientBuilder clientBuilder = PulsarClient.builder() //
-                .memoryLimit(0, SizeUnit.BYTES)
+                .memoryLimit(SizeUnit.MEGA_BYTES.toBytes(config.getWebSocketPulsarClientMemoryLimitInMB()),
+                        SizeUnit.BYTES)
                 .statsInterval(0, TimeUnit.SECONDS) //
                 .enableTls(config.isTlsEnabled()) //
                 .allowTlsInsecureConnection(config.isTlsAllowInsecureConnection()) //

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -176,6 +176,9 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     @FieldContext(doc = "Number of connections per broker in Pulsar client used in WebSocket proxy")
     private int webSocketConnectionsPerBroker = Runtime.getRuntime().availableProcessors();
 
+    @FieldContext(doc = "Memory limit in MBs for direct memory in Pulsar Client used in WebSocket proxy")
+    private int webSocketPulsarClientMemoryLimitInMB = 0;
+
     @FieldContext(doc = "Timeout of idling WebSocket session (in milliseconds)")
     private int webSocketSessionIdleTimeoutMillis = 300000;
 


### PR DESCRIPTION
### Motivation

There's no explicit flow control in the Websocket proxy for producers. If too many messages are pushed, the proxy (or broker, if ws proxy runs with the broker) will run out of memory.

### Modifications

add `webSocketPulsarClientMemoryLimitInMB` configuration option to limit the memory.
by default, it is unlimited. Can be set to a value such as `64` to keep the direct memory used by the Pulsar client under 64 MB.
 
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->