### PR TITLE
[improve] [pip] PIP-354: apply topK mechanism to ModularLoadManagerImpl

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1470,7 +1470,9 @@ loadBalancerBrokerLoadDataTTLInSeconds=1800
 # The load balancer distributes bundles across brokers,
 # based on topK bundle load data and other broker load data.
 # The bigger value will increase the overhead of reporting many bundles in load data.
-# (only used in load balancer extension logics)
+# Used for ExtensibleLoadManagerImpl and ModularLoadManagerImpl, default value is 10.
+# User can disable the bundle filtering feature of ModularLoadManagerImpl by setting this value to -1.
+# Enabling this feature can reduce the pressure on the zookeeper when doing load report.
 loadBalancerMaxNumberOfBundlesInBundleLoadReport=10
 
 # Service units'(bundles) split interval. Broker periodically checks whether

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1473,6 +1473,7 @@ loadBalancerBrokerLoadDataTTLInSeconds=1800
 # Used for ExtensibleLoadManagerImpl and ModularLoadManagerImpl, default value is 10.
 # User can disable the bundle filtering feature of ModularLoadManagerImpl by setting this value to -1.
 # Enabling this feature can reduce the pressure on the zookeeper when doing load report.
+# WARNING: too small value could result in a long load balance time.
 loadBalancerMaxNumberOfBundlesInBundleLoadReport=10
 
 # Service units'(bundles) split interval. Broker periodically checks whether

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2665,6 +2665,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
                     + "Used for ExtensibleLoadManagerImpl and ModularLoadManagerImpl, default value is 10. "
                     + "User can disable the bundle filtering feature of ModularLoadManagerImpl by setting this value to -1. "
                     + "Enabling this feature can reduce the pressure on the zookeeper when doing load report."
+                    + "WARNING: too small value could result in a long load balance time."
     )
     private int loadBalancerMaxNumberOfBundlesInBundleLoadReport = 10;
     @FieldContext(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2662,8 +2662,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
                     + "The load balancer distributes bundles across brokers, "
                     + "based on topK bundle load data and other broker load data."
                     + "The bigger value will increase the overhead of reporting many bundles in load data. "
-                    + "Used for ExtensibleLoadManagerImpl and ModularLoadManagerImpl. "
-                    + "For ModularLoadManagerImpl, value not greater than 0 will disable the bundle filtering feature."
+                    + "Used for ExtensibleLoadManagerImpl and ModularLoadManagerImpl, default value is 10. "
+                    + "User can disable the bundle filtering feature of ModularLoadManagerImpl by setting this value to -1. "
+                    + "Enabling this feature can reduce the pressure on the zookeeper when doing load report."
     )
     private int loadBalancerMaxNumberOfBundlesInBundleLoadReport = 10;
     @FieldContext(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2662,7 +2662,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
                     + "The load balancer distributes bundles across brokers, "
                     + "based on topK bundle load data and other broker load data."
                     + "The bigger value will increase the overhead of reporting many bundles in load data. "
-                    + "(only used in load balancer extension logics)"
+                    + "Used for ExtensibleLoadManagerImpl and ModularLoadManagerImpl. For ModularLoadManagerImpl," +
+                    "value not greater than 0 will disable the feature."
     )
     private int loadBalancerMaxNumberOfBundlesInBundleLoadReport = 10;
     @FieldContext(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2663,7 +2663,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
                     + "based on topK bundle load data and other broker load data."
                     + "The bigger value will increase the overhead of reporting many bundles in load data. "
                     + "Used for ExtensibleLoadManagerImpl and ModularLoadManagerImpl, default value is 10. "
-                    + "User can disable the bundle filtering feature of ModularLoadManagerImpl by setting this value to -1. "
+                    + "User can disable the bundle filtering feature of ModularLoadManagerImpl by setting to -1."
                     + "Enabling this feature can reduce the pressure on the zookeeper when doing load report."
                     + "WARNING: too small value could result in a long load balance time."
     )

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2662,8 +2662,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
                     + "The load balancer distributes bundles across brokers, "
                     + "based on topK bundle load data and other broker load data."
                     + "The bigger value will increase the overhead of reporting many bundles in load data. "
-                    + "Used for ExtensibleLoadManagerImpl and ModularLoadManagerImpl. For ModularLoadManagerImpl," +
-                    "value not greater than 0 will disable the feature."
+                    + "Used for ExtensibleLoadManagerImpl and ModularLoadManagerImpl. "
+                    + "For ModularLoadManagerImpl, value not greater than 0 will disable the bundle filtering feature."
     )
     private int loadBalancerMaxNumberOfBundlesInBundleLoadReport = 10;
     @FieldContext(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/models/TopKBundles.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/models/TopKBundles.java
@@ -99,7 +99,7 @@ public class TopKBundles {
         }
     }
 
-    static void partitionSort(List<Map.Entry<String, ? extends Comparable>> arr, int k) {
+    public static void partitionSort(List<Map.Entry<String, ? extends Comparable>> arr, int k) {
         int start = 0;
         int end = arr.size() - 1;
         int target = k - 1;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -1164,8 +1164,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                 final Map.Entry<String, BundleData> entry = (Map.Entry<String, BundleData>) bundleArr.get(i);
                 final String bundle = entry.getKey();
                 final BundleData data = entry.getValue();
-                futures.add(
-                        pulsarResources.getLoadBalanceResources().getBundleDataResources().updateBundleData(bundle, data));
+                futures.add(pulsarResources.getLoadBalanceResources().getBundleDataResources()
+                        .updateBundleData(bundle, data));
             }
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -1162,15 +1162,11 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         List<CompletableFuture<Void>> futures = new ArrayList<>();
 
         // use synchronized to protect bundleArr.
-        synchronized (this) {
+        synchronized (bundleArr) {
             int updateBundleCount = selectTopKBundle();
-            for (int i = 0; i < updateBundleCount; i++) {
-                final Map.Entry<String, BundleData> entry = (Map.Entry<String, BundleData>) bundleArr.get(i);
-                final String bundle = entry.getKey();
-                final BundleData data = entry.getValue();
-                futures.add(pulsarResources.getLoadBalanceResources().getBundleDataResources()
-                        .updateBundleData(bundle, data));
-            }
+            bundleArr.stream().limit(updateBundleCount).forEach(entry -> futures.add(
+                    pulsarResources.getLoadBalanceResources().getBundleDataResources().updateBundleData(
+                            entry.getKey(), (BundleData) entry.getValue())));
         }
 
         // Write the time average broker data to metadata store.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -1143,6 +1143,10 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
             // select topK bundle for each broker, so select topK * brokerCount bundle in total
             int brokerCount = Math.max(1, loadData.getBrokerData().size());
             int updateBundleCount = Math.min(maxNumberOfBundlesInBundleLoadReport * brokerCount, bundleArr.size());
+            if (updateBundleCount == 0) {
+                // no bundle to update
+                return 0;
+            }
             TopKBundles.partitionSort(bundleArr, updateBundleCount);
             return updateBundleCount;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -57,6 +57,7 @@ import org.apache.pulsar.broker.loadbalance.LoadManager;
 import org.apache.pulsar.broker.loadbalance.LoadSheddingStrategy;
 import org.apache.pulsar.broker.loadbalance.ModularLoadManager;
 import org.apache.pulsar.broker.loadbalance.ModularLoadManagerStrategy;
+import org.apache.pulsar.broker.loadbalance.extensions.models.TopKBundles;
 import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared.BrokerTopicLoadingPredicate;
 import org.apache.pulsar.broker.resources.PulsarResources;
 import org.apache.pulsar.broker.stats.prometheus.metrics.Summary;
@@ -187,6 +188,9 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
     private final Lock lock = new ReentrantLock();
     private final Set<String> knownBrokers = new HashSet<>();
     private Map<String, String> bundleBrokerAffinityMap;
+    // array used for sorting and select topK bundles
+    private final List<Map.Entry<String, ? extends Comparable>> bundleArr = new ArrayList<>();
+
 
     /**
      * Initializes fields which do not depend on PulsarService. initialize(PulsarService) should subsequently be called.
@@ -1123,6 +1127,30 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
     }
 
     /**
+     * sort bundles by load and select topK bundles for each broker.
+     * @return the number of bundles selected
+     */
+    private CompletableFuture<Integer> selectTopKBundle() {
+        CompletableFuture<Integer> completableFuture = new CompletableFuture<>();
+
+        executors.execute(() -> {
+            // make the bundle-data update and sorting executed in single thread
+            bundleArr.clear();
+            bundleArr.addAll((Collection<? extends Map.Entry<String, ? extends Comparable>>)
+                    loadData.getBundleData().entrySet());
+
+            // select topK bundle for each broker, so select topK * brokerCount bundle in total
+            int brokerCount = Math.max(1, loadData.getBrokerData().size());
+            int updateBundleCount = Math.min(pulsar.getConfiguration()
+                    .getLoadBalancerMaxNumberOfBundlesInBundleLoadReport() * brokerCount, bundleArr.size());
+
+            TopKBundles.partitionSort(bundleArr, updateBundleCount);
+            completableFuture.complete(updateBundleCount);
+        });
+        return completableFuture;
+    }
+
+    /**
      * As the leader broker, write bundle data aggregated from all brokers to metadata store.
      */
     @Override
@@ -1131,7 +1159,9 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         // Write the bundle data to metadata store.
         List<CompletableFuture<Void>> futures = new ArrayList<>();
 
-        for (Map.Entry<String, BundleData> entry : loadData.getBundleData().entrySet()) {
+        int updateBundleCount = selectTopKBundle().join();
+        for (int i = 0; i < updateBundleCount; i++) {
+            final Map.Entry<String, BundleData> entry = (Map.Entry<String, BundleData>) bundleArr.get(i);
             final String bundle = entry.getKey();
             final BundleData data = entry.getValue();
             futures.add(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
@@ -435,7 +435,8 @@ public class ModularLoadManagerImplTest {
         pulsarServices.put(pulsar1.getWebServiceAddress(), pulsar1);
         pulsarServices.put(pulsar2.getWebServiceAddress(), pulsar2);
         MetadataCache<BundleData> metadataCache = pulsar1.getLocalMetadataStore().getMetadataCache(BundleData.class);
-        PulsarService leaderBroker = pulsarServices.get("http://" + pulsar1.getLeaderElectionService().getCurrentLeader().get().getBrokerId());
+        String protocol = "http://";
+        PulsarService leaderBroker = pulsarServices.get(protocol + pulsar1.getLeaderElectionService().getCurrentLeader().get().getBrokerId());
         ModularLoadManagerImpl loadManager = (ModularLoadManagerImpl) getField(
                 leaderBroker.getLoadManager().get(), "loadManager");
         int topK = 1;
@@ -448,7 +449,6 @@ public class ModularLoadManagerImplTest {
         final NamespaceBundle[] bundles = LoadBalancerTestingUtils.makeBundles(
                 nsFactory, "test", "test", "test", totalBundles);
         LoadData loadData = (LoadData) getField(loadManager, "loadData");
-        String protocol = "http://";
         for (int i = 0; i < totalBundles; i++) {
             final BundleData bundleData = new BundleData(10, 1000);
             final String bundleDataPath = String.format("%s/%s", BUNDLE_DATA_BASE_PATH, bundles[i]);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
@@ -425,6 +425,61 @@ public class ModularLoadManagerImplTest {
         }
     }
 
+    /**
+     * It verifies that the load-manager of leader broker only write topK * brokerCount bundles to zk.
+     */
+    @Test
+    public void testFilterBundlesWhileWritingToMetadataStore() throws Exception {
+        Map<String, PulsarService> pulsarServices = new HashMap<>();
+        pulsarServices.put(pulsar1.getWebServiceAddress(), pulsar1);
+        pulsarServices.put(pulsar2.getWebServiceAddress(), pulsar2);
+        MetadataCache<BundleData> metadataCache = pulsar1.getLocalMetadataStore().getMetadataCache(BundleData.class);
+        PulsarService leaderBroker = pulsarServices.get(pulsar1.getLeaderElectionService().getCurrentLeader().get().getServiceUrl());
+        ModularLoadManagerImpl loadManager = (ModularLoadManagerImpl) getField(
+                leaderBroker.getLoadManager().get(), "loadManager");
+        int topK = 1;
+        leaderBroker.getConfiguration().setLoadBalancerMaxNumberOfBundlesInBundleLoadReport(topK);
+        // there are two broker in cluster, so total bundle count will be topK * 2
+        int exportBundleCount = topK * 2;
+
+        // create and configure bundle-data
+        final int totalBundles = 5;
+        final NamespaceBundle[] bundles = LoadBalancerTestingUtils.makeBundles(
+                nsFactory, "test", "test", "test", totalBundles);
+        LoadData loadData = (LoadData) getField(loadManager, "loadData");
+        String protocol = "http://";
+        for (int i = 0; i < totalBundles; i++) {
+            final BundleData bundleData = new BundleData(10, 1000);
+            final String bundleDataPath = String.format("%s/%s", ModularLoadManagerImpl.BUNDLE_DATA_PATH, bundles[i]);
+            final TimeAverageMessageData longTermMessageData = new TimeAverageMessageData(1000);
+            longTermMessageData.setMsgThroughputIn(1000 * i);
+            longTermMessageData.setMsgThroughputOut(1000 * i);
+            longTermMessageData.setMsgRateIn(1000 * i);
+            longTermMessageData.setNumSamples(1000);
+            bundleData.setLongTermData(longTermMessageData);
+            loadData.getBundleData().put(bundles[i].toString(), bundleData);
+            loadData.getBrokerData().get(leaderBroker.getWebServiceAddress().substring(protocol.length()))
+                    .getLocalData().getLastStats().put(bundles[i].toString(), new NamespaceBundleStats());
+            metadataCache.create(bundleDataPath, bundleData).join();
+        }
+        for (int i = 0; i < totalBundles; i++) {
+            final String bundleDataPath = String.format("%s/%s", ModularLoadManagerImpl.BUNDLE_DATA_PATH, bundles[i]);
+            assertEquals(metadataCache.getWithStats(bundleDataPath).get().get().getStat().getVersion(), 0);
+        }
+
+        // update bundle data to zk and verify
+        loadManager.writeBundleDataOnZooKeeper();
+        int filterBundleCount = totalBundles - exportBundleCount;
+        for (int i = 0; i < filterBundleCount; i++) {
+            final String bundleDataPath = String.format("%s/%s", ModularLoadManagerImpl.BUNDLE_DATA_PATH, bundles[i]);
+            assertEquals(metadataCache.getWithStats(bundleDataPath).get().get().getStat().getVersion(), 0);
+        }
+        for (int i = filterBundleCount; i < totalBundles; i++) {
+            final String bundleDataPath = String.format("%s/%s", ModularLoadManagerImpl.BUNDLE_DATA_PATH, bundles[i]);
+            assertEquals(metadataCache.getWithStats(bundleDataPath).get().get().getStat().getVersion(), 1);
+        }
+    }
+
     // Test that load shedding works
     @Test
     public void testLoadShedding() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
@@ -435,7 +435,7 @@ public class ModularLoadManagerImplTest {
         pulsarServices.put(pulsar1.getWebServiceAddress(), pulsar1);
         pulsarServices.put(pulsar2.getWebServiceAddress(), pulsar2);
         MetadataCache<BundleData> metadataCache = pulsar1.getLocalMetadataStore().getMetadataCache(BundleData.class);
-        PulsarService leaderBroker = pulsarServices.get(pulsar1.getLeaderElectionService().getCurrentLeader().get().getServiceUrl());
+        PulsarService leaderBroker = pulsarServices.get("http://" + pulsar1.getLeaderElectionService().getCurrentLeader().get().getBrokerId());
         ModularLoadManagerImpl loadManager = (ModularLoadManagerImpl) getField(
                 leaderBroker.getLoadManager().get(), "loadManager");
         int topK = 1;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
@@ -40,6 +40,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -450,7 +451,7 @@ public class ModularLoadManagerImplTest {
         String protocol = "http://";
         for (int i = 0; i < totalBundles; i++) {
             final BundleData bundleData = new BundleData(10, 1000);
-            final String bundleDataPath = String.format("%s/%s", ModularLoadManagerImpl.BUNDLE_DATA_PATH, bundles[i]);
+            final String bundleDataPath = String.format("%s/%s", BUNDLE_DATA_BASE_PATH, bundles[i]);
             final TimeAverageMessageData longTermMessageData = new TimeAverageMessageData(1000);
             longTermMessageData.setMsgThroughputIn(1000 * i);
             longTermMessageData.setMsgThroughputOut(1000 * i);
@@ -463,7 +464,7 @@ public class ModularLoadManagerImplTest {
             metadataCache.create(bundleDataPath, bundleData).join();
         }
         for (int i = 0; i < totalBundles; i++) {
-            final String bundleDataPath = String.format("%s/%s", ModularLoadManagerImpl.BUNDLE_DATA_PATH, bundles[i]);
+            final String bundleDataPath = String.format("%s/%s", BUNDLE_DATA_BASE_PATH, bundles[i]);
             assertEquals(metadataCache.getWithStats(bundleDataPath).get().get().getStat().getVersion(), 0);
         }
 
@@ -471,11 +472,11 @@ public class ModularLoadManagerImplTest {
         loadManager.writeBundleDataOnZooKeeper();
         int filterBundleCount = totalBundles - exportBundleCount;
         for (int i = 0; i < filterBundleCount; i++) {
-            final String bundleDataPath = String.format("%s/%s", ModularLoadManagerImpl.BUNDLE_DATA_PATH, bundles[i]);
+            final String bundleDataPath = String.format("%s/%s", BUNDLE_DATA_BASE_PATH, bundles[i]);
             assertEquals(metadataCache.getWithStats(bundleDataPath).get().get().getStat().getVersion(), 0);
         }
         for (int i = filterBundleCount; i < totalBundles; i++) {
-            final String bundleDataPath = String.format("%s/%s", ModularLoadManagerImpl.BUNDLE_DATA_PATH, bundles[i]);
+            final String bundleDataPath = String.format("%s/%s", BUNDLE_DATA_BASE_PATH, bundles[i]);
             assertEquals(metadataCache.getWithStats(bundleDataPath).get().get().getStat().getVersion(), 1);
         }
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/BundleData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/BundleData.java
@@ -18,10 +18,13 @@
  */
 package org.apache.pulsar.policies.data.loadbalancer;
 
+import lombok.EqualsAndHashCode;
+
 /**
  * Data class comprising the short term and long term historical data for this bundle.
  */
-public class BundleData {
+@EqualsAndHashCode
+public class BundleData implements Comparable<BundleData> {
     // Short term data for this bundle. The time frame of this data is
     // determined by the number of short term samples
     // and the bundle update period.
@@ -102,5 +105,14 @@ public class BundleData {
 
     public void setTopics(int topics) {
         this.topics = topics;
+    }
+
+    @Override
+    public int compareTo(BundleData o) {
+        int result = this.shortTermData.compareTo(o.shortTermData);
+        if (result == 0) {
+            result = this.longTermData.compareTo(o.longTermData);
+        }
+        return result;
     }
 }


### PR DESCRIPTION
Implementation PR for https://github.com/apache/pulsar/pull/22765

### Motivation
`ModularLoadManagerImpl` rely on zk to store and synchronize metadata about load, which pose greate pressure on zk, threatening the stability of system. Every broker will upload its `LocalBrokerData` to zk, and leader broker will retrieve all `LocalBrokerData` from zk, generate all `BundleData` from each `LocalBrokerData`, and update all `BundleData` to zk. 

As every bundle in the cluster corresponds to a zk node, it is common that there are thousands of zk nodes in a cluster, which results into thousands of read/update operations to zk. This will cause a lot of pressure on zk.

**As All Load Shedding Algorithm pick bundles from top to bottom based on throughput/msgRate, bundles with low throughput/msgRate are rarely be selected for shedding. So that we don't need to contain these bundles in the bundle load report.**


### Modifications

Reuse the configuration loadBalancerMaxNumberOfBundlesInBundleLoadReport in ExtensibleLoadManager, apply the topK mechanism to ModularLoadManagerImpl.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*
This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/52

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
