### PR TITLE
[fix][test] Fix flaky AuthorizationTest.testGetListWithGetBundleOp

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.auth;
 
-import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
@@ -322,7 +322,6 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
                         : brokerUrlTls.toString())
                 .authentication(new MockAuthentication("pass.pass2"))
                 .build();
-        when(pulsar.getAdminClient()).thenReturn(admin2);
         Assert.assertEquals(admin2.topics().getList(namespaceV1, TopicDomain.non_persistent).size(), 0);
         Assert.assertEquals(admin2.topics().getList(namespaceV2, TopicDomain.non_persistent).size(), 0);
     }


### PR DESCRIPTION
Fixes #22712 

### Motivation

AuthorizationTest.testGetListWithGetBundleOp is flaky.

### Modifications

Remove unnecessary call which causes issues, see #22712 for stack trace. [Mockito isn't thread safe](https://github.com/mockito/mockito/wiki/FAQ#is-mockito-thread-safe). The removed line seems unnecessary in the test since the test passes without it.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->