### PR TITLE
[fix][admin][part-4]Clearly define REST API on Open API

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
@@ -39,7 +39,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.StreamingOutput;
 import org.apache.pulsar.broker.admin.AdminResource;
-import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.FunctionDefinition;
 import org.apache.pulsar.common.functions.FunctionState;
@@ -486,7 +485,7 @@ public class FunctionsBase extends AdminResource {
     @POST
     @ApiOperation(
             value = "Triggers a Pulsar Function with a user-specified value or file data",
-            response = Message.class
+            response = String.class
     )
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid request"),
@@ -541,6 +540,7 @@ public class FunctionsBase extends AdminResource {
             value = "Put the state associated with a Pulsar Function"
     )
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
             @ApiResponse(code = 404, message = "The Pulsar Function does not exist"),
@@ -557,8 +557,9 @@ public class FunctionsBase extends AdminResource {
     }
 
     @POST
-    @ApiOperation(value = "Restart an instance of a Pulsar Function", response = Void.class)
+    @ApiOperation(value = "Restart an instance of a Pulsar Function")
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace of this function"),
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 404, message = "The Pulsar Function does not exist"),
@@ -578,8 +579,9 @@ public class FunctionsBase extends AdminResource {
     }
 
     @POST
-    @ApiOperation(value = "Restart all instances of a Pulsar Function", response = Void.class)
+    @ApiOperation(value = "Restart all instances of a Pulsar Function")
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 404, message = "The Pulsar Function does not exist"),
             @ApiResponse(code = 500, message = "Internal server error")
@@ -597,8 +599,9 @@ public class FunctionsBase extends AdminResource {
     }
 
     @POST
-    @ApiOperation(value = "Stop an instance of a Pulsar Function", response = Void.class)
+    @ApiOperation(value = "Stop an instance of a Pulsar Function")
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 404, message = "The Pulsar Function does not exist"),
             @ApiResponse(code = 500, message = "Internal server error")
@@ -617,8 +620,9 @@ public class FunctionsBase extends AdminResource {
     }
 
     @POST
-    @ApiOperation(value = "Stop all instances of a Pulsar Function", response = Void.class)
+    @ApiOperation(value = "Stop all instances of a Pulsar Function")
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 404, message = "The Pulsar Function does not exist"),
             @ApiResponse(code = 500, message = "Internal server error")
@@ -636,8 +640,9 @@ public class FunctionsBase extends AdminResource {
     }
 
     @POST
-    @ApiOperation(value = "Start an instance of a Pulsar Function", response = Void.class)
+    @ApiOperation(value = "Start an instance of a Pulsar Function")
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 404, message = "The Pulsar Function does not exist"),
             @ApiResponse(code = 500, message = "Internal server error")
@@ -656,8 +661,9 @@ public class FunctionsBase extends AdminResource {
     }
 
     @POST
-    @ApiOperation(value = "Start all instances of a Pulsar Function", response = Void.class)
+    @ApiOperation(value = "Start all instances of a Pulsar Function")
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 404, message = "The Pulsar Function does not exist"),
             @ApiResponse(code = 500, message = "Internal server error")
@@ -718,7 +724,8 @@ public class FunctionsBase extends AdminResource {
     @GET
     @ApiOperation(
             value = "Fetches a list of supported Pulsar IO connectors currently running in cluster mode",
-            response = List.class
+            response = ConnectorDefinition.class,
+            responseContainer = "List"
     )
     @ApiResponses(value = {
             @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
@@ -739,6 +746,7 @@ public class FunctionsBase extends AdminResource {
             value = "Reload the built-in Functions"
     )
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 401, message = "This operation requires super-user access"),
             @ApiResponse(code = 503, message = "Function worker service is now initializing. Please try again later."),
             @ApiResponse(code = 500, message = "Internal server error")
@@ -768,6 +776,7 @@ public class FunctionsBase extends AdminResource {
     @PUT
     @ApiOperation(value = "Updates a Pulsar Function on the worker leader", hidden = true)
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 403, message = "The requester doesn't have super-user permissions"),
             @ApiResponse(code = 404, message = "The function does not exist"),
             @ApiResponse(code = 400, message = "Invalid request"),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SinksBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SinksBase.java
@@ -389,8 +389,9 @@ public class SinksBase extends AdminResource {
     }
 
     @POST
-    @ApiOperation(value = "Restart an instance of a Pulsar Sink", response = Void.class)
+    @ApiOperation(value = "Restart an instance of a Pulsar Sink")
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace of this sink"),
             @ApiResponse(code = 400, message = "Invalid restart request"),
             @ApiResponse(code = 401, message = "The client is not authorized to perform this operation"),
@@ -415,8 +416,9 @@ public class SinksBase extends AdminResource {
     }
 
     @POST
-    @ApiOperation(value = "Restart all instances of a Pulsar Sink", response = Void.class)
+    @ApiOperation(value = "Restart all instances of a Pulsar Sink")
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 400, message = "Invalid restart request"),
             @ApiResponse(code = 401, message = "The client is not authorized to perform this operation"),
             @ApiResponse(code = 404, message = "The Pulsar Sink does not exist"),
@@ -436,8 +438,9 @@ public class SinksBase extends AdminResource {
     }
 
     @POST
-    @ApiOperation(value = "Stop an instance of a Pulsar Sink", response = Void.class)
+    @ApiOperation(value = "Stop an instance of a Pulsar Sink")
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 400, message = "Invalid stop request"),
             @ApiResponse(code = 404, message = "The Pulsar Sink instance does not exist"),
             @ApiResponse(code = 500, message =
@@ -460,8 +463,9 @@ public class SinksBase extends AdminResource {
     }
 
     @POST
-    @ApiOperation(value = "Stop all instances of a Pulsar Sink", response = Void.class)
+    @ApiOperation(value = "Stop all instances of a Pulsar Sink")
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 400, message = "Invalid stop request"),
             @ApiResponse(code = 404, message = "The Pulsar Sink does not exist"),
             @ApiResponse(code = 500, message =
@@ -481,8 +485,9 @@ public class SinksBase extends AdminResource {
     }
 
     @POST
-    @ApiOperation(value = "Start an instance of a Pulsar Sink", response = Void.class)
+    @ApiOperation(value = "Start an instance of a Pulsar Sink")
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 400, message = "Invalid start request"),
             @ApiResponse(code = 404, message = "The Pulsar Sink does not exist"),
             @ApiResponse(code = 500, message =
@@ -505,8 +510,9 @@ public class SinksBase extends AdminResource {
     }
 
     @POST
-    @ApiOperation(value = "Start all instances of a Pulsar Sink", response = Void.class)
+    @ApiOperation(value = "Start all instances of a Pulsar Sink")
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 400, message = "Invalid start request"),
             @ApiResponse(code = 404, message = "The Pulsar Sink does not exist"),
             @ApiResponse(code = 500, message =

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SourcesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SourcesBase.java
@@ -323,7 +323,7 @@ public class SourcesBase extends AdminResource {
     @ApiOperation(
             value = "Lists all Pulsar Sources currently deployed in a given namespace",
             response = String.class,
-            responseContainer = "Collection"
+            responseContainer = "List"
     )
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid request"),
@@ -342,8 +342,9 @@ public class SourcesBase extends AdminResource {
     }
 
     @POST
-    @ApiOperation(value = "Restart an instance of a Pulsar Source", response = Void.class)
+    @ApiOperation(value = "Restart an instance of a Pulsar Source")
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace of this source"),
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 401, message = "Client is not authorized to perform operation"),
@@ -365,8 +366,9 @@ public class SourcesBase extends AdminResource {
     }
 
     @POST
-    @ApiOperation(value = "Restart all instances of a Pulsar Source", response = Void.class)
+    @ApiOperation(value = "Restart all instances of a Pulsar Source")
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 401, message = "Client is not authorized to perform operation"),
             @ApiResponse(code = 404, message = "Not Found(The Pulsar Source doesn't exist)"),
@@ -386,8 +388,9 @@ public class SourcesBase extends AdminResource {
     }
 
     @POST
-    @ApiOperation(value = "Stop instance of a Pulsar Source", response = Void.class)
+    @ApiOperation(value = "Stop instance of a Pulsar Source")
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 401, message = "Client is not authorized to perform operation"),
             @ApiResponse(code = 404, message = "Not Found(The Pulsar Source doesn't exist)"),
@@ -407,8 +410,9 @@ public class SourcesBase extends AdminResource {
     }
 
     @POST
-    @ApiOperation(value = "Stop all instances of a Pulsar Source", response = Void.class)
+    @ApiOperation(value = "Stop all instances of a Pulsar Source")
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 401, message = "Client is not authorized to perform operation"),
             @ApiResponse(code = 404, message = "Not Found(The Pulsar Source doesn't exist)"),
@@ -428,8 +432,9 @@ public class SourcesBase extends AdminResource {
     }
 
     @POST
-    @ApiOperation(value = "Start an instance of a Pulsar Source", response = Void.class)
+    @ApiOperation(value = "Start an instance of a Pulsar Source")
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 401, message = "Client is not authorized to perform operation"),
             @ApiResponse(code = 404, message = "Not Found(The Pulsar Source doesn't exist)"),
@@ -449,8 +454,9 @@ public class SourcesBase extends AdminResource {
     }
 
     @POST
-    @ApiOperation(value = "Start all instances of a Pulsar Source", response = Void.class)
+    @ApiOperation(value = "Start all instances of a Pulsar Source")
     @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 401, message = "Client is not authorized to perform operation"),
             @ApiResponse(code = 404, message = "Not Found(The Pulsar Source doesn't exist)"),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -103,7 +103,9 @@ public class TenantsBase extends PulsarWebResource {
     @PUT
     @Path("/{tenant}")
     @ApiOperation(value = "Create a new tenant.", notes = "This operation requires Pulsar super-user privileges.")
-    @ApiResponses(value = {@ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Operation successful"),
+            @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
             @ApiResponse(code = 409, message = "Tenant already exists"),
             @ApiResponse(code = 412, message = "Tenant name is not valid"),
             @ApiResponse(code = 412, message = "Clusters can not be empty"),
@@ -155,7 +157,9 @@ public class TenantsBase extends PulsarWebResource {
     @Path("/{tenant}")
     @ApiOperation(value = "Update the admins for a tenant.",
             notes = "This operation requires Pulsar super-user privileges.")
-    @ApiResponses(value = {@ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Operation successful"),
+            @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
             @ApiResponse(code = 404, message = "Tenant does not exist"),
             @ApiResponse(code = 409, message = "Tenant already exists"),
             @ApiResponse(code = 412, message = "Clusters can not be empty"),
@@ -190,7 +194,9 @@ public class TenantsBase extends PulsarWebResource {
     @DELETE
     @Path("/{tenant}")
     @ApiOperation(value = "Delete a tenant and all namespaces and topics under it.")
-    @ApiResponses(value = {@ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Operation successful"),
+            @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
             @ApiResponse(code = 404, message = "Tenant does not exist"),
             @ApiResponse(code = 405, message = "Broker doesn't allow forced deletion of tenants"),
             @ApiResponse(code = 409, message = "The tenant still has active namespaces")})

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/ResourceGroups.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/ResourceGroups.java
@@ -60,7 +60,9 @@ public class ResourceGroups extends ResourceGroupsBase {
     @PUT
     @Path("/{resourcegroup}")
     @ApiOperation(value = "Creates a new resourcegroup with the specified rate limiters")
-    @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Operation successful"),
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "cluster doesn't exist")})
     public void createOrUpdateResourceGroup(@PathParam("resourcegroup") String name,
                                     @ApiParam(value = "Rate limiters for the resourcegroup")
@@ -72,6 +74,7 @@ public class ResourceGroups extends ResourceGroupsBase {
     @Path("/{resourcegroup}")
     @ApiOperation(value = "Delete a resourcegroup.")
     @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Operation successful"),
             @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "ResourceGroup doesn't exist"),
             @ApiResponse(code = 409, message = "ResourceGroup is in use")})

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/ResourceQuotas.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/ResourceQuotas.java
@@ -75,7 +75,7 @@ public class ResourceQuotas extends ResourceQuotasBase {
 
     @GET
     @Path("/{tenant}/{namespace}/{bundle}")
-    @ApiOperation(value = "Get resource quota of a namespace bundle.")
+    @ApiOperation(value = "Get resource quota of a namespace bundle.", response = ResourceQuota.class)
     @ApiResponses(value = {
             @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace"),
             @ApiResponse(code = 403, message = "Don't have admin permission"),
@@ -103,6 +103,7 @@ public class ResourceQuotas extends ResourceQuotasBase {
     @Path("/{tenant}/{namespace}/{bundle}")
     @ApiOperation(value = "Set resource quota on a namespace.")
     @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Operation successful"),
             @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace"),
             @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 409, message = "Concurrent modification") })
@@ -133,6 +134,7 @@ public class ResourceQuotas extends ResourceQuotasBase {
     @Path("/{tenant}/{namespace}/{bundle}")
     @ApiOperation(value = "Remove resource quota for a namespace.")
     @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Operation successful"),
             @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace"),
             @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 409, message = "Concurrent modification") })

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Worker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Worker.java
@@ -87,7 +87,9 @@ public class Worker extends AdminResource implements Supplier<WorkerService> {
     @GET
     @ApiOperation(
             value = "Fetches information about which Pulsar Functions are assigned to which Pulsar clusters",
-            response = Map.class
+            response = Map.class,
+            notes = "Returns a nested map structure which Swagger does not fully support for display."
+                    + "Structure: Map<String, Set<String>>. Please refer to this structure for details."
     )
     @ApiResponses(value = {
             @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
@@ -102,7 +104,8 @@ public class Worker extends AdminResource implements Supplier<WorkerService> {
     @GET
     @ApiOperation(
             value = "Fetches a list of supported Pulsar IO connectors currently running in cluster mode",
-            response = List.class
+            response = ConnectorDefinition.class,
+            responseContainer = "List"
     )
     @ApiResponses(value = {
             @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
@@ -120,6 +123,7 @@ public class Worker extends AdminResource implements Supplier<WorkerService> {
             value = "Triggers a rebalance of functions to workers"
     )
     @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Operation successful"),
             @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 408, message = "Request timeout")
@@ -134,6 +138,7 @@ public class Worker extends AdminResource implements Supplier<WorkerService> {
             value = "Drains the specified worker, i.e., moves its work-assignments to other workers"
     )
     @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Operation successful"),
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
             @ApiResponse(code = 408, message = "Request timeout"),
@@ -150,6 +155,7 @@ public class Worker extends AdminResource implements Supplier<WorkerService> {
             value = "Drains this worker, i.e., moves its work-assignments to other workers"
     )
     @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Operation successful"),
             @ApiResponse(code = 400, message = "Invalid request"),
             @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
             @ApiResponse(code = 408, message = "Request timeout"),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Packages.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Packages.java
@@ -80,7 +80,7 @@ public class Packages extends PackagesBase {
     )
     @ApiResponses(
         value = {
-            @ApiResponse(code = 200, message = "Update the metadata of the specified package successfully."),
+            @ApiResponse(code = 204, message = "Update the metadata of the specified package successfully."),
             @ApiResponse(code = 404, message = "The specified package is not existent."),
             @ApiResponse(code = 412, message = "The package name is illegal."),
             @ApiResponse(code = 500, message = "Internal server error."),
@@ -113,7 +113,7 @@ public class Packages extends PackagesBase {
     )
     @ApiResponses(
         value = {
-            @ApiResponse(code = 200, message = "Upload the specified package successfully."),
+            @ApiResponse(code = 204, message = "Upload the specified package successfully."),
             @ApiResponse(code = 412, message = "The package name is illegal."),
             @ApiResponse(code = 500, message = "Internal server error."),
             @ApiResponse(code = 503, message = "Package Management Service is not enabled in the broker.")
@@ -169,7 +169,7 @@ public class Packages extends PackagesBase {
     @Path("/{type}/{tenant}/{namespace}/{packageName}/{version}")
     @ApiResponses(
         value = {
-            @ApiResponse(code = 200, message = "Delete the specified package successfully."),
+            @ApiResponse(code = 204, message = "Delete the specified package successfully."),
             @ApiResponse(code = 404, message = "The specified package is not existent."),
             @ApiResponse(code = 412, message = "The package name is illegal."),
             @ApiResponse(code = 500, message = "Internal server error."),
@@ -218,7 +218,8 @@ public class Packages extends PackagesBase {
     @Path("/{type}/{tenant}/{namespace}")
     @ApiOperation(
         value = "Get all the specified type packages in a namespace.",
-        response = PackageMetadata.class
+        response = PackageMetadata.class,
+        responseContainer = "List"
     )
     @ApiResponses(
         value = {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
@@ -43,6 +43,17 @@ import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.admin.impl.TransactionsBase;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.web.RestException;
+import org.apache.pulsar.common.policies.data.TransactionBufferInternalStats;
+import org.apache.pulsar.common.policies.data.TransactionBufferStats;
+import org.apache.pulsar.common.policies.data.TransactionCoordinatorInfo;
+import org.apache.pulsar.common.policies.data.TransactionCoordinatorInternalStats;
+import org.apache.pulsar.common.policies.data.TransactionCoordinatorStats;
+import org.apache.pulsar.common.policies.data.TransactionInBufferStats;
+import org.apache.pulsar.common.policies.data.TransactionInPendingAckStats;
+import org.apache.pulsar.common.policies.data.TransactionMetadata;
+import org.apache.pulsar.common.policies.data.TransactionPendingAckInternalStats;
+import org.apache.pulsar.common.policies.data.TransactionPendingAckStats;
+import org.apache.pulsar.common.stats.PositionInPendingAckStats;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.jetbrains.annotations.Nullable;
 
@@ -55,7 +66,8 @@ public class Transactions extends TransactionsBase {
 
     @GET
     @Path("/coordinators")
-    @ApiOperation(value = "List transaction coordinators.")
+    @ApiOperation(value = "List transaction coordinators.",
+            response = TransactionCoordinatorInfo.class, responseContainer = "List")
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 503, message = "This Broker is not "
                     + "configured with transactionCoordinatorEnabled=true.")})
@@ -66,7 +78,7 @@ public class Transactions extends TransactionsBase {
 
     @GET
     @Path("/coordinatorStats")
-    @ApiOperation(value = "Get transaction coordinator stats.")
+    @ApiOperation(value = "Get transaction coordinator stats.", response = TransactionCoordinatorStats.class)
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 503, message = "This Broker is not "
                     + "configured with transactionCoordinatorEnabled=true."),
@@ -82,7 +94,7 @@ public class Transactions extends TransactionsBase {
 
     @GET
     @Path("/transactionInBufferStats/{tenant}/{namespace}/{topic}/{mostSigBits}/{leastSigBits}")
-    @ApiOperation(value = "Get transaction state in transaction buffer.")
+    @ApiOperation(value = "Get transaction state in transaction buffer.", response = TransactionInBufferStats.class)
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Tenant or cluster or namespace or topic doesn't exist"),
             @ApiResponse(code = 503, message = "This Broker is not configured "
@@ -119,7 +131,7 @@ public class Transactions extends TransactionsBase {
 
     @GET
     @Path("/transactionInPendingAckStats/{tenant}/{namespace}/{topic}/{subName}/{mostSigBits}/{leastSigBits}")
-    @ApiOperation(value = "Get transaction state in pending ack.")
+    @ApiOperation(value = "Get transaction state in pending ack.", response = TransactionInPendingAckStats.class)
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Tenant or cluster or namespace or topic doesn't exist"),
             @ApiResponse(code = 503, message = "This Broker is not configured "
@@ -157,7 +169,7 @@ public class Transactions extends TransactionsBase {
 
     @GET
     @Path("/transactionBufferStats/{tenant}/{namespace}/{topic}")
-    @ApiOperation(value = "Get transaction buffer stats in topic.")
+    @ApiOperation(value = "Get transaction buffer stats in topic.", response = TransactionBufferStats.class)
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Tenant or cluster or namespace or topic doesn't exist"),
             @ApiResponse(code = 503, message = "This Broker is not configured "
@@ -195,7 +207,7 @@ public class Transactions extends TransactionsBase {
 
     @GET
     @Path("/pendingAckStats/{tenant}/{namespace}/{topic}/{subName}")
-    @ApiOperation(value = "Get transaction pending ack stats in topic.")
+    @ApiOperation(value = "Get transaction pending ack stats in topic.", response = TransactionPendingAckStats.class)
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Tenant or cluster or namespace or topic or subName doesn't exist"),
             @ApiResponse(code = 503, message = "This Broker is not configured "
@@ -231,7 +243,7 @@ public class Transactions extends TransactionsBase {
 
     @GET
     @Path("/transactionMetadata/{mostSigBits}/{leastSigBits}")
-    @ApiOperation(value = "Get transaction metadata")
+    @ApiOperation(value = "Get transaction metadata", response = TransactionMetadata.class)
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Tenant or cluster or namespace or topic "
                     + "or coordinator or transaction doesn't exist"),
@@ -252,7 +264,7 @@ public class Transactions extends TransactionsBase {
 
     @GET
     @Path("/slowTransactions/{timeout}")
-    @ApiOperation(value = "Get slow transactions.")
+    @ApiOperation(value = "Get slow transactions.", response = TransactionMetadata.class, responseContainer = "Map")
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Tenant or cluster or namespace or topic "
                     + "or coordinator or transaction doesn't exist"),
@@ -272,7 +284,7 @@ public class Transactions extends TransactionsBase {
 
     @GET
     @Path("/coordinatorInternalStats/{coordinatorId}")
-    @ApiOperation(value = "Get coordinator internal stats.")
+    @ApiOperation(value = "Get coordinator internal stats.", response = TransactionCoordinatorInternalStats.class)
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 503, message = "This Broker is not "
                     + "configured with transactionCoordinatorEnabled=true."),
@@ -290,7 +302,8 @@ public class Transactions extends TransactionsBase {
 
     @GET
     @Path("/pendingAckInternalStats/{tenant}/{namespace}/{topic}/{subName}")
-    @ApiOperation(value = "Get transaction pending ack internal stats.")
+    @ApiOperation(value = "Get transaction pending ack internal stats.",
+            response = TransactionPendingAckInternalStats.class)
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Tenant or cluster or namespace or topic "
                     + "or subscription name doesn't exist"),
@@ -343,7 +356,7 @@ public class Transactions extends TransactionsBase {
 
     @GET
     @Path("/transactionBufferInternalStats/{tenant}/{namespace}/{topic}")
-    @ApiOperation(value = "Get transaction buffer internal stats.")
+    @ApiOperation(value = "Get transaction buffer internal stats.", response = TransactionBufferInternalStats.class)
     @ApiResponses(value = {
             @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Tenant or cluster or namespace or topic doesn't exist"),
@@ -379,6 +392,7 @@ public class Transactions extends TransactionsBase {
     @POST
     @Path("/transactionCoordinator/replicas")
     @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Operation successful"),
             @ApiResponse(code = 503, message = "This Broker is not configured "
                     + "with transactionCoordinatorEnabled=true."),
             @ApiResponse(code = 406, message = "The number of replicas should be more than "
@@ -401,7 +415,7 @@ public class Transactions extends TransactionsBase {
 
     @GET
     @Path("/positionStatsInPendingAck/{tenant}/{namespace}/{topic}/{subName}/{ledgerId}/{entryId}")
-    @ApiOperation(value = "Get position stats in pending ack.")
+    @ApiOperation(value = "Get position stats in pending ack.", response = PositionInPendingAckStats.class)
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Tenant or cluster or namespace or topic "
                     + "or subscription name doesn't exist"),
@@ -443,6 +457,7 @@ public class Transactions extends TransactionsBase {
     @Path("/abortTransaction/{mostSigBits}/{leastSigBits}")
     @ApiOperation(value = "Abort transaction")
     @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Operation successful"),
             @ApiResponse(code = 404, message = "Tenant or cluster or namespace or topic "
                     + "or coordinator or transaction doesn't exist"),
             @ApiResponse(code = 503, message = "This Broker is not configured "


### PR DESCRIPTION
### Motivation
#22770

### Modifications
- Clearly define REST API on Open API for Topics
- [x] [ResourceGroups](https://github.com/apache/pulsar/blob/82237d3684fe506bcb6426b3b23f413422e6e4fb/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/ResourceGroups.java#L41)
- [x] [ResourceQuotas](https://github.com/apache/pulsar/blob/82237d3684fe506bcb6426b3b23f413422e6e4fb/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/ResourceQuotas.java#L46)
- [x] [SchemasResource](https://github.com/apache/pulsar/blob/04055fcd79f69b3f50f41acd54e1c121256a34ab/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/SchemasResource.java#L70-L69)
- [x] [Tenants@TenantsBase](https://github.com/apache/pulsar/blob/bbdc173e80157296ff0475cfdc4e36f5d063a7df/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java#L61)
- [x] [Worker](https://github.com/apache/pulsar/blob/55acbe6cef2a0fbd356ad7d085c87e398b7c69db/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Worker.java#L45)
- [x] [WorkerStats](https://github.com/apache/pulsar/blob/55acbe6cef2a0fbd356ad7d085c87e398b7c69db/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/WorkerStats.java#L40)
- [x] [Sinks@SinksBase](https://github.com/apache/pulsar/blob/55acbe6cef2a0fbd356ad7d085c87e398b7c69db/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SinksBase.java#L58)
- [x] [Sources@SourcesBase](https://github.com/apache/pulsar/blob/55acbe6cef2a0fbd356ad7d085c87e398b7c69db/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SourcesBase.java#L60)
- [x] [Transactions](https://github.com/apache/pulsar/blob/cd6f53baee7dbe0651e6581cb9bd3570017348c7/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java#L55-L54)
- [x] [Packages](https://github.com/apache/pulsar/blob/82237d3684fe506bcb6426b3b23f413422e6e4fb/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Packages.java#L54)
- [x] [Functions-V3@FunctionsBase](https://github.com/apache/pulsar/blob/55acbe6cef2a0fbd356ad7d085c87e398b7c69db/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java#L57-L56)

### Verifying this change
- Local validation confirmed that the generated swagger.json file displays well on the web page.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
