### PR TITLE
[fix][build] Fix pulsar-client-python installation on ARM arch

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -48,28 +48,6 @@ RUN for SUBDIRECTORY in conf data download logs instances/deps packages-storage;
 RUN chmod -R g+rx /pulsar/bin
 RUN chmod -R o+rx /pulsar
 
-## Create 2nd stage to build the Python dependencies
-## Since it needs to have GCC available, we're doing it in a different layer
-FROM alpine:3.19 AS python-deps
-
-RUN apk add --no-cache \
-       bash \
-       python3-dev \
-       g++ \
-       musl-dev \
-       libffi-dev \
-       py3-pip \
-       py3-grpcio \
-       py3-yaml
-
-RUN pip3 install --break-system-packages \
-        kazoo
-
-ARG PULSAR_CLIENT_PYTHON_VERSION
-RUN pip3 install --break-system-packages \
-    pulsar-client[all]==${PULSAR_CLIENT_PYTHON_VERSION}
-
-
 ###  Create one stage to include JVM distribution
 FROM alpine AS jvm
 
@@ -96,6 +74,8 @@ RUN apk add --no-cache \
             bash \
             python3 \
             py3-pip \
+            py3-grpcio \
+            py3-yaml \
             gcompat \
             ca-certificates \
             procps \
@@ -104,6 +84,30 @@ RUN apk add --no-cache \
 # Fix CVE-2024-2511 by upgrading to OpenSSL 3.1.4-r6
 # We can remove once new Alpine image is released
 RUN apk upgrade --no-cache libssl3 libcrypto3
+
+# Python dependencies
+
+# The grpcio@1.59.3 is installed by apk, and Pulsar-client@3.4.0 requires grpcio>=1.60.0, which causes the grocio to be reinstalled by pip.
+# If pip cannot find the grpcio wheel that the doesn't match the OS, the grpcio will be compiled locally.
+# Once https://github.com/apache/pulsar-client-python/pull/211 is released, keep only the pulsar-client[all] and kazoo dependencies, and remove comments.
+ARG PULSAR_CLIENT_PYTHON_VERSION
+RUN echo -e "\
+#pulsar-client[all]==${PULSAR_CLIENT_PYTHON_VERSION}\n\
+pulsar-client==${PULSAR_CLIENT_PYTHON_VERSION}\n\
+# Zookeeper\n\
+kazoo\n\
+# functions\n\
+protobuf>=3.6.1,<=3.20.3\n\
+grpcio>=1.59.3\n\
+apache-bookkeeper-client>=4.16.1\n\
+prometheus_client\n\
+ratelimit\n\
+# avro\n\
+fastavro>=1.9.2\n\
+" > /requirements.txt
+
+RUN pip3 install --break-system-packages --no-cache-dir --only-binary grpcio -r /requirements.txt
+RUN rm /requirements.txt
 
 # Install GLibc compatibility library
 COPY --from=glibc /root/packages /root/packages
@@ -114,9 +118,6 @@ ENV JAVA_HOME=/opt/jvm
 
 # The default is /pulsat/bin and cannot be written.
 ENV PULSAR_PID_DIR=/pulsar/logs
-
-# Copy Python depedencies from the other stage
-COPY --from=python-deps /usr/lib/python3.11/site-packages /usr/lib/python3.11/site-packages
 
 ENV PULSAR_ROOT_LOGGER=INFO,CONSOLE
 


### PR DESCRIPTION
### Motivation

The grpcio@1.59.3 is installed by apk, and Pulsar-client@3.4.0 requires grpcio>=1.60.0, which causes the grpcio to be reinstalled by pip, but the grpcio doesn't provide the arm64 wheel, and then pip3 will take a long time to compile the grpcio locally, please see [job](https://github.com/nodece/pulsar-python-deps-build/actions/runs/8891459473/job/24418839959#step:6:315) for detailed compilation information.

Contexts:
- https://github.com/apache/pulsar/pull/22613
 - https://github.com/apache/pulsar-client-python/pull/211
 - https://lists.apache.org/thread/cknro58cty8xjpf8zsb2p02flw6wqs2h

### Modifications

- `pip install` with `--only-binary` option avoids compiling the grpcio locally, so the python-deps stage is unnecessary
- Use independent installation instead of pulsar-client[all]

### Verifying this change

Verified locally and works fine. After this PR has been merged, I will add a job to verify the multi-arch image.

```
Collecting pulsar-client==3.4.0 (from -r /requirements.txt (line 2))
  Downloading pulsar_client-3.4.0-cp311-cp311-musllinux_1_1_aarch64.whl.metadata (1.0 kB)
Collecting protobuf<=3.20.3,>=3.6.1 (from -r /requirements.txt (line 4))
  Downloading protobuf-3.20.3-py2.py3-none-any.whl.metadata (720 bytes)
Requirement already satisfied: grpcio>=1.59.3 in /usr/lib/python3.11/site-packages (from -r /requirements.txt (line 5)) (1.59.3)
Collecting apache-bookkeeper-client>=4.16.1 (from -r /requirements.txt (line 6))
  Downloading apache_bookkeeper_client-4.16.5-py2.py3-none-any.whl.metadata (2.1 kB)
Collecting prometheus_client (from -r /requirements.txt (line 7))
  Downloading prometheus_client-0.20.0-py3-none-any.whl.metadata (1.8 kB)
Collecting ratelimit (from -r /requirements.txt (line 8))
  Downloading ratelimit-2.2.1.tar.gz (5.3 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting fastavro>=1.9.2 (from -r /requirements.txt (line 10))
  Downloading fastavro-1.9.4-cp311-cp311-musllinux_1_1_aarch64.whl.metadata (5.5 kB)
Collecting certifi (from pulsar-client==3.4.0->-r /requirements.txt (line 2))
  Downloading certifi-2024.2.2-py3-none-any.whl.metadata (2.2 kB)
Requirement already satisfied: setuptools>=34.0.0 in /usr/lib/python3.11/site-packages (from apache-bookkeeper-client>=4.16.1->-r /requirements.txt (line 6)) (68.2.2)
Requirement already satisfied: six>=1.10.0 in /usr/lib/python3.11/site-packages (from apache-bookkeeper-client>=4.16.1->-r /requirements.txt (line 6)) (1.16.0)
Collecting pytz (from apache-bookkeeper-client>=4.16.1->-r /requirements.txt (line 6))
  Downloading pytz-2024.1-py2.py3-none-any.whl.metadata (22 kB)
Collecting pymmh3>=0.0.5 (from apache-bookkeeper-client>=4.16.1->-r /requirements.txt (line 6))
  Downloading pymmh3-0.0.5-py2.py3-none-any.whl.metadata (822 bytes)
Downloading pulsar_client-3.4.0-cp311-cp311-musllinux_1_1_aarch64.whl (5.7 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.7/5.7 MB 7.9 MB/s eta 0:00:00
Downloading protobuf-3.20.3-py2.py3-none-any.whl (162 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 162.1/162.1 kB 6.8 MB/s eta 0:00:00
Downloading apache_bookkeeper_client-4.16.5-py2.py3-none-any.whl (62 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 62.4/62.4 kB 4.0 MB/s eta 0:00:00
Downloading prometheus_client-0.20.0-py3-none-any.whl (54 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 54.5/54.5 kB 3.6 MB/s eta 0:00:00
Downloading fastavro-1.9.4-cp311-cp311-musllinux_1_1_aarch64.whl (3.3 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.3/3.3 MB 9.6 MB/s eta 0:00:00
Downloading pymmh3-0.0.5-py2.py3-none-any.whl (7.4 kB)
Downloading certifi-2024.2.2-py3-none-any.whl (163 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 163.8/163.8 kB 7.0 MB/s eta 0:00:00
Downloading pytz-2024.1-py2.py3-none-any.whl (505 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 505.5/505.5 kB 8.1 MB/s eta 0:00:00
Building wheels for collected packages: ratelimit
  Building wheel for ratelimit (pyproject.toml): started
  Building wheel for ratelimit (pyproject.toml): finished with status 'done'
  Created wheel for ratelimit: filename=ratelimit-2.2.1-py3-none-any.whl size=5894 sha256=a1a1765d8022acfe8ae03c938830b6f7832df995875cb5f57ad81b53e8ff8d9b
  Stored in directory: /root/.cache/pip/wheels/ee/d5/e5/8fbffe089140fb498987b7709becf861086daace105d243475
Successfully built ratelimit
Installing collected packages: ratelimit, pytz, pymmh3, protobuf, prometheus_client, fastavro, certifi, pulsar-client, apache-bookkeeper-client
Successfully installed apache-bookkeeper-client-4.16.5 certifi-2024.2.2 fastavro-1.9.4 prometheus_client-0.20.0 protobuf-3.20.3 pulsar-client-3.4.0 pymmh3-0.0.5 pytz-2024.1 ratelimit-2.2.1
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->