### PR TITLE
[fix] [broker] fix topic partitions was expanded even if disabled topic level replication

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -456,7 +456,7 @@ public class PersistentTopicsBase extends AdminResource {
                                 Set<String> replicationClusters = policies.get().replication_clusters;
                                 TopicPolicies topicPolicies =
                                         pulsarService.getTopicPoliciesService().getTopicPoliciesIfExists(topicName);
-                                if (topicPolicies != null ) {
+                                if (topicPolicies != null) {
                                     replicationClusters = new HashSet<>(topicPolicies.getReplicationClusters());
                                 }
                                 // Do check replicated clusters.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -451,7 +452,14 @@ public class PersistentTopicsBase extends AdminResource {
                                 if (!policies.isPresent()) {
                                     return CompletableFuture.completedFuture(null);
                                 }
-                                final Set<String> replicationClusters = policies.get().replication_clusters;
+                                // Combine namespace level policies and topic level policies.
+                                Set<String> replicationClusters = policies.get().replication_clusters;
+                                TopicPolicies topicPolicies =
+                                        pulsarService.getTopicPoliciesService().getTopicPoliciesIfExists(topicName);
+                                if (topicPolicies != null ) {
+                                    replicationClusters = new HashSet<>(topicPolicies.getReplicationClusters());
+                                }
+                                // Do check replicated clusters.
                                 if (replicationClusters.size() == 0) {
                                     return CompletableFuture.completedFuture(null);
                                 }
@@ -467,6 +475,7 @@ public class PersistentTopicsBase extends AdminResource {
                                     // The replication clusters just has the current cluster itself.
                                     return CompletableFuture.completedFuture(null);
                                 }
+                                // Do sync operation to other clusters.
                                 List<CompletableFuture<Void>> futures = replicationClusters.stream()
                                         .map(replicationCluster -> admin.clusters().getClusterAsync(replicationCluster)
                                                 .thenCompose(clusterData -> pulsarService.getBrokerService()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -67,7 +67,6 @@ import org.apache.pulsar.client.impl.ProducerBuilderImpl;
 import org.apache.pulsar.client.impl.ProducerImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
-import org.apache.pulsar.common.policies.data.TopicPolicies;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.apache.pulsar.common.naming.TopicName;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -707,16 +707,9 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         // Verify replicator works.
         verifyReplicationWorks(topicName);
 
-        admin1.topicPolicies().setCompactionThreshold(topicName, 1000_000);
-        Awaitility.await().untilAsserted(() -> {
-            assertEquals(admin2.topicPolicies().getCompactionThreshold(topicName), 1000_000);
-        });
-
         // Disable replication.
         setTopicLevelClusters(topicName, Arrays.asList(cluster1), admin1, pulsar1);
         setTopicLevelClusters(topicName, Arrays.asList(cluster2), admin2, pulsar2);
-
-        Thread.sleep(3 * 1000);
 
         // Delete topic.
         admin1.topics().delete(topicName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -67,6 +67,7 @@ import org.apache.pulsar.client.impl.ProducerBuilderImpl;
 import org.apache.pulsar.client.impl.ProducerImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
+import org.apache.pulsar.common.policies.data.TopicPolicies;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.apache.pulsar.common.naming.TopicName;
@@ -495,8 +496,17 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         admin2.topics().createPartitionedTopic(topicName, 2);
         admin1.topics().setReplicationClusters(topicName, Arrays.asList(cluster1, cluster2));
         // Check the partitioned topic has been created at the remote cluster.
-        PartitionedTopicMetadata topicMetadata2 = admin2.topics().getPartitionedTopicMetadata(topicName);
-        assertEquals(topicMetadata2.partitions, 2);
+        Awaitility.await().untilAsserted(() -> {
+            PartitionedTopicMetadata topicMetadata2 = admin2.topics().getPartitionedTopicMetadata(topicName);
+            assertEquals(topicMetadata2.partitions, 2);
+        });
+
+        // Expand partitions
+        admin2.topics().updatePartitionedTopic(topicName, 3);
+        Awaitility.await().untilAsserted(() -> {
+            PartitionedTopicMetadata topicMetadata2 = admin2.topics().getPartitionedTopicMetadata(topicName);
+            assertEquals(topicMetadata2.partitions, 3);
+        });
         // cleanup.
         admin1.topics().setReplicationClusters(topicName, Arrays.asList(cluster1));
         waitReplicatorStopped(partition0);
@@ -698,9 +708,18 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         // Verify replicator works.
         verifyReplicationWorks(topicName);
 
+        admin1.topicPolicies().setCompactionThreshold(topicName, 1000_000);
+        Awaitility.await().atMost(Duration.ofSeconds(3600)).untilAsserted(() -> {
+            assertEquals(admin2.topicPolicies().getCompactionThreshold(topicName), 1000_000);
+        });
+
         // Disable replication.
         setTopicLevelClusters(topicName, Arrays.asList(cluster1), admin1, pulsar1);
         setTopicLevelClusters(topicName, Arrays.asList(cluster2), admin2, pulsar2);
+
+        Thread.sleep(3 * 1000);
+        TopicPolicies topicPolicies1 = pulsar1.getTopicPoliciesService().getTopicPolicies(TopicName.get(topicName));
+        TopicPolicies topicPolicies2 = pulsar2.getTopicPoliciesService().getTopicPolicies(TopicName.get(topicName));
 
         // Delete topic.
         admin1.topics().delete(topicName);
@@ -747,5 +766,56 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
             assertFalse(pulsar2.getPulsarResources().getTopicResources()
                     .persistentTopicExists(TopicName.get(topicName).getPartition(1)).join());
         }
+    }
+
+    @Test
+    public void testNoExpandTopicPartitionsWhenDisableTopicLevelReplication() throws Exception {
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://" + replicatedNamespace + "/tp_");
+        admin1.topics().createPartitionedTopic(topicName, 2);
+
+        // Verify replicator works.
+        verifyReplicationWorks(topicName);
+
+        // Disable topic level replication.
+        setTopicLevelClusters(topicName, Arrays.asList(cluster1), admin1, pulsar1);
+        setTopicLevelClusters(topicName, Arrays.asList(cluster2), admin2, pulsar2);
+
+        // Expand topic.
+        admin1.topics().updatePartitionedTopic(topicName, 3);
+        assertEquals(admin1.topics().getPartitionedTopicMetadata(topicName).partitions, 3);
+
+        // Wait for async tasks that were triggered by expanding topic partitions.
+        Thread.sleep(3 * 1000);
+
+        // Verify: the topics on the remote cluster did not been expanded.
+        assertEquals(admin2.topics().getPartitionedTopicMetadata(topicName).partitions, 2);
+
+        cleanupTopics(() -> {
+            admin1.topics().deletePartitionedTopic(topicName, false);
+            admin2.topics().deletePartitionedTopic(topicName, false);
+        });
+    }
+
+    @Test
+    public void testExpandTopicPartitionsOnNamespaceLevelReplication() throws Exception {
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://" + replicatedNamespace + "/tp_");
+        admin1.topics().createPartitionedTopic(topicName, 2);
+
+        // Verify replicator works.
+        verifyReplicationWorks(topicName);
+
+        // Expand topic.
+        admin1.topics().updatePartitionedTopic(topicName, 3);
+        assertEquals(admin1.topics().getPartitionedTopicMetadata(topicName).partitions, 3);
+
+        // Verify: the topics on the remote cluster did not been expanded.
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(admin2.topics().getPartitionedTopicMetadata(topicName).partitions, 3);
+        });
+
+        cleanupTopics(() -> {
+            admin1.topics().deletePartitionedTopic(topicName, false);
+            admin2.topics().deletePartitionedTopic(topicName, false);
+        });
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -709,7 +709,7 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         verifyReplicationWorks(topicName);
 
         admin1.topicPolicies().setCompactionThreshold(topicName, 1000_000);
-        Awaitility.await().atMost(Duration.ofSeconds(3600)).untilAsserted(() -> {
+        Awaitility.await().untilAsserted(() -> {
             assertEquals(admin2.topicPolicies().getCompactionThreshold(topicName), 1000_000);
         });
 
@@ -718,8 +718,6 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         setTopicLevelClusters(topicName, Arrays.asList(cluster2), admin2, pulsar2);
 
         Thread.sleep(3 * 1000);
-        TopicPolicies topicPolicies1 = pulsar1.getTopicPoliciesService().getTopicPolicies(TopicName.get(topicName));
-        TopicPolicies topicPolicies2 = pulsar2.getTopicPoliciesService().getTopicPolicies(TopicName.get(topicName));
 
         // Delete topic.
         admin1.topics().delete(topicName);
@@ -787,6 +785,7 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         // Wait for async tasks that were triggered by expanding topic partitions.
         Thread.sleep(3 * 1000);
 
+
         // Verify: the topics on the remote cluster did not been expanded.
         assertEquals(admin2.topics().getPartitionedTopicMetadata(topicName).partitions, 2);
 
@@ -808,7 +807,7 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         admin1.topics().updatePartitionedTopic(topicName, 3);
         assertEquals(admin1.topics().getPartitionedTopicMetadata(topicName).partitions, 3);
 
-        // Verify: the topics on the remote cluster did not been expanded.
+        // Verify: the topics on the remote cluster will be expanded.
         Awaitility.await().untilAsserted(() -> {
             assertEquals(admin2.topics().getPartitionedTopicMetadata(topicName).partitions, 3);
         });

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
@@ -94,4 +94,14 @@ public class OneWayReplicatorUsingGlobalZKTest extends OneWayReplicatorTest {
     public void testDeletePartitionedTopic() throws Exception {
         super.testDeletePartitionedTopic();
     }
+
+    @Test(enabled = false)
+    public void testNoExpandTopicPartitionsWhenDisableTopicLevelReplication() throws Exception {
+        super.testNoExpandTopicPartitionsWhenDisableTopicLevelReplication();
+    }
+
+    @Test(enabled = false)
+    public void testExpandTopicPartitionsOnNamespaceLevelReplication() throws Exception {
+        super.testExpandTopicPartitionsOnNamespaceLevelReplication();
+    }
 }


### PR DESCRIPTION
### Motivation

1. The topic partitions on the remote cluster will be expanded when namespace level Geo-Replication is enabled, even if the topic level Geo-Replication is disabled. It is not correct.

2. The topic partitions on the remote cluster will not be expanded if the topic level Geo-Replication is enabled. It is not correct.

### Modifications

Fix the two issues.

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x