### PR TITLE
[fix] [broker] fix subscribe a non-existent cluster/namespace/topic.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -486,6 +486,7 @@ public abstract class AdminResource extends PulsarWebResource {
         return validateTopicOperationAsync(topicName, TopicOperation.LOOKUP)
                 .thenCompose(__ -> validateClusterOwnershipAsync(topicName.getCluster()))
                 .thenCompose(__ -> validateGlobalNamespaceOwnershipAsync(topicName.getNamespaceObject()))
+                .thenCompose(__ -> validateNamespaceExists(topicName.getNamespaceObject()))
                 .thenCompose(__ -> {
                     if (checkAllowAutoCreation) {
                         return pulsar().getBrokerService()
@@ -503,6 +504,18 @@ public abstract class AdminResource extends PulsarWebResource {
             }
         } catch (Exception e) {
             throw new RestException(e);
+        }
+    }
+
+    protected CompletableFuture<Void> validateNamespaceExists(NamespaceName namespace) {
+        try {
+            if (namespaceResources().namespaceExists(namespace)) {
+                return CompletableFuture.completedFuture(null);
+            } else {
+                return FutureUtil.failedFuture(new RestException(Status.NOT_FOUND, "Namespace does not exist"));
+            }
+        } catch (Exception e) {
+            return FutureUtil.failedFuture(e);
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
@@ -74,6 +74,7 @@ import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Slf4j
@@ -267,6 +268,29 @@ public class ConsumerStatsTest extends ProducerConsumerBase {
         }
 
         consumer.close();
+    }
+
+    @DataProvider(name = "topicName")
+    public static Object[][] topicName() {
+        return new Object[][]{
+                {"persistent://prop/use/ns-abc/testNonExistNamespace"},
+                {"persistent://prop/ns-abc/testNonExistNamespace"}
+        };
+    }
+
+    @Test(dataProvider = "topicName")
+    public void testNonExistNamespace(String topicName) throws Exception {
+        final String subName = "my-subscription";
+        try {
+            Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                    .topic(topicName)
+                    .subscriptionType(SubscriptionType.Shared)
+                    .subscriptionName(subName)
+                    .subscribe();
+            Assert.fail("should have failed");
+        } catch (Exception e) {
+            // ok
+        }
     }
 
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
@@ -246,7 +246,7 @@ public class ConsumerStatsTest extends ProducerConsumerBase {
                 "connectedSince",
                 "clientVersion");
 
-        final String topicName = "persistent://prop/use/ns-abc/testConsumerStatsOutput";
+        final String topicName = "persistent://my-property/my-ns/testConsumerStatsOutput";
         final String subName = "my-subscription";
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
@@ -270,20 +270,21 @@ public class ConsumerStatsTest extends ProducerConsumerBase {
         consumer.close();
     }
 
-    @DataProvider(name = "topicName")
-    public static Object[][] topicName() {
+    @DataProvider(name = "invalidTopicName")
+    public static Object[][] invalidTopicName() {
+        // some topic names in non-exist namespace
         return new Object[][]{
                 {"persistent://prop/use/ns-abc/testNonExistNamespace"},
                 {"persistent://prop/ns-abc/testNonExistNamespace"}
         };
     }
 
-    @Test(dataProvider = "topicName")
-    public void testNonExistNamespace(String topicName) throws Exception {
+    @Test(dataProvider = "invalidTopicName")
+    public void testNonExistNamespace(String invalidTopicName) throws Exception {
         final String subName = "my-subscription";
         try {
             Consumer<byte[]> consumer = pulsarClient.newConsumer()
-                    .topic(topicName)
+                    .topic(invalidTopicName)
                     .subscriptionType(SubscriptionType.Shared)
                     .subscriptionName(subName)
                     .subscribe();


### PR DESCRIPTION
### Motivation

If the topic name is in the format of V1, we can subscribe a topic in non-existent cluster/namespace without any exception.

### Modifications

Need to add check for such case.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/51
