### PR TITLE
[improve] [log] Print source client addr when enabled haProxyProtocolEnabled

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -934,7 +934,7 @@ public class Consumer {
     public String toString() {
         if (subscription != null && cnx != null) {
             return MoreObjects.toStringHelper(this).add("subscription", subscription).add("consumerId", consumerId)
-                    .add("consumerName", consumerName).add("address", this.cnx.clientAddress()).toString();
+                    .add("consumerName", consumerName).add("address", this.cnx.toString()).toString();
         } else {
             return MoreObjects.toStringHelper(this).add("consumerId", consumerId)
                     .add("consumerName", consumerName).toString();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -666,7 +666,7 @@ public class Producer {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("topic", topic).add("client", cnx.clientAddress())
+        return MoreObjects.toStringHelper(this).add("topic", topic).add("client", cnx.toString())
                 .add("producerName", producerName).add("producerId", producerId).toString();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -3365,7 +3365,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     }
 
     /**
-     * Demo: [id: 0x2561bcd1, L:/10.0.136.103:58038 ! R:/240.240.0.5:6650] [SR:/240.240.0.5:6650].
+     * Demo: [id: 0x2561bcd1, L:/10.0.136.103:6650 ! R:/240.240.0.5:58038] [SR:/240.240.0.5:58038].
      * L: local Address.
      * R: remote address.
      * SR: source remote address. It is the source address when enabled "haProxyProtocolEnabled".

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1201,7 +1201,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             remoteAddress, getPrincipal());
                 }
 
-                log.info("[{}] Subscribing on topic {} / {}. consumerId: {}", this.ctx().channel().toString(),
+                log.info("[{}] Subscribing on topic {} / {}. consumerId: {}", this.toString(),
                         topicName, subscriptionName, consumerId);
                 try {
                     Metadata.validateMetadata(metadata,
@@ -1921,7 +1921,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             if (log.isDebugEnabled()) {
                 log.debug("Consumer future is not complete(not complete or error), but received command ack. so discard"
                                 + " this command. consumerId: {}, cnx: {}, messageIdCount: {}", ack.getConsumerId(),
-                        this.ctx().channel().toString(), ack.getMessageIdsCount());
+                        this.toString(), ack.getMessageIdsCount());
             }
         }
     }
@@ -2267,7 +2267,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 @Override
                 public String toString() {
                     return String.format("ServerCnx [%s] get largest batch index when possible",
-                            ServerCnx.this.ctx.channel());
+                            ServerCnx.this.toString());
                 }
             }, null);
 
@@ -3301,7 +3301,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 }
             } catch (Throwable t) {
                 log.warn("[{}] [{}] Failed to remove TCP no-delay property on client cnx {}", topic, producerName,
-                        ctx.channel());
+                        this.toString());
             }
         }
     }
@@ -3362,6 +3362,31 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     public SocketAddress getRemoteAddress() {
         return remoteAddress;
+    }
+
+    /**
+     * Demo: [id: 0x2561bcd1, L:/10.0.136.103:58038 ! R:/240.240.0.5:6650] [SR:/240.240.0.5:6650].
+     * L: local Address.
+     * R: remote address.
+     * SR: source remote address. It is the source address when enabled "haProxyProtocolEnabled".
+     */
+    @Override
+    public String toString() {
+        ChannelHandlerContext ctx = ctx();
+        // ctx.channel(): 96.
+        // clientSourceAddress: 5 + 46(ipv6).
+        // state: 19.
+        // Len = 166.
+        StringBuilder buf = new StringBuilder(166);
+        if (ctx == null) {
+            buf.append("[ctx: null]");
+        } else {
+            buf.append(ctx.channel().toString());
+        }
+        String clientSourceAddr = clientSourceAddress();
+        buf.append(" [SR:").append(clientSourceAddr == null ? "-" : clientSourceAddr)
+                .append(", state:").append(state).append("]");
+        return buf.toString();
     }
 
     @Override
@@ -3510,7 +3535,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     ctx.executor().schedule(() -> {
                         if (finalConnectionCheckInProgress == connectionCheckInProgress
                                 && !finalConnectionCheckInProgress.isDone()) {
-                            log.warn("[{}] Connection check timed out. Closing connection.", remoteAddress);
+                            log.warn("[{}] Connection check timed out. Closing connection.", this.toString());
                             ctx.close();
                         }
                     }, connectionLivenessCheckTimeoutMillis, TimeUnit.MILLISECONDS);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnxThrottleTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnxThrottleTracker.java
@@ -87,7 +87,7 @@ final class ServerCnxThrottleTracker {
     private void changeAutoRead(boolean autoRead) {
         if (isChannelActive()) {
             if (log.isDebugEnabled()) {
-                log.debug("[{}] Setting auto read to {}", serverCnx.ctx().channel(), autoRead);
+                log.debug("[{}] Setting auto read to {}", serverCnx.toString(), autoRead);
             }
             // change the auto read flag on the channel
             serverCnx.ctx().channel().config().setAutoRead(autoRead);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
@@ -122,7 +122,7 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
             cmd.parseFrom(buffer, cmdSize);
 
             if (log.isDebugEnabled()) {
-                log.debug("[{}] Received cmd {}", ctx.channel().remoteAddress(), cmd.getType());
+                log.debug("[{}] Received cmd {}", ctx.channel(), cmd.getType());
             }
             messageReceived();
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarHandler.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarHandler.java
@@ -153,7 +153,7 @@ public abstract class PulsarHandler extends PulsarDecoder {
     protected abstract boolean isHandshakeCompleted();
 
     /**
-     * Demo: [id: 0x2561bcd1, L:/10.0.136.103:58038 ! R:/240.240.0.5:6650].
+     * Demo: [id: 0x2561bcd1, L:/10.0.136.103:6650 ! R:/240.240.0.5:58038].
      * L: local Address.
      * R: remote address.
      */

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarHandler.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarHandler.java
@@ -67,7 +67,7 @@ public abstract class PulsarHandler extends PulsarDecoder {
         this.ctx = ctx;
 
         if (log.isDebugEnabled()) {
-            log.debug("[{}] Scheduling keep-alive task every {} s", ctx.channel(), keepAliveIntervalSeconds);
+            log.debug("[{}] Scheduling keep-alive task every {} s", this.toString(), keepAliveIntervalSeconds);
         }
         if (keepAliveIntervalSeconds > 0) {
             this.keepAliveTask = ctx.executor()
@@ -85,13 +85,13 @@ public abstract class PulsarHandler extends PulsarDecoder {
     protected final void handlePing(CommandPing ping) {
         // Immediately reply success to ping requests
         if (log.isDebugEnabled()) {
-            log.debug("[{}] Replying back to ping message", ctx.channel());
+            log.debug("[{}] Replying back to ping message", this.toString());
         }
         ctx.writeAndFlush(Commands.newPong())
                 .addListener(future -> {
                     if (!future.isSuccess()) {
                         log.warn("[{}] Forcing connection to close since cannot send a pong message.",
-                                ctx.channel(), future.cause());
+                                toString(), future.cause());
                         ctx.close();
                     }
                 });
@@ -107,24 +107,24 @@ public abstract class PulsarHandler extends PulsarDecoder {
         }
 
         if (!isHandshakeCompleted()) {
-            log.warn("[{}] Pulsar Handshake was not completed within timeout, closing connection", ctx.channel());
+            log.warn("[{}] Pulsar Handshake was not completed within timeout, closing connection", this.toString());
             ctx.close();
         } else if (waitingForPingResponse && ctx.channel().config().isAutoRead()) {
             // We were waiting for a response and another keep-alive just completed.
             // If auto-read was disabled, it means we stopped reading from the connection, so we might receive the Ping
             // response later and thus not enforce the strict timeout here.
-            log.warn("[{}] Forcing connection to close after keep-alive timeout", ctx.channel());
+            log.warn("[{}] Forcing connection to close after keep-alive timeout", this.toString());
             ctx.close();
         } else if (getRemoteEndpointProtocolVersion() >= ProtocolVersion.v1.getValue()) {
             // Send keep alive probe to peer only if it supports the ping/pong commands, added in v1
             if (log.isDebugEnabled()) {
-                log.debug("[{}] Sending ping message", ctx.channel());
+                log.debug("[{}] Sending ping message", this.toString());
             }
             waitingForPingResponse = true;
             sendPing();
         } else {
             if (log.isDebugEnabled()) {
-                log.debug("[{}] Peer doesn't support keep-alive", ctx.channel());
+                log.debug("[{}] Peer doesn't support keep-alive", this.toString());
             }
         }
     }
@@ -134,7 +134,7 @@ public abstract class PulsarHandler extends PulsarDecoder {
                 .addListener(future -> {
                     if (!future.isSuccess()) {
                         log.warn("[{}] Forcing connection to close since cannot send a ping message.",
-                                ctx.channel(), future.cause());
+                                this.toString(), future.cause());
                         ctx.close();
                     }
                 });
@@ -151,6 +151,20 @@ public abstract class PulsarHandler extends PulsarDecoder {
      * @return true if the connection is ready to use, meaning the Pulsar handshake was already completed
      */
     protected abstract boolean isHandshakeCompleted();
+
+    /**
+     * Demo: [id: 0x2561bcd1, L:/10.0.136.103:58038 ! R:/240.240.0.5:6650].
+     * L: local Address.
+     * R: remote address.
+     */
+    @Override
+    public String toString() {
+        if (ctx == null) {
+            return "[ctx: null]";
+        } else {
+            return ctx.channel().toString();
+        }
+    }
 
     private static final Logger log = LoggerFactory.getLogger(PulsarHandler.class);
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarHandler.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarHandler.java
@@ -159,6 +159,7 @@ public abstract class PulsarHandler extends PulsarDecoder {
      */
     @Override
     public String toString() {
+        ChannelHandlerContext ctx = this.ctx;
         if (ctx == null) {
             return "[ctx: null]";
         } else {


### PR DESCRIPTION
### Motivation

`PulsarHandler.remoteAddress` is the socket address of the Proxy when enabled `haProxyProtocolEnabled`, we'd better print three addresses: `local address`, `remote address`, `source remote address` in the log.

### Modifications
Print three addresses: `local address`, `remote address`, `source remote address` in the log.

After this PR, the demo of addresses in the log is below:
- `Demo: [id: 0x2561bcd1, L:/10.0.136.103:6650! R:/240.240.0.5:58038] [SR:/240.240.0.5:58038]`
- `L`: local Address
- `R`: remote address
- `SR`: source remote address. It is the source address when enabled "haProxyProtocolEnabled".

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
