### PR TITLE
[fix] [broker] disable loadBalancerDirectMemoryResourceWeight by default

### DIFF
--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -928,7 +928,7 @@ loadBalancerMemoryResourceWeight=1.0
 
 # The direct memory usage weight when calculating new resource usage.
 # It only takes effect in the ThresholdShedder strategy.
-loadBalancerDirectMemoryResourceWeight=1.0
+loadBalancerDirectMemoryResourceWeight=0
 
 # Bundle unload minimum throughput threshold (MB), avoiding bundle unload frequently.
 # It only takes effect in the ThresholdShedder strategy.

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -971,7 +971,7 @@ loadBalancerMemoryResourceWeight=1.0
 
 # The direct memory usage weight when calculating new resourde usage.
 # It only take effect in ThresholdShedder strategy.
-loadBalancerDirectMemoryResourceWeight=1.0
+loadBalancerDirectMemoryResourceWeight=0
 
 # Bundle unload minimum throughput threshold (MB), avoding bundle unload frequently.
 # It only take effect in ThresholdShedder strategy.


### PR DESCRIPTION

### Motivation

PR https://github.com/apache/pulsar/pull/21168 has disable `loadBalancerDirectMemoryResourceWeight` by default.  But there is still some places not changed.

### Modifications

Change the default value of all places to 0.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 