### PR TITLE
[fix][broker] The result is inaccurate when schema is non-recoverable in method trimDeletedSchemaAndGetList.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
@@ -566,12 +566,11 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
                         return;
                     }
                 });
-                trimDeletedSchemaAndGetList(list);
                 // clean up the broken schema from zk
                 deleteSchemaStorage(schemaId, true).handle((sv, th) -> {
                     log.info("Clean up non-recoverable schema {}. Deletion of schema {} {}", rc.getMessage(),
                             schemaId, (th == null ? "successful" : "failed, " + th.getCause().getMessage()));
-                    schemaResult.complete(list);
+                    schemaResult.complete(trimDeletedSchemaAndGetList(list));
                     return null;
                 });
                 return null;


### PR DESCRIPTION
### Motivation
The return secheamResult is inaccurate when schema encounter an non-recoverable exception in method `trimDeletedSchemaAndGetList`.
 
Although, we executed the `trimDeletedSchemaAndGetList` method at line 563, however the returned result is not used. We finally still returned `list` at line 568 `schemaResult.complete(list)`

### Modifications
Replace `list`  with the method `trimDeletedSchemaAndGetList` result.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->