### PR TITLE
[improve][broker] Reduce number of OpenTelemetry consumer attributes

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -1222,16 +1222,13 @@ public class Consumer {
             if (oldValue != null) {
                 return oldValue;
             }
-            var subscription = getSubscription();
             var topicName = TopicName.get(subscription.getTopic().getName());
 
             var builder = Attributes.builder()
-                    .put(OpenTelemetryAttributes.PULSAR_CONSUMER_NAME, consumerName())
-                    .put(OpenTelemetryAttributes.PULSAR_CONSUMER_ID, consumerId())
-                    .put(OpenTelemetryAttributes.PULSAR_CONSUMER_CONNECTED_SINCE,
-                            getConnectedSince().getEpochSecond())
+                    .put(OpenTelemetryAttributes.PULSAR_CONSUMER_NAME, consumerName)
+                    .put(OpenTelemetryAttributes.PULSAR_CONSUMER_ID, consumerId)
                     .put(OpenTelemetryAttributes.PULSAR_SUBSCRIPTION_NAME, subscription.getName())
-                    .put(OpenTelemetryAttributes.PULSAR_SUBSCRIPTION_TYPE, subType().toString())
+                    .put(OpenTelemetryAttributes.PULSAR_SUBSCRIPTION_TYPE, subType.toString())
                     .put(OpenTelemetryAttributes.PULSAR_DOMAIN, topicName.getDomain().toString())
                     .put(OpenTelemetryAttributes.PULSAR_TENANT, topicName.getTenant())
                     .put(OpenTelemetryAttributes.PULSAR_NAMESPACE, topicName.getNamespace())
@@ -1239,20 +1236,6 @@ public class Consumer {
             if (topicName.isPartitioned()) {
                 builder.put(OpenTelemetryAttributes.PULSAR_PARTITION_INDEX, topicName.getPartitionIndex());
             }
-            var clientAddress = getClientAddressAndPort();
-            if (clientAddress != null) {
-                builder.put(OpenTelemetryAttributes.PULSAR_CLIENT_ADDRESS, clientAddress);
-            }
-            var clientVersion = getClientVersion();
-            if (clientVersion != null) {
-                builder.put(OpenTelemetryAttributes.PULSAR_CLIENT_VERSION, clientVersion);
-            }
-            var metadataList = getMetadata()
-                    .entrySet()
-                    .stream()
-                    .map(e -> String.format("%s:%s", e.getKey(), e.getValue()))
-                    .toList();
-            builder.put(OpenTelemetryAttributes.PULSAR_CONSUMER_METADATA, metadataList);
             return builder.build();
         });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -25,6 +25,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.AtomicDouble;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
+import io.opentelemetry.api.common.Attributes;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -35,6 +36,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 import lombok.Getter;
@@ -69,6 +71,7 @@ import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.BitSetRecyclable;
 import org.apache.pulsar.common.util.collections.ConcurrentLongLongPairHashMap;
 import org.apache.pulsar.common.util.collections.ConcurrentLongLongPairHashMap.LongPair;
+import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
 import org.apache.pulsar.transaction.common.exception.TransactionConflictException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -158,6 +161,10 @@ public class Consumer {
     @Getter
     private final Instant connectedSince = Instant.now();
 
+    private volatile Attributes openTelemetryAttributes;
+    private static final AtomicReferenceFieldUpdater<Consumer, Attributes> OPEN_TELEMETRY_ATTRIBUTES_FIELD_UPDATER =
+            AtomicReferenceFieldUpdater.newUpdater(Consumer.class, Attributes.class, "openTelemetryAttributes");
+
     public Consumer(Subscription subscription, SubType subType, String topicName, long consumerId,
                     int priorityLevel, String consumerName,
                     boolean isDurable, TransportCnx cnx, String appId,
@@ -231,6 +238,8 @@ public class Consumer {
                 .getPulsar().getConfiguration().isAcknowledgmentAtBatchIndexLevelEnabled();
 
         this.schemaType = schemaType;
+
+        OPEN_TELEMETRY_ATTRIBUTES_FIELD_UPDATER.set(this, null);
     }
 
     @VisibleForTesting
@@ -263,6 +272,7 @@ public class Consumer {
         this.isAcknowledgmentAtBatchIndexLevelEnabled = false;
         this.schemaType = null;
         MESSAGE_PERMITS_UPDATER.set(this, availablePermits);
+        OPEN_TELEMETRY_ATTRIBUTES_FIELD_UPDATER.set(this, null);
     }
 
     public SubType subType() {
@@ -1203,4 +1213,47 @@ public class Consumer {
     }
 
     private static final Logger log = LoggerFactory.getLogger(Consumer.class);
+
+    public Attributes getOpenTelemetryAttributes() {
+        if (openTelemetryAttributes != null) {
+            return openTelemetryAttributes;
+        }
+        return OPEN_TELEMETRY_ATTRIBUTES_FIELD_UPDATER.updateAndGet(this, oldValue -> {
+            if (oldValue != null) {
+                return oldValue;
+            }
+            var subscription = getSubscription();
+            var topicName = TopicName.get(subscription.getTopic().getName());
+
+            var builder = Attributes.builder()
+                    .put(OpenTelemetryAttributes.PULSAR_CONSUMER_NAME, consumerName())
+                    .put(OpenTelemetryAttributes.PULSAR_CONSUMER_ID, consumerId())
+                    .put(OpenTelemetryAttributes.PULSAR_CONSUMER_CONNECTED_SINCE,
+                            getConnectedSince().getEpochSecond())
+                    .put(OpenTelemetryAttributes.PULSAR_SUBSCRIPTION_NAME, subscription.getName())
+                    .put(OpenTelemetryAttributes.PULSAR_SUBSCRIPTION_TYPE, subType().toString())
+                    .put(OpenTelemetryAttributes.PULSAR_DOMAIN, topicName.getDomain().toString())
+                    .put(OpenTelemetryAttributes.PULSAR_TENANT, topicName.getTenant())
+                    .put(OpenTelemetryAttributes.PULSAR_NAMESPACE, topicName.getNamespace())
+                    .put(OpenTelemetryAttributes.PULSAR_TOPIC, topicName.getPartitionedTopicName());
+            if (topicName.isPartitioned()) {
+                builder.put(OpenTelemetryAttributes.PULSAR_PARTITION_INDEX, topicName.getPartitionIndex());
+            }
+            var clientAddress = getClientAddressAndPort();
+            if (clientAddress != null) {
+                builder.put(OpenTelemetryAttributes.PULSAR_CLIENT_ADDRESS, clientAddress);
+            }
+            var clientVersion = getClientVersion();
+            if (clientVersion != null) {
+                builder.put(OpenTelemetryAttributes.PULSAR_CLIENT_VERSION, clientVersion);
+            }
+            var metadataList = getMetadata()
+                    .entrySet()
+                    .stream()
+                    .map(e -> String.format("%s:%s", e.getKey(), e.getValue()))
+                    .toList();
+            builder.put(OpenTelemetryAttributes.PULSAR_CONSUMER_METADATA, metadataList);
+            return builder.build();
+        });
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStats.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.stats;
 
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.BatchCallback;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import java.util.Collection;
@@ -27,7 +26,6 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.Topic;
-import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
 
 public class OpenTelemetryConsumerStats implements AutoCloseable {
 
@@ -50,6 +48,9 @@ public class OpenTelemetryConsumerStats implements AutoCloseable {
     // Replaces pulsar_consumer_unacked_messages
     public static final String MESSAGE_UNACKNOWLEDGED_COUNTER = "pulsar.broker.consumer.message.unack.count";
     private final ObservableLongMeasurement messageUnacknowledgedCounter;
+
+    public static final String CONSUMER_BLOCKED_COUNTER = "pulsar.broker.consumer.blocked";
+    private final ObservableLongMeasurement consumerBlockedCounter;
 
     // Replaces pulsar_consumer_available_permits
     public static final String MESSAGE_PERMITS_COUNTER = "pulsar.broker.consumer.permit.count";
@@ -90,6 +91,12 @@ public class OpenTelemetryConsumerStats implements AutoCloseable {
                 .setDescription("The total number of messages unacknowledged by this consumer.")
                 .buildObserver();
 
+        consumerBlockedCounter = meter
+                .upDownCounterBuilder(CONSUMER_BLOCKED_COUNTER)
+                .setUnit("1")
+                .setDescription("Indicates whether the consumer is currently blocked due to unacknowledged messages.")
+                .buildObserver();
+
         messagePermitsCounter = meter
                 .upDownCounterBuilder(MESSAGE_PERMITS_COUNTER)
                 .setUnit("{permit}")
@@ -113,6 +120,7 @@ public class OpenTelemetryConsumerStats implements AutoCloseable {
                 messageAckCounter,
                 messageRedeliverCounter,
                 messageUnacknowledgedCounter,
+                consumerBlockedCounter,
                 messagePermitsCounter);
     }
 
@@ -127,11 +135,8 @@ public class OpenTelemetryConsumerStats implements AutoCloseable {
         bytesOutCounter.record(consumer.getBytesOutCounter(), attributes);
         messageAckCounter.record(consumer.getMessageAckCounter(), attributes);
         messageRedeliverCounter.record(consumer.getMessageRedeliverCounter(), attributes);
-        messageUnacknowledgedCounter.record(consumer.getUnackedMessages(),
-                Attributes.builder()
-                        .putAll(attributes)
-                        .put(OpenTelemetryAttributes.PULSAR_CONSUMER_BLOCKED, consumer.isBlocked())
-                        .build());
+        messageUnacknowledgedCounter.record(consumer.getUnackedMessages(), attributes);
+        consumerBlockedCounter.record(consumer.isBlocked() ? 1 : 0, attributes);
         messagePermitsCounter.record(consumer.getAvailablePermits(), attributes);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStatsTest.java
@@ -141,9 +141,9 @@ public class OpenTelemetryConsumerStatsTest extends BrokerTestBase {
                     actual -> assertThat(actual).isGreaterThanOrEqualTo(receiverQueueSize - messageCount - ackCount));
 
             var unAckCount = messageCount - ackCount;
-            assertMetricLongSumValue(metrics, OpenTelemetryConsumerStats.MESSAGE_UNACKNOWLEDGED_COUNTER,
-                    attributes.toBuilder().put(OpenTelemetryAttributes.PULSAR_CONSUMER_BLOCKED, false).build(),
+            assertMetricLongSumValue(metrics, OpenTelemetryConsumerStats.MESSAGE_UNACKNOWLEDGED_COUNTER, attributes,
                     unAckCount);
+            assertMetricLongSumValue(metrics, OpenTelemetryConsumerStats.CONSUMER_BLOCKED_COUNTER, attributes, 0);
             assertMetricLongSumValue(metrics, OpenTelemetryConsumerStats.MESSAGE_REDELIVER_COUNTER, attributes,
                     actual -> assertThat(actual).isGreaterThanOrEqualTo(unAckCount));
         });

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryConsumerStatsTest.java
@@ -20,37 +20,25 @@ package org.apache.pulsar.broker.stats;
 
 import static org.apache.pulsar.broker.stats.BrokerOpenTelemetryTestUtil.assertMetricLongSumValue;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.doAnswer;
 import io.opentelemetry.api.common.Attributes;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
 import org.apache.pulsar.broker.BrokerTestUtil;
-import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import org.apache.pulsar.broker.service.BrokerTestBase;
-import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
 import org.awaitility.Awaitility;
-import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class OpenTelemetryConsumerStatsTest extends BrokerTestBase {
 
-    private BrokerInterceptor brokerInterceptor;
-
     @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
-        brokerInterceptor =
-                Mockito.mock(BrokerInterceptor.class, Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
         super.baseSetup();
     }
 
@@ -64,7 +52,6 @@ public class OpenTelemetryConsumerStatsTest extends BrokerTestBase {
     protected void customizeMainPulsarTestContextBuilder(PulsarTestContext.Builder builder) {
         super.customizeMainPulsarTestContextBuilder(builder);
         builder.enableOpenTelemetry(true);
-        builder.brokerInterceptor(brokerInterceptor);
     }
 
     @Test(timeOut = 30_000)
@@ -78,14 +65,6 @@ public class OpenTelemetryConsumerStatsTest extends BrokerTestBase {
         var subscriptionName = BrokerTestUtil.newUniqueName("test");
         var receiverQueueSize = 100;
 
-        // Intercept calls to create consumer, in order to fetch client information.
-        var consumerRef = new AtomicReference<Consumer>();
-        doAnswer(invocation -> {
-            consumerRef.compareAndSet(null, invocation.getArgument(1));
-            return null;
-        }).when(brokerInterceptor)
-          .consumerCreated(any(), argThat(arg -> arg.getSubscription().getName().equals(subscriptionName)), any());
-
         @Cleanup
         var consumer = pulsarClient.newConsumer()
                 .topic(topicName)
@@ -94,11 +73,7 @@ public class OpenTelemetryConsumerStatsTest extends BrokerTestBase {
                 .subscriptionType(SubscriptionType.Shared)
                 .ackTimeout(1, TimeUnit.SECONDS)
                 .receiverQueueSize(receiverQueueSize)
-                .property("prop1", "value1")
                 .subscribe();
-
-        Awaitility.await().until(() -> consumerRef.get() != null);
-        var serverConsumer = consumerRef.get();
 
         @Cleanup
         var producer = pulsarClient.newProducer()
@@ -121,11 +96,6 @@ public class OpenTelemetryConsumerStatsTest extends BrokerTestBase {
                 .put(OpenTelemetryAttributes.PULSAR_SUBSCRIPTION_TYPE, SubscriptionType.Shared.toString())
                 .put(OpenTelemetryAttributes.PULSAR_CONSUMER_NAME, consumer.getConsumerName())
                 .put(OpenTelemetryAttributes.PULSAR_CONSUMER_ID, 0)
-                .put(OpenTelemetryAttributes.PULSAR_CONSUMER_CONNECTED_SINCE,
-                        serverConsumer.getConnectedSince().getEpochSecond())
-                .put(OpenTelemetryAttributes.PULSAR_CLIENT_ADDRESS, serverConsumer.getClientAddressAndPort())
-                .put(OpenTelemetryAttributes.PULSAR_CLIENT_VERSION, serverConsumer.getClientVersion())
-                .put(OpenTelemetryAttributes.PULSAR_CONSUMER_METADATA, List.of("prop1:value1"))
                 .build();
 
         Awaitility.await().untilAsserted(() -> {

--- a/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
+++ b/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
@@ -77,11 +77,6 @@ public interface OpenTelemetryAttributes {
     AttributeKey<Long> PULSAR_CONSUMER_ID = AttributeKey.longKey("pulsar.consumer.id");
 
     /**
-     * Indicates whether the consumer is currently blocked on unacknowledged messages or not.
-     */
-    AttributeKey<Boolean> PULSAR_CONSUMER_BLOCKED = AttributeKey.booleanKey("pulsar.consumer.blocked");
-
-    /**
      * The consumer metadata properties, as a list of "key:value" pairs.
      */
     AttributeKey<List<String>> PULSAR_CONSUMER_METADATA = AttributeKey.stringArrayKey("pulsar.consumer.metadata");


### PR DESCRIPTION
### Motivation

PR https://github.com/apache/pulsar/pull/22693 introduced OpenTelemetry consumer stats. Two issues surfaced as part of a follow-up review:

1. The attribute sets are immutable and should be cached, such that they are not allocated on each metric collection run.
2. Too many attributes are being exposed, potentially slowing down the metric pipeline as a result. Many of these attributes are currently being emitted as 'string' metrics in Prometheus.

### Modifications

1. Cache the attribute sets in the Consumer class, using lazy initialization to conserve memory if OTel is disabled.
2. Remove consumer attributes `pulsar.consumer.connected_since`, `pulsar.consumer.metadata`, `pulsar.client.address`, and `pulsar.client.version`.
3. Extract attribute `pulsar.consumer.blocked` from metric `"pulsar.broker.consumer.message.unack.count` into its own metric `pulsar.broker.consumer.blocked`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - Updated test `OpenTelemetryTopicStatsTest#testMessagingMetrics` to account for these changes

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics: _As described above_
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dragosvictor/pulsar/pull/30
