### PR TITLE
[fix] [broker] Fix broker deadlock in metadata-callback thread due to single thread processing

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -389,6 +389,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                         .batchingMaxDelayMillis(config.getMetadataStoreBatchingMaxDelayMillis())
                         .batchingMaxOperations(config.getMetadataStoreBatchingMaxOperations())
                         .batchingMaxSizeKb(config.getMetadataStoreBatchingMaxSizeKb())
+                        .processingThreads(config.getNumIOThreads())
                         .metadataStoreName(MetadataStoreConfig.CONFIGURATION_METADATA_STORE)
                         .synchronizer(synchronizer)
                         .build());

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreConfig.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreConfig.java
@@ -92,4 +92,10 @@ public class MetadataStoreConfig {
      * separate clusters.
      */
     private MetadataEventSynchronizer synchronizer;
+
+    /**
+     * Number of metadata store callback processing threads.
+     */
+    @Builder.Default
+    private final int processingThreads = 1;
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -54,6 +54,7 @@ import org.apache.pulsar.metadata.api.MetadataCacheConfig;
 import org.apache.pulsar.metadata.api.MetadataEvent;
 import org.apache.pulsar.metadata.api.MetadataEventSynchronizer;
 import org.apache.pulsar.metadata.api.MetadataSerde;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.Notification;
 import org.apache.pulsar.metadata.api.NotificationType;
@@ -89,7 +90,12 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
     protected abstract CompletableFuture<Boolean> existsFromStore(String path);
 
     protected AbstractMetadataStore(String metadataStoreName) {
-        this.executor = new ScheduledThreadPoolExecutor(1,
+        this(MetadataStoreConfig.builder().metadataStoreName(metadataStoreName).build());
+    }
+
+    protected AbstractMetadataStore(MetadataStoreConfig conf) {
+        this.metadataStoreName = conf.getMetadataStoreName();
+        this.executor = new ScheduledThreadPoolExecutor(conf.getProcessingThreads(),
                 new DefaultThreadFactory(
                         StringUtils.isNotBlank(metadataStoreName) ? metadataStoreName : getClass().getSimpleName()));
         registerListener(this);
@@ -136,7 +142,6 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
                     }
                 });
 
-        this.metadataStoreName = metadataStoreName;
         this.metadataStoreStats = new MetadataStoreStats(metadataStoreName);
     }
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/batching/AbstractBatchedMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/batching/AbstractBatchedMetadataStore.java
@@ -56,7 +56,7 @@ public abstract class AbstractBatchedMetadataStore extends AbstractMetadataStore
     private final BatchMetadataStoreStats batchMetadataStoreStats;
 
     protected AbstractBatchedMetadataStore(MetadataStoreConfig conf) {
-        super(conf.getMetadataStoreName());
+        super(conf);
 
         this.enabled = conf.isBatchingEnabled();
         this.maxDelayMillis = conf.getBatchingMaxDelayMillis();


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/22840

<!-- or this PR is one task of an issue -->

Main Issue: #22840

### Motivation

This PR addresses the first issue discussed in #22840
Having a single metadata store callback can easily cause deadlock in any regression. Therefore, we must have multiple or the same number of callback threads as number of IO threads so that, callback thread doesn't face bottleneck and doesn't cause any deadlock in the system.

```
"metadata-store-10-1" #25 prio=5 os_prio=0 cpu=7574.38ms elapsed=703.54s tid=0x00007fafdd884ed0 nid=0x37eb waiting for monitor entry  [0x00007fae8f9d3000]
   java.lang.Thread.State: BLOCKED (on object monitor)
        at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(java.base@11.0.19/ConcurrentHashMap.java:1723)
        - waiting to lock <0x00001000f4a02bc0> (a java.util.concurrent.ConcurrentHashMap$ReservationNode)
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl.asyncOpen(ManagedLedgerFactoryImpl.java:365)
        at org.apache.pulsar.broker.service.BrokerService.lambda$createPersistentTopic$66(BrokerService.java:1533)
        at org.apache.pulsar.broker.service.BrokerService$$Lambda$644/0x00007facb91c8040.accept(Unknown Source)
        at java.util.concurrent.CompletableFuture.uniAcceptNow(java.base@11.0.19/CompletableFuture.java:753)
        at java.util.concurrent.CompletableFuture.uniAcceptStage(java.base@11.0.19/CompletableFuture.java:731)
        at java.util.concurrent.CompletableFuture.thenAccept(java.base@11.0.19/CompletableFuture.java:2108)
        at org.apache.pulsar.broker.service.BrokerService.createPersistentTopic(BrokerService.java:1514)
        at org.apache.pulsar.broker.service.BrokerService.lambda$checkOwnershipAndCreatePersistentTopic$60(BrokerService.java:1472)
        at org.apache.pulsar.broker.service.BrokerService$$Lambda$634/0x00007facb91c6968.accept(Unknown Source)
        at java.util.concurrent.CompletableFuture.uniAcceptNow(java.base@11.0.19/CompletableFuture.java:753)
        at java.util.concurrent.CompletableFuture.uniAcceptStage(java.base@11.0.19/CompletableFuture.java:731)
        at java.util.concurrent.CompletableFuture.thenAccept(java.base@11.0.19/CompletableFuture.java:2108)
        at org.apache.pulsar.broker.service.BrokerService.checkOwnershipAndCreatePersistentTopic(BrokerService.java:1470)
        at org.apache.pulsar.broker.service.BrokerService.lambda$loadOrCreatePersistentTopic$57(BrokerService.java:1437)
        at org.apache.pulsar.broker.service.BrokerService$$Lambda$492/0x00007facc317a960.run(Unknown Source)
        at java.util.concurrent.CompletableFuture$UniRun.tryFire(java.base@11.0.19/CompletableFuture.java:783)
        at java.util.concurrent.CompletableFuture.postComplete(java.base@11.0.19/CompletableFuture.java:506)
        at java.util.concurrent.CompletableFuture.complete(java.base@11.0.19/CompletableFuture.java:2073)
        at org.apache.pulsar.metadata.coordination.impl.LockManagerImpl.lambda$acquireLock$1(LockManagerImpl.java:105)
        at org.apache.pulsar.metadata.coordination.impl.LockManagerImpl$$Lambda$613/0x00007facbf1d9d08.run(Unknown Source)
        at java.util.concurrent.CompletableFuture$UniRun.tryFire(java.base@11.0.19/CompletableFuture.java:783)
        at java.util.concurrent.CompletableFuture.postComplete(java.base@11.0.19/CompletableFuture.java:506)
        at java.util.concurrent.CompletableFuture.complete(java.base@11.0.19/CompletableFuture.java:2073)
        at org.apache.pulsar.metadata.coordination.impl.ResourceLockImpl.lambda$acquire$2(ResourceLockImpl.java:128)
        at org.apache.pulsar.metadata.coordination.impl.ResourceLockImpl$$Lambda$611/0x00007facbdc40040.run(Unknown Source)
        at java.util.concurrent.CompletableFuture$UniRun.tryFire(java.base@11.0.19/CompletableFuture.java:783)
        at java.util.concurrent.CompletableFuture.postComplete(java.base@11.0.19/CompletableFuture.java:506)
        at java.util.concurrent.CompletableFuture.complete(java.base@11.0.19/CompletableFuture.java:2073)
        at org.apache.pulsar.metadata.coordination.impl.ResourceLockImpl.lambda$acquireWithNoRevalidation$6(ResourceLockImpl.java:167)
        at org.apache.pulsar.metadata.coordination.impl.ResourceLockImpl$$Lambda$609/0x00007facbdc42908.accept(Unknown Source)
        at java.util.concurrent.CompletableFuture$UniAccept.tryFire(java.base@11.0.19/CompletableFuture.java:714)
        at java.util.concurrent.CompletableFuture.postComplete(java.base@11.0.19/CompletableFuture.java:506)
        at java.util.concurrent.CompletableFuture.complete(java.base@11.0.19/CompletableFuture.java:2073)
        at org.apache.pulsar.metadata.impl.ZKMetadataStore.handlePutResult(ZKMetadataStore.java:225)
        at org.apache.pulsar.metadata.impl.ZKMetadataStore.lambda$batchOperation$7(ZKMetadataStore.java:182)
        at org.apache.pulsar.metadata.impl.ZKMetadataStore$$Lambda$160/0x00007fae8db950b0.run(Unknown Source)
        at java.util.concurrent.Executors$RunnableAdapter.call(java.base@11.0.19/Executors.java:515)
        at java.util.concurrent.FutureTask.run(java.base@11.0.19/FutureTask.java:264)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(java.base@11.0.19/ScheduledThreadPoolExecutor.java:304)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.19/ThreadPoolExecutor.java:1128)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.19/ThreadPoolExecutor.java:628)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.lang.Thread.run(java.base@11.0.19/Thread.java:829)




"pulsar-io-4-32" #166 prio=5 os_prio=0 cpu=429.42ms elapsed=701.77s tid=0x00007facc80314b0 nid=0x3881 waiting on condition  [0x00007facc73f4000]
   java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@11.0.19/Native Method)
        - parking to wait for  <0x00001000f838ac60> (a java.util.concurrent.CompletableFuture$Signaller)
        at java.util.concurrent.locks.LockSupport.park(java.base@11.0.19/LockSupport.java:194)
        at java.util.concurrent.CompletableFuture$Signaller.block(java.base@11.0.19/CompletableFuture.java:1796)
        at java.util.concurrent.ForkJoinPool.managedBlock(java.base@11.0.19/ForkJoinPool.java:3128)
        at java.util.concurrent.CompletableFuture.waitingGet(java.base@11.0.19/CompletableFuture.java:1823)
        at java.util.concurrent.CompletableFuture.get(java.base@11.0.19/CompletableFuture.java:1998)
        at org.apache.pulsar.bookie.rackawareness.BookieRackAffinityMapping.setConf(BookieRackAffinityMapping.java:121)
        - locked <0x00001000f8389698> (a org.apache.pulsar.bookie.rackawareness.BookieRackAffinityMapping)
        at org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicyImpl.initialize(RackawareEnsemblePlacementPolicyImpl.java:265)
        at org.apache.pulsar.bookie.rackawareness.IsolatedBookieEnsemblePlacementPolicy.initialize(IsolatedBookieEnsemblePlacementPolicy.java:105)
        at org.apache.pulsar.bookie.rackawareness.IsolatedBookieEnsemblePlacementPolicy.initialize(IsolatedBookieEnsemblePlacementPolicy.java:51)
        at org.apache.bookkeeper.client.BookKeeper.initializeEnsemblePlacementPolicy(BookKeeper.java:581)
        at org.apache.bookkeeper.client.BookKeeper.<init>(BookKeeper.java:505)
        at org.apache.bookkeeper.client.BookKeeper$Builder.build(BookKeeper.java:306)
        at org.apache.pulsar.broker.BookKeeperClientFactoryImpl.create(BookKeeperClientFactoryImpl.java:87)
        at org.apache.pulsar.broker.ManagedLedgerClientFactory.lambda$initialize$0(ManagedLedgerClientFactory.java:95)
        at org.apache.pulsar.broker.ManagedLedgerClientFactory$$Lambda$1006/0x00007facb41b1440.apply(Unknown Source)
        at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(java.base@11.0.19/ConcurrentHashMap.java:1705)
        - locked <0x00001000f3c03a28> (a java.util.concurrent.ConcurrentHashMap$ReservationNode)
        at org.apache.pulsar.broker.ManagedLedgerClientFactory.lambda$initialize$1(ManagedLedgerClientFactory.java:93)
        at org.apache.pulsar.broker.ManagedLedgerClientFactory$$Lambda$202/0x00007fae1e73e9b0.get(Unknown Source)
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl.lambda$asyncOpen$6(ManagedLedgerFactoryImpl.java:369)
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl$$Lambda$660/0x00007facb91ecd60.apply(Unknown Source)
        at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(java.base@11.0.19/ConcurrentHashMap.java:1705)
        - locked <0x00001000f4a02bc0> (a java.util.concurrent.ConcurrentHashMap$ReservationNode)
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl.asyncOpen(ManagedLedgerFactoryImpl.java:365)
        at org.apache.pulsar.broker.service.BrokerService.lambda$createPersistentTopic$66(BrokerService.java:1533)
        at org.apache.pulsar.broker.service.BrokerService$$Lambda$644/0x00007facb91c8040.accept(Unknown Source)
        at java.util.concurrent.CompletableFuture.uniAcceptNow(java.base@11.0.19/CompletableFuture.java:753)
        at java.util.concurrent.CompletableFuture.uniAcceptStage(java.base@11.0.19/CompletableFuture.java:731)
        at java.util.concurrent.CompletableFuture.thenAccept(java.base@11.0.19/CompletableFuture.java:2108)
        at org.apache.pulsar.broker.service.BrokerService.createPersistentTopic(BrokerService.java:1514)
        at org.apache.pulsar.broker.service.BrokerService.lambda$checkOwnershipAndCreatePersistentTopic$60(BrokerService.java:1472)
        at org.apache.pulsar.broker.service.BrokerService$$Lambda$634/0x00007facb91c6968.accept(Unknown Source)
        at java.util.concurrent.CompletableFuture.uniAcceptNow(java.base@11.0.19/CompletableFuture.java:753)
        at java.util.concurrent.CompletableFuture.uniAcceptStage(java.base@11.0.19/CompletableFuture.java:731)
        at java.util.concurrent.CompletableFuture.thenAccept(java.base@11.0.19/CompletableFuture.java:2108)
        at org.apache.pulsar.broker.service.BrokerService.checkOwnershipAndCreatePersistentTopic(BrokerService.java:1470)
        at org.apache.pulsar.broker.service.BrokerService.lambda$loadOrCreatePersistentTopic$57(BrokerService.java:1437)
        at org.apache.pulsar.broker.service.BrokerService$$Lambda$492/0x00007facc317a960.run(Unknown Source)
        at java.util.concurrent.CompletableFuture.uniRunNow(java.base@11.0.19/CompletableFuture.java:815)
        at java.util.concurrent.CompletableFuture.uniRunStage(java.base@11.0.19/CompletableFuture.java:799)
        at java.util.concurrent.CompletableFuture.thenRun(java.base@11.0.19/CompletableFuture.java:2121)
        at org.apache.pulsar.broker.service.BrokerService.loadOrCreatePersistentTopic(BrokerService.java:1433)
        at org.apache.pulsar.broker.service.BrokerService.lambda$getTopic$31(BrokerService.java:1014)
        at org.apache.pulsar.broker.service.BrokerService$$Lambda$476/0x00007facc3057108.apply(Unknown Source)
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.put(ConcurrentOpenHashMap.java:404)
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.computeIfAbsent(ConcurrentOpenHashMap.java:238)
        at org.apache.pulsar.broker.service.BrokerService.getTopic(BrokerService.java:1013)
        at org.apache.pulsar.broker.service.BrokerService.getTopic(BrokerService.java:978)
        at org.apache.pulsar.broker.service.BrokerService.lambda$getOrCreateTopic$29(BrokerService.java:973)
```

This PR has unit-test which fails with single thread and it can be fixed by providing multiple threads into callback processing.


### Modifications

Allow metadata-store to use multiple callback threads to avoid deadlock situation in broker.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
