### PR TITLE
[fix][ml] Fix race conditions in RangeCache

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryImpl.java
@@ -27,9 +27,10 @@ import io.netty.util.ReferenceCounted;
 import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.util.AbstractCASReferenceCounted;
+import org.apache.bookkeeper.mledger.util.RangeCache;
 
 public final class EntryImpl extends AbstractCASReferenceCounted implements Entry, Comparable<EntryImpl>,
-        ReferenceCounted {
+        RangeCache.ValueWithKeyValidation<PositionImpl> {
 
     private static final Recycler<EntryImpl> RECYCLER = new Recycler<EntryImpl>() {
         @Override
@@ -205,4 +206,8 @@ public final class EntryImpl extends AbstractCASReferenceCounted implements Entr
         recyclerHandle.recycle(this);
     }
 
+    @Override
+    public boolean matchesKey(PositionImpl key) {
+        return key.compareTo(ledgerId, entryId) == 0;
+    }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java
@@ -376,7 +376,7 @@ public class RangeCache<Key extends Comparable<Key>, Value extends ValueWithKeyV
      *
      * @return size of removed entries
      */
-    public synchronized Pair<Integer, Long> clear() {
+    public Pair<Integer, Long> clear() {
         RemovalCounters counters = RemovalCounters.create();
         while (true) {
             Map.Entry<Key, IdentityWrapper<Key, Value>> entry = entries.firstEntry();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java
@@ -37,6 +37,10 @@ import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * Special type of cache where get() and delete() operations can be done over a range of keys.
+ * The implementation avoids locks and synchronization and relies on ConcurrentSkipListMap for storing the entries.
+ * Since there is no locks, there is a need to have a way to ensure that a single entry in the cache is removed
+ * exactly once. Removing an entry multiple times would result in the entries of the cache getting released too
+ * while they could still be in use.
  *
  * @param <Key>
  *            Cache key. Needs to be Comparable

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/util/RangeCacheTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/util/RangeCacheTest.java
@@ -23,25 +23,29 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
-
 import com.google.common.collect.Lists;
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.ReferenceCounted;
-import org.apache.commons.lang3.tuple.Pair;
-import org.testng.annotations.Test;
-import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.tuple.Pair;
+import org.testng.annotations.Test;
 
 public class RangeCacheTest {
 
-    class RefString extends AbstractReferenceCounted implements ReferenceCounted {
+    class RefString extends AbstractReferenceCounted implements RangeCache.ValueWithKeyValidation<Integer> {
         String s;
+        Integer matchingKey;
 
         RefString(String s) {
+            this(s, null);
+        }
+
+        RefString(String s, Integer matchingKey) {
             super();
             this.s = s;
+            this.matchingKey = matchingKey != null ? matchingKey : Integer.parseInt(s);
             setRefCnt(1);
         }
 
@@ -64,6 +68,11 @@ public class RangeCacheTest {
             }
 
             return false;
+        }
+
+        @Override
+        public boolean matchesKey(Integer key) {
+            return matchingKey.equals(key);
         }
     }
 
@@ -119,8 +128,8 @@ public class RangeCacheTest {
     public void customWeighter() {
         RangeCache<Integer, RefString> cache = new RangeCache<>(value -> value.s.length(), x -> 0);
 
-        cache.put(0, new RefString("zero"));
-        cache.put(1, new RefString("one"));
+        cache.put(0, new RefString("zero", 0));
+        cache.put(1, new RefString("one", 1));
 
         assertEquals(cache.getSize(), 7);
         assertEquals(cache.getNumberOfEntries(), 2);
@@ -132,9 +141,9 @@ public class RangeCacheTest {
         RangeCache<Integer, RefString> cache = new RangeCache<>(value -> value.s.length(), x -> x.s.length());
 
         cache.put(1, new RefString("1"));
-        cache.put(2, new RefString("22"));
-        cache.put(3, new RefString("333"));
-        cache.put(4, new RefString("4444"));
+        cache.put(22, new RefString("22"));
+        cache.put(333, new RefString("333"));
+        cache.put(4444, new RefString("4444"));
 
         assertEquals(cache.getSize(), 10);
         assertEquals(cache.getNumberOfEntries(), 4);
@@ -151,12 +160,12 @@ public class RangeCacheTest {
     public void doubleInsert() {
         RangeCache<Integer, RefString> cache = new RangeCache<>();
 
-        RefString s0 = new RefString("zero");
+        RefString s0 = new RefString("zero", 0);
         assertEquals(s0.refCnt(), 1);
         assertTrue(cache.put(0, s0));
         assertEquals(s0.refCnt(), 1);
 
-        cache.put(1, new RefString("one"));
+        cache.put(1, new RefString("one", 1));
 
         assertEquals(cache.getSize(), 2);
         assertEquals(cache.getNumberOfEntries(), 2);
@@ -164,7 +173,7 @@ public class RangeCacheTest {
         assertEquals(s.s, "one");
         assertEquals(s.refCnt(), 2);
 
-        RefString s1 = new RefString("uno");
+        RefString s1 = new RefString("uno", 1);
         assertEquals(s1.refCnt(), 1);
         assertFalse(cache.put(1, s1));
         assertEquals(s1.refCnt(), 1);
@@ -201,10 +210,10 @@ public class RangeCacheTest {
     public void eviction() {
         RangeCache<Integer, RefString> cache = new RangeCache<>(value -> value.s.length(), x -> 0);
 
-        cache.put(0, new RefString("zero"));
-        cache.put(1, new RefString("one"));
-        cache.put(2, new RefString("two"));
-        cache.put(3, new RefString("three"));
+        cache.put(0, new RefString("zero", 0));
+        cache.put(1, new RefString("one", 1));
+        cache.put(2, new RefString("two", 2));
+        cache.put(3, new RefString("three", 3));
 
         // This should remove the LRU entries: 0, 1 whose combined size is 7
         assertEquals(cache.evictLeastAccessedEntries(5), Pair.of(2, (long) 7));
@@ -277,11 +286,11 @@ public class RangeCacheTest {
 
     @Test
     public void testInParallel() {
-        RangeCache<String, RefString> cache = new RangeCache<>(value -> value.s.length(), x -> 0);
+        RangeCache<Integer, RefString> cache = new RangeCache<>(value -> value.s.length(), x -> 0);
         ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
         executor.scheduleWithFixedDelay(cache::clear, 10, 10, TimeUnit.MILLISECONDS);
         for (int i = 0; i < 1000; i++) {
-            cache.put(UUID.randomUUID().toString(), new RefString("zero"));
+            cache.put(i, new RefString(String.valueOf(i)));
         }
         executor.shutdown();
     }
@@ -289,7 +298,7 @@ public class RangeCacheTest {
     @Test
     public void testPutSameObj() {
         RangeCache<Integer, RefString> cache = new RangeCache<>(value -> value.s.length(), x -> 0);
-        RefString s0 = new RefString("zero");
+        RefString s0 = new RefString("zero", 0);
         assertEquals(s0.refCnt(), 1);
         assertTrue(cache.put(0, s0));
         assertFalse(cache.put(0, s0));


### PR DESCRIPTION
### Motivation

The RangeCache class contains several race conditions which cause instability.

When one thread removes the entry and another one uses it, that will become a problem. 

The `cacheEvictionIntervalMs` setting is 10 ms by default. This results in the 
`RangeCache.evictLEntriesBeforeTimestamp` method getting called about 100 times per second.
The default expiration is `managedLedgerCacheEvictionTimeThresholdMillis` which is 1000 ms by default.

It's also possible that 2 threads remove the entry at the same time. `ManagedLedgerImpl.invalidateEntriesUpToSlowestReaderPosition` will result in calls to `RangeCache.removeRange` method. These calls happen independently of the `RangeCache.evictLEntriesBeforeTimestamp` calls so there's a chance for race conditions.

### Modifications

- Add checks to validate that the value hasn't already been released before it is removed.
  - add extra `.retain()` and `.release()` calls
  - add a way to validate that the value matches the key
    - this is to prevent a possible race condition where the entry has already been recycled and contains another valid entry which is for a different key
- Make all removals using the `remove(key, value)` method so that removals remove the correct value exactly once
  - Add a wrapper object for the value to ensure this so that exact identity match is used for the removal.
  - The wrapper instance is recycled to reduce the overhead.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->