### PR TITLE
[fix] [broker] local metadata sync topic contains configuration events causing all operations stuck

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -583,6 +583,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String configurationMetadataSyncEventTopic = null;
 
     @FieldContext(
+            dynamic = false,
+            category = CATEGORY_SERVER,
+            doc = "If you want to enable or disable the metadata synchronizer dynamically, this value should be true."
+                + "Enabled: Pulsar will initialize itself to update the metadata synchronizer dynamically."
+    )
+    private boolean mayEnableMetadataSynchronizer = false;
+
+    @FieldContext(
             dynamic = true,
             doc = "Factory class-name to create topic with custom workflow"
         )

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -585,10 +585,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
             dynamic = false,
             category = CATEGORY_SERVER,
-            doc = "If you want to enable or disable the metadata synchronizer dynamically, this value should be true."
-                + "Enabled: Pulsar will initialize itself to update the metadata synchronizer dynamically."
+            doc = "Create a separate configuration metadata store object in memory even if the URL of the configuration"
+                    + " metadata store is the same as the local metadata store. It is useful for some case, for"
+                    + " example: to enable Metadata Synchronizer dynamically."
     )
-    private boolean mayEnableMetadataSynchronizer = false;
+    private boolean forceUseSeparatedConfigurationStoreInMemory = false;
 
     @FieldContext(
             dynamic = true,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -877,7 +877,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             // In order to ensure that the two synchronizer receive events of interest to each other (in other words,
             // ensure that different types of events are sent to different topics), create the single configuration
             // metadata store.
-            if (config.isConfigurationStoreSeparated() || config.isMayEnableMetadataSynchronizer()
+            if (config.isConfigurationStoreSeparated() || config.isForceUseSeparatedConfigurationStoreInMemory()
                     || localMetadataSynchronizer != null || configMetadataSynchronizer != null) {
                 configurationMetadataStore = createConfigurationMetadataStore(configMetadataSynchronizer,
                         openTelemetry.getOpenTelemetryService().getOpenTelemetry());
@@ -1094,8 +1094,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         if ("configurationMetadataSyncEventTopic".equals(confName) || "metadataSyncEventTopic".equals(confName)) {
             if (localMetadataStore == configurationMetadataStore) {
                 return Pair.of(false, String.format("Can not update conf %s dynamically, please enable"
-                        + " mayEnableMetadataSynchronizer if you want to enable or disable the metadata synchronizer"
-                        + " dynamically.", confName));
+                        + " forceUseSeparatedConfigurationStoreInMemory if you want to enable or disable the metadata"
+                        + " synchronizer dynamically.", confName));
             }
         }
         return Pair.of(true, "");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -80,6 +80,7 @@ import org.apache.bookkeeper.mledger.impl.NullLedgerOffloader;
 import org.apache.bookkeeper.mledger.offload.Offloaders;
 import org.apache.bookkeeper.mledger.offload.OffloadersCache;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.broker.authorization.AuthorizationService;
@@ -867,10 +868,17 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
             coordinationService = new CoordinationServiceImpl(localMetadataStore);
 
-            if (config.isConfigurationStoreSeparated()) {
-                configMetadataSynchronizer = StringUtils.isNotBlank(config.getConfigurationMetadataSyncEventTopic())
-                        ? new PulsarMetadataEventSynchronizer(this, config.getConfigurationMetadataSyncEventTopic())
-                        : null;
+            configMetadataSynchronizer = StringUtils.isNotBlank(config.getConfigurationMetadataSyncEventTopic())
+                    ? new PulsarMetadataEventSynchronizer(this, config.getConfigurationMetadataSyncEventTopic())
+                    : null;
+
+            // If "localMetadataStore" and "configurationMetadataStore" is the same object, "localMetadataSynchronizer"
+            // will receive both local metadata event and configuration metadata event, which is in-correct.
+            // In order to ensure that the two synchronizer receive events of interest to each other (in other words,
+            // ensure that different types of events are sent to different topics), create the single configuration
+            // metadata store.
+            if (config.isConfigurationStoreSeparated() || config.isMayEnableMetadataSynchronizer()
+                    || localMetadataSynchronizer != null || configMetadataSynchronizer != null) {
                 configurationMetadataStore = createConfigurationMetadataStore(configMetadataSynchronizer,
                         openTelemetry.getOpenTelemetryService().getOpenTelemetry());
                 shouldShutdownConfigurationMetadataStore = true;
@@ -1080,6 +1088,17 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
     public void waitUntilReadyForIncomingRequests() throws ExecutionException, InterruptedException {
         readyForIncomingRequestsFuture.get();
+    }
+
+    public Pair<Boolean, String> hasConditionOfDynamicUpdateConf(String confName) {
+        if ("configurationMetadataSyncEventTopic".equals(confName) || "metadataSyncEventTopic".equals(confName)) {
+            if (localMetadataStore == configurationMetadataStore) {
+                return Pair.of(false, String.format("Can not update conf %s dynamically, please enable"
+                        + " mayEnableMetadataSynchronizer if you want to enable or disable the metadata synchronizer"
+                        + " dynamically.", confName));
+            }
+        }
+        return Pair.of(true, "");
     }
 
     protected BrokerInterceptor newBrokerInterceptor() throws IOException {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarMetadataEventSynchronizer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarMetadataEventSynchronizer.java
@@ -118,8 +118,9 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
 
     private void publishAsync(MetadataEvent event, CompletableFuture<Void> future) {
         if (!isProducerStarted()) {
-            log.info("Producer is not started on {}, failed to publish {}", topicName, event);
+            log.warn("Producer is not started on {}, failed to publish {}", topicName, event);
             future.completeExceptionally(new IllegalStateException("producer is not started yet"));
+            return;
         }
         producer.newMessage().value(event).sendAsync().thenAccept(__ -> {
             log.info("successfully published metadata change event {}", event);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarMetadataEventSynchronizer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarMetadataEventSynchronizer.java
@@ -156,8 +156,8 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
                     State stateTransient = state;
                     log.info("[{}] Closing the new producer because the synchronizer state is {}", prod,
                             stateTransient);
-                    CompletableFuture closeProducer = new CompletableFuture<>();
-                    closeResource(() -> prod.closeAsync(), closeProducer);
+                    CompletableFuture<Void> closeProducer = new CompletableFuture<>();
+                    closeResource(prod::closeAsync, closeProducer);
                     closeProducer.thenRun(() -> {
                         log.info("[{}] Closed the new producer because the synchronizer state is {}", prod,
                                 stateTransient);
@@ -221,11 +221,13 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
                 log.info("successfully created consumer {}", topicName);
             } else {
                 State stateTransient = state;
-                log.info("[{}] Closing the new consumer because the synchronizer state is {}", stateTransient);
-                CompletableFuture closeConsumer = new CompletableFuture<>();
-                closeResource(() -> consumer.closeAsync(), closeConsumer);
+                log.info("[{}] Closing the new consumer because the synchronizer state is {}", topicName,
+                        stateTransient);
+                CompletableFuture<Void> closeConsumer = new CompletableFuture<>();
+                closeResource(consumer::closeAsync, closeConsumer);
                 closeConsumer.thenRun(() -> {
-                    log.info("[{}] Closed the new consumer because the synchronizer state is {}", stateTransient);
+                    log.info("[{}] Closed the new consumer because the synchronizer state is {}", topicName,
+                            stateTransient);
                 });
             }
         }).exceptionally(ex -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/GeoReplicationWithConfigurationSyncTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/GeoReplicationWithConfigurationSyncTestBase.java
@@ -64,16 +64,39 @@ public abstract class GeoReplicationWithConfigurationSyncTestBase extends TestRe
 
     protected void startZKAndBK() throws Exception {
         // Start ZK.
-        brokerConfigZk1 = new ZookeeperServerTest(0);
-        brokerConfigZk1.start();
-        brokerConfigZk2 = new ZookeeperServerTest(0);
-        brokerConfigZk2.start();
+        tryInitBrokerConfigZK();
 
         // Start BK.
         bkEnsemble1 = new LocalBookkeeperEnsemble(3, 0, () -> 0);
         bkEnsemble1.start();
         bkEnsemble2 = new LocalBookkeeperEnsemble(3, 0, () -> 0);
         bkEnsemble2.start();
+    }
+
+    protected void tryInitBrokerConfigZK() throws Exception {
+        brokerConfigZk1 = new ZookeeperServerTest(0);
+        brokerConfigZk1.start();
+        brokerConfigZk2 = new ZookeeperServerTest(0);
+        brokerConfigZk2.start();
+    }
+
+    protected void stopZKAndBK() throws Exception {
+        if (bkEnsemble1 != null) {
+            bkEnsemble1.stop();
+            bkEnsemble1 = null;
+        }
+        if (bkEnsemble2 != null) {
+            bkEnsemble2.stop();
+            bkEnsemble2 = null;
+        }
+        if (brokerConfigZk1 != null) {
+            brokerConfigZk1.stop();
+            brokerConfigZk1 = null;
+        }
+        if (brokerConfigZk2 != null) {
+            brokerConfigZk2.stop();
+            brokerConfigZk2 = null;
+        }
     }
 
     protected void startBrokers() throws Exception {
@@ -162,7 +185,11 @@ public abstract class GeoReplicationWithConfigurationSyncTestBase extends TestRe
         config.setWebServicePort(Optional.of(0));
         config.setWebServicePortTls(Optional.of(0));
         config.setMetadataStoreUrl("zk:127.0.0.1:" + bookkeeperEnsemble.getZookeeperPort());
-        config.setConfigurationMetadataStoreUrl("zk:127.0.0.1:" + brokerConfigZk.getZookeeperPort() + "/foo");
+        if (brokerConfigZk != null) {
+            config.setConfigurationMetadataStoreUrl("zk:127.0.0.1:" + brokerConfigZk.getZookeeperPort());
+        } else {
+            config.setConfigurationMetadataStoreUrl("zk:127.0.0.1:" + bookkeeperEnsemble.getZookeeperPort());
+        }
         config.setBrokerDeleteInactiveTopicsEnabled(false);
         config.setBrokerDeleteInactiveTopicsFrequencySeconds(60);
         config.setBrokerShutdownTimeoutMs(0L);
@@ -210,22 +237,7 @@ public abstract class GeoReplicationWithConfigurationSyncTestBase extends TestRe
         }
 
         // Stop ZK and BK.
-        if (bkEnsemble1 != null) {
-            bkEnsemble1.stop();
-            bkEnsemble1 = null;
-        }
-        if (bkEnsemble2 != null) {
-            bkEnsemble2.stop();
-            bkEnsemble2 = null;
-        }
-        if (brokerConfigZk1 != null) {
-            brokerConfigZk1.stop();
-            brokerConfigZk1 = null;
-        }
-        if (brokerConfigZk2 != null) {
-            brokerConfigZk2.stop();
-            brokerConfigZk2 = null;
-        }
+        stopZKAndBK();
 
         // Reset configs.
         config1 = new ServiceConfiguration();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SyncConfigStore1ZKPerClusterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SyncConfigStore1ZKPerClusterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import lombok.extern.slf4j.Slf4j;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker")
+public class SyncConfigStore1ZKPerClusterTest extends SyncConfigStore2ZKPerClusterTest {
+
+    @Override
+    @BeforeClass(alwaysRun = true, timeOut = 300000)
+    public void setup() throws Exception {
+        super.setup();
+    }
+
+    @Override
+    @AfterClass(alwaysRun = true, timeOut = 300000)
+    public void cleanup() throws Exception {
+        super.cleanup();
+    }
+
+    @Override
+    protected void tryInitBrokerConfigZK() {
+        // Init nothing, the super class will use the local metadata ZK URL as config metadata ZK URL.
+    }
+
+    @Override
+    protected void verifyMetadataStores() {
+        Awaitility.await().untilAsserted(() -> {
+            // Verify: config metadata store url is the same as local metadata store url.
+            assertFalse(pulsar1.getConfig().isConfigurationStoreSeparated());
+            assertFalse(pulsar2.getConfig().isConfigurationStoreSeparated());
+            // Verify: Pulsar initialized itself to update the metadata synchronizer dynamically.
+            assertTrue(pulsar1.hasConditionOfDynamicUpdateConf("configurationMetadataSyncEventTopic")
+                    .getLeft());
+            assertTrue(pulsar2.hasConditionOfDynamicUpdateConf("configurationMetadataSyncEventTopic")
+                    .getLeft());
+            assertTrue(pulsar1.hasConditionOfDynamicUpdateConf("metadataSyncEventTopic")
+                    .getLeft());
+            assertTrue(pulsar2.hasConditionOfDynamicUpdateConf("metadataSyncEventTopic")
+                    .getLeft());
+        });
+    }
+
+    @Test
+    public void testDynamicEnableConfigurationMetadataSyncEventTopic() throws Exception {
+        super.testDynamicEnableConfigurationMetadataSyncEventTopic();
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SyncConfigStore2ZKPerClusterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SyncConfigStore2ZKPerClusterTest.java
@@ -72,7 +72,7 @@ public class SyncConfigStore2ZKPerClusterTest extends GeoReplicationWithConfigur
     protected void setConfigDefaults(ServiceConfiguration config, String clusterName,
                                      LocalBookkeeperEnsemble bookkeeperEnsemble, ZookeeperServerTest brokerConfigZk) {
         super.setConfigDefaults(config, clusterName, bookkeeperEnsemble, brokerConfigZk);
-        config.setMayEnableMetadataSynchronizer(true);
+        config.setForceUseSeparatedConfigurationStoreInMemory(true);
     }
 
     protected void verifyMetadataStores() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SyncConfigStore2ZKPerClusterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SyncConfigStore2ZKPerClusterTest.java
@@ -24,6 +24,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import lombok.extern.slf4j.Slf4j;
@@ -44,10 +45,10 @@ import org.testng.annotations.Test;
 
 @Slf4j
 @Test(groups = "broker")
-public class SyncConfigStoreTest extends GeoReplicationWithConfigurationSyncTestBase {
+public class SyncConfigStore2ZKPerClusterTest extends GeoReplicationWithConfigurationSyncTestBase {
 
-    private static final String CONF_NAME_SYNC_EVENT_TOPIC = "configurationMetadataSyncEventTopic";
-    private static final String SYNC_EVENT_TOPIC = TopicDomain.persistent.value() + "://" + SYSTEM_NAMESPACE
+    protected static final String CONF_NAME_SYNC_EVENT_TOPIC = "configurationMetadataSyncEventTopic";
+    protected static final String SYNC_EVENT_TOPIC = TopicDomain.persistent.value() + "://" + SYSTEM_NAMESPACE
             + "/__sync_config_meta";
 
     @Override
@@ -58,6 +59,7 @@ public class SyncConfigStoreTest extends GeoReplicationWithConfigurationSyncTest
         tenantInfo.setAllowedClusters(new HashSet<>(Arrays.asList(cluster1, cluster2)));
         admin1.tenants().createTenant(TopicName.get(SYNC_EVENT_TOPIC).getTenant(), tenantInfo);
         admin1.namespaces().createNamespace(TopicName.get(SYNC_EVENT_TOPIC).getNamespace());
+        verifyMetadataStores();
     }
 
     @Override
@@ -66,23 +68,35 @@ public class SyncConfigStoreTest extends GeoReplicationWithConfigurationSyncTest
         super.cleanup();
     }
 
+    @Override
     protected void setConfigDefaults(ServiceConfiguration config, String clusterName,
                                      LocalBookkeeperEnsemble bookkeeperEnsemble, ZookeeperServerTest brokerConfigZk) {
         super.setConfigDefaults(config, clusterName, bookkeeperEnsemble, brokerConfigZk);
+        config.setMayEnableMetadataSynchronizer(true);
+    }
+
+    protected void verifyMetadataStores() {
+        Awaitility.await().untilAsserted(() -> {
+            // Verify: config metadata store url is not the same as local metadata store url.
+            assertTrue(pulsar1.getConfig().isConfigurationStoreSeparated());
+            assertTrue(pulsar2.getConfig().isConfigurationStoreSeparated());
+            // Verify: Pulsar initialized itself to update the metadata synchronizer dynamically.
+            assertTrue(pulsar1.hasConditionOfDynamicUpdateConf("configurationMetadataSyncEventTopic")
+                    .getLeft());
+            assertTrue(pulsar2.hasConditionOfDynamicUpdateConf("configurationMetadataSyncEventTopic")
+                    .getLeft());
+            assertTrue(pulsar1.hasConditionOfDynamicUpdateConf("metadataSyncEventTopic")
+                    .getLeft());
+            assertTrue(pulsar2.hasConditionOfDynamicUpdateConf("metadataSyncEventTopic")
+                    .getLeft());
+        });
     }
 
     @Test
     public void testDynamicEnableConfigurationMetadataSyncEventTopic() throws Exception {
-        // Verify the condition that supports synchronizer: the metadata store is a different one.
-        Awaitility.await().untilAsserted(() -> {
-            boolean shouldShutdownConfigurationMetadataStore =
-                    WhiteboxImpl.getInternalState(pulsar1, "shouldShutdownConfigurationMetadataStore");
-            assertTrue(shouldShutdownConfigurationMetadataStore);
-        });
-
         // Verify the synchronizer will be created dynamically.
         admin1.brokers().updateDynamicConfiguration(CONF_NAME_SYNC_EVENT_TOPIC, SYNC_EVENT_TOPIC);
-        Awaitility.await().untilAsserted(() -> {
+        Awaitility.await().atMost(Duration.ofSeconds(3600)).untilAsserted(() -> {
             assertEquals(pulsar1.getConfig().getConfigurationMetadataSyncEventTopic(), SYNC_EVENT_TOPIC);
             PulsarMetadataEventSynchronizer synchronizer =
                     WhiteboxImpl.getInternalState(pulsar1, "configMetadataSynchronizer");
@@ -100,7 +114,7 @@ public class SyncConfigStoreTest extends GeoReplicationWithConfigurationSyncTest
 
         // Verify the synchronizer will be closed dynamically.
         admin1.brokers().deleteDynamicConfiguration(CONF_NAME_SYNC_EVENT_TOPIC);
-        Awaitility.await().untilAsserted(() -> {
+        Awaitility.await().atMost(Duration.ofSeconds(3600)).untilAsserted(() -> {
             // The synchronizer that was started will be closed.
             assertEquals(synchronizerStarted.getState(), PulsarMetadataEventSynchronizer.State.Closed);
             assertTrue(synchronizerStarted.isClosingOrClosed());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SyncConfigStoreWrongConfigTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SyncConfigStoreWrongConfigTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
+import org.apache.pulsar.zookeeper.ZookeeperServerTest;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/***
+ * The test is used to test update the dynamic metadata store synchronizer will fail if the broker has not initialized
+ * itself to support yet.
+ */
+@Slf4j
+@Test(groups = "broker")
+public class SyncConfigStoreWrongConfigTest extends SyncConfigStore1ZKPerClusterTest {
+
+    @Override
+    @BeforeClass(alwaysRun = true, timeOut = 300000)
+    public void setup() throws Exception {
+        super.setup();
+    }
+
+    @Override
+    @AfterClass(alwaysRun = true, timeOut = 300000)
+    public void cleanup() throws Exception {
+        super.cleanup();
+    }
+
+    @Override
+    protected void setConfigDefaults(ServiceConfiguration config, String clusterName,
+                                     LocalBookkeeperEnsemble bookkeeperEnsemble, ZookeeperServerTest brokerConfigZk) {
+        super.setConfigDefaults(config, clusterName, bookkeeperEnsemble, brokerConfigZk);
+        config.setMayEnableMetadataSynchronizer(false);
+    }
+
+    @Override
+    protected void verifyMetadataStores() {
+        Awaitility.await().untilAsserted(() -> {
+            // Verify: config metadata store url is the same as local metadata store url.
+            assertFalse(pulsar1.getConfig().isConfigurationStoreSeparated());
+            assertFalse(pulsar2.getConfig().isConfigurationStoreSeparated());
+            // Verify: Pulsar has not initialized itself to update the metadata synchronizer dynamically yet.
+            assertFalse(pulsar1.hasConditionOfDynamicUpdateConf("configurationMetadataSyncEventTopic")
+                    .getLeft());
+            assertFalse(pulsar2.hasConditionOfDynamicUpdateConf("configurationMetadataSyncEventTopic")
+                    .getLeft());
+            assertFalse(pulsar1.hasConditionOfDynamicUpdateConf("metadataSyncEventTopic")
+                    .getLeft());
+            assertFalse(pulsar2.hasConditionOfDynamicUpdateConf("metadataSyncEventTopic")
+                    .getLeft());
+        });
+    }
+
+    @Test
+    public void testDynamicEnableConfigurationMetadataSyncEventTopic() throws Exception {
+        // 1. update configurationMetadataSyncEventTopic.
+        try {
+            admin1.brokers().updateDynamicConfiguration("configurationMetadataSyncEventTopic", "123");
+            fail("Expected an 400 error.");
+        } catch (Exception ex) {
+            assertTrue(ex.getMessage().contains("please enable mayEnableMetadataSynchronizer"));
+        }
+        // 2. update metadataSyncEventTopic.
+        try {
+            admin1.brokers().updateDynamicConfiguration("metadataSyncEventTopic", "123");
+            fail("Expected an 400 error.");
+        } catch (Exception ex) {
+            assertTrue(ex.getMessage().contains("please enable mayEnableMetadataSynchronizer"));
+        }
+        // 3. delete configurationMetadataSyncEventTopic.
+        try {
+            admin1.brokers().deleteDynamicConfiguration("configurationMetadataSyncEventTopic");
+            fail("Expected an 400 error.");
+        } catch (Exception ex) {
+            assertTrue(ex.getMessage().contains("please enable mayEnableMetadataSynchronizer"));
+        }
+        // 4. delete metadataSyncEventTopic.
+        try {
+            admin1.brokers().deleteDynamicConfiguration("metadataSyncEventTopic");
+            fail("Expected an 400 error.");
+        } catch (Exception ex) {
+            assertTrue(ex.getMessage().contains("please enable mayEnableMetadataSynchronizer"));
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SyncConfigStoreWrongConfigTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SyncConfigStoreWrongConfigTest.java
@@ -54,7 +54,7 @@ public class SyncConfigStoreWrongConfigTest extends SyncConfigStore1ZKPerCluster
     protected void setConfigDefaults(ServiceConfiguration config, String clusterName,
                                      LocalBookkeeperEnsemble bookkeeperEnsemble, ZookeeperServerTest brokerConfigZk) {
         super.setConfigDefaults(config, clusterName, bookkeeperEnsemble, brokerConfigZk);
-        config.setMayEnableMetadataSynchronizer(false);
+        config.setForceUseSeparatedConfigurationStoreInMemory(false);
     }
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/zookeeper/ZookeeperServerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/zookeeper/ZookeeperServerTest.java
@@ -22,6 +22,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import lombok.Getter;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.slf4j.Logger;
@@ -29,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 public class ZookeeperServerTest implements Closeable {
     private final File zkTmpDir;
+    @Getter
     private ZooKeeperServer zks;
     private NIOServerCnxnFactory serverFactory;
     private int zkPort;


### PR DESCRIPTION
### Motivation

**Background**: 

- [PIP-136: Sync Pulsar policies across multiple clouds](https://github.com/apache/pulsar/pull/16425) defines two topics below:
  - `metadataSyncEventTopic`: monitors local metadata store changes
  - `configurationMetadataSyncEventTopic `: monitors local metadata store changes

- Local metadata store and Configuration metadata store share the same object in memory when their URLs are the same.

**Issue 1**

Since the event synchronizer is bound to the `metadata store` object in memory, the synchronizer receives all the events about the Local metadata store and Configuration metadata store when the two metadata stores are the same object in memory, the data in the two topics got mixed up.

**Issue 2**
The internal producer of the synchronizer relies on the `SyncEventTopic`; this topic relies on the namespace local policies; the operation of writing namespace local policies to ZK relies on the internal producer. A deadlock occurs. See the following flow:
- Try to start the internal producer of the synchronizer.
- Try to load the topic named `metadataSyncEventTopic` up.
- Try to write data to the Local Metadata Store.
- Try to send events to `metadataSyncEventTopic` before writing data to the Local Metadata Store.
- The internal producer is starting now.
- Stuck.....

You can reproduce this issue by the test `SyncConfigStore1ZKPerClusterTest. testDynamicEnableConfigurationMetadataSyncEventTopic`. This PR fixed the issue that the synchronizer got stuck due to two metadata stores relying on it. I will write a separate PR that skips syncing data that relies on the synchronizer itself.


### Modifications
- Create a separate configuration metadata store if users want to enable Metadata Synchronizer, even if the URL of the configuration metadata store is the same as the local metadata store.
- Correct the behavior: `metadataSyncEventTopic` only receives the event about the local metadata store and `configurationMetadataSyncEventTopic` only receives the event about the configuration metadata store.
- If the Broker has initialized itself with one metadata store, reject the dynamic config changes.
- Add an optional choice `mayEnableMetadataSynchronizer` to let the Broker initialize itself with a separate configuration metadata store.

### Next PRs
Skip to sync events that rely on the synchronizer itself. For example: 
- `metadataSyncEventTopic` is `public/default/tp`
- **(Highlight)** Do not sync the events related to the topic `public/default/tp`, because the synchronizer relies on this topic 😂 , I will send a discussion for this change. See more details the Issue 2 in the section Motivation.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
