### PR TITLE
[improve][build] Support git worktree working directory while building docker images

### DIFF
--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -70,7 +70,7 @@
       <id>git-commit-id-no-git</id>
       <activation>
         <file>
-          <missing>${basedir}/../../.git/index</missing>
+          <missing>${basedir}/../../.git</missing>
         </file>
       </activation>
       <properties>

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -52,7 +52,7 @@
       <id>git-commit-id-no-git</id>
       <activation>
         <file>
-          <missing>${basedir}/../../.git/index</missing>
+          <missing>${basedir}/../../.git</missing>
         </file>
       </activation>
       <properties>


### PR DESCRIPTION
### Motivation

git supports sharing a single local directory across multiple working directories as explained in https://pulsar.apache.org/contribute/setup-git/#checking-out-each-pulsar-maintenance-branch-in-a-separate-working-directory . This makes it easier to maintain multiple Pulsar branches since each maintenance branch will be checked out in it's own working directory and could be open simultaneously in IntelliJ.

However, building docker images has been broken when using `git worktree` working directory. This is fixed with this PR.

### Modifications

- fix the check for git repository existence

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->