### PR TITLE
[improve][fn] Add Go support for pulsar function secrets

### DIFF
--- a/pulsar-function-go/conf/conf.go
+++ b/pulsar-function-go/conf/conf.go
@@ -60,6 +60,9 @@ type Conf struct {
 	// Deprecated
 	AutoACK     bool  `json:"autoAck" yaml:"autoAck"`
 	Parallelism int32 `json:"parallelism" yaml:"parallelism"`
+	// SecretProvider config
+	SecretsProviderClassName string `json:"secretsProviderClassName" yaml:"secretsProviderClassName"`
+	SecretsProviderConfig    string `json:"secretsProviderConfig" yaml:"secretsProviderConfig"`
 	//source config
 	SubscriptionType     int32  `json:"subscriptionType" yaml:"subscriptionType"`
 	TimeoutMs            uint64 `json:"timeoutMs" yaml:"timeoutMs"`

--- a/pulsar-function-go/pf/instance.go
+++ b/pulsar-function-go/pf/instance.go
@@ -138,6 +138,11 @@ func (gi *goInstance) startFunction(function function) error {
 		log.Errorf("setup log appender failed, error is:%v", err)
 		return err
 	}
+	err = gi.setupSecretsProvider()
+	if err != nil {
+		log.Errorf("setup secret provider failed, error is:%v", err)
+		return err
+	}
 
 	idleDuration := getIdleTimeout(time.Millisecond * gi.context.instanceConf.killAfterIdle)
 	idleTimer := time.NewTimer(idleDuration)
@@ -494,6 +499,19 @@ func (gi *goInstance) addLogTopicHandler() {
 	for _, logByte := range log.StrEntry {
 		gi.context.logAppender.Append([]byte(logByte))
 	}
+}
+
+func (gi *goInstance) setupSecretsProvider() error {
+	switch gi.context.instanceConf.secretsProviderClassName {
+	case "ClearTextSecretsProvider":
+		gi.context.secretsProvider = &ClearTextSecretsProvider{}
+	case "EnvironmentBasedSecretsProvider":
+		gi.context.secretsProvider = &EnvironmentBasedSecretsProvider{}
+	default:
+		return fmt.Errorf("unknown secretsProviderClassName: %s",
+			gi.context.instanceConf.secretsProviderClassName)
+	}
+	return nil
 }
 
 func (gi *goInstance) closeLogTopic() {

--- a/pulsar-function-go/pf/instanceConf.go
+++ b/pulsar-function-go/pf/instanceConf.go
@@ -48,6 +48,8 @@ type instanceConf struct {
 	metricsPort                 int
 	authPlugin                  string
 	authParams                  string
+	secretsProviderClassName    string
+	secretsProviderConfig       string
 	tlsTrustCertsPath           string
 	tlsAllowInsecure            bool
 	tlsHostnameVerification     bool
@@ -118,11 +120,13 @@ func newInstanceConfWithConf(cfg *conf.Conf) *instanceConf {
 			},
 			UserConfig: cfg.UserConfig,
 		},
-		authPlugin:              cfg.ClientAuthenticationPlugin,
-		authParams:              cfg.ClientAuthenticationParameters,
-		tlsTrustCertsPath:       cfg.TLSTrustCertsFilePath,
-		tlsAllowInsecure:        cfg.TLSAllowInsecureConnection,
-		tlsHostnameVerification: cfg.TLSHostnameVerificationEnable,
+		authPlugin:               cfg.ClientAuthenticationPlugin,
+		authParams:               cfg.ClientAuthenticationParameters,
+		secretsProviderClassName: cfg.SecretsProviderClassName,
+		secretsProviderConfig:    cfg.SecretsProviderConfig,
+		tlsTrustCertsPath:        cfg.TLSTrustCertsFilePath,
+		tlsAllowInsecure:         cfg.TLSAllowInsecureConnection,
+		tlsHostnameVerification:  cfg.TLSHostnameVerificationEnable,
 	}
 	// parse the raw function details and ignore the unmarshal error(fallback to original way)
 	if cfg.FunctionDetails != "" {

--- a/pulsar-function-go/pf/secretsProvider.go
+++ b/pulsar-function-go/pf/secretsProvider.go
@@ -1,0 +1,52 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package pf
+
+import (
+	"os"
+
+	log "github.com/apache/pulsar/pulsar-function-go/logutil"
+)
+
+type SecretsProvider interface {
+	GetValue(secrets map[string]interface{}, key string) interface{}
+}
+
+type ClearTextSecretsProvider struct{}
+
+func (p *ClearTextSecretsProvider) GetValue(secrets map[string]interface{}, key string) interface{} {
+	val, ok := secrets[key]
+	if !ok {
+		log.Debugf("secret key %s not present in function secrets", key)
+		return nil
+	}
+	return val
+}
+
+type EnvironmentBasedSecretsProvider struct{}
+
+func (p *EnvironmentBasedSecretsProvider) GetValue(_ map[string]interface{}, key string) interface{} {
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		log.Debugf("secret key %s does not match an environment variable", key)
+		return nil
+	}
+	return val
+}

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/go/GoInstanceConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/go/GoInstanceConfig.java
@@ -57,6 +57,9 @@ public class GoInstanceConfig {
     private boolean autoAck;
     private int parallelism;
 
+    private String secretsProviderClassName = "";
+    private String secretsProviderConfig = "";
+
     private int subscriptionType;
     private long timeoutMs;
     private String subscriptionName = "";

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -135,6 +135,8 @@ public class RuntimeUtils {
                                                 String pulsarServiceUrl,
                                                 String stateStorageServiceUrl,
                                                 String pulsarWebServiceUrl,
+                                                String secretsProviderClassName,
+                                                String secretsProviderConfig,
                                                 boolean k8sRuntime) throws IOException {
         final List<String> args = new LinkedList<>();
         GoInstanceConfig goInstanceConfig = new GoInstanceConfig();
@@ -285,6 +287,14 @@ public class RuntimeUtils {
             goInstanceConfig.setMetricsPort(instanceConfig.getMetricsPort());
         }
 
+        if (secretsProviderClassName != null) {
+            goInstanceConfig.setSecretsProviderClassName(secretsProviderClassName);
+        }
+
+        if (secretsProviderConfig != null) {
+            goInstanceConfig.setSecretsProviderConfig(secretsProviderConfig);
+        }
+
         goInstanceConfig.setKillAfterIdleMs(0);
         goInstanceConfig.setPort(instanceConfig.getPort());
 
@@ -329,7 +339,7 @@ public class RuntimeUtils {
         if (instanceConfig.getFunctionDetails().getRuntime() == Function.FunctionDetails.Runtime.GO) {
             return getGoInstanceCmd(instanceConfig, authConfig, originalCodeFileName,
                     pulsarServiceUrl, stateStorageServiceUrl, pulsarWebServiceUrl,
-                    k8sRuntime);
+                    secretsProviderClassName, secretsProviderConfig, k8sRuntime);
         }
 
         if (instanceConfig.getFunctionDetails().getRuntime() == Function.FunctionDetails.Runtime.JAVA) {

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
@@ -123,7 +123,9 @@ public class RuntimeUtilsTest {
         instanceConfig.setFunctionDetails(functionDetails);
         instanceConfig.setExposePulsarAdminClientEnabled(true);
 
-        List<String> commands = RuntimeUtils.getGoInstanceCmd(instanceConfig, authConfig, "config", "pulsar://localhost:6650", "bk://localhost:4181",  "http://localhost:8080", k8sRuntime);
+        List<String> commands = RuntimeUtils.getGoInstanceCmd(
+                instanceConfig, authConfig, "config", "pulsar://localhost:6650", "bk://localhost:4181",
+                "http://localhost:8080", "ClearTextSecretsProvider", "", k8sRuntime);
         if (k8sRuntime) {
             goInstanceConfig = new ObjectMapper().readValue(commands.get(2).replaceAll("^\'|\'$", ""), HashMap.class);
         } else {
@@ -174,6 +176,8 @@ public class RuntimeUtilsTest {
         Assert.assertEquals(goInstanceConfig.get("tlsTrustCertsFilePath"), "/secret/ca.cert.pem");
         Assert.assertEquals(goInstanceConfig.get("tlsHostnameVerificationEnable"), true);
         Assert.assertEquals(goInstanceConfig.get("tlsAllowInsecureConnection"), false);
+        Assert.assertEquals(goInstanceConfig.get("secretsProviderClassName"), "ClearTextSecretsProvider");
+        Assert.assertEquals(goInstanceConfig.get("secretsProviderConfig"), "");
     }
 
     @DataProvider(name = "k8sRuntime")

--- a/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/DefaultSecretsProviderConfigurator.java
+++ b/pulsar-functions/secrets/src/main/java/org/apache/pulsar/functions/secretsproviderconfigurator/DefaultSecretsProviderConfigurator.java
@@ -40,7 +40,7 @@ public class DefaultSecretsProviderConfigurator implements SecretsProviderConfig
             case PYTHON:
                 return "secretsprovider.ClearTextSecretsProvider";
             case GO:
-                return "";
+                return "ClearTextSecretsProvider";
             default:
                 throw new RuntimeException("Unknown runtime " + functionDetails.getRuntime());
         }


### PR DESCRIPTION
Fixes #8425

### Motivation

Currently the Java and Python pulsar functions can access secrets that are set when functions are installed, but not pulsar functions written in Go.

### Modifications

 - The pulsar function runtime code has been updated so that `secretsProviderClassName` and `secretsProviderConfig` are passed to Go pulsar functions.
 - The default `secretsProviderClassName` for Go functions has been set to `ClearTextSecretsProvider`
 - Go pulsar function start-up has been updated to setup the secrets provider.
 - A new Go method `GetSecretValue` has been added to the `FunctionContext` type so that a pulsar function can retrieve secrets.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
 - A pulsar function runtime unit test has been updated to ensure that `secretsProviderClassName` and `secretsProviderConfig` are passed to the Go function.
 - New Go unit tests have been written to test the `GetValue` method for the two Go `SecretsProvider` implementations

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API

A new Go method `GetSecretValue` has been added to the FunctionContext type.

- [ ] The schema
- [x] The default values of configurations

The default `secretsProviderClassName` for Go functions has been set to `ClearTextSecretsProvider`

- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

Pulsar-site changes here: https://github.com/apache/pulsar-site/pull/903

### Matching PR in forked repository

PR in forked repository: [<!-- ENTER URL HERE -->](https://github.com/DavidRayner/pulsar/pull/3)

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
