### PR TITLE
[improve] Handle PositionInfo that's too large to serialize as a single entry

### DIFF
--- a/buildtools/src/main/resources/pulsar/suppressions.xml
+++ b/buildtools/src/main/resources/pulsar/suppressions.xml
@@ -36,6 +36,7 @@
     <suppress checks=".*" files=".+[\\/]generated[\\/].+\.java"/>
     <suppress checks=".*" files=".+[\\/]generated-sources[\\/].+\.java"/>
     <suppress checks=".*" files=".+[\\/]generated-test-sources[\\/].+\.java"/>
+    <suppress checks=".*" files=".+PositionInfoUtils.java"/>
 
     <!-- suppress most all checks expect below-->
     <suppress checks="^(?!.*(UnusedImports|IllegalImport)).*$" files=".*[\\/]src[\\/]test[\\/].*"/>

--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -176,6 +176,22 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>com.github.splunk.lightproto</groupId>
+        <artifactId>lightproto-maven-plugin</artifactId>
+        <version>${lightproto-maven-plugin.version}</version>
+        <configuration>
+          <singleOuterClass>true</singleOuterClass>
+          <classPrefix>Light</classPrefix>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <executions>

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LedgerMetadataUtils.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LedgerMetadataUtils.java
@@ -44,6 +44,7 @@ public final class LedgerMetadataUtils {
 
     private static final String METADATA_PROPERTY_MANAGED_LEDGER_NAME = "pulsar/managed-ledger";
     private static final String METADATA_PROPERTY_CURSOR_NAME = "pulsar/cursor";
+    public static final String METADATA_PROPERTY_CURSOR_COMPRESSION_TYPE = "pulsar/cursor-compressionType";
     private static final String METADATA_PROPERTY_COMPACTEDTOPIC = "pulsar/compactedTopic";
     private static final String METADATA_PROPERTY_COMPACTEDTO = "pulsar/compactedTo";
     private static final String METADATA_PROPERTY_SCHEMAID = "pulsar/schemaId";
@@ -72,8 +73,13 @@ public final class LedgerMetadataUtils {
      * @return an immutable map which describes the cursor
      * @see #buildBaseManagedLedgerMetadata(java.lang.String)
      */
-    static Map<String, byte[]> buildAdditionalMetadataForCursor(String name) {
-        return Map.of(METADATA_PROPERTY_CURSOR_NAME, name.getBytes(StandardCharsets.UTF_8));
+    static Map<String, byte[]> buildAdditionalMetadataForCursor(String name, String compressionType) {
+        if (compressionType != null) {
+            return Map.of(METADATA_PROPERTY_CURSOR_NAME, name.getBytes(StandardCharsets.UTF_8),
+                    METADATA_PROPERTY_CURSOR_COMPRESSION_TYPE, compressionType.getBytes(StandardCharsets.UTF_8));
+        } else {
+            return Map.of(METADATA_PROPERTY_CURSOR_NAME, name.getBytes(StandardCharsets.UTF_8));
+        }
     }
 
     /**

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -678,6 +678,8 @@ public class ManagedCursorImpl implements ManagedCursor {
         try {
             data = decompressDataIfNeeded(data, lh);
         } catch (Throwable e) {
+            log.error("[{}] Failed to decompress position info from ledger {} for cursor {}: {}", ledger.getName(),
+                    lh.getId(), name, e);
             callback.operationFailed(new ManagedLedgerException(e));
             return;
         }
@@ -688,12 +690,8 @@ public class ManagedCursorImpl implements ManagedCursor {
         } catch (InvalidProtocolBufferException e) {
             log.error("[{}] Failed to parse position info from ledger {} for cursor {}: {}", ledger.getName(),
                     lh.getId(), name, e);
-            // Rewind to oldest entry available
-            positionInfo = PositionInfo
-                    .newBuilder()
-                    .setLedgerId(-1)
-                    .setEntryId(-1)
-                    .build();
+            callback.operationFailed(new ManagedLedgerException(e));
+            return;
         }
 
         Map<String, Long> recoveredProperties = Collections.emptyMap();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.mledger.impl;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static org.apache.bookkeeper.mledger.ManagedLedgerException.getManagedLedgerException;
+import static org.apache.bookkeeper.mledger.impl.LedgerMetadataUtils.METADATA_PROPERTY_CURSOR_COMPRESSION_TYPE;
 import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.DEFAULT_LEDGER_DELETE_BACKOFF_TIME_SEC;
 import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.DEFAULT_LEDGER_DELETE_RETRIES;
 import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.createManagedLedgerException;
@@ -32,6 +33,14 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.protobuf.InvalidProtocolBufferException;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.time.Clock;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -96,6 +105,9 @@ import org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.PositionInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.StringProperty;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pulsar.common.api.proto.CompressionType;
+import org.apache.pulsar.common.compression.CompressionCodec;
+import org.apache.pulsar.common.compression.CompressionCodecProvider;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.BitSetRecyclable;
 import org.apache.pulsar.common.util.collections.LongPairRangeSet;
@@ -121,6 +133,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     protected final BookKeeper bookkeeper;
     protected final ManagedLedgerImpl ledger;
     private final String name;
+    private final String cursorInfoCompressionType;
 
     public static final String CURSOR_INTERNAL_PROPERTY_PREFIX = "#pulsar.internal.";
 
@@ -327,6 +340,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             markDeleteLimiter = null;
         }
         this.mbean = new ManagedCursorMXBeanImpl(this);
+        this.cursorInfoCompressionType = ledger.getFactory().getConfig().getManagedCursorInfoCompressionType();
     }
 
     private void updateCursorLedgerStat(ManagedCursorInfo cursorInfo, Stat stat) {
@@ -585,11 +599,14 @@ public class ManagedCursorImpl implements ManagedCursor {
                 mbean.addReadCursorLedgerSize(entry.getLength());
                 PositionInfo positionInfo;
                 try {
-                    positionInfo = PositionInfo.parseFrom(entry.getEntry());
+                    byte[] data = entry.getEntry();
+                    data = decompressDataIfNeeded(data, lh);
+                    positionInfo = PositionInfo.parseFrom(data);
                 } catch (InvalidProtocolBufferException e) {
                     callback.operationFailed(new ManagedLedgerException(e));
                     return;
                 }
+                log.info("[{}] Cursor {} recovered to position {}", ledger.getName(), name, positionInfo);
 
                 Map<String, Long> recoveredProperties = Collections.emptyMap();
                 if (positionInfo.getPropertiesCount() > 0) {
@@ -600,6 +617,9 @@ public class ManagedCursorImpl implements ManagedCursor {
                         recoveredProperties.put(property.getName(), property.getValue());
                     }
                 }
+
+                log.info("[{}] Cursor {} recovered with recoveredProperties {}, individualDeletedMessagesCount {}",
+                        ledger.getName(), name, recoveredProperties, positionInfo.getIndividualDeletedMessagesCount());
 
                 PositionImpl position = new PositionImpl(positionInfo);
                 if (positionInfo.getIndividualDeletedMessagesCount() > 0) {
@@ -624,6 +644,8 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
     private void recoverIndividualDeletedMessages(List<MLDataFormats.MessageRange> individualDeletedMessagesList) {
+        log.info("[{}] [{}] Recovering individual deleted messages. Number of ranges: {}",
+                ledger.getName(), name, individualDeletedMessagesList.size());
         lock.writeLock().lock();
         try {
             individualDeletedMessages.clear();
@@ -2971,7 +2993,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                 }
                 future.complete(lh);
             });
-        }, LedgerMetadataUtils.buildAdditionalMetadataForCursor(name));
+        }, LedgerMetadataUtils.buildAdditionalMetadataForCursor(name, cursorInfoCompressionType));
 
         return future;
     }
@@ -3022,6 +3044,8 @@ public class ManagedCursorImpl implements ManagedCursor {
     private List<MLDataFormats.MessageRange> buildIndividualDeletedMessageRanges() {
         lock.readLock().lock();
         try {
+            log.info("[{}] [{}] buildIndividualDeletedMessageRanges, numRanges {}",
+                    ledger.getName(), name, individualDeletedMessages.size());
             if (individualDeletedMessages.isEmpty()) {
                 this.individualDeletedMessagesSerializedSize = 0;
                 return Collections.emptyList();
@@ -3060,6 +3084,13 @@ public class ManagedCursorImpl implements ManagedCursor {
 
             this.individualDeletedMessagesSerializedSize = acksSerializedSize.get();
             individualDeletedMessages.resetDirtyKeys();
+            log.info("[{}] [{}] buildIndividualDeletedMessageRanges, numRanges {} "
+                            + "individualDeletedMessagesSerializedSize {} rangeListSize {} "
+                            + "maxUnackedRangesToPersist {}",
+                    ledger.getName(), name, individualDeletedMessages.size(),
+                    individualDeletedMessagesSerializedSize, rangeList.size(),
+                    getConfig().getMaxUnackedRangesToPersist());
+
             return rangeList;
         } finally {
             lock.readLock().unlock();
@@ -3113,7 +3144,14 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
 
         requireNonNull(lh);
-        byte[] data = pi.toByteArray();
+        byte[] rawData = pi.toByteArray();
+
+        byte[] data = compressDataIfNeeded(rawData, lh);
+
+        log.info("[{}] Cursor {} Appending to ledger={} position={} data size {} bytes",
+                ledger.getName(), name, lh.getId(),
+                position, data.length);
+
         lh.asyncAddEntry(data, (rc, lh1, entryId, ctx) -> {
             if (rc == BKException.Code.OK) {
                 if (log.isDebugEnabled()) {
@@ -3137,6 +3175,62 @@ public class ManagedCursorImpl implements ManagedCursor {
                 persistPositionToMetaStore(mdEntry, callback);
             }
         }, null);
+    }
+
+    private byte[] compressDataIfNeeded(byte[] data, LedgerHandle lh) {
+        byte[] pulsarCursorInfoCompression =
+                lh.getCustomMetadata().get(METADATA_PROPERTY_CURSOR_COMPRESSION_TYPE);
+        if (pulsarCursorInfoCompression != null) {
+            String pulsarCursorInfoCompressionString = new String(pulsarCursorInfoCompression);
+            CompressionCodec compressionCodec = CompressionCodecProvider.getCompressionCodec(
+                    CompressionType.valueOf(pulsarCursorInfoCompressionString));
+            ByteBuf encode = compressionCodec.encode(Unpooled.wrappedBuffer(data));
+            try {
+                int uncompressedSize = data.length;
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                DataOutputStream dataOutputStream = new DataOutputStream(out);
+                dataOutputStream.writeInt(uncompressedSize);
+                dataOutputStream.write(ByteBufUtil.getBytes(encode));
+                dataOutputStream.flush();
+                byte[] result =  out.toByteArray();
+                int ratio = (int) (result.length * 100.0 / uncompressedSize);
+                log.info("[{}] Cursor {} Compressed data size {} bytes (with {}, original size {} bytes, ratio {}%)",
+                        ledger.getName(), name, result.length, pulsarCursorInfoCompressionString, data.length, ratio);
+                return result;
+            } catch (IOException error) {
+                throw new RuntimeException(error);
+            } finally {
+                encode.release();
+            }
+        } else {
+            return data;
+        }
+    }
+
+    private static byte[] decompressDataIfNeeded(byte[] data, LedgerHandle lh) {
+        byte[] pulsarCursorInfoCompression =
+                lh.getCustomMetadata().get(METADATA_PROPERTY_CURSOR_COMPRESSION_TYPE);
+        if (pulsarCursorInfoCompression != null) {
+            String pulsarCursorInfoCompressionString = new String(pulsarCursorInfoCompression);
+            CompressionCodec compressionCodec = CompressionCodecProvider.getCompressionCodec(
+                    CompressionType.valueOf(pulsarCursorInfoCompressionString));
+            ByteArrayInputStream input = new ByteArrayInputStream(data);
+            DataInputStream dataInputStream = new DataInputStream(input);
+            try {
+                int uncompressedSize = dataInputStream.readInt();
+                byte[] compressedData = dataInputStream.readNBytes(uncompressedSize);
+                ByteBuf decode = compressionCodec.decode(Unpooled.wrappedBuffer(compressedData), uncompressedSize);
+                try {
+                    return ByteBufUtil.getBytes(decode);
+                } finally {
+                    decode.release();
+                }
+            } catch (IOException error) {
+                throw new RuntimeException(error);
+            }
+        } else {
+            return data;
+        }
     }
 
     public boolean periodicRollover() {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -26,6 +26,7 @@ import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.DEFAULT_LEDGE
 import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.DEFAULT_LEDGER_DELETE_RETRIES;
 import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.createManagedLedgerException;
 import static org.apache.bookkeeper.mledger.util.Errors.isNoSuchLedgerExistsException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Collections2;
@@ -35,11 +36,11 @@ import com.google.common.util.concurrent.RateLimiter;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.time.Clock;
 import java.util.ArrayDeque;
@@ -69,6 +70,11 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.LongStream;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.apache.bookkeeper.client.AsyncCallback.CloseCallback;
 import org.apache.bookkeeper.client.AsyncCallback.OpenCallback;
 import org.apache.bookkeeper.client.BKException;
@@ -97,6 +103,7 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.ScanOutcome;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.PositionBound;
 import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
+import org.apache.bookkeeper.mledger.proto.LightMLDataFormats;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.LongProperty;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedCursorInfo;
@@ -105,10 +112,12 @@ import org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.PositionInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.StringProperty;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.proto.CompressionType;
 import org.apache.pulsar.common.compression.CompressionCodec;
 import org.apache.pulsar.common.compression.CompressionCodecProvider;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.common.util.collections.BitSetRecyclable;
 import org.apache.pulsar.common.util.collections.LongPairRangeSet;
 import org.apache.pulsar.common.util.collections.LongPairRangeSet.LongPairConsumer;
@@ -119,6 +128,14 @@ import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("checkstyle:javadoctype")
 public class ManagedCursorImpl implements ManagedCursor {
+
+    private static final FastThreadLocal<LightMLDataFormats.PositionInfo> piThreadLocal = new FastThreadLocal<>() {
+        @Override
+        protected LightMLDataFormats.PositionInfo initialValue() {
+            return new LightMLDataFormats.PositionInfo();
+        }
+    };
+
     private static final Comparator<Entry> ENTRY_COMPARATOR = (e1, e2) -> {
         if (e1.getLedgerId() != e2.getLedgerId()) {
             return e1.getLedgerId() < e2.getLedgerId() ? -1 : 1;
@@ -641,6 +658,25 @@ public class ManagedCursorImpl implements ManagedCursor {
                 ledger.getName(), ledgerId, name, t);
             openCallback.openComplete(BKException.Code.UnexpectedConditionException, null, null);
         }
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @ToString
+    @Data
+    public static final class ChunkSequenceFooter {
+        private static final ChunkSequenceFooter NOT_CHUNKED = new ChunkSequenceFooter(0, 0);
+        private int numParts;
+        private int length;
+    }
+
+    private ChunkSequenceFooter parseChunkSequenceFooter(byte[] data) throws IOException {
+        if (data.length == 0 || data[0] != '{') {
+            // this is not JSON
+            return ChunkSequenceFooter.NOT_CHUNKED;
+        }
+        return ObjectMapperFactory.getMapper().getObjectMapper().readValue(data, ChunkSequenceFooter.class);
     }
 
     private void recoverIndividualDeletedMessages(List<MLDataFormats.MessageRange> individualDeletedMessagesList) {
@@ -3013,6 +3049,18 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
 
+    private static void addAllProperties(LightMLDataFormats.PositionInfo lpi, Map<String, Long> properties) {
+        if (properties.isEmpty()) {
+            return;
+        }
+
+        properties.forEach((name, value) -> {
+            lpi.addProperty()
+                    .setName(name)
+                    .setValue(value);
+        });
+    }
+
     private static List<LongProperty> buildPropertiesMap(Map<String, Long> properties) {
         if (properties.isEmpty()) {
             return Collections.emptyList();
@@ -3097,6 +3145,44 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
     }
 
+    private void addIndividualDeletedMessageRanges(LightMLDataFormats.PositionInfo lpi) {
+        lock.readLock().lock();
+        try {
+            if (individualDeletedMessages.isEmpty()) {
+                this.individualDeletedMessagesSerializedSize = 0;
+                return;
+            }
+
+            AtomicInteger acksSerializedSize = new AtomicInteger(0);
+            AtomicInteger rangeCount = new AtomicInteger(0);
+
+            individualDeletedMessages.forEachRawRange((lowerKey, lowerValue, upperKey, upperValue) -> {
+                LightMLDataFormats.MessageRange messageRange = lpi.addIndividualDeletedMessage();
+                messageRange.setLowerEndpoint()
+                        .setLedgerId(lowerKey)
+                        .setEntryId(lowerValue);
+                messageRange.setUpperEndpoint()
+                        .setLedgerId(upperKey)
+                        .setEntryId(upperValue);
+
+                acksSerializedSize.addAndGet(messageRange.getSerializedSize());
+
+                return rangeCount.incrementAndGet() <= getConfig().getMaxUnackedRangesToPersist();
+            });
+
+            this.individualDeletedMessagesSerializedSize = acksSerializedSize.get();
+            individualDeletedMessages.resetDirtyKeys();
+            log.info("[{}] [{}] buildIndividualDeletedMessageRanges, numRanges {} "
+                            + "individualDeletedMessagesSerializedSize {} rangeListSize {} "
+                            + "maxUnackedRangesToPersist {}",
+                    ledger.getName(), name, individualDeletedMessages.size(),
+                    individualDeletedMessagesSerializedSize, rangeCount.get(),
+                    getConfig().getMaxUnackedRangesToPersist());
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
     private List<MLDataFormats.BatchedEntryDeletionIndexInfo> buildBatchEntryDeletionIndexInfoList() {
         lock.readLock().lock();
         try {
@@ -3129,14 +3215,52 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
     }
 
+    private void addAllBatchedEntryDeletionIndexInfo(LightMLDataFormats.PositionInfo lpi) {
+        lock.readLock().lock();
+        try {
+            if (!getConfig().isDeletionAtBatchIndexLevelEnabled() || batchDeletedIndexes.isEmpty()) {
+                return;
+            }
+            Iterator<Map.Entry<PositionImpl, BitSetRecyclable>> iterator = batchDeletedIndexes.entrySet().iterator();
+            int count = 0;
+            while (iterator.hasNext() && count < getConfig().getMaxBatchDeletedIndexToPersist()) {
+                Map.Entry<PositionImpl, BitSetRecyclable> entry = iterator.next();
+
+                LightMLDataFormats.BatchedEntryDeletionIndexInfo batchInfo = lpi.addBatchedEntryDeletionIndexInfo();
+                batchInfo.setPosition()
+                        .setLedgerId(entry.getKey().getLedgerId())
+                        .setEntryId(entry.getKey().getEntryId());
+
+                long[] array = entry.getValue().toLongArray();
+                List<Long> deleteSet = new ArrayList<>(array.length);
+                for (long l : array) {
+                    batchInfo.addDeleteSet(l);
+                }
+                count++;
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    private static ByteBuf toByteBuf(LightMLDataFormats.PositionInfo pi) {
+        int size = pi.getSerializedSize();
+        ByteBuf buf = PulsarByteBufAllocator.DEFAULT.buffer(size, size);
+        pi.writeTo(buf);
+        return buf;
+    }
+
     void persistPositionToLedger(final LedgerHandle lh, MarkDeleteEntry mdEntry, final VoidCallback callback) {
         PositionImpl position = mdEntry.newPosition;
-        PositionInfo pi = PositionInfo.newBuilder().setLedgerId(position.getLedgerId())
-                .setEntryId(position.getEntryId())
-                .addAllIndividualDeletedMessages(buildIndividualDeletedMessageRanges())
-                .addAllBatchedEntryDeletionIndexInfo(buildBatchEntryDeletionIndexInfoList())
-                .addAllProperties(buildPropertiesMap(mdEntry.properties)).build();
 
+        LightMLDataFormats.PositionInfo pi = piThreadLocal.get();
+        pi.clear();
+
+        pi.setLedgerId(position.getLedgerId())
+                .setEntryId(position.getEntryId());
+        addIndividualDeletedMessageRanges(pi);
+        addAllBatchedEntryDeletionIndexInfo(pi);
+        addAllProperties(pi, mdEntry.properties);
 
         if (log.isDebugEnabled()) {
             log.debug("[{}] Cursor {} Appending to ledger={} position={}", ledger.getName(), name, lh.getId(),
@@ -3144,14 +3268,75 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
 
         requireNonNull(lh);
-        byte[] rawData = pi.toByteArray();
+        ByteBuf rawData = toByteBuf(pi);
 
-        byte[] data = compressDataIfNeeded(rawData, lh);
+        // rawData is released by compressDataIfNeeded if needed
+        ByteBuf data = compressDataIfNeeded(rawData, lh);
 
-        log.info("[{}] Cursor {} Appending to ledger={} position={} data size {} bytes",
-                ledger.getName(), name, lh.getId(),
-                position, data.length);
+        int maxSize = 1024 * 1024;
+        int offset = 0;
+        final int len = data.readableBytes();
+        int numParts = 1 + (len / maxSize);
 
+        if (log.isDebugEnabled()) {
+            log.debug("[{}] Cursor {} Appending to ledger={} position={} data size {} bytes, numParts {}",
+                    ledger.getName(), name, lh.getId(),
+                    position, len, numParts);
+        }
+
+        if (numParts == 1) {
+            // no need for chunking
+            // asyncAddEntry will release data ByteBuf
+            writeToBookKeeperLastChunk(lh, mdEntry, callback, data, position, () -> {});
+        } else {
+            // chunking
+            int part = 0;
+            while (part != numParts) {
+                int remaining = len - offset;
+                int currentLen = Math.min(maxSize, remaining);
+                boolean isLast = part == numParts - 1;
+
+                if (log.isDebugEnabled()) {
+                    log.info("[{}] Cursor {} Appending to ledger={} position={} data size {} bytes, numParts {} "
+                                    + "part {} offset {} len {}",
+                            ledger.getName(), name, lh.getId(),
+                            position, len, numParts, part, offset, currentLen);
+                }
+
+                // just send the addEntry, BK client guarantees that each entry succeeds only if all
+                // the previous entries succeeded
+                // asyncAddEntry takes ownership of the buffer
+                lh.asyncAddEntry(data.retainedSlice(offset, currentLen), (rc, lh1, entryId, ctx) -> {
+                }, null);
+
+                if (isLast) {
+                    // last, send a footer with the number of parts
+                    ChunkSequenceFooter footer = new ChunkSequenceFooter(numParts, len);
+                    byte[] footerData;
+                    try {
+                        footerData = ObjectMapperFactory.getMapper()
+                                .getObjectMapper().writeValueAsBytes(footer);
+                    } catch (JsonProcessingException e) {
+                        // this is almost impossible to happen
+                        log.error("Cannot serialize footer {}", footer);
+                        return;
+                    }
+                    // need to explicitly release data ByteBuf
+                    writeToBookKeeperLastChunk(lh, mdEntry, callback,
+                            Unpooled.wrappedBuffer(footerData), position, data::release);
+                }
+                offset += currentLen;
+                part++;
+            }
+        }
+    }
+
+    private void writeToBookKeeperLastChunk(LedgerHandle lh,
+                                            MarkDeleteEntry mdEntry,
+                                            VoidCallback callback,
+                                            ByteBuf data,
+                                            PositionImpl position,
+                                            Runnable onFinished) {
         lh.asyncAddEntry(data, (rc, lh1, entryId, ctx) -> {
             if (rc == BKException.Code.OK) {
                 if (log.isDebugEnabled()) {
@@ -3162,8 +3347,9 @@ public class ManagedCursorImpl implements ManagedCursor {
                 rolloverLedgerIfNeeded(lh1);
 
                 mbean.persistToLedger(true);
-                mbean.addWriteCursorLedgerSize(data.length);
+                mbean.addWriteCursorLedgerSize(data.readableBytes());
                 callback.operationComplete();
+                onFinished.run();
             } else {
                 log.warn("[{}] Error updating cursor {} position {} in meta-ledger {}: {}", ledger.getName(), name,
                         position, lh1.getId(), BKException.getMessage(rc));
@@ -3173,37 +3359,41 @@ public class ManagedCursorImpl implements ManagedCursor {
 
                 // Before giving up, try to persist the position in the metadata store.
                 persistPositionToMetaStore(mdEntry, callback);
+                onFinished.run();
             }
         }, null);
     }
 
-    private byte[] compressDataIfNeeded(byte[] data, LedgerHandle lh) {
+    private ByteBuf compressDataIfNeeded(ByteBuf data, LedgerHandle lh) {
         byte[] pulsarCursorInfoCompression =
                 lh.getCustomMetadata().get(METADATA_PROPERTY_CURSOR_COMPRESSION_TYPE);
-        if (pulsarCursorInfoCompression != null) {
+        if (pulsarCursorInfoCompression == null) {
+            return data;
+        }
+
+        try {
+            int uncompressedSize = data.readableBytes();
             String pulsarCursorInfoCompressionString = new String(pulsarCursorInfoCompression);
             CompressionCodec compressionCodec = CompressionCodecProvider.getCompressionCodec(
                     CompressionType.valueOf(pulsarCursorInfoCompressionString));
-            ByteBuf encode = compressionCodec.encode(Unpooled.wrappedBuffer(data));
-            try {
-                int uncompressedSize = data.length;
-                ByteArrayOutputStream out = new ByteArrayOutputStream();
-                DataOutputStream dataOutputStream = new DataOutputStream(out);
-                dataOutputStream.writeInt(uncompressedSize);
-                dataOutputStream.write(ByteBufUtil.getBytes(encode));
-                dataOutputStream.flush();
-                byte[] result =  out.toByteArray();
-                int ratio = (int) (result.length * 100.0 / uncompressedSize);
-                log.info("[{}] Cursor {} Compressed data size {} bytes (with {}, original size {} bytes, ratio {}%)",
-                        ledger.getName(), name, result.length, pulsarCursorInfoCompressionString, data.length, ratio);
-                return result;
-            } catch (IOException error) {
-                throw new RuntimeException(error);
-            } finally {
-                encode.release();
-            }
-        } else {
-            return data;
+            ByteBuf encode = compressionCodec.encode(data);
+
+            int compressedSize = encode.readableBytes();
+
+            ByteBuf szBuf = PulsarByteBufAllocator.DEFAULT.buffer(4).writeInt(uncompressedSize);
+
+            CompositeByteBuf result = PulsarByteBufAllocator.DEFAULT.compositeBuffer(2);
+            result.addComponent(szBuf)
+                    .addComponent(encode);
+            result.readerIndex(0)
+                    .writerIndex(4 + compressedSize);
+
+            int ratio = (int) (compressedSize * 100.0 / uncompressedSize);
+            log.info("[{}] Cursor {} Compressed data size {} bytes (with {}, original size {} bytes, ratio {}%)",
+                    ledger.getName(), name, compressedSize, pulsarCursorInfoCompressionString, uncompressedSize, ratio);
+            return result;
+        } finally {
+            data.release();
         }
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3278,6 +3278,9 @@ public class ManagedCursorImpl implements ManagedCursor {
             Iterator<Map.Entry<PositionImpl, BitSetRecyclable>> iterator = batchDeletedIndexes.entrySet().iterator();
             while (iterator.hasNext() && result.size() < getConfig().getMaxBatchDeletedIndexToPersist()) {
                 Map.Entry<PositionImpl, BitSetRecyclable> entry = iterator.next();
+                nestedPositionBuilder.setLedgerId(entry.getKey().getLedgerId());
+                nestedPositionBuilder.setEntryId(entry.getKey().getEntryId());
+                batchDeletedIndexInfoBuilder.setPosition(nestedPositionBuilder.build());
                 long[] array = entry.getValue().toLongArray();
                 List<Long> deleteSet = new ArrayList<>(array.length);
                 for (long l : array) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -40,6 +40,7 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.time.Clock;
@@ -47,6 +48,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -75,6 +77,7 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.apache.bookkeeper.client.AsyncCallback;
 import org.apache.bookkeeper.client.AsyncCallback.CloseCallback;
 import org.apache.bookkeeper.client.AsyncCallback.OpenCallback;
 import org.apache.bookkeeper.client.BKException;
@@ -243,6 +246,8 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     // active state cache in ManagedCursor. It should be in sync with the state in activeCursors in ManagedLedger.
     private volatile boolean isActive = false;
+
+    protected int maxPositionChunkSize = 1024 * 1024;
 
     static class MarkDeleteEntry {
         final PositionImpl newPosition;
@@ -581,71 +586,9 @@ public class ManagedCursorImpl implements ManagedCursor {
 
             // Read the last entry in the ledger
             long lastEntryInLedger = lh.getLastAddConfirmed();
-
-            if (lastEntryInLedger < 0) {
-                log.warn("[{}] Error reading from metadata ledger {} for cursor {}: No entries in ledger",
-                        ledger.getName(), ledgerId, name);
-                // Rewind to last cursor snapshot available
-                initialize(getRollbackPosition(info), Collections.emptyMap(), cursorProperties, callback);
-                return;
-            }
-
-            lh.asyncReadEntries(lastEntryInLedger, lastEntryInLedger, (rc1, lh1, seq, ctx1) -> {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}} readComplete rc={} entryId={}", ledger.getName(), rc1, lh1.getLastAddConfirmed());
-                }
-                if (isBkErrorNotRecoverable(rc1)) {
-                    log.error("[{}] Error reading from metadata ledger {} for cursor {}: {}", ledger.getName(),
-                            ledgerId, name, BKException.getMessage(rc1));
-                    // Rewind to oldest entry available
-                    initialize(getRollbackPosition(info), Collections.emptyMap(), cursorProperties, callback);
-                    return;
-                } else if (rc1 != BKException.Code.OK) {
-                    log.warn("[{}] Error reading from metadata ledger {} for cursor {}: {}", ledger.getName(),
-                            ledgerId, name, BKException.getMessage(rc1));
-
-                    callback.operationFailed(createManagedLedgerException(rc1));
-                    return;
-                }
-
-                LedgerEntry entry = seq.nextElement();
-                mbean.addReadCursorLedgerSize(entry.getLength());
-                PositionInfo positionInfo;
-                try {
-                    byte[] data = entry.getEntry();
-                    data = decompressDataIfNeeded(data, lh);
-                    positionInfo = PositionInfo.parseFrom(data);
-                } catch (InvalidProtocolBufferException e) {
-                    callback.operationFailed(new ManagedLedgerException(e));
-                    return;
-                }
-                log.info("[{}] Cursor {} recovered to position {}", ledger.getName(), name, positionInfo);
-
-                Map<String, Long> recoveredProperties = Collections.emptyMap();
-                if (positionInfo.getPropertiesCount() > 0) {
-                    // Recover properties map
-                    recoveredProperties = new HashMap<>();
-                    for (int i = 0; i < positionInfo.getPropertiesCount(); i++) {
-                        LongProperty property = positionInfo.getProperties(i);
-                        recoveredProperties.put(property.getName(), property.getValue());
-                    }
-                }
-
-                log.info("[{}] Cursor {} recovered with recoveredProperties {}, individualDeletedMessagesCount {}",
-                        ledger.getName(), name, recoveredProperties, positionInfo.getIndividualDeletedMessagesCount());
-
-                PositionImpl position = new PositionImpl(positionInfo);
-                if (positionInfo.getIndividualDeletedMessagesCount() > 0) {
-                    recoverIndividualDeletedMessages(positionInfo.getIndividualDeletedMessagesList());
-                }
-                if (getConfig().isDeletionAtBatchIndexLevelEnabled()
-                    && positionInfo.getBatchedEntryDeletionIndexInfoCount() > 0) {
-                    recoverBatchDeletedIndexes(positionInfo.getBatchedEntryDeletionIndexInfoList());
-                }
-                recoveredCursor(position, recoveredProperties, cursorProperties, lh);
-                callback.operationComplete();
-            }, null);
+            recoverFromLedgerByEntryId(info, callback, lh, lastEntryInLedger);
         };
+
         try {
             bookkeeper.asyncOpenLedger(ledgerId, digestType, getConfig().getPassword(), openCallback,
                     null);
@@ -654,6 +597,101 @@ public class ManagedCursorImpl implements ManagedCursor {
                 ledger.getName(), ledgerId, name, t);
             openCallback.openComplete(BKException.Code.UnexpectedConditionException, null, null);
         }
+    }
+
+    private void recoverFromLedgerByEntryId(ManagedCursorInfo info,
+                                            VoidCallback callback,
+                                            LedgerHandle lh,
+                                            long entryId) {
+        long ledgerId = lh.getId();
+
+        if (entryId < 0) {
+            log.warn("[{}] Error reading from metadata ledger {} for cursor {}: No valid entries in ledger",
+                    ledger.getName(), ledgerId, name);
+            // Rewind to last cursor snapshot available
+            initialize(getRollbackPosition(info), Collections.emptyMap(), cursorProperties, callback);
+            return;
+        }
+
+        lh.asyncReadEntries(entryId, entryId, (rc1, lh1, seq, ctx1) -> {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}} readComplete rc={} entryId={}", ledger.getName(), rc1, lh1.getLastAddConfirmed());
+            }
+            if (isBkErrorNotRecoverable(rc1)) {
+                log.error("[{}] Error reading from metadata ledger {} for cursor {}: {}", ledger.getName(),
+                        ledgerId, name, BKException.getMessage(rc1));
+                // Rewind to oldest entry available
+                initialize(getRollbackPosition(info), Collections.emptyMap(), cursorProperties, callback);
+                return;
+            } else if (rc1 != BKException.Code.OK) {
+                log.warn("[{}] Error reading from metadata ledger {} for cursor {}: {}", ledger.getName(),
+                        ledgerId, name, BKException.getMessage(rc1));
+
+                callback.operationFailed(createManagedLedgerException(rc1));
+                return;
+            }
+
+            LedgerEntry entry = seq.nextElement();
+            byte[] data = entry.getEntry();
+            try {
+                ChunkSequenceFooter chunkSequenceFooter = parseChunkSequenceFooter(data);
+                if (chunkSequenceFooter.numParts > 0) {
+                    readChunkSequence(callback, lh, entryId, chunkSequenceFooter);
+                } else {
+                    Throwable res = tryCompleteCursorRecovery(lh, data);
+                    if (res == null) {
+                        callback.operationComplete();
+                    } else {
+                        log.warn("[{}] Error recovering from metadata ledger {} entry {} for cursor {}. "
+                                        + "Will try recovery from previous entry.",
+                                ledger.getName(), ledgerId, entryId, name, res);
+                        //try recovery from previous entry
+                        recoverFromLedgerByEntryId(info, callback, lh, entryId - 1);
+                    }
+                }
+            } catch (IOException error) {
+                log.error("Cannot parse footer", error);
+                log.warn("[{}] Error recovering from metadata ledger {} entry {} for cursor {}, cannot parse footer. "
+                                + "Will try recovery from previous entry.",
+                        ledger.getName(), ledgerId, entryId, name, error);
+                recoverFromLedgerByEntryId(info, callback, lh, entryId - 1);
+            }
+        }, null);
+    }
+
+    private void readChunkSequence(VoidCallback callback, LedgerHandle lh,
+                                   long footerPosition, ChunkSequenceFooter chunkSequenceFooter) {
+        long startPos = footerPosition - chunkSequenceFooter.numParts;
+        long endPos = footerPosition - 1;
+        log.info("readChunkSequence from pos {}, num parts {}, startPos {}, endPos {}",
+                footerPosition, chunkSequenceFooter.numParts, startPos, endPos);
+        lh.asyncReadEntries(startPos, endPos, new AsyncCallback.ReadCallback() {
+            @Override
+            public void readComplete(int rc, LedgerHandle lh, Enumeration<LedgerEntry> entries, Object ctx) {
+                ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+                entries.asIterator().forEachRemaining(entry -> {
+                    log.info("pos {} len {} bytes ", entry.getEntryId(), entry.getLength());
+                    try {
+                        buffer.write(entry.getEntry());
+                    } catch (IOException err) {
+                        throw new RuntimeException(err);
+                    }
+                });
+                byte[] result = buffer.toByteArray();
+                log.info("Read {} chunks, total of {} bytes, expected {} bytes", chunkSequenceFooter.numParts,
+                        result.length, chunkSequenceFooter.length);
+                if (result.length != chunkSequenceFooter.length) {
+                    callback.operationFailed(ManagedLedgerException.getManagedLedgerException(new IOException(
+                            "Expected " + chunkSequenceFooter.length + " bytes but read " + result.length + " bytes")));
+                }
+                Throwable res = tryCompleteCursorRecovery(lh, result);
+                if (res == null) {
+                    callback.operationComplete();
+                } else {
+                    callback.operationFailed(new ManagedLedgerException(res));
+                }
+            }
+        }, null);
     }
 
     @AllArgsConstructor
@@ -675,7 +713,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         return ObjectMapperFactory.getMapper().getObjectMapper().readValue(data, ChunkSequenceFooter.class);
     }
 
-    private void completeCursorRecovery(VoidCallback callback, LedgerHandle lh,  byte[] data) {
+    private Throwable tryCompleteCursorRecovery(LedgerHandle lh,  byte[] data) {
         mbean.addReadCursorLedgerSize(data.length);
 
         try {
@@ -683,8 +721,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         } catch (Throwable e) {
             log.error("[{}] Failed to decompress position info from ledger {} for cursor {}: {}", ledger.getName(),
                     lh.getId(), name, e);
-            callback.operationFailed(new ManagedLedgerException(e));
-            return;
+            return e;
         }
 
         PositionInfo positionInfo;
@@ -693,8 +730,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         } catch (InvalidProtocolBufferException e) {
             log.error("[{}] Failed to parse position info from ledger {} for cursor {}: {}", ledger.getName(),
                     lh.getId(), name, e);
-            callback.operationFailed(new ManagedLedgerException(e));
-            return;
+            return e;
         }
 
         Map<String, Long> recoveredProperties = Collections.emptyMap();
@@ -716,7 +752,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             recoverBatchDeletedIndexes(positionInfo.getBatchedEntryDeletionIndexInfoList());
         }
         recoveredCursor(position, recoveredProperties, cursorProperties, lh);
-        callback.operationComplete();
+        return null;
     }
 
     private void recoverIndividualDeletedMessages(List<MLDataFormats.MessageRange> individualDeletedMessagesList) {
@@ -3282,6 +3318,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
     void persistPositionToLedger(final LedgerHandle lh, MarkDeleteEntry mdEntry, final VoidCallback callback) {
+        checkArgument(maxPositionChunkSize > 0, "maxPositionChunkSize mus be greater than zero");
         long now = System.nanoTime();
         PositionImpl position = mdEntry.newPosition;
 
@@ -3302,10 +3339,9 @@ public class ManagedCursorImpl implements ManagedCursor {
 
         long endCompress = System.nanoTime();
 
-        int maxSize = 1024 * 1024;
         int offset = 0;
         final int len = data.readableBytes();
-        int numParts = 1 + (len / maxSize);
+        int numParts = 1 + (len / maxPositionChunkSize);
 
         if (log.isDebugEnabled()) {
             log.debug("[{}] Cursor {} Appending to ledger={} position={} data size {} bytes, numParts {}",
@@ -3328,7 +3364,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             int part = 0;
             while (part != numParts) {
                 int remaining = len - offset;
-                int currentLen = Math.min(maxSize, remaining);
+                int currentLen = Math.min(maxPositionChunkSize, remaining);
                 boolean isLast = part == numParts - 1;
 
                 if (log.isDebugEnabled()) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -479,7 +479,9 @@ public class ManagedCursorImpl implements ManagedCursor {
         if (lastMarkDeleteEntry != null) {
             LAST_MARK_DELETE_ENTRY_UPDATER.updateAndGet(this, last -> {
                 Map<String, Long> properties = last.properties;
-                if (properties != null) {
+                // we can call remove only if the property is present
+                // some implementation of the map can throw exceptions
+                if (properties != null && properties.containsKey(key)) {
                     properties.remove(key);
                 }
                 return last;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -38,7 +38,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.util.concurrent.FastThreadLocal;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -128,13 +127,6 @@ import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("checkstyle:javadoctype")
 public class ManagedCursorImpl implements ManagedCursor {
-
-    private static final FastThreadLocal<LightMLDataFormats.PositionInfo> piThreadLocal = new FastThreadLocal<>() {
-        @Override
-        protected LightMLDataFormats.PositionInfo initialValue() {
-            return new LightMLDataFormats.PositionInfo();
-        }
-    };
 
     private static final Comparator<Entry> ENTRY_COMPARATOR = (e1, e2) -> {
         if (e1.getLedgerId() != e2.getLedgerId()) {
@@ -487,7 +479,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         if (lastMarkDeleteEntry != null) {
             LAST_MARK_DELETE_ENTRY_UPDATER.updateAndGet(this, last -> {
                 Map<String, Long> properties = last.properties;
-                if (properties != null && properties.containsKey(key)) {
+                if (properties != null) {
                     properties.remove(key);
                 }
                 return last;
@@ -2056,7 +2048,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             }
             callback.markDeleteFailed(
                     new ManagedLedgerException("Reset cursor in progress - unable to mark delete position "
-                            + position.toString()),
+                            + position),
                     ctx);
             return;
         }
@@ -3277,13 +3269,6 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
     }
 
-    private static ByteBuf toByteBuf(LightMLDataFormats.PositionInfo pi) {
-        int size = pi.getSerializedSize();
-        ByteBuf buf = PulsarByteBufAllocator.DEFAULT.buffer(size, size);
-        pi.writeTo(buf);
-        return buf;
-    }
-
     void persistPositionToLedger(final LedgerHandle lh, MarkDeleteEntry mdEntry, final VoidCallback callback) {
         long now = System.nanoTime();
         PositionImpl position = mdEntry.newPosition;
@@ -3522,7 +3507,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         long now = clock.millis();
         if (ledger.getFactory().isMetadataServiceAvailable()
                 && (lh.getLastAddConfirmed() >= getConfig().getMetadataMaxEntriesPerLedger()
-                || lastLedgerSwitchTimestamp < (now - getConfig().getLedgerRolloverTimeout() * 1000))
+                || lastLedgerSwitchTimestamp < (now - getConfig().getLedgerRolloverTimeout() * 1000L))
                 && (STATE_UPDATER.get(this) != State.Closed && STATE_UPDATER.get(this) != State.Closing)) {
             // It's safe to modify the timestamp since this method will be only called from a callback, implying that
             // calls will be serialized on one single thread
@@ -3661,7 +3646,6 @@ public class ManagedCursorImpl implements ManagedCursor {
                     ledger.getScheduledExecutor().schedule(() -> asyncDeleteLedger(lh, retry - 1),
                         DEFAULT_LEDGER_DELETE_BACKOFF_TIME_SEC, TimeUnit.SECONDS);
                 }
-                return;
             } else {
                 log.info("[{}][{}] Successfully closed & deleted ledger {} in cursor", ledger.getName(), name,
                         lh.getId());

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3322,7 +3322,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         if (numParts == 1) {
             // no need for chunking
             // asyncAddEntry will release data ByteBuf
-            writeToBookKeeperLastChunk(lh, mdEntry, callback, data, position, () -> {});
+            writeToBookKeeperLastChunk(lh, mdEntry, callback, data, len, position, () -> {});
         } else {
             // chunking
             int part = 0;
@@ -3358,7 +3358,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                     }
                     // need to explicitly release data ByteBuf
                     writeToBookKeeperLastChunk(lh, mdEntry, callback,
-                            Unpooled.wrappedBuffer(footerData), position, data::release);
+                            Unpooled.wrappedBuffer(footerData), len, position, data::release);
                 }
                 offset += currentLen;
                 part++;
@@ -3371,6 +3371,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                                             MarkDeleteEntry mdEntry,
                                             VoidCallback callback,
                                             ByteBuf data,
+                                            int totalLength,
                                             PositionImpl position,
                                             Runnable onFinished) {
         lh.asyncAddEntry(data, (rc, lh1, entryId, ctx) -> {
@@ -3385,7 +3386,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                     rolloverLedgerIfNeeded(lh1);
 
                     mbean.persistToLedger(true);
-                    mbean.addWriteCursorLedgerSize(data.readableBytes());
+                    mbean.addWriteCursorLedgerSize(totalLength);
                     callback.operationComplete();
                 } else {
                     log.warn("[{}] Error updating cursor {} position {} in meta-ledger {}: {}", ledger.getName(), name,

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -34,6 +34,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.protobuf.InvalidProtocolBufferException;
+import io.airlift.compress.MalformedInputException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.CompositeByteBuf;
@@ -3435,25 +3436,33 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
     }
 
-    private static byte[] decompressDataIfNeeded(byte[] data, LedgerHandle lh) {
+    static byte[] decompressDataIfNeeded(byte[] data, LedgerHandle lh) {
         byte[] pulsarCursorInfoCompression =
                 lh.getCustomMetadata().get(METADATA_PROPERTY_CURSOR_COMPRESSION_TYPE);
         if (pulsarCursorInfoCompression != null) {
             String pulsarCursorInfoCompressionString = new String(pulsarCursorInfoCompression);
-            CompressionCodec compressionCodec = CompressionCodecProvider.getCompressionCodec(
-                    CompressionType.valueOf(pulsarCursorInfoCompressionString));
+            if (log.isDebugEnabled()) {
+                log.debug("Ledger {} compression {} decompressing {} bytes, full {}",
+                        lh.getId(), pulsarCursorInfoCompressionString, data.length,
+                        ByteBufUtil.prettyHexDump(Unpooled.wrappedBuffer(data)));
+            }
             ByteArrayInputStream input = new ByteArrayInputStream(data);
             DataInputStream dataInputStream = new DataInputStream(input);
             try {
                 int uncompressedSize = dataInputStream.readInt();
-                byte[] compressedData = dataInputStream.readNBytes(uncompressedSize);
+                byte[] compressedData = dataInputStream.readAllBytes();
+                CompressionCodec compressionCodec = CompressionCodecProvider.getCompressionCodec(
+                        CompressionType.valueOf(pulsarCursorInfoCompressionString));
                 ByteBuf decode = compressionCodec.decode(Unpooled.wrappedBuffer(compressedData), uncompressedSize);
                 try {
                     return ByteBufUtil.getBytes(decode);
                 } finally {
                     decode.release();
                 }
-            } catch (IOException error) {
+            } catch (IOException | MalformedInputException error) {
+                log.error("Cannot decompress cursor position using {}. Payload is {}",
+                        pulsarCursorInfoCompressionString,
+                        ByteBufUtil.prettyHexDump(Unpooled.wrappedBuffer(data)), error);
                 throw new RuntimeException(error);
             }
         } else {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -158,6 +158,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     private final BookKeeper.DigestType digestType;
 
     protected volatile PositionImpl markDeletePosition;
+    private int lastSerializedSize;
 
     // this position is have persistent mark delete position
     protected volatile PositionImpl persistentMarkDeletePosition;
@@ -250,7 +251,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     // active state cache in ManagedCursor. It should be in sync with the state in activeCursors in ManagedLedger.
     private volatile boolean isActive = false;
 
-    class MarkDeleteEntry {
+    static class MarkDeleteEntry {
         final PositionImpl newPosition;
         final MarkDeleteCallback callback;
         final Object ctx;
@@ -677,6 +678,52 @@ public class ManagedCursorImpl implements ManagedCursor {
             return ChunkSequenceFooter.NOT_CHUNKED;
         }
         return ObjectMapperFactory.getMapper().getObjectMapper().readValue(data, ChunkSequenceFooter.class);
+    }
+
+    private void completeCursorRecovery(VoidCallback callback, LedgerHandle lh,  byte[] data) {
+        mbean.addReadCursorLedgerSize(data.length);
+
+        try {
+            data = decompressDataIfNeeded(data, lh);
+        } catch (Throwable e) {
+            callback.operationFailed(new ManagedLedgerException(e));
+            return;
+        }
+
+        PositionInfo positionInfo;
+        try {
+            positionInfo = PositionInfo.parseFrom(data);
+        } catch (InvalidProtocolBufferException e) {
+            log.error("[{}] Failed to parse position info from ledger {} for cursor {}: {}", ledger.getName(),
+                    lh.getId(), name, e);
+            // Rewind to oldest entry available
+            positionInfo = PositionInfo
+                    .newBuilder()
+                    .setLedgerId(-1)
+                    .setEntryId(-1)
+                    .build();
+        }
+
+        Map<String, Long> recoveredProperties = Collections.emptyMap();
+        if (positionInfo.getPropertiesCount() > 0) {
+            // Recover properties map
+            recoveredProperties = new HashMap<>();
+            for (int i = 0; i < positionInfo.getPropertiesCount(); i++) {
+                LongProperty property = positionInfo.getProperties(i);
+                recoveredProperties.put(property.getName(), property.getValue());
+            }
+        }
+
+        PositionImpl position = new PositionImpl(positionInfo);
+        if (positionInfo.getIndividualDeletedMessagesCount() > 0) {
+            recoverIndividualDeletedMessages(positionInfo.getIndividualDeletedMessagesList());
+        }
+        if (getConfig().isDeletionAtBatchIndexLevelEnabled()
+                && positionInfo.getBatchedEntryDeletionIndexInfoCount() > 0) {
+            recoverBatchDeletedIndexes(positionInfo.getBatchedEntryDeletionIndexInfoList());
+        }
+        recoveredCursor(position, recoveredProperties, cursorProperties, lh);
+        callback.operationComplete();
     }
 
     private void recoverIndividualDeletedMessages(List<MLDataFormats.MessageRange> individualDeletedMessagesList) {
@@ -3145,7 +3192,12 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
     }
 
-    private void addIndividualDeletedMessageRanges(LightMLDataFormats.PositionInfo lpi) {
+    private void scanIndividualDeletedMessageRanges(
+            PositionInfoUtils.IndividuallyDeletedMessagesRangeConsumer consumer) {
+        final int maxUnackedRangesToPersist = getConfig().getMaxUnackedRangesToPersist();
+        AtomicInteger acksSerializedSize = new AtomicInteger(0);
+        AtomicInteger rangeCount = new AtomicInteger(0);
+
         lock.readLock().lock();
         try {
             if (individualDeletedMessages.isEmpty()) {
@@ -3153,26 +3205,15 @@ public class ManagedCursorImpl implements ManagedCursor {
                 return;
             }
 
-            AtomicInteger acksSerializedSize = new AtomicInteger(0);
-            AtomicInteger rangeCount = new AtomicInteger(0);
-
             individualDeletedMessages.forEachRawRange((lowerKey, lowerValue, upperKey, upperValue) -> {
-                LightMLDataFormats.MessageRange messageRange = lpi.addIndividualDeletedMessage();
-                messageRange.setLowerEndpoint()
-                        .setLedgerId(lowerKey)
-                        .setEntryId(lowerValue);
-                messageRange.setUpperEndpoint()
-                        .setLedgerId(upperKey)
-                        .setEntryId(upperValue);
-
-                acksSerializedSize.addAndGet(messageRange.getSerializedSize());
-
-                return rangeCount.incrementAndGet() <= getConfig().getMaxUnackedRangesToPersist();
+                acksSerializedSize.addAndGet(16 * 4);
+                consumer.acceptRange(lowerKey, lowerValue, upperKey, upperValue);
+                return rangeCount.incrementAndGet() <= maxUnackedRangesToPersist;
             });
 
             this.individualDeletedMessagesSerializedSize = acksSerializedSize.get();
             individualDeletedMessages.resetDirtyKeys();
-            log.info("[{}] [{}] buildIndividualDeletedMessageRanges, numRanges {} "
+            log.info("[{}] [{}] scanIndividualDeletedMessageRanges, numRanges {} "
                             + "individualDeletedMessagesSerializedSize {} rangeListSize {} "
                             + "maxUnackedRangesToPersist {}",
                     ledger.getName(), name, individualDeletedMessages.size(),
@@ -3197,9 +3238,6 @@ public class ManagedCursorImpl implements ManagedCursor {
             Iterator<Map.Entry<PositionImpl, BitSetRecyclable>> iterator = batchDeletedIndexes.entrySet().iterator();
             while (iterator.hasNext() && result.size() < getConfig().getMaxBatchDeletedIndexToPersist()) {
                 Map.Entry<PositionImpl, BitSetRecyclable> entry = iterator.next();
-                nestedPositionBuilder.setLedgerId(entry.getKey().getLedgerId());
-                nestedPositionBuilder.setEntryId(entry.getKey().getEntryId());
-                batchDeletedIndexInfoBuilder.setPosition(nestedPositionBuilder.build());
                 long[] array = entry.getValue().toLongArray();
                 List<Long> deleteSet = new ArrayList<>(array.length);
                 for (long l : array) {
@@ -3215,27 +3253,23 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
     }
 
-    private void addAllBatchedEntryDeletionIndexInfo(LightMLDataFormats.PositionInfo lpi) {
+    private void buildBatchEntryDeletionIndexInfoList(
+            PositionInfoUtils.BatchedEntryDeletionIndexInfoConsumer consumer) {
+        if (!getConfig().isDeletionAtBatchIndexLevelEnabled()) {
+            return;
+        }
+        int maxBatchDeletedIndexToPersist = getConfig().getMaxBatchDeletedIndexToPersist();
         lock.readLock().lock();
         try {
             if (!getConfig().isDeletionAtBatchIndexLevelEnabled() || batchDeletedIndexes.isEmpty()) {
                 return;
             }
-            Iterator<Map.Entry<PositionImpl, BitSetRecyclable>> iterator = batchDeletedIndexes.entrySet().iterator();
             int count = 0;
-            while (iterator.hasNext() && count < getConfig().getMaxBatchDeletedIndexToPersist()) {
+            Iterator<Map.Entry<PositionImpl, BitSetRecyclable>> iterator = batchDeletedIndexes.entrySet().iterator();
+            while (iterator.hasNext() && count < maxBatchDeletedIndexToPersist) {
                 Map.Entry<PositionImpl, BitSetRecyclable> entry = iterator.next();
-
-                LightMLDataFormats.BatchedEntryDeletionIndexInfo batchInfo = lpi.addBatchedEntryDeletionIndexInfo();
-                batchInfo.setPosition()
-                        .setLedgerId(entry.getKey().getLedgerId())
-                        .setEntryId(entry.getKey().getEntryId());
-
                 long[] array = entry.getValue().toLongArray();
-                List<Long> deleteSet = new ArrayList<>(array.length);
-                for (long l : array) {
-                    batchInfo.addDeleteSet(l);
-                }
+                consumer.acceptRange(entry.getKey().getLedgerId(), entry.getKey().getEntryId(), array);
                 count++;
             }
         } finally {
@@ -3254,23 +3288,17 @@ public class ManagedCursorImpl implements ManagedCursor {
         long now = System.nanoTime();
         PositionImpl position = mdEntry.newPosition;
 
-        LightMLDataFormats.PositionInfo pi = piThreadLocal.get();
-        pi.clear();
-
-        pi.setLedgerId(position.getLedgerId())
-                .setEntryId(position.getEntryId());
-        addIndividualDeletedMessageRanges(pi);
-        addAllBatchedEntryDeletionIndexInfo(pi);
-        addAllProperties(pi, mdEntry.properties);
-
         if (log.isDebugEnabled()) {
             log.debug("[{}] Cursor {} Appending to ledger={} position={}", ledger.getName(), name, lh.getId(),
                     position);
         }
 
         requireNonNull(lh);
-        ByteBuf rawData = toByteBuf(pi);
+        ByteBuf rawData = PositionInfoUtils.serializePositionInfo(mdEntry, position,
+                this::scanIndividualDeletedMessageRanges, this::buildBatchEntryDeletionIndexInfoList,
+                lastSerializedSize);
         long endSer = System.nanoTime();
+        this.lastSerializedSize = rawData.readableBytes();
 
         // rawData is released by compressDataIfNeeded if needed
         ByteBuf data = compressDataIfNeeded(rawData, lh);
@@ -3340,6 +3368,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             }
         }
     }
+
 
     private void writeToBookKeeperLastChunk(LedgerHandle lh,
                                             MarkDeleteEntry mdEntry,
@@ -3977,4 +4006,5 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
         return newNonDurableCursor;
     }
+
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3251,6 +3251,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
     void persistPositionToLedger(final LedgerHandle lh, MarkDeleteEntry mdEntry, final VoidCallback callback) {
+        long now = System.nanoTime();
         PositionImpl position = mdEntry.newPosition;
 
         LightMLDataFormats.PositionInfo pi = piThreadLocal.get();
@@ -3269,9 +3270,12 @@ public class ManagedCursorImpl implements ManagedCursor {
 
         requireNonNull(lh);
         ByteBuf rawData = toByteBuf(pi);
+        long endSer = System.nanoTime();
 
         // rawData is released by compressDataIfNeeded if needed
         ByteBuf data = compressDataIfNeeded(rawData, lh);
+
+        long endCompress = System.nanoTime();
 
         int maxSize = 1024 * 1024;
         int offset = 0;
@@ -3283,6 +3287,12 @@ public class ManagedCursorImpl implements ManagedCursor {
                     ledger.getName(), name, lh.getId(),
                     position, len, numParts);
         }
+        log.info("[{}] Cursor {} Appending to ledger={} position={} data size {} bytes, "
+                        + "numParts {}, serializeTime {} ms"
+                        + " compressTime {} ms, total {} ms", ledger.getName(), name, lh.getId(),
+                position, len, numParts,
+                (endSer - now) / 1000000,
+                (endCompress - endSer)  / 1000000, (endCompress - now) / 1000000);
 
         if (numParts == 1) {
             // no need for chunking
@@ -3297,7 +3307,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                 boolean isLast = part == numParts - 1;
 
                 if (log.isDebugEnabled()) {
-                    log.info("[{}] Cursor {} Appending to ledger={} position={} data size {} bytes, numParts {} "
+                    log.debug("[{}] Cursor {} Appending to ledger={} position={} data size {} bytes, numParts {} "
                                     + "part {} offset {} len {}",
                             ledger.getName(), name, lh.getId(),
                             position, len, numParts, part, offset, currentLen);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2767,6 +2767,8 @@ public class ManagedCursorImpl implements ManagedCursor {
                     new CursorAlreadyClosedException(name + " cursor already closed"))));
             return;
         }
+        log.info("[{}][{}] Persisting cursor metadata into metadata store (persistIndividualDeletedMessageRanges: {})",
+                ledger.getName(), name, persistIndividualDeletedMessageRanges);
 
         final Stat lastCursorLedgerStat = cursorLedgerStat;
 
@@ -2781,7 +2783,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         info.addAllProperties(buildPropertiesMap(properties));
         info.addAllCursorProperties(buildStringPropertiesMap(cursorProperties));
         if (persistIndividualDeletedMessageRanges) {
-            info.addAllIndividualDeletedMessages(buildIndividualDeletedMessageRanges());
+            info.addAllIndividualDeletedMessages(buildIndividualDeletedMessageRanges(true));
             if (getConfig().isDeletionAtBatchIndexLevelEnabled()) {
                 info.addAllBatchedEntryDeletionIndexInfo(buildBatchEntryDeletionIndexInfoList());
             }
@@ -3128,7 +3130,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         return stringProperties;
     }
 
-    private List<MLDataFormats.MessageRange> buildIndividualDeletedMessageRanges() {
+    private List<MLDataFormats.MessageRange> buildIndividualDeletedMessageRanges(boolean forMetastore) {
         lock.readLock().lock();
         try {
             log.info("[{}] [{}] buildIndividualDeletedMessageRanges, numRanges {}",
@@ -3163,19 +3165,28 @@ public class ManagedCursorImpl implements ManagedCursor {
                         .setUpperEndpoint(upperPosition)
                         .build();
 
-                acksSerializedSize.addAndGet(messageRange.getSerializedSize());
+                int currentSize = acksSerializedSize.addAndGet(messageRange.getSerializedSize());
                 rangeList.add(messageRange);
+
+                if (forMetastore && currentSize > (1024 * 1024 - 10 * 1024)) {
+                    log.warn("[{}] [{}] buildIndividualDeletedMessageRanges, "
+                                    + "rangeListSize {} "
+                                    + "maxUnackedRangesToPersist {}, "
+                                    + "reached {} bytes that is too big for the metastore",
+                            ledger.getName(), name,
+                            rangeList.size(),
+                            getConfig().getMaxUnackedRangesToPersist(), currentSize);
+                    return false;
+                }
 
                 return rangeList.size() <= getConfig().getMaxUnackedRangesToPersist();
             });
 
             this.individualDeletedMessagesSerializedSize = acksSerializedSize.get();
             individualDeletedMessages.resetDirtyKeys();
-            log.info("[{}] [{}] buildIndividualDeletedMessageRanges, numRanges {} "
-                            + "individualDeletedMessagesSerializedSize {} rangeListSize {} "
+            log.info("[{}] [{}] buildIndividualDeletedMessageRanges, rangeListSize {} "
                             + "maxUnackedRangesToPersist {}",
-                    ledger.getName(), name, individualDeletedMessages.size(),
-                    individualDeletedMessagesSerializedSize, rangeList.size(),
+                    ledger.getName(), name, rangeList.size(),
                     getConfig().getMaxUnackedRangesToPersist());
 
             return rangeList;
@@ -3205,11 +3216,11 @@ public class ManagedCursorImpl implements ManagedCursor {
 
             this.individualDeletedMessagesSerializedSize = acksSerializedSize.get();
             individualDeletedMessages.resetDirtyKeys();
-            log.info("[{}] [{}] scanIndividualDeletedMessageRanges, numRanges {} "
-                            + "individualDeletedMessagesSerializedSize {} rangeListSize {} "
+            log.info("[{}] [{}] scanIndividualDeletedMessageRanges, "
+                            + "rangeListSize {} "
                             + "maxUnackedRangesToPersist {}",
-                    ledger.getName(), name, individualDeletedMessages.size(),
-                    individualDeletedMessagesSerializedSize, rangeCount.get(),
+                    ledger.getName(), name,
+                    rangeCount.get(),
                     getConfig().getMaxUnackedRangesToPersist());
         } finally {
             lock.readLock().unlock();
@@ -3362,27 +3373,30 @@ public class ManagedCursorImpl implements ManagedCursor {
                                             PositionImpl position,
                                             Runnable onFinished) {
         lh.asyncAddEntry(data, (rc, lh1, entryId, ctx) -> {
-            if (rc == BKException.Code.OK) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Updated cursor {} position {} in meta-ledger {}", ledger.getName(), name, position,
-                            lh1.getId());
+            try {
+                if (rc == BKException.Code.OK) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] Updated cursor {} position {} in meta-ledger {}", ledger.getName(), name,
+                                position,
+                                lh1.getId());
+                    }
+
+                    rolloverLedgerIfNeeded(lh1);
+
+                    mbean.persistToLedger(true);
+                    mbean.addWriteCursorLedgerSize(data.readableBytes());
+                    callback.operationComplete();
+                } else {
+                    log.warn("[{}] Error updating cursor {} position {} in meta-ledger {}: {}", ledger.getName(), name,
+                            position, lh1.getId(), BKException.getMessage(rc));
+                    // If we've had a write error, the ledger will be automatically closed, we need to create a new one,
+                    // in the meantime the mark-delete will be queued.
+                    STATE_UPDATER.compareAndSet(ManagedCursorImpl.this, State.Open, State.NoLedger);
+
+                    // Before giving up, try to persist the position in the metadata store.
+                    persistPositionToMetaStore(mdEntry, callback);
                 }
-
-                rolloverLedgerIfNeeded(lh1);
-
-                mbean.persistToLedger(true);
-                mbean.addWriteCursorLedgerSize(data.readableBytes());
-                callback.operationComplete();
-                onFinished.run();
-            } else {
-                log.warn("[{}] Error updating cursor {} position {} in meta-ledger {}: {}", ledger.getName(), name,
-                        position, lh1.getId(), BKException.getMessage(rc));
-                // If we've had a write error, the ledger will be automatically closed, we need to create a new one,
-                // in the meantime the mark-delete will be queued.
-                STATE_UPDATER.compareAndSet(ManagedCursorImpl.this, State.Open, State.NoLedger);
-
-                // Before giving up, try to persist the position in the metadata store.
-                persistPositionToMetaStore(mdEntry, callback);
+            } finally {
                 onFinished.run();
             }
         }, null);
@@ -3477,6 +3491,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
     void persistPositionToMetaStore(MarkDeleteEntry mdEntry, final VoidCallback callback) {
+        log.info("[{}][{}] Persisting cursor metadata into metadata store", ledger.getName(), name);
         final PositionImpl newPosition = mdEntry.newPosition;
         STATE_UPDATER.compareAndSet(ManagedCursorImpl.this, State.Open, State.NoLedger);
         mbean.persistToLedger(false);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -249,6 +249,8 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
 
         String path = PREFIX + ledgerName + "/" + cursorName;
         byte[] content = compressCursorInfo(info);
+        log.info("[{}] Persisting cursor={} info with content size {} bytes to metastore",
+                ledgerName, cursorName, content.length);
 
         long expectedVersion;
 
@@ -267,6 +269,7 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
                 .thenAcceptAsync(optStat -> callback.operationComplete(null, optStat), executor
                         .chooseThread(ledgerName))
                 .exceptionally(ex -> {
+                    log.error("[{}] [{}] Failed to update cursor info", ledgerName, cursorName, ex);
                     executor.executeOrdered(ledgerName,
                             () -> callback.operationFailed(getException(ex)));
                     return null;
@@ -525,6 +528,8 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
             compositeByteBuf.addComponent(true, encodeByteBuf);
             byte[] dataBytes = new byte[compositeByteBuf.readableBytes()];
             compositeByteBuf.readBytes(dataBytes);
+            log.info("Compressed cursor info, info size {}, metadata size {}, compressed size: {}",
+                    info.length, metadata.length, dataBytes.length);
             return dataBytes;
         } finally {
             if (metadataByteBuf != null) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -453,8 +453,13 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
             try {
                 MLDataFormats.ManagedLedgerInfoMetadata metadata =
                         MLDataFormats.ManagedLedgerInfoMetadata.parseFrom(metadataBytes);
-                return ManagedLedgerInfo.parseFrom(getCompressionCodec(metadata.getCompressionType())
-                        .decode(byteBuf, metadata.getUncompressedSize()).nioBuffer());
+                ByteBuf decode = getCompressionCodec(metadata.getCompressionType())
+                        .decode(byteBuf, metadata.getUncompressedSize());
+                try {
+                    return ManagedLedgerInfo.parseFrom(decode.nioBuffer());
+                } finally {
+                    decode.release();
+                }
             } catch (Exception e) {
                 log.error("Failed to parse managedLedgerInfo metadata, "
                         + "fall back to parse managedLedgerInfo directly.", e);
@@ -475,8 +480,13 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
             try {
                 MLDataFormats.ManagedCursorInfoMetadata metadata =
                         MLDataFormats.ManagedCursorInfoMetadata.parseFrom(metadataBytes);
-                return ManagedCursorInfo.parseFrom(getCompressionCodec(metadata.getCompressionType())
-                        .decode(byteBuf, metadata.getUncompressedSize()).nioBuffer());
+                ByteBuf decode = getCompressionCodec(metadata.getCompressionType())
+                        .decode(byteBuf, metadata.getUncompressedSize());
+                try {
+                    return ManagedCursorInfo.parseFrom(decode.nioBuffer());
+                } finally {
+                    decode.release();
+                }
             } catch (Exception e) {
                 log.error("Failed to parse ManagedCursorInfo metadata, "
                         + "fall back to parse ManagedCursorInfo directly", e);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionInfoUtils.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionInfoUtils.java
@@ -1,0 +1,1514 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats;
+import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
+import org.apache.pulsar.common.util.collections.BitSetRecyclable;
+
+final class PositionInfoUtils {
+
+    interface IndividuallyDeletedMessagesRangeConsumer {
+        void acceptRange(long lowerLegerId, long lowerEntryId, long upperLedgerId, long upperEntryId);
+    }
+
+    interface BatchedEntryDeletionIndexInfoConsumer {
+        void acceptRange(long ledgerId, long entryId, long[] array);
+    }
+
+    static ByteBuf serializePositionInfo(ManagedCursorImpl.MarkDeleteEntry mdEntry, PositionImpl position,
+                                         Consumer<IndividuallyDeletedMessagesRangeConsumer> rangeScanner,
+                                         Consumer<BatchedEntryDeletionIndexInfoConsumer> batchDeletedIndexesScanner,
+                                         int lastSerializedSize) {
+        int size = Math.max(lastSerializedSize, 64 * 1024);
+        ByteBuf _b = PulsarByteBufAllocator.DEFAULT.buffer(size);
+
+        int _writeIdx = _b.writerIndex();
+        LightProtoCodec.writeVarInt(_b, PositionInfo._LEDGER_ID_TAG);
+        LightProtoCodec.writeVarInt64(_b, position.getLedgerId());
+        LightProtoCodec.writeVarInt(_b, PositionInfo._ENTRY_ID_TAG);
+        LightProtoCodec.writeVarInt64(_b, position.getEntryId());
+
+        MessageRange _item = new MessageRange();
+        NestedPositionInfo lower = _item.setLowerEndpoint();
+        NestedPositionInfo upper = _item.setUpperEndpoint();
+        rangeScanner.accept(new IndividuallyDeletedMessagesRangeConsumer() {
+            @Override
+            public void acceptRange(long lowerLegerId, long lowerEntryId, long upperLedgerId, long upperEntryId) {
+                lower.setLedgerId(lowerLegerId);
+                lower.setEntryId(lowerEntryId);
+                upper.setLedgerId(upperLedgerId);
+                upper.setEntryId(upperEntryId);
+                LightProtoCodec.writeVarInt(_b, PositionInfo._INDIVIDUAL_DELETED_MESSAGES_TAG);
+                LightProtoCodec.writeVarInt(_b, _item.getSerializedSize());
+                _item.writeTo(_b);
+            }
+        });
+
+        final LongProperty longProperty = new LongProperty();
+        Map<String, Long> properties = mdEntry.properties;
+        if (properties != null) {
+            properties.forEach((k, v) -> {
+                longProperty.setName(k);
+                longProperty.setValue(v);
+                LightProtoCodec.writeVarInt(_b, PositionInfo._PROPERTIES_TAG);
+                LightProtoCodec.writeVarInt(_b, longProperty.getSerializedSize());
+                longProperty.writeTo(_b);
+            });
+        }
+
+        final BatchedEntryDeletionIndexInfo batchDeletedIndexInfo = new BatchedEntryDeletionIndexInfo();
+        final NestedPositionInfo nestedPositionInfo = batchDeletedIndexInfo.setPosition();
+
+        batchDeletedIndexesScanner.accept(new BatchedEntryDeletionIndexInfoConsumer() {
+            @Override
+            public void acceptRange(long ledgerId, long entryId, long[] array) {
+                nestedPositionInfo.setLedgerId(ledgerId);
+                nestedPositionInfo.setEntryId(entryId);
+                List<Long> deleteSet = new ArrayList<>(array.length);
+                batchDeletedIndexInfo.clearDeleteSet();
+                for (long l : array) {
+                    batchDeletedIndexInfo.addDeleteSet(l);
+                }
+                LightProtoCodec.writeVarInt(_b, PositionInfo._BATCHED_ENTRY_DELETION_INDEX_INFO_TAG);
+                LightProtoCodec.writeVarInt(_b, batchDeletedIndexInfo.getSerializedSize());
+                batchDeletedIndexInfo.writeTo(_b);
+            }
+        });
+
+        return _b;
+    }
+
+    public static final class PositionInfo {
+        private long ledgerId;
+        private static final int _LEDGER_ID_FIELD_NUMBER = 1;
+        private static final int _LEDGER_ID_TAG = (_LEDGER_ID_FIELD_NUMBER << LightProtoCodec.TAG_TYPE_BITS)
+                | LightProtoCodec.WIRETYPE_VARINT;
+        private static final int _LEDGER_ID_TAG_SIZE = LightProtoCodec.computeVarIntSize(_LEDGER_ID_TAG);
+        private static final int _LEDGER_ID_MASK = 1 << (0 % 32);
+        public boolean hasLedgerId() {
+            return (_bitField0 & _LEDGER_ID_MASK) != 0;
+        }
+        public long getLedgerId() {
+            if (!hasLedgerId()) {
+                throw new IllegalStateException("Field 'ledgerId' is not set");
+            }
+            return ledgerId;
+        }
+        public PositionInfo setLedgerId(long ledgerId) {
+            this.ledgerId = ledgerId;
+            _bitField0 |= _LEDGER_ID_MASK;
+            _cachedSize = -1;
+            return this;
+        }
+        public PositionInfo clearLedgerId() {
+            _bitField0 &= ~_LEDGER_ID_MASK;
+            return this;
+        }
+
+        private long entryId;
+        private static final int _ENTRY_ID_FIELD_NUMBER = 2;
+        private static final int _ENTRY_ID_TAG = (_ENTRY_ID_FIELD_NUMBER << LightProtoCodec.TAG_TYPE_BITS)
+                | LightProtoCodec.WIRETYPE_VARINT;
+        private static final int _ENTRY_ID_TAG_SIZE = LightProtoCodec.computeVarIntSize(_ENTRY_ID_TAG);
+        private static final int _ENTRY_ID_MASK = 1 << (1 % 32);
+        public boolean hasEntryId() {
+            return (_bitField0 & _ENTRY_ID_MASK) != 0;
+        }
+        public long getEntryId() {
+            if (!hasEntryId()) {
+                throw new IllegalStateException("Field 'entryId' is not set");
+            }
+            return entryId;
+        }
+        public PositionInfo setEntryId(long entryId) {
+            this.entryId = entryId;
+            _bitField0 |= _ENTRY_ID_MASK;
+            _cachedSize = -1;
+            return this;
+        }
+        public PositionInfo clearEntryId() {
+            _bitField0 &= ~_ENTRY_ID_MASK;
+            return this;
+        }
+
+        private java.util.List<MessageRange> individualDeletedMessages = null;
+        private int _individualDeletedMessagesCount = 0;
+        private static final int _INDIVIDUAL_DELETED_MESSAGES_FIELD_NUMBER = 3;
+        private static final int _INDIVIDUAL_DELETED_MESSAGES_TAG = (_INDIVIDUAL_DELETED_MESSAGES_FIELD_NUMBER << LightProtoCodec.TAG_TYPE_BITS)
+                | LightProtoCodec.WIRETYPE_LENGTH_DELIMITED;
+        private static final int _INDIVIDUAL_DELETED_MESSAGES_TAG_SIZE = LightProtoCodec
+                .computeVarIntSize(_INDIVIDUAL_DELETED_MESSAGES_TAG);
+        public int getIndividualDeletedMessagesCount() {
+            return _individualDeletedMessagesCount;
+        }
+        public MessageRange getIndividualDeletedMessageAt(int idx) {
+            if (idx < 0 || idx >= _individualDeletedMessagesCount) {
+                throw new IndexOutOfBoundsException("Index " + idx + " is out of the list size ("
+                        + _individualDeletedMessagesCount + ") for field 'individualDeletedMessages'");
+            }
+            return individualDeletedMessages.get(idx);
+        }
+        public java.util.List<MessageRange> getIndividualDeletedMessagesList() {
+            if (_individualDeletedMessagesCount == 0) {
+                return java.util.Collections.emptyList();
+            } else {
+                return individualDeletedMessages.subList(0, _individualDeletedMessagesCount);
+            }
+        }
+        public MessageRange addIndividualDeletedMessage() {
+            if (individualDeletedMessages == null) {
+                individualDeletedMessages = new java.util.ArrayList<MessageRange>();
+            }
+            if (individualDeletedMessages.size() == _individualDeletedMessagesCount) {
+                individualDeletedMessages.add(new MessageRange());
+            }
+            _cachedSize = -1;
+            return individualDeletedMessages.get(_individualDeletedMessagesCount++);
+        }
+        public PositionInfo addAllIndividualDeletedMessages(Iterable<MessageRange> individualDeletedMessages) {
+            for (MessageRange _o : individualDeletedMessages) {
+                addIndividualDeletedMessage().copyFrom(_o);
+            }
+            return this;
+        }
+        public PositionInfo clearIndividualDeletedMessages() {
+            for (int i = 0; i < _individualDeletedMessagesCount; i++) {
+                individualDeletedMessages.get(i).clear();
+            }
+            _individualDeletedMessagesCount = 0;
+            return this;
+        }
+
+        private java.util.List<LongProperty> properties = null;
+        private int _propertiesCount = 0;
+        private static final int _PROPERTIES_FIELD_NUMBER = 4;
+        private static final int _PROPERTIES_TAG = (_PROPERTIES_FIELD_NUMBER << LightProtoCodec.TAG_TYPE_BITS)
+                | LightProtoCodec.WIRETYPE_LENGTH_DELIMITED;
+        private static final int _PROPERTIES_TAG_SIZE = LightProtoCodec.computeVarIntSize(_PROPERTIES_TAG);
+        public int getPropertiesCount() {
+            return _propertiesCount;
+        }
+        public LongProperty getPropertyAt(int idx) {
+            if (idx < 0 || idx >= _propertiesCount) {
+                throw new IndexOutOfBoundsException(
+                        "Index " + idx + " is out of the list size (" + _propertiesCount + ") for field 'properties'");
+            }
+            return properties.get(idx);
+        }
+        public java.util.List<LongProperty> getPropertiesList() {
+            if (_propertiesCount == 0) {
+                return java.util.Collections.emptyList();
+            } else {
+                return properties.subList(0, _propertiesCount);
+            }
+        }
+        public LongProperty addProperty() {
+            if (properties == null) {
+                properties = new java.util.ArrayList<LongProperty>();
+            }
+            if (properties.size() == _propertiesCount) {
+                properties.add(new LongProperty());
+            }
+            _cachedSize = -1;
+            return properties.get(_propertiesCount++);
+        }
+        public PositionInfo addAllProperties(Iterable<LongProperty> properties) {
+            for (LongProperty _o : properties) {
+                addProperty().copyFrom(_o);
+            }
+            return this;
+        }
+        public PositionInfo clearProperties() {
+            for (int i = 0; i < _propertiesCount; i++) {
+                properties.get(i).clear();
+            }
+            _propertiesCount = 0;
+            return this;
+        }
+
+        private java.util.List<BatchedEntryDeletionIndexInfo> batchedEntryDeletionIndexInfos = null;
+        private int _batchedEntryDeletionIndexInfosCount = 0;
+        private static final int _BATCHED_ENTRY_DELETION_INDEX_INFO_FIELD_NUMBER = 5;
+        private static final int _BATCHED_ENTRY_DELETION_INDEX_INFO_TAG = (_BATCHED_ENTRY_DELETION_INDEX_INFO_FIELD_NUMBER << LightProtoCodec.TAG_TYPE_BITS)
+                | LightProtoCodec.WIRETYPE_LENGTH_DELIMITED;
+        private static final int _BATCHED_ENTRY_DELETION_INDEX_INFO_TAG_SIZE = LightProtoCodec
+                .computeVarIntSize(_BATCHED_ENTRY_DELETION_INDEX_INFO_TAG);
+        public int getBatchedEntryDeletionIndexInfosCount() {
+            return _batchedEntryDeletionIndexInfosCount;
+        }
+        public BatchedEntryDeletionIndexInfo getBatchedEntryDeletionIndexInfoAt(int idx) {
+            if (idx < 0 || idx >= _batchedEntryDeletionIndexInfosCount) {
+                throw new IndexOutOfBoundsException("Index " + idx + " is out of the list size ("
+                        + _batchedEntryDeletionIndexInfosCount + ") for field 'batchedEntryDeletionIndexInfo'");
+            }
+            return batchedEntryDeletionIndexInfos.get(idx);
+        }
+        public java.util.List<BatchedEntryDeletionIndexInfo> getBatchedEntryDeletionIndexInfosList() {
+            if (_batchedEntryDeletionIndexInfosCount == 0) {
+                return java.util.Collections.emptyList();
+            } else {
+                return batchedEntryDeletionIndexInfos.subList(0, _batchedEntryDeletionIndexInfosCount);
+            }
+        }
+        public BatchedEntryDeletionIndexInfo addBatchedEntryDeletionIndexInfo() {
+            if (batchedEntryDeletionIndexInfos == null) {
+                batchedEntryDeletionIndexInfos = new java.util.ArrayList<BatchedEntryDeletionIndexInfo>();
+            }
+            if (batchedEntryDeletionIndexInfos.size() == _batchedEntryDeletionIndexInfosCount) {
+                batchedEntryDeletionIndexInfos.add(new BatchedEntryDeletionIndexInfo());
+            }
+            _cachedSize = -1;
+            return batchedEntryDeletionIndexInfos.get(_batchedEntryDeletionIndexInfosCount++);
+        }
+        public PositionInfo addAllBatchedEntryDeletionIndexInfos(
+                Iterable<BatchedEntryDeletionIndexInfo> batchedEntryDeletionIndexInfos) {
+            for (BatchedEntryDeletionIndexInfo _o : batchedEntryDeletionIndexInfos) {
+                addBatchedEntryDeletionIndexInfo().copyFrom(_o);
+            }
+            return this;
+        }
+        public PositionInfo clearBatchedEntryDeletionIndexInfo() {
+            for (int i = 0; i < _batchedEntryDeletionIndexInfosCount; i++) {
+                batchedEntryDeletionIndexInfos.get(i).clear();
+            }
+            _batchedEntryDeletionIndexInfosCount = 0;
+            return this;
+        }
+
+        private int _bitField0;
+        private static final int _REQUIRED_FIELDS_MASK0 = 0 | _LEDGER_ID_MASK | _ENTRY_ID_MASK;
+        public int writeTo(io.netty.buffer.ByteBuf _b) {
+            checkRequiredFields();
+            int _writeIdx = _b.writerIndex();
+            LightProtoCodec.writeVarInt(_b, _LEDGER_ID_TAG);
+            LightProtoCodec.writeVarInt64(_b, ledgerId);
+            LightProtoCodec.writeVarInt(_b, _ENTRY_ID_TAG);
+            LightProtoCodec.writeVarInt64(_b, entryId);
+            for (int i = 0; i < _individualDeletedMessagesCount; i++) {
+                MessageRange _item = individualDeletedMessages.get(i);
+                LightProtoCodec.writeVarInt(_b, _INDIVIDUAL_DELETED_MESSAGES_TAG);
+                LightProtoCodec.writeVarInt(_b, _item.getSerializedSize());
+                _item.writeTo(_b);
+            }
+            for (int i = 0; i < _propertiesCount; i++) {
+                LongProperty _item = properties.get(i);
+                LightProtoCodec.writeVarInt(_b, _PROPERTIES_TAG);
+                LightProtoCodec.writeVarInt(_b, _item.getSerializedSize());
+                _item.writeTo(_b);
+            }
+            for (int i = 0; i < _batchedEntryDeletionIndexInfosCount; i++) {
+                BatchedEntryDeletionIndexInfo _item = batchedEntryDeletionIndexInfos.get(i);
+                LightProtoCodec.writeVarInt(_b, _BATCHED_ENTRY_DELETION_INDEX_INFO_TAG);
+                LightProtoCodec.writeVarInt(_b, _item.getSerializedSize());
+                _item.writeTo(_b);
+            }
+            return (_b.writerIndex() - _writeIdx);
+        }
+        public int getSerializedSize() {
+            if (_cachedSize > -1) {
+                return _cachedSize;
+            }
+
+            int _size = 0;
+            _size += _LEDGER_ID_TAG_SIZE;
+            _size += LightProtoCodec.computeVarInt64Size(ledgerId);
+            _size += _ENTRY_ID_TAG_SIZE;
+            _size += LightProtoCodec.computeVarInt64Size(entryId);
+            for (int i = 0; i < _individualDeletedMessagesCount; i++) {
+                MessageRange _item = individualDeletedMessages.get(i);
+                _size += _INDIVIDUAL_DELETED_MESSAGES_TAG_SIZE;
+                int MsgsizeIndividualDeletedMessages = _item.getSerializedSize();
+                _size += LightProtoCodec.computeVarIntSize(MsgsizeIndividualDeletedMessages)
+                        + MsgsizeIndividualDeletedMessages;
+            }
+            for (int i = 0; i < _propertiesCount; i++) {
+                LongProperty _item = properties.get(i);
+                _size += _PROPERTIES_TAG_SIZE;
+                int MsgsizeProperties = _item.getSerializedSize();
+                _size += LightProtoCodec.computeVarIntSize(MsgsizeProperties) + MsgsizeProperties;
+            }
+            for (int i = 0; i < _batchedEntryDeletionIndexInfosCount; i++) {
+                BatchedEntryDeletionIndexInfo _item = batchedEntryDeletionIndexInfos.get(i);
+                _size += _BATCHED_ENTRY_DELETION_INDEX_INFO_TAG_SIZE;
+                int MsgsizeBatchedEntryDeletionIndexInfo = _item.getSerializedSize();
+                _size += LightProtoCodec.computeVarIntSize(MsgsizeBatchedEntryDeletionIndexInfo)
+                        + MsgsizeBatchedEntryDeletionIndexInfo;
+            }
+            _cachedSize = _size;
+            return _size;
+        }
+        public void parseFrom(io.netty.buffer.ByteBuf _buffer, int _size) {
+            clear();
+            int _endIdx = _buffer.readerIndex() + _size;
+            while (_buffer.readerIndex() < _endIdx) {
+                int _tag = LightProtoCodec.readVarInt(_buffer);
+                switch (_tag) {
+                    case _LEDGER_ID_TAG :
+                        _bitField0 |= _LEDGER_ID_MASK;
+                        ledgerId = LightProtoCodec.readVarInt64(_buffer);
+                        break;
+                    case _ENTRY_ID_TAG :
+                        _bitField0 |= _ENTRY_ID_MASK;
+                        entryId = LightProtoCodec.readVarInt64(_buffer);
+                        break;
+                    case _INDIVIDUAL_DELETED_MESSAGES_TAG :
+                        int _individualDeletedMessagesSize = LightProtoCodec.readVarInt(_buffer);
+                        addIndividualDeletedMessage().parseFrom(_buffer, _individualDeletedMessagesSize);
+                        break;
+                    case _PROPERTIES_TAG :
+                        int _propertiesSize = LightProtoCodec.readVarInt(_buffer);
+                        addProperty().parseFrom(_buffer, _propertiesSize);
+                        break;
+                    case _BATCHED_ENTRY_DELETION_INDEX_INFO_TAG :
+                        int _batchedEntryDeletionIndexInfoSize = LightProtoCodec.readVarInt(_buffer);
+                        addBatchedEntryDeletionIndexInfo().parseFrom(_buffer, _batchedEntryDeletionIndexInfoSize);
+                        break;
+                    default :
+                        LightProtoCodec.skipUnknownField(_tag, _buffer);
+                }
+            }
+            checkRequiredFields();
+            _parsedBuffer = _buffer;
+        }
+        private void checkRequiredFields() {
+            if ((_bitField0 & _REQUIRED_FIELDS_MASK0) != _REQUIRED_FIELDS_MASK0) {
+                throw new IllegalStateException("Some required fields are missing");
+            }
+        }
+        public PositionInfo clear() {
+            for (int i = 0; i < _individualDeletedMessagesCount; i++) {
+                individualDeletedMessages.get(i).clear();
+            }
+            _individualDeletedMessagesCount = 0;
+            for (int i = 0; i < _propertiesCount; i++) {
+                properties.get(i).clear();
+            }
+            _propertiesCount = 0;
+            for (int i = 0; i < _batchedEntryDeletionIndexInfosCount; i++) {
+                batchedEntryDeletionIndexInfos.get(i).clear();
+            }
+            _batchedEntryDeletionIndexInfosCount = 0;
+            _parsedBuffer = null;
+            _cachedSize = -1;
+            _bitField0 = 0;
+            return this;
+        }
+        public PositionInfo copyFrom(PositionInfo _other) {
+            _cachedSize = -1;
+            if (_other.hasLedgerId()) {
+                setLedgerId(_other.ledgerId);
+            }
+            if (_other.hasEntryId()) {
+                setEntryId(_other.entryId);
+            }
+            for (int i = 0; i < _other.getIndividualDeletedMessagesCount(); i++) {
+                addIndividualDeletedMessage().copyFrom(_other.getIndividualDeletedMessageAt(i));
+            }
+            for (int i = 0; i < _other.getPropertiesCount(); i++) {
+                addProperty().copyFrom(_other.getPropertyAt(i));
+            }
+            for (int i = 0; i < _other.getBatchedEntryDeletionIndexInfosCount(); i++) {
+                addBatchedEntryDeletionIndexInfo().copyFrom(_other.getBatchedEntryDeletionIndexInfoAt(i));
+            }
+            return this;
+        }
+        public byte[] toByteArray() {
+            byte[] a = new byte[getSerializedSize()];
+            io.netty.buffer.ByteBuf b = io.netty.buffer.Unpooled.wrappedBuffer(a).writerIndex(0);
+            this.writeTo(b);
+            return a;
+        }
+        public void parseFrom(byte[] a) {
+            io.netty.buffer.ByteBuf b = io.netty.buffer.Unpooled.wrappedBuffer(a);
+            this.parseFrom(b, b.readableBytes());
+        }
+        private int _cachedSize;
+
+        private io.netty.buffer.ByteBuf _parsedBuffer;
+
+    }
+
+    public static final class NestedPositionInfo {
+        private long ledgerId;
+        private static final int _LEDGER_ID_FIELD_NUMBER = 1;
+        private static final int _LEDGER_ID_TAG = (_LEDGER_ID_FIELD_NUMBER << LightProtoCodec.TAG_TYPE_BITS)
+                | LightProtoCodec.WIRETYPE_VARINT;
+        private static final int _LEDGER_ID_TAG_SIZE = LightProtoCodec.computeVarIntSize(_LEDGER_ID_TAG);
+        private static final int _LEDGER_ID_MASK = 1 << (0 % 32);
+        public boolean hasLedgerId() {
+            return (_bitField0 & _LEDGER_ID_MASK) != 0;
+        }
+        public long getLedgerId() {
+            if (!hasLedgerId()) {
+                throw new IllegalStateException("Field 'ledgerId' is not set");
+            }
+            return ledgerId;
+        }
+        public NestedPositionInfo setLedgerId(long ledgerId) {
+            this.ledgerId = ledgerId;
+            _bitField0 |= _LEDGER_ID_MASK;
+            _cachedSize = -1;
+            return this;
+        }
+        public NestedPositionInfo clearLedgerId() {
+            _bitField0 &= ~_LEDGER_ID_MASK;
+            return this;
+        }
+
+        private long entryId;
+        private static final int _ENTRY_ID_FIELD_NUMBER = 2;
+        private static final int _ENTRY_ID_TAG = (_ENTRY_ID_FIELD_NUMBER << LightProtoCodec.TAG_TYPE_BITS)
+                | LightProtoCodec.WIRETYPE_VARINT;
+        private static final int _ENTRY_ID_TAG_SIZE = LightProtoCodec.computeVarIntSize(_ENTRY_ID_TAG);
+        private static final int _ENTRY_ID_MASK = 1 << (1 % 32);
+        public boolean hasEntryId() {
+            return (_bitField0 & _ENTRY_ID_MASK) != 0;
+        }
+        public long getEntryId() {
+            if (!hasEntryId()) {
+                throw new IllegalStateException("Field 'entryId' is not set");
+            }
+            return entryId;
+        }
+        public NestedPositionInfo setEntryId(long entryId) {
+            this.entryId = entryId;
+            _bitField0 |= _ENTRY_ID_MASK;
+            _cachedSize = -1;
+            return this;
+        }
+        public NestedPositionInfo clearEntryId() {
+            _bitField0 &= ~_ENTRY_ID_MASK;
+            return this;
+        }
+
+        private int _bitField0;
+        private static final int _REQUIRED_FIELDS_MASK0 = 0 | _LEDGER_ID_MASK | _ENTRY_ID_MASK;
+        public int writeTo(io.netty.buffer.ByteBuf _b) {
+            checkRequiredFields();
+            int _writeIdx = _b.writerIndex();
+            LightProtoCodec.writeVarInt(_b, _LEDGER_ID_TAG);
+            LightProtoCodec.writeVarInt64(_b, ledgerId);
+            LightProtoCodec.writeVarInt(_b, _ENTRY_ID_TAG);
+            LightProtoCodec.writeVarInt64(_b, entryId);
+            return (_b.writerIndex() - _writeIdx);
+        }
+        public int getSerializedSize() {
+            if (_cachedSize > -1) {
+                return _cachedSize;
+            }
+
+            int _size = 0;
+            _size += _LEDGER_ID_TAG_SIZE;
+            _size += LightProtoCodec.computeVarInt64Size(ledgerId);
+            _size += _ENTRY_ID_TAG_SIZE;
+            _size += LightProtoCodec.computeVarInt64Size(entryId);
+            _cachedSize = _size;
+            return _size;
+        }
+        public void parseFrom(io.netty.buffer.ByteBuf _buffer, int _size) {
+            clear();
+            int _endIdx = _buffer.readerIndex() + _size;
+            while (_buffer.readerIndex() < _endIdx) {
+                int _tag = LightProtoCodec.readVarInt(_buffer);
+                switch (_tag) {
+                    case _LEDGER_ID_TAG :
+                        _bitField0 |= _LEDGER_ID_MASK;
+                        ledgerId = LightProtoCodec.readVarInt64(_buffer);
+                        break;
+                    case _ENTRY_ID_TAG :
+                        _bitField0 |= _ENTRY_ID_MASK;
+                        entryId = LightProtoCodec.readVarInt64(_buffer);
+                        break;
+                    default :
+                        LightProtoCodec.skipUnknownField(_tag, _buffer);
+                }
+            }
+            checkRequiredFields();
+            _parsedBuffer = _buffer;
+        }
+        private void checkRequiredFields() {
+            if ((_bitField0 & _REQUIRED_FIELDS_MASK0) != _REQUIRED_FIELDS_MASK0) {
+                throw new IllegalStateException("Some required fields are missing");
+            }
+        }
+        public NestedPositionInfo clear() {
+            _parsedBuffer = null;
+            _cachedSize = -1;
+            _bitField0 = 0;
+            return this;
+        }
+        public NestedPositionInfo copyFrom(NestedPositionInfo _other) {
+            _cachedSize = -1;
+            if (_other.hasLedgerId()) {
+                setLedgerId(_other.ledgerId);
+            }
+            if (_other.hasEntryId()) {
+                setEntryId(_other.entryId);
+            }
+            return this;
+        }
+        public byte[] toByteArray() {
+            byte[] a = new byte[getSerializedSize()];
+            io.netty.buffer.ByteBuf b = io.netty.buffer.Unpooled.wrappedBuffer(a).writerIndex(0);
+            this.writeTo(b);
+            return a;
+        }
+        public void parseFrom(byte[] a) {
+            io.netty.buffer.ByteBuf b = io.netty.buffer.Unpooled.wrappedBuffer(a);
+            this.parseFrom(b, b.readableBytes());
+        }
+        private int _cachedSize;
+
+        private io.netty.buffer.ByteBuf _parsedBuffer;
+
+    }
+
+    public static final class MessageRange {
+        private NestedPositionInfo lowerEndpoint;
+        private static final int _LOWER_ENDPOINT_FIELD_NUMBER = 1;
+        private static final int _LOWER_ENDPOINT_TAG = (_LOWER_ENDPOINT_FIELD_NUMBER << LightProtoCodec.TAG_TYPE_BITS)
+                | LightProtoCodec.WIRETYPE_LENGTH_DELIMITED;
+        private static final int _LOWER_ENDPOINT_TAG_SIZE = LightProtoCodec.computeVarIntSize(_LOWER_ENDPOINT_TAG);
+        private static final int _LOWER_ENDPOINT_MASK = 1 << (0 % 32);
+        public boolean hasLowerEndpoint() {
+            return (_bitField0 & _LOWER_ENDPOINT_MASK) != 0;
+        }
+        public NestedPositionInfo getLowerEndpoint() {
+            if (!hasLowerEndpoint()) {
+                throw new IllegalStateException("Field 'lowerEndpoint' is not set");
+            }
+            return lowerEndpoint;
+        }
+        public NestedPositionInfo setLowerEndpoint() {
+            if (lowerEndpoint == null) {
+                lowerEndpoint = new NestedPositionInfo();
+            }
+            _bitField0 |= _LOWER_ENDPOINT_MASK;
+            _cachedSize = -1;
+            return lowerEndpoint;
+        }
+        public MessageRange clearLowerEndpoint() {
+            _bitField0 &= ~_LOWER_ENDPOINT_MASK;
+            if (hasLowerEndpoint()) {
+                lowerEndpoint.clear();
+            }
+            return this;
+        }
+
+        private NestedPositionInfo upperEndpoint;
+        private static final int _UPPER_ENDPOINT_FIELD_NUMBER = 2;
+        private static final int _UPPER_ENDPOINT_TAG = (_UPPER_ENDPOINT_FIELD_NUMBER << LightProtoCodec.TAG_TYPE_BITS)
+                | LightProtoCodec.WIRETYPE_LENGTH_DELIMITED;
+        private static final int _UPPER_ENDPOINT_TAG_SIZE = LightProtoCodec.computeVarIntSize(_UPPER_ENDPOINT_TAG);
+        private static final int _UPPER_ENDPOINT_MASK = 1 << (1 % 32);
+        public boolean hasUpperEndpoint() {
+            return (_bitField0 & _UPPER_ENDPOINT_MASK) != 0;
+        }
+        public NestedPositionInfo getUpperEndpoint() {
+            if (!hasUpperEndpoint()) {
+                throw new IllegalStateException("Field 'upperEndpoint' is not set");
+            }
+            return upperEndpoint;
+        }
+        public NestedPositionInfo setUpperEndpoint() {
+            if (upperEndpoint == null) {
+                upperEndpoint = new NestedPositionInfo();
+            }
+            _bitField0 |= _UPPER_ENDPOINT_MASK;
+            _cachedSize = -1;
+            return upperEndpoint;
+        }
+        public MessageRange clearUpperEndpoint() {
+            _bitField0 &= ~_UPPER_ENDPOINT_MASK;
+            if (hasUpperEndpoint()) {
+                upperEndpoint.clear();
+            }
+            return this;
+        }
+
+        private int _bitField0;
+        private static final int _REQUIRED_FIELDS_MASK0 = 0 | _LOWER_ENDPOINT_MASK | _UPPER_ENDPOINT_MASK;
+        public int writeTo(io.netty.buffer.ByteBuf _b) {
+            checkRequiredFields();
+            int _writeIdx = _b.writerIndex();
+            LightProtoCodec.writeVarInt(_b, _LOWER_ENDPOINT_TAG);
+            LightProtoCodec.writeVarInt(_b, lowerEndpoint.getSerializedSize());
+            lowerEndpoint.writeTo(_b);
+            LightProtoCodec.writeVarInt(_b, _UPPER_ENDPOINT_TAG);
+            LightProtoCodec.writeVarInt(_b, upperEndpoint.getSerializedSize());
+            upperEndpoint.writeTo(_b);
+            return (_b.writerIndex() - _writeIdx);
+        }
+        public int getSerializedSize() {
+            if (_cachedSize > -1) {
+                return _cachedSize;
+            }
+
+            int _size = 0;
+            _size += LightProtoCodec.computeVarIntSize(_LOWER_ENDPOINT_TAG);
+            int MsgsizeLowerEndpoint = lowerEndpoint.getSerializedSize();
+            _size += LightProtoCodec.computeVarIntSize(MsgsizeLowerEndpoint) + MsgsizeLowerEndpoint;
+            _size += LightProtoCodec.computeVarIntSize(_UPPER_ENDPOINT_TAG);
+            int MsgsizeUpperEndpoint = upperEndpoint.getSerializedSize();
+            _size += LightProtoCodec.computeVarIntSize(MsgsizeUpperEndpoint) + MsgsizeUpperEndpoint;
+            _cachedSize = _size;
+            return _size;
+        }
+        public void parseFrom(io.netty.buffer.ByteBuf _buffer, int _size) {
+            clear();
+            int _endIdx = _buffer.readerIndex() + _size;
+            while (_buffer.readerIndex() < _endIdx) {
+                int _tag = LightProtoCodec.readVarInt(_buffer);
+                switch (_tag) {
+                    case _LOWER_ENDPOINT_TAG :
+                        _bitField0 |= _LOWER_ENDPOINT_MASK;
+                        int lowerEndpointSize = LightProtoCodec.readVarInt(_buffer);
+                        setLowerEndpoint().parseFrom(_buffer, lowerEndpointSize);
+                        break;
+                    case _UPPER_ENDPOINT_TAG :
+                        _bitField0 |= _UPPER_ENDPOINT_MASK;
+                        int upperEndpointSize = LightProtoCodec.readVarInt(_buffer);
+                        setUpperEndpoint().parseFrom(_buffer, upperEndpointSize);
+                        break;
+                    default :
+                        LightProtoCodec.skipUnknownField(_tag, _buffer);
+                }
+            }
+            checkRequiredFields();
+            _parsedBuffer = _buffer;
+        }
+        private void checkRequiredFields() {
+            if ((_bitField0 & _REQUIRED_FIELDS_MASK0) != _REQUIRED_FIELDS_MASK0) {
+                throw new IllegalStateException("Some required fields are missing");
+            }
+        }
+        public MessageRange clear() {
+            if (hasLowerEndpoint()) {
+                lowerEndpoint.clear();
+            }
+            if (hasUpperEndpoint()) {
+                upperEndpoint.clear();
+            }
+            _parsedBuffer = null;
+            _cachedSize = -1;
+            _bitField0 = 0;
+            return this;
+        }
+        public MessageRange copyFrom(MessageRange _other) {
+            _cachedSize = -1;
+            if (_other.hasLowerEndpoint()) {
+                setLowerEndpoint().copyFrom(_other.lowerEndpoint);
+            }
+            if (_other.hasUpperEndpoint()) {
+                setUpperEndpoint().copyFrom(_other.upperEndpoint);
+            }
+            return this;
+        }
+        public byte[] toByteArray() {
+            byte[] a = new byte[getSerializedSize()];
+            io.netty.buffer.ByteBuf b = io.netty.buffer.Unpooled.wrappedBuffer(a).writerIndex(0);
+            this.writeTo(b);
+            return a;
+        }
+        public void parseFrom(byte[] a) {
+            io.netty.buffer.ByteBuf b = io.netty.buffer.Unpooled.wrappedBuffer(a);
+            this.parseFrom(b, b.readableBytes());
+        }
+        private int _cachedSize;
+
+        private io.netty.buffer.ByteBuf _parsedBuffer;
+
+    }
+
+    public static final class BatchedEntryDeletionIndexInfo {
+        private NestedPositionInfo position;
+        private static final int _POSITION_FIELD_NUMBER = 1;
+        private static final int _POSITION_TAG = (_POSITION_FIELD_NUMBER << LightProtoCodec.TAG_TYPE_BITS)
+                | LightProtoCodec.WIRETYPE_LENGTH_DELIMITED;
+        private static final int _POSITION_TAG_SIZE = LightProtoCodec.computeVarIntSize(_POSITION_TAG);
+        private static final int _POSITION_MASK = 1 << (0 % 32);
+        public boolean hasPosition() {
+            return (_bitField0 & _POSITION_MASK) != 0;
+        }
+        public NestedPositionInfo getPosition() {
+            if (!hasPosition()) {
+                throw new IllegalStateException("Field 'position' is not set");
+            }
+            return position;
+        }
+        public NestedPositionInfo setPosition() {
+            if (position == null) {
+                position = new NestedPositionInfo();
+            }
+            _bitField0 |= _POSITION_MASK;
+            _cachedSize = -1;
+            return position;
+        }
+        public BatchedEntryDeletionIndexInfo clearPosition() {
+            _bitField0 &= ~_POSITION_MASK;
+            if (hasPosition()) {
+                position.clear();
+            }
+            return this;
+        }
+
+        private long[] deleteSets = null;
+        private int _deleteSetsCount = 0;
+        private static final int _DELETE_SET_FIELD_NUMBER = 2;
+        private static final int _DELETE_SET_TAG = (_DELETE_SET_FIELD_NUMBER << LightProtoCodec.TAG_TYPE_BITS)
+                | LightProtoCodec.WIRETYPE_VARINT;
+        private static final int _DELETE_SET_TAG_SIZE = LightProtoCodec.computeVarIntSize(_DELETE_SET_TAG);
+        private static final int _DELETE_SET_TAG_PACKED = (_DELETE_SET_FIELD_NUMBER << LightProtoCodec.TAG_TYPE_BITS)
+                | LightProtoCodec.WIRETYPE_LENGTH_DELIMITED;
+        public int getDeleteSetsCount() {
+            return _deleteSetsCount;
+        }
+        public long getDeleteSetAt(int idx) {
+            if (idx < 0 || idx >= _deleteSetsCount) {
+                throw new IndexOutOfBoundsException(
+                        "Index " + idx + " is out of the list size (" + _deleteSetsCount + ") for field 'deleteSet'");
+            }
+            return deleteSets[idx];
+        }
+        public void addDeleteSet(long deleteSet) {
+            if (deleteSets == null) {
+                deleteSets = new long[4];
+            }
+            if (deleteSets.length == _deleteSetsCount) {
+                deleteSets = java.util.Arrays.copyOf(deleteSets, _deleteSetsCount * 2);
+            }
+            _cachedSize = -1;
+            deleteSets[_deleteSetsCount++] = deleteSet;
+        }
+        public BatchedEntryDeletionIndexInfo clearDeleteSet() {
+            _deleteSetsCount = 0;
+            return this;
+        }
+
+        private int _bitField0;
+        private static final int _REQUIRED_FIELDS_MASK0 = 0 | _POSITION_MASK;
+        public int writeTo(io.netty.buffer.ByteBuf _b) {
+            checkRequiredFields();
+            int _writeIdx = _b.writerIndex();
+            LightProtoCodec.writeVarInt(_b, _POSITION_TAG);
+            LightProtoCodec.writeVarInt(_b, position.getSerializedSize());
+            position.writeTo(_b);
+            for (int i = 0; i < _deleteSetsCount; i++) {
+                long _item = deleteSets[i];
+                LightProtoCodec.writeVarInt(_b, _DELETE_SET_TAG);
+                LightProtoCodec.writeVarInt64(_b, _item);
+            }
+            return (_b.writerIndex() - _writeIdx);
+        }
+        public int getSerializedSize() {
+            if (_cachedSize > -1) {
+                return _cachedSize;
+            }
+
+            int _size = 0;
+            _size += LightProtoCodec.computeVarIntSize(_POSITION_TAG);
+            int MsgsizePosition = position.getSerializedSize();
+            _size += LightProtoCodec.computeVarIntSize(MsgsizePosition) + MsgsizePosition;
+            for (int i = 0; i < _deleteSetsCount; i++) {
+                long _item = deleteSets[i];
+                _size += _DELETE_SET_TAG_SIZE;
+                _size += LightProtoCodec.computeVarInt64Size(_item);
+            }
+            _cachedSize = _size;
+            return _size;
+        }
+        public void parseFrom(io.netty.buffer.ByteBuf _buffer, int _size) {
+            clear();
+            int _endIdx = _buffer.readerIndex() + _size;
+            while (_buffer.readerIndex() < _endIdx) {
+                int _tag = LightProtoCodec.readVarInt(_buffer);
+                switch (_tag) {
+                    case _POSITION_TAG :
+                        _bitField0 |= _POSITION_MASK;
+                        int positionSize = LightProtoCodec.readVarInt(_buffer);
+                        setPosition().parseFrom(_buffer, positionSize);
+                        break;
+                    case _DELETE_SET_TAG :
+                        addDeleteSet(LightProtoCodec.readVarInt64(_buffer));
+                        break;
+                    case _DELETE_SET_TAG_PACKED :
+                        int _deleteSetSize = LightProtoCodec.readVarInt(_buffer);
+                        int _deleteSetEndIdx = _buffer.readerIndex() + _deleteSetSize;
+                        while (_buffer.readerIndex() < _deleteSetEndIdx) {
+                            addDeleteSet(LightProtoCodec.readVarInt64(_buffer));
+                        }
+                        break;
+                    default :
+                        LightProtoCodec.skipUnknownField(_tag, _buffer);
+                }
+            }
+            checkRequiredFields();
+            _parsedBuffer = _buffer;
+        }
+        private void checkRequiredFields() {
+            if ((_bitField0 & _REQUIRED_FIELDS_MASK0) != _REQUIRED_FIELDS_MASK0) {
+                throw new IllegalStateException("Some required fields are missing");
+            }
+        }
+        public BatchedEntryDeletionIndexInfo clear() {
+            if (hasPosition()) {
+                position.clear();
+            }
+            _deleteSetsCount = 0;
+            _parsedBuffer = null;
+            _cachedSize = -1;
+            _bitField0 = 0;
+            return this;
+        }
+        public BatchedEntryDeletionIndexInfo copyFrom(
+                BatchedEntryDeletionIndexInfo _other) {
+            _cachedSize = -1;
+            if (_other.hasPosition()) {
+                setPosition().copyFrom(_other.position);
+            }
+            for (int i = 0; i < _other.getDeleteSetsCount(); i++) {
+                addDeleteSet(_other.getDeleteSetAt(i));
+            }
+            return this;
+        }
+        public byte[] toByteArray() {
+            byte[] a = new byte[getSerializedSize()];
+            io.netty.buffer.ByteBuf b = io.netty.buffer.Unpooled.wrappedBuffer(a).writerIndex(0);
+            this.writeTo(b);
+            return a;
+        }
+        public void parseFrom(byte[] a) {
+            io.netty.buffer.ByteBuf b = io.netty.buffer.Unpooled.wrappedBuffer(a);
+            this.parseFrom(b, b.readableBytes());
+        }
+        private int _cachedSize;
+
+        private io.netty.buffer.ByteBuf _parsedBuffer;
+
+    }
+
+    public static final class LongProperty {
+        private String name;
+        private int _nameBufferIdx = -1;
+        private int _nameBufferLen = -1;
+        private static final int _NAME_FIELD_NUMBER = 1;
+        private static final int _NAME_TAG = (_NAME_FIELD_NUMBER << LightProtoCodec.TAG_TYPE_BITS)
+                | LightProtoCodec.WIRETYPE_LENGTH_DELIMITED;
+        private static final int _NAME_TAG_SIZE = LightProtoCodec.computeVarIntSize(_NAME_TAG);
+        private static final int _NAME_MASK = 1 << (0 % 32);
+        public boolean hasName() {
+            return (_bitField0 & _NAME_MASK) != 0;
+        }
+        public String getName() {
+            if (!hasName()) {
+                throw new IllegalStateException("Field 'name' is not set");
+            }
+            if (name == null) {
+                name = LightProtoCodec.readString(_parsedBuffer, _nameBufferIdx, _nameBufferLen);
+            }
+            return name;
+        }
+        public LongProperty setName(String name) {
+            this.name = name;
+            _bitField0 |= _NAME_MASK;
+            _nameBufferIdx = -1;
+            _nameBufferLen = LightProtoCodec.computeStringUTF8Size(name);
+            _cachedSize = -1;
+            return this;
+        }
+        public LongProperty clearName() {
+            _bitField0 &= ~_NAME_MASK;
+            name = null;
+            _nameBufferIdx = -1;
+            _nameBufferLen = -1;
+            return this;
+        }
+
+        private long value;
+        private static final int _VALUE_FIELD_NUMBER = 2;
+        private static final int _VALUE_TAG = (_VALUE_FIELD_NUMBER << LightProtoCodec.TAG_TYPE_BITS)
+                | LightProtoCodec.WIRETYPE_VARINT;
+        private static final int _VALUE_TAG_SIZE = LightProtoCodec.computeVarIntSize(_VALUE_TAG);
+        private static final int _VALUE_MASK = 1 << (1 % 32);
+        public boolean hasValue() {
+            return (_bitField0 & _VALUE_MASK) != 0;
+        }
+        public long getValue() {
+            if (!hasValue()) {
+                throw new IllegalStateException("Field 'value' is not set");
+            }
+            return value;
+        }
+        public LongProperty setValue(long value) {
+            this.value = value;
+            _bitField0 |= _VALUE_MASK;
+            _cachedSize = -1;
+            return this;
+        }
+        public LongProperty clearValue() {
+            _bitField0 &= ~_VALUE_MASK;
+            return this;
+        }
+
+        private int _bitField0;
+        private static final int _REQUIRED_FIELDS_MASK0 = 0 | _NAME_MASK | _VALUE_MASK;
+        public int writeTo(io.netty.buffer.ByteBuf _b) {
+            checkRequiredFields();
+            int _writeIdx = _b.writerIndex();
+            LightProtoCodec.writeVarInt(_b, _NAME_TAG);
+            LightProtoCodec.writeVarInt(_b, _nameBufferLen);
+            if (_nameBufferIdx == -1) {
+                LightProtoCodec.writeString(_b, name, _nameBufferLen);
+            } else {
+                _parsedBuffer.getBytes(_nameBufferIdx, _b, _nameBufferLen);
+            }
+            LightProtoCodec.writeVarInt(_b, _VALUE_TAG);
+            LightProtoCodec.writeVarInt64(_b, value);
+            return (_b.writerIndex() - _writeIdx);
+        }
+        public int getSerializedSize() {
+            if (_cachedSize > -1) {
+                return _cachedSize;
+            }
+
+            int _size = 0;
+            _size += _NAME_TAG_SIZE;
+            _size += LightProtoCodec.computeVarIntSize(_nameBufferLen);
+            _size += _nameBufferLen;
+            _size += _VALUE_TAG_SIZE;
+            _size += LightProtoCodec.computeVarInt64Size(value);
+            _cachedSize = _size;
+            return _size;
+        }
+        public void parseFrom(io.netty.buffer.ByteBuf _buffer, int _size) {
+            clear();
+            int _endIdx = _buffer.readerIndex() + _size;
+            while (_buffer.readerIndex() < _endIdx) {
+                int _tag = LightProtoCodec.readVarInt(_buffer);
+                switch (_tag) {
+                    case _NAME_TAG :
+                        _bitField0 |= _NAME_MASK;
+                        _nameBufferLen = LightProtoCodec.readVarInt(_buffer);
+                        _nameBufferIdx = _buffer.readerIndex();
+                        _buffer.skipBytes(_nameBufferLen);
+                        break;
+                    case _VALUE_TAG :
+                        _bitField0 |= _VALUE_MASK;
+                        value = LightProtoCodec.readVarInt64(_buffer);
+                        break;
+                    default :
+                        LightProtoCodec.skipUnknownField(_tag, _buffer);
+                }
+            }
+            checkRequiredFields();
+            _parsedBuffer = _buffer;
+        }
+        private void checkRequiredFields() {
+            if ((_bitField0 & _REQUIRED_FIELDS_MASK0) != _REQUIRED_FIELDS_MASK0) {
+                throw new IllegalStateException("Some required fields are missing");
+            }
+        }
+        public LongProperty clear() {
+            name = null;
+            _nameBufferIdx = -1;
+            _nameBufferLen = -1;
+            _parsedBuffer = null;
+            _cachedSize = -1;
+            _bitField0 = 0;
+            return this;
+        }
+        public LongProperty copyFrom(LongProperty _other) {
+            _cachedSize = -1;
+            if (_other.hasName()) {
+                setName(_other.getName());
+            }
+            if (_other.hasValue()) {
+                setValue(_other.value);
+            }
+            return this;
+        }
+        public byte[] toByteArray() {
+            byte[] a = new byte[getSerializedSize()];
+            io.netty.buffer.ByteBuf b = io.netty.buffer.Unpooled.wrappedBuffer(a).writerIndex(0);
+            this.writeTo(b);
+            return a;
+        }
+        public void parseFrom(byte[] a) {
+            io.netty.buffer.ByteBuf b = io.netty.buffer.Unpooled.wrappedBuffer(a);
+            this.parseFrom(b, b.readableBytes());
+        }
+        private int _cachedSize;
+
+        private io.netty.buffer.ByteBuf _parsedBuffer;
+
+    }
+
+    public static final class StringProperty {
+        private String name;
+        private int _nameBufferIdx = -1;
+        private int _nameBufferLen = -1;
+        private static final int _NAME_FIELD_NUMBER = 1;
+        private static final int _NAME_TAG = (_NAME_FIELD_NUMBER << LightProtoCodec.TAG_TYPE_BITS)
+                | LightProtoCodec.WIRETYPE_LENGTH_DELIMITED;
+        private static final int _NAME_TAG_SIZE = LightProtoCodec.computeVarIntSize(_NAME_TAG);
+        private static final int _NAME_MASK = 1 << (0 % 32);
+        public boolean hasName() {
+            return (_bitField0 & _NAME_MASK) != 0;
+        }
+        public String getName() {
+            if (!hasName()) {
+                throw new IllegalStateException("Field 'name' is not set");
+            }
+            if (name == null) {
+                name = LightProtoCodec.readString(_parsedBuffer, _nameBufferIdx, _nameBufferLen);
+            }
+            return name;
+        }
+        public StringProperty setName(String name) {
+            this.name = name;
+            _bitField0 |= _NAME_MASK;
+            _nameBufferIdx = -1;
+            _nameBufferLen = LightProtoCodec.computeStringUTF8Size(name);
+            _cachedSize = -1;
+            return this;
+        }
+        public StringProperty clearName() {
+            _bitField0 &= ~_NAME_MASK;
+            name = null;
+            _nameBufferIdx = -1;
+            _nameBufferLen = -1;
+            return this;
+        }
+
+        private String value;
+        private int _valueBufferIdx = -1;
+        private int _valueBufferLen = -1;
+        private static final int _VALUE_FIELD_NUMBER = 2;
+        private static final int _VALUE_TAG = (_VALUE_FIELD_NUMBER << LightProtoCodec.TAG_TYPE_BITS)
+                | LightProtoCodec.WIRETYPE_LENGTH_DELIMITED;
+        private static final int _VALUE_TAG_SIZE = LightProtoCodec.computeVarIntSize(_VALUE_TAG);
+        private static final int _VALUE_MASK = 1 << (1 % 32);
+        public boolean hasValue() {
+            return (_bitField0 & _VALUE_MASK) != 0;
+        }
+        public String getValue() {
+            if (!hasValue()) {
+                throw new IllegalStateException("Field 'value' is not set");
+            }
+            if (value == null) {
+                value = LightProtoCodec.readString(_parsedBuffer, _valueBufferIdx, _valueBufferLen);
+            }
+            return value;
+        }
+        public StringProperty setValue(String value) {
+            this.value = value;
+            _bitField0 |= _VALUE_MASK;
+            _valueBufferIdx = -1;
+            _valueBufferLen = LightProtoCodec.computeStringUTF8Size(value);
+            _cachedSize = -1;
+            return this;
+        }
+        public StringProperty clearValue() {
+            _bitField0 &= ~_VALUE_MASK;
+            value = null;
+            _valueBufferIdx = -1;
+            _valueBufferLen = -1;
+            return this;
+        }
+
+        private int _bitField0;
+        private static final int _REQUIRED_FIELDS_MASK0 = 0 | _NAME_MASK | _VALUE_MASK;
+        public int writeTo(io.netty.buffer.ByteBuf _b) {
+            checkRequiredFields();
+            int _writeIdx = _b.writerIndex();
+            LightProtoCodec.writeVarInt(_b, _NAME_TAG);
+            LightProtoCodec.writeVarInt(_b, _nameBufferLen);
+            if (_nameBufferIdx == -1) {
+                LightProtoCodec.writeString(_b, name, _nameBufferLen);
+            } else {
+                _parsedBuffer.getBytes(_nameBufferIdx, _b, _nameBufferLen);
+            }
+            LightProtoCodec.writeVarInt(_b, _VALUE_TAG);
+            LightProtoCodec.writeVarInt(_b, _valueBufferLen);
+            if (_valueBufferIdx == -1) {
+                LightProtoCodec.writeString(_b, value, _valueBufferLen);
+            } else {
+                _parsedBuffer.getBytes(_valueBufferIdx, _b, _valueBufferLen);
+            }
+            return (_b.writerIndex() - _writeIdx);
+        }
+        public int getSerializedSize() {
+            if (_cachedSize > -1) {
+                return _cachedSize;
+            }
+
+            int _size = 0;
+            _size += _NAME_TAG_SIZE;
+            _size += LightProtoCodec.computeVarIntSize(_nameBufferLen);
+            _size += _nameBufferLen;
+            _size += _VALUE_TAG_SIZE;
+            _size += LightProtoCodec.computeVarIntSize(_valueBufferLen);
+            _size += _valueBufferLen;
+            _cachedSize = _size;
+            return _size;
+        }
+        public void parseFrom(io.netty.buffer.ByteBuf _buffer, int _size) {
+            clear();
+            int _endIdx = _buffer.readerIndex() + _size;
+            while (_buffer.readerIndex() < _endIdx) {
+                int _tag = LightProtoCodec.readVarInt(_buffer);
+                switch (_tag) {
+                    case _NAME_TAG :
+                        _bitField0 |= _NAME_MASK;
+                        _nameBufferLen = LightProtoCodec.readVarInt(_buffer);
+                        _nameBufferIdx = _buffer.readerIndex();
+                        _buffer.skipBytes(_nameBufferLen);
+                        break;
+                    case _VALUE_TAG :
+                        _bitField0 |= _VALUE_MASK;
+                        _valueBufferLen = LightProtoCodec.readVarInt(_buffer);
+                        _valueBufferIdx = _buffer.readerIndex();
+                        _buffer.skipBytes(_valueBufferLen);
+                        break;
+                    default :
+                        LightProtoCodec.skipUnknownField(_tag, _buffer);
+                }
+            }
+            checkRequiredFields();
+            _parsedBuffer = _buffer;
+        }
+        private void checkRequiredFields() {
+            if ((_bitField0 & _REQUIRED_FIELDS_MASK0) != _REQUIRED_FIELDS_MASK0) {
+                throw new IllegalStateException("Some required fields are missing");
+            }
+        }
+        public StringProperty clear() {
+            name = null;
+            _nameBufferIdx = -1;
+            _nameBufferLen = -1;
+            value = null;
+            _valueBufferIdx = -1;
+            _valueBufferLen = -1;
+            _parsedBuffer = null;
+            _cachedSize = -1;
+            _bitField0 = 0;
+            return this;
+        }
+        public StringProperty copyFrom(StringProperty _other) {
+            _cachedSize = -1;
+            if (_other.hasName()) {
+                setName(_other.getName());
+            }
+            if (_other.hasValue()) {
+                setValue(_other.getValue());
+            }
+            return this;
+        }
+        public byte[] toByteArray() {
+            byte[] a = new byte[getSerializedSize()];
+            io.netty.buffer.ByteBuf b = io.netty.buffer.Unpooled.wrappedBuffer(a).writerIndex(0);
+            this.writeTo(b);
+            return a;
+        }
+        public void parseFrom(byte[] a) {
+            io.netty.buffer.ByteBuf b = io.netty.buffer.Unpooled.wrappedBuffer(a);
+            this.parseFrom(b, b.readableBytes());
+        }
+        private int _cachedSize;
+
+        private io.netty.buffer.ByteBuf _parsedBuffer;
+
+    }
+
+
+
+    static final class LightProtoCodec {
+        static final int TAG_TYPE_MASK = 7;
+        static final int TAG_TYPE_BITS = 3;
+        static final int WIRETYPE_VARINT = 0;
+        static final int WIRETYPE_FIXED64 = 1;
+        static final int WIRETYPE_LENGTH_DELIMITED = 2;
+        static final int WIRETYPE_START_GROUP = 3;
+        static final int WIRETYPE_END_GROUP = 4;
+        static final int WIRETYPE_FIXED32 = 5;
+        private LightProtoCodec() {
+        }
+
+        private static int getTagType(int tag) {
+            return tag & TAG_TYPE_MASK;
+        }
+
+        static int getFieldId(int tag) {
+            return tag >>> TAG_TYPE_BITS;
+        }
+
+        static void writeVarInt(ByteBuf b, int n) {
+            if (n >= 0) {
+                _writeVarInt(b, n);
+            } else {
+                writeVarInt64(b, n);
+            }
+        }
+
+        static void writeSignedVarInt(ByteBuf b, int n) {
+            writeVarInt(b, encodeZigZag32(n));
+        }
+
+        static int readSignedVarInt(ByteBuf b) {
+            return decodeZigZag32(readVarInt(b));
+        }
+
+        static long readSignedVarInt64(ByteBuf b) {
+            return decodeZigZag64(readVarInt64(b));
+        }
+
+        static void writeFloat(ByteBuf b, float n) {
+            writeFixedInt32(b, Float.floatToRawIntBits(n));
+        }
+
+        static void writeDouble(ByteBuf b, double n) {
+            writeFixedInt64(b, Double.doubleToRawLongBits(n));
+        }
+
+        static float readFloat(ByteBuf b) {
+            return Float.intBitsToFloat(readFixedInt32(b));
+        }
+
+        static double readDouble(ByteBuf b) {
+            return Double.longBitsToDouble(readFixedInt64(b));
+        }
+
+        private static void _writeVarInt(ByteBuf b, int n) {
+            while (true) {
+                if ((n & ~0x7F) == 0) {
+                    b.writeByte(n);
+                    return;
+                } else {
+                    b.writeByte((n & 0x7F) | 0x80);
+                    n >>>= 7;
+                }
+            }
+        }
+
+        static void writeVarInt64(ByteBuf b, long value) {
+            while (true) {
+                if ((value & ~0x7FL) == 0) {
+                    b.writeByte((int) value);
+                    return;
+                } else {
+                    b.writeByte(((int) value & 0x7F) | 0x80);
+                    value >>>= 7;
+                }
+            }
+        }
+
+        static void writeFixedInt32(ByteBuf b, int n) {
+            b.writeIntLE(n);
+        }
+
+        static void writeFixedInt64(ByteBuf b, long n) {
+            b.writeLongLE(n);
+        }
+
+        static int readFixedInt32(ByteBuf b) {
+            return b.readIntLE();
+        }
+
+        static long readFixedInt64(ByteBuf b) {
+            return b.readLongLE();
+        }
+
+        static void writeSignedVarInt64(ByteBuf b, long n) {
+            writeVarInt64(b, encodeZigZag64(n));
+        }
+
+        private static int encodeZigZag32(final int n) {
+            return (n << 1) ^ (n >> 31);
+        }
+
+        private static long encodeZigZag64(final long n) {
+            return (n << 1) ^ (n >> 63);
+        }
+
+        private static int decodeZigZag32(int n) {
+            return n >>> 1 ^ -(n & 1);
+        }
+
+        private static long decodeZigZag64(long n) {
+            return n >>> 1 ^ -(n & 1L);
+        }
+
+        static int readVarInt(ByteBuf buf) {
+            byte tmp = buf.readByte();
+            if (tmp >= 0) {
+                return tmp;
+            }
+            int result = tmp & 0x7f;
+            if ((tmp = buf.readByte()) >= 0) {
+                result |= tmp << 7;
+            } else {
+                result |= (tmp & 0x7f) << 7;
+                if ((tmp = buf.readByte()) >= 0) {
+                    result |= tmp << 14;
+                } else {
+                    result |= (tmp & 0x7f) << 14;
+                    if ((tmp = buf.readByte()) >= 0) {
+                        result |= tmp << 21;
+                    } else {
+                        result |= (tmp & 0x7f) << 21;
+                        result |= (tmp = buf.readByte()) << 28;
+                        if (tmp < 0) {
+                            // Discard upper 32 bits.
+                            for (int i = 0; i < 5; i++) {
+                                if (buf.readByte() >= 0) {
+                                    return result;
+                                }
+                            }
+                            throw new IllegalArgumentException("Encountered a malformed varint.");
+                        }
+                    }
+                }
+            }
+            return result;
+        }
+
+        static long readVarInt64(ByteBuf buf) {
+            int shift = 0;
+            long result = 0;
+            while (shift < 64) {
+                final byte b = buf.readByte();
+                result |= (long) (b & 0x7F) << shift;
+                if ((b & 0x80) == 0) {
+                    return result;
+                }
+                shift += 7;
+            }
+            throw new IllegalArgumentException("Encountered a malformed varint.");
+        }
+
+        static int computeSignedVarIntSize(final int value) {
+            return computeVarUIntSize(encodeZigZag32(value));
+        }
+
+        static int computeSignedVarInt64Size(final long value) {
+            return computeVarInt64Size(encodeZigZag64(value));
+        }
+
+        static int computeVarIntSize(final int value) {
+            if (value < 0) {
+                return 10;
+            } else {
+                return computeVarUIntSize(value);
+            }
+        }
+
+        static int computeVarUIntSize(final int value) {
+            if ((value & (0xffffffff << 7)) == 0) {
+                return 1;
+            } else if ((value & (0xffffffff << 14)) == 0) {
+                return 2;
+            } else if ((value & (0xffffffff << 21)) == 0) {
+                return 3;
+            } else if ((value & (0xffffffff << 28)) == 0) {
+                return 4;
+            } else {
+                return 5;
+            }
+        }
+
+        static int computeVarInt64Size(final long value) {
+            if ((value & (0xffffffffffffffffL << 7)) == 0) {
+                return 1;
+            } else if ((value & (0xffffffffffffffffL << 14)) == 0) {
+                return 2;
+            } else if ((value & (0xffffffffffffffffL << 21)) == 0) {
+                return 3;
+            } else if ((value & (0xffffffffffffffffL << 28)) == 0) {
+                return 4;
+            } else if ((value & (0xffffffffffffffffL << 35)) == 0) {
+                return 5;
+            } else if ((value & (0xffffffffffffffffL << 42)) == 0) {
+                return 6;
+            } else if ((value & (0xffffffffffffffffL << 49)) == 0) {
+                return 7;
+            } else if ((value & (0xffffffffffffffffL << 56)) == 0) {
+                return 8;
+            } else if ((value & (0xffffffffffffffffL << 63)) == 0) {
+                return 9;
+            } else {
+                return 10;
+            }
+        }
+
+        static int computeStringUTF8Size(String s) {
+            return ByteBufUtil.utf8Bytes(s);
+        }
+
+        static void writeString(ByteBuf b, String s, int bytesCount) {
+            ByteBufUtil.reserveAndWriteUtf8(b, s, bytesCount);
+        }
+
+        static String readString(ByteBuf b, int index, int len) {
+            return b.toString(index, len, StandardCharsets.UTF_8);
+        }
+
+        static void skipUnknownField(int tag, ByteBuf buffer) {
+            int tagType = getTagType(tag);
+            switch (tagType) {
+                case WIRETYPE_VARINT :
+                    readVarInt(buffer);
+                    break;
+                case WIRETYPE_FIXED64 :
+                    buffer.skipBytes(8);
+                    break;
+                case WIRETYPE_LENGTH_DELIMITED :
+                    int len = readVarInt(buffer);
+                    buffer.skipBytes(len);
+                    break;
+                case WIRETYPE_FIXED32 :
+                    buffer.skipBytes(4);
+                    break;
+                default :
+                    throw new IllegalArgumentException("Invalid unknonwn tag type: " + tagType);
+            }
+        }
+
+        static final class StringHolder {
+            String s;
+            int idx;
+            int len;
+        }
+
+        static final class BytesHolder {
+            ByteBuf b;
+            int idx;
+            int len;
+        }
+    }
+
+}

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorIndividualDeletedMessagesTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorIndividualDeletedMessagesTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactoryConfig;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo;
@@ -40,8 +41,18 @@ import org.apache.pulsar.common.util.collections.LongPairRangeSet;
 import org.testng.annotations.Test;
 
 public class ManagedCursorIndividualDeletedMessagesTest {
+
     @Test(timeOut = 10000)
     void testRecoverIndividualDeletedMessages() throws Exception {
+        testRecoverIndividualDeletedMessages(null);
+    }
+
+    @Test(timeOut = 10000)
+    void testRecoverIndividualDeletedMessagesWithZSTDCompression() throws Exception {
+        testRecoverIndividualDeletedMessages("ZSTD");
+    }
+
+    void testRecoverIndividualDeletedMessages(String compression) throws Exception {
         BookKeeper bookkeeper = mock(BookKeeper.class);
 
         ManagedLedgerConfig config = new ManagedLedgerConfig();
@@ -54,8 +65,13 @@ public class ManagedCursorIndividualDeletedMessagesTest {
         ledgersInfo.put(10L, createLedgerInfo(10, 2, 32));
         ledgersInfo.put(20L, createLedgerInfo(20, 10, 256));
 
+        ManagedLedgerFactoryImpl factory = mock(ManagedLedgerFactoryImpl.class);
+        ManagedLedgerFactoryConfig factoryConfig = new ManagedLedgerFactoryConfig();
+        factoryConfig.setManagedCursorInfoCompressionType(compression);
+        doReturn(factoryConfig).when(factory).getConfig();
         ManagedLedgerImpl ledger = mock(ManagedLedgerImpl.class);
         doReturn(ledgersInfo).when(ledger).getLedgersInfo();
+        doReturn(factory).when(ledger).getFactory();
         doReturn(config).when(ledger).getConfig();
 
         ManagedCursorImpl cursor = spy(new ManagedCursorImpl(bookkeeper, ledger, "test-cursor"));

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -75,6 +75,7 @@ import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.LedgerEntry;
+import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
@@ -98,6 +99,7 @@ import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedCursorInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.PositionInfo;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.api.proto.IntRange;
 import org.apache.pulsar.common.util.FutureUtil;
@@ -3618,6 +3620,82 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(c.getReadPosition(), readPositionBeforeRecover);
         assertEquals(c.getNumberOfEntries(), 2L);
     }
+
+    @Test(timeOut = 20000)
+    public void testRecoverCursorCorruptLastEntry() throws Exception {
+        ManagedLedger ml = factory.open("testRecoverCursorCorruptLastEntry");
+        ManagedCursorImpl c = (ManagedCursorImpl) ml.openCursor("sub", CommandSubscribe.InitialPosition.Latest);
+        // force chunking
+        c.maxPositionChunkSize = 2;
+
+        // A new cursor starts out with these values. The rest of the test assumes this, so we assert it here.
+        assertEquals(c.getMarkDeletedPosition().getEntryId(), -1);
+        assertEquals(c.getReadPosition().getEntryId(), 0);
+        assertEquals(ml.getLastConfirmedEntry().getEntryId(), -1);
+
+        c.resetCursor(PositionImpl.LATEST);
+
+        // A reset cursor starts out with these values. The rest of the test assumes this, so we assert it here.
+        assertEquals(c.getMarkDeletedPosition().getEntryId(), -1);
+        assertEquals(c.getReadPosition().getEntryId(), 0);
+        assertEquals(ml.getLastConfirmedEntry().getEntryId(), -1);
+
+        // Trigger the lastConfirmedEntry to move forward
+        ml.addEntry(new byte[1]);
+        ml.addEntry(new byte[1]);
+        ml.addEntry(new byte[1]);
+        ml.addEntry(new byte[1]);
+
+        c.resetCursor(PositionImpl.LATEST);
+        //corrupt last entry
+        LedgerHandle cursorLedger = (LedgerHandle)FieldUtils.readDeclaredField(c, "cursorLedger", true);
+        // can't parse json
+        cursorLedger.addEntry("{{".getBytes());
+        // can't parse PositionInfo protobuf
+        cursorLedger.addEntry("aa".getBytes());
+
+        assertEquals(c.getMarkDeletedPosition().getEntryId(), 3);
+        assertEquals(c.getReadPosition().getEntryId(), 4);
+        assertEquals(ml.getLastConfirmedEntry().getEntryId(), 3);
+
+        // Publish messages to move the lastConfirmedEntry field forward
+        ml.addEntry(new byte[1]);
+        ml.addEntry(new byte[1]);
+
+        final Position markDeleteBeforeRecover = c.getMarkDeletedPosition();
+        final Position readPositionBeforeRecover = c.getReadPosition();
+
+        ManagedCursorInfo info = ManagedCursorInfo.newBuilder()
+                .setCursorsLedgerId(c.getCursorLedger())
+                .setMarkDeleteLedgerId(markDeleteBeforeRecover.getLedgerId())
+                .setMarkDeleteEntryId(markDeleteBeforeRecover.getEntryId())
+                .setLastActive(0L)
+                .build();
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicBoolean failed = new AtomicBoolean(false);
+        c.recoverFromLedger(info, new VoidCallback() {
+            @Override
+            public void operationComplete() {
+                latch.countDown();
+            }
+
+            @Override
+            public void operationFailed(ManagedLedgerException exception) {
+                failed.set(true);
+                latch.countDown();
+            }
+        });
+
+        latch.await();
+        if (failed.get()) {
+            fail("Cursor recovery should not fail");
+        }
+        assertEquals(c.getMarkDeletedPosition(), markDeleteBeforeRecover);
+        assertEquals(c.getReadPosition(), readPositionBeforeRecover);
+        assertEquals(c.getNumberOfEntries(), 2L);
+    }
+
     @Test
     void testAlwaysInactive() throws Exception {
         ManagedLedger ml = factory.open("testAlwaysInactive");

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -127,6 +127,11 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         return new Object[][] { { Boolean.TRUE }, { Boolean.FALSE } };
     }
 
+    @Override
+    protected void setupManagedLedgerFactoryConfig(ManagedLedgerFactoryConfig config) {
+        super.setupManagedLedgerFactoryConfig(config);
+        config.setManagedCursorInfoCompressionType("LZ4");
+    }
 
     @Test
     public void testCloseCursor() throws Exception {
@@ -3268,7 +3273,9 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
                     try {
                         LedgerEntry entry = seq.nextElement();
                         PositionInfo positionInfo;
-                        positionInfo = PositionInfo.parseFrom(entry.getEntry());
+                        byte[] data = entry.getEntry();
+                        data = ManagedCursorImpl.decompressDataIfNeeded(data, lh);
+                        positionInfo = PositionInfo.parseFrom(data);
                         individualDeletedMessagesCount.set(positionInfo.getIndividualDeletedMessagesCount());
                     } catch (Exception e) {
                     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.mledger.impl;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -3466,6 +3467,11 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         when(ml.getNextValidPosition(lastPosition)).thenReturn(nextPosition);
         when(ml.ledgerExists(markDeleteLedgerId)).thenReturn(false);
         when(ml.getConfig()).thenReturn(new ManagedLedgerConfig());
+
+        ManagedLedgerFactoryImpl factory = mock(ManagedLedgerFactoryImpl.class);
+        ManagedLedgerFactoryConfig factoryConfig = new ManagedLedgerFactoryConfig();
+        doReturn(factoryConfig).when(factory).getConfig();
+        when(ml.getFactory()).thenReturn(factory);
 
         BookKeeper mockBookKeeper = mock(BookKeeper.class);
         final ManagedCursorImpl cursor = new ManagedCursorImpl(mockBookKeeper, ml, cursorName);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3256,7 +3256,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         class MockLedgerHandle extends PulsarMockLedgerHandle {
             public MockLedgerHandle(PulsarMockBookKeeper bk, long id, DigestType digest, byte[] passwd)
                     throws GeneralSecurityException {
-                super(bk, id, digest, passwd);
+                super(bk, id, digest, passwd, null);
             }
 
             @Override

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/PositionInfoUtilsTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/PositionInfoUtilsTest.java
@@ -19,14 +19,23 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import static org.testng.Assert.*;
+
+import com.google.protobuf.InvalidProtocolBufferException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import java.util.Map;
 import java.util.List;
+
+import org.apache.bookkeeper.mledger.proto.LightMLDataFormats;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
+import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 public class PositionInfoUtilsTest {
+    private static final Logger log = LoggerFactory.getLogger(PositionInfoUtilsTest.class);
+
     @Test
     public void testSerializeDeserialize() throws Exception {
         PositionImpl position = new PositionImpl(1, 2);
@@ -88,4 +97,118 @@ public class PositionInfoUtilsTest {
         assertEquals(0, positionInfoParsed.getBatchedEntryDeletionIndexInfoCount());
         result.release();
     }
+
+    @Test
+    public void testSerializeDeserialize2() throws Exception {
+        PositionImpl position = new PositionImpl(1, 2);
+        ManagedCursorImpl.MarkDeleteEntry entry = new ManagedCursorImpl.MarkDeleteEntry(position,
+                Map.of("foo", 1L), null, null);
+
+        final int numRanges = 10000;
+        ByteBuf result = PositionInfoUtils.serializePositionInfo(entry, position, (scanner) -> {
+            for (int i = 0; i < numRanges; i++) {
+                scanner.acceptRange(i*4 + 1, i*4 + 2, i*4 + 3, i*4 + 4);
+            }
+        }, (scanner) -> {
+            long[] array = {7L, 8L};
+            for (int i = 0; i < numRanges; i++) {
+                scanner.acceptRange(i*2 + 1, i*2 + 2, array);
+            }
+        }, 1024);
+
+        // deserialize PIUtils -> lightproto
+        final int idx = result.readerIndex();
+        LightMLDataFormats.PositionInfo lighPositionInfoParsed = new LightMLDataFormats.PositionInfo();
+        lighPositionInfoParsed.parseFrom(result, result.readableBytes());
+        result.readerIndex(idx);
+
+        validateLightproto(lighPositionInfoParsed, numRanges);
+
+        // serialize lightproto
+        int serializedSz = lighPositionInfoParsed.getSerializedSize();
+        ByteBuf lightResult = PulsarByteBufAllocator.DEFAULT.buffer(serializedSz);
+        lighPositionInfoParsed.writeTo(lightResult);
+
+        byte[] light = ByteBufUtil.getBytes(lightResult);
+        byte[] util = ByteBufUtil.getBytes(result);
+
+        assertEquals(light.length, util.length);
+
+        for (int i = 0; i < light.length; i++) {
+            if (light[i] != util[i]) {
+                log.error("Mismatch at index {} light={} util={}", i, light[i], util[i]);
+            }
+        }
+
+        assertEquals(light, util);
+
+        // deserialize lightproto -> protobuf
+        parseProtobufAndValidate(light, numRanges);
+
+        // deserialize PIUtils -> protobuf
+        parseProtobufAndValidate(util, numRanges);
+
+        result.release();
+        lightResult.release();
+    }
+
+    private static void validateLightproto(LightMLDataFormats.PositionInfo lighPositionInfoParsed, int numRanges) {
+        assertEquals(1, lighPositionInfoParsed.getLedgerId());
+        assertEquals(2, lighPositionInfoParsed.getEntryId());
+
+        assertEquals(1, lighPositionInfoParsed.getPropertiesCount());
+        assertEquals("foo", lighPositionInfoParsed.getPropertyAt(0).getName());
+        assertEquals(1, lighPositionInfoParsed.getPropertyAt(0).getValue());
+
+        assertEquals(numRanges, lighPositionInfoParsed.getIndividualDeletedMessagesCount());
+        int curr = 0;
+        for (int i = 0; i < numRanges; i++) {
+            assertEquals(i*4 + 1, lighPositionInfoParsed.getIndividualDeletedMessageAt(curr).getLowerEndpoint().getLedgerId());
+            assertEquals(i*4 + 2, lighPositionInfoParsed.getIndividualDeletedMessageAt(curr).getLowerEndpoint().getEntryId());
+            assertEquals(i*4 + 3, lighPositionInfoParsed.getIndividualDeletedMessageAt(curr).getUpperEndpoint().getLedgerId());
+            assertEquals(i*4 + 4, lighPositionInfoParsed.getIndividualDeletedMessageAt(curr).getUpperEndpoint().getEntryId());
+            curr++;
+        }
+
+        assertEquals(numRanges, lighPositionInfoParsed.getBatchedEntryDeletionIndexInfosCount());
+        curr = 0;
+        for (int i = 0; i < numRanges; i++) {
+            assertEquals(i*2 + 1, lighPositionInfoParsed.getBatchedEntryDeletionIndexInfoAt(curr).getPosition().getLedgerId());
+            assertEquals(i*2 + 2, lighPositionInfoParsed.getBatchedEntryDeletionIndexInfoAt(curr).getPosition().getEntryId());
+            assertEquals(7L, lighPositionInfoParsed.getBatchedEntryDeletionIndexInfoAt(curr).getDeleteSetAt(0));
+            assertEquals(8L, lighPositionInfoParsed.getBatchedEntryDeletionIndexInfoAt(curr).getDeleteSetAt(1));
+            curr++;
+        }
+    }
+
+    private static void parseProtobufAndValidate(byte[] data, int numRanges) throws InvalidProtocolBufferException {
+        MLDataFormats.PositionInfo positionInfoParsed = MLDataFormats.PositionInfo.parseFrom(data);
+
+        assertEquals(1, positionInfoParsed.getLedgerId());
+        assertEquals(2, positionInfoParsed.getEntryId());
+
+        assertEquals(1, positionInfoParsed.getPropertiesCount());
+        assertEquals("foo", positionInfoParsed.getProperties(0).getName());
+        assertEquals(1, positionInfoParsed.getProperties(0).getValue());
+
+        assertEquals(numRanges, positionInfoParsed.getIndividualDeletedMessagesCount());
+        int curr = 0;
+        for (int i = 0; i < numRanges; i++) {
+            assertEquals(i*4 + 1, positionInfoParsed.getIndividualDeletedMessages(curr).getLowerEndpoint().getLedgerId());
+            assertEquals(i*4 + 2, positionInfoParsed.getIndividualDeletedMessages(curr).getLowerEndpoint().getEntryId());
+            assertEquals(i*4 + 3, positionInfoParsed.getIndividualDeletedMessages(curr).getUpperEndpoint().getLedgerId());
+            assertEquals(i*4 + 4, positionInfoParsed.getIndividualDeletedMessages(curr).getUpperEndpoint().getEntryId());
+            curr++;
+        }
+
+        assertEquals(numRanges, positionInfoParsed.getBatchedEntryDeletionIndexInfoCount());
+        curr = 0;
+        for (int i = 0; i < numRanges; i++) {
+            assertEquals(i*2 + 1, positionInfoParsed.getBatchedEntryDeletionIndexInfo(curr).getPosition().getLedgerId());
+            assertEquals(i*2 + 2, positionInfoParsed.getBatchedEntryDeletionIndexInfo(curr).getPosition().getEntryId());
+            assertEquals(List.of(7L, 8L), positionInfoParsed.getBatchedEntryDeletionIndexInfo(curr).getDeleteSetList());
+            curr++;
+        }
+    }
+
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/PositionInfoUtilsTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/PositionInfoUtilsTest.java
@@ -39,7 +39,7 @@ public class PositionInfoUtilsTest {
         }, (scanner) -> {
             long[] array = {7L, 8L};
             scanner.acceptRange(1, 2, array);
-        });
+        }, 1024);
 
         byte[] data = ByteBufUtil.getBytes(result);
         MLDataFormats.PositionInfo positionInfoParsed = MLDataFormats.PositionInfo.parseFrom(data);
@@ -76,7 +76,7 @@ public class PositionInfoUtilsTest {
 
         ByteBuf result = PositionInfoUtils.serializePositionInfo(entry, position, (scanner) -> {
         }, (scanner) -> {
-        });
+        }, 1024);
 
         byte[] data = ByteBufUtil.getBytes(result);
         MLDataFormats.PositionInfo positionInfoParsed = MLDataFormats.PositionInfo.parseFrom(data);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/PositionInfoUtilsTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/PositionInfoUtilsTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import static org.testng.Assert.*;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import java.util.Map;
+import java.util.List;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats;
+import org.testng.annotations.Test;
+
+public class PositionInfoUtilsTest {
+    @Test
+    public void testSerializeDeserialize() throws Exception {
+        PositionImpl position = new PositionImpl(1, 2);
+        ManagedCursorImpl.MarkDeleteEntry entry = new ManagedCursorImpl.MarkDeleteEntry(position,
+                Map.of("foo", 1L), null, null);
+
+        ByteBuf result = PositionInfoUtils.serializePositionInfo(entry, position, (scanner) -> {
+            scanner.acceptRange(1, 2, 3, 4);
+            scanner.acceptRange(5, 6, 7, 8);
+        }, (scanner) -> {
+            long[] array = {7L, 8L};
+            scanner.acceptRange(1, 2, array);
+        });
+
+        byte[] data = ByteBufUtil.getBytes(result);
+        MLDataFormats.PositionInfo positionInfoParsed = MLDataFormats.PositionInfo.parseFrom(data);
+        assertEquals(1, positionInfoParsed.getLedgerId());
+        assertEquals(2, positionInfoParsed.getEntryId());
+
+        assertEquals(1, positionInfoParsed.getPropertiesCount());
+        assertEquals("foo", positionInfoParsed.getProperties(0).getName());
+        assertEquals(1, positionInfoParsed.getProperties(0).getValue());
+
+        assertEquals(2, positionInfoParsed.getIndividualDeletedMessagesCount());
+        assertEquals(1, positionInfoParsed.getIndividualDeletedMessages(0).getLowerEndpoint().getLedgerId());
+        assertEquals(2, positionInfoParsed.getIndividualDeletedMessages(0).getLowerEndpoint().getEntryId());
+        assertEquals(3, positionInfoParsed.getIndividualDeletedMessages(0).getUpperEndpoint().getLedgerId());
+        assertEquals(4, positionInfoParsed.getIndividualDeletedMessages(0).getUpperEndpoint().getEntryId());
+
+        assertEquals(5, positionInfoParsed.getIndividualDeletedMessages(1).getLowerEndpoint().getLedgerId());
+        assertEquals(6, positionInfoParsed.getIndividualDeletedMessages(1).getLowerEndpoint().getEntryId());
+        assertEquals(7, positionInfoParsed.getIndividualDeletedMessages(1).getUpperEndpoint().getLedgerId());
+        assertEquals(8, positionInfoParsed.getIndividualDeletedMessages(1).getUpperEndpoint().getEntryId());
+
+        assertEquals(1, positionInfoParsed.getBatchedEntryDeletionIndexInfoCount());
+        assertEquals(1, positionInfoParsed.getBatchedEntryDeletionIndexInfo(0).getPosition().getLedgerId());
+        assertEquals(2, positionInfoParsed.getBatchedEntryDeletionIndexInfo(0).getPosition().getEntryId());
+        assertEquals(List.of(7L, 8L), positionInfoParsed.getBatchedEntryDeletionIndexInfo(0).getDeleteSetList());
+        result.release();
+    }
+
+    @Test
+    public void testSerializeDeserializeEmpty() throws Exception {
+        PositionImpl position = new PositionImpl(1, 2);
+        ManagedCursorImpl.MarkDeleteEntry entry = new ManagedCursorImpl.MarkDeleteEntry(position,
+               null, null, null);
+
+        ByteBuf result = PositionInfoUtils.serializePositionInfo(entry, position, (scanner) -> {
+        }, (scanner) -> {
+        });
+
+        byte[] data = ByteBufUtil.getBytes(result);
+        MLDataFormats.PositionInfo positionInfoParsed = MLDataFormats.PositionInfo.parseFrom(data);
+        assertEquals(1, positionInfoParsed.getLedgerId());
+        assertEquals(2, positionInfoParsed.getEntryId());
+
+        assertEquals(0, positionInfoParsed.getPropertiesCount());
+        assertEquals(0, positionInfoParsed.getIndividualDeletedMessagesCount());
+        assertEquals(0, positionInfoParsed.getBatchedEntryDeletionIndexInfoCount());
+        result.release();
+    }
+}

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
@@ -67,6 +67,10 @@ public abstract class MockedBookKeeperTestCase {
         this.numBookies = numBookies;
     }
 
+    protected void setupManagedLedgerFactoryConfig(ManagedLedgerFactoryConfig config) {
+        // No-op
+    }
+
     @BeforeMethod(alwaysRun = true)
     public final void setUp(Method method) throws Exception {
         LOG.info(">>>>>> starting {}", method);
@@ -85,7 +89,8 @@ public abstract class MockedBookKeeperTestCase {
         ManagedLedgerFactoryConfig managedLedgerFactoryConfig = new ManagedLedgerFactoryConfig();
         // increase default cache eviction interval so that caching could be tested with less flakyness
         managedLedgerFactoryConfig.setCacheEvictionIntervalMs(200);
-        factory = new ManagedLedgerFactoryImpl(metadataStore, bkc);
+        setupManagedLedgerFactoryConfig(managedLedgerFactoryConfig);
+        factory = new ManagedLedgerFactoryImpl(metadataStore, bkc, managedLedgerFactoryConfig);
 
         setUpTestCase();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -729,7 +729,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         class MockLedgerHandle extends PulsarMockLedgerHandle {
             public MockLedgerHandle(PulsarMockBookKeeper bk, long id, DigestType digest, byte[] passwd)
                     throws GeneralSecurityException {
-                super(bk, id, digest, passwd);
+                super(bk, id, digest, passwd, null);
             }
 
             @Override

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockBookKeeper.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockBookKeeper.java
@@ -124,7 +124,7 @@ public class PulsarMockBookKeeper extends BookKeeper {
                     long id = sequence.getAndIncrement();
                     log.info("Creating ledger {}", id);
                     PulsarMockLedgerHandle lh =
-                            new PulsarMockLedgerHandle(PulsarMockBookKeeper.this, id, digestType, passwd);
+                            new PulsarMockLedgerHandle(PulsarMockBookKeeper.this, id, digestType, passwd, properties);
                     ledgers.put(id, lh);
                     return FutureUtils.value(lh);
                 } catch (Throwable t) {
@@ -147,7 +147,7 @@ public class PulsarMockBookKeeper extends BookKeeper {
         try {
             long id = sequence.getAndIncrement();
             log.info("Creating ledger {}", id);
-            PulsarMockLedgerHandle lh = new PulsarMockLedgerHandle(this, id, digestType, passwd);
+            PulsarMockLedgerHandle lh = new PulsarMockLedgerHandle(this, id, digestType, passwd, null);
             ledgers.put(id, lh);
             return lh;
         } catch (Throwable t) {

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
@@ -26,8 +26,10 @@ import java.security.GeneralSecurityException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import lombok.Getter;
@@ -65,8 +67,10 @@ public class PulsarMockLedgerHandle extends LedgerHandle {
     boolean fenced = false;
 
     public PulsarMockLedgerHandle(PulsarMockBookKeeper bk, long id,
-                           DigestType digest, byte[] passwd) throws GeneralSecurityException {
-        super(bk.getClientCtx(), id, new Versioned<>(createMetadata(id, digest, passwd), new LongVersion(0L)),
+                           DigestType digest, byte[] passwd,
+                                  Map<String, byte[]> properties) throws GeneralSecurityException {
+        super(bk.getClientCtx(), id, new Versioned<>(createMetadata(id, digest, passwd, properties),
+                        new LongVersion(0L)),
               digest, passwd, WriteFlag.NONE);
         this.bk = bk;
         this.id = id;
@@ -267,13 +271,15 @@ public class PulsarMockLedgerHandle extends LedgerHandle {
         return readHandle.readLastAddConfirmedAndEntryAsync(entryId, timeOutInMillis, parallel);
     }
 
-    private static LedgerMetadata createMetadata(long id, DigestType digest, byte[] passwd) {
+    private static LedgerMetadata createMetadata(long id, DigestType digest, byte[] passwd,
+                                                 Map<String, byte[]> properties) {
         List<BookieId> ensemble = new ArrayList<>(PulsarMockBookKeeper.getMockEnsemble());
         return LedgerMetadataBuilder.create()
             .withDigestType(digest.toApiDigestType())
             .withPassword(passwd)
             .withId(id)
             .newEnsembleEntry(0L, ensemble)
+            .withCustomMetadata(properties != null ? properties : Collections.emptyMap())
             .build();
     }
 


### PR DESCRIPTION
### Motivation

In some cases cursor position info can be too large to serialize as a single entry, e.g. in case of too many deleted ranges. Also the serialization can be too slow.

cherry-picks of changes by @eolivelli @nicoloboschi and I.

### Modifications

Cursor PositionInfo serialization is reworked to produce less garbage/serialize faster; serialized data can be compressed.
In case the serialized data too large it is chunked and saved as a sequence of entries.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests.

### Does this pull request potentially affect one of the following parts:

NO

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dlg99/pulsar/pull/17

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
