### PR TITLE
[fix][ci] Fix snappy-java native lib fails to load in x86 alpine

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -313,9 +313,6 @@ OPTS="$OPTS -Dpulsar.functions.extra.dependencies.dir=${FUNCTIONS_EXTRA_DEPS_DIR
 OPTS="$OPTS -Dpulsar.functions.instance.classpath=${PULSAR_CLASSPATH}"
 OPTS="$OPTS -Dpulsar.functions.log.conf=${FUNCTIONS_LOG_CONF}"
 
-# Enable snappy-java to use system lib
-OPTS="$OPTS -Dorg.xerial.snappy.use.systemlib=true"
-
 ZK_OPTS=" -Dzookeeper.4lw.commands.whitelist=* -Dzookeeper.snapshot.trust.empty=true -Dzookeeper.tcpKeepAlive=true"
 
 LOG4J2_SHUTDOWN_HOOK_DISABLED="-Dlog4j.shutdownHookEnabled=false"

--- a/bin/pulsar
+++ b/bin/pulsar
@@ -313,6 +313,9 @@ OPTS="$OPTS -Dpulsar.functions.extra.dependencies.dir=${FUNCTIONS_EXTRA_DEPS_DIR
 OPTS="$OPTS -Dpulsar.functions.instance.classpath=${PULSAR_CLASSPATH}"
 OPTS="$OPTS -Dpulsar.functions.log.conf=${FUNCTIONS_LOG_CONF}"
 
+# Enable snappy-java to use system lib
+OPTS="$OPTS -Dorg.xerial.snappy.use.systemlib=true"
+
 ZK_OPTS=" -Dzookeeper.4lw.commands.whitelist=* -Dzookeeper.snapshot.trust.empty=true -Dzookeeper.tcpKeepAlive=true"
 
 LOG4J2_SHUTDOWN_HOOK_DISABLED="-Dlog4j.shutdownHookEnabled=false"

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -61,11 +61,13 @@ RUN /usr/lib/jvm/default-jvm/bin/jlink --add-modules ALL-MODULE-PATH --compress 
 RUN echo networkaddress.cache.ttl=1 >> /opt/jvm/conf/security/java.security
 RUN echo networkaddress.cache.negative.ttl=1 >> /opt/jvm/conf/security/java.security
 
+# Enable snappy-java to use system lib
+RUN echo 'OPTS="$OPTS -Dorg.xerial.snappy.use.systemlib=true"' >> /pulsar/conf/bkenv.sh
+
 ## Create one stage to include snappy-java native lib
 # Fix the issue when using snappy-java in x86 arch alpine
 # See https://github.com/xerial/snappy-java/issues/181 https://github.com/xerial/snappy-java/issues/579
 # We need to ensure that the version of the native library matches the version of snappy-java imported via Maven
-# If you need snappy, add -Dorg.xerial.snappy.use.systemlib=true to the PULSAR_EXTRA_OPTS
 FROM alpine AS snappy-java
 
 ARG SNAPPY_VERSION

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -61,6 +61,16 @@ RUN /usr/lib/jvm/default-jvm/bin/jlink --add-modules ALL-MODULE-PATH --compress 
 RUN echo networkaddress.cache.ttl=1 >> /opt/jvm/conf/security/java.security
 RUN echo networkaddress.cache.negative.ttl=1 >> /opt/jvm/conf/security/java.security
 
+## Create one stage to include snappy-java native lib
+# Fix the issue when using snappy-java in x86 arch alpine
+# See https://github.com/xerial/snappy-java/issues/181 https://github.com/xerial/snappy-java/issues/579
+# We need to ensure that the version of the native library matches the version of snappy-java imported via Maven
+FROM alpine AS snappy-java
+
+RUN apk add git alpine-sdk cmake autoconf automake libtool openjdk17 maven curl bash
+RUN export JAVA_HOME=/usr
+RUN git clone https://github.com/xerial/snappy-java.git
+RUN cd snappy-java && git checkout v1.1.10.5
 
 FROM apachepulsar/glibc-base:2.38 as glibc
 
@@ -114,6 +124,8 @@ RUN apk add --allow-untrusted --force-overwrite /root/packages/glibc-*.apk
 
 COPY --from=jvm /opt/jvm /opt/jvm
 ENV JAVA_HOME=/opt/jvm
+
+COPY --from=snappy-java /tmp/libsnappyjava.so /usr/lib/libsnappyjava.so
 
 # The default is /pulsat/bin and cannot be written.
 ENV PULSAR_PID_DIR=/pulsar/logs

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -70,8 +70,7 @@ FROM alpine AS snappy-java
 RUN apk add git alpine-sdk cmake autoconf automake libtool openjdk17 maven curl bash
 RUN export JAVA_HOME=/usr
 RUN git clone https://github.com/xerial/snappy-java.git
-RUN cd snappy-java && git checkout v1.1.10.5
-RUN make clean-native native
+RUN cd snappy-java && git checkout v1.1.10.5 && make clean-native native
 
 FROM apachepulsar/glibc-base:2.38 as glibc
 

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -71,6 +71,7 @@ RUN apk add git alpine-sdk cmake autoconf automake libtool openjdk17 maven curl 
 RUN export JAVA_HOME=/usr
 RUN git clone https://github.com/xerial/snappy-java.git
 RUN cd snappy-java && git checkout v1.1.10.5
+RUN make clean-native native
 
 FROM apachepulsar/glibc-base:2.38 as glibc
 

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -48,6 +48,9 @@ RUN for SUBDIRECTORY in conf data download logs instances/deps packages-storage;
 RUN chmod -R g+rx /pulsar/bin
 RUN chmod -R o+rx /pulsar
 
+# Enable snappy-java to use system lib
+RUN echo 'OPTS="$OPTS -Dorg.xerial.snappy.use.systemlib=true"' >> /pulsar/conf/bkenv.sh
+
 ###  Create one stage to include JVM distribution
 FROM alpine AS jvm
 
@@ -60,9 +63,6 @@ RUN apk add --no-cache amazon-corretto-21 binutils
 RUN /usr/lib/jvm/default-jvm/bin/jlink --add-modules ALL-MODULE-PATH --compress zip-9 --no-man-pages --no-header-files --strip-debug --output /opt/jvm
 RUN echo networkaddress.cache.ttl=1 >> /opt/jvm/conf/security/java.security
 RUN echo networkaddress.cache.negative.ttl=1 >> /opt/jvm/conf/security/java.security
-
-# Enable snappy-java to use system lib
-RUN echo 'OPTS="$OPTS -Dorg.xerial.snappy.use.systemlib=true"' >> /pulsar/conf/bkenv.sh
 
 ## Create one stage to include snappy-java native lib
 # Fix the issue when using snappy-java in x86 arch alpine

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -61,17 +61,19 @@ RUN /usr/lib/jvm/default-jvm/bin/jlink --add-modules ALL-MODULE-PATH --compress 
 RUN echo networkaddress.cache.ttl=1 >> /opt/jvm/conf/security/java.security
 RUN echo networkaddress.cache.negative.ttl=1 >> /opt/jvm/conf/security/java.security
 
+# Enable snappy-java to use system lib
+RUN echo 'OPTS="$OPTS -Dorg.xerial.snappy.use.systemlib=true"' >> /pulsar/conf/bkenv.sh
+
 ## Create one stage to include snappy-java native lib
 # Fix the issue when using snappy-java in x86 arch alpine
 # See https://github.com/xerial/snappy-java/issues/181 https://github.com/xerial/snappy-java/issues/579
 # We need to ensure that the version of the native library matches the version of snappy-java imported via Maven
 FROM alpine AS snappy-java
 
-RUN apk add git alpine-sdk util-linux cmake autoconf automake libtool openjdk17 maven curl bash
+ARG SNAPPY_VERSION
+RUN apk add git alpine-sdk util-linux cmake autoconf automake libtool openjdk17 maven curl bash tar
 ENV JAVA_HOME=/usr
-RUN git clone https://github.com/xerial/snappy-java.git
-RUN cd snappy-java && git checkout v1.1.10.5 && make clean-native native
-
+RUN curl -Ls https://github.com/xerial/snappy-java/archive/refs/tags/v$SNAPPY_VERSION.tar.gz | tar zxf - && cd snappy-java-$SNAPPY_VERSION && make clean-native native
 FROM apachepulsar/glibc-base:2.38 as glibc
 
 ## Create final stage from Alpine image

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -61,13 +61,11 @@ RUN /usr/lib/jvm/default-jvm/bin/jlink --add-modules ALL-MODULE-PATH --compress 
 RUN echo networkaddress.cache.ttl=1 >> /opt/jvm/conf/security/java.security
 RUN echo networkaddress.cache.negative.ttl=1 >> /opt/jvm/conf/security/java.security
 
-# Enable snappy-java to use system lib
-RUN echo 'OPTS="$OPTS -Dorg.xerial.snappy.use.systemlib=true"' >> /pulsar/conf/bkenv.sh
-
 ## Create one stage to include snappy-java native lib
 # Fix the issue when using snappy-java in x86 arch alpine
 # See https://github.com/xerial/snappy-java/issues/181 https://github.com/xerial/snappy-java/issues/579
 # We need to ensure that the version of the native library matches the version of snappy-java imported via Maven
+# If you need snappy, add -Dorg.xerial.snappy.use.systemlib=true to the PULSAR_EXTRA_OPTS
 FROM alpine AS snappy-java
 
 ARG SNAPPY_VERSION

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -68,7 +68,7 @@ RUN echo networkaddress.cache.negative.ttl=1 >> /opt/jvm/conf/security/java.secu
 FROM alpine AS snappy-java
 
 RUN apk add git alpine-sdk cmake autoconf automake libtool openjdk17 maven curl bash
-RUN export JAVA_HOME=/usr
+ENV JAVA_HOME=/usr
 RUN git clone https://github.com/xerial/snappy-java.git
 RUN cd snappy-java && git checkout v1.1.10.5 && make clean-native native
 

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -67,7 +67,7 @@ RUN echo networkaddress.cache.negative.ttl=1 >> /opt/jvm/conf/security/java.secu
 # We need to ensure that the version of the native library matches the version of snappy-java imported via Maven
 FROM alpine AS snappy-java
 
-RUN apk add git alpine-sdk cmake autoconf automake libtool openjdk17 maven curl bash
+RUN apk add git alpine-sdk util-linux cmake autoconf automake libtool openjdk17 maven curl bash
 ENV JAVA_HOME=/usr
 RUN git clone https://github.com/xerial/snappy-java.git
 RUN cd snappy-java && git checkout v1.1.10.5 && make clean-native native

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -83,6 +83,7 @@
                         <args>
                           <PULSAR_TARBALL>target/pulsar-server-distribution-${project.version}-bin.tar.gz</PULSAR_TARBALL>
                           <PULSAR_CLIENT_PYTHON_VERSION>${pulsar.client.python.version}</PULSAR_CLIENT_PYTHON_VERSION>
+                          <SNAPPY_VERSION>${snappy.version}</SNAPPY_VERSION>
                         </args>
                         <contextDir>${project.basedir}</contextDir>
                         <tags>


### PR DESCRIPTION
### Motivation

From branch-3.3, pulsar starts to use alpine as base image, but it throws exception when using snappy-java lib. 

```
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.UnsatisfiedLinkError: /tmp/snappy-1.1.10-4b05b6fe-7374-45fc-b770-7e3728aa63de-libsnappyjava.so: Error relocating /lib/ld-linux-x86-64.so.2: unsupported relocation type 37 [in thread "pulsar-offload-write-OrderedExecutor-1-0"]
```

The reason is that alpine is musl-based OS while snappy-java lib built-in libsnappyjava.so is compiled with glibc.

In order to fix this issue, we need to re-compile the snappy-java native lib in alpine docker.

### Modifications


### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/yaalsn/pulsar/pull/2