### PR TITLE
[improve] [broker] [break change] Do not create partitioned DLQ/Retry topic automatically

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -24,6 +24,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.bookkeeper.mledger.ManagedLedgerConfig.PROPERTY_SOURCE_TOPIC_KEY;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.pulsar.client.util.RetryMessageUtil.DLQ_GROUP_TOPIC_SUFFIX;
+import static org.apache.pulsar.client.util.RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX;
 import static org.apache.pulsar.common.naming.SystemTopicNames.isTransactionInternalName;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Queues;
@@ -3493,6 +3495,10 @@ public class BrokerService implements Closeable {
     }
 
     public boolean isDefaultTopicTypePartitioned(final TopicName topicName, final Optional<Policies> policies) {
+        if (topicName.getPartitionedTopicName().endsWith(DLQ_GROUP_TOPIC_SUFFIX)
+                || topicName.getPartitionedTopicName().endsWith(RETRY_GROUP_TOPIC_SUFFIX)) {
+            return false;
+        }
         AutoTopicCreationOverride autoTopicCreationOverride = getAutoTopicCreationOverride(topicName, policies);
         if (autoTopicCreationOverride != null) {
             return TopicType.PARTITIONED.toString().equals(autoTopicCreationOverride.getTopicType());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicDefaultMultiPartitionsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicDefaultMultiPartitionsTest.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import static org.apache.pulsar.client.util.RetryMessageUtil.DLQ_GROUP_TOPIC_SUFFIX;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.TopicType;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker-impl")
+public class DeadLetterTopicDefaultMultiPartitionsTest extends ProducerConsumerBase {
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        this.conf.setMaxMessageSize(5 * 1024);
+        this.conf.setAllowAutoTopicCreation(true);
+        this.conf.setDefaultNumPartitions(2);
+        this.conf.setAllowAutoTopicCreationType(TopicType.PARTITIONED);
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    private void triggerDLQGenerate(String topic, String subscription) throws Exception {
+        String DLQ = getDLQName(topic, subscription);
+        String p0OfDLQ = TopicName.get(DLQ).getPartition(0).toString();
+        Consumer consumer = pulsarClient.newConsumer().topic(topic).subscriptionName(subscription)
+                .ackTimeout(1000, TimeUnit.MILLISECONDS)
+                .subscriptionType(SubscriptionType.Shared)
+                .receiverQueueSize(10)
+                .negativeAckRedeliveryDelay(100, TimeUnit.MILLISECONDS)
+                .deadLetterPolicy(DeadLetterPolicy.builder().maxRedeliverCount(1).build())
+                .subscribe();
+        Producer producer = pulsarClient.newProducer().topic(topic).create();
+        producer.newMessage().value(new byte[]{1}).send();
+
+        Message<Integer> message1 = consumer.receive();
+        consumer.negativeAcknowledge(message1);
+        Message<Integer> message2 = consumer.receive();
+        consumer.negativeAcknowledge(message2);
+
+        Awaitility.await().atMost(Duration.ofSeconds(30)).untilAsserted(() -> {
+            List<String> topicList = pulsar.getPulsarResources().getTopicResources()
+                    .listPersistentTopicsAsync(TopicName.get(topic).getNamespaceObject()).join();
+            assertTrue(topicList.contains(DLQ) || topicList.contains(p0OfDLQ));
+        });
+        admin.topics().unload(topic);
+    }
+
+    private static String getDLQName(String primaryTopic, String subscription) {
+        String domain = TopicName.get(primaryTopic).getDomain().toString();
+        return domain + "://" + TopicName.get(primaryTopic)
+                .toString().substring(( domain + "://").length())
+                + "-" + subscription + DLQ_GROUP_TOPIC_SUFFIX;
+    }
+
+    @Test
+    public void testGenerateNonPartitionedDLQ() throws Exception {
+        final String topic = BrokerTestUtil.newUniqueName( "persistent://public/default/tp");
+        final String subscription = "s1";
+        admin.topics().createNonPartitionedTopic(topic);
+
+        triggerDLQGenerate(topic, "s1");
+        String DLQ = getDLQName(topic, subscription);
+        String p0OfDLQ = TopicName.get(DLQ).getPartition(0).toString();
+
+        // Verify: no partitioned DLQ.
+        List<String> partitionedTopics = pulsar.getPulsarResources().getNamespaceResources()
+                .getPartitionedTopicResources()
+                .listPartitionedTopicsAsync(TopicName.get(topic).getNamespaceObject(), TopicDomain.persistent).join();
+        assertFalse(partitionedTopics.contains(DLQ));
+        assertFalse(partitionedTopics.contains(p0OfDLQ));
+        // Verify: non-partitioned DLQ exists.
+        List<String> partitions = pulsar.getPulsarResources().getTopicResources()
+                .listPersistentTopicsAsync(TopicName.get(topic).getNamespaceObject()).join();
+        assertTrue(partitions.contains(DLQ));
+        assertFalse(partitions.contains(p0OfDLQ));
+
+        // cleanup.
+        admin.topics().delete(topic, false);
+    }
+
+    @Test
+    public void testManuallyCreatePartitionedDLQ() throws Exception {
+        final String topic = BrokerTestUtil.newUniqueName( "persistent://public/default/tp");
+        final String subscription = "s1";
+        String DLQ = getDLQName(topic, subscription);
+        String p0OfDLQ = TopicName.get(DLQ).getPartition(0).toString();
+        String p1OfDLQ = TopicName.get(DLQ).getPartition(1).toString();
+        admin.topics().createNonPartitionedTopic(topic);
+        admin.topics().createPartitionedTopic(DLQ, 2);
+
+        Awaitility.await().untilAsserted(() -> {
+            // Verify: partitioned DLQ exists.
+            List<String> partitionedTopics = pulsar.getPulsarResources().getNamespaceResources()
+                    .getPartitionedTopicResources()
+                    .listPartitionedTopicsAsync(TopicName.get(topic).getNamespaceObject(), TopicDomain.persistent).join();
+            assertTrue(partitionedTopics.contains(DLQ));
+            assertFalse(partitionedTopics.contains(p0OfDLQ));
+            // Verify: DLQ partitions exists.
+            List<String> partitions = pulsar.getPulsarResources().getTopicResources()
+                    .listPersistentTopicsAsync(TopicName.get(topic).getNamespaceObject()).join();
+            assertFalse(partitions.contains(DLQ));
+            assertTrue(partitions.contains(p0OfDLQ));
+            assertTrue(partitions.contains(p1OfDLQ));
+        });
+
+        // cleanup.
+        admin.topics().delete(topic, false);
+        admin.topics().deletePartitionedTopic(DLQ, false);
+    }
+
+    @Test
+    public void testManuallyCreatePartitionedDLQ2() throws Exception {
+        final String topic = BrokerTestUtil.newUniqueName( "persistent://public/default/tp");
+        final String subscription = "s1";
+        final String p0OfTopic = TopicName.get(topic).getPartition(0).toString();
+        String DLQ = getDLQName(p0OfTopic, subscription);
+        String p0OfDLQ = TopicName.get(DLQ).getPartition(0).toString();
+        admin.topics().createPartitionedTopic(topic, 10);
+        try {
+            admin.topics().createPartitionedTopic(DLQ, 2);
+        } catch (Exception ex) {
+            // Keep multiple versions compatible.
+            if (ex.getMessage().contains("Partitioned Topic Name should not contain '-partition-'")){
+                return;
+            } else {
+                fail("Failed to create partitioned DLQ");
+            }
+        }
+
+        Awaitility.await().untilAsserted(() -> {
+            // Verify: partitioned DLQ exists.
+            List<String> partitionedTopics = pulsar.getPulsarResources().getNamespaceResources()
+                    .getPartitionedTopicResources()
+                    .listPartitionedTopicsAsync(TopicName.get(topic).getNamespaceObject(), TopicDomain.persistent).join();
+            assertTrue(partitionedTopics.contains(DLQ));
+            assertFalse(partitionedTopics.contains(p0OfDLQ));
+            // Verify: DLQ partitions exists.
+            List<String> partitions = pulsar.getPulsarResources().getTopicResources()
+                    .listPersistentTopicsAsync(TopicName.get(topic).getNamespaceObject()).join();
+            assertFalse(partitions.contains(DLQ));
+        });
+
+        // cleanup.
+        admin.topics().deletePartitionedTopic(topic, false);
+        admin.topics().deletePartitionedTopic(DLQ, false);
+    }
+}


### PR DESCRIPTION
Discussion: https://lists.apache.org/thread/t756oy8881vqf9fz2zzgk3y04zsyykbh

### Motivation

After you set `defaultNumPartitions` to `16`, you will get `16` partitions per topic, and `16*16` DLQ partitions per subscription, you will get a huge number of DLQs if you have more than one subscription under one topic.  For example: 
- create topic `t1` with `16` partitions
- you will get `t1-partition-0`, `t1-partition-1`...`tp-partition-15`.
- after you enable DLQ, you will get the following `16*16` DLQs per subscription
  - `t1-partition-0-{subscription}-DLQ-partition-0`
  - `t1-partition-0-{subscription}-DLQ-partition-1`
  - ...
  - `t1-partition-15-{subscription}-DLQ-partition-15`
  - `t1-partition-1-{subscription}-DLQ-partition-0`
  - `t1-partition-1-{subscription}-DLQ-partition-1`
  - ...
  - ...
  - ...
  - `t1-partition-15-{subscription}-partition-15`

### Issue both partitioned DLQ and non-partitioned DLQ were created automatically.

- Background
  - Broker settings: `{allowAutoTopicCreation=true, defaultNumPartitions=1, allowAutoTopicCreationType=partitioned}`
  - client version `< 3.1`
- Flows of creating DLQ.
  - Trigger the DLQ creation.
  - Get partitioned metadata of DLQ: `partitions: 1`.
    - Broker created the partitioned metadata at this step. 
  - Before `3.1`, the client mistakenly assumed `{tenant}/{namespace}/{topic}-partition-0-{subscription}-DLQ-partition-0` is `{tenant}/{namespace}/{topic}-partition-0-{subscription}-DLQ` due to the bug that was fixed by https://github.com/apache/pulsar/pull/19841.
  - Start a dead-letter producer under `{tenant}/{namespace}/{topic}-partition-0-{subscription}-DLQ`
    - Triggered a non-partitioned topic creation.

Eventually, you will get both partitioned and non-partitioned DLQ.
```
> bin/pulsar-admin topics list-partitioned-topics {tenant}/{namespace}
persistent://{tenant}/{namespace}/{topic}-partition-0-{subscription}-DLQ

> bin/pulsar-admin topics list {tenant}/{namespace}                  
persistent://{tenant}/{namespace}/{topic}-partition-0-{subscription}-DLQ
``` 

### Modifications
- Do not create partitioned DLQs/Retry topics automatically.
- Users can also create partitioned DLQ manually if they need it.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
