### PR TITLE
[improve][build] Support custom image and label names

### DIFF
--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -150,17 +150,17 @@
                 <configuration>
                   <images>
                     <image>
-                      <name>${docker.organization}/pulsar-all</name>
+                      <name>${docker.organization}/${docker.image}-all</name>
                       <build>
                         <contextDir>${project.basedir}</contextDir>
                         <tags>
-                          <tag>latest</tag>
+                          <tag>${docker.tag}</tag>
                           <tag>${project.version}-${git.commit.id.abbrev}</tag>
                         </tags>
                         <args>
                           <PULSAR_IO_DIR>target/apache-pulsar-io-connectors-${project.version}-bin</PULSAR_IO_DIR>
                           <PULSAR_OFFLOADER_TARBALL>target/pulsar-offloader-distribution-${project.version}-bin.tar.gz</PULSAR_OFFLOADER_TARBALL>
-                          <PULSAR_IMAGE>${docker.organization}/pulsar:${project.version}-${git.commit.id.abbrev}</PULSAR_IMAGE>
+                          <PULSAR_IMAGE>${docker.organization}/${docker.image}:${project.version}-${git.commit.id.abbrev}</PULSAR_IMAGE>
                         </args>
                         <buildx>
                           <platforms>

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -77,7 +77,7 @@
                 <configuration>
                   <images>
                     <image>
-                      <name>${docker.organization}/pulsar</name>
+                      <name>${docker.organization}/${docker.image}</name>
                       <build>
                         <args>
                           <PULSAR_TARBALL>target/pulsar-server-distribution-${project.version}-bin.tar.gz</PULSAR_TARBALL>
@@ -85,7 +85,7 @@
                         </args>
                         <contextDir>${project.basedir}</contextDir>
                         <tags>
-                          <tag>latest</tag>
+                          <tag>${docker.tag}</tag>
                           <tag>${project.version}-${git.commit.id.abbrev}</tag>
                         </tags>
                         <buildx>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,8 @@ flexible messaging model and an intuitive client API.</description>
     <testHeapDumpPath>/tmp</testHeapDumpPath>
     <surefire.shutdown>kill</surefire.shutdown>
     <docker.organization>apachepulsar</docker.organization>
+    <docker.image>pulsar</docker.image>
+    <docker.tag>latest</docker.tag>
     <skipSourceReleaseAssembly>false</skipSourceReleaseAssembly>
     <skipBuildDistribution>false</skipBuildDistribution>
     <shadePluginPhase>package</shadePluginPhase>

--- a/tests/docker-images/java-test-image/pom.xml
+++ b/tests/docker-images/java-test-image/pom.xml
@@ -151,11 +151,11 @@
                       <name>${docker.organization}/java-test-image</name>
                       <build>
                         <args>
-                          <PULSAR_IMAGE>${docker.organization}/pulsar:${project.version}-${git.commit.id.abbrev}</PULSAR_IMAGE>
+                          <PULSAR_IMAGE>${docker.organization}/${docker.image}:${project.version}-${git.commit.id.abbrev}</PULSAR_IMAGE>
                         </args>
                         <contextDir>${project.basedir}</contextDir>
                         <tags>
-                          <tag>latest</tag>
+                          <tag>${docker.tag}</tag>
                           <tag>${project.version}</tag>
                         </tags>
                         <noCache>true</noCache>

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -18,6 +18,7 @@
 #
 
 # build go lang examples first in a separate layer
+ARG PULSAR_ALL_IMAGE
 
 FROM golang:1.21-alpine as pulsar-function-go
 
@@ -27,7 +28,6 @@ RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go/pf && go install
 RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go/examples && go install ./...
 
 # Reference pulsar-all to copy connectors from there
-ARG PULSAR_ALL_IMAGE
 FROM $PULSAR_ALL_IMAGE as pulsar-all
 
 ########################################

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -19,6 +19,7 @@
 
 # build go lang examples first in a separate layer
 ARG PULSAR_ALL_IMAGE
+ARG PULSAR_IMAGE
 
 FROM golang:1.21-alpine as pulsar-function-go
 
@@ -33,7 +34,6 @@ FROM $PULSAR_ALL_IMAGE as pulsar-all
 ########################################
 ###### Main image build
 ########################################
-ARG PULSAR_IMAGE
 FROM $PULSAR_IMAGE
 
 # Switch to run as the root user to simplify building container and then running

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -27,12 +27,14 @@ RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go/pf && go install
 RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go/examples && go install ./...
 
 # Reference pulsar-all to copy connectors from there
-FROM apachepulsar/pulsar-all:latest as pulsar-all
+ARG PULSAR_ALL_IMAGE
+FROM $PULSAR_ALL_IMAGE as pulsar-all
 
 ########################################
 ###### Main image build
 ########################################
-FROM apachepulsar/pulsar:latest
+ARG PULSAR_IMAGE
+FROM $PULSAR_IMAGE
 
 # Switch to run as the root user to simplify building container and then running
 # supervisord. Each of the pulsar components are spawned by supervisord and their

--- a/tests/docker-images/latest-version-image/pom.xml
+++ b/tests/docker-images/latest-version-image/pom.xml
@@ -152,7 +152,7 @@
                 <configuration>
                   <images>
                     <image>
-                      <name>${docker.organization}/${docker.tag}-test-latest-version</name>
+                      <name>${docker.organization}/${docker.image}-test-latest-version</name>
                       <build>
                         <contextDir>${project.basedir}</contextDir>
                         <args>

--- a/tests/docker-images/latest-version-image/pom.xml
+++ b/tests/docker-images/latest-version-image/pom.xml
@@ -152,11 +152,15 @@
                 <configuration>
                   <images>
                     <image>
-                      <name>${docker.organization}/pulsar-test-latest-version</name>
+                      <name>${docker.organization}/${docker.tag}-test-latest-version</name>
                       <build>
                         <contextDir>${project.basedir}</contextDir>
+                        <args>
+                          <PULSAR_IMAGE>${docker.organization}/${docker.image}:${project.version}-${git.commit.id.abbrev}</PULSAR_IMAGE>
+                          <PULSAR_ALL_IMAGE>${docker.organization}/${docker.image}-all:${project.version}-${git.commit.id.abbrev}</PULSAR_ALL_IMAGE>
+                        </args>
                         <tags>
-                          <tag>latest</tag>
+                          <tag>${docker.tag}</tag>
                           <tag>${project.version}</tag>
                         </tags>
                         <noCache>true</noCache>


### PR DESCRIPTION
### Motivation

When pushing pulsar and pulsar-all to a custom repository, I don't want to use the original name. If we can support custom image and label names, it will reduce the workload of copying.

### Modifications

- Add `docker.image` property to define the image name, default to `pulsar`
- Add `docker.tag` property to define the tag name, default to `latest`
- Apply `docker.image` and `docker.tag` to the pulsar, pulsar-all, java-test-image, latest-version-image

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->