### PR TITLE
[improve][build] Remove invalid relativePath definitions in pom.xml files

### DIFF
--- a/bouncy-castle/bc/pom.xml
+++ b/bouncy-castle/bc/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>bouncy-castle-parent</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>bouncy-castle-bc</artifactId>

--- a/bouncy-castle/bcfips-include-test/pom.xml
+++ b/bouncy-castle/bcfips-include-test/pom.xml
@@ -25,7 +25,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>bouncy-castle-parent</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>bcfips-include-test</artifactId>

--- a/bouncy-castle/bcfips/pom.xml
+++ b/bouncy-castle/bcfips/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>bouncy-castle-parent</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>bouncy-castle-bcfips</artifactId>

--- a/bouncy-castle/pom.xml
+++ b/bouncy-castle/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <build>

--- a/distribution/io/pom.xml
+++ b/distribution/io/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>distribution</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-io-distribution</artifactId>

--- a/distribution/offloaders/pom.xml
+++ b/distribution/offloaders/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>distribution</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-offloader-distribution</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>distribution</artifactId>

--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>distribution</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-server-distribution</artifactId>

--- a/distribution/shell/pom.xml
+++ b/distribution/shell/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>distribution</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-shell-distribution</artifactId>

--- a/jclouds-shaded/pom.xml
+++ b/jclouds-shaded/pom.xml
@@ -27,7 +27,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>jclouds-shaded</artifactId>

--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>managed-ledger</artifactId>
@@ -147,7 +146,7 @@
           </execution>
         </executions>
       </plugin>
-      
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>microbench</artifactId>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>pulsar-broker</artifactId>

--- a/pulsar-cli-utils/pom.xml
+++ b/pulsar-cli-utils/pom.xml
@@ -27,7 +27,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-cli-utils</artifactId>
@@ -73,7 +72,7 @@
           </execution>
         </executions>
       </plugin>
-      
+
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
@@ -112,7 +111,7 @@
           </execution>
         </executions>
       </plugin>
-      
+
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>

--- a/pulsar-client-1x-base/pom.xml
+++ b/pulsar-client-1x-base/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-client-1x-base</artifactId>

--- a/pulsar-client-1x-base/pulsar-client-1x/pom.xml
+++ b/pulsar-client-1x-base/pulsar-client-1x/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-client-1x-base</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-client-1x</artifactId>

--- a/pulsar-client-1x-base/pulsar-client-2x-shaded/pom.xml
+++ b/pulsar-client-1x-base/pulsar-client-2x-shaded/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-client-1x-base</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-client-2x-shaded</artifactId>

--- a/pulsar-client-admin-api/pom.xml
+++ b/pulsar-client-admin-api/pom.xml
@@ -26,7 +26,6 @@
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar</artifactId>
         <version>3.4.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>pulsar-client-admin-api</artifactId>
@@ -43,7 +42,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        
+
     </dependencies>
 
     <build>

--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -27,7 +27,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-client-admin</artifactId>

--- a/pulsar-client-admin/pom.xml
+++ b/pulsar-client-admin/pom.xml
@@ -27,7 +27,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-client-admin-original</artifactId>

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-client-all</artifactId>

--- a/pulsar-client-api/pom.xml
+++ b/pulsar-client-api/pom.xml
@@ -26,7 +26,6 @@
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar</artifactId>
         <version>3.4.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>pulsar-client-api</artifactId>

--- a/pulsar-client-auth-athenz/pom.xml
+++ b/pulsar-client-auth-athenz/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-client-auth-athenz</artifactId>

--- a/pulsar-client-auth-sasl/pom.xml
+++ b/pulsar-client-auth-sasl/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-client-auth-sasl</artifactId>

--- a/pulsar-client-messagecrypto-bc/pom.xml
+++ b/pulsar-client-messagecrypto-bc/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-client-messagecrypto-bc</artifactId>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-client</artifactId>

--- a/pulsar-client-tools-api/pom.xml
+++ b/pulsar-client-tools-api/pom.xml
@@ -25,7 +25,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-client-tools-api</artifactId>

--- a/pulsar-client-tools-customcommand-example/pom.xml
+++ b/pulsar-client-tools-customcommand-example/pom.xml
@@ -23,7 +23,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>pulsar-client-tools-customcommand-example</artifactId>

--- a/pulsar-client-tools-test/pom.xml
+++ b/pulsar-client-tools-test/pom.xml
@@ -25,7 +25,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-client-tools-test</artifactId>

--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -25,7 +25,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-client-tools</artifactId>

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-client-original</artifactId>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -27,7 +27,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-common</artifactId>

--- a/pulsar-config-validation/pom.xml
+++ b/pulsar-config-validation/pom.xml
@@ -27,7 +27,6 @@
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar</artifactId>
         <version>3.4.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>pulsar-config-validation</artifactId>
@@ -59,7 +58,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>

--- a/pulsar-functions/localrun-shaded/pom.xml
+++ b/pulsar-functions/localrun-shaded/pom.xml
@@ -27,7 +27,6 @@
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-functions</artifactId>
         <version>3.4.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>pulsar-functions-local-runner</artifactId>

--- a/pulsar-functions/localrun/pom.xml
+++ b/pulsar-functions/localrun/pom.xml
@@ -27,7 +27,6 @@
         <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-functions</artifactId>
         <version>3.4.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>pulsar-functions-local-runner-original</artifactId>

--- a/pulsar-functions/runtime-all/pom.xml
+++ b/pulsar-functions/runtime-all/pom.xml
@@ -27,7 +27,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-functions</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <!--

--- a/pulsar-functions/worker/pom.xml
+++ b/pulsar-functions/worker/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar-functions</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-functions-worker</artifactId>
@@ -223,7 +222,7 @@
           </execution>
         </executions>
       </plugin>
-      
+
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>

--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <properties>

--- a/pulsar-package-management/pom.xml
+++ b/pulsar-package-management/pom.xml
@@ -26,7 +26,6 @@
         <artifactId>pulsar</artifactId>
         <groupId>org.apache.pulsar</groupId>
         <version>3.4.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pulsar-testclient/pom.xml
+++ b/pulsar-testclient/pom.xml
@@ -26,7 +26,6 @@
 		<groupId>org.apache.pulsar</groupId>
 		<artifactId>pulsar</artifactId>
 		<version>3.4.0-SNAPSHOT</version>
-		<relativePath>..</relativePath>
 	</parent>
 
 	<artifactId>pulsar-testclient</artifactId>

--- a/pulsar-websocket/pom.xml
+++ b/pulsar-websocket/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>pulsar-websocket</artifactId>

--- a/structured-event-log/pom.xml
+++ b/structured-event-log/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>structured-event-log</artifactId>

--- a/tiered-storage/file-system/pom.xml
+++ b/tiered-storage/file-system/pom.xml
@@ -26,7 +26,6 @@
         <groupId>org.apache.pulsar</groupId>
         <artifactId>tiered-storage-parent</artifactId>
         <version>3.4.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>tiered-storage-file-system</artifactId>

--- a/tiered-storage/jcloud/pom.xml
+++ b/tiered-storage/jcloud/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>tiered-storage-parent</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>tiered-storage-jcloud</artifactId>

--- a/tiered-storage/pom.xml
+++ b/tiered-storage/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.pulsar</groupId>
     <artifactId>pulsar</artifactId>
     <version>3.4.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>tiered-storage-parent</artifactId>


### PR DESCRIPTION
### Motivation

Using `<relativePath>..</relativePath>` is invalid, it should be `<relativePath>../pom.xml</relativePath>`.
Since the default for `relativePath` value is `../pom.xml`, there's no need to include the relativePath definition when it's `../pom.xml`.

### Modifications

- remove `relativePath` elements from `pom.xml` files when the value is `..` or `../pom.xml`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->