### PR TITLE
[improve][cli] PIP-353: Improve transaction message visibility for peek-message

### DIFF
--- a/pip/pip-353.md
+++ b/pip/pip-353.md
@@ -25,7 +25,7 @@ This behavior can confuse users and lead to incorrect data handling. The proposa
 
 ### In Scope
 
-- Implement flags to selectively display `server markers`, `uncommitted messages`, and `aborted messages` in peek operations.
+- Implement flags to selectively display `server markers`, `uncommitted messages(include aborted messages) for transaction` in peek operations.
 - Set the default behavior to only show messages from committed transactions to ensure data integrity.
 
 ### Out of Scope
@@ -37,8 +37,9 @@ This behavior can confuse users and lead to incorrect data handling. The proposa
 The proposal introduces three new flags to the `peek-messages` command:
 
 1. `--show-server-marker`: Controls the visibility of server markers (default: `false`).
-2. `--show-txn-uncommitted`: Controls the visibility of messages from uncommitted transactions (default: `false`).
-3. `--show-txn-aborted`: Controls the visibility of messages from aborted transactions (default: `false`).
+2. `---transaction-isolation-level`: Controls the visibility of messages for transactions. (default: `READ_COMMITTED`). Options:
+   - READ_COMMITTED: Can only consume all transactional messages which have been committed.
+   - READ_UNCOMMITTED: Can consume all messages, even transactional messages which have been aborted.
 
 These flags will allow administrators and developers to tailor the peek functionality to their needs, improving the usability and security of message handling in transactional contexts.
 
@@ -46,7 +47,7 @@ These flags will allow administrators and developers to tailor the peek function
 
 ### Design & Implementation Details
 
-To support the `--show-server-marker` and `--show-txn-aborted`, `--show-txn-uncommitted` flags, needs to introduce specific tag into the `headers` of messages returned by the 
+To support the `--show-server-marker` and `---transaction-isolation-level` flags, needs to introduce specific tag into the `headers` of messages returned by the 
 [peekNthMessage REST API](https://github.com/apache/pulsar/blob/8ca01cd42edfd4efd986f752f6f8538ea5bf4f94/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java#L1892-L1905). 
 
 - `X-Pulsar-marker-type`: Already exists.
@@ -62,11 +63,10 @@ see the following code: [https://github.com/shibd/pulsar/pull/34](https://github
 
 New command line flags added for the `bin/pulsar-admin topics peek-messages` command:
 
-| Flag                     | Abbreviation | Type    | Default | Description                                                    |
-|--------------------------|--------------|---------|---------|----------------------------------------------------------------|
-| `--show-server-marker`   | `-ssm`       | Boolean | `false` | Enables the display of internal server write markers.          |
-| `--show-txn-uncommitted` | `-stu`       | Boolean | `false` | Enables the display of messages from uncommitted transactions. |
-| `--show-txn-aborted`     | `-sta`       | Boolean | `false` | Enables the display of messages from aborted transactions.     |
+| Flag                             | Abbreviation | Type    | Default | Description                                                                                                                                                                                                                                                                     |
+|----------------------------------|--------------|---------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--show-server-marker`           | `-ssm`       | Boolean | `false` | Enables the display of internal server write markers.                                                                                                                                                                                                                           |
+| `---transaction-isolation-level` | `-til`       | Enum    | `false` | Enables theSets the isolation level for consuming messages within transactions. </br> - 'READ_COMMITTED' allows consuming only committed transactional messages. </br> - 'READ_UNCOMMITTED' allows consuming all messages, even transactional messages which have been aborted. |
 
 
 ## Public-facing Changes
@@ -85,10 +85,11 @@ Add two methods to the admin.Topics() interface.
      *            Number of messages
      * @param showServerMarker
      *            Enables the display of internal server write markers
-     * @param showTxnAborted
-     *            Enables the display of messages from aborted transactions
-     * @param showTxnUncommitted
-     *            Enables the display of messages from uncommitted transactions
+     * @param transactionIsolationLevel
+     *            Sets the isolation level for consuming messages within transactions.
+     *            - 'READ_COMMITTED' allows consuming only committed transactional messages.
+     *            - 'READ_UNCOMMITTED' allows consuming all messages,
+     *                                 even transactional messages which have been aborted.
      * @return
      * @throws NotAuthorizedException
      *             Don't have admin permission
@@ -98,8 +99,9 @@ Add two methods to the admin.Topics() interface.
      *             Unexpected error
      */
     List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages,
-                                       boolean showServerMarker, boolean showTxnAborted,
-                                       boolean showTxnUncommitted) throws PulsarAdminException;
+                                       boolean showServerMarker, SubscriptionIsolationLevel transactionIsolationLevel)
+            throws PulsarAdminException;
+
 
     /**
      * Peek messages from a topic subscription asynchronously.
@@ -112,15 +114,16 @@ Add two methods to the admin.Topics() interface.
      *            Number of messages
      * @param showServerMarker
      *            Enables the display of internal server write markers
-     * @param showTxnAborted
-     *            Enables the display of messages from aborted transactions
-     * @param showTxnUncommitted
-     *            Enables the display of messages from uncommitted transactions
-     * @return a future that can be used to track when the messages are returned
+     @param transactionIsolationLevel
+      *            Sets the isolation level for consuming messages within transactions.
+      *            - 'READ_COMMITTED' allows consuming only committed transactional messages.
+      *            - 'READ_UNCOMMITTED' allows consuming all messages,
+      *                                 even transactional messages which have been aborted.
+      * @return a future that can be used to track when the messages are returned
      */
-    CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages,
-                                                               boolean showServerMarker, boolean showTxnAborted,
-                                                               boolean showTxnUncommitted);
+    CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(
+            String topic, String subName, int numMessages,
+            boolean showServerMarker, SubscriptionIsolationLevel transactionIsolationLevel);
 ```
 
 ## Backward & Forward Compatibility
@@ -130,5 +133,5 @@ Reverting to a previous version of Pulsar without this feature will remove the a
 
 ### Upgrade
 While upgrading to the new version of Pulsar that includes these changes, the default behavior of the `peek-messages` command will change.
-Existing scripts or commands that rely on the old behavior (where transaction markers and messages from uncommitted or aborted transactions are visible) will need to explicitly set the new flags (`--show-server-marker`, `--show-txn-uncommitted`, `--show-txn-aborted`) to `true` to maintain the old behavior. 
+Existing scripts or commands that rely on the old behavior (where transaction markers and messages from uncommitted or aborted transactions are visible) will need to explicitly set the new flags (`--show-server-marker true` and `--transaction-isolation-level READ_UNCOMMITTED` to maintain the old behavior. 
 This change is necessary as the previous default behavior did not align with typical expectations around data visibility and integrity in transactional systems.

--- a/pip/pip-353.md
+++ b/pip/pip-353.md
@@ -99,7 +99,7 @@ Add two methods to the admin.Topics() interface.
      *             Unexpected error
      */
     List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages,
-                                       boolean showServerMarker, SubscriptionIsolationLevel transactionIsolationLevel)
+                                       boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel)
             throws PulsarAdminException;
 
 
@@ -123,7 +123,7 @@ Add two methods to the admin.Topics() interface.
      */
     CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(
             String topic, String subName, int numMessages,
-            boolean showServerMarker, SubscriptionIsolationLevel transactionIsolationLevel);
+            boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel);
 ```
 
 ## Backward & Forward Compatibility

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -97,6 +97,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedExc
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
@@ -2717,7 +2718,7 @@ public class PersistentTopicsBase extends AdminResource {
                         @Override
                         public void readEntryComplete(Entry entry, Object ctx) {
                             try {
-                                results.complete(generateResponseWithEntry(entry));
+                                results.complete(generateResponseWithEntry(entry, (PersistentTopic) topic));
                             } catch (IOException exception) {
                                 throw new RestException(exception);
                             } finally {
@@ -2858,10 +2859,12 @@ public class PersistentTopicsBase extends AdminResource {
                     entry = sub.peekNthMessage(messagePosition);
                 }
             }
-            return entry;
-        }).thenCompose(entry -> {
+            return entry.thenApply(e -> Pair.of(e, (PersistentTopic) topic));
+        }).thenCompose(entryTopicPair -> {
+            Entry entry = entryTopicPair.getLeft();
+            PersistentTopic persistentTopic = entryTopicPair.getRight();
             try {
-                Response response = generateResponseWithEntry(entry);
+                Response response = generateResponseWithEntry(entry, persistentTopic);
                 return CompletableFuture.completedFuture(response);
             } catch (NullPointerException npe) {
                 throw new RestException(Status.NOT_FOUND, "Message not found");
@@ -2940,17 +2943,18 @@ public class PersistentTopicsBase extends AdminResource {
                                 PersistentTopicsBase.this.topicName);
                     }
                 }, null);
-                return future;
+                return future.thenApply(entry -> Pair.of(entry, (PersistentTopic) topic));
             } catch (ManagedLedgerException exception) {
                 log.error("[{}] Failed to examine message at position {} from {} due to {}", clientAppId(),
                         messagePosition,
                         topicName, exception);
                 throw new RestException(exception);
             }
-
-        }).thenApply(entry -> {
+        }).thenApply(entryTopicPair -> {
+            Entry entry = entryTopicPair.getLeft();
+            PersistentTopic persistentTopic = entryTopicPair.getRight();
             try {
-                return generateResponseWithEntry(entry);
+                return generateResponseWithEntry(entry, persistentTopic);
             } catch (IOException exception) {
                 throw new RestException(exception);
             } finally {
@@ -2961,7 +2965,7 @@ public class PersistentTopicsBase extends AdminResource {
         });
     }
 
-    private Response generateResponseWithEntry(Entry entry) throws IOException {
+    private Response generateResponseWithEntry(Entry entry, PersistentTopic persistentTopic) throws IOException {
         checkNotNull(entry);
         PositionImpl pos = (PositionImpl) entry.getPosition();
         ByteBuf metadataAndPayload = entry.getDataBuffer();
@@ -3079,6 +3083,14 @@ public class PersistentTopicsBase extends AdminResource {
         if (metadata.hasNullPartitionKey()) {
             responseBuilder.header("X-Pulsar-null-partition-key", metadata.isNullPartitionKey());
         }
+        if (metadata.hasTxnidMostBits() && metadata.hasTxnidLeastBits()) {
+            TxnID txnID = new TxnID(metadata.getTxnidMostBits(), metadata.getTxnidLeastBits());
+            boolean isTxnAborted = persistentTopic.isTxnAborted(txnID, (PositionImpl) entry.getPosition());
+            responseBuilder.header("X-Pulsar-txn-aborted", isTxnAborted);
+        }
+        boolean isTxnUncommitted = ((PositionImpl) entry.getPosition())
+                .compareTo(persistentTopic.getMaxReadPosition()) > 0;
+        responseBuilder.header("X-Pulsar-txn-uncommitted", isTxnUncommitted);
 
         // Decode if needed
         CompressionCodec codec = CompressionCodecProvider.getCompressionCodec(metadata.getCompression());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -49,7 +49,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.SubscriptionIsolationLevel;
+import org.apache.pulsar.client.api.TransactionIsolationLevel;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.client.api.transaction.TxnID;
@@ -938,7 +938,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         }
 
         List<Message<byte[]>> peekMsgs = admin.topics().peekMessages(topic, "t-sub", n,
-                false, SubscriptionIsolationLevel.READ_UNCOMMITTED);
+                false, TransactionIsolationLevel.READ_UNCOMMITTED);
         assertEquals(peekMsgs.size(), n);
         for (Message<byte[]> peekMsg : peekMsgs) {
             assertEquals(new String(peekMsg.getValue()), "msg");
@@ -976,7 +976,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         // peek n message, all messages value should be "msg"
         {
             List<Message<byte[]>> peekMsgs = admin.topics().peekMessages(topic, "t-sub", n,
-                    false, SubscriptionIsolationLevel.READ_COMMITTED);
+                    false, TransactionIsolationLevel.READ_COMMITTED);
             assertEquals(peekMsgs.size(), n);
             for (Message<byte[]> peekMsg : peekMsgs) {
                 assertEquals(new String(peekMsg.getValue()), "msg");
@@ -986,7 +986,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         // peek 3 * n message, and still get n message, all messages value should be "msg"
         {
             List<Message<byte[]>> peekMsgs = admin.topics().peekMessages(topic, "t-sub", 2 * n,
-                    false, SubscriptionIsolationLevel.READ_COMMITTED);
+                    false, TransactionIsolationLevel.READ_COMMITTED);
             assertEquals(peekMsgs.size(), n);
             for (Message<byte[]> peekMsg : peekMsgs) {
                 assertEquals(new String(peekMsg.getValue()), "msg");
@@ -1022,7 +1022,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
 
         // peek 5 * n message, will get 5 * n msg.
         List<Message<byte[]>> peekMsgs = admin.topics().peekMessages(topic, "t-sub", 5 * n,
-                true, SubscriptionIsolationLevel.READ_UNCOMMITTED);
+                true, TransactionIsolationLevel.READ_UNCOMMITTED);
         assertEquals(peekMsgs.size(), 5 * n);
 
         for (int i = 0; i < 4 * n; i++) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -49,6 +49,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionIsolationLevel;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.client.api.transaction.TxnID;
@@ -937,7 +938,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         }
 
         List<Message<byte[]>> peekMsgs = admin.topics().peekMessages(topic, "t-sub", n,
-                false, true, true);
+                false, SubscriptionIsolationLevel.READ_UNCOMMITTED);
         assertEquals(peekMsgs.size(), n);
         for (Message<byte[]> peekMsg : peekMsgs) {
             assertEquals(new String(peekMsg.getValue()), "msg");
@@ -945,7 +946,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
-    public void testPeekMessageForSkipAbortedAndUnCommittedMessages() throws Exception {
+    public void testPeekMessageFoReadCommittedMessages() throws Exception {
         initTransaction(1);
 
         final String topic = BrokerTestUtil.newUniqueName("persistent://public/default/peek_txn");
@@ -975,7 +976,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         // peek n message, all messages value should be "msg"
         {
             List<Message<byte[]>> peekMsgs = admin.topics().peekMessages(topic, "t-sub", n,
-                    false, false, false);
+                    false, SubscriptionIsolationLevel.READ_COMMITTED);
             assertEquals(peekMsgs.size(), n);
             for (Message<byte[]> peekMsg : peekMsgs) {
                 assertEquals(new String(peekMsg.getValue()), "msg");
@@ -985,7 +986,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
         // peek 3 * n message, and still get n message, all messages value should be "msg"
         {
             List<Message<byte[]>> peekMsgs = admin.topics().peekMessages(topic, "t-sub", 2 * n,
-                    false, false, false);
+                    false, SubscriptionIsolationLevel.READ_COMMITTED);
             assertEquals(peekMsgs.size(), n);
             for (Message<byte[]> peekMsg : peekMsgs) {
                 assertEquals(new String(peekMsg.getValue()), "msg");
@@ -1021,7 +1022,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
 
         // peek 5 * n message, will get 5 * n msg.
         List<Message<byte[]>> peekMsgs = admin.topics().peekMessages(topic, "t-sub", 5 * n,
-                true, true, true);
+                true, SubscriptionIsolationLevel.READ_UNCOMMITTED);
         assertEquals(peekMsgs.size(), 5 * n);
 
         for (int i = 0; i < 4 * n; i++) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.http.HttpStatus;
+import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.transaction.buffer.AbortedTxnProcessor;
@@ -53,7 +54,10 @@ import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.client.impl.transaction.TransactionImpl;
+import org.apache.pulsar.common.api.proto.MarkerType;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.naming.TopicDomain;
@@ -914,6 +918,127 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
             fail();
         } catch (ExecutionException e) {
             assertTrue(e.getCause() instanceof CoordinatorException.TransactionNotFoundException);
+        }
+    }
+
+    @Test
+    public void testPeekMessageForSkipTxnMarker() throws Exception {
+        initTransaction(1);
+
+        final String topic = BrokerTestUtil.newUniqueName("persistent://public/default/peek_marker");
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
+        int n = 10;
+        for (int i = 0; i < n; i++) {
+            Transaction txn = pulsarClient.newTransaction().build().get();
+            producer.newMessage(txn).value("msg").send();
+            txn.commit().get();
+        }
+
+        List<Message<byte[]>> peekMsgs = admin.topics().peekMessages(topic, "t-sub", n,
+                false, true, true);
+        assertEquals(peekMsgs.size(), n);
+        for (Message<byte[]> peekMsg : peekMsgs) {
+            assertEquals(new String(peekMsg.getValue()), "msg");
+        }
+    }
+
+    @Test
+    public void testPeekMessageForSkipAbortedAndUnCommittedMessages() throws Exception {
+        initTransaction(1);
+
+        final String topic = BrokerTestUtil.newUniqueName("persistent://public/default/peek_txn");
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
+        int n = 10;
+        // Alternately sends `n` committed transactional messages and `n` abort transactional messages.
+        for (int i = 0; i < 2 * n; i++) {
+            Transaction txn = pulsarClient.newTransaction().build().get();
+            if (i % 2 == 0) {
+                producer.newMessage(txn).value("msg").send();
+                txn.commit().get();
+            } else {
+                producer.newMessage(txn).value("msg-aborted").send();
+                txn.abort();
+            } 
+        }
+        // Then sends 1 uncommitted transactional messages.
+        Transaction txn = pulsarClient.newTransaction().build().get();
+        producer.newMessage(txn).value("msg-uncommitted").send();
+        // Then sends n-1 no transaction messages.
+        for (int i = 0; i < n - 1; i++) {
+            producer.newMessage().value("msg-after-uncommitted").send();
+        }
+        
+        // peek n message, all messages value should be "msg"
+        {
+            List<Message<byte[]>> peekMsgs = admin.topics().peekMessages(topic, "t-sub", n,
+                    false, false, false);
+            assertEquals(peekMsgs.size(), n);
+            for (Message<byte[]> peekMsg : peekMsgs) {
+                assertEquals(new String(peekMsg.getValue()), "msg");
+            }
+        }
+
+        // peek 3 * n message, and still get n message, all messages value should be "msg"
+        {
+            List<Message<byte[]>> peekMsgs = admin.topics().peekMessages(topic, "t-sub", 2 * n,
+                    false, false, false);
+            assertEquals(peekMsgs.size(), n);
+            for (Message<byte[]> peekMsg : peekMsgs) {
+                assertEquals(new String(peekMsg.getValue()), "msg");
+            }
+        }
+    }
+
+    @Test
+    public void testPeekMessageForShowAllMessages() throws Exception {
+        initTransaction(1);
+
+        final String topic = BrokerTestUtil.newUniqueName("persistent://public/default/peek_all");
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
+        int n = 10;
+        // Alternately sends `n` committed transactional messages and `n` abort transactional messages.
+        for (int i = 0; i < 2 * n; i++) {
+            Transaction txn = pulsarClient.newTransaction().build().get();
+            if (i % 2 == 0) {
+                producer.newMessage(txn).value("msg").send();
+                txn.commit().get();
+            } else {
+                producer.newMessage(txn).value("msg-aborted").send();
+                txn.abort();
+            }
+        }
+        // Then sends `n` uncommitted transactional messages.
+        Transaction txn = pulsarClient.newTransaction().build().get();
+        for (int i = 0; i < n; i++) {
+            producer.newMessage(txn).value("msg-uncommitted").send();
+        }
+
+        // peek 5 * n message, will get 5 * n msg.
+        List<Message<byte[]>> peekMsgs = admin.topics().peekMessages(topic, "t-sub", 5 * n,
+                true, true, true);
+        assertEquals(peekMsgs.size(), 5 * n);
+
+        for (int i = 0; i < 4 * n; i++) {
+            Message<byte[]> peekMsg = peekMsgs.get(i);
+            MessageImpl peekMsgImpl = (MessageImpl) peekMsg;
+            MessageMetadata metadata = peekMsgImpl.getMessageBuilder();
+            if (metadata.hasMarkerType()) {
+                assertTrue(metadata.getMarkerType() == MarkerType.TXN_COMMIT_VALUE ||
+                        metadata.getMarkerType() == MarkerType.TXN_ABORT_VALUE);
+            } else {
+                String value = new String(peekMsg.getValue());
+                assertTrue(value.equals("msg") || value.equals("msg-aborted"));
+            } 
+        }
+        for (int i = 4 * n; i < peekMsgs.size(); i++) {
+            Message<byte[]> peekMsg = peekMsgs.get(i);
+            assertEquals(new String(peekMsg.getValue()), "msg-uncommitted"); 
         }
     }
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -30,6 +30,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.SubscriptionIsolationLevel;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
@@ -1638,7 +1639,6 @@ public interface Topics {
 
     /**
      * Peek messages from a topic subscription.
-     * This method will show server marker, uncommitted and aborted messages for transaction by default.
      *
      * @param topic
      *            topic name
@@ -1667,10 +1667,11 @@ public interface Topics {
      *            Number of messages
      * @param showServerMarker
      *            Enables the display of internal server write markers
-     * @param showTxnAborted
-     *            Enables the display of messages from aborted transactions
-     * @param showTxnUncommitted
-     *            Enables the display of messages from uncommitted transactions
+     * @param transactionIsolationLevel
+     *            Sets the isolation level for peeking messages within transactions.
+     *            - 'READ_COMMITTED' allows peeking only committed transactional messages.
+     *            - 'READ_UNCOMMITTED' allows peeking all messages,
+     *                                 even transactional messages which have been aborted.
      * @return
      * @throws NotAuthorizedException
      *             Don't have admin permission
@@ -1680,12 +1681,11 @@ public interface Topics {
      *             Unexpected error
      */
     List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages,
-                                       boolean showServerMarker, boolean showTxnAborted,
-                                       boolean showTxnUncommitted) throws PulsarAdminException;
+                                       boolean showServerMarker, SubscriptionIsolationLevel transactionIsolationLevel)
+            throws PulsarAdminException;
 
     /**
      * Peek messages from a topic subscription asynchronously.
-     * This method will show server marker, uncommitted and aborted messages for transaction by default.
      *
      * @param topic
      *            topic name
@@ -1708,15 +1708,16 @@ public interface Topics {
      *            Number of messages
      * @param showServerMarker
      *            Enables the display of internal server write markers
-     * @param showTxnAborted
-     *            Enables the display of messages from aborted transactions
-     * @param showTxnUncommitted
-     *            Enables the display of messages from uncommitted transactions
+      @param transactionIsolationLevel
+     *            Sets the isolation level for peeking messages within transactions.
+     *            - 'READ_COMMITTED' allows peeking only committed transactional messages.
+     *            - 'READ_UNCOMMITTED' allows peeking all messages,
+     *                                 even transactional messages which have been aborted.
      * @return a future that can be used to track when the messages are returned
      */
-    CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages,
-                                                               boolean showServerMarker, boolean showTxnAborted,
-                                                               boolean showTxnUncommitted);
+    CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(
+            String topic, String subName, int numMessages,
+            boolean showServerMarker, SubscriptionIsolationLevel transactionIsolationLevel);
 
     /**
      * Get a message by its messageId via a topic subscription.

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -30,8 +30,8 @@ import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.SubscriptionIsolationLevel;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.TransactionIsolationLevel;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.AuthAction;
@@ -1656,7 +1656,7 @@ public interface Topics {
      */
     default List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages)
             throws PulsarAdminException {
-        return peekMessages(topic, subName, numMessages, false, SubscriptionIsolationLevel.READ_COMMITTED);
+        return peekMessages(topic, subName, numMessages, false, TransactionIsolationLevel.READ_COMMITTED);
     }
 
     /**
@@ -1684,7 +1684,7 @@ public interface Topics {
      *             Unexpected error
      */
     List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages,
-                                       boolean showServerMarker, SubscriptionIsolationLevel transactionIsolationLevel)
+                                       boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel)
             throws PulsarAdminException;
 
     /**
@@ -1699,7 +1699,7 @@ public interface Topics {
      * @return a future that can be used to track when the messages are returned
      */
     default CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages) {
-        return peekMessagesAsync(topic, subName, numMessages, false, SubscriptionIsolationLevel.READ_COMMITTED);
+        return peekMessagesAsync(topic, subName, numMessages, false, TransactionIsolationLevel.READ_COMMITTED);
     }
 
     /**
@@ -1722,7 +1722,7 @@ public interface Topics {
      */
     CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(
             String topic, String subName, int numMessages,
-            boolean showServerMarker, SubscriptionIsolationLevel transactionIsolationLevel);
+            boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel);
 
     /**
      * Get a message by its messageId via a topic subscription.

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1654,7 +1654,10 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages) throws PulsarAdminException;
+    default List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages)
+            throws PulsarAdminException {
+        return peekMessages(topic, subName, numMessages, false, SubscriptionIsolationLevel.READ_COMMITTED);
+    }
 
     /**
      * Peek messages from a topic subscription.
@@ -1695,7 +1698,9 @@ public interface Topics {
      *            Number of messages
      * @return a future that can be used to track when the messages are returned
      */
-    CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages);
+    default CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages) {
+        return peekMessagesAsync(topic, subName, numMessages, false, SubscriptionIsolationLevel.READ_COMMITTED);
+    }
 
     /**
      * Peek messages from a topic subscription asynchronously.

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1638,6 +1638,7 @@ public interface Topics {
 
     /**
      * Peek messages from a topic subscription.
+     * This method will show server marker, uncommitted and aborted messages for transaction by default.
      *
      * @param topic
      *            topic name
@@ -1656,7 +1657,35 @@ public interface Topics {
     List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages) throws PulsarAdminException;
 
     /**
+     * Peek messages from a topic subscription.
+     *
+     * @param topic
+     *            topic name
+     * @param subName
+     *            Subscription name
+     * @param numMessages
+     *            Number of messages
+     * @param showServerMarker
+     *            Enables the display of internal server write markers
+     * @param showTxnAborted
+     *            Enables the display of messages from aborted transactions
+     * @param showTxnUncommitted
+     *            Enables the display of messages from uncommitted transactions
+     * @return
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Topic or subscription does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages,
+                                       boolean showServerMarker, boolean showTxnAborted,
+                                       boolean showTxnUncommitted) throws PulsarAdminException;
+
+    /**
      * Peek messages from a topic subscription asynchronously.
+     * This method will show server marker, uncommitted and aborted messages for transaction by default.
      *
      * @param topic
      *            topic name
@@ -1667,6 +1696,27 @@ public interface Topics {
      * @return a future that can be used to track when the messages are returned
      */
     CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages);
+
+    /**
+     * Peek messages from a topic subscription asynchronously.
+     *
+     * @param topic
+     *            topic name
+     * @param subName
+     *            Subscription name
+     * @param numMessages
+     *            Number of messages
+     * @param showServerMarker
+     *            Enables the display of internal server write markers
+     * @param showTxnAborted
+     *            Enables the display of messages from aborted transactions
+     * @param showTxnUncommitted
+     *            Enables the display of messages from uncommitted transactions
+     * @return a future that can be used to track when the messages are returned
+     */
+    CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages,
+                                                               boolean showServerMarker, boolean showTxnAborted,
+                                                               boolean showTxnUncommitted);
 
     /**
      * Get a message by its messageId via a topic subscription.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -900,27 +900,11 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
-    public List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages)
-            throws PulsarAdminException {
-        return sync(() -> peekMessagesAsync(topic, subName, numMessages,
-                false, SubscriptionIsolationLevel.READ_COMMITTED));
-    }
-
-    @Override
     public List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages,
                                               boolean showServerMarker,
                                               SubscriptionIsolationLevel transactionIsolationLevel)
             throws PulsarAdminException {
         return sync(() -> peekMessagesAsync(topic, subName, numMessages, showServerMarker, transactionIsolationLevel));
-    }
-
-    @Override
-    public CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages) {
-        checkArgument(numMessages > 0);
-        CompletableFuture<List<Message<byte[]>>> future = new CompletableFuture<List<Message<byte[]>>>();
-        peekMessagesAsync(topic, subName, numMessages, new ArrayList<>(),
-                future, 1, false, SubscriptionIsolationLevel.READ_COMMITTED);
-        return future;
     }
 
     @Override

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -55,8 +55,8 @@ import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.SubscriptionIsolationLevel;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.TransactionIsolationLevel;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.MessageImpl;
@@ -872,7 +872,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     private CompletableFuture<List<Message<byte[]>>> peekNthMessage(
             String topic, String subName, int messagePosition, boolean showServerMarker,
-            SubscriptionIsolationLevel transactionIsolationLevel) {
+            TransactionIsolationLevel transactionIsolationLevel) {
         TopicName tn = validateTopic(topic);
         String encodedSubName = Codec.encode(subName);
         WebTarget path = topicPath(tn, "subscription", encodedSubName,
@@ -902,7 +902,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages,
                                               boolean showServerMarker,
-                                              SubscriptionIsolationLevel transactionIsolationLevel)
+                                              TransactionIsolationLevel transactionIsolationLevel)
             throws PulsarAdminException {
         return sync(() -> peekMessagesAsync(topic, subName, numMessages, showServerMarker, transactionIsolationLevel));
     }
@@ -910,7 +910,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     @Override
     public CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(
             String topic, String subName, int numMessages,
-            boolean showServerMarker, SubscriptionIsolationLevel transactionIsolationLevel) {
+            boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel) {
         checkArgument(numMessages > 0);
         CompletableFuture<List<Message<byte[]>>> future = new CompletableFuture<List<Message<byte[]>>>();
         peekMessagesAsync(topic, subName, numMessages, new ArrayList<>(),
@@ -920,7 +920,7 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     private void peekMessagesAsync(String topic, String subName, int numMessages,
             List<Message<byte[]>> messages, CompletableFuture<List<Message<byte[]>>> future, int nthMessage,
-            boolean showServerMarker, SubscriptionIsolationLevel transactionIsolationLevel) {
+            boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel) {
         if (numMessages <= 0) {
             future.complete(messages);
             return;
@@ -1268,12 +1268,12 @@ public class TopicsImpl extends BaseResource implements Topics {
 
     private List<Message<byte[]>> getMessagesFromHttpResponse(String topic, Response response) throws Exception {
         return getMessagesFromHttpResponse(topic, response, true,
-                SubscriptionIsolationLevel.READ_UNCOMMITTED);
+                TransactionIsolationLevel.READ_UNCOMMITTED);
     }
 
     private List<Message<byte[]>> getMessagesFromHttpResponse(
             String topic, Response response, boolean showServerMarker,
-            SubscriptionIsolationLevel transactionIsolationLevel) throws Exception {
+            TransactionIsolationLevel transactionIsolationLevel) throws Exception {
 
         if (response.getStatus() != Status.OK.getStatusCode()) {
             throw getApiException(response);
@@ -1317,7 +1317,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             tmp = headers.getFirst(TXN_ABORTED);
             if (tmp != null && Boolean.parseBoolean(tmp.toString())) {
                 properties.put(TXN_ABORTED, tmp.toString());
-                if (transactionIsolationLevel == SubscriptionIsolationLevel.READ_COMMITTED) {
+                if (transactionIsolationLevel == TransactionIsolationLevel.READ_COMMITTED) {
                     return new ArrayList<>();
                 }
             }
@@ -1325,7 +1325,7 @@ public class TopicsImpl extends BaseResource implements Topics {
             tmp = headers.getFirst(TXN_UNCOMMITTED);
             if (tmp != null && Boolean.parseBoolean(tmp.toString())) {
                 properties.put(TXN_UNCOMMITTED, tmp.toString());
-                if (transactionIsolationLevel == SubscriptionIsolationLevel.READ_COMMITTED) {
+                if (transactionIsolationLevel == TransactionIsolationLevel.READ_COMMITTED) {
                     return new ArrayList<>();
                 }
             }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/SubscriptionIsolationLevel.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/SubscriptionIsolationLevel.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+public enum SubscriptionIsolationLevel {
+    // Consumer can only consume all transactional messages which have been committed.
+    READ_COMMITTED,
+    // Consumer can consume all messages, even transactional messages which have been aborted.
+    READ_UNCOMMITTED;
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/SubscriptionIsolationLevel.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/SubscriptionIsolationLevel.java
@@ -18,6 +18,11 @@
  */
 package org.apache.pulsar.client.api;
 
+import org.apache.pulsar.common.classification.InterfaceAudience;
+import org.apache.pulsar.common.classification.InterfaceStability;
+
+@InterfaceAudience.Public
+@InterfaceStability.Stable
 public enum SubscriptionIsolationLevel {
     // Consumer can only consume all transactional messages which have been committed.
     READ_COMMITTED,

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TransactionIsolationLevel.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TransactionIsolationLevel.java
@@ -23,7 +23,7 @@ import org.apache.pulsar.common.classification.InterfaceStability;
 
 @InterfaceAudience.Public
 @InterfaceStability.Stable
-public enum SubscriptionIsolationLevel {
+public enum TransactionIsolationLevel {
     // Consumer can only consume all transactional messages which have been committed.
     READ_COMMITTED,
     // Consumer can consume all messages, even transactional messages which have been aborted.

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -81,7 +81,7 @@ import org.apache.pulsar.client.admin.Transactions;
 import org.apache.pulsar.client.admin.internal.OffloadProcessStatusImpl;
 import org.apache.pulsar.client.admin.internal.PulsarAdminImpl;
 import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.SubscriptionIsolationLevel;
+import org.apache.pulsar.client.api.TransactionIsolationLevel;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.api.transaction.TxnID;
@@ -1746,7 +1746,7 @@ public class PulsarAdminToolTest {
 
         cmdTopics.run(split("peek-messages persistent://myprop/clust/ns1/ds1 -s sub1 -n 3"));
         verify(mockTopics).peekMessages("persistent://myprop/clust/ns1/ds1", "sub1", 3,
-                false, SubscriptionIsolationLevel.READ_COMMITTED);
+                false, TransactionIsolationLevel.READ_COMMITTED);
 
         MessageImpl message = mock(MessageImpl.class);
         when(message.getData()).thenReturn(new byte[]{});

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -1744,7 +1744,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).deletePartitionedTopic("persistent://myprop/clust/ns1/ds1", true);
 
         cmdTopics.run(split("peek-messages persistent://myprop/clust/ns1/ds1 -s sub1 -n 3"));
-        verify(mockTopics).peekMessages("persistent://myprop/clust/ns1/ds1", "sub1", 3);
+        verify(mockTopics).peekMessages("persistent://myprop/clust/ns1/ds1", "sub1", 3, false, false, false);
 
         MessageImpl message = mock(MessageImpl.class);
         when(message.getData()).thenReturn(new byte[]{});

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -81,6 +81,7 @@ import org.apache.pulsar.client.admin.Transactions;
 import org.apache.pulsar.client.admin.internal.OffloadProcessStatusImpl;
 import org.apache.pulsar.client.admin.internal.PulsarAdminImpl;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.SubscriptionIsolationLevel;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.api.transaction.TxnID;
@@ -1744,7 +1745,8 @@ public class PulsarAdminToolTest {
         verify(mockTopics).deletePartitionedTopic("persistent://myprop/clust/ns1/ds1", true);
 
         cmdTopics.run(split("peek-messages persistent://myprop/clust/ns1/ds1 -s sub1 -n 3"));
-        verify(mockTopics).peekMessages("persistent://myprop/clust/ns1/ds1", "sub1", 3, false, false, false);
+        verify(mockTopics).peekMessages("persistent://myprop/clust/ns1/ds1", "sub1", 3,
+                false, SubscriptionIsolationLevel.READ_COMMITTED);
 
         MessageImpl message = mock(MessageImpl.class);
         when(message.getData()).thenReturn(new byte[]{});

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -61,8 +61,8 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.admin.Topics;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.SubscriptionIsolationLevel;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.TransactionIsolationLevel;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.MessageImpl;
@@ -1110,7 +1110,7 @@ public class CmdTopics extends CmdBase {
                    + "'READ_UNCOMMITTED' allows peeking all messages, "
                         + "even transactional messages which have been aborted.",
                 required = false)
-        private SubscriptionIsolationLevel transactionIsolationLevel = SubscriptionIsolationLevel.READ_COMMITTED;
+        private TransactionIsolationLevel transactionIsolationLevel = TransactionIsolationLevel.READ_COMMITTED;
 
         @Override
         void run() throws PulsarAdminException {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -61,6 +61,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.admin.Topics;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.SubscriptionIsolationLevel;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
@@ -1103,19 +1104,19 @@ public class CmdTopics extends CmdBase {
                 description = "Enables the display of internal server write markers.", required = false)
         private boolean showServerMarker = false;
 
-        @Option(names = { "-sta", "--show-txn-aborted" },
-                description = "Enables the display of messages from aborted transactions.", required = false)
-        private boolean showTxnAborted = false;
-
-        @Option(names = { "-stu", "--show-txn-uncommitted" },
-                description = "Enables the display of messages from uncommitted transactions.", required = false)
-        private boolean showTxnUncommitted = false;
+        @Option(names = { "-til", "--transaction-isolation-level" },
+                description = "Sets the isolation level for peeking messages within transactions. "
+                   + "'READ_COMMITTED' allows peeking only committed transactional messages. "
+                   + "'READ_UNCOMMITTED' allows peeking all messages, "
+                        + "even transactional messages which have been aborted.",
+                required = false)
+        private SubscriptionIsolationLevel transactionIsolationLevel = SubscriptionIsolationLevel.READ_COMMITTED;
 
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(topicName);
             List<Message<byte[]>> messages = getTopics().peekMessages(persistentTopic, subName, numMessages,
-                    showServerMarker, showTxnAborted, showTxnUncommitted);
+                    showServerMarker, transactionIsolationLevel);
             int position = 0;
             for (Message<byte[]> msg : messages) {
                 MessageImpl message = (MessageImpl) msg;


### PR DESCRIPTION
### Motivation
#22746 

### Modifications

- Support `--show-server-marker` and `--transaction-isolation-level` flags for peek-messages cmd.

### Verifying this change
- Add `testPeekMessageForSkipTxnMarker`, `testPeekMessageForSkipAbortedAndUnCommittedMessages` and `testPeekMessageForShowAllMessages` unit test to corver this change. 


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [x] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/shibd/pulsar/pull/34