### PR TITLE
[improve][misc] PIP-351: Add options to Pulsar-Test client to support KeyStore based TLS

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/DefaultMessageFormatter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/DefaultMessageFormatter.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.testclient;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Random;
 import org.apache.commons.lang3.RandomStringUtils;
 
@@ -89,8 +90,7 @@ public class DefaultMessageFormatter implements IMessageFormatter {
             return String.valueOf(r.nextFloat());
         }
         String format = "%" + size + "f";
-
-        return String.format(format, get_FloatValue(size));
+        return String.format(Locale.US, format, get_FloatValue(size));
     }
 
     private String getIntValue(float size) {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/DefaultMessageFormatter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/DefaultMessageFormatter.java
@@ -90,7 +90,7 @@ public class DefaultMessageFormatter implements IMessageFormatter {
             return String.valueOf(r.nextFloat());
         }
         String format = "%" + size + "f";
-        return String.format(Locale.US, format, get_FloatValue(size));
+        return String.format(format, get_FloatValue(size));
     }
 
     private String getIntValue(float size) {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/DefaultMessageFormatter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/DefaultMessageFormatter.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.testclient;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Locale;
 import java.util.Random;
 import org.apache.commons.lang3.RandomStringUtils;
 

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
@@ -73,6 +73,14 @@ public class PerfClientUtils {
                 .serviceUrl(arguments.serviceURL)
                 .connectionsPerBroker(arguments.maxConnections)
                 .ioThreads(arguments.ioThreads)
+                .useKeyStoreTls(arguments.useKeyStoreTls)
+                .tlsTrustStoreType(arguments.tlsTrustStoreType)
+                .tlsTrustStorePath(arguments.tlsTrustStorePath)
+                .tlsTrustStorePassword(arguments.tlsTrustStorePassword)
+                .tlsKeyStoreType(arguments.tlsKeyStoreType)
+                .tlsKeyStorePath(arguments.tlsKeyStorePath)
+                .tlsKeyStorePassword(arguments.tlsKeyStorePassword)
+                .tlsTrustCertsFilePath(arguments.tlsTrustCertsFilePath)
                 .statsInterval(arguments.statsIntervalSeconds, TimeUnit.SECONDS)
                 .enableBusyWait(arguments.enableBusyWait)
                 .listenerThreads(arguments.listenerThreads)
@@ -83,18 +91,6 @@ public class PerfClientUtils {
                                 "otel.sdk.disabled", "true"
                         ))
                         .build().getOpenTelemetrySdk());
-
-        if (arguments.useKeyStoreTls) {
-            clientBuilder.useKeyStoreTls(arguments.useKeyStoreTls);
-            clientBuilder.tlsTrustStoreType(arguments.tlsTrustStoreType);
-            clientBuilder.tlsTrustStorePath(arguments.tlsTrustStorePath);
-            clientBuilder.tlsTrustStorePassword(arguments.tlsTrustStorePassword);
-            clientBuilder.tlsKeyStoreType(arguments.tlsKeyStoreType);
-            clientBuilder.tlsKeyStorePath(arguments.tlsKeyStorePath);
-            clientBuilder.tlsKeyStorePassword(arguments.tlsKeyStorePassword);
-        } else {
-            clientBuilder.tlsTrustCertsFilePath(arguments.tlsTrustCertsFilePath);
-        }
 
         if (isNotBlank(arguments.authPluginClassName)) {
             clientBuilder.authentication(arguments.authPluginClassName, arguments.authParams);
@@ -124,19 +120,15 @@ public class PerfClientUtils {
             throws PulsarClientException.UnsupportedAuthenticationException {
 
         PulsarAdminBuilder pulsarAdminBuilder = PulsarAdmin.builder()
+                .useKeyStoreTls(arguments.useKeyStoreTls)
+                .tlsTrustStoreType(arguments.tlsTrustStoreType)
+                .tlsTrustStorePath(arguments.tlsTrustStorePath)
+                .tlsTrustStorePassword(arguments.tlsTrustStorePassword)
+                .tlsKeyStoreType(arguments.tlsKeyStoreType)
+                .tlsKeyStorePath(arguments.tlsKeyStorePath)
+                .tlsKeyStorePassword(arguments.tlsKeyStorePassword)
+                .tlsTrustCertsFilePath(arguments.tlsTrustCertsFilePath)
                 .serviceHttpUrl(adminUrl);
-
-        if (arguments.useKeyStoreTls) {
-            pulsarAdminBuilder.useKeyStoreTls(arguments.useKeyStoreTls);
-            pulsarAdminBuilder.tlsTrustStoreType(arguments.tlsTrustStoreType);
-            pulsarAdminBuilder.tlsTrustStorePath(arguments.tlsTrustStorePath);
-            pulsarAdminBuilder.tlsTrustStorePassword(arguments.tlsTrustStorePassword);
-            pulsarAdminBuilder.tlsKeyStoreType(arguments.tlsKeyStoreType);
-            pulsarAdminBuilder.tlsKeyStorePath(arguments.tlsKeyStorePath);
-            pulsarAdminBuilder.tlsKeyStorePassword(arguments.tlsKeyStorePassword);
-        } else {
-            pulsarAdminBuilder.tlsTrustCertsFilePath(arguments.tlsTrustCertsFilePath);
-        }
 
         if (isNotBlank(arguments.authPluginClassName)) {
             pulsarAdminBuilder.authentication(arguments.authPluginClassName, arguments.authParams);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
@@ -84,8 +84,8 @@ public class PerfClientUtils {
                         ))
                         .build().getOpenTelemetrySdk());
 
-        if (arguments.useKeystoreTls != null) {
-            clientBuilder.useKeyStoreTls(arguments.useKeystoreTls);
+        if (arguments.useKeyStoreTls != null) {
+            clientBuilder.useKeyStoreTls(arguments.useKeyStoreTls);
             clientBuilder.tlsTrustStoreType(arguments.tlsTrustStoreType);
             clientBuilder.tlsTrustStorePath(arguments.tlsTrustStorePath);
             clientBuilder.tlsTrustStorePassword(arguments.tlsTrustStorePassword);
@@ -126,8 +126,8 @@ public class PerfClientUtils {
         PulsarAdminBuilder pulsarAdminBuilder = PulsarAdmin.builder()
                 .serviceHttpUrl(adminUrl);
 
-        if (arguments.useKeystoreTls != null) {
-            pulsarAdminBuilder.useKeyStoreTls(arguments.useKeystoreTls);
+        if (arguments.useKeyStoreTls != null) {
+            pulsarAdminBuilder.useKeyStoreTls(arguments.useKeyStoreTls);
             pulsarAdminBuilder.tlsTrustStoreType(arguments.tlsTrustStoreType);
             pulsarAdminBuilder.tlsTrustStorePath(arguments.tlsTrustStorePath);
             pulsarAdminBuilder.tlsTrustStorePassword(arguments.tlsTrustStorePassword);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
@@ -84,7 +84,7 @@ public class PerfClientUtils {
                         ))
                         .build().getOpenTelemetrySdk());
 
-        if (arguments.useKeyStoreTls != null) {
+        if (arguments.useKeyStoreTls) {
             clientBuilder.useKeyStoreTls(arguments.useKeyStoreTls);
             clientBuilder.tlsTrustStoreType(arguments.tlsTrustStoreType);
             clientBuilder.tlsTrustStorePath(arguments.tlsTrustStorePath);
@@ -126,7 +126,7 @@ public class PerfClientUtils {
         PulsarAdminBuilder pulsarAdminBuilder = PulsarAdmin.builder()
                 .serviceHttpUrl(adminUrl);
 
-        if (arguments.useKeyStoreTls != null) {
+        if (arguments.useKeyStoreTls) {
             pulsarAdminBuilder.useKeyStoreTls(arguments.useKeyStoreTls);
             pulsarAdminBuilder.tlsTrustStoreType(arguments.tlsTrustStoreType);
             pulsarAdminBuilder.tlsTrustStorePath(arguments.tlsTrustStorePath);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
@@ -76,7 +76,6 @@ public class PerfClientUtils {
                 .statsInterval(arguments.statsIntervalSeconds, TimeUnit.SECONDS)
                 .enableBusyWait(arguments.enableBusyWait)
                 .listenerThreads(arguments.listenerThreads)
-                .tlsTrustCertsFilePath(arguments.tlsTrustCertsFilePath)
                 .maxLookupRequests(arguments.maxLookupRequest)
                 .proxyServiceUrl(arguments.proxyServiceURL, arguments.proxyProtocol)
                 .openTelemetry(AutoConfiguredOpenTelemetrySdk.builder()
@@ -84,6 +83,18 @@ public class PerfClientUtils {
                                 "otel.sdk.disabled", "true"
                         ))
                         .build().getOpenTelemetrySdk());
+
+        if (arguments.useKeystoreTls != null) {
+            clientBuilder.useKeyStoreTls(arguments.useKeystoreTls);
+            clientBuilder.tlsTrustStoreType(arguments.trustStoreType);
+            clientBuilder.tlsTrustStorePath(arguments.trustStorePath);
+            clientBuilder.tlsTrustStorePassword(arguments.trustStorePath);
+            clientBuilder.tlsKeyStoreType(arguments.keyStoreType);
+            clientBuilder.tlsKeyStorePath(arguments.keyStorePath);
+            clientBuilder.tlsKeyStorePassword(arguments.keyStorePass);
+        } else {
+            clientBuilder.tlsTrustCertsFilePath(arguments.tlsTrustCertsFilePath);
+        }
 
         if (isNotBlank(arguments.authPluginClassName)) {
             clientBuilder.authentication(arguments.authPluginClassName, arguments.authParams);
@@ -113,8 +124,19 @@ public class PerfClientUtils {
             throws PulsarClientException.UnsupportedAuthenticationException {
 
         PulsarAdminBuilder pulsarAdminBuilder = PulsarAdmin.builder()
-                .serviceHttpUrl(adminUrl)
-                .tlsTrustCertsFilePath(arguments.tlsTrustCertsFilePath);
+                .serviceHttpUrl(adminUrl);
+
+        if (arguments.useKeystoreTls != null) {
+            pulsarAdminBuilder.useKeyStoreTls(arguments.useKeystoreTls);
+            pulsarAdminBuilder.tlsTrustStoreType(arguments.trustStoreType);
+            pulsarAdminBuilder.tlsTrustStorePath(arguments.trustStorePath);
+            pulsarAdminBuilder.tlsTrustStorePassword(arguments.trustStorePath);
+            pulsarAdminBuilder.tlsKeyStoreType(arguments.keyStoreType);
+            pulsarAdminBuilder.tlsKeyStorePath(arguments.keyStorePath);
+            pulsarAdminBuilder.tlsKeyStorePassword(arguments.keyStorePass);
+        } else {
+            pulsarAdminBuilder.tlsTrustCertsFilePath(arguments.tlsTrustCertsFilePath);
+        }
 
         if (isNotBlank(arguments.authPluginClassName)) {
             pulsarAdminBuilder.authentication(arguments.authPluginClassName, arguments.authParams);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
@@ -86,12 +86,12 @@ public class PerfClientUtils {
 
         if (arguments.useKeystoreTls != null) {
             clientBuilder.useKeyStoreTls(arguments.useKeystoreTls);
-            clientBuilder.tlsTrustStoreType(arguments.trustStoreType);
-            clientBuilder.tlsTrustStorePath(arguments.trustStorePath);
-            clientBuilder.tlsTrustStorePassword(arguments.trustStorePath);
-            clientBuilder.tlsKeyStoreType(arguments.keyStoreType);
-            clientBuilder.tlsKeyStorePath(arguments.keyStorePath);
-            clientBuilder.tlsKeyStorePassword(arguments.keyStorePass);
+            clientBuilder.tlsTrustStoreType(arguments.tlsTrustStoreType);
+            clientBuilder.tlsTrustStorePath(arguments.tlsTrustStorePath);
+            clientBuilder.tlsTrustStorePassword(arguments.tlsTrustStorePassword);
+            clientBuilder.tlsKeyStoreType(arguments.tlsKeyStoreType);
+            clientBuilder.tlsKeyStorePath(arguments.tlsKeyStorePath);
+            clientBuilder.tlsKeyStorePassword(arguments.tlsKeyStorePassword);
         } else {
             clientBuilder.tlsTrustCertsFilePath(arguments.tlsTrustCertsFilePath);
         }
@@ -128,12 +128,12 @@ public class PerfClientUtils {
 
         if (arguments.useKeystoreTls != null) {
             pulsarAdminBuilder.useKeyStoreTls(arguments.useKeystoreTls);
-            pulsarAdminBuilder.tlsTrustStoreType(arguments.trustStoreType);
-            pulsarAdminBuilder.tlsTrustStorePath(arguments.trustStorePath);
-            pulsarAdminBuilder.tlsTrustStorePassword(arguments.trustStorePath);
-            pulsarAdminBuilder.tlsKeyStoreType(arguments.keyStoreType);
-            pulsarAdminBuilder.tlsKeyStorePath(arguments.keyStorePath);
-            pulsarAdminBuilder.tlsKeyStorePassword(arguments.keyStorePass);
+            pulsarAdminBuilder.tlsTrustStoreType(arguments.tlsTrustStoreType);
+            pulsarAdminBuilder.tlsTrustStorePath(arguments.tlsTrustStorePath);
+            pulsarAdminBuilder.tlsTrustStorePassword(arguments.tlsTrustStorePassword);
+            pulsarAdminBuilder.tlsKeyStoreType(arguments.tlsKeyStoreType);
+            pulsarAdminBuilder.tlsKeyStorePath(arguments.tlsKeyStorePath);
+            pulsarAdminBuilder.tlsKeyStorePassword(arguments.tlsKeyStorePassword);
         } else {
             pulsarAdminBuilder.tlsTrustCertsFilePath(arguments.tlsTrustCertsFilePath);
         }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
@@ -141,7 +141,7 @@ public abstract class PerformanceBaseArguments extends CmdBase {
     @Override
     public void validate() throws Exception {
         parseCLI();
-        if (Boolean.TRUE.equals(useKeyStoreTls) && isBlank(tlsTrustStorePath)) {
+        if (useKeyStoreTls && isBlank(tlsTrustStorePath)) {
             throw new ParameterException("tlsTrustStorePath is required if useKeystoreTls is used");
         }
     }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
@@ -27,7 +27,7 @@ import picocli.CommandLine.Option;
  * PerformanceBaseArguments contains common CLI arguments and parsing logic available to all sub-commands.
  * Sub-commands should create Argument subclasses and override the `validate` method as necessary.
  */
-public abstract class PerformanceBaseArguments extends CmdBase{
+public abstract class PerformanceBaseArguments extends CmdBase {
 
 
     @Option(names = { "-u", "--service-url" }, description = "Pulsar Service URL", descriptionKey = "brokerServiceUrl")
@@ -62,26 +62,26 @@ public abstract class PerformanceBaseArguments extends CmdBase{
     public Boolean useKeystoreTls = null;
 
     @Option(names = {"--truststore-type"}, description = "Type of the truststore, PKCS12 or JKS. The default is JKS.",
-            descriptionKey = "trustStoreType")
-    public String trustStoreType = "JKS";
+            descriptionKey = "tlsTrustStoreType")
+    public String tlsTrustStoreType = "JKS";
 
     @Option(names = {"--truststore-path"}, description = "Path to the truststore.",
-            descriptionKey = "trustStorePath")
-    public String trustStorePath = "";
+            descriptionKey = "tlsTrustStorePath")
+    public String tlsTrustStorePath = "";
 
     @Option(names = {"--truststore-pass"}, description = "Password to the truststore.",
-            descriptionKey = "trustStorePass")
-    public String trustStorePass = "";
+            descriptionKey = "tlsTrustStorePassword")
+    public String tlsTrustStorePassword = "";
 
     @Option(names = {"--keystore-type"}, description = "Type of the keystore, PKCS12 or JKS. The default is JKS.",
-            descriptionKey = "keyStoreType")
-    public String keyStoreType = "JKS";
+            descriptionKey = "tlsKeyStoreType")
+    public String tlsKeyStoreType = "JKS";
 
-    @Option(names = {"--keystore-path"}, description = "Path to the keystore.", descriptionKey = "keyStorePath")
-    public String keyStorePath = "";
+    @Option(names = {"--keystore-path"}, description = "Path to the keystore.", descriptionKey = "tlsKeyStorePath")
+    public String tlsKeyStorePath = "";
 
-    @Option(names = {"--keystore-pass"}, description = "Password to the keystore.", descriptionKey = "keyStorePass")
-    public String keyStorePass = "";
+    @Option(names = {"--keystore-pass"}, description = "Password to the keystore.", descriptionKey = "keyStorePassword")
+    public String tlsKeyStorePassword = "";
 
     @Option(names = {
             "--tls-allow-insecure" }, description = "Allow insecure TLS connection",

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
@@ -80,7 +80,8 @@ public abstract class PerformanceBaseArguments extends CmdBase {
     @Option(names = {"--keystore-path"}, description = "Path to the keystore.", descriptionKey = "tlsKeyStorePath")
     public String tlsKeyStorePath = "";
 
-    @Option(names = {"--keystore-pass"}, description = "Password to the keystore.", descriptionKey = "tlsKeyStorePassword")
+    @Option(names = {"--keystore-pass"}, description = "Password to the keystore.",
+            descriptionKey = "tlsKeyStorePassword")
     public String tlsKeyStorePassword = "";
 
     @Option(names = {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
@@ -80,7 +80,7 @@ public abstract class PerformanceBaseArguments extends CmdBase {
     @Option(names = {"--keystore-path"}, description = "Path to the keystore.", descriptionKey = "tlsKeyStorePath")
     public String tlsKeyStorePath = "";
 
-    @Option(names = {"--keystore-pass"}, description = "Password to the keystore.", descriptionKey = "keyStorePassword")
+    @Option(names = {"--keystore-pass"}, description = "Password to the keystore.", descriptionKey = "tlsKeyStorePassword")
     public String tlsKeyStorePassword = "";
 
     @Option(names = {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
@@ -58,6 +58,31 @@ public abstract class PerformanceBaseArguments extends CmdBase{
             descriptionKey = "tlsTrustCertsFilePath")
     public String tlsTrustCertsFilePath = "";
 
+    @Option(names = {"--use-keystore-tls" }, description = "Use KeyStore TLS", descriptionKey = "useKeyStoreTls")
+    public Boolean useKeystoreTls = null;
+
+    @Option(names = {"--truststore-type"}, description = "Type of the truststore, PKCS12 or JKS. The default is JKS.",
+            descriptionKey = "trustStoreType")
+    public String trustStoreType = "JKS";
+
+    @Option(names = {"--truststore-path"}, description = "Path to the truststore.",
+            descriptionKey = "trustStorePath")
+    public String trustStorePath = "";
+
+    @Option(names = {"--truststore-pass"}, description = "Password to the truststore.",
+            descriptionKey = "trustStorePass")
+    public String trustStorePass = "";
+
+    @Option(names = {"--keystore-type"}, description = "Type of the keystore, PKCS12 or JKS. The default is JKS.",
+            descriptionKey = "keyStoreType")
+    public String keyStoreType = "JKS";
+
+    @Option(names = {"--keystore-path"}, description = "Path to the keystore.", descriptionKey = "keyStorePath")
+    public String keyStorePath = "";
+
+    @Option(names = {"--keystore-pass"}, description = "Password to the keystore.", descriptionKey = "keyStorePass")
+    public String keyStorePass = "";
+
     @Option(names = {
             "--tls-allow-insecure" }, description = "Allow insecure TLS connection",
             descriptionKey = "tlsAllowInsecureConnection")

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
@@ -141,6 +141,9 @@ public abstract class PerformanceBaseArguments extends CmdBase {
     @Override
     public void validate() throws Exception {
         parseCLI();
+        if (Boolean.TRUE.equals(useKeystoreTls) && isBlank(tlsTrustStorePath)) {
+            throw new ParameterException("tlsTrustStorePath is required if useKeystoreTls is used");
+        }
     }
 
     /**

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
@@ -59,7 +59,7 @@ public abstract class PerformanceBaseArguments extends CmdBase {
     public String tlsTrustCertsFilePath = "";
 
     @Option(names = {"--use-keystore-tls" }, description = "Use KeyStore TLS", descriptionKey = "useKeyStoreTls")
-    public Boolean useKeystoreTls = null;
+    public Boolean useKeyStoreTls = null;
 
     @Option(names = {"--truststore-type"}, description = "Type of the truststore, PKCS12 or JKS. The default is JKS.",
             descriptionKey = "tlsTrustStoreType")
@@ -141,7 +141,7 @@ public abstract class PerformanceBaseArguments extends CmdBase {
     @Override
     public void validate() throws Exception {
         parseCLI();
-        if (Boolean.TRUE.equals(useKeystoreTls) && isBlank(tlsTrustStorePath)) {
+        if (Boolean.TRUE.equals(useKeyStoreTls) && isBlank(tlsTrustStorePath)) {
             throw new ParameterException("tlsTrustStorePath is required if useKeystoreTls is used");
         }
     }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceBaseArguments.java
@@ -59,7 +59,7 @@ public abstract class PerformanceBaseArguments extends CmdBase {
     public String tlsTrustCertsFilePath = "";
 
     @Option(names = {"--use-keystore-tls" }, description = "Use KeyStore TLS", descriptionKey = "useKeyStoreTls")
-    public Boolean useKeyStoreTls = null;
+    public boolean useKeyStoreTls = false;
 
     @Option(names = {"--truststore-type"}, description = "Type of the truststore, PKCS12 or JKS. The default is JKS.",
             descriptionKey = "tlsTrustStoreType")

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerfClientUtilsTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerfClientUtilsTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Properties;
+import org.apache.pulsar.client.admin.internal.PulsarAdminBuilderImpl;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.ProxyProtocol;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -77,7 +78,7 @@ public class PerfClientUtilsTest {
         final ClientConfigurationData conf = builder.getClientConfigurationData();
 
         Assert.assertTrue(conf.isTlsHostnameVerificationEnable());
-        Assert.assertEquals(conf.getAuthPluginClassName(), MyAuth.class.getName());
+        Assert.assertEquals(conf.getAuthentication().getClass(), MyAuth.class);
         Assert.assertEquals(conf.getAuthParams(), "params");
         Assert.assertTrue(conf.isEnableBusyWait());
         Assert.assertEquals(conf.getConnectionsPerBroker(), 100);
@@ -92,6 +93,69 @@ public class PerfClientUtilsTest {
         Assert.assertNull(conf.getProxyServiceUrl());
         Assert.assertNull(conf.getProxyProtocol());
         Assert.assertEquals(conf.getMemoryLimitBytes(), 10240L);
+
+    }
+
+    @Test
+    public void testClientCreationWithKeyStoreEnabled() throws Exception {
+
+        final PerformanceBaseArguments args = new PerformanceArgumentsTestDefault("");
+
+        args.authPluginClassName = MyAuth.class.getName();
+        args.authParams = "params";
+        args.serviceURL = "pulsar+ssl://my-pulsar:6651";
+        args.useKeyStoreTls = Boolean.TRUE;
+        args.tlsTrustStoreType = "PKCS12";
+        args.tlsTrustStorePath = "./tlsTrustStorePath";
+        args.tlsTrustStorePassword = "tlsTrustStorePassword";
+        args.tlsKeyStoreType = "JKS";
+        args.tlsKeyStorePath = "./tlsKeyStorePath";
+        args.tlsKeyStorePassword = "tlsKeyStorePassword";
+
+        final ClientBuilderImpl builder = (ClientBuilderImpl)PerfClientUtils.createClientBuilderFromArguments(args);
+        final ClientConfigurationData conf = builder.getClientConfigurationData();
+
+        Assert.assertEquals(conf.getAuthPluginClassName(), MyAuth.class.getName());
+        Assert.assertEquals(conf.getAuthParams(), "params");
+        Assert.assertEquals(conf.getServiceUrl(), "pulsar+ssl://my-pulsar:6651");
+        Assert.assertTrue(conf.isUseKeyStoreTls());
+        Assert.assertEquals(conf.getTlsTrustStoreType(), "PKCS12");
+        Assert.assertEquals(conf.getTlsTrustStorePath(), "./tlsTrustStorePath");
+        Assert.assertEquals(conf.getTlsTrustStorePassword(), "tlsTrustStorePassword");
+        Assert.assertEquals(conf.getTlsKeyStoreType(), "JKS");
+        Assert.assertEquals(conf.getTlsKeyStorePath(), "./tlsKeyStorePath");
+        Assert.assertEquals(conf.getTlsKeyStorePassword(), "tlsKeyStorePassword");
+
+    }
+
+    @Test
+    public void testAdminCreationWithKeyStoreEnabled() throws Exception {
+
+        final PerformanceBaseArguments args = new PerformanceArgumentsTestDefault("");
+
+        args.authPluginClassName = MyAuth.class.getName();
+        args.authParams = "params";
+        args.useKeyStoreTls = Boolean.TRUE;
+        args.tlsTrustStoreType = "PKCS12";
+        args.tlsTrustStorePath = "./tlsTrustStorePath";
+        args.tlsTrustStorePassword = "tlsTrustStorePassword";
+        args.tlsKeyStoreType = "JKS";
+        args.tlsKeyStorePath = "./tlsKeyStorePath";
+        args.tlsKeyStorePassword = "tlsKeyStorePassword";
+
+        final PulsarAdminBuilderImpl builder = (PulsarAdminBuilderImpl)PerfClientUtils.createAdminBuilderFromArguments(args,
+                "https://localhost:8081");
+        final ClientConfigurationData conf = builder.getConf();
+
+        Assert.assertEquals(conf.getServiceUrl(), "https://localhost:8081");
+        Assert.assertEquals(conf.getAuthentication().getClass().getName(), MyAuth.class.getName());
+        Assert.assertTrue(conf.isUseKeyStoreTls());
+        Assert.assertEquals(conf.getTlsTrustStoreType(), "PKCS12");
+        Assert.assertEquals(conf.getTlsTrustStorePath(), "./tlsTrustStorePath");
+        Assert.assertEquals(conf.getTlsTrustStorePassword(), "tlsTrustStorePassword");
+        Assert.assertEquals(conf.getTlsKeyStoreType(), "JKS");
+        Assert.assertEquals(conf.getTlsKeyStorePath(), "./tlsKeyStorePath");
+        Assert.assertEquals(conf.getTlsKeyStorePassword(), "tlsKeyStorePassword");
 
     }
 

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerfClientUtilsTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerfClientUtilsTest.java
@@ -78,7 +78,7 @@ public class PerfClientUtilsTest {
         final ClientConfigurationData conf = builder.getClientConfigurationData();
 
         Assert.assertTrue(conf.isTlsHostnameVerificationEnable());
-        Assert.assertEquals(conf.getAuthentication().getClass(), MyAuth.class);
+        Assert.assertEquals(conf.getAuthPluginClassName(), MyAuth.class.getName());
         Assert.assertEquals(conf.getAuthParams(), "params");
         Assert.assertTrue(conf.isEnableBusyWait());
         Assert.assertEquals(conf.getConnectionsPerBroker(), 100);
@@ -104,7 +104,7 @@ public class PerfClientUtilsTest {
         args.authPluginClassName = MyAuth.class.getName();
         args.authParams = "params";
         args.serviceURL = "pulsar+ssl://my-pulsar:6651";
-        args.useKeyStoreTls = Boolean.TRUE;
+        args.useKeyStoreTls = true;
         args.tlsTrustStoreType = "PKCS12";
         args.tlsTrustStorePath = "./tlsTrustStorePath";
         args.tlsTrustStorePassword = "tlsTrustStorePassword";
@@ -135,7 +135,7 @@ public class PerfClientUtilsTest {
 
         args.authPluginClassName = MyAuth.class.getName();
         args.authParams = "params";
-        args.useKeyStoreTls = Boolean.TRUE;
+        args.useKeyStoreTls = true;
         args.tlsTrustStoreType = "PKCS12";
         args.tlsTrustStorePath = "./tlsTrustStorePath";
         args.tlsTrustStorePassword = "tlsTrustStorePassword";

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerfClientUtilsTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerfClientUtilsTest.java
@@ -97,6 +97,43 @@ public class PerfClientUtilsTest {
     }
 
     @Test
+    public void testClientCreationWithKeyStoreEnabledViaConfFile() throws Exception {
+        Path testConf = Files.createTempFile("keystore-test", ".conf");
+        try {
+            Files.writeString(testConf, "brokerServiceUrl=pulsar+ssl://pulsar:6651\n"
+                    + "useKeyStoreTls=true\n"
+                    + String.format("authPlugin=%s\n", MyAuth.class.getName())
+                    + "tlsTrustStoreType=PKCS12\n"
+                    + "tlsTrustStorePath=./tlsTrustStorePath\n"
+                    + "tlsTrustStorePassword=tlsTrustStorePassword\n"
+                    + "tlsKeyStorePath=./tlsKeyStorePath\n"
+                    + "tlsKeyStorePassword=tlsKeyStorePassword\n"
+                    + "tlsKeyStoreType=JKS\n");
+            final PerformanceBaseArguments args = new PerformanceArgumentsTestDefault("");
+            Properties prop = new Properties(System.getProperties());
+            try (FileInputStream fis = new FileInputStream(testConf.toString())) {
+                prop.load(fis);
+            }
+            args.getCommander().setDefaultValueProvider(PulsarPerfTestPropertiesProvider.create(prop));
+            args.parse(new String[]{});
+            final ClientBuilderImpl builder = (ClientBuilderImpl) PerfClientUtils.createClientBuilderFromArguments(args);
+            final ClientConfigurationData conf = builder.getClientConfigurationData();
+
+            Assert.assertEquals(conf.getServiceUrl(), "pulsar+ssl://pulsar:6651");
+            Assert.assertEquals(conf.getAuthentication().getClass().getName(), MyAuth.class.getName());
+            Assert.assertTrue(conf.isUseKeyStoreTls());
+            Assert.assertEquals(conf.getTlsTrustStoreType(), "PKCS12");
+            Assert.assertEquals(conf.getTlsTrustStorePath(), "./tlsTrustStorePath");
+            Assert.assertEquals(conf.getTlsTrustStorePassword(), "tlsTrustStorePassword");
+            Assert.assertEquals(conf.getTlsKeyStoreType(), "JKS");
+            Assert.assertEquals(conf.getTlsKeyStorePath(), "./tlsKeyStorePath");
+            Assert.assertEquals(conf.getTlsKeyStorePassword(), "tlsKeyStorePassword");
+        } finally {
+            Files.deleteIfExists(testConf);
+        }
+    }
+
+    @Test
     public void testClientCreationWithKeyStoreEnabled() throws Exception {
 
         final PerformanceBaseArguments args = new PerformanceArgumentsTestDefault("");
@@ -157,6 +194,45 @@ public class PerfClientUtilsTest {
         Assert.assertEquals(conf.getTlsKeyStorePath(), "./tlsKeyStorePath");
         Assert.assertEquals(conf.getTlsKeyStorePassword(), "tlsKeyStorePassword");
 
+    }
+
+    @Test
+    public void testAdminCreationWithKeyStoreEnabledViaConfFile() throws Exception {
+        Path testConf = Files.createTempFile("keystore-test", ".conf");
+        try {
+            Files.writeString(testConf, "brokerServiceUrl=pulsar+ssl://pulsar:6651\n"
+                    + "useKeyStoreTls=true\n"
+                    + String.format("authPlugin=%s\n", MyAuth.class.getName())
+                    + "tlsTrustStoreType=PKCS12\n"
+                    + "tlsTrustStorePath=./tlsTrustStorePath\n"
+                    + "tlsTrustStorePassword=tlsTrustStorePassword\n"
+                    + "tlsKeyStorePath=./tlsKeyStorePath\n"
+                    + "tlsKeyStorePassword=tlsKeyStorePassword\n"
+                    + "tlsKeyStoreType=JKS\n");
+            final PerformanceBaseArguments args = new PerformanceArgumentsTestDefault("");
+            Properties prop = new Properties(System.getProperties());
+            try (FileInputStream fis = new FileInputStream(testConf.toString())) {
+                prop.load(fis);
+            }
+            args.getCommander().setDefaultValueProvider(PulsarPerfTestPropertiesProvider.create(prop));
+            args.parse(new String[]{});
+            final PulsarAdminBuilderImpl builder =
+                    (PulsarAdminBuilderImpl) PerfClientUtils.createAdminBuilderFromArguments(args,
+                            "https://localhost:8081");
+            final ClientConfigurationData conf = builder.getConf();
+
+            Assert.assertEquals(conf.getServiceUrl(), "https://localhost:8081");
+            Assert.assertEquals(conf.getAuthentication().getClass().getName(), MyAuth.class.getName());
+            Assert.assertTrue(conf.isUseKeyStoreTls());
+            Assert.assertEquals(conf.getTlsTrustStoreType(), "PKCS12");
+            Assert.assertEquals(conf.getTlsTrustStorePath(), "./tlsTrustStorePath");
+            Assert.assertEquals(conf.getTlsTrustStorePassword(), "tlsTrustStorePassword");
+            Assert.assertEquals(conf.getTlsKeyStoreType(), "JKS");
+            Assert.assertEquals(conf.getTlsKeyStorePath(), "./tlsKeyStorePath");
+            Assert.assertEquals(conf.getTlsKeyStorePassword(), "tlsKeyStorePassword");
+        } finally {
+            Files.deleteIfExists(testConf);
+        }
     }
 
     @Test

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceBaseArgumentsTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceBaseArgumentsTest.java
@@ -333,6 +333,8 @@ public class PerformanceBaseArgumentsTest {
             }
             args.getCommander().setDefaultValueProvider(PulsarPerfTestPropertiesProvider.create(prop));
             args.parse(new String[]{});
+            args.validate();
+            assertTrue(args.useKeyStoreTls);
             assertEquals("PKCS12", args.tlsTrustStoreType);
             assertEquals("./path", args.tlsTrustStorePath);
             assertEquals("changeme", args.tlsTrustStorePassword);

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceBaseArgumentsTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceBaseArgumentsTest.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.testclient;
 
 import static org.apache.pulsar.client.api.ProxyProtocol.SNI;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.fail;
 import java.io.File;
 import java.io.FileInputStream;
@@ -29,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import picocli.CommandLine;
@@ -54,15 +55,15 @@ public class PerformanceBaseArgumentsTest {
         args.parse(new String[]{});
 
 
-        Assert.assertEquals(args.serviceURL, "https://my-pulsar:8443/");
-        Assert.assertEquals(args.authPluginClassName,
+        assertEquals(args.serviceURL, "https://my-pulsar:8443/");
+        assertEquals(args.authPluginClassName,
                 "org.apache.pulsar.testclient.PerfClientUtilsTest.MyAuth");
-        Assert.assertEquals(args.authParams, "myparams");
-        Assert.assertEquals(args.tlsTrustCertsFilePath, "./path");
-        Assert.assertTrue(args.tlsAllowInsecureConnection);
-        Assert.assertTrue(args.tlsHostnameVerificationEnable);
-        Assert.assertEquals(args.proxyServiceURL, "https://my-proxy-pulsar:4443/");
-        Assert.assertEquals(args.proxyProtocol, SNI);
+        assertEquals(args.authParams, "myparams");
+        assertEquals(args.tlsTrustCertsFilePath, "./path");
+        assertTrue(args.tlsAllowInsecureConnection);
+        assertTrue(args.tlsHostnameVerificationEnable);
+        assertEquals(args.proxyServiceURL, "https://my-proxy-pulsar:4443/");
+        assertEquals(args.proxyProtocol, SNI);
     }
 
     @Test
@@ -103,13 +104,13 @@ public class PerformanceBaseArgumentsTest {
             args.getCommander().setDefaultValueProvider(PulsarPerfTestPropertiesProvider.create(prop));
             args.parse(new String[]{});
 
-            Assert.assertEquals(args.serviceURL, "https://my-pulsar:8443/");
-            Assert.assertEquals(args.authPluginClassName,
+            assertEquals(args.serviceURL, "https://my-pulsar:8443/");
+            assertEquals(args.authPluginClassName,
                     "org.apache.pulsar.testclient.PerfClientUtilsTest.MyAuth");
-            Assert.assertEquals(args.authParams, "myparams");
-            Assert.assertEquals(args.tlsTrustCertsFilePath, "./path");
-            Assert.assertTrue(args.tlsAllowInsecureConnection);
-            Assert.assertTrue(args.tlsHostnameVerificationEnable);
+            assertEquals(args.authParams, "myparams");
+            assertEquals(args.tlsTrustCertsFilePath, "./path");
+            assertTrue(args.tlsAllowInsecureConnection);
+            assertTrue(args.tlsHostnameVerificationEnable);
 
         } catch (IOException e) {
             e.printStackTrace();
@@ -162,7 +163,7 @@ public class PerformanceBaseArgumentsTest {
             }catch (CommandLine.ParameterException e){
                 calledVar2.set(true);
             }
-            Assert.assertTrue(calledVar2.get());
+            assertTrue(calledVar2.get());
         } catch (IOException e) {
             e.printStackTrace();
             fail("Error while updating/reading config file");
@@ -253,4 +254,97 @@ public class PerformanceBaseArgumentsTest {
             assertEquals(baseArgument.memoryLimit, 0L);
         }
     }
+
+    @Test
+    public void testReadConfigFileWithUseKeyStoreTlsAndNoTrustStorePath() throws Exception {
+        final PerformanceBaseArguments args = new PerformanceBaseArguments("") {
+            @Override
+            public void run() throws Exception {
+
+            }
+        };
+
+        String confFile = "./perf_client_keystore_invalid.conf";
+
+        File tempConfigFile = new File(confFile);
+        if (tempConfigFile.exists()) {
+            tempConfigFile.delete();
+        }
+        try {
+            Properties props = new Properties();
+
+            Map<String, String> configs = Map.of("brokerServiceUrl", "https://my-pulsar:8443/",
+                    "authPlugin", "org.apache.pulsar.testclient.PerfClientUtilsTest.MyAuth",
+                    "authParams", "myparams",
+                    "useKeyStoreTls", "true"
+            );
+            props.putAll(configs);
+            FileOutputStream out = new FileOutputStream(tempConfigFile);
+            props.store(out, "properties file");
+            out.close();
+            Properties prop = new Properties(System.getProperties());
+            try (FileInputStream fis = new FileInputStream(confFile)) {
+                prop.load(fis);
+            }
+            args.getCommander().setDefaultValueProvider(PulsarPerfTestPropertiesProvider.create(prop));
+            args.parse(new String[]{});
+            assertThrows(CommandLine.ParameterException.class, args::validate);
+        } catch (IOException e) {
+            fail("Error while updating/reading config file");
+        } finally {
+            tempConfigFile.delete();
+        }
+    }
+
+    @Test
+    public void testReadConfigFileWithUseKeyStoreTlsAndTrustStorePath() throws Exception {
+        final PerformanceBaseArguments args = new PerformanceBaseArguments("") {
+            @Override
+            public void run() throws Exception {
+
+            }
+        };
+
+        String confFile = "./perf_client_keystore.conf";
+
+        File tempConfigFile = new File(confFile);
+        if (tempConfigFile.exists()) {
+            tempConfigFile.delete();
+        }
+        try {
+            Properties props = new Properties();
+
+            Map<String, String> configs = Map.of("brokerServiceUrl", "https://my-pulsar:8443/",
+                    "authPlugin", "org.apache.pulsar.testclient.PerfClientUtilsTest.MyAuth",
+                    "authParams", "myparams",
+                    "useKeyStoreTls", "true",
+                    "tlsTrustStorePath", "./path",
+                    "tlsTrustStoreType", "PKCS12",
+                    "tlsTrustStorePassword", "changeme",
+                    "tlsKeyStorePath", "./path"
+            );
+            props.putAll(configs);
+            FileOutputStream out = new FileOutputStream(tempConfigFile);
+            props.store(out, "properties file");
+            out.close();
+            Properties prop = new Properties(System.getProperties());
+            try (FileInputStream fis = new FileInputStream(confFile)) {
+                prop.load(fis);
+            }
+            args.getCommander().setDefaultValueProvider(PulsarPerfTestPropertiesProvider.create(prop));
+            args.parse(new String[]{});
+            assertEquals("PKCS12", args.tlsTrustStoreType);
+            assertEquals("./path", args.tlsTrustStorePath);
+            assertEquals("changeme", args.tlsTrustStorePassword);
+            assertEquals("JKS", args.tlsKeyStoreType);
+            assertEquals("./path", args.tlsKeyStorePath);
+            assertEquals("", args.tlsKeyStorePassword);
+
+        } catch (IOException e) {
+            fail("Error while updating/reading config file");
+        } finally {
+            tempConfigFile.delete();
+        }
+    }
+
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #22678

<!-- or this PR is one task of an issue -->

Main Issue: #22678

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #22694

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

If you want to create a TestClient which uses AuthenticationKeyStoreTls as its authPlugin, Pulsar Test Admin/Client utilized in Pulsar-perf is unable to setup a vaild SSL context due to the requirement of the property "useKeyStoreTls" to be "true" for using keystores properly.
Moreover, utilizing the property "useKeyStoreTls" requires the use of trust-stores and not trust certificates, therefore requiring additional trustStoreType, trustStorePath and trustStorePass as parameters to be available, to utilize PulsarPerf.

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

<!-- Describe the modifications you've done. -->

The following changes have been made:
1. New properties for useKeyStoreTls, trustStore options and keystore options have been added in PerformanceBaseArguments.java
2. An if check has been added in PerfClientUtils.java, to switch between trustCertsFilePath and keyStore related properties based on useKeyStoreTls.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

*(example:)*
  - *Added test cases to check parameterException when useKeyStoreTls is true but no trustStore Path is provided.*
  - *Added test cases to verify that arguments are correctly mapped to PulsarAdminBuilder and PulsarClientBuilder*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: [PR](https://github.com/shasank112001/pulsar/pull/2)

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
