### PR TITLE
[improve][pip] PIP-351: Additional options for Pulsar-Test client to support KeyStore based TLS

### DIFF
--- a/pip/pip-351.md
+++ b/pip/pip-351.md
@@ -1,0 +1,166 @@
+<!--
+RULES
+* Never place a link to an external site like Google Doc. The proposal should be in this issue entirely.
+* Use a spelling and grammar checker tools if available for you (there are plenty of free ones).
+
+PROPOSAL HEALTH CHECK
+I can read the design document and understand the problem statement and what you plan to change *without* resorting to a couple of hours of code reading just to start having a high level understanding of the change.
+
+IMAGES
+If you need diagrams, avoid attaching large files. You can use [MermaidJS]([url](https://mermaid.js.org/)) as a simple language to describe many types of diagrams.
+
+THIS COMMENTS
+Please remove them when done.
+-->
+
+# PIP-351: Additional options for Pulsar-Test client to 
+
+# Background knowledge
+
+<!--
+Describes all the knowledge you need to know in order to understand all the other sections in this PIP
+
+* Give a high level explanation on all concepts you will be using throughout this document. For example, if you want to talk about Persistent Subscriptions, explain briefly (1 paragraph) what this is. If you're going to talk about Transaction Buffer, explain briefly what this is. 
+  If you're going to change something specific, then go into more detail about it and how it works. 
+* Provide links where possible if a person wants to dig deeper into the background information. 
+
+DON'T
+* Do not include links *instead* explanation. Do provide links for further explanation.
+
+EXAMPLES
+* See [PIP-248](https://github.com/apache/pulsar/issues/19601), Background section to get an understanding on how you add the background knowledge needed.
+  (They also included the motivation there, but ignore it as we place that in Motivation section explicitly).
+-->
+
+In both Pulsar Client and Pulsar Admin, we support the use of KeyStores. This feature is provided by means of the boolean
+"useKeyStoreTls". The boolean is also the only way authentication mechanisms such as AuthenticationKeyStoreTls can be utilised
+properly, as the logic to use keystores for SSL Connections, from either ClientConfigurationData stored in Pulsar Admin/Client
+or AuthData hinges on the "useKeyStoreTls" boolean as can be seen below:
+
+<b>AsyncHttpConnector.java</b>
+```java
+if (conf.isUseKeyStoreTls()) {
+                    KeyStoreParams params = authData.hasDataForTls() ? authData.getTlsKeyStoreParams() :
+                            new KeyStoreParams(conf.getTlsKeyStoreType(), conf.getTlsKeyStorePath(),
+                                    conf.getTlsKeyStorePassword());
+
+                    final SSLContext sslCtx = KeyStoreSSLContext.createClientSslContext(
+                            conf.getSslProvider(),
+                            params.getKeyStoreType(),
+                            params.getKeyStorePath(),
+                            params.getKeyStorePassword(),
+                            conf.isTlsAllowInsecureConnection(),
+                            conf.getTlsTrustStoreType(),
+                            conf.getTlsTrustStorePath(),
+                            conf.getTlsTrustStorePassword(),
+                            conf.getTlsCiphers(),
+                            conf.getTlsProtocols());
+
+                    JsseSslEngineFactory sslEngineFactory = new JsseSslEngineFactory(sslCtx);
+                    confBuilder.setSslEngineFactory(sslEngineFactory);
+                } 
+```
+
+None of these options can be currently configured when using Pulsar Test client.
+
+# Motivation
+
+<!--
+Describe the problem this proposal is trying to solve.
+
+* Explain what is the problem you're trying to solve - current situation.
+* This section is the "Why" of your proposal.
+-->
+
+As we already let users both extend authentication and use just the keystore and truststore properties to set up mTLS
+connections, without using any authentication plugin class, a lot of them might want to use this method of authentication
+during Performance Testing as well.
+
+I understand that currently mTLS (for testing purposes) can be achieved by using trust and client certificates.
+However, the issue of users extending authentication plugin classes and utilizing keystores is still not covered 
+with the current options. Therefore, I propose we make these already existing options be configured in test clients,
+increasing its usability.
+
+# Goals
+
+## In Scope
+
+Create new Arguments for the following properties, in PerformanceBaseArguments.java :
+1. useKeyStoreTls
+2. trustStoreType
+3. trustStorePath
+4. trustStorePass
+5. keyStoreType
+6. keyStorePath
+7. keyStorePass
+
+Update the code to change between TrustCerts and TrustStore based on useKeyStoreTls.
+
+<!--
+What this PIP intend to achieve once It's integrated into Pulsar.
+Why does it benefit Pulsar.
+-->
+
+[//]: # (## Out of Scope)
+
+<!--
+Describe what you have decided to keep out of scope, perhaps left for a different PIP/s.
+-->
+
+
+[//]: # (# High Level Design)
+
+<!--
+Describe the design of your solution in *high level*.
+Describe the solution end to end, from a birds-eye view.
+Don't go into implementation details in this section.
+
+I should be able to finish reading from beginning of the PIP to here (including) and understand the feature and 
+how you intend to solve it, end to end.
+
+DON'T
+* Avoid code snippets, unless it's essential to explain your intent.
+-->
+
+# Detailed Design
+
+## Design & Implementation Details
+
+<!--
+This is the section where you dive into the details. It can be:
+* Concrete class names and their roles and responsibility, including methods.
+* Code snippets of existing code.
+* Interface names and its methods.
+* ...
+-->
+
+Add the options for utilizing keystores as part of performance base arguments, along with forwarding their values
+to the client/admin builders.
+
+## Public-facing Changes
+
+<!--
+Describe the additions you plan to make for each public facing component. 
+Remove the sections you are not changing.
+Clearly mark any changes which are BREAKING backward compatability.
+-->
+
+### CLI
+
+All places we utilize Pulsar Test client, for example Pulsar-Perf will have the following new options:
+
+1. --use-keystore-tls &rarr; Default value = false, Possible values = true, false
+2. --truststore-type &rarr; Default value = JKS, Possible values = JKS, PKCS12
+3. --truststore-path &rarr; Default value = ""
+4. --truststore-pass &rarr; Default value = ""
+5. --keystore-type &rarr; Default value = JKS, Possible values = JKS, PKCS12
+6. --keystore-path &rarr; Default value = ""
+7. --keystore-pass &rarr; Default value = ""
+
+
+
+# Backward & Forward Compatibility
+
+The change will not affect any previous releases. The options can also be brought to previous versions, however, I have
+noticed that Pulsar has moved away from JCommander in Version 3.2.x to Picocli (currently in master)
+Therefore, to add these options to previous versions, the code has to be replicated to those versions.

--- a/pip/pip-351.md
+++ b/pip/pip-351.md
@@ -149,7 +149,7 @@ Clearly mark any changes which are BREAKING backward compatability.
 
 All places we utilize Pulsar Test client, for example Pulsar-Perf will have the following new options:
 
-1. --use-keystore-tls &rarr; Default value = false, Possible values = true, false
+1. --use-keystore-tls &rarr; Default value = false
 2. --truststore-type &rarr; Default value = JKS, Possible values = JKS, PKCS12
 3. --truststore-path &rarr; Default value = ""
 4. --truststore-pass &rarr; Default value = ""

--- a/pip/pip-351.md
+++ b/pip/pip-351.md
@@ -39,26 +39,26 @@ or AuthData hinges on the "useKeyStoreTls" boolean as can be seen below:
 
 <b>AsyncHttpConnector.java</b>
 ```java
-if (conf.isUseKeyStoreTls()) {
-                    KeyStoreParams params = authData.hasDataForTls() ? authData.getTlsKeyStoreParams() :
-                            new KeyStoreParams(conf.getTlsKeyStoreType(), conf.getTlsKeyStorePath(),
-                                    conf.getTlsKeyStorePassword());
+ if (conf.isUseKeyStoreTls()) {
+    KeyStoreParams params = authData.hasDataForTls() ? authData.getTlsKeyStoreParams() :
+            new KeyStoreParams(conf.getTlsKeyStoreType(), conf.getTlsKeyStorePath(),
+                    conf.getTlsKeyStorePassword());
 
-                    final SSLContext sslCtx = KeyStoreSSLContext.createClientSslContext(
-                            conf.getSslProvider(),
-                            params.getKeyStoreType(),
-                            params.getKeyStorePath(),
-                            params.getKeyStorePassword(),
-                            conf.isTlsAllowInsecureConnection(),
-                            conf.getTlsTrustStoreType(),
-                            conf.getTlsTrustStorePath(),
-                            conf.getTlsTrustStorePassword(),
-                            conf.getTlsCiphers(),
-                            conf.getTlsProtocols());
+    final SSLContext sslCtx = KeyStoreSSLContext.createClientSslContext(
+            conf.getSslProvider(),
+            params.getKeyStoreType(),
+            params.getKeyStorePath(),
+            params.getKeyStorePassword(),
+            conf.isTlsAllowInsecureConnection(),
+            conf.getTlsTrustStoreType(),
+            conf.getTlsTrustStorePath(),
+            conf.getTlsTrustStorePassword(),
+            conf.getTlsCiphers(),
+            conf.getTlsProtocols());
 
-                    JsseSslEngineFactory sslEngineFactory = new JsseSslEngineFactory(sslCtx);
-                    confBuilder.setSslEngineFactory(sslEngineFactory);
-                } 
+    JsseSslEngineFactory sslEngineFactory = new JsseSslEngineFactory(sslCtx);
+    confBuilder.setSslEngineFactory(sslEngineFactory);
+}
 ```
 
 None of these options can be currently configured when using Pulsar Test client.

--- a/pip/pip-351.md
+++ b/pip/pip-351.md
@@ -39,7 +39,7 @@ or AuthData hinges on the "useKeyStoreTls" boolean as can be seen below:
 
 <b>AsyncHttpConnector.java</b>
 ```java
- if (conf.isUseKeyStoreTls()) {
+if (conf.isUseKeyStoreTls()) {
     KeyStoreParams params = authData.hasDataForTls() ? authData.getTlsKeyStoreParams() :
             new KeyStoreParams(conf.getTlsKeyStoreType(), conf.getTlsKeyStorePath(),
                     conf.getTlsKeyStorePassword());

--- a/pip/pip-351.md
+++ b/pip/pip-351.md
@@ -13,7 +13,7 @@ THIS COMMENTS
 Please remove them when done.
 -->
 
-# PIP-351: Additional options for Pulsar-Test client to 
+# PIP-351: Additional options for Pulsar-Test client to support KeyStore based TLS
 
 # Background knowledge
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Main Issue: #22678

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

If you want to create a TestClient which uses AuthenticationKeyStoreTls as its authPlugin, Pulsar Test Admin/Client utilized in Pulsar-perf is unable to setup a vaild SSL context due to the requirement of the property "useKeyStoreTls" to be "true" for using keystores properly.
Moreover, utilizing the property "useKeyStoreTls" requires the use of trust-store and not trust certificates, therefore requiring additional trustStoreType, trustStorePath and trustStorePass as parameters to be available, to utilize PulsarPerf.

### Modifications

Added PIP.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
