### PR TITLE
[improve] [pip] Correct the conf name in load balance module.

### DIFF
--- a/pip/pip-357.md
+++ b/pip/pip-357.md
@@ -1,0 +1,28 @@
+# PIP-357: Correct the conf name in load balance module.
+
+# Background knowledge
+
+We use `loadBalancerBandwithInResourceWeight` and `loadBalancerBandwithOutResourceWeight` to calculate the broker's load in the load balance module. However, the correct conf name should be `loadBalancerBandwidthInResourceWeight` and `loadBalancerBandwidthOutResourceWeight`. This PIP is to correct the conf name in the load balance module.
+
+# Motivation
+
+The current conf name is incorrect.
+
+
+# Detailed Design
+
+Rename `loadBalancerBandwithInResourceWeight` to `loadBalancerBandwidthInResourceWeight` and `loadBalancerBandwithOutResourceWeight` to `loadBalancerBandwidthOutResourceWeight` in the load balance module.
+
+# Backward & Forward Compatibility
+
+Not backward compatible, users upgrading to this version need to update the conf name in the configuration file.
+
+# General Notes
+
+# Links
+
+<!--
+Updated afterwards
+-->
+* Mailing List discussion thread:
+* Mailing List voting thread:


### PR DESCRIPTION

### Motivation

We use `loadBalancerBandwithInResourceWeight` and `loadBalancerBandwithOutResourceWeight` to calculate the broker's load in the load balance module. However, the correct conf name should be `loadBalancerBandwidthInResourceWeight` and `loadBalancerBandwidthOutResourceWeight`. This PIP is to correct the conf name in the load balance module.


### Modifications

Rename `loadBalancerBandwithInResourceWeight` to `loadBalancerBandwidthInResourceWeight` and `loadBalancerBandwithOutResourceWeight` to `loadBalancerBandwidthOutResourceWeight` in the load balance module.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
