### PR TITLE
[feat][broker] PIP-264: Add broker web executor metrics

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/WebExecutorThreadPoolStats.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/WebExecutorThreadPoolStats.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.web;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.ObservableLongUpDownCounter;
+
+public class WebExecutorThreadPoolStats implements AutoCloseable {
+    // Replaces ['pulsar_web_executor_max_threads', 'pulsar_web_executor_min_threads']
+    public static final String LIMIT_COUNTER = "pulsar.web.executor.thread.limit";
+    private final ObservableLongUpDownCounter limitCounter;
+
+    // Replaces
+    // ['pulsar_web_executor_active_threads', 'pulsar_web_executor_current_threads', 'pulsar_web_executor_idle_threads']
+    public static final String USAGE_COUNTER = "pulsar.web.executor.thread.usage";
+    private final ObservableLongUpDownCounter usageCounter;
+
+    public static final AttributeKey<String> LIMIT_TYPE_KEY = AttributeKey.stringKey("pulsar.limit.type");
+    @VisibleForTesting
+    enum LimitType {
+        MAX,
+        MIN;
+        public final Attributes attributes = Attributes.of(LIMIT_TYPE_KEY, name().toLowerCase());
+    }
+
+    public static final AttributeKey<String> USAGE_TYPE_KEY =
+            AttributeKey.stringKey("pulsar.web.executor.thread.usage");
+    @VisibleForTesting
+    enum UsageType {
+        ACTIVE,
+        CURRENT,
+        IDLE;
+        public final Attributes attributes = Attributes.of(USAGE_TYPE_KEY, name().toLowerCase());
+    }
+
+    public WebExecutorThreadPoolStats(Meter meter, WebExecutorThreadPool executor) {
+        limitCounter = meter
+                .upDownCounterBuilder(LIMIT_COUNTER)
+                .setUnit("{thread}")
+                .setDescription("The thread limits for the pulsar-web executor pool.")
+                .buildWithCallback(measurement -> {
+                    measurement.record(executor.getMaxThreads(), LimitType.MAX.attributes);
+                    measurement.record(executor.getMinThreads(), LimitType.MIN.attributes);
+                });
+        usageCounter = meter
+                .upDownCounterBuilder(USAGE_COUNTER)
+                .setUnit("{thread}")
+                .setDescription("The current usage of threads in the pulsar-web executor pool.")
+                .buildWithCallback(measurement -> {
+                    var idleThreads = executor.getIdleThreads();
+                    var currentThreads = executor.getThreads();
+                    measurement.record(idleThreads, UsageType.IDLE.attributes);
+                    measurement.record(currentThreads, UsageType.CURRENT.attributes);
+                    measurement.record(currentThreads - idleThreads, UsageType.ACTIVE.attributes);
+                });
+    }
+
+    @Override
+    public synchronized void close() {
+        limitCounter.close();
+        usageCounter.close();
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/WebExecutorThreadPoolStats.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/WebExecutorThreadPoolStats.java
@@ -34,7 +34,8 @@ public class WebExecutorThreadPoolStats implements AutoCloseable {
     public static final String USAGE_COUNTER = "pulsar.web.executor.thread.usage";
     private final ObservableLongUpDownCounter usageCounter;
 
-    public static final AttributeKey<String> LIMIT_TYPE_KEY = AttributeKey.stringKey("pulsar.limit.type");
+    public static final AttributeKey<String> LIMIT_TYPE_KEY =
+            AttributeKey.stringKey("pulsar.web.executor.thread.limit.type");
     @VisibleForTesting
     enum LimitType {
         MAX,
@@ -43,7 +44,7 @@ public class WebExecutorThreadPoolStats implements AutoCloseable {
     }
 
     public static final AttributeKey<String> USAGE_TYPE_KEY =
-            AttributeKey.stringKey("pulsar.web.executor.thread.usage");
+            AttributeKey.stringKey("pulsar.web.executor.thread.usage.type");
     @VisibleForTesting
     enum UsageType {
         ACTIVE,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebExecutorStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebExecutorStats.java
@@ -21,14 +21,21 @@ package org.apache.pulsar.broker.web;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Gauge;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.pulsar.opentelemetry.annotations.PulsarDeprecatedMetric;
 
+@Deprecated
 class WebExecutorStats implements AutoCloseable {
     private static final AtomicBoolean CLOSED = new AtomicBoolean(false);
 
+    @PulsarDeprecatedMetric(newMetricName = WebExecutorThreadPoolStats.LIMIT_COUNTER)
     private final Gauge maxThreads;
+    @PulsarDeprecatedMetric(newMetricName = WebExecutorThreadPoolStats.LIMIT_COUNTER)
     private final Gauge minThreads;
+    @PulsarDeprecatedMetric(newMetricName = WebExecutorThreadPoolStats.USAGE_COUNTER)
     private final Gauge idleThreads;
+    @PulsarDeprecatedMetric(newMetricName = WebExecutorThreadPoolStats.USAGE_COUNTER)
     private final Gauge activeThreads;
+    @PulsarDeprecatedMetric(newMetricName = WebExecutorThreadPoolStats.USAGE_COUNTER)
     private final Gauge currentThreads;
     private final WebExecutorThreadPool executor;
 


### PR DESCRIPTION
[PIP-264](https://github.com/apache/pulsar/blob/master/pip/pip-264.md)

### Motivation

Adds metrics for the web service executor thread pool, as currently described [here](https://pulsar.apache.org/docs/next/reference-metrics/#web-service-executor-metrics). Reference documentation for the new metrics can be found in the respective PR: https://github.com/apache/pulsar-site/pull/907.

### Modifications

Expose the respective OpenTelemetry metrics in new class `org.apache.pulsar.broker.web.WebExecutorThreadPoolStats#WebExecutorThreadPoolStats`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - Extended test `org.apache.pulsar.broker.web.WebServiceTest#testWebExecutorMetrics` to validate the OpenTelemetry metrics

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics: _As describe above_
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required`: https://github.com/apache/pulsar-site/pull/907
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dragosvictor/pulsar/pull/27