### PR TITLE
[improve][test] Increase ram to 200MB for PulsarIODebeziumSourceRunner

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/PulsarIOSinkRunner.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/PulsarIOSinkRunner.java
@@ -51,8 +51,15 @@ import net.jodah.failsafe.Failsafe;
 @Slf4j
 public class PulsarIOSinkRunner extends PulsarIOTestRunner {
 
-	public PulsarIOSinkRunner(PulsarCluster cluster, String functionRuntimeType) {
+    private final long runtimeInstanceRamBytes;
+
+    public PulsarIOSinkRunner(PulsarCluster cluster, String functionRuntimeType) {
+        this(cluster, functionRuntimeType, RUNTIME_INSTANCE_RAM_BYTES);
+    }
+
+    public PulsarIOSinkRunner(PulsarCluster cluster, String functionRuntimeType, long runtimeInstanceRamBytes) {
 		super(cluster, functionRuntimeType);
+        this.runtimeInstanceRamBytes = runtimeInstanceRamBytes;
 	}
 
 	@SuppressWarnings({ "rawtypes" })
@@ -156,7 +163,7 @@ public class PulsarIOSinkRunner extends PulsarIOTestRunner {
                     "--sink-type", tester.sinkType().getValue().toLowerCase(),
                     "--sinkConfig", new Gson().toJson(tester.sinkConfig()),
                     "--inputs", inputTopicName,
-                    "--ram", String.valueOf(RUNTIME_INSTANCE_RAM_BYTES)
+                    "--ram", String.valueOf(runtimeInstanceRamBytes)
             };
         } else {
             commands = new String[] {
@@ -169,7 +176,7 @@ public class PulsarIOSinkRunner extends PulsarIOTestRunner {
                     "--classname", tester.getSinkClassName(),
                     "--sinkConfig", new Gson().toJson(tester.sinkConfig()),
                     "--inputs", inputTopicName,
-                    "--ram", String.valueOf(RUNTIME_INSTANCE_RAM_BYTES)
+                    "--ram", String.valueOf(runtimeInstanceRamBytes)
             };
         }
         log.info("Run command : {}", StringUtils.join(commands, ' '));
@@ -196,7 +203,7 @@ public class PulsarIOSinkRunner extends PulsarIOTestRunner {
                     "--sinkConfig", new Gson().toJson(tester.sinkConfig()),
                     "--inputs", inputTopicName,
                     "--parallelism", "2",
-                    "--ram", String.valueOf(RUNTIME_INSTANCE_RAM_BYTES)
+                    "--ram", String.valueOf(runtimeInstanceRamBytes)
             };
         } else {
             commands = new String[] {
@@ -210,7 +217,7 @@ public class PulsarIOSinkRunner extends PulsarIOTestRunner {
                     "--sinkConfig", new Gson().toJson(tester.sinkConfig()),
                     "--inputs", inputTopicName,
                     "--parallelism", "2",
-                    "--ram", String.valueOf(RUNTIME_INSTANCE_RAM_BYTES)
+                    "--ram", String.valueOf(runtimeInstanceRamBytes)
             };
         }
         log.info("Run command : {}", StringUtils.join(commands, ' '));

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/PulsarIOSourceRunner.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/PulsarIOSourceRunner.java
@@ -50,8 +50,15 @@ import net.jodah.failsafe.Failsafe;
 @Slf4j
 public class PulsarIOSourceRunner extends PulsarIOTestRunner {
 
+    private final long runtimeInstanceRamBytes;
+
     public PulsarIOSourceRunner(PulsarCluster cluster, String functionRuntimeType) {
+        this(cluster, functionRuntimeType, RUNTIME_INSTANCE_RAM_BYTES);
+    }
+
+    public PulsarIOSourceRunner(PulsarCluster cluster, String functionRuntimeType, long runtimeInstanceRamBytes) {
 		super(cluster, functionRuntimeType);
+        this.runtimeInstanceRamBytes = runtimeInstanceRamBytes;
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -132,7 +139,7 @@ public class PulsarIOSourceRunner extends PulsarIOTestRunner {
             "--source-type", tester.sourceType(),
             "--sourceConfig", new Gson().toJson(tester.sourceConfig()),
             "--destinationTopicName", outputTopicName,
-            "--ram", String.valueOf(RUNTIME_INSTANCE_RAM_BYTES)
+            "--ram", String.valueOf(runtimeInstanceRamBytes)
         };
 
         log.info("Run command : {}", StringUtils.join(commands, ' '));
@@ -158,7 +165,7 @@ public class PulsarIOSourceRunner extends PulsarIOTestRunner {
                 "--sourceConfig", new Gson().toJson(tester.sourceConfig()),
                 "--destinationTopicName", outputTopicName,
                 "--parallelism", "2",
-                "--ram", String.valueOf(RUNTIME_INSTANCE_RAM_BYTES)
+                "--ram", String.valueOf(runtimeInstanceRamBytes)
         };
 
         log.info("Run command : {}", StringUtils.join(commands, ' '));

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarIODebeziumSourceRunner.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarIODebeziumSourceRunner.java
@@ -24,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.jodah.failsafe.Failsafe;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.SizeUnit;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.tests.integration.io.sources.PulsarIOSourceRunner;
@@ -43,11 +44,11 @@ public class PulsarIODebeziumSourceRunner extends PulsarIOSourceRunner {
     private int numMessages;
     private boolean jsonWithEnvelope;
     private PulsarClient client;
-    
+
     public PulsarIODebeziumSourceRunner(PulsarCluster cluster, String functionRuntimeType, String converterClassName,
             String tenant, String ns, String sourceName, String outputTopic, int numMessages, boolean jsonWithEnvelope,
             String consumeTopicName, PulsarClient client) {
-        super(cluster, functionRuntimeType);
+        super(cluster, functionRuntimeType, SizeUnit.MEGA_BYTES.toBytes(200));
         this.converterClassName = converterClassName;
         this.tenant = tenant;
         this.namespace = ns;


### PR DESCRIPTION
### Motivation

"Pulsar IO - Oracle" job is failing very often

### Modifications

Increase the ram from 128MB to 200MB for the container that runs Debezium.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->