### PR TITLE
[improve][misc] Upgrade OTel library to 1.38.0 version

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -522,26 +522,26 @@ The Apache Software License, Version 2.0
     - org.roaringbitmap-RoaringBitmap-0.9.44.jar
     - org.roaringbitmap-shims-0.9.44.jar
   * OpenTelemetry
-    - io.opentelemetry-opentelemetry-api-1.37.0.jar
-    - io.opentelemetry-opentelemetry-api-incubator-1.37.0-alpha.jar
-    - io.opentelemetry-opentelemetry-context-1.37.0.jar
-    - io.opentelemetry-opentelemetry-exporter-common-1.37.0.jar
-    - io.opentelemetry-opentelemetry-exporter-otlp-1.37.0.jar
-    - io.opentelemetry-opentelemetry-exporter-otlp-common-1.37.0.jar
-    - io.opentelemetry-opentelemetry-exporter-prometheus-1.37.0-alpha.jar
-    - io.opentelemetry-opentelemetry-exporter-sender-okhttp-1.37.0.jar
-    - io.opentelemetry-opentelemetry-sdk-1.37.0.jar
-    - io.opentelemetry-opentelemetry-sdk-common-1.37.0.jar
-    - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-1.37.0.jar
-    - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-spi-1.37.0.jar
-    - io.opentelemetry-opentelemetry-sdk-logs-1.37.0.jar
-    - io.opentelemetry-opentelemetry-sdk-metrics-1.37.0.jar
-    - io.opentelemetry-opentelemetry-sdk-trace-1.37.0.jar
-    - io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-1.33.2.jar
-    - io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-semconv-1.33.2-alpha.jar
-    - io.opentelemetry.instrumentation-opentelemetry-resources-1.33.2-alpha.jar
-    - io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-java17-1.33.2-alpha.jar
-    - io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-java8-1.33.2-alpha.jar
+    - io.opentelemetry-opentelemetry-api-1.38.0.jar
+    - io.opentelemetry-opentelemetry-api-incubator-1.38.0-alpha.jar
+    - io.opentelemetry-opentelemetry-context-1.38.0.jar
+    - io.opentelemetry-opentelemetry-exporter-common-1.38.0.jar
+    - io.opentelemetry-opentelemetry-exporter-otlp-1.38.0.jar
+    - io.opentelemetry-opentelemetry-exporter-otlp-common-1.38.0.jar
+    - io.opentelemetry-opentelemetry-exporter-prometheus-1.38.0-alpha.jar
+    - io.opentelemetry-opentelemetry-exporter-sender-okhttp-1.38.0.jar
+    - io.opentelemetry-opentelemetry-sdk-1.38.0.jar
+    - io.opentelemetry-opentelemetry-sdk-common-1.38.0.jar
+    - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-1.38.0.jar
+    - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-spi-1.38.0.jar
+    - io.opentelemetry-opentelemetry-sdk-logs-1.38.0.jar
+    - io.opentelemetry-opentelemetry-sdk-metrics-1.38.0.jar
+    - io.opentelemetry-opentelemetry-sdk-trace-1.38.0.jar
+    - io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-1.33.3.jar
+    - io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-semconv-1.33.3-alpha.jar
+    - io.opentelemetry.instrumentation-opentelemetry-resources-1.33.3-alpha.jar
+    - io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-java17-1.33.3-alpha.jar
+    - io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-java8-1.33.3-alpha.jar
     - io.opentelemetry.semconv-opentelemetry-semconv-1.25.0-alpha.jar
 
 BSD 3-clause "New" or "Revised" License

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -389,9 +389,9 @@ The Apache Software License, Version 2.0
     - log4j-slf4j2-impl-2.23.1.jar
     - log4j-web-2.23.1.jar
  * OpenTelemetry
-    - opentelemetry-api-1.37.0.jar
-    - opentelemetry-api-incubator-1.37.0-alpha.jar
-    - opentelemetry-context-1.37.0.jar
+    - opentelemetry-api-1.38.0.jar
+    - opentelemetry-api-incubator-1.38.0-alpha.jar
+    - opentelemetry-context-1.38.0.jar
 
  * BookKeeper
     - bookkeeper-common-allocator-4.17.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -259,9 +259,9 @@ flexible messaging model and an intuitive client API.</description>
     <disruptor.version>3.4.3</disruptor.version>
     <zstd-jni.version>1.5.2-3</zstd-jni.version>
     <netty-reactive-streams.version>2.0.6</netty-reactive-streams.version>
-    <opentelemetry.version>1.37.0</opentelemetry.version>
+    <opentelemetry.version>1.38.0</opentelemetry.version>
     <opentelemetry.alpha.version>${opentelemetry.version}-alpha</opentelemetry.alpha.version>
-    <opentelemetry.instrumentation.version>1.33.2</opentelemetry.instrumentation.version>
+    <opentelemetry.instrumentation.version>1.33.3</opentelemetry.instrumentation.version>
     <opentelemetry.instrumentation.alpha.version>${opentelemetry.instrumentation.version}-alpha</opentelemetry.instrumentation.alpha.version>
     <opentelemetry.semconv.version>1.25.0-alpha</opentelemetry.semconv.version>
     <picocli.version>4.7.5</picocli.version>


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/22649#issuecomment-2143514831

### Modifications

- Upgrade OTel library version to 1.38.0
  -  release notes: https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.38.0
- Bump instrumentation library version to 1.33.3
  -  release notes: https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.33.3

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->