### PR TITLE
[improve] Upgrade Jetcd to 0.7.7 and VertX to 4.5.8

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -493,12 +493,12 @@ The Apache Software License, Version 2.0
   * JCTools - Java Concurrency Tools for the JVM
     - org.jctools-jctools-core-2.1.2.jar
   * Vertx
-    - io.vertx-vertx-auth-common-4.3.8.jar
-    - io.vertx-vertx-bridge-common-4.3.8.jar
-    - io.vertx-vertx-core-4.3.8.jar
-    - io.vertx-vertx-web-4.3.8.jar
-    - io.vertx-vertx-web-common-4.3.8.jar
-    - io.vertx-vertx-grpc-4.3.8.jar
+    - io.vertx-vertx-auth-common-4.5.8.jar
+    - io.vertx-vertx-bridge-common-4.5.8.jar
+    - io.vertx-vertx-core-4.5.8.jar
+    - io.vertx-vertx-web-4.5.8.jar
+    - io.vertx-vertx-web-common-4.5.8.jar
+    - io.vertx-vertx-grpc-4.5.8.jar
   * Apache ZooKeeper
     - org.apache.zookeeper-zookeeper-3.9.2.jar
     - org.apache.zookeeper-zookeeper-jute-3.9.2.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -447,6 +447,7 @@ The Apache Software License, Version 2.0
     - io.grpc-grpc-rls-1.56.0.jar
     - io.grpc-grpc-servlet-1.56.0.jar
     - io.grpc-grpc-servlet-jakarta-1.56.0.jar
+    - io.grpc-grpc-util-1.60.0.jar
   * Perfmark
     - io.perfmark-perfmark-api-0.26.0.jar
   * OpenCensus
@@ -455,7 +456,7 @@ The Apache Software License, Version 2.0
     - io.opencensus-opencensus-proto-0.2.0.jar
   * Jodah
     - net.jodah-typetools-0.5.0.jar
-    - net.jodah-failsafe-2.4.4.jar
+    - dev.failsafe-failsafe-3.3.2.jar
   * Byte Buddy
     - net.bytebuddy-byte-buddy-1.14.12.jar
   * zt-zip
@@ -497,7 +498,7 @@ The Apache Software License, Version 2.0
     - io.vertx-vertx-core-4.3.8.jar
     - io.vertx-vertx-web-4.3.8.jar
     - io.vertx-vertx-web-common-4.3.8.jar
-    - io.vertx-vertx-grpc-4.3.5.jar
+    - io.vertx-vertx-grpc-4.3.8.jar
   * Apache ZooKeeper
     - org.apache.zookeeper-zookeeper-3.9.2.jar
     - org.apache.zookeeper-zookeeper-jute-3.9.2.jar
@@ -510,10 +511,10 @@ The Apache Software License, Version 2.0
     - com.google.auto.value-auto-value-annotations-1.10.1.jar
     - com.google.re2j-re2j-1.7.jar
   * Jetcd
-    - io.etcd-jetcd-api-0.7.5.jar
-    - io.etcd-jetcd-common-0.7.5.jar
-    - io.etcd-jetcd-core-0.7.5.jar
-    - io.etcd-jetcd-grpc-0.7.5.jar
+    - io.etcd-jetcd-api-0.7.7.jar
+    - io.etcd-jetcd-common-0.7.7.jar
+    - io.etcd-jetcd-core-0.7.7.jar
+    - io.etcd-jetcd-grpc-0.7.7.jar
   * IPAddress
     - com.github.seancfoley-ipaddress-5.3.3.jar
   * RxJava

--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@ flexible messaging model and an intuitive client API.</description>
     <spring.version>5.3.27</spring.version>
     <apache-http-client.version>4.5.13</apache-http-client.version>
     <apache-httpcomponents.version>4.4.15</apache-httpcomponents.version>
-    <jetcd.version>0.7.5</jetcd.version>
+    <jetcd.version>0.7.7</jetcd.version>
     <oxia.version>0.3.0</oxia.version>
     <snakeyaml.version>2.0</snakeyaml.version>
     <ant.version>1.10.12</ant.version>
@@ -509,6 +509,11 @@ flexible messaging model and an intuitive client API.</description>
         <artifactId>vertx-web</artifactId>
         <version>${vertx.version}</version>
       </dependency>
+      <dependency>
+          <groupId>io.vertx</groupId>
+          <artifactId>vertx-grpc</artifactId>
+          <version>${vertx.version}</version>
+      </dependency>
 
       <dependency>
          <groupId>org.apache.curator</groupId>
@@ -605,6 +610,13 @@ flexible messaging model and an intuitive client API.</description>
             <artifactId>freebuilder</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-util</artifactId>
+        <!-- This is only used for JEtcd so far. Once we upgrade Grpc to >= 1.60, we can remove the special version pin -->
+        <version>1.60.0</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@ flexible messaging model and an intuitive client API.</description>
     <jersey.version>2.41</jersey.version>
     <athenz.version>1.10.50</athenz.version>
     <prometheus.version>0.16.0</prometheus.version>
-    <vertx.version>4.3.8</vertx.version>
+    <vertx.version>4.5.8</vertx.version>
     <rocksdb.version>7.9.2</rocksdb.version>
     <slf4j.version>2.0.13</slf4j.version>
     <commons.collections4.version>4.4</commons.collections4.version>

--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,7 @@ flexible messaging model and an intuitive client API.</description>
     <opentelemetry.instrumentation.alpha.version>${opentelemetry.instrumentation.version}-alpha</opentelemetry.instrumentation.alpha.version>
     <opentelemetry.semconv.version>1.25.0-alpha</opentelemetry.semconv.version>
     <picocli.version>4.7.5</picocli.version>
+    <failsafe.version>3.3.2</failsafe.version>
 
     <!-- test dependencies -->
     <testcontainers.version>1.18.3</testcontainers.version>
@@ -382,6 +383,12 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>dev.failsafe</groupId>
+        <artifactId>failsafe</artifactId>
+        <version>${failsafe.version}</version>
       </dependency>
 
       <dependency>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -116,6 +116,12 @@
     </dependency>
 
     <dependency>
+      <groupId>dev.failsafe</groupId>
+      <artifactId>failsafe</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mysql</artifactId>
       <scope>test</scope>

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/PulsarIOTestRunner.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/PulsarIOTestRunner.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.tests.integration.io;
 
+import dev.failsafe.RetryPolicy;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -33,7 +34,6 @@ import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
 
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import net.jodah.failsafe.RetryPolicy;
 
 @Slf4j
 public abstract class PulsarIOTestRunner {
@@ -42,10 +42,11 @@ public abstract class PulsarIOTestRunner {
     final Duration ONE_MINUTE = Duration.ofMinutes(1);
     final Duration TEN_SECONDS = Duration.ofSeconds(10);
 
-	protected final RetryPolicy<Void> statusRetryPolicy = new RetryPolicy<Void>()
+	protected final RetryPolicy<?> statusRetryPolicy = RetryPolicy.builder()
             .withMaxDuration(ONE_MINUTE)
             .withDelay(TEN_SECONDS)
-            .onRetry(e -> log.error("Retry ... "));
+            .onRetry(e -> log.error("Retry ... "))
+            .build();
 
     protected PulsarCluster pulsarCluster;
     protected String functionRuntimeType;

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/PulsarIOSinkRunner.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/PulsarIOSinkRunner.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import dev.failsafe.Failsafe;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -46,7 +47,6 @@ import com.google.gson.Gson;
 
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import net.jodah.failsafe.Failsafe;
 
 @Slf4j
 public class PulsarIOSinkRunner extends PulsarIOTestRunner {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/PulsarIOSourceRunner.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/PulsarIOSourceRunner.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import dev.failsafe.Failsafe;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
@@ -45,7 +46,6 @@ import com.google.gson.Gson;
 
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import net.jodah.failsafe.Failsafe;
 
 @Slf4j
 public class PulsarIOSourceRunner extends PulsarIOTestRunner {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarIODebeziumSourceRunner.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarIODebeziumSourceRunner.java
@@ -19,9 +19,9 @@
 package org.apache.pulsar.tests.integration.io.sources.debezium;
 
 import com.google.common.base.Preconditions;
+import dev.failsafe.Failsafe;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import net.jodah.failsafe.Failsafe;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;


### PR DESCRIPTION
### Motivation

Upgrade Jetcd so that we can later upgrade Vertx, which contains a security issue.

This is replacing #21896 & #22427.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
