### PR TITLE
[fix] [broker] response not-found error if topic does not exist when calling getPartitionedTopicMetadata

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -724,7 +724,7 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
     protected CompletableFuture<Void> internalCheckNonPartitionedTopicExists(TopicName topicName) {
-        return pulsar().getNamespaceService().checkNonPartitionedTopicExists(topicName, false)
+        return pulsar().getNamespaceService().checkNonPartitionedTopicExists(topicName)
                 .thenAccept(exist -> {
                     if (!exist) {
                         throw new RestException(Status.NOT_FOUND, getTopicNotFoundErrorMessage(topicName.toString()));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -560,13 +560,13 @@ public class PersistentTopicsBase extends AdminResource {
                         // is a non-partitioned topic so we shouldn't check if the topic exists.
                         return pulsar().getBrokerService().isAllowAutoTopicCreationAsync(topicName)
                                 .thenCompose(brokerAllowAutoTopicCreation -> {
-                            if (checkAllowAutoCreation) {
+                            if (checkAllowAutoCreation && brokerAllowAutoTopicCreation) {
                                 // Whether it exists or not, auto create a non-partitioned topic by client.
                                 return CompletableFuture.completedFuture(metadata);
                             } else {
                                 // If it does not exist, response a Not Found error.
                                 // Otherwise, response a non-partitioned metadata.
-                                return internalCheckTopicExists(topicName).thenApply(__ -> metadata);
+                                return internalCheckNonPartitionedTopicExists(topicName).thenApply(__ -> metadata);
                             }
                         });
                     }
@@ -714,6 +714,17 @@ public class PersistentTopicsBase extends AdminResource {
 
     protected CompletableFuture<Void> internalCheckTopicExists(TopicName topicName) {
         return pulsar().getNamespaceService().checkTopicExists(topicName)
+                .thenAccept(info -> {
+                    boolean exists = info.isExists();
+                    info.recycle();
+                    if (!exists) {
+                        throw new RestException(Status.NOT_FOUND, getTopicNotFoundErrorMessage(topicName.toString()));
+                    }
+                });
+    }
+
+    protected CompletableFuture<Void> internalCheckNonPartitionedTopicExists(TopicName topicName) {
+        return pulsar().getNamespaceService().checkNonPartitionedTopicExists(topicName, false)
                 .thenAccept(exist -> {
                     if (!exist) {
                         throw new RestException(Status.NOT_FOUND, getTopicNotFoundErrorMessage(topicName.toString()));
@@ -5337,8 +5348,10 @@ public class PersistentTopicsBase extends AdminResource {
                             "Only persistent topic can be set as shadow topic"));
                 }
                 futures.add(pulsar().getNamespaceService().checkTopicExists(shadowTopicName)
-                        .thenAccept(isExists -> {
-                            if (!isExists) {
+                        .thenAccept(info -> {
+                            boolean exists = info.isExists();
+                            info.recycle();
+                            if (!exists) {
                                 throw new RestException(Status.PRECONDITION_FAILED,
                                         "Shadow topic [" + shadowTopic + "] not exists.");
                             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -73,7 +73,10 @@ public class TopicLookupBase extends PulsarWebResource {
                     return pulsar().getNamespaceService().checkTopicExists(topicName, true).thenCompose(info -> {
                         boolean exists = info.isExists();
                         info.recycle();
-                        return CompletableFuture.completedFuture(exists);
+                        if (exists) {
+                            return CompletableFuture.completedFuture(true);
+                        }
+                        return pulsar().getBrokerService().isAllowAutoTopicCreationAsync(topicName);
                     });
                 })
                 .thenCompose(exist -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -51,6 +51,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -72,6 +73,7 @@ import org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic;
 import org.apache.pulsar.broker.stats.prometheus.metrics.Summary;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -123,6 +125,7 @@ import org.slf4j.LoggerFactory;
  *
  * @see org.apache.pulsar.broker.PulsarService
  */
+@Slf4j
 public class NamespaceService implements AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(NamespaceService.class);
 
@@ -1400,40 +1403,100 @@ public class NamespaceService implements AutoCloseable {
                 });
     }
 
-    public CompletableFuture<Boolean> checkTopicExists(TopicName topic) {
-        CompletableFuture<Boolean> future;
-        // If the topic is persistent and the name includes `-partition-`, find the topic from the managed/ledger.
-        if (topic.isPersistent() && topic.isPartitioned()) {
-            future = pulsar.getPulsarResources().getTopicResources().persistentTopicExists(topic);
-        } else {
-            future = CompletableFuture.completedFuture(false);
-        }
+    public CompletableFuture<TopicExistsInfo> checkTopicExists(TopicName topic) {
+        return checkTopicExists(topic, false);
+    }
 
-        return future.thenCompose(found -> {
-            if (found != null && found) {
+    /***
+     * Check topic exists( partitioned or non-partitioned ).
+     * @param assumedNonPartitionedNonPersistentTopicAlwaysExists Currently, it's hard to check the
+     *        non-persistent-non-partitioned topic, because it only exists in the broker, it doesn't have metadata.
+     *        If the topic is non-persistent and non-partitioned, we'll return the true flag.
+     */
+    public CompletableFuture<TopicExistsInfo> checkTopicExists(TopicName topic,
+                                                    boolean assumedNonPartitionedNonPersistentTopicAlwaysExists) {
+        return pulsar.getBrokerService()
+            .fetchPartitionedTopicMetadataAsync(TopicName.get(topic.getPartitionedTopicName()))
+            .thenCompose(metadata -> {
+                if (metadata.partitions > 0) {
+                    return CompletableFuture.completedFuture(TopicExistsInfo.partitionedExists(metadata.partitions));
+                }
+                return checkNonPartitionedTopicExists(topic, assumedNonPartitionedNonPersistentTopicAlwaysExists)
+                    .thenApply(b -> b ? TopicExistsInfo.nonPartitionedExists() : TopicExistsInfo.notExists());
+            });
+    }
+
+    /***
+     * Check non-partitioned topic exists.
+     * @param assumedNonPartitionedNonPersistentTopicAlwaysExists Currently, it's hard to check the
+     *        non-persistent-non-partitioned topic, because it only exists in the broker, it doesn't have metadata.
+     *        If the topic is non-persistent and non-partitioned, we'll return the true flag.
+     */
+    public CompletableFuture<Boolean> checkNonPartitionedTopicExists(TopicName topic,
+                                                     boolean assumedNonPartitionedNonPersistentTopicAlwaysExists) {
+        if (topic.isPersistent()) {
+            return pulsar.getPulsarResources().getTopicResources().persistentTopicExists(topic);
+        } else {
+            if (assumedNonPartitionedNonPersistentTopicAlwaysExists) {
                 return CompletableFuture.completedFuture(true);
+            } else {
+                return checkNonPersistentNonPartitionedTopicExists(topic.toString());
+            }
+        }
+    }
+
+    /**
+     * Regarding non-persistent topic, we do not know whether it exists or not. Redirect the request to the ownership
+     * broker of this topic. HTTP API has implemented the mechanism that redirect to ownership broker, so just call
+     * HTTP API here.
+     */
+    public CompletableFuture<Boolean> checkNonPersistentNonPartitionedTopicExists(String topic) {
+        TopicName topicName = TopicName.get(topic);
+        // "non-partitioned & non-persistent" topics only exist on the owner broker.
+        return checkTopicOwnership(TopicName.get(topic)).thenCompose(isOwned -> {
+            // The current broker is the owner.
+            if (isOwned) {
+               CompletableFuture<Optional<Topic>> nonPersistentTopicFuture = pulsar.getBrokerService()
+                       .getTopic(topic, false);
+               if (nonPersistentTopicFuture != null) {
+                   return nonPersistentTopicFuture.thenApply(Optional::isPresent);
+               } else {
+                   return CompletableFuture.completedFuture(false);
+               }
             }
 
-            return pulsar.getBrokerService()
-                    .fetchPartitionedTopicMetadataAsync(TopicName.get(topic.getPartitionedTopicName()))
-                    .thenCompose(metadata -> {
-                        if (metadata.partitions > 0) {
-                            return CompletableFuture.completedFuture(true);
-                        }
-
-                        if (topic.isPersistent()) {
-                            return pulsar.getPulsarResources().getTopicResources().persistentTopicExists(topic);
-                        } else {
-                            // The non-partitioned non-persistent topic only exist in the broker topics.
-                            CompletableFuture<Optional<Topic>> nonPersistentTopicFuture =
-                                    pulsar.getBrokerService().getTopics().get(topic.toString());
-                            if (nonPersistentTopicFuture == null) {
+            // Forward to the owner broker.
+            PulsarClientImpl pulsarClient;
+            try {
+                pulsarClient = (PulsarClientImpl) pulsar.getClient();
+            } catch (Exception ex) {
+                // This error will never occur.
+                log.error("{} Failed to get partition metadata due to create internal admin client fails", topic, ex);
+                return FutureUtil.failedFuture(ex);
+            }
+            LookupOptions lookupOptions = LookupOptions.builder().readOnly(false).authoritative(true).build();
+            return getBrokerServiceUrlAsync(TopicName.get(topic), lookupOptions)
+                .thenCompose(lookupResult -> {
+                    if (!lookupResult.isPresent()) {
+                        log.error("{} Failed to get partition metadata due can not find the owner broker", topic);
+                        return FutureUtil.failedFuture(new ServiceUnitNotReadyException(
+                                "No broker was available to own " + topicName));
+                    }
+                    return pulsarClient.getLookup(lookupResult.get().getLookupData().getBrokerUrl())
+                        .getPartitionedTopicMetadata(topicName, false)
+                        .thenApply(metadata -> true)
+                        .exceptionallyCompose(ex -> {
+                            Throwable actEx = FutureUtil.unwrapCompletionException(ex);
+                            if (actEx instanceof PulsarClientException.NotFoundException
+                                    || actEx instanceof PulsarClientException.TopicDoesNotExistException
+                                    || actEx instanceof PulsarAdminException.NotFoundException) {
                                 return CompletableFuture.completedFuture(false);
                             } else {
-                                return nonPersistentTopicFuture.thenApply(Optional::isPresent);
+                                log.error("{} Failed to get partition metadata due to redirecting fails", topic, ex);
+                                return CompletableFuture.failedFuture(ex);
                             }
-                        }
-                    });
+                        });
+            });
         });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1416,7 +1416,7 @@ public class NamespaceService implements AutoCloseable {
     public CompletableFuture<TopicExistsInfo> checkTopicExists(TopicName topic,
                                                     boolean assumedNonPartitionedNonPersistentTopicAlwaysExists) {
         return pulsar.getBrokerService()
-            .fetchPartitionedTopicMetadataAsync(TopicName.get(topic.getPartitionedTopicName()))
+            .fetchPartitionedTopicMetadataAsync(TopicName.get(topic.toString()))
             .thenCompose(metadata -> {
                 if (metadata.partitions > 0) {
                     return CompletableFuture.completedFuture(TopicExistsInfo.partitionedExists(metadata.partitions));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1419,10 +1419,12 @@ public class NamespaceService implements AutoCloseable {
             .fetchPartitionedTopicMetadataAsync(TopicName.get(topic.toString()))
             .thenCompose(metadata -> {
                 if (metadata.partitions > 0) {
-                    return CompletableFuture.completedFuture(TopicExistsInfo.partitionedExists(metadata.partitions));
+                    return CompletableFuture.completedFuture(
+                            TopicExistsInfo.newPartitionedTopicExists(metadata.partitions));
                 }
                 return checkNonPartitionedTopicExists(topic, assumedNonPartitionedNonPersistentTopicAlwaysExists)
-                    .thenApply(b -> b ? TopicExistsInfo.nonPartitionedExists() : TopicExistsInfo.notExists());
+                    .thenApply(b -> b ? TopicExistsInfo.newNonPartitionedTopicExists()
+                            : TopicExistsInfo.newTopicNotExists());
             });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/TopicExistsInfo.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/TopicExistsInfo.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.namespace;
+
+import io.netty.util.Recycler;
+import lombok.Getter;
+import org.apache.pulsar.common.policies.data.TopicType;
+
+public class TopicExistsInfo {
+
+    private static final Recycler<TopicExistsInfo> RECYCLER = new Recycler<>() {
+        @Override
+        protected TopicExistsInfo newObject(Handle<TopicExistsInfo> handle) {
+            return new TopicExistsInfo(handle);
+        }
+    };
+
+    private static TopicExistsInfo EXISTS_NON_PARTITIONED = newInstance(true, TopicType.NON_PARTITIONED, null);
+
+    private static TopicExistsInfo NOT_EXISTS = newInstance(false, TopicType.NON_PARTITIONED, null);
+
+    public static TopicExistsInfo partitionedExists(Integer partitions){
+        return newInstance(true, TopicType.PARTITIONED, partitions);
+    }
+
+    public static TopicExistsInfo nonPartitionedExists(){
+        return EXISTS_NON_PARTITIONED;
+    }
+
+    public static TopicExistsInfo notExists(){
+        return NOT_EXISTS;
+    }
+
+    private static TopicExistsInfo newInstance(boolean exists, TopicType topicType, Integer partitions){
+        TopicExistsInfo info = RECYCLER.get();
+        info.exists = exists;
+        info.topicType = topicType;
+        if (topicType == null) {
+            throw new IllegalArgumentException("The param topicType can not be null when creating a TopicExistsInfo"
+                    + " obj.");
+        }
+        if (topicType.equals(TopicType.PARTITIONED)) {
+            if (partitions == null || partitions.intValue() < 1) {
+                throw new IllegalArgumentException("The param partitions can not be null or less than 1 when creating"
+                        + " a partitioned TopicExistsInfo obj.");
+            }
+            info.partitions = partitions.intValue();
+        } else {
+            if (partitions != null) {
+                throw new IllegalArgumentException("The param partitions must be null when creating a non-partitioned"
+                        + " TopicExistsInfo obj.");
+            }
+        }
+        return info;
+    }
+
+    private final Recycler.Handle<TopicExistsInfo> handle;
+
+    @Getter
+    private TopicType topicType;
+    @Getter
+    private Integer partitions;
+    @Getter
+    private boolean exists;
+
+    private TopicExistsInfo(Recycler.Handle<TopicExistsInfo> handle) {
+        this.handle = handle;
+    }
+
+    public void recycle(){
+        if (this == NOT_EXISTS || this == EXISTS_NON_PARTITIONED) {
+            return;
+        }
+        this.exists = false;
+        this.topicType = null;
+        this.partitions = null;
+        this.handle.recycle(this);
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/TopicExistsInfo.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/TopicExistsInfo.java
@@ -31,9 +31,19 @@ public class TopicExistsInfo {
         }
     };
 
-    private static TopicExistsInfo nonPartitionedExists = newInstance(true, TopicType.NON_PARTITIONED, null);
+    private static TopicExistsInfo nonPartitionedExists = new TopicExistsInfo(null);
+    static {
+        nonPartitionedExists.exists = true;
+        nonPartitionedExists.topicType = TopicType.NON_PARTITIONED;
+        nonPartitionedExists.partitions = null;
+    }
 
-    private static TopicExistsInfo notExists = newInstance(false, TopicType.NON_PARTITIONED, null);
+    private static TopicExistsInfo notExists = new TopicExistsInfo(null);
+    static {
+        notExists.exists = false;
+        notExists.topicType = TopicType.NON_PARTITIONED;
+        notExists.partitions = null;
+    }
 
     public static TopicExistsInfo partitionedExists(Integer partitions){
         return newInstance(true, TopicType.PARTITIONED, partitions);
@@ -84,7 +94,7 @@ public class TopicExistsInfo {
     }
 
     public void recycle(){
-        if (this == notExists || this == nonPartitionedExists) {
+        if (this == notExists || this == nonPartitionedExists || this.handle == null) {
             return;
         }
         this.exists = false;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/TopicExistsInfo.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/TopicExistsInfo.java
@@ -31,20 +31,20 @@ public class TopicExistsInfo {
         }
     };
 
-    private static TopicExistsInfo EXISTS_NON_PARTITIONED = newInstance(true, TopicType.NON_PARTITIONED, null);
+    private static TopicExistsInfo nonPartitionedExists = newInstance(true, TopicType.NON_PARTITIONED, null);
 
-    private static TopicExistsInfo NOT_EXISTS = newInstance(false, TopicType.NON_PARTITIONED, null);
+    private static TopicExistsInfo notExists = newInstance(false, TopicType.NON_PARTITIONED, null);
 
     public static TopicExistsInfo partitionedExists(Integer partitions){
         return newInstance(true, TopicType.PARTITIONED, partitions);
     }
 
     public static TopicExistsInfo nonPartitionedExists(){
-        return EXISTS_NON_PARTITIONED;
+        return nonPartitionedExists;
     }
 
     public static TopicExistsInfo notExists(){
-        return NOT_EXISTS;
+        return notExists;
     }
 
     private static TopicExistsInfo newInstance(boolean exists, TopicType topicType, Integer partitions){
@@ -84,7 +84,7 @@ public class TopicExistsInfo {
     }
 
     public void recycle(){
-        if (this == NOT_EXISTS || this == EXISTS_NON_PARTITIONED) {
+        if (this == notExists || this == nonPartitionedExists) {
             return;
         }
         this.exists = false;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -3179,65 +3179,66 @@ public class BrokerService implements Closeable {
         if (pulsar.getNamespaceService() == null) {
             return FutureUtil.failedFuture(new NamingException("namespace service is not ready"));
         }
-        return pulsar.getPulsarResources().getNamespaceResources().getPoliciesAsync(topicName.getNamespaceObject())
-                .thenCompose(policies -> pulsar.getNamespaceService().checkTopicExists(topicName)
-                    .thenCompose(topicExists -> fetchPartitionedTopicMetadataAsync(topicName)
-                            .thenCompose(metadata -> {
-                                CompletableFuture<PartitionedTopicMetadata> future = new CompletableFuture<>();
+        return pulsar.getNamespaceService().checkTopicExists(topicName).thenComposeAsync(topicExistsInfo -> {
+            final boolean topicExists = topicExistsInfo.isExists();
+            final TopicType topicType = topicExistsInfo.getTopicType();
+            final Integer partitions = topicExistsInfo.getPartitions();
+            topicExistsInfo.recycle();
 
-                                // There are a couple of potentially blocking calls, which we cannot make from the
-                                // MetadataStore callback thread.
-                                pulsar.getExecutor().execute(() -> {
-                                    // If topic is already exist, creating partitioned topic is not allowed.
+            // Topic exists.
+            if (topicExists) {
+                if (topicType.equals(TopicType.PARTITIONED)) {
+                    return CompletableFuture.completedFuture(new PartitionedTopicMetadata(partitions));
+                }
+                return CompletableFuture.completedFuture(new PartitionedTopicMetadata(0));
+            }
 
-                                    if (metadata.partitions == 0
-                                            && !topicExists
-                                            && !topicName.isPartitioned()
-                                            && pulsar.getBrokerService()
-                                            .isDefaultTopicTypePartitioned(topicName, policies)) {
-                                        isAllowAutoTopicCreationAsync(topicName, policies).thenAccept(allowed -> {
-                                            if (allowed) {
-                                                pulsar.getBrokerService()
-                                                        .createDefaultPartitionedTopicAsync(topicName, policies)
-                                                        .thenAccept(md -> future.complete(md))
-                                                        .exceptionally(ex -> {
-                                                            if (ex.getCause()
-                                                                    instanceof MetadataStoreException
-                                                                    .AlreadyExistsException) {
-                                                                log.info("[{}] The partitioned topic is already"
-                                                                        + " created, try to refresh the cache and read"
-                                                                        + " again.", topicName);
-                                                                // The partitioned topic might be created concurrently
-                                                                fetchPartitionedTopicMetadataAsync(topicName, true)
-                                                                        .whenComplete((metadata2, ex2) -> {
-                                                                            if (ex2 == null) {
-                                                                                future.complete(metadata2);
-                                                                            } else {
-                                                                                future.completeExceptionally(ex2);
-                                                                            }
-                                                                        });
-                                                            } else {
-                                                                log.error("[{}] operation of creating partitioned"
-                                                                        + " topic metadata failed",
-                                                                        topicName, ex);
-                                                                future.completeExceptionally(ex);
-                                                            }
-                                                            return null;
-                                                        });
-                                            } else {
-                                                future.complete(metadata);
-                                            }
-                                        }).exceptionally(ex -> {
-                                            future.completeExceptionally(ex);
-                                            return null;
-                                        });
-                                    } else {
-                                        future.complete(metadata);
-                                    }
-                                });
+            // Try created if allowed to create a partitioned topic automatically.
+            return pulsar.getPulsarResources().getNamespaceResources().getPoliciesAsync(topicName.getNamespaceObject())
+                .thenComposeAsync(policies -> {
+                    return isAllowAutoTopicCreationAsync(topicName, policies).thenComposeAsync(allowed -> {
+                        // Not Allow auto-creation.
+                        if (!allowed) {
+                            // Do not change the original behavior, or default return a non-partitioned topic.
+                            return CompletableFuture.completedFuture(new PartitionedTopicMetadata(0));
+                        }
 
-                                return future;
-                            })));
+                        // Allow auto create non-partitioned topic.
+                        boolean autoCreatePartitionedTopic = pulsar.getBrokerService()
+                                .isDefaultTopicTypePartitioned(topicName, policies);
+                        if (!autoCreatePartitionedTopic) {
+                            return CompletableFuture.completedFuture(new PartitionedTopicMetadata(0));
+                        }
+
+                        // Create partitioned metadata.
+                        return pulsar.getBrokerService().createDefaultPartitionedTopicAsync(topicName, policies)
+                            .exceptionallyCompose(ex -> {
+                                // The partitioned topic might be created concurrently.
+                                if (ex.getCause() instanceof MetadataStoreException.AlreadyExistsException) {
+                                    log.info("[{}] The partitioned topic is already created, try to refresh the cache"
+                                            + " and read again.", topicName);
+                                    CompletableFuture<PartitionedTopicMetadata> recheckFuture =
+                                            fetchPartitionedTopicMetadataAsync(topicName, true);
+                                    recheckFuture.exceptionally(ex2 -> {
+                                        // Just for printing a log if error occurs.
+                                        log.error("[{}] Fetch partitioned topic metadata failed", topicName, ex);
+                                        return null;
+                                    });
+                                    return recheckFuture;
+                                } else {
+                                    log.error("[{}] operation of creating partitioned topic metadata failed",
+                                            topicName, ex);
+                                    return CompletableFuture.failedFuture(ex);
+                                }
+                            });
+                    }, pulsar.getExecutor()).exceptionallyCompose(ex -> {
+                        log.error("[{}] operation of get partitioned metadata failed due to calling"
+                                        + " isAllowAutoTopicCreationAsync failed",
+                                topicName, ex);
+                        return CompletableFuture.failedFuture(ex);
+                    });
+            }, pulsar.getExecutor());
+        }, pulsar.getExecutor());
     }
 
     @SuppressWarnings("deprecation")

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -3206,7 +3206,7 @@ public class BrokerService implements Closeable {
                         // Allow auto create non-partitioned topic.
                         boolean autoCreatePartitionedTopic = pulsar.getBrokerService()
                                 .isDefaultTopicTypePartitioned(topicName, policies);
-                        if (!autoCreatePartitionedTopic) {
+                        if (!autoCreatePartitionedTopic || topicName.isPartitioned()) {
                             return CompletableFuture.completedFuture(new PartitionedTopicMetadata(0));
                         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -83,8 +83,7 @@ import org.apache.pulsar.broker.limiter.ConnectionController;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.namespace.LookupOptions;
-import org.apache.pulsar.broker.resources.NamespaceResources;
-import org.apache.pulsar.broker.resources.TopicResources;
+import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.BrokerServiceException.ConsumerBusyException;
 import org.apache.pulsar.broker.service.BrokerServiceException.ServerMetadataException;
 import org.apache.pulsar.broker.service.BrokerServiceException.ServiceUnitNotReadyException;
@@ -160,6 +159,7 @@ import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
 import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.NamespaceOperation;
 import org.apache.pulsar.common.policies.data.TopicOperation;
+import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.common.policies.data.stats.ConsumerStatsImpl;
 import org.apache.pulsar.common.protocol.ByteBufPair;
 import org.apache.pulsar.common.protocol.CommandUtils;
@@ -613,58 +613,33 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 if (isAuthorized) {
                     // Get if exists, respond not found error if not exists.
                     getBrokerService().isAllowAutoTopicCreationAsync(topicName).thenAccept(brokerAllowAutoCreate -> {
-                        boolean autoCreateIfNotExist = partitionMetadata.isMetadataAutoCreationEnabled();
+                        boolean autoCreateIfNotExist = partitionMetadata.isMetadataAutoCreationEnabled()
+                                && brokerAllowAutoCreate;
                         if (!autoCreateIfNotExist) {
-                            final NamespaceResources namespaceResources = getBrokerService().pulsar()
-                                    .getPulsarResources().getNamespaceResources();
-                            final TopicResources topicResources = getBrokerService().pulsar().getPulsarResources()
-                                    .getTopicResources();
-                            namespaceResources.getPartitionedTopicResources()
-                                .getPartitionedTopicMetadataAsync(topicName, false)
-                                .handle((metadata, getMetadataEx) -> {
-                                    if (getMetadataEx != null) {
-                                        log.error("{} {} Failed to get partition metadata", topicName,
-                                                ServerCnx.this.toString(), getMetadataEx);
-                                        writeAndFlush(
-                                                Commands.newPartitionMetadataResponse(ServerError.MetadataError,
-                                                        "Failed to get partition metadata",
-                                                        requestId));
-                                    } else if (metadata.isPresent()) {
-                                        commandSender.sendPartitionMetadataResponse(metadata.get().partitions,
-                                                requestId);
-                                    } else if (topicName.isPersistent()) {
-                                        topicResources.persistentTopicExists(topicName).thenAccept(exists -> {
-                                            if (exists) {
-                                                commandSender.sendPartitionMetadataResponse(0, requestId);
-                                                return;
-                                            }
-                                            writeAndFlush(Commands.newPartitionMetadataResponse(
-                                                    ServerError.TopicNotFound, "", requestId));
-                                        }).exceptionally(ex -> {
-                                            log.error("{} {} Failed to get partition metadata", topicName,
-                                                    ServerCnx.this.toString(), ex);
-                                            writeAndFlush(
-                                                    Commands.newPartitionMetadataResponse(ServerError.MetadataError,
-                                                            "Failed to check partition metadata",
-                                                            requestId));
-                                            return null;
-                                        });
-                                    } else {
-                                        // Regarding non-persistent topic, we do not know whether it exists or not.
-                                        // Just return a non-partitioned metadata if partitioned metadata does not
-                                        // exist.
-                                        // Broker will respond a not found error when doing subscribing or producing if
-                                        // broker not allow to auto create topics.
-                                        commandSender.sendPartitionMetadataResponse(0, requestId);
-                                    }
-                                    return null;
-                                }).whenComplete((ignore, ignoreEx) -> {
-                                    lookupSemaphore.release();
-                                    if (ignoreEx != null) {
-                                        log.error("{} {} Failed to handle partition metadata request", topicName,
-                                                ServerCnx.this.toString(), ignoreEx);
-                                    }
-                                });
+                            NamespaceService namespaceService = getBrokerService().getPulsar().getNamespaceService();
+                            namespaceService.checkTopicExists(topicName).thenAccept(topicExistsInfo -> {
+                                lookupSemaphore.release();
+                                if (!topicExistsInfo.isExists()) {
+                                    writeAndFlush(Commands.newPartitionMetadataResponse(
+                                            ServerError.TopicNotFound, "", requestId));
+                                } else if (topicExistsInfo.getTopicType().equals(TopicType.PARTITIONED)) {
+                                    commandSender.sendPartitionMetadataResponse(topicExistsInfo.getPartitions(),
+                                            requestId);
+                                } else {
+                                    commandSender.sendPartitionMetadataResponse(0, requestId);
+                                }
+                                // release resources.
+                                topicExistsInfo.recycle();
+                            }).exceptionally(ex -> {
+                                lookupSemaphore.release();
+                                log.error("{} {} Failed to get partition metadata", topicName,
+                                        ServerCnx.this.toString(), ex);
+                                writeAndFlush(
+                                        Commands.newPartitionMetadataResponse(ServerError.MetadataError,
+                                                "Failed to get partition metadata",
+                                                requestId));
+                                return null;
+                            });
                         } else {
                             // Get if exists, create a new one if not exists.
                             unsafeGetPartitionedTopicMetadataAsync(getBrokerService().pulsar(), topicName)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataMultiBrokerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataMultiBrokerTest.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import java.net.URL;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.TopicType;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker-admin")
+@Slf4j
+public class GetPartitionMetadataMultiBrokerTest extends GetPartitionMetadataTest {
+
+    private PulsarService pulsar2;
+    private URL url2;
+    private PulsarAdmin admin2;
+    private PulsarClientImpl clientWithHttpLookup2;
+    private PulsarClientImpl clientWitBinaryLookup2;
+
+    @BeforeClass(alwaysRun = true)
+    protected void setup() throws Exception {
+        super.setup();
+    }
+
+    @Override
+    @AfterClass(alwaysRun = true)
+    protected void cleanup() throws Exception {
+        super.cleanup();
+    }
+
+    @Override
+    protected void cleanupBrokers() throws Exception {
+        // Cleanup broker2.
+        if (clientWithHttpLookup2 != null) {
+            clientWithHttpLookup2.close();
+            clientWithHttpLookup2 = null;
+        }
+        if (clientWitBinaryLookup2 != null) {
+            clientWitBinaryLookup2.close();
+            clientWitBinaryLookup2 = null;
+        }
+        if (admin2 != null) {
+            admin2.close();
+            admin2 = null;
+        }
+        if (pulsar2 != null) {
+            pulsar2.close();
+            pulsar2 = null;
+        }
+
+        // Super cleanup.
+        super.cleanupBrokers();
+    }
+
+    @Override
+    protected void setupBrokers() throws Exception {
+        super.setupBrokers();
+        doInitConf();
+        pulsar2 = new PulsarService(conf);
+        pulsar2.start();
+        url2 = new URL(pulsar2.getWebServiceAddress());
+        admin2 = PulsarAdmin.builder().serviceHttpUrl(url2.toString()).build();
+        clientWithHttpLookup2 =
+                (PulsarClientImpl) PulsarClient.builder().serviceUrl(pulsar2.getWebServiceAddress()).build();
+        clientWitBinaryLookup2 =
+                (PulsarClientImpl) PulsarClient.builder().serviceUrl(pulsar2.getBrokerServiceUrl()).build();
+    }
+
+    @Override
+    protected PulsarClientImpl[] getClientsToTest() {
+        return new PulsarClientImpl[] {clientWithHttpLookup1, clientWitBinaryLookup1,
+                clientWithHttpLookup2, clientWitBinaryLookup2};
+    }
+
+    protected PulsarClientImpl[] getClientsToTest(boolean isUsingHttpLookup) {
+        if (isUsingHttpLookup) {
+            return new PulsarClientImpl[]{clientWithHttpLookup1, clientWithHttpLookup2};
+        } else {
+            return new PulsarClientImpl[]{clientWitBinaryLookup1, clientWitBinaryLookup2};
+        }
+    }
+
+    @Override
+    protected int getLookupRequestPermits() {
+        return pulsar1.getBrokerService().getLookupRequestSemaphore().availablePermits()
+                + pulsar2.getBrokerService().getLookupRequestSemaphore().availablePermits();
+    }
+
+    protected void verifyPartitionsNeverCreated(String topicNameStr) throws Exception {
+        TopicName topicName = TopicName.get(topicNameStr);
+        try {
+            List<String> topicList = admin1.topics().getList("public/default");
+            for (int i = 0; i < 3; i++) {
+                assertFalse(topicList.contains(topicName.getPartition(i)));
+            }
+        } catch (Exception ex) {
+            // If the namespace bundle has not been loaded yet, it means no non-persistent topic was created. So
+            //   this behavior is also correct.
+            // This error is not expected, a seperated PR is needed to fix this issue.
+            assertTrue(ex.getMessage().contains("Failed to find ownership for"));
+        }
+    }
+
+    protected void verifyNonPartitionedTopicNeverCreated(String topicNameStr) throws Exception {
+        TopicName topicName = TopicName.get(topicNameStr);
+        try {
+            List<String> topicList = admin1.topics().getList("public/default");
+            assertFalse(topicList.contains(topicName.getPartitionedTopicName()));
+        } catch (Exception ex) {
+            // If the namespace bundle has not been loaded yet, it means no non-persistent topic was created. So
+            //   this behavior is also correct.
+            // This error is not expected, a seperated PR is needed to fix this issue.
+            assertTrue(ex.getMessage().contains("Failed to find ownership for"));
+        }
+    }
+
+    protected void modifyTopicAutoCreation(boolean allowAutoTopicCreation,
+                                           TopicType allowAutoTopicCreationType,
+                                           int defaultNumPartitions) throws Exception {
+        doModifyTopicAutoCreation(admin1, pulsar1, allowAutoTopicCreation, allowAutoTopicCreationType,
+                defaultNumPartitions);
+        doModifyTopicAutoCreation(admin2, pulsar2, allowAutoTopicCreation, allowAutoTopicCreationType,
+                defaultNumPartitions);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Test(dataProvider = "topicDomains")
+    public void testAutoCreatingMetadataWhenCallingOldAPI(TopicDomain topicDomain) throws Exception {
+        super.testAutoCreatingMetadataWhenCallingOldAPI(topicDomain);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Test(dataProvider = "autoCreationParamsAll", enabled = false)
+    public void testGetMetadataIfNonPartitionedTopicExists(boolean configAllowAutoTopicCreation,
+                                                           boolean paramMetadataAutoCreationEnabled,
+                                                           boolean isUsingHttpLookup,
+                                                           TopicDomain topicDomain) throws Exception {
+        super.testGetMetadataIfNonPartitionedTopicExists(configAllowAutoTopicCreation, paramMetadataAutoCreationEnabled,
+                isUsingHttpLookup, topicDomain);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Test(dataProvider = "autoCreationParamsAll")
+    public void testGetMetadataIfPartitionedTopicExists(boolean configAllowAutoTopicCreation,
+                                                        boolean paramMetadataAutoCreationEnabled,
+                                                        boolean isUsingHttpLookup,
+                                                        TopicDomain topicDomain) throws Exception {
+        super.testGetMetadataIfNonPartitionedTopicExists(configAllowAutoTopicCreation, paramMetadataAutoCreationEnabled,
+                isUsingHttpLookup, topicDomain);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Test(dataProvider = "clients")
+    public void testAutoCreatePartitionedTopic(boolean isUsingHttpLookup, TopicDomain topicDomain) throws Exception {
+        super.testAutoCreatePartitionedTopic(isUsingHttpLookup, topicDomain);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Test(dataProvider = "clients")
+    public void testAutoCreateNonPartitionedTopic(boolean isUsingHttpLookup, TopicDomain topicDomain) throws Exception {
+        super.testAutoCreateNonPartitionedTopic(isUsingHttpLookup, topicDomain);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Test(dataProvider = "autoCreationParamsNotAllow")
+    public void testGetMetadataIfNotAllowedCreate(boolean configAllowAutoTopicCreation,
+                                                  boolean paramMetadataAutoCreationEnabled,
+                                                  boolean isUsingHttpLookup) throws Exception {
+        super.testGetMetadataIfNotAllowedCreate(configAllowAutoTopicCreation, paramMetadataAutoCreationEnabled,
+                isUsingHttpLookup);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Test(dataProvider = "autoCreationParamsNotAllow")
+    public void testGetMetadataIfNotAllowedCreateOfNonPersistentTopic(boolean configAllowAutoTopicCreation,
+                                                  boolean paramMetadataAutoCreationEnabled,
+                                                  boolean isUsingHttpLookup) throws Exception {
+        super.testGetMetadataIfNotAllowedCreateOfNonPersistentTopic(configAllowAutoTopicCreation,
+                paramMetadataAutoCreationEnabled, isUsingHttpLookup);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
@@ -22,70 +22,150 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+import com.google.common.collect.Sets;
+import java.net.URL;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.Semaphore;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.client.impl.LookupService;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+import org.apache.pulsar.common.policies.data.ClusterDataImpl;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
 import org.awaitility.Awaitility;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker-admin")
 @Slf4j
-public class GetPartitionMetadataTest extends ProducerConsumerBase {
+public class GetPartitionMetadataTest {
 
-    private static final String DEFAULT_NS = "public/default";
+    protected static final String DEFAULT_NS = "public/default";
 
-    private PulsarClientImpl clientWithHttpLookup;
-    private PulsarClientImpl clientWitBinaryLookup;
+    protected String clusterName = "c1";
 
-    @Override
+    protected LocalBookkeeperEnsemble bkEnsemble;
+
+    protected ServiceConfiguration conf = new ServiceConfiguration();
+
+    protected PulsarService pulsar1;
+    protected URL url1;
+    protected PulsarAdmin admin1;
+    protected PulsarClientImpl clientWithHttpLookup1;
+    protected PulsarClientImpl clientWitBinaryLookup1;
+
+    @BeforeClass(alwaysRun = true)
     protected void setup() throws Exception {
-        super.internalSetup();
-        super.producerBaseSetup();
-        clientWithHttpLookup =
-                (PulsarClientImpl) PulsarClient.builder().serviceUrl(pulsar.getWebServiceAddress()).build();
-        clientWitBinaryLookup =
-                (PulsarClientImpl) PulsarClient.builder().serviceUrl(pulsar.getBrokerServiceUrl()).build();
+        bkEnsemble = new LocalBookkeeperEnsemble(3, 0, () -> 0);
+        bkEnsemble.start();
+        // Start broker.
+        setupBrokers();
+        // Create default NS.
+        admin1.clusters().createCluster(clusterName, new ClusterDataImpl());
+        admin1.tenants().createTenant(NamespaceName.get(DEFAULT_NS).getTenant(),
+                new TenantInfoImpl(Collections.emptySet(), Sets.newHashSet(clusterName)));
+        admin1.namespaces().createNamespace(DEFAULT_NS);
     }
 
-    @Override
-    @AfterMethod(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
-        super.internalCleanup();
-        if (clientWithHttpLookup != null) {
-            clientWithHttpLookup.close();
-        }
-        if (clientWitBinaryLookup != null) {
-            clientWitBinaryLookup.close();
+        cleanupBrokers();
+        if (bkEnsemble != null) {
+            bkEnsemble.stop();
+            bkEnsemble = null;
         }
     }
 
-    @Override
-    protected void doInitConf() throws Exception {
-        super.doInitConf();
+    protected void cleanupBrokers() throws Exception {
+        // Cleanup broker2.
+        if (clientWithHttpLookup1 != null) {
+            clientWithHttpLookup1.close();
+            clientWithHttpLookup1 = null;
+        }
+        if (clientWitBinaryLookup1 != null) {
+            clientWitBinaryLookup1.close();
+            clientWitBinaryLookup1 = null;
+        }
+        if (admin1 != null) {
+            admin1.close();
+            admin1 = null;
+        }
+        if (pulsar1 != null) {
+            pulsar1.close();
+            pulsar1 = null;
+        }
+        // Reset configs.
+        conf = new ServiceConfiguration();
     }
 
-    private LookupService getLookupService(boolean isUsingHttpLookup) {
+    protected void setupBrokers() throws Exception {
+        doInitConf();
+        // Start broker.
+        pulsar1 = new PulsarService(conf);
+        pulsar1.start();
+        url1 = new URL(pulsar1.getWebServiceAddress());
+        admin1 = PulsarAdmin.builder().serviceHttpUrl(url1.toString()).build();
+        clientWithHttpLookup1 =
+                (PulsarClientImpl) PulsarClient.builder().serviceUrl(pulsar1.getWebServiceAddress()).build();
+        clientWitBinaryLookup1 =
+                (PulsarClientImpl) PulsarClient.builder().serviceUrl(pulsar1.getBrokerServiceUrl()).build();
+    }
+
+    protected void doInitConf() {
+        conf.setClusterName(clusterName);
+        conf.setAdvertisedAddress("localhost");
+        conf.setBrokerServicePort(Optional.of(0));
+        conf.setWebServicePort(Optional.of(0));
+        conf.setMetadataStoreUrl("zk:127.0.0.1:" + bkEnsemble.getZookeeperPort());
+        conf.setConfigurationMetadataStoreUrl("zk:127.0.0.1:" + bkEnsemble.getZookeeperPort() + "/foo");
+        conf.setBrokerDeleteInactiveTopicsEnabled(false);
+        conf.setBrokerShutdownTimeoutMs(0L);
+        conf.setLoadBalancerSheddingEnabled(false);
+    }
+
+    protected PulsarClientImpl[] getClientsToTest() {
+        return new PulsarClientImpl[] {clientWithHttpLookup1, clientWitBinaryLookup1};
+    }
+
+    protected PulsarClientImpl[] getClientsToTest(boolean isUsingHttpLookup) {
         if (isUsingHttpLookup) {
-            return clientWithHttpLookup.getLookup();
+            return new PulsarClientImpl[] {clientWithHttpLookup1};
         } else {
-            return clientWitBinaryLookup.getLookup();
+            return new PulsarClientImpl[] {clientWitBinaryLookup1};
         }
+
+    }
+
+    protected int getLookupRequestPermits() {
+        return pulsar1.getBrokerService().getLookupRequestSemaphore().availablePermits();
+    }
+
+    protected void verifyPartitionsNeverCreated(String topicNameStr) throws Exception {
+        TopicName topicName = TopicName.get(topicNameStr);
+        List<String> topicList = admin1.topics().getList("public/default");
+        for (int i = 0; i < 3; i++) {
+            assertFalse(topicList.contains(topicName.getPartition(i)));
+        }
+    }
+
+    protected void verifyNonPartitionedTopicNeverCreated(String topicNameStr) throws Exception {
+        TopicName topicName = TopicName.get(topicNameStr);
+        List<String> topicList = admin1.topics().getList("public/default");
+        assertFalse(topicList.contains(topicName.getPartitionedTopicName()));
     }
 
     @DataProvider(name = "topicDomains")
@@ -96,43 +176,53 @@ public class GetPartitionMetadataTest extends ProducerConsumerBase {
         };
     }
 
+    protected static void doModifyTopicAutoCreation(PulsarAdmin admin1, PulsarService pulsar1,
+                                                  boolean allowAutoTopicCreation, TopicType allowAutoTopicCreationType,
+                                                  int defaultNumPartitions) throws Exception {
+        admin1.brokers().updateDynamicConfiguration(
+                "allowAutoTopicCreation", allowAutoTopicCreation + "");
+        admin1.brokers().updateDynamicConfiguration(
+                "allowAutoTopicCreationType", allowAutoTopicCreationType + "");
+        admin1.brokers().updateDynamicConfiguration(
+                "defaultNumPartitions", defaultNumPartitions + "");
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(pulsar1.getConfiguration().isAllowAutoTopicCreation(), allowAutoTopicCreation);
+            assertEquals(pulsar1.getConfiguration().getAllowAutoTopicCreationType(), allowAutoTopicCreationType);
+            assertEquals(pulsar1.getConfiguration().getDefaultNumPartitions(), defaultNumPartitions);
+        });
+    }
+
+    protected void modifyTopicAutoCreation(boolean allowAutoTopicCreation,
+                                           TopicType allowAutoTopicCreationType,
+                                           int defaultNumPartitions) throws Exception {
+        doModifyTopicAutoCreation(admin1, pulsar1, allowAutoTopicCreation, allowAutoTopicCreationType,
+                defaultNumPartitions);
+    }
+
     @Test(dataProvider = "topicDomains")
     public void testAutoCreatingMetadataWhenCallingOldAPI(TopicDomain topicDomain) throws Exception {
-        conf.setAllowAutoTopicCreationType(TopicType.PARTITIONED);
-        conf.setDefaultNumPartitions(3);
-        conf.setAllowAutoTopicCreation(true);
-        setup();
+        modifyTopicAutoCreation(true, TopicType.PARTITIONED, 3);
 
-        Semaphore semaphore = pulsar.getBrokerService().getLookupRequestSemaphore();
-        int lookupPermitsBefore = semaphore.availablePermits();
+        int lookupPermitsBefore = getLookupRequestPermits();
 
-        // HTTP client.
-        final String tp1 = BrokerTestUtil.newUniqueName(topicDomain.value() + "://" + DEFAULT_NS + "/tp");
-        clientWithHttpLookup.getPartitionsForTopic(tp1).join();
-        Optional<PartitionedTopicMetadata> metadata1 = pulsar.getPulsarResources().getNamespaceResources()
-                .getPartitionedTopicResources()
-                .getPartitionedTopicMetadataAsync(TopicName.get(tp1), true).join();
-        assertTrue(metadata1.isPresent());
-        assertEquals(metadata1.get().partitions, 3);
+        for (PulsarClientImpl client : getClientsToTest()) {
+            // Verify: the behavior of topic creation.
+            final String tp = BrokerTestUtil.newUniqueName(topicDomain.value() + "://" + DEFAULT_NS + "/tp");
+            client.getPartitionsForTopic(tp).join();
+            Optional<PartitionedTopicMetadata> metadata1 = pulsar1.getPulsarResources().getNamespaceResources()
+                    .getPartitionedTopicResources()
+                    .getPartitionedTopicMetadataAsync(TopicName.get(tp), true).join();
+            assertTrue(metadata1.isPresent());
+            assertEquals(metadata1.get().partitions, 3);
 
-        // Binary client.
-        final String tp2 = BrokerTestUtil.newUniqueName(topicDomain.value() + "://" + DEFAULT_NS + "/tp");
-        clientWitBinaryLookup.getPartitionsForTopic(tp2).join();
-        Optional<PartitionedTopicMetadata> metadata2 = pulsar.getPulsarResources().getNamespaceResources()
-                .getPartitionedTopicResources()
-                .getPartitionedTopicMetadataAsync(TopicName.get(tp2), true).join();
-        assertTrue(metadata2.isPresent());
-        assertEquals(metadata2.get().partitions, 3);
+            // Verify: lookup semaphore has been releases.
+            Awaitility.await().untilAsserted(() -> {
+                assertEquals(getLookupRequestPermits(), lookupPermitsBefore);
+            });
 
-        // Verify: lookup semaphore has been releases.
-        Awaitility.await().untilAsserted(() -> {
-            int lookupPermitsAfter = semaphore.availablePermits();
-            assertEquals(lookupPermitsAfter, lookupPermitsBefore);
-        });
-
-        // Cleanup.
-        admin.topics().deletePartitionedTopic(tp1, false);
-        admin.topics().deletePartitionedTopic(tp2, false);
+            // Cleanup.
+            admin1.topics().deletePartitionedTopic(tp, false);
+        }
     }
 
     @DataProvider(name = "autoCreationParamsAll")
@@ -163,40 +253,32 @@ public class GetPartitionMetadataTest extends ProducerConsumerBase {
                                                            boolean paramMetadataAutoCreationEnabled,
                                                            boolean isUsingHttpLookup,
                                                            TopicDomain topicDomain) throws Exception {
-        conf.setAllowAutoTopicCreationType(TopicType.PARTITIONED);
-        conf.setDefaultNumPartitions(3);
-        conf.setAllowAutoTopicCreation(configAllowAutoTopicCreation);
-        setup();
+        modifyTopicAutoCreation(configAllowAutoTopicCreation, TopicType.PARTITIONED, 3);
 
-        Semaphore semaphore = pulsar.getBrokerService().getLookupRequestSemaphore();
-        int lookupPermitsBefore = semaphore.availablePermits();
+        int lookupPermitsBefore = getLookupRequestPermits();
 
-        LookupService lookup = getLookupService(isUsingHttpLookup);
         // Create topic.
-        final String topicNameStr = BrokerTestUtil.newUniqueName(topicDomain.value() + "://" + DEFAULT_NS + "/tp");
-        final TopicName topicName = TopicName.get(topicNameStr);
-        admin.topics().createNonPartitionedTopic(topicNameStr);
-        // Verify.
-        PulsarClient client = PulsarClient.builder().serviceUrl(pulsar.getBrokerServiceUrl()).build();
-        PartitionedTopicMetadata response =
-                lookup.getPartitionedTopicMetadata(topicName, paramMetadataAutoCreationEnabled).join();
-        assertEquals(response.partitions, 0);
-        List<String> partitionedTopics = admin.topics().getPartitionedTopicList("public/default");
-        assertFalse(partitionedTopics.contains(topicNameStr));
-        List<String> topicList = admin.topics().getList("public/default");
-        for (int i = 0; i < 3; i++) {
-            assertFalse(topicList.contains(topicName.getPartition(i)));
+        final String topicNameStr = BrokerTestUtil.newUniqueName(topicDomain.value() + "://" + DEFAULT_NS + "/tp_");
+        admin1.topics().createNonPartitionedTopic(topicNameStr);
+
+        PulsarClientImpl[] clientArray = getClientsToTest(isUsingHttpLookup);
+        for (PulsarClientImpl client : clientArray) {
+            // Verify: the result of get partitioned topic metadata.
+            PartitionedTopicMetadata response =
+                    client.getPartitionedTopicMetadata(topicNameStr, paramMetadataAutoCreationEnabled).join();
+            assertEquals(response.partitions, 0);
+            List<String> partitionedTopics = admin1.topics().getPartitionedTopicList("public/default");
+            assertFalse(partitionedTopics.contains(topicNameStr));
+            verifyPartitionsNeverCreated(topicNameStr);
+
+            // Verify: lookup semaphore has been releases.
+            Awaitility.await().untilAsserted(() -> {
+                assertEquals(getLookupRequestPermits(), lookupPermitsBefore);
+            });
         }
 
-        // Verify: lookup semaphore has been releases.
-        Awaitility.await().untilAsserted(() -> {
-            int lookupPermitsAfter = semaphore.availablePermits();
-            assertEquals(lookupPermitsAfter, lookupPermitsBefore);
-        });
-
         // Cleanup.
-        client.close();
-        admin.topics().delete(topicNameStr, false);
+        admin1.topics().delete(topicNameStr, false);
     }
 
     @Test(dataProvider = "autoCreationParamsAll")
@@ -204,36 +286,30 @@ public class GetPartitionMetadataTest extends ProducerConsumerBase {
                                                         boolean paramMetadataAutoCreationEnabled,
                                                         boolean isUsingHttpLookup,
                                                         TopicDomain topicDomain) throws Exception {
-        conf.setAllowAutoTopicCreationType(TopicType.PARTITIONED);
-        conf.setDefaultNumPartitions(3);
-        conf.setAllowAutoTopicCreation(configAllowAutoTopicCreation);
-        setup();
+        modifyTopicAutoCreation(configAllowAutoTopicCreation, TopicType.PARTITIONED, 3);
 
-        Semaphore semaphore = pulsar.getBrokerService().getLookupRequestSemaphore();
-        int lookupPermitsBefore = semaphore.availablePermits();
+        int lookupPermitsBefore = getLookupRequestPermits();
 
-        LookupService lookup = getLookupService(isUsingHttpLookup);
         // Create topic.
         final String topicNameStr = BrokerTestUtil.newUniqueName(topicDomain.value() + "://" + DEFAULT_NS + "/tp");
-        final TopicName topicName = TopicName.get(topicNameStr);
-        admin.topics().createPartitionedTopic(topicNameStr, 3);
-        // Verify.
-        PulsarClient client = PulsarClient.builder().serviceUrl(pulsar.getBrokerServiceUrl()).build();
-        PartitionedTopicMetadata response =
-                lookup.getPartitionedTopicMetadata(topicName, paramMetadataAutoCreationEnabled).join();
-        assertEquals(response.partitions, 3);
-        List<String> topicList = admin.topics().getList("public/default");
-        assertFalse(topicList.contains(topicNameStr));
+        admin1.topics().createPartitionedTopic(topicNameStr, 3);
 
-        // Verify: lookup semaphore has been releases.
-        Awaitility.await().untilAsserted(() -> {
-            int lookupPermitsAfter = semaphore.availablePermits();
-            assertEquals(lookupPermitsAfter, lookupPermitsBefore);
-        });
+        PulsarClientImpl[] clientArray = getClientsToTest(isUsingHttpLookup);
+        for (PulsarClientImpl client : clientArray) {
+            // Verify: the result of get partitioned topic metadata.
+            PartitionedTopicMetadata response =
+                    client.getPartitionedTopicMetadata(topicNameStr, paramMetadataAutoCreationEnabled).join();
+            assertEquals(response.partitions, 3);
+            verifyNonPartitionedTopicNeverCreated(topicNameStr);
+
+            // Verify: lookup semaphore has been releases.
+            Awaitility.await().untilAsserted(() -> {
+                assertEquals(getLookupRequestPermits(), lookupPermitsBefore);
+            });
+        }
 
         // Cleanup.
-        client.close();
-        admin.topics().deletePartitionedTopic(topicNameStr, false);
+        admin1.topics().deletePartitionedTopic(topicNameStr, false);
     }
 
     @DataProvider(name = "clients")
@@ -247,76 +323,61 @@ public class GetPartitionMetadataTest extends ProducerConsumerBase {
 
     @Test(dataProvider = "clients")
     public void testAutoCreatePartitionedTopic(boolean isUsingHttpLookup, TopicDomain topicDomain) throws Exception {
-        conf.setAllowAutoTopicCreationType(TopicType.PARTITIONED);
-        conf.setDefaultNumPartitions(3);
-        conf.setAllowAutoTopicCreation(true);
-        setup();
+        modifyTopicAutoCreation(true, TopicType.PARTITIONED, 3);
 
-        Semaphore semaphore = pulsar.getBrokerService().getLookupRequestSemaphore();
-        int lookupPermitsBefore = semaphore.availablePermits();
+        int lookupPermitsBefore = getLookupRequestPermits();
 
-        LookupService lookup = getLookupService(isUsingHttpLookup);
-        // Create topic.
-        final String topicNameStr = BrokerTestUtil.newUniqueName(topicDomain.value() + "://" + DEFAULT_NS + "/tp");
-        final TopicName topicName = TopicName.get(topicNameStr);
-        // Verify.
-        PulsarClient client = PulsarClient.builder().serviceUrl(pulsar.getBrokerServiceUrl()).build();
-        PartitionedTopicMetadata response = lookup.getPartitionedTopicMetadata(topicName, true).join();
-        assertEquals(response.partitions, 3);
-        List<String> partitionedTopics = admin.topics().getPartitionedTopicList("public/default");
-        assertTrue(partitionedTopics.contains(topicNameStr));
-        List<String> topicList = admin.topics().getList("public/default");
-        assertFalse(topicList.contains(topicNameStr));
-        for (int i = 0; i < 3; i++) {
+        PulsarClientImpl[] clientArray = getClientsToTest(isUsingHttpLookup);
+        for (PulsarClientImpl client : clientArray) {
+            // Define topic.
+            final String topicNameStr = BrokerTestUtil.newUniqueName(topicDomain.value() + "://" + DEFAULT_NS + "/tp");
+            final TopicName topicName = TopicName.get(topicNameStr);
+            // Verify: the result of get partitioned topic metadata.
+            PartitionedTopicMetadata response = client.getPartitionedTopicMetadata(topicNameStr, true).join();
+            assertEquals(response.partitions, 3);
+            // Verify: the behavior of topic creation.
+            List<String> partitionedTopics = admin1.topics().getPartitionedTopicList("public/default");
+            assertTrue(partitionedTopics.contains(topicNameStr));
+            verifyNonPartitionedTopicNeverCreated(topicNameStr);
             // The API "getPartitionedTopicMetadata" only creates the partitioned metadata, it will not create the
             // partitions.
-            assertFalse(topicList.contains(topicName.getPartition(i)));
+            verifyPartitionsNeverCreated(topicNameStr);
+            // Verify: lookup semaphore has been releases.
+            Awaitility.await().untilAsserted(() -> {
+                assertEquals(getLookupRequestPermits(), lookupPermitsBefore);
+            });
+            // Cleanup.
+            admin1.topics().deletePartitionedTopic(topicNameStr, false);
         }
 
-        // Verify: lookup semaphore has been releases.
-        Awaitility.await().untilAsserted(() -> {
-            int lookupPermitsAfter = semaphore.availablePermits();
-            assertEquals(lookupPermitsAfter, lookupPermitsBefore);
-        });
-
-        // Cleanup.
-        client.close();
-        admin.topics().deletePartitionedTopic(topicNameStr, false);
     }
 
     @Test(dataProvider = "clients")
     public void testAutoCreateNonPartitionedTopic(boolean isUsingHttpLookup, TopicDomain topicDomain) throws Exception {
-        conf.setAllowAutoTopicCreationType(TopicType.NON_PARTITIONED);
-        conf.setAllowAutoTopicCreation(true);
-        setup();
+        modifyTopicAutoCreation(true, TopicType.NON_PARTITIONED, 1);
 
-        Semaphore semaphore = pulsar.getBrokerService().getLookupRequestSemaphore();
-        int lookupPermitsBefore = semaphore.availablePermits();
+        int lookupPermitsBefore = getLookupRequestPermits();
 
-        LookupService lookup = getLookupService(isUsingHttpLookup);
-        // Create topic.
-        final String topicNameStr = BrokerTestUtil.newUniqueName(topicDomain.value() + "://" + DEFAULT_NS + "/tp");
-        final TopicName topicName = TopicName.get(topicNameStr);
-        // Verify.
-        PulsarClient client = PulsarClient.builder().serviceUrl(pulsar.getBrokerServiceUrl()).build();
-        PartitionedTopicMetadata response = lookup.getPartitionedTopicMetadata(topicName, true).join();
-        assertEquals(response.partitions, 0);
-        List<String> partitionedTopics = admin.topics().getPartitionedTopicList("public/default");
-        assertFalse(partitionedTopics.contains(topicNameStr));
-        List<String> topicList = admin.topics().getList("public/default");
-        assertFalse(topicList.contains(topicNameStr));
-
-        // Verify: lookup semaphore has been releases.
-        Awaitility.await().untilAsserted(() -> {
-            int lookupPermitsAfter = semaphore.availablePermits();
-            assertEquals(lookupPermitsAfter, lookupPermitsBefore);
-        });
-
-        // Cleanup.
-        client.close();
-        try {
-            admin.topics().delete(topicNameStr, false);
-        } catch (Exception ex) {}
+        PulsarClientImpl[] clientArray = getClientsToTest(isUsingHttpLookup);
+        for (PulsarClientImpl client : clientArray) {
+            // Define topic.
+            final String topicNameStr = BrokerTestUtil.newUniqueName(topicDomain.value() + "://" + DEFAULT_NS + "/tp");
+            // Verify: the result of get partitioned topic metadata.
+            PartitionedTopicMetadata response = client.getPartitionedTopicMetadata(topicNameStr, true).join();
+            assertEquals(response.partitions, 0);
+            // Verify: the behavior of topic creation.
+            List<String> partitionedTopics = admin1.topics().getPartitionedTopicList("public/default");
+            assertFalse(partitionedTopics.contains(topicNameStr));
+            verifyPartitionsNeverCreated(topicNameStr);
+            // Verify: lookup semaphore has been releases.
+            Awaitility.await().untilAsserted(() -> {
+                assertEquals(getLookupRequestPermits(), lookupPermitsBefore);
+            });
+            // Cleanup.
+            try {
+                admin1.topics().delete(topicNameStr, false);
+            } catch (Exception ex) {}
+        }
     }
 
     @DataProvider(name = "autoCreationParamsNotAllow")
@@ -336,64 +397,38 @@ public class GetPartitionMetadataTest extends ProducerConsumerBase {
     public void testGetMetadataIfNotAllowedCreate(boolean configAllowAutoTopicCreation,
                                                   boolean paramMetadataAutoCreationEnabled,
                                                   boolean isUsingHttpLookup) throws Exception {
-        if (!configAllowAutoTopicCreation && paramMetadataAutoCreationEnabled) {
-            // These test cases are for the following PR.
-            // Which was described in the Motivation of https://github.com/apache/pulsar/pull/22206.
-            return;
+        modifyTopicAutoCreation(configAllowAutoTopicCreation, TopicType.PARTITIONED, 3);
+
+        int lookupPermitsBefore = getLookupRequestPermits();
+
+        PulsarClientImpl[] clientArray = getClientsToTest(isUsingHttpLookup);
+        for (PulsarClientImpl client : clientArray) {
+            // Define topic.
+            final String topicNameStr = BrokerTestUtil.newUniqueName("persistent://" + DEFAULT_NS + "/tp");
+            final TopicName topicName = TopicName.get(topicNameStr);
+            // Verify: the result of get partitioned topic metadata.
+            try {
+                client.getPartitionedTopicMetadata(topicNameStr, paramMetadataAutoCreationEnabled)
+                        .join();
+                fail("Expect a not found exception");
+            } catch (Exception e) {
+                Throwable unwrapEx = FutureUtil.unwrapCompletionException(e);
+                assertTrue(unwrapEx instanceof PulsarClientException.TopicDoesNotExistException
+                        || unwrapEx instanceof PulsarClientException.NotFoundException);
+            }
+            // Verify: the behavior of topic creation.
+            List<String> partitionedTopics = admin1.topics().getPartitionedTopicList("public/default");
+            pulsar1.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                    .partitionedTopicExists(topicName);
+            assertFalse(partitionedTopics.contains(topicNameStr));
+            verifyNonPartitionedTopicNeverCreated(topicNameStr);
+            verifyPartitionsNeverCreated(topicNameStr);
+
+            // Verify: lookup semaphore has been releases.
+            Awaitility.await().untilAsserted(() -> {
+                assertEquals(getLookupRequestPermits(), lookupPermitsBefore);
+            });
         }
-        conf.setAllowAutoTopicCreationType(TopicType.PARTITIONED);
-        conf.setDefaultNumPartitions(3);
-        conf.setAllowAutoTopicCreation(configAllowAutoTopicCreation);
-        setup();
-
-        Semaphore semaphore = pulsar.getBrokerService().getLookupRequestSemaphore();
-        int lookupPermitsBefore = semaphore.availablePermits();
-
-        LookupService lookup = getLookupService(isUsingHttpLookup);
-        // Define topic.
-        final String topicNameStr = BrokerTestUtil.newUniqueName("persistent://" + DEFAULT_NS + "/tp");
-        final TopicName topicName = TopicName.get(topicNameStr);
-        // Verify.
-        PulsarClient client = PulsarClient.builder().serviceUrl(pulsar.getBrokerServiceUrl()).build();
-        try {
-            lookup.getPartitionedTopicMetadata(TopicName.get(topicNameStr), paramMetadataAutoCreationEnabled).join();
-            fail("Expect a not found exception");
-        } catch (Exception e) {
-            log.warn("", e);
-            Throwable unwrapEx = FutureUtil.unwrapCompletionException(e);
-            assertTrue(unwrapEx instanceof PulsarClientException.TopicDoesNotExistException
-                    || unwrapEx instanceof PulsarClientException.NotFoundException);
-        }
-
-        List<String> partitionedTopics = admin.topics().getPartitionedTopicList("public/default");
-        pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources().partitionedTopicExists(topicName);
-        assertFalse(partitionedTopics.contains(topicNameStr));
-        List<String> topicList = admin.topics().getList("public/default");
-        assertFalse(topicList.contains(topicNameStr));
-        for (int i = 0; i < 3; i++) {
-            assertFalse(topicList.contains(topicName.getPartition(i)));
-        }
-
-        // Verify: lookup semaphore has been releases.
-        Awaitility.await().untilAsserted(() -> {
-            int lookupPermitsAfter = semaphore.availablePermits();
-            assertEquals(lookupPermitsAfter, lookupPermitsBefore);
-        });
-
-        // Cleanup.
-        client.close();
-    }
-
-    @DataProvider(name = "autoCreationParamsForNonPersistentTopic")
-    public Object[][] autoCreationParamsForNonPersistentTopic(){
-        return new Object[][]{
-                // configAllowAutoTopicCreation, paramCreateIfAutoCreationEnabled, isUsingHttpLookup.
-                {true, true, true},
-                {true, true, false},
-                {false, true, true},
-                {false, true, false},
-                {false, false, true}
-        };
     }
 
     /**
@@ -408,66 +443,46 @@ public class GetPartitionMetadataTest extends ProducerConsumerBase {
      *   param-auto-create = false
      *     HTTP API: not found error
      *     binary API: not support
-     *  This test only guarantees that the behavior is the same as before. The following separated PR will fix the
-     *  incorrect behavior.
+     * After PIP-344, the behavior will be the same as persistent topics, which was described in PIP-344.
      */
-    @Test(dataProvider = "autoCreationParamsForNonPersistentTopic")
-    public void testGetNonPersistentMetadataIfNotAllowedCreate(boolean configAllowAutoTopicCreation,
+    @Test(dataProvider = "autoCreationParamsNotAllow")
+    public void testGetMetadataIfNotAllowedCreateOfNonPersistentTopic(boolean configAllowAutoTopicCreation,
                                                   boolean paramMetadataAutoCreationEnabled,
                                                   boolean isUsingHttpLookup) throws Exception {
-        conf.setAllowAutoTopicCreationType(TopicType.PARTITIONED);
-        conf.setDefaultNumPartitions(3);
-        conf.setAllowAutoTopicCreation(configAllowAutoTopicCreation);
-        setup();
+        modifyTopicAutoCreation(configAllowAutoTopicCreation, TopicType.PARTITIONED, 3);
 
-        Semaphore semaphore = pulsar.getBrokerService().getLookupRequestSemaphore();
-        int lookupPermitsBefore = semaphore.availablePermits();
+        int lookupPermitsBefore = getLookupRequestPermits();
 
-        LookupService lookup = getLookupService(isUsingHttpLookup);
-        // Define topic.
-        final String topicNameStr = BrokerTestUtil.newUniqueName("non-persistent://" + DEFAULT_NS + "/tp");
-        final TopicName topicName = TopicName.get(topicNameStr);
-        // Verify.
-        // Regarding non-persistent topic, we do not know whether it exists or not.
-        // Broker will return a non-partitioned metadata if partitioned metadata does not exist.
-        PulsarClient client = PulsarClient.builder().serviceUrl(pulsar.getBrokerServiceUrl()).build();
-
-        if (!configAllowAutoTopicCreation && !paramMetadataAutoCreationEnabled && isUsingHttpLookup) {
+        PulsarClientImpl[] clientArray = getClientsToTest(isUsingHttpLookup);
+        for (PulsarClientImpl client : clientArray) {
+            // Define topic.
+            final String topicNameStr = BrokerTestUtil.newUniqueName("non-persistent://" + DEFAULT_NS + "/tp");
+            final TopicName topicName = TopicName.get(topicNameStr);
+            // Verify: the result of get partitioned topic metadata.
             try {
-                lookup.getPartitionedTopicMetadata(TopicName.get(topicNameStr), paramMetadataAutoCreationEnabled)
+                PartitionedTopicMetadata topicMetadata = client
+                        .getPartitionedTopicMetadata(topicNameStr, paramMetadataAutoCreationEnabled)
                         .join();
-                Assert.fail("Expected a not found ex");
+                log.info("Get topic metadata: {}", topicMetadata.partitions);
+                fail("Expected a not found ex");
             } catch (Exception ex) {
-                // Cleanup.
-                client.close();
-                return;
+                Throwable unwrapEx = FutureUtil.unwrapCompletionException(ex);
+                assertTrue(unwrapEx instanceof PulsarClientException.TopicDoesNotExistException
+                        || unwrapEx instanceof PulsarClientException.NotFoundException);
             }
-        }
 
-        PartitionedTopicMetadata metadata = lookup
-                .getPartitionedTopicMetadata(TopicName.get(topicNameStr), paramMetadataAutoCreationEnabled).join();
-        if (configAllowAutoTopicCreation && paramMetadataAutoCreationEnabled) {
-            assertEquals(metadata.partitions, 3);
-        } else {
-            assertEquals(metadata.partitions, 0);
-        }
-
-        List<String> partitionedTopics = admin.topics().getPartitionedTopicList("public/default");
-        pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
-                .partitionedTopicExists(topicName);
-        if (configAllowAutoTopicCreation && paramMetadataAutoCreationEnabled) {
-            assertTrue(partitionedTopics.contains(topicNameStr));
-        } else {
+            // Verify: the behavior of topic creation.
+            List<String> partitionedTopics = admin1.topics().getPartitionedTopicList("public/default");
+            pulsar1.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                    .partitionedTopicExists(topicName);
             assertFalse(partitionedTopics.contains(topicNameStr));
+            verifyNonPartitionedTopicNeverCreated(topicNameStr);
+            verifyPartitionsNeverCreated(topicNameStr);
         }
 
         // Verify: lookup semaphore has been releases.
         Awaitility.await().untilAsserted(() -> {
-            int lookupPermitsAfter = semaphore.availablePermits();
-            assertEquals(lookupPermitsAfter, lookupPermitsBefore);
+            assertEquals(getLookupRequestPermits(), lookupPermitsBefore);
         });
-
-        // Cleanup.
-        client.close();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
@@ -346,13 +346,15 @@ public class GetPartitionMetadataTest {
             final String topicNameStrWithSuffix = BrokerTestUtil.newUniqueName(
                     topicDomain.value() + "://" + DEFAULT_NS + "/tp") + "-partition-1";
             // Verify: the result of get partitioned topic metadata.
-            PartitionedTopicMetadata responseWithSuffix =
+            PartitionedTopicMetadata response2 =
                     client.getPartitionedTopicMetadata(topicNameStrWithSuffix, true).join();
-            assertEquals(responseWithSuffix.partitions, 0);
+            assertEquals(response2.partitions, 0);
             // Verify: the behavior of topic creation.
-            List<String> partitionedTopicsWithSuffix =
+            List<String> partitionedTopics2 =
                     admin1.topics().getPartitionedTopicList("public/default");
-            assertFalse(partitionedTopicsWithSuffix.contains(topicNameStrWithSuffix));
+            assertFalse(partitionedTopics2.contains(topicNameStrWithSuffix));
+            assertFalse(partitionedTopics2.contains(
+                    TopicName.get(topicNameStrWithSuffix).getPartitionedTopicName()));
 
             // Verify: lookup semaphore has been releases.
             Awaitility.await().untilAsserted(() -> {
@@ -389,13 +391,15 @@ public class GetPartitionMetadataTest {
             final String topicNameStrWithSuffix = BrokerTestUtil.newUniqueName(
                     topicDomain.value() + "://" + DEFAULT_NS + "/tp") + "-partition-1";
             // Verify: the result of get partitioned topic metadata.
-            PartitionedTopicMetadata responseWithSuffix =
+            PartitionedTopicMetadata response2 =
                     client.getPartitionedTopicMetadata(topicNameStrWithSuffix, true).join();
-            assertEquals(responseWithSuffix.partitions, 0);
+            assertEquals(response2.partitions, 0);
             // Verify: the behavior of topic creation.
-            List<String> partitionedTopicsWithSuffix =
+            List<String> partitionedTopics2 =
                     admin1.topics().getPartitionedTopicList("public/default");
-            assertFalse(partitionedTopicsWithSuffix.contains(topicNameStrWithSuffix));
+            assertFalse(partitionedTopics2.contains(topicNameStrWithSuffix));
+            assertFalse(partitionedTopics2.contains(
+                    TopicName.get(topicNameStrWithSuffix).getPartitionedTopicName()));
 
             // Verify: lookup semaphore has been releases.
             Awaitility.await().untilAsserted(() -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
@@ -358,7 +358,7 @@ public class TopicsTest extends MockedPulsarServiceBaseTest {
         CompletableFuture future = new CompletableFuture();
         future.completeExceptionally(new BrokerServiceException("Fake Exception"));
         CompletableFuture existFuture = new CompletableFuture();
-        existFuture.complete(TopicExistsInfo.nonPartitionedExists());
+        existFuture.complete(TopicExistsInfo.newNonPartitionedTopicExists());
         doReturn(future).when(nameSpaceService).getBrokerServiceUrlAsync(any(), any());
         doReturn(existFuture).when(nameSpaceService).checkTopicExists(any());
         doReturn(existFuture).when(nameSpaceService).checkTopicExists(any(), anyBoolean());
@@ -383,7 +383,7 @@ public class TopicsTest extends MockedPulsarServiceBaseTest {
         String topicName = "persistent://" + testTenant + "/" + testNamespace + "/" + testTopicName;
         NamespaceService nameSpaceService = mock(NamespaceService.class);
         CompletableFuture existFuture = new CompletableFuture();
-        existFuture.complete(TopicExistsInfo.notExists());
+        existFuture.complete(TopicExistsInfo.newTopicNotExists());
         CompletableFuture existBooleanFuture = new CompletableFuture();
         existBooleanFuture.complete(false);
         doReturn(existFuture).when(nameSpaceService).checkTopicExists(any());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
@@ -56,6 +56,7 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.authentication.AuthenticationDataHttps;
 import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.broker.namespace.TopicExistsInfo;
 import org.apache.pulsar.broker.rest.Topics;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.BrokerServiceException;
@@ -357,7 +358,7 @@ public class TopicsTest extends MockedPulsarServiceBaseTest {
         CompletableFuture future = new CompletableFuture();
         future.completeExceptionally(new BrokerServiceException("Fake Exception"));
         CompletableFuture existFuture = new CompletableFuture();
-        existFuture.complete(true);
+        existFuture.complete(TopicExistsInfo.nonPartitionedExists());
         doReturn(future).when(nameSpaceService).getBrokerServiceUrlAsync(any(), any());
         doReturn(existFuture).when(nameSpaceService).checkTopicExists(any());
         doReturn(nameSpaceService).when(pulsar).getNamespaceService();
@@ -378,7 +379,7 @@ public class TopicsTest extends MockedPulsarServiceBaseTest {
         String topicName = "persistent://" + testTenant + "/" + testNamespace + "/" + testTopicName;
         NamespaceService nameSpaceService = mock(NamespaceService.class);
         CompletableFuture existFuture = new CompletableFuture();
-        existFuture.complete(false);
+        existFuture.complete(TopicExistsInfo.notExists());
         doReturn(existFuture).when(nameSpaceService).checkTopicExists(any());
         doReturn(nameSpaceService).when(pulsar).getNamespaceService();
         AsyncResponse asyncResponse = mock(AsyncResponse.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
@@ -361,6 +361,9 @@ public class TopicsTest extends MockedPulsarServiceBaseTest {
         existFuture.complete(TopicExistsInfo.nonPartitionedExists());
         doReturn(future).when(nameSpaceService).getBrokerServiceUrlAsync(any(), any());
         doReturn(existFuture).when(nameSpaceService).checkTopicExists(any());
+        CompletableFuture existBooleanFuture = new CompletableFuture();
+        existBooleanFuture.complete(false);
+        doReturn(existBooleanFuture).when(nameSpaceService).checkNonPartitionedTopicExists(any(), anyBoolean());
         doReturn(nameSpaceService).when(pulsar).getNamespaceService();
         AsyncResponse asyncResponse = mock(AsyncResponse.class);
         ProducerMessages producerMessages = new ProducerMessages();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
@@ -361,10 +361,9 @@ public class TopicsTest extends MockedPulsarServiceBaseTest {
         existFuture.complete(TopicExistsInfo.newNonPartitionedTopicExists());
         doReturn(future).when(nameSpaceService).getBrokerServiceUrlAsync(any(), any());
         doReturn(existFuture).when(nameSpaceService).checkTopicExists(any());
-        doReturn(existFuture).when(nameSpaceService).checkTopicExists(any(), anyBoolean());
         CompletableFuture existBooleanFuture = new CompletableFuture();
         existBooleanFuture.complete(false);
-        doReturn(existBooleanFuture).when(nameSpaceService).checkNonPartitionedTopicExists(any(), anyBoolean());
+        doReturn(existBooleanFuture).when(nameSpaceService).checkNonPartitionedTopicExists(any());
         doReturn(nameSpaceService).when(pulsar).getNamespaceService();
         AsyncResponse asyncResponse = mock(AsyncResponse.class);
         ProducerMessages producerMessages = new ProducerMessages();
@@ -387,7 +386,7 @@ public class TopicsTest extends MockedPulsarServiceBaseTest {
         CompletableFuture existBooleanFuture = new CompletableFuture();
         existBooleanFuture.complete(false);
         doReturn(existFuture).when(nameSpaceService).checkTopicExists(any());
-        doReturn(existBooleanFuture).when(nameSpaceService).checkNonPartitionedTopicExists(any(), anyBoolean());
+        doReturn(existBooleanFuture).when(nameSpaceService).checkNonPartitionedTopicExists(any());
         doReturn(nameSpaceService).when(pulsar).getNamespaceService();
         AsyncResponse asyncResponse = mock(AsyncResponse.class);
         ProducerMessages producerMessages = new ProducerMessages();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
@@ -380,7 +380,10 @@ public class TopicsTest extends MockedPulsarServiceBaseTest {
         NamespaceService nameSpaceService = mock(NamespaceService.class);
         CompletableFuture existFuture = new CompletableFuture();
         existFuture.complete(TopicExistsInfo.notExists());
+        CompletableFuture existBooleanFuture = new CompletableFuture();
+        existBooleanFuture.complete(false);
         doReturn(existFuture).when(nameSpaceService).checkTopicExists(any());
+        doReturn(existBooleanFuture).when(nameSpaceService).checkNonPartitionedTopicExists(any(), anyBoolean());
         doReturn(nameSpaceService).when(pulsar).getNamespaceService();
         AsyncResponse asyncResponse = mock(AsyncResponse.class);
         ProducerMessages producerMessages = new ProducerMessages();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
@@ -361,6 +361,7 @@ public class TopicsTest extends MockedPulsarServiceBaseTest {
         existFuture.complete(TopicExistsInfo.nonPartitionedExists());
         doReturn(future).when(nameSpaceService).getBrokerServiceUrlAsync(any(), any());
         doReturn(existFuture).when(nameSpaceService).checkTopicExists(any());
+        doReturn(existFuture).when(nameSpaceService).checkTopicExists(any(), anyBoolean());
         CompletableFuture existBooleanFuture = new CompletableFuture();
         existBooleanFuture.complete(false);
         doReturn(existBooleanFuture).when(nameSpaceService).checkNonPartitionedTopicExists(any(), anyBoolean());
@@ -374,7 +375,7 @@ public class TopicsTest extends MockedPulsarServiceBaseTest {
         topics.produceOnPersistentTopic(asyncResponse, testTenant, testNamespace, testTopicName, false, producerMessages);
         ArgumentCaptor<RestException> responseCaptor = ArgumentCaptor.forClass(RestException.class);
         verify(asyncResponse, timeout(5000).times(1)).resume(responseCaptor.capture());
-        Assert.assertEquals(responseCaptor.getValue().getMessage(), "Can't find owner of given topic.");
+        Assert.assertTrue(responseCaptor.getValue().getMessage().contains(topicName + " not found"));
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.lookup.http;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -153,6 +154,11 @@ public class HttpTopicLookupv2Test {
         CompletableFuture<TopicExistsInfo> future = new CompletableFuture<>();
         future.complete(TopicExistsInfo.notExists());
         doReturn(future).when(namespaceService).checkTopicExists(any(TopicName.class));
+        doReturn(future).when(namespaceService).checkTopicExists(any(TopicName.class), anyBoolean());
+        CompletableFuture<Boolean> booleanFuture = new CompletableFuture<>();
+        booleanFuture.complete(false);
+        doReturn(booleanFuture).when(namespaceService).checkNonPartitionedTopicExists(any(TopicName.class),
+                anyBoolean());
 
         AsyncResponse asyncResponse1 = mock(AsyncResponse.class);
         destLookup.lookupTopicAsync(asyncResponse1, TopicDomain.persistent.value(), "myprop", "usc", "ns2", "topic_not_exist", false, null, null);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
@@ -270,6 +270,10 @@ public class HttpTopicLookupv2Test {
         CompletableFuture<TopicExistsInfo> future = new CompletableFuture<>();
         future.complete(TopicExistsInfo.notExists());
         doReturn(future).when(namespaceService).checkTopicExists(any(TopicName.class));
+        doReturn(future).when(namespaceService).checkTopicExists(any(TopicName.class), anyBoolean());
+        CompletableFuture<Boolean> booleanFuture = new CompletableFuture<>();
+        booleanFuture.complete(false);
+        doReturn(future).when(namespaceService).checkNonPartitionedTopicExists(any(TopicName.class), anyBoolean());
         destLookup.lookupTopicAsync(asyncResponse, TopicDomain.persistent.value(), property, cluster, ns2,
                 "invalid-localCluster", false, null, null);
         verify(asyncResponse).resume(arg.capture());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
@@ -152,7 +152,7 @@ public class HttpTopicLookupv2Test {
 
         NamespaceService namespaceService = pulsar.getNamespaceService();
         CompletableFuture<TopicExistsInfo> future = new CompletableFuture<>();
-        future.complete(TopicExistsInfo.notExists());
+        future.complete(TopicExistsInfo.newTopicNotExists());
         doReturn(future).when(namespaceService).checkTopicExists(any(TopicName.class));
         doReturn(future).when(namespaceService).checkTopicExists(any(TopicName.class), anyBoolean());
         CompletableFuture<Boolean> booleanFuture = new CompletableFuture<>();
@@ -268,7 +268,7 @@ public class HttpTopicLookupv2Test {
         doReturn(policies3Future).when(namespaceResources).getPoliciesAsync(namespaceName2);
         NamespaceService namespaceService = pulsar.getNamespaceService();
         CompletableFuture<TopicExistsInfo> future = new CompletableFuture<>();
-        future.complete(TopicExistsInfo.notExists());
+        future.complete(TopicExistsInfo.newTopicNotExists());
         doReturn(future).when(namespaceService).checkTopicExists(any(TopicName.class));
         doReturn(future).when(namespaceService).checkTopicExists(any(TopicName.class), anyBoolean());
         CompletableFuture<Boolean> booleanFuture = new CompletableFuture<>();
@@ -306,7 +306,7 @@ public class HttpTopicLookupv2Test {
         config.setAuthorizationEnabled(true);
         NamespaceService namespaceService = pulsar.getNamespaceService();
         CompletableFuture<TopicExistsInfo> future = new CompletableFuture<>();
-        future.complete(TopicExistsInfo.notExists());
+        future.complete(TopicExistsInfo.newTopicNotExists());
         doReturn(future).when(namespaceService).checkTopicExists(any(TopicName.class));
 
         // Get the current semaphore first

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
@@ -154,11 +154,9 @@ public class HttpTopicLookupv2Test {
         CompletableFuture<TopicExistsInfo> future = new CompletableFuture<>();
         future.complete(TopicExistsInfo.newTopicNotExists());
         doReturn(future).when(namespaceService).checkTopicExists(any(TopicName.class));
-        doReturn(future).when(namespaceService).checkTopicExists(any(TopicName.class), anyBoolean());
         CompletableFuture<Boolean> booleanFuture = new CompletableFuture<>();
         booleanFuture.complete(false);
-        doReturn(booleanFuture).when(namespaceService).checkNonPartitionedTopicExists(any(TopicName.class),
-                anyBoolean());
+        doReturn(booleanFuture).when(namespaceService).checkNonPartitionedTopicExists(any(TopicName.class));
 
         AsyncResponse asyncResponse1 = mock(AsyncResponse.class);
         destLookup.lookupTopicAsync(asyncResponse1, TopicDomain.persistent.value(), "myprop", "usc", "ns2", "topic_not_exist", false, null, null);
@@ -270,10 +268,9 @@ public class HttpTopicLookupv2Test {
         CompletableFuture<TopicExistsInfo> future = new CompletableFuture<>();
         future.complete(TopicExistsInfo.newTopicNotExists());
         doReturn(future).when(namespaceService).checkTopicExists(any(TopicName.class));
-        doReturn(future).when(namespaceService).checkTopicExists(any(TopicName.class), anyBoolean());
         CompletableFuture<Boolean> booleanFuture = new CompletableFuture<>();
         booleanFuture.complete(false);
-        doReturn(future).when(namespaceService).checkNonPartitionedTopicExists(any(TopicName.class), anyBoolean());
+        doReturn(future).when(namespaceService).checkNonPartitionedTopicExists(any(TopicName.class));
         destLookup.lookupTopicAsync(asyncResponse, TopicDomain.persistent.value(), property, cluster, ns2,
                 "invalid-localCluster", false, null, null);
         verify(asyncResponse).resume(arg.capture());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.broker.lookup.http;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpTopicLookupv2Test.java
@@ -44,6 +44,7 @@ import org.apache.pulsar.broker.lookup.NamespaceData;
 import org.apache.pulsar.broker.lookup.RedirectData;
 import org.apache.pulsar.broker.lookup.v1.TopicLookup;
 import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.broker.namespace.TopicExistsInfo;
 import org.apache.pulsar.broker.resources.ClusterResources;
 import org.apache.pulsar.broker.resources.NamespaceResources;
 import org.apache.pulsar.broker.resources.PulsarResources;
@@ -149,8 +150,8 @@ public class HttpTopicLookupv2Test {
         config.setAuthorizationEnabled(true);
 
         NamespaceService namespaceService = pulsar.getNamespaceService();
-        CompletableFuture<Boolean> future = new CompletableFuture<>();
-        future.complete(false);
+        CompletableFuture<TopicExistsInfo> future = new CompletableFuture<>();
+        future.complete(TopicExistsInfo.notExists());
         doReturn(future).when(namespaceService).checkTopicExists(any(TopicName.class));
 
         AsyncResponse asyncResponse1 = mock(AsyncResponse.class);
@@ -260,8 +261,8 @@ public class HttpTopicLookupv2Test {
         policies3Future.complete(Optional.of(policies3));
         doReturn(policies3Future).when(namespaceResources).getPoliciesAsync(namespaceName2);
         NamespaceService namespaceService = pulsar.getNamespaceService();
-        CompletableFuture<Boolean> future = new CompletableFuture<>();
-        future.complete(false);
+        CompletableFuture<TopicExistsInfo> future = new CompletableFuture<>();
+        future.complete(TopicExistsInfo.notExists());
         doReturn(future).when(namespaceService).checkTopicExists(any(TopicName.class));
         destLookup.lookupTopicAsync(asyncResponse, TopicDomain.persistent.value(), property, cluster, ns2,
                 "invalid-localCluster", false, null, null);
@@ -294,8 +295,8 @@ public class HttpTopicLookupv2Test {
         doReturn(uri).when(uriInfo).getRequestUri();
         config.setAuthorizationEnabled(true);
         NamespaceService namespaceService = pulsar.getNamespaceService();
-        CompletableFuture<Boolean> future = new CompletableFuture<>();
-        future.complete(false);
+        CompletableFuture<TopicExistsInfo> future = new CompletableFuture<>();
+        future.complete(TopicExistsInfo.notExists());
         doReturn(future).when(namespaceService).checkTopicExists(any(TopicName.class));
 
         // Get the current semaphore first

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -815,14 +815,15 @@ public class NamespaceServiceTest extends BrokerTestBase {
         String topic = topicDomain + "://prop/ns-abc/" + UUID.randomUUID();
         admin.topics().createNonPartitionedTopic(topic);
         Awaitility.await().untilAsserted(() -> {
-            assertTrue(pulsar.getNamespaceService().checkTopicExists(TopicName.get(topic)).get());
+            assertTrue(pulsar.getNamespaceService().checkTopicExists(TopicName.get(topic)).get().isExists());
         });
 
         String partitionedTopic = topicDomain + "://prop/ns-abc/" + UUID.randomUUID();
         admin.topics().createPartitionedTopic(partitionedTopic, 5);
         Awaitility.await().untilAsserted(() -> {
-            assertTrue(pulsar.getNamespaceService().checkTopicExists(TopicName.get(partitionedTopic)).get());
-            assertTrue(pulsar.getNamespaceService().checkTopicExists(TopicName.get(partitionedTopic + "-partition-2")).get());
+            assertTrue(pulsar.getNamespaceService().checkTopicExists(TopicName.get(partitionedTopic)).get().isExists());
+            assertTrue(pulsar.getNamespaceService()
+                    .checkTopicExists(TopicName.get(partitionedTopic + "-partition-2")).get().isExists());
         });
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicGCTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicGCTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service;
 
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -99,6 +100,7 @@ public class TopicGCTest extends ProducerConsumerBase {
         Consumer<String> consumerAllPartition = pulsarClient.newConsumer(Schema.STRING).topic(topic)
                 .subscriptionName(subscription).isAckReceiptEnabled(true).subscribe();
         Message<String> msg = consumerAllPartition.receive(2, TimeUnit.SECONDS);
+        assertNotNull(msg);
         String receivedMsgValue = msg.getValue();
         log.info("received msg: {}", receivedMsgValue);
         consumerAllPartition.acknowledge(msg);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -107,7 +107,12 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     private CompletableFuture<Boolean> topicExists(String topic) {
         CompletableFuture<Boolean> existsFuture = new CompletableFuture<>();
         client.getPartitionedTopicMetadata(topic, false).thenAccept(metadata -> {
-            existsFuture.complete(true);
+            TopicName topicName = TopicName.get(topic);
+            if (topicName.isPersistent()) {
+                existsFuture.complete(true);
+            } else {
+                existsFuture.complete(metadata != null && metadata.partitions > 0);
+            }
         }).exceptionally(ex -> {
             Throwable actEx = FutureUtil.unwrapCompletionException(ex);
             if (actEx instanceof PulsarClientException.NotFoundException

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -59,7 +59,6 @@ import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.client.impl.conf.TopicConsumerConfigurationData;
 import org.apache.pulsar.client.util.RetryMessageUtil;
 import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.util.FutureUtil;
 
 @Getter(AccessLevel.PUBLIC)

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -754,14 +754,6 @@ public class PulsarClientImpl implements PulsarClient {
         final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
         List<CompletableFuture<Void>> futures = new ArrayList<>();
 
-        urlLookupMap.entrySet().forEach(e -> {
-            try {
-                e.getValue().close();
-            } catch (Exception ex) {
-                log.error("Error closing lookup service {}", e.getKey(), ex);
-            }
-        });
-
         producers.forEach(p -> futures.add(p.closeAsync().handle((__, t) -> {
             if (t != null) {
                 log.error("Error closing producer {}", p, t);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -754,6 +754,14 @@ public class PulsarClientImpl implements PulsarClient {
         final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
         List<CompletableFuture<Void>> futures = new ArrayList<>();
 
+        urlLookupMap.entrySet().forEach(e -> {
+            try {
+                e.getValue().close();
+            } catch (Exception ex) {
+                log.error("Error closing lookup service {}", e.getKey(), ex);
+            }
+        });
+
         producers.forEach(p -> futures.add(p.closeAsync().handle((__, t) -> {
             if (t != null) {
                 log.error("Error closing producer {}", p, t);


### PR DESCRIPTION
### Motivation & Modifications


Section [Instead of returning a 0 partitioned metadata, respond to a not found error when calling pulsarClient.getPartitionsForTopic(String) if the topic does not exist.](https://github.com/apache/pulsar/blob/master/pip/pip-344.md#goals)

Main PIP: [PIP-344 Correct the behavior of the public API pulsarClient.getPartitionsForTopic(topicName)](https://github.com/apache/pulsar/pull/22182)

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
