### PR TITLE
[improve][broker] Remove unused method CompactionRecord.reset

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactionRecord.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactionRecord.java
@@ -51,14 +51,6 @@ public class CompactionRecord {
     public final Rate writeRate = new Rate();
     public final Rate readRate = new Rate();
 
-    public void reset() {
-        compactionRemovedEventCount.reset();
-        compactionSucceedCount.reset();
-        compactionFailedCount.reset();
-        compactionDurationTimeInMills.reset();
-        writeLatencyStats.reset();
-    }
-
     public void addCompactionRemovedEvent() {
         lastCompactionRemovedEventCountOp.increment();
         compactionRemovedEventCount.increment();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorMXBeanImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorMXBeanImpl.java
@@ -53,10 +53,6 @@ public class CompactorMXBeanImpl implements CompactorMXBean {
         return compactionRecordOps.keySet();
     }
 
-    public void reset() {
-        compactionRecordOps.values().forEach(CompactionRecord::reset);
-    }
-
     public void addCompactionReadOp(String topic, long readableBytes) {
         compactionRecordOps.computeIfAbsent(topic, k -> new CompactionRecord()).addCompactionReadOp(readableBytes);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorMXBeanImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorMXBeanImplTest.java
@@ -59,11 +59,6 @@ public class CompactorMXBeanImplTest {
         assertTrue(compaction.getCompactionWriteThroughput() > 0L);
         mxBean.addCompactionLatencyOp(topic, 10, TimeUnit.NANOSECONDS);
         assertTrue(compaction.getCompactionLatencyBuckets()[0] > 0L);
-        mxBean.reset();
-        assertEquals(compaction.getCompactionRemovedEventCount(), 0, 0);
-        assertEquals(compaction.getCompactionSucceedCount(), 0, 0);
-        assertEquals(compaction.getCompactionFailedCount(), 0, 0);
-        assertEquals(compaction.getCompactionDurationTimeInMills(), 0, 0);
     }
 
 }


### PR DESCRIPTION
### Motivation

Remove unused methods `CompactionRecord::reset` and caller `CompactionRecordMXBeanImpl::reset`. These methods are not used anywhere outside of the tests. Mistakenly using them can cause the topic compaction metrics to be invalidated.

### Modifications

Trivial cleanup.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dragosvictor/pulsar/pull/21
