### PR TITLE
[fix] [conf] fix configuration name and typo.

### DIFF
--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -320,7 +320,7 @@ dispatcherMinReadBatchSize=1
 # Max number of entries to dispatch for a shared subscription. By default it is 20 entries.
 dispatcherMaxRoundRobinBatchSize=20
 
-# Precise dispathcer flow control according to history message number of each entry
+# Precise dispatcher flow control according to history message number of each entry
 preciseDispatcherFlowControl=false
 
 # Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
@@ -638,7 +638,7 @@ bookkeeperMetadataServiceUri=
 # Authentication plugin to use when connecting to bookies
 bookkeeperClientAuthenticationPlugin=
 
-# BookKeeper auth plugin implementatation specifics parameters name and values
+# BookKeeper auth plugin implementation specifics parameters name and values
 bookkeeperClientAuthenticationParametersName=
 bookkeeperClientAuthenticationParameters=
 
@@ -944,7 +944,7 @@ defaultNamespaceBundleSplitAlgorithm=range_equally_divide
 loadBalancerLoadSheddingStrategy=org.apache.pulsar.broker.loadbalance.impl.ThresholdShedder
 
 # The broker resource usage threshold.
-# When the broker resource usage is gratter than the pulsar cluster average resource usge,
+# When the broker resource usage is greater than the pulsar cluster average resource usge,
 # the threshold shedder will be triggered to offload bundles from the broker.
 # It only take effect in ThresholdShedder strategy.
 loadBalancerBrokerThresholdShedderPercentage=10
@@ -953,27 +953,27 @@ loadBalancerBrokerThresholdShedderPercentage=10
 # It only take effect in ThresholdShedder strategy.
 loadBalancerHistoryResourcePercentage=0.9
 
-# The BandWithIn usage weight when calculating new resourde usage.
+# The BandWithIn usage weight when calculating new resource usage.
 # It only take effect in ThresholdShedder strategy.
 loadBalancerBandwithInResourceWeight=1.0
 
-# The BandWithOut usage weight when calculating new resourde usage.
+# The BandWithOut usage weight when calculating new resource usage.
 # It only take effect in ThresholdShedder strategy.
 loadBalancerBandwithOutResourceWeight=1.0
 
-# The CPU usage weight when calculating new resourde usage.
+# The CPU usage weight when calculating new resource usage.
 # It only take effect in ThresholdShedder strategy.
 loadBalancerCPUResourceWeight=1.0
 
-# The heap memory usage weight when calculating new resourde usage.
+# The heap memory usage weight when calculating new resource usage.
 # It only take effect in ThresholdShedder strategy.
 loadBalancerMemoryResourceWeight=1.0
 
-# The direct memory usage weight when calculating new resourde usage.
+# The direct memory usage weight when calculating new resource usage.
 # It only take effect in ThresholdShedder strategy.
 loadBalancerDirectMemoryResourceWeight=1.0
 
-# Bundle unload minimum throughput threshold (MB), avoding bundle unload frequently.
+# Bundle unload minimum throughput threshold (MB), avoiding bundle unload frequently.
 # It only take effect in ThresholdShedder strategy.
 loadBalancerBundleUnloadMinThroughputThreshold=10
 
@@ -995,7 +995,7 @@ replicatorPrefix=pulsar.repl
 
 # Duration to check replication policy to avoid replicator inconsistency
 # due to missing ZooKeeper watch (disable with value 0)
-replicatioPolicyCheckDurationSeconds=600
+replicationPolicyCheckDurationSeconds=600
 
 # Default message retention time. 0 means retention is disabled. -1 means data is not removed by time quota
 defaultRetentionTimeInMinutes=0


### PR DESCRIPTION
### Motivation

Some conf name is spell incorrectly in conf file `deployment/terraform-ansible/templates/broker.conf`, and there are many typo errors.

### Modifications

- correct the conf name: `replicatioPolicyCheckDurationSeconds` to `replicationPolicyCheckDurationSeconds`.
- fix the typo errors.


### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
