### PR TITLE
[improve] Validate range of argument before long -> int conversion

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TransactionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TransactionsBase.java
@@ -564,8 +564,15 @@ public abstract class TransactionsBase extends AdminResource {
 
     protected CompletableFuture<Void> internalAbortTransaction(boolean authoritative, long mostSigBits,
                                                                long leastSigBits) {
+
+        if (mostSigBits < 0 || mostSigBits > Integer.MAX_VALUE) {
+            return CompletableFuture.failedFuture(new IllegalArgumentException("mostSigBits out of bounds"));
+        }
+
+        int partitionIdx = (int) mostSigBits;
+
         return validateTopicOwnershipAsync(
-                SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN.getPartition((int) mostSigBits), authoritative)
+                SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN.getPartition(partitionIdx), authoritative)
                 .thenCompose(__ -> validateSuperUserAccessAsync())
                 .thenCompose(__ -> pulsar().getTransactionMetadataStoreService()
                         .endTransaction(new TxnID(mostSigBits, leastSigBits), TxnAction.ABORT_VALUE, false));


### PR DESCRIPTION
### Motivation

Instead of silently dropping bits in the casting, validate upfront and fail if out of range.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
