### PR TITLE
[fix] [doc] fix the class name of transaction exception.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.pulsar.broker.transaction.exception.TransactionException;
+import org.apache.pulsar.broker.transaction.exception.buffer.TransactionBufferException;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.policies.data.TransactionBufferStats;
 import org.apache.pulsar.common.policies.data.TransactionInBufferStats;
@@ -56,8 +58,7 @@ public interface TransactionBuffer {
      *
      * @param txnID the transaction id
      * @return a future represents the result of the operation
-     * @throws org.apache.pulsar.broker.transaction.exception.buffer.TransactionBufferException.TransactionNotFoundException if the transaction
-     *         is not in the buffer.
+     * @throws TransactionBufferException.TransactionNotFoundException if the transaction is not in the buffer.
      */
     CompletableFuture<TransactionMeta> getTransactionMeta(TxnID txnID);
 
@@ -70,8 +71,7 @@ public interface TransactionBuffer {
      * @param sequenceId the sequence id of the entry in this transaction buffer.
      * @param buffer the entry buffer
      * @return a future represents the result of the operation.
-     * @throws org.apache.pulsar.broker.transaction.exception.TransactionException.TransactionSealedException if the transaction
-     *         has been sealed.
+     * @throws TransactionException.TransactionSealedException if the transaction has been sealed.
      */
     CompletableFuture<Position> appendBufferToTxn(TxnID txnId, long sequenceId, ByteBuf buffer);
 
@@ -82,8 +82,7 @@ public interface TransactionBuffer {
      * @param txnID transaction id
      * @param startSequenceId the sequence id to start read
      * @return a future represents the result of open operation.
-     * @throws org.apache.pulsar.broker.transaction.exception.buffer.TransactionBufferException.TransactionNotFoundException if the transaction
-     *         is not in the buffer.
+     * @throws TransactionBufferException.TransactionNotFoundException if the transaction is not in the buffer.
      */
     CompletableFuture<TransactionBufferReader> openTransactionBufferReader(TxnID txnID, long startSequenceId);
 
@@ -95,8 +94,7 @@ public interface TransactionBuffer {
      * @param txnID the transaction id
      * @param lowWaterMark the low water mark of this transaction
      * @return a future represents the result of commit operation.
-     * @throws org.apache.pulsar.broker.transaction.exception.buffer.TransactionBufferException.TransactionNotFoundException if the transaction
-     *         is not in the buffer.
+     * @throws TransactionBufferException.TransactionNotFoundException if the transaction is not in the buffer.
      */
     CompletableFuture<Void> commitTxn(TxnID txnID, long lowWaterMark);
 
@@ -107,8 +105,7 @@ public interface TransactionBuffer {
      * @param txnID the transaction id
      * @param lowWaterMark the low water mark of this transaction
      * @return a future represents the result of abort operation.
-     * @throws org.apache.pulsar.broker.transaction.exception.buffer.TransactionBufferException.TransactionNotFoundException if the transaction
-     *         is not in the buffer.
+     * @throws TransactionBufferException.TransactionNotFoundException if the transaction is not in the buffer.
      */
     CompletableFuture<Void> abortTxn(TxnID txnID, long lowWaterMark);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
@@ -56,7 +56,7 @@ public interface TransactionBuffer {
      *
      * @param txnID the transaction id
      * @return a future represents the result of the operation
-     * @throws org.apache.pulsar.broker.transaction.buffer.exceptions.TransactionNotFoundException if the transaction
+     * @throws org.apache.pulsar.broker.transaction.exception.buffer.TransactionBufferException.TransactionNotFoundException if the transaction
      *         is not in the buffer.
      */
     CompletableFuture<TransactionMeta> getTransactionMeta(TxnID txnID);
@@ -70,7 +70,7 @@ public interface TransactionBuffer {
      * @param sequenceId the sequence id of the entry in this transaction buffer.
      * @param buffer the entry buffer
      * @return a future represents the result of the operation.
-     * @throws org.apache.pulsar.broker.transaction.buffer.exceptions.TransactionSealedException if the transaction
+     * @throws org.apache.pulsar.broker.transaction.exception.TransactionException.TransactionSealedException if the transaction
      *         has been sealed.
      */
     CompletableFuture<Position> appendBufferToTxn(TxnID txnId, long sequenceId, ByteBuf buffer);
@@ -82,7 +82,7 @@ public interface TransactionBuffer {
      * @param txnID transaction id
      * @param startSequenceId the sequence id to start read
      * @return a future represents the result of open operation.
-     * @throws org.apache.pulsar.broker.transaction.buffer.exceptions.TransactionNotFoundException if the transaction
+     * @throws org.apache.pulsar.broker.transaction.exception.buffer.TransactionBufferException.TransactionNotFoundException if the transaction
      *         is not in the buffer.
      */
     CompletableFuture<TransactionBufferReader> openTransactionBufferReader(TxnID txnID, long startSequenceId);
@@ -95,7 +95,7 @@ public interface TransactionBuffer {
      * @param txnID the transaction id
      * @param lowWaterMark the low water mark of this transaction
      * @return a future represents the result of commit operation.
-     * @throws org.apache.pulsar.broker.transaction.buffer.exceptions.TransactionNotFoundException if the transaction
+     * @throws org.apache.pulsar.broker.transaction.exception.buffer.TransactionBufferException.TransactionNotFoundException if the transaction
      *         is not in the buffer.
      */
     CompletableFuture<Void> commitTxn(TxnID txnID, long lowWaterMark);
@@ -107,7 +107,7 @@ public interface TransactionBuffer {
      * @param txnID the transaction id
      * @param lowWaterMark the low water mark of this transaction
      * @return a future represents the result of abort operation.
-     * @throws org.apache.pulsar.broker.transaction.buffer.exceptions.TransactionNotFoundException if the transaction
+     * @throws org.apache.pulsar.broker.transaction.exception.buffer.TransactionBufferException.TransactionNotFoundException if the transaction
      *         is not in the buffer.
      */
     CompletableFuture<Void> abortTxn(TxnID txnID, long lowWaterMark);


### PR DESCRIPTION
### Motivation
![image](https://github.com/apache/pulsar/assets/52550727/e9ff7189-b35b-40d8-934b-8e4e12769ae3)
The full qulified path of the exception in transaction module is wrong, need to fix it.

### Modifications

Correct the full qulified path of the exception.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/50
