### PR TITLE
[feat][broker] PIP-264: Add OpenTelemetry consumer metrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -109,6 +109,7 @@ import org.apache.pulsar.broker.service.TransactionBufferSnapshotServiceFactory;
 import org.apache.pulsar.broker.service.schema.SchemaRegistryService;
 import org.apache.pulsar.broker.service.schema.SchemaStorageFactory;
 import org.apache.pulsar.broker.stats.MetricsGenerator;
+import org.apache.pulsar.broker.stats.OpenTelemetryConsumerStats;
 import org.apache.pulsar.broker.stats.OpenTelemetryTopicStats;
 import org.apache.pulsar.broker.stats.PulsarBrokerOpenTelemetry;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsServlet;
@@ -254,6 +255,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     private MetricsGenerator metricsGenerator;
     private final PulsarBrokerOpenTelemetry openTelemetry;
     private OpenTelemetryTopicStats openTelemetryTopicStats;
+    private OpenTelemetryConsumerStats openTelemetryConsumerStats;
 
     private TransactionMetadataStoreService transactionMetadataStoreService;
     private TransactionBufferProvider transactionBufferProvider;
@@ -631,6 +633,9 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             brokerClientSharedTimer.stop();
             monotonicSnapshotClock.close();
 
+            if (openTelemetryConsumerStats != null) {
+                openTelemetryConsumerStats.close();
+            }
             if (openTelemetryTopicStats != null) {
                 openTelemetryTopicStats.close();
             }
@@ -776,6 +781,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             }
 
             openTelemetryTopicStats = new OpenTelemetryTopicStats(this);
+            openTelemetryConsumerStats = new OpenTelemetryConsumerStats(this);
 
             localMetadataSynchronizer = StringUtils.isNotBlank(config.getMetadataSyncEventTopic())
                     ? new PulsarMetadataEventSynchronizer(this, config.getMetadataSyncEventTopic())

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -635,9 +635,11 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
             if (openTelemetryConsumerStats != null) {
                 openTelemetryConsumerStats.close();
+                openTelemetryConsumerStats = null;
             }
             if (openTelemetryTopicStats != null) {
                 openTelemetryTopicStats.close();
+                openTelemetryTopicStats = null;
             }
 
             asyncCloseFutures.add(EventLoopUtil.shutdownGracefully(ioEventLoopGroup));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -90,6 +90,7 @@ public class Consumer {
     private final Rate msgOut;
     private final Rate msgRedeliver;
     private final LongAdder msgOutCounter;
+    private final LongAdder msgRedeliverCounter;
     private final LongAdder bytesOutCounter;
     private final LongAdder messageAckCounter;
     private final Rate messageAckRate;
@@ -183,6 +184,7 @@ public class Consumer {
         this.msgOut = new Rate();
         this.chunkedMessageRate = new Rate();
         this.msgRedeliver = new Rate();
+        this.msgRedeliverCounter = new LongAdder();
         this.bytesOutCounter = new LongAdder();
         this.msgOutCounter = new LongAdder();
         this.messageAckCounter = new LongAdder();
@@ -240,6 +242,7 @@ public class Consumer {
         this.consumerName = consumerName;
         this.msgOut = null;
         this.msgRedeliver = null;
+        this.msgRedeliverCounter = null;
         this.msgOutCounter = null;
         this.bytesOutCounter = null;
         this.messageAckCounter = null;
@@ -930,6 +933,10 @@ public class Consumer {
         return messageAckCounter.sum();
     }
 
+    public long getMessageRedeliverCounter() {
+        return msgRedeliverCounter.sum();
+    }
+
     public int getUnackedMessages() {
         return unackedMessages;
     }
@@ -1067,6 +1074,8 @@ public class Consumer {
             }
 
             msgRedeliver.recordMultipleEvents(totalRedeliveryMessages.intValue(), totalRedeliveryMessages.intValue());
+            msgRedeliverCounter.add(totalRedeliveryMessages.intValue());
+
             subscription.redeliverUnacknowledgedMessages(this, pendingPositions);
         } else {
             subscription.redeliverUnacknowledgedMessages(this, consumerEpoch);
@@ -1099,6 +1108,7 @@ public class Consumer {
 
         subscription.redeliverUnacknowledgedMessages(this, pendingPositions);
         msgRedeliver.recordMultipleEvents(totalRedeliveryMessages, totalRedeliveryMessages);
+        msgRedeliverCounter.add(totalRedeliveryMessages);
 
         int numberOfBlockedPermits = PERMITS_RECEIVED_WHILE_CONSUMER_BLOCKED_UPDATER.getAndSet(this, 0);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -25,6 +25,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.AtomicDouble;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
@@ -154,6 +155,9 @@ public class Consumer {
     @Getter
     private final SchemaType schemaType;
 
+    @Getter
+    private final Instant connectedSince = Instant.now();
+
     public Consumer(Subscription subscription, SubType subType, String topicName, long consumerId,
                     int priorityLevel, String consumerName,
                     boolean isDurable, TransportCnx cnx, String appId,
@@ -204,7 +208,7 @@ public class Consumer {
         stats = new ConsumerStatsImpl();
         stats.setAddress(cnx.clientSourceAddressAndPort());
         stats.consumerName = consumerName;
-        stats.setConnectedSince(DateFormatter.now());
+        stats.setConnectedSince(DateFormatter.format(connectedSince));
         stats.setClientVersion(cnx.getClientVersion());
         stats.metadata = this.metadata;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -1175,6 +1175,10 @@ public class Consumer {
         return cnx.clientSourceAddressAndPort();
     }
 
+    public String getClientVersion() {
+        return cnx.getClientVersion();
+    }
+
     public MessageId getStartMessageId() {
         return startMessageId;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -91,6 +91,7 @@ public class Consumer {
     private final Rate msgRedeliver;
     private final LongAdder msgOutCounter;
     private final LongAdder bytesOutCounter;
+    private final LongAdder messageAckCounter;
     private final Rate messageAckRate;
 
     private volatile long lastConsumedTimestamp;
@@ -184,6 +185,7 @@ public class Consumer {
         this.msgRedeliver = new Rate();
         this.bytesOutCounter = new LongAdder();
         this.msgOutCounter = new LongAdder();
+        this.messageAckCounter = new LongAdder();
         this.messageAckRate = new Rate();
         this.appId = appId;
 
@@ -240,6 +242,7 @@ public class Consumer {
         this.msgRedeliver = null;
         this.msgOutCounter = null;
         this.bytesOutCounter = null;
+        this.messageAckCounter = null;
         this.messageAckRate = null;
         this.pendingAcks = null;
         this.stats = null;
@@ -502,6 +505,7 @@ public class Consumer {
         return future
                 .thenApply(v -> {
                     this.messageAckRate.recordEvent(v);
+                    this.messageAckCounter.add(v);
                     return null;
                 });
     }
@@ -920,6 +924,10 @@ public class Consumer {
 
     public long getBytesOutCounter() {
         return bytesOutCounter.longValue();
+    }
+
+    public long getMessageAckCounter() {
+        return messageAckCounter.sum();
     }
 
     public int getUnackedMessages() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -1171,6 +1171,10 @@ public class Consumer {
         return clientAddress;
     }
 
+    public String getClientAddressAndPort() {
+        return cnx.clientSourceAddressAndPort();
+    }
+
     public MessageId getStartMessageId() {
         return startMessageId;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStats.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.BatchCallback;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import java.util.Collection;
+import java.util.Optional;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.service.Consumer;
+import org.apache.pulsar.broker.service.Subscription;
+import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
+
+public class OpenTelemetryConsumerStats implements AutoCloseable {
+
+    // Replaces pulsar_consumer_msg_rate_out
+    public static final String MESSAGE_OUT_COUNTER = "pulsar.broker.consumer.message.outgoing.count";
+    private final ObservableLongMeasurement messageOutCounter;
+
+    // Replaces pulsar_consumer_msg_throughput_out
+    public static final String BYTES_OUT_COUNTER = "pulsar.broker.consumer.message.outgoing.size";
+    private final ObservableLongMeasurement bytesOutCounter;
+
+    // Replaces pulsar_consumer_msg_ack_rate
+    public static final String MESSAGE_ACK_COUNTER = "pulsar.broker.consumer.message.ack.count";
+    private final ObservableLongMeasurement messageAckCounter;
+
+    // Replaces pulsar_consumer_msg_rate_redeliver
+    public static final String MESSAGE_REDELIVER_COUNTER = "pulsar.broker.consumer.message.redeliver.count";
+    private final ObservableLongMeasurement messageRedeliverCounter;
+
+    // Replaces pulsar_consumer_unacked_messages
+    public static final String MESSAGE_UNACKNOWLEDGED_COUNTER = "pulsar.broker.consumer.message.unack.count";
+    private final ObservableLongMeasurement messageUnacknowledgedCounter;
+
+    // Replaces pulsar_consumer_blocked_on_unacked_messages
+    public static final String MESSAGE_BLOCKED_ON_UNACKNOWLEDGED_MESSAGES_GAUGE = "pulsar.broker.consumer.message.unack.blocked";
+    private final ObservableLongMeasurement messageBlockedOnUnacknowledgedMessagesGauge;
+
+    // Replaces pulsar_consumer_available_permits
+    public static final String MESSAGE_PERMITS_COUNTER = "pulsar.broker.consumer.permit.count";
+    private final ObservableLongMeasurement messagePermitsCounter;
+
+
+    private final BatchCallback batchCallback;
+    private final PulsarService pulsar;
+
+    public OpenTelemetryConsumerStats(PulsarService pulsar) {
+        this.pulsar = pulsar;
+        var meter = pulsar.getOpenTelemetry().getMeter();
+
+        messageOutCounter = meter
+                .counterBuilder(MESSAGE_OUT_COUNTER)
+                .setUnit("{message}")
+                .setDescription("The total number of messages dispatched to this consumer.")
+                .buildObserver();
+
+        bytesOutCounter = meter
+                .counterBuilder(BYTES_OUT_COUNTER)
+                .setUnit("By")
+                .setDescription("The total number of messages bytes dispatched to this consumer.")
+                .buildObserver();
+
+        messageAckCounter = meter
+                .counterBuilder(MESSAGE_ACK_COUNTER)
+                .setUnit("{ack}")
+                .setDescription("The total number of message acknowledgments received from this consumer.")
+                .buildObserver();
+
+        messageRedeliverCounter = meter
+                .counterBuilder(MESSAGE_REDELIVER_COUNTER)
+                .setUnit("{message}")
+                .setDescription("The total number of message acknowledgments that have been redelivered to this consumer.")
+                .buildObserver();
+
+        messageUnacknowledgedCounter = meter
+                .counterBuilder(MESSAGE_UNACKNOWLEDGED_COUNTER)
+                .setUnit("{message}")
+                .setDescription("The total number of messages unacknowledged by this consumer.")
+                .buildObserver();
+
+        messageBlockedOnUnacknowledgedMessagesGauge = meter
+                .gaugeBuilder(MESSAGE_BLOCKED_ON_UNACKNOWLEDGED_MESSAGES_GAUGE)
+                .ofLongs()
+                .setUnit("Boolean")
+                .setDescription("TODO: Indicates whether a consumer is blocked on acknowledged messages or not.")
+                .buildObserver();
+
+        messagePermitsCounter = meter
+                .counterBuilder(MESSAGE_PERMITS_COUNTER)
+                .setUnit("{permit}")
+                .setDescription("The total number of available permits for this consumer.")
+                .buildObserver();
+
+        batchCallback = meter.batchCallback(() -> pulsar.getBrokerService()
+                        .getTopics()
+                        .values()
+                        .stream()
+                        .map(topicFuture -> topicFuture.getNow(Optional.empty()))
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .map(Topic::getSubscriptions)
+                        .flatMap(s -> s.values().stream())
+                        .map(Subscription::getConsumers)
+                        .flatMap(Collection::stream)
+                        .forEach(this::recordMetricsForConsumer),
+                messageOutCounter,
+                bytesOutCounter,
+                messageAckCounter,
+                messageRedeliverCounter,
+                messageUnacknowledgedCounter,
+                messageBlockedOnUnacknowledgedMessagesGauge,
+                messagePermitsCounter);
+    }
+
+    @Override
+    public void close() {
+        batchCallback.close();
+    }
+
+    private void recordMetricsForConsumer(Consumer consumer) {
+        var attributes = Attributes.builder()
+                .put(OpenTelemetryAttributes.PULSAR_TOPIC, topic.getName())
+                .build();
+
+        messageOutCounter.record(dummyValue, attributes);
+        bytesOutCounter.record(dummyValue, attributes);
+        messageAckCounter.record(dummyValue, attributes);
+        messageRedeliverCounter.record(dummyValue, attributes);
+        messageUnacknowledgedCounter.record(dummyValue, attributes);
+        messageBlockedOnUnacknowledgedMessagesGauge.record(dummyValue, attributes);
+        messagePermitsCounter.record(dummyValue, attributes);
+
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStats.java
@@ -27,6 +27,7 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
 
 public class OpenTelemetryConsumerStats implements AutoCloseable {
@@ -136,11 +137,21 @@ public class OpenTelemetryConsumerStats implements AutoCloseable {
 
     private void recordMetricsForConsumer(Consumer consumer) {
         var subscription = consumer.getSubscription();
-        var topic = subscription.getTopic();
+        var topicName = TopicName.get(subscription.getTopic().getName());
 
-        var attributes = Attributes.builder()
-                .put(OpenTelemetryAttributes.PULSAR_TOPIC, topic.getName())
-                .build();
+        var builder = Attributes.builder()
+                .put(OpenTelemetryAttributes.PULSAR_CONSUMER_NAME, consumer.consumerName())
+                .put(OpenTelemetryAttributes.PULSAR_CONSUMER_ID, consumer.consumerId())
+                .put(OpenTelemetryAttributes.PULSAR_SUBSCRIPTION_NAME, subscription.getName())
+                .put(OpenTelemetryAttributes.PULSAR_SUBSCRIPTION_TYPE, consumer.subType().toString())
+                .put(OpenTelemetryAttributes.PULSAR_DOMAIN, topicName.getDomain().toString())
+                .put(OpenTelemetryAttributes.PULSAR_TENANT, topicName.getTenant())
+                .put(OpenTelemetryAttributes.PULSAR_NAMESPACE, topicName.getNamespace())
+                .put(OpenTelemetryAttributes.PULSAR_TOPIC, topicName.getPartitionedTopicName());
+        if (topicName.isPartitioned()) {
+            builder.put(OpenTelemetryAttributes.PULSAR_PARTITION_INDEX, topicName.getPartitionIndex());
+        }
+        var attributes = builder.build();
 
         messageOutCounter.record(consumer.getMsgOutCounter(), attributes);
         bytesOutCounter.record(consumer.getBytesOutCounter(), attributes);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStats.java
@@ -52,13 +52,13 @@ public class OpenTelemetryConsumerStats implements AutoCloseable {
     private final ObservableLongMeasurement messageUnacknowledgedCounter;
 
     // Replaces pulsar_consumer_blocked_on_unacked_messages
-    public static final String MESSAGE_BLOCKED_ON_UNACKNOWLEDGED_MESSAGES_GAUGE = "pulsar.broker.consumer.message.unack.blocked";
+    public static final String MESSAGE_BLOCKED_ON_UNACKNOWLEDGED_MESSAGES_GAUGE =
+            "pulsar.broker.consumer.message.unack.blocked";
     private final ObservableLongMeasurement messageBlockedOnUnacknowledgedMessagesGauge;
 
     // Replaces pulsar_consumer_available_permits
     public static final String MESSAGE_PERMITS_COUNTER = "pulsar.broker.consumer.permit.count";
     private final ObservableLongMeasurement messagePermitsCounter;
-
 
     private final BatchCallback batchCallback;
 
@@ -86,7 +86,7 @@ public class OpenTelemetryConsumerStats implements AutoCloseable {
         messageRedeliverCounter = meter
                 .counterBuilder(MESSAGE_REDELIVER_COUNTER)
                 .setUnit("{message}")
-                .setDescription("The total number of message acknowledgments that have been redelivered to this consumer.")
+                .setDescription("The total number of messages that have been redelivered to this consumer.")
                 .buildObserver();
 
         messageUnacknowledgedCounter = meter

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStats.java
@@ -129,6 +129,8 @@ public class OpenTelemetryConsumerStats implements AutoCloseable {
         var builder = Attributes.builder()
                 .put(OpenTelemetryAttributes.PULSAR_CONSUMER_NAME, consumer.consumerName())
                 .put(OpenTelemetryAttributes.PULSAR_CONSUMER_ID, consumer.consumerId())
+                .put(OpenTelemetryAttributes.PULSAR_CONSUMER_CONNECTED_SINCE,
+                        consumer.getConnectedSince().getEpochSecond())
                 .put(OpenTelemetryAttributes.PULSAR_SUBSCRIPTION_NAME, subscription.getName())
                 .put(OpenTelemetryAttributes.PULSAR_SUBSCRIPTION_TYPE, consumer.subType().toString())
                 .put(OpenTelemetryAttributes.PULSAR_DOMAIN, topicName.getDomain().toString())

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStats.java
@@ -138,6 +138,10 @@ public class OpenTelemetryConsumerStats implements AutoCloseable {
         if (topicName.isPartitioned()) {
             builder.put(OpenTelemetryAttributes.PULSAR_PARTITION_INDEX, topicName.getPartitionIndex());
         }
+        var clientAddress = consumer.getClientAddressAndPort();
+        if (clientAddress != null) {
+            builder.put(OpenTelemetryAttributes.PULSAR_CLIENT_ADDRESS, clientAddress);
+        }
         var attributes = builder.build();
 
         messageOutCounter.record(consumer.getMsgOutCounter(), attributes);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStats.java
@@ -148,6 +148,12 @@ public class OpenTelemetryConsumerStats implements AutoCloseable {
         if (clientVersion != null) {
             builder.put(OpenTelemetryAttributes.PULSAR_CLIENT_VERSION, clientVersion);
         }
+        var metadataList = consumer.getMetadata()
+                .entrySet()
+                .stream()
+                .map(e -> String.format("%s:%s", e.getKey(), e.getValue()))
+                .toList();
+        builder.put(OpenTelemetryAttributes.PULSAR_CONSUMER_METADATA, metadataList);
         var attributes = builder.build();
 
         messageOutCounter.record(consumer.getMsgOutCounter(), attributes);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStats.java
@@ -61,10 +61,8 @@ public class OpenTelemetryConsumerStats implements AutoCloseable {
 
 
     private final BatchCallback batchCallback;
-    private final PulsarService pulsar;
 
     public OpenTelemetryConsumerStats(PulsarService pulsar) {
-        this.pulsar = pulsar;
         var meter = pulsar.getOpenTelemetry().getMeter();
 
         messageOutCounter = meter

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStats.java
@@ -142,6 +142,10 @@ public class OpenTelemetryConsumerStats implements AutoCloseable {
         if (clientAddress != null) {
             builder.put(OpenTelemetryAttributes.PULSAR_CLIENT_ADDRESS, clientAddress);
         }
+        var clientVersion = consumer.getClientVersion();
+        if (clientVersion != null) {
+            builder.put(OpenTelemetryAttributes.PULSAR_CLIENT_VERSION, clientVersion);
+        }
         var attributes = builder.build();
 
         messageOutCounter.record(consumer.getMsgOutCounter(), attributes);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStatsTest.java
@@ -22,21 +22,30 @@ import static org.apache.pulsar.broker.stats.BrokerOpenTelemetryTestUtil.assertM
 import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
+import lombok.SneakyThrows;
 import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
 import org.awaitility.Awaitility;
+import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class OpenTelemetryConsumerStatsTest extends BrokerTestBase {
+
+    private final BrokerInterceptor brokerInterceptor = Mockito.mock(BrokerInterceptor.class);
 
     @BeforeMethod(alwaysRun = true)
     @Override
@@ -50,13 +59,16 @@ public class OpenTelemetryConsumerStatsTest extends BrokerTestBase {
         super.internalCleanup();
     }
 
+    @SneakyThrows
     @Override
     protected void customizeMainPulsarTestContextBuilder(PulsarTestContext.Builder builder) {
         super.customizeMainPulsarTestContextBuilder(builder);
         builder.enableOpenTelemetry(true);
+        Mockito.doCallRealMethod().when(brokerInterceptor).onFilter(Mockito.any(), Mockito.any(), Mockito.any());
+        builder.brokerInterceptor(brokerInterceptor);
     }
 
-    @Test(timeOut = 30_000, invocationCount = 100)
+    @Test(timeOut = 30_000, invocationCount = 1)
     public void testMessagingMetrics() throws Exception {
         var topicName = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/testConsumerMessagingMetrics");
         admin.topics().createNonPartitionedTopic(topicName);
@@ -67,6 +79,17 @@ public class OpenTelemetryConsumerStatsTest extends BrokerTestBase {
         var subscriptionName = BrokerTestUtil.newUniqueName("test");
         var receiverQueueSize = 100;
 
+        var consumerRef = new AtomicReference<Consumer>();
+        // Intercept calls to create consumer, in order to fetch client information.
+        Mockito.doAnswer(invocation -> {
+            consumerRef.set(invocation.getArgument(1));
+            return null;
+        }).doNothing()
+                .when(brokerInterceptor)
+                .consumerCreated(Mockito.any(),
+                        Mockito.argThat(argument -> argument.getSubscription().getName().equals(subscriptionName)),
+                        Mockito.any());
+
         @Cleanup
         var consumer = pulsarClient.newConsumer()
                 .topic(topicName)
@@ -75,7 +98,11 @@ public class OpenTelemetryConsumerStatsTest extends BrokerTestBase {
                 .subscriptionType(SubscriptionType.Shared)
                 .ackTimeout(1, TimeUnit.SECONDS)
                 .receiverQueueSize(receiverQueueSize)
+                .subscriptionProperties(Map.of("prop1", "value1"))
                 .subscribe();
+
+        var serverConsumer = consumerRef.get();
+        assertThat(serverConsumer).isNotNull();
 
         @Cleanup
         var producer = pulsarClient.newProducer()
@@ -101,6 +128,11 @@ public class OpenTelemetryConsumerStatsTest extends BrokerTestBase {
                 .put(OpenTelemetryAttributes.PULSAR_SUBSCRIPTION_TYPE, SubscriptionType.Shared.toString())
                 .put(OpenTelemetryAttributes.PULSAR_CONSUMER_NAME, consumer.getConsumerName())
                 .put(OpenTelemetryAttributes.PULSAR_CONSUMER_ID, 0)
+                .put(OpenTelemetryAttributes.PULSAR_CONSUMER_CONNECTED_SINCE,
+                        serverConsumer.getConnectedSince().getEpochSecond())
+                .put(OpenTelemetryAttributes.PULSAR_CLIENT_ADDRESS, serverConsumer.getClientAddressAndPort())
+                .put(OpenTelemetryAttributes.PULSAR_CLIENT_VERSION, serverConsumer.getClientVersion())
+                .put(OpenTelemetryAttributes.PULSAR_CONSUMER_METADATA, Collections.emptyList())
                 .build();
 
         Awaitility.await().untilAsserted(() -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStatsTest.java
@@ -67,7 +67,7 @@ public class OpenTelemetryConsumerStatsTest extends BrokerTestBase {
         builder.brokerInterceptor(brokerInterceptor);
     }
 
-    @Test(timeOut = 30_000, invocationCount = 1)
+    @Test(timeOut = 30_000)
     public void testMessagingMetrics() throws Exception {
         var topicName = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/testConsumerMessagingMetrics");
         admin.topics().createNonPartitionedTopic(topicName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStatsTest.java
@@ -22,9 +22,8 @@ import static org.apache.pulsar.broker.stats.BrokerOpenTelemetryTestUtil.assertM
 import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.data.MetricData;
-import java.util.Collections;
 import java.util.Comparator;
-import java.util.Map;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
@@ -98,7 +97,7 @@ public class OpenTelemetryConsumerStatsTest extends BrokerTestBase {
                 .subscriptionType(SubscriptionType.Shared)
                 .ackTimeout(1, TimeUnit.SECONDS)
                 .receiverQueueSize(receiverQueueSize)
-                .subscriptionProperties(Map.of("prop1", "value1"))
+                .property("prop1", "value1")
                 .subscribe();
 
         var serverConsumer = consumerRef.get();
@@ -132,7 +131,7 @@ public class OpenTelemetryConsumerStatsTest extends BrokerTestBase {
                         serverConsumer.getConnectedSince().getEpochSecond())
                 .put(OpenTelemetryAttributes.PULSAR_CLIENT_ADDRESS, serverConsumer.getClientAddressAndPort())
                 .put(OpenTelemetryAttributes.PULSAR_CLIENT_VERSION, serverConsumer.getClientVersion())
-                .put(OpenTelemetryAttributes.PULSAR_CONSUMER_METADATA, Collections.emptyList())
+                .put(OpenTelemetryAttributes.PULSAR_CONSUMER_METADATA, List.of("prop1:value1"))
                 .build();
 
         Awaitility.await().untilAsserted(() -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStatsTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats;
+
+import static org.apache.pulsar.broker.stats.BrokerOpenTelemetryTestUtil.assertMetricLongSumValue;
+import static org.assertj.core.api.Assertions.assertThat;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import java.util.Comparator;
+import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.broker.testcontext.PulsarTestContext;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class OpenTelemetryConsumerStatsTest extends BrokerTestBase {
+
+    @BeforeMethod(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        super.baseSetup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Override
+    protected void customizeMainPulsarTestContextBuilder(PulsarTestContext.Builder builder) {
+        super.customizeMainPulsarTestContextBuilder(builder);
+        builder.enableOpenTelemetry(true);
+    }
+
+    @Test(timeOut = 30_000, invocationCount = 100)
+    public void testMessagingMetrics() throws Exception {
+        var topicName = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/testConsumerMessagingMetrics");
+        admin.topics().createNonPartitionedTopic(topicName);
+
+        var messageCount = 5;
+        var ackCount = 3;
+
+        var subscriptionName = BrokerTestUtil.newUniqueName("test");
+        var receiverQueueSize = 100;
+
+        @Cleanup
+        var consumer = pulsarClient.newConsumer()
+                .topic(topicName)
+                .subscriptionName(subscriptionName)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscriptionType(SubscriptionType.Shared)
+                .ackTimeout(1, TimeUnit.SECONDS)
+                .receiverQueueSize(receiverQueueSize)
+                .subscribe();
+
+        @Cleanup
+        var producer = pulsarClient.newProducer()
+                .topic(topicName)
+                .create();
+        for (int j = 0; j < messageCount; j++) {
+            producer.send(String.format("msg-%d", j).getBytes());
+        }
+
+        for (int i = 0; i < messageCount; i++) {
+            var message = consumer.receive();
+            if (i < ackCount) {
+                consumer.acknowledge(message);
+            }
+        }
+
+        var attributes = Attributes.builder()
+                .put(OpenTelemetryAttributes.PULSAR_DOMAIN, "persistent")
+                .put(OpenTelemetryAttributes.PULSAR_TENANT, "prop")
+                .put(OpenTelemetryAttributes.PULSAR_NAMESPACE, "prop/ns-abc")
+                .put(OpenTelemetryAttributes.PULSAR_TOPIC, topicName)
+                .put(OpenTelemetryAttributes.PULSAR_SUBSCRIPTION_NAME, subscriptionName)
+                .put(OpenTelemetryAttributes.PULSAR_SUBSCRIPTION_TYPE, SubscriptionType.Shared.toString())
+                .put(OpenTelemetryAttributes.PULSAR_CONSUMER_NAME, consumer.getConsumerName())
+                .put(OpenTelemetryAttributes.PULSAR_CONSUMER_ID, 0)
+                .build();
+
+        Awaitility.await().untilAsserted(() -> {
+            var metrics = pulsarTestContext.getOpenTelemetryMetricReader().collectAllMetrics()
+                    .stream()
+                    .sorted(Comparator.comparing(MetricData::getName))
+                    .toList();
+
+            assertMetricLongSumValue(metrics, OpenTelemetryConsumerStats.MESSAGE_OUT_COUNTER, attributes,
+                    actual -> assertThat(actual).isPositive());
+            assertMetricLongSumValue(metrics, OpenTelemetryConsumerStats.BYTES_OUT_COUNTER, attributes,
+                    actual -> assertThat(actual).isPositive());
+
+            var unackCount = messageCount - ackCount;
+
+            assertMetricLongSumValue(metrics, OpenTelemetryConsumerStats.MESSAGE_ACK_COUNTER, attributes, ackCount);
+            assertMetricLongSumValue(metrics, OpenTelemetryConsumerStats.MESSAGE_PERMITS_COUNTER, attributes,
+                    actual -> assertThat(actual).isGreaterThanOrEqualTo(receiverQueueSize - messageCount - unackCount));
+            assertMetricLongSumValue(metrics, OpenTelemetryConsumerStats.MESSAGE_UNACKNOWLEDGED_COUNTER,
+                    attributes.toBuilder().put(OpenTelemetryAttributes.PULSAR_CONSUMER_BLOCKED, false).build(),
+                    unackCount);
+            assertMetricLongSumValue(metrics, OpenTelemetryConsumerStats.MESSAGE_REDELIVER_COUNTER, attributes,
+                    actual -> assertThat(actual).isGreaterThanOrEqualTo(unackCount));
+        });
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
@@ -746,6 +746,7 @@ public class PulsarTestContext implements AutoCloseable {
             if (builder.enableOpenTelemetry) {
                 var reader = InMemoryMetricReader.create();
                 openTelemetryMetricReader(reader);
+                registerCloseable(reader);
                 openTelemetrySdkBuilderCustomizer = BrokerOpenTelemetryTestUtil.getOpenTelemetrySdkBuilderConsumer(reader);
             } else {
                 openTelemetrySdkBuilderCustomizer = null;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -191,6 +191,7 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
 
         // Disable collecting topic stats during this test, as it deadlocks on access to map BrokerService.topics.
         pulsar2.getOpenTelemetryTopicStats().close();
+        pulsar2.getOpenTelemetryConsumerStats().close();
 
         var metricReader = pulsarTestContext.getOpenTelemetryMetricReader();
         var lookupRequestSemaphoreField = BrokerService.class.getDeclaredField("lookupRequestSemaphore");

--- a/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
+++ b/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
@@ -76,6 +76,11 @@ public interface OpenTelemetryAttributes {
     AttributeKey<Long> PULSAR_CONSUMER_ID = AttributeKey.longKey("pulsar.consumer.id");
 
     /**
+     * Indicates whether the consumer is currently blocked on unacknowledged messages or not.
+     */
+    AttributeKey<Boolean> PULSAR_CONSUMER_BLOCKED = AttributeKey.booleanKey("pulsar.consumer.blocked");
+
+    /**
      * The status of the Pulsar transaction.
      */
     AttributeKey<String> PULSAR_TRANSACTION_STATUS = AttributeKey.stringKey("pulsar.transaction.status");

--- a/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
+++ b/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
@@ -86,6 +86,11 @@ public interface OpenTelemetryAttributes {
     AttributeKey<String> PULSAR_CLIENT_ADDRESS = AttributeKey.stringKey("pulsar.client.address");
 
     /**
+     * The address of the Pulsar client.
+     */
+    AttributeKey<String> PULSAR_CLIENT_VERSION = AttributeKey.stringKey("pulsar.client.version");
+
+    /**
      * The status of the Pulsar transaction.
      */
     AttributeKey<String> PULSAR_TRANSACTION_STATUS = AttributeKey.stringKey("pulsar.transaction.status");

--- a/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
+++ b/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
@@ -81,6 +81,11 @@ public interface OpenTelemetryAttributes {
     AttributeKey<Boolean> PULSAR_CONSUMER_BLOCKED = AttributeKey.booleanKey("pulsar.consumer.blocked");
 
     /**
+     * The UTC timestamp of the Pulsar consumer creation.
+     */
+    AttributeKey<Long> PULSAR_CONSUMER_CONNECTED_SINCE = AttributeKey.longKey("pulsar.consumer.connected_since");
+
+    /**
      * The address of the Pulsar client.
      */
     AttributeKey<String> PULSAR_CLIENT_ADDRESS = AttributeKey.stringKey("pulsar.client.address");

--- a/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
+++ b/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.opentelemetry;
 
 import io.opentelemetry.api.common.AttributeKey;
+import java.util.List;
 
 /**
  * Common OpenTelemetry attributes to be used by Pulsar components.
@@ -79,6 +80,11 @@ public interface OpenTelemetryAttributes {
      * Indicates whether the consumer is currently blocked on unacknowledged messages or not.
      */
     AttributeKey<Boolean> PULSAR_CONSUMER_BLOCKED = AttributeKey.booleanKey("pulsar.consumer.blocked");
+
+    /**
+     * Indicates whether the consumer is currently blocked on unacknowledged messages or not.
+     */
+    AttributeKey<List<String>> PULSAR_CONSUMER_METADATA = AttributeKey.stringArrayKey("pulsar.consumer.metadata");
 
     /**
      * The UTC timestamp of the Pulsar consumer creation.

--- a/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
+++ b/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
@@ -82,7 +82,7 @@ public interface OpenTelemetryAttributes {
     AttributeKey<Boolean> PULSAR_CONSUMER_BLOCKED = AttributeKey.booleanKey("pulsar.consumer.blocked");
 
     /**
-     * Indicates whether the consumer is currently blocked on unacknowledged messages or not.
+     * The consumer metadata properties, as a list of "key:value" pairs.
      */
     AttributeKey<List<String>> PULSAR_CONSUMER_METADATA = AttributeKey.stringArrayKey("pulsar.consumer.metadata");
 
@@ -97,7 +97,7 @@ public interface OpenTelemetryAttributes {
     AttributeKey<String> PULSAR_CLIENT_ADDRESS = AttributeKey.stringKey("pulsar.client.address");
 
     /**
-     * The address of the Pulsar client.
+     * The version of the Pulsar client.
      */
     AttributeKey<String> PULSAR_CLIENT_VERSION = AttributeKey.stringKey("pulsar.client.version");
 

--- a/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
+++ b/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
@@ -81,6 +81,11 @@ public interface OpenTelemetryAttributes {
     AttributeKey<Boolean> PULSAR_CONSUMER_BLOCKED = AttributeKey.booleanKey("pulsar.consumer.blocked");
 
     /**
+     * The address of the Pulsar client.
+     */
+    AttributeKey<String> PULSAR_CLIENT_ADDRESS = AttributeKey.stringKey("pulsar.client.address");
+
+    /**
      * The status of the Pulsar transaction.
      */
     AttributeKey<String> PULSAR_TRANSACTION_STATUS = AttributeKey.stringKey("pulsar.transaction.status");

--- a/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
+++ b/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
@@ -56,6 +56,26 @@ public interface OpenTelemetryAttributes {
     AttributeKey<Long> PULSAR_PARTITION_INDEX = AttributeKey.longKey("pulsar.partition.index");
 
     /**
+     * The name of the Pulsar subscription.
+     */
+    AttributeKey<String> PULSAR_SUBSCRIPTION_NAME = AttributeKey.stringKey("pulsar.subscription.name");
+
+    /**
+     * The type of the Pulsar subscription.
+     */
+    AttributeKey<String> PULSAR_SUBSCRIPTION_TYPE = AttributeKey.stringKey("pulsar.subscription.type");
+
+    /**
+     * The name of the Pulsar consumer.
+     */
+    AttributeKey<String> PULSAR_CONSUMER_NAME = AttributeKey.stringKey("pulsar.consumer.name");
+
+    /**
+     * The ID of the Pulsar consumer.
+     */
+    AttributeKey<Long> PULSAR_CONSUMER_ID = AttributeKey.longKey("pulsar.consumer.id");
+
+    /**
      * The status of the Pulsar transaction.
      */
     AttributeKey<String> PULSAR_TRANSACTION_STATUS = AttributeKey.stringKey("pulsar.transaction.status");


### PR DESCRIPTION
[PIP-264](https://github.com/apache/pulsar/blob/master/pip/pip-264.md)

### Motivation

Using OpenTelemetry, exposes the current consumer-level metrics emitted by the broker and described in the [doc](https://pulsar.apache.org/docs/next/reference-metrics/#consumer-metrics).

### Modifications

Similar to topic metrics PR https://github.com/apache/pulsar/pull/22467, navigate all the current consumers connected to the broker and expose their respective metrics in OpenTelemetry format.

The metric details can be consulted in the doc PR: https://github.com/apache/pulsar-site/pull/896. Prometheus metric `pulsar_consumer_blocked_on_unacked_messages` has been dropped in favor of OpenTelemetry boolean attribute `pulsar.consumer.blocked` on metric `pulsar.broker.consumer.message.unack.count`, as these values are tightly related.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - Added test `org.apache.pulsar.broker.stats.OpenTelemetryConsumerStatsTest#testMessagingMetrics`, verifying all the new metrics.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics: _As described above_
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` https://github.com/apache/pulsar-site/pull/896
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dragosvictor/pulsar/pull/24