### PR TITLE
[improve][offload] Replace usage of shaded class in OffsetsCache

### DIFF
--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/OffsetsCache.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/OffsetsCache.java
@@ -20,7 +20,7 @@ package org.apache.bookkeeper.mledger.offload.jcloud.impl;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import io.grpc.netty.shaded.io.netty.util.concurrent.DefaultThreadFactory;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -49,7 +49,7 @@ public class OffsetsCache implements AutoCloseable {
                     .build();
             cacheEvictionExecutor =
                     Executors.newSingleThreadScheduledExecutor(
-                            new DefaultThreadFactory("jcloud-offsets-cache-eviction"));
+                            new ThreadFactoryBuilder().setNameFormat("jcloud-offsets-cache-eviction").build());
             int period = Math.max(CACHE_TTL_SECONDS / 2, 1);
             cacheEvictionExecutor.scheduleAtFixedRate(() -> {
                 entryOffsetsCache.cleanUp();


### PR DESCRIPTION
### Motivation

When cherry-picking #22679 to branch-3.0, the build failed. 
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project tiered-storage-jcloud: Compilation failure
[ERROR] /Users/lari/workspace-pulsar/pulsar-branch-3.0/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/OffsetsCache.java:[23,53] package io.grpc.netty.shaded.io.netty.util.concurrent does not exist
```
I had made a mistake and used a shaded class in OffsetsCache

### Modifications

- replace with Guava's ThreadFactoryBuilder since Guava is already available in the tiered storage dependencies

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->