### PR TITLE
[fix][client] Fix MessageIdUtils cannot handle TopicMessageId

### DIFF
--- a/pulsar-client/src/test/java/org/apache/pulsar/client/util/MessageIdUtilsTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/util/MessageIdUtilsTest.java
@@ -18,28 +18,17 @@
  */
 package org.apache.pulsar.client.util;
 
-import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.MessageIdAdv;
+import static org.testng.Assert.assertEquals;
 import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.client.impl.TopicMessageIdImpl;
+import org.testng.annotations.Test;
 
-public class MessageIdUtils {
-    public static final long getOffset(MessageId messageId) {
-        MessageIdAdv msgId = (MessageIdAdv) messageId;
-        long ledgerId = msgId.getLedgerId();
-        long entryId = msgId.getEntryId();
-
-        // Combine ledger id and entry id to form offset
-        // Use less than 32 bits to represent entry id since it will get
-        // rolled over way before overflowing the max int range
-        long offset = (ledgerId << 28) | entryId;
-        return offset;
-    }
-
-    public static final MessageId getMessageId(long offset) {
-        // Demultiplex ledgerId and entryId from offset
-        long ledgerId = offset >>> 28;
-        long entryId = offset & 0x0F_FF_FF_FFL;
-
-        return new MessageIdImpl(ledgerId, entryId, -1);
+public class MessageIdUtilsTest {
+    @Test
+    public void testTopicMessageIdGetOffset() {
+        MessageIdImpl msgId = new MessageIdImpl(1, 2, 3);
+        TopicMessageIdImpl topicMsgId = new TopicMessageIdImpl("topic", msgId);
+        long offset = MessageIdUtils.getOffset(topicMsgId);
+        assertEquals(offset, 268435458L);
     }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


### Motivation

[PIP-229](https://github.com/apache/pulsar/pull/19414) introduces an interface change for the messageId which break the behavior in and after Pulsar 3.0.

This leads to the `MessageIdUtils` not be able to handle the `TopicMessageId`. It will throw error like:
```
java.lang.ClassCastException: class org.apache.pulsar.client.impl.TopicMessageIdImpl cannot be cast to class org.apache.pulsar.client.impl.MessageIdImpl (org.apache.pulsar.client.impl.TopicMessageIdImpl and org.apache.pulsar.client.impl.MessageIdImpl are in unnamed module of loader 'app')

	at org.apache.pulsar.client.util.MessageIdUtils.getOffset(MessageIdUtils.java:27)
...
```

### Modifications

- Use MessageIdAdv to convert the MessageId to offset

### Verifying this change

This change added tests.
### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
