### PR TITLE
[fix][sec] Upgrade Bouncycastle libraries to address CVEs

### DIFF
--- a/bouncy-castle/bc/LICENSE
+++ b/bouncy-castle/bc/LICENSE
@@ -207,4 +207,3 @@ Bouncy Castle License
  * Bouncy Castle -- licenses/LICENSE-bouncycastle.txt
     - org.bouncycastle-bcpkix-jdk18on-1.78.1.jar
     - org.bouncycastle-bcprov-jdk18on-1.78.1.jar
-    - org.bouncycastle-bcprov-ext-jdk18on-1.78.1.jar

--- a/bouncy-castle/bc/LICENSE
+++ b/bouncy-castle/bc/LICENSE
@@ -205,6 +205,6 @@
 This projects includes binary packages with the following licenses:
 Bouncy Castle License
  * Bouncy Castle -- licenses/LICENSE-bouncycastle.txt
-    - org.bouncycastle-bcpkix-jdk18on-1.78.jar
-    - org.bouncycastle-bcprov-jdk18on-1.78.jar
-    - org.bouncycastle-bcprov-ext-jdk18on-1.78.jar
+    - org.bouncycastle-bcpkix-jdk18on-1.78.1.jar
+    - org.bouncycastle-bcprov-jdk18on-1.78.1.jar
+    - org.bouncycastle-bcprov-ext-jdk18on-1.78.1.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -618,7 +618,6 @@ Creative Commons Attribution License
 Bouncy Castle License
  * Bouncy Castle -- ../licenses/LICENSE-bouncycastle.txt
     - org.bouncycastle-bcpkix-jdk18on-1.78.1.jar
-    - org.bouncycastle-bcprov-ext-jdk18on-1.78.1.jar
     - org.bouncycastle-bcprov-jdk18on-1.78.1.jar
     - org.bouncycastle-bcutil-jdk18on-1.78.1.jar
 

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -617,10 +617,10 @@ Creative Commons Attribution License
 
 Bouncy Castle License
  * Bouncy Castle -- ../licenses/LICENSE-bouncycastle.txt
-    - org.bouncycastle-bcpkix-jdk18on-1.78.jar
-    - org.bouncycastle-bcprov-ext-jdk18on-1.78.jar
-    - org.bouncycastle-bcprov-jdk18on-1.78.jar
-    - org.bouncycastle-bcutil-jdk18on-1.78.jar
+    - org.bouncycastle-bcpkix-jdk18on-1.78.1.jar
+    - org.bouncycastle-bcprov-ext-jdk18on-1.78.1.jar
+    - org.bouncycastle-bcprov-jdk18on-1.78.1.jar
+    - org.bouncycastle-bcutil-jdk18on-1.78.1.jar
 
 ------------------------
 

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -475,7 +475,6 @@ Creative Commons Attribution License
 Bouncy Castle License
  * Bouncy Castle -- ../licenses/LICENSE-bouncycastle.txt
     - bcpkix-jdk18on-1.78.1.jar
-    - bcprov-ext-jdk18on-1.78.1.jar
     - bcprov-jdk18on-1.78.1.jar
     - bcutil-jdk18on-1.78.1.jar
 

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -474,10 +474,10 @@ Creative Commons Attribution License
 
 Bouncy Castle License
  * Bouncy Castle -- ../licenses/LICENSE-bouncycastle.txt
-    - bcpkix-jdk18on-1.78.jar
-    - bcprov-ext-jdk18on-1.78.jar
-    - bcprov-jdk18on-1.78.jar
-    - bcutil-jdk18on-1.78.jar
+    - bcpkix-jdk18on-1.78.1.jar
+    - bcprov-ext-jdk18on-1.78.1.jar
+    - bcprov-jdk18on-1.78.1.jar
+    - bcutil-jdk18on-1.78.1.jar
 
 ------------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -160,9 +160,9 @@ flexible messaging model and an intuitive client API.</description>
     <slf4j.version>2.0.13</slf4j.version>
     <commons.collections4.version>4.4</commons.collections4.version>
     <log4j2.version>2.23.1</log4j2.version>
-    <bouncycastle.version>1.78</bouncycastle.version>
-    <bouncycastle.bcpkix-fips.version>1.0.6</bouncycastle.bcpkix-fips.version>
-    <bouncycastle.bc-fips.version>1.0.2.4</bouncycastle.bc-fips.version>
+    <bouncycastle.version>1.78.1</bouncycastle.version>
+    <bouncycastle.bcpkix-fips.version>1.0.7</bouncycastle.bcpkix-fips.version>
+    <bouncycastle.bc-fips.version>1.0.2.5</bouncycastle.bc-fips.version>
     <jackson.version>2.14.2</jackson.version>
     <reflections.version>0.10.2</reflections.version>
     <swagger.version>1.6.2</swagger.version>


### PR DESCRIPTION
### Motivation

- org.bouncycastle:bc-fips:1.0.2.4 contains CVE-2024-29857. 


### Modifications

Upgrade to org.bouncycastle:bc-fips 1.0.2.5.
- also update
  - org.bouncycastle:bcpkix-fips to 1.0.7
  - non-fips version to 1.78.1 (from 1.78)
    - remove bcprov-ext-jdk18on since it has been relocated to bcprov-jdk18on

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->