### PR TITLE
[improve][ml] RangeCache refactoring: test race conditions and prevent endless loops

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -106,17 +105,6 @@ public class RangeCache<Key extends Comparable<Key>, Value extends ValueWithKeyV
         void recycle() {
             value = null;
             recyclerHandle.recycle(this);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            // only match exact identity of the value
-            return this == o;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hashCode(key);
         }
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java
@@ -103,6 +103,7 @@ public class RangeCache<Key extends Comparable<Key>, Value extends ValueWithKeyV
         }
 
         void recycle() {
+            key = null;
             value = null;
             recyclerHandle.recycle(this);
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java
@@ -305,6 +305,7 @@ public class RangeCache<Key extends Comparable<Key>, Value extends ValueWithKeyV
                     log.info("Key {} does not match the entry's value wrapper's key {}, removed entry by key without "
                             + "releasing the value", key, entryWrapper.getKey());
                     counters.entryRemoved(removed.getSize());
+                    return RemoveEntryResult.ENTRY_REMOVED;
                 }
             }
             return RemoveEntryResult.CONTINUE_LOOP;
@@ -319,6 +320,7 @@ public class RangeCache<Key extends Comparable<Key>, Value extends ValueWithKeyV
                 if (entries.remove(key, entryWrapper)) {
                     log.info("Value was already released for key {}, removed entry without releasing the value", key);
                     counters.entryRemoved(entryWrapper.getSize());
+                    return RemoveEntryResult.ENTRY_REMOVED;
                 }
             }
             return RemoveEntryResult.CONTINUE_LOOP;
@@ -347,7 +349,6 @@ public class RangeCache<Key extends Comparable<Key>, Value extends ValueWithKeyV
                     } else {
                         log.info("Unexpected refCnt {} for key {}, removed entry without releasing the value",
                                 value.refCnt(), key);
-                        return RemoveEntryResult.CONTINUE_LOOP;
                     }
                 }
             } else if (skipInvalid && value.refCnt() > 1 && entries.remove(key, entryWrapper)) {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCacheManagerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCacheManagerTest.java
@@ -193,9 +193,9 @@ public class EntryCacheManagerTest extends MockedBookKeeperTestCase {
         }
 
         cacheManager.removeEntryCache(ml1.getName());
-        assertTrue(cacheManager.getSize() > 0);
         assertEquals(factory2.getMbean().getCacheInsertedEntriesCount(), 20);
         assertEquals(factory2.getMbean().getCacheEntriesCount(), 0);
+        assertEquals(0, cacheManager.getSize());
         assertEquals(factory2.getMbean().getCacheEvictedEntriesCount(), 20);
     }
 


### PR DESCRIPTION
### Motivation

Follow up on #22789. Test a few basic race conditions. 
The solution in #22789 could lead to an endless loop. This PR fixes this problem.

Race conditions are logged with info level, for example:
```
2024-05-31T08:57:44,823 - INFO  - [pool-2-thread-4:RangeCache@308] - Value was already released for key 59, removing entry without releasing the value
2024-05-31T08:57:44,824 - INFO  - [pool-2-thread-4:RangeCache@308] - Value was already released for key 153, removing entry without releasing the value
2024-05-31T08:57:44,824 - INFO  - [pool-2-thread-7:RangeCache@308] - Value was already released for key 153, removing entry without releasing the value
2024-05-31T08:57:44,824 - INFO  - [pool-2-thread-8:RangeCache@308] - Value was already released for key 60, removing entry without releasing the value
2024-05-31T08:57:44,827 - INFO  - [pool-2-thread-2:RangeCache@296] - Key 580 does not match the entry's value wrapper's key 660, removing entry by key without releasing the value
2024-05-31T08:57:44,827 - INFO  - [pool-2-thread-3:RangeCache@296] - Key 226 does not match the entry's value wrapper's key 668, removing entry by key without releasing the value
2024-05-31T08:57:44,827 - INFO  - [pool-2-thread-4:RangeCache@308] - Value was already released for key 741, removing entry without releasing the value
2024-05-31T08:57:44,829 - INFO  - [pool-2-thread-6:RangeCache@308] - Value was already released for key 980, removing entry without releasing the value
2024-05-31T08:57:44,830 - INFO  - [pool-2-thread-6:RangeCache@308] - Value was already released for key 1074, removing entry without releasing the value
2024-05-31T08:57:44,830 - INFO  - [pool-2-thread-3:RangeCache@296] - Key 1088 does not match the entry's value wrapper's key 1358, removing entry by key without releasing the value
2024-05-31T08:57:44,911 - INFO  - [main:RangeCache@337] - Value RangeCacheTest.RefString(s=1, matchingKey=123) does not match the key 1, removed entry without releasing the value
2024-05-31T08:57:44,912 - INFO  - [main:RangeCache@308] - Value was already released for key 1, removing entry without releasing the value
```

### Modifications

- test some invalid entry cases which could be a result of race conditions
- prevent endless loops in `evictLeastAccessedEntries`, `evictLEntriesBeforeTimestamp` and `clear`.
  - invalid entries cannot be skipped since `.firstEntry()` method is used for iterating in removal. If the entry isn't removed and persists, it causes the endless loop.
- add logic for skipping invalid entries for `removeRange`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->