### PR TITLE
[improve] [broker] Fail fast when it failed to create LoadSheddingStrategy instance

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -298,9 +298,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         } catch (Exception e) {
             log.error("Error when trying to create load shedding strategy: {}",
                     conf.getLoadBalancerLoadSheddingStrategy(), e);
+            throw e;
         }
-        log.error("create load shedding strategy failed. using ThresholdShedder by default.");
-        return new ThresholdShedder();
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -297,10 +297,10 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                     Thread.currentThread().getContextClassLoader());
         } catch (Exception e) {
             log.error("Error when trying to create load shedding strategy: {}",
-                    conf.getLoadBalancerLoadPlacementStrategy(), e);
+                    conf.getLoadBalancerLoadSheddingStrategy(), e);
         }
-        log.error("create load shedding strategy failed. using OverloadShedder instead.");
-        return new OverloadShedder();
+        log.error("create load shedding strategy failed. using ThresholdShedder by default.");
+        return new ThresholdShedder();
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -292,14 +292,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
     }
 
     private LoadSheddingStrategy createLoadSheddingStrategy() {
-        try {
-            return Reflections.createInstance(conf.getLoadBalancerLoadSheddingStrategy(), LoadSheddingStrategy.class,
-                    Thread.currentThread().getContextClassLoader());
-        } catch (Exception e) {
-            log.error("Error when trying to create load shedding strategy: {}",
-                    conf.getLoadBalancerLoadSheddingStrategy(), e);
-            throw e;
-        }
+        return Reflections.createInstance(conf.getLoadBalancerLoadSheddingStrategy(), LoadSheddingStrategy.class,
+                Thread.currentThread().getContextClassLoader());
     }
 
     /**


### PR DESCRIPTION
### Motivation

There are two error in method `org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl#createLoadSheddingStrategy`.
- log `LoadSheddingStrategy` instead of `PlacementStrategy`.
- create `ThresholdShedder` by default instead of `OverloadShedder`.

### Modifications

~~Fix these two errors.~~
Fail fast when it failed to create LoadSheddingStrategy.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
