### PR TITLE
[fix] [broker] disable loadBalancerMemoryResourceWeight by default

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1816,7 +1816,7 @@ strictBookieAffinityEnabled=false
 # The heap memory usage weight when calculating new resource usage.
 # It only takes effect in the ThresholdShedder strategy.
 # Deprecated: Memory is no longer used as a load balancing item
-loadBalancerMemoryResourceWeight=1.0
+loadBalancerMemoryResourceWeight=0
 
 # Zookeeper quorum connection string
 # Deprecated: use metadataStoreUrl instead

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -924,7 +924,7 @@ loadBalancerCPUResourceWeight=1.0
 
 # The heap memory usage weight when calculating new resource usage.
 # It only takes effect in the ThresholdShedder strategy.
-loadBalancerMemoryResourceWeight=1.0
+loadBalancerMemoryResourceWeight=0
 
 # The direct memory usage weight when calculating new resource usage.
 # It only takes effect in the ThresholdShedder strategy.

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -967,7 +967,7 @@ loadBalancerCPUResourceWeight=1.0
 
 # The heap memory usage weight when calculating new resourde usage.
 # It only take effect in ThresholdShedder strategy.
-loadBalancerMemoryResourceWeight=1.0
+loadBalancerMemoryResourceWeight=0
 
 # The direct memory usage weight when calculating new resourde usage.
 # It only take effect in ThresholdShedder strategy.

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2469,7 +2469,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             doc = "Memory Resource Usage Weight. Deprecated: Memory is no longer used as a load balancing item.",
             deprecated = true
     )
-    private double loadBalancerMemoryResourceWeight = 1.0;
+    private double loadBalancerMemoryResourceWeight = 0;
 
     @FieldContext(
             dynamic = true,


### PR DESCRIPTION

### Motivation

We have deprecated `loadBalancerMemoryResourceWeight` in PR: https://github.com/apache/pulsar/pull/19559, because the memory usage increase all the way until the GC reclaim the space, thus there is no relation between the actual load with the memory usage.
But PR: https://github.com/apache/pulsar/pull/19559 don't remove all usage of this conf, there is still some logic using this deprecated conf. Meanwhile, there is a try to enhance the memory usage collection by Lari (https://github.com/apache/pulsar/issues/21973), so there is possibilty that we may enable this conf again if the memory usage is proved to be related with the actual load.
Based on info aboved, i think that we have better to make the default value of deprecated `loadBalancerMemoryResourceWeight` to 0, in such way we can avoid the interference from the memory usage and waiting for Lari's enhancement.


### Modifications

Change the default value of `loadBalancerMemoryResourceWeight` to 0.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
