### PR TITLE
[fix][doc] Fix the doc for the message redelivery backoff

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -791,31 +791,66 @@ public interface ConsumerBuilder<T> extends Cloneable {
     ConsumerBuilder<T> messagePayloadProcessor(MessagePayloadProcessor payloadProcessor);
 
     /**
-     * negativeAckRedeliveryBackoff doesn't work with `consumer.negativeAcknowledge(MessageId messageId)`
-     * because we are unable to get the redelivery count from the message ID.
+     * negativeAckRedeliveryBackoff sets the redelivery backoff policy for messages that are negatively acknowledged
+     * using
+     * `consumer.negativeAcknowledge(Message<?> message)` but not with `consumer.negativeAcknowledge(MessageId
+     * messageId)`.
+     * This setting allows specifying a backoff policy for messages that are negatively acknowledged,
+     * enabling more flexible control over the delay before such messages are redelivered.
      *
-     * <p>Example:
-     * <pre>
-     * client.newConsumer().negativeAckRedeliveryBackoff(ExponentialRedeliveryBackoff.builder()
-     *              .minNackTimeMs(1000)
-     *              .maxNackTimeMs(60 * 1000)
-     *              .build()).subscribe();
-     * </pre>
+     * <p>This configuration accepts a {@link RedeliveryBackoff} object that defines the backoff policy.
+     * The policy can be either a fixed delay or an exponential backoff. An exponential backoff policy
+     * is beneficial in scenarios where increasing the delay between consecutive redeliveries can help
+     * mitigate issues like temporary resource constraints or processing bottlenecks.
+     *
+     * <p>Note: This backoff policy does not apply when using `consumer.negativeAcknowledge(MessageId messageId)`
+     * because the redelivery count cannot be determined from just the message ID. It is recommended to use
+     * `consumer.negativeAcknowledge(Message<?> message)` if you want to leverage the redelivery backoff policy.
+     *
+     * <p>Example usage:
+     * <pre>{@code
+     * client.newConsumer()
+     *       .negativeAckRedeliveryBackoff(ExponentialRedeliveryBackoff.builder()
+     *           .minDelayMs(1000)   // Set minimum delay to 1 second
+     *           .maxDelayMs(60000)  // Set maximum delay to 60 seconds
+     *           .build())
+     *       .subscribe();
+     * }</pre>
+     *
+     * @param negativeAckRedeliveryBackoff the backoff policy to use for negatively acknowledged messages
+     * @return the consumer builder instance
      */
     ConsumerBuilder<T> negativeAckRedeliveryBackoff(RedeliveryBackoff negativeAckRedeliveryBackoff);
 
+
     /**
-     * redeliveryBackoff doesn't work with `consumer.negativeAcknowledge(MessageId messageId)`
-     * because we are unable to get the redelivery count from the message ID.
+     * Sets the redelivery backoff policy for messages that are redelivered due to acknowledgement timeout.
+     * This setting allows you to specify a backoff policy for messages that are not acknowledged within
+     * the specified ack timeout. By using a backoff policy, you can control the delay before a message
+     * is redelivered, potentially improving consumer performance by avoiding immediate redelivery of
+     * messages that might still be processing.
      *
-     * <p>Example:
-     * <pre>
-     * client.newConsumer().ackTimeout(10, TimeUnit.SECOND)
-     *              .ackTimeoutRedeliveryBackoff(ExponentialRedeliveryBackoff.builder()
-     *              .minNackTimeMs(1000)
-     *              .maxNackTimeMs(60 * 1000)
-     *              .build()).subscribe();
-     * </pre>
+     * <p>This method accepts a {@link RedeliveryBackoff} object that defines the backoff policy to be used.
+     * You can use either a fixed backoff policy or an exponential backoff policy. The exponential backoff
+     * policy is particularly useful for scenarios where it may be beneficial to progressively increase the
+     * delay between redeliveries, reducing the load on the consumer and giving more time to process messages.
+     *
+     * <p>Example usage:
+     * <pre>{@code
+     * client.newConsumer()
+     *       .ackTimeout(10, TimeUnit.SECONDS)
+     *       .ackTimeoutRedeliveryBackoff(ExponentialRedeliveryBackoff.builder()
+     *           .minDelayMs(1000)   // Set minimum delay to 1 second
+     *           .maxDelayMs(60000)  // Set maximum delay to 60 seconds
+     *           .build())
+     *       .subscribe();
+     * }</pre>
+     *
+     * <p>Note: This configuration is effective only if the ack timeout is triggered. It does not apply to
+     * messages negatively acknowledged using the negative acknowledgment API.
+     *
+     * @param ackTimeoutRedeliveryBackoff the backoff policy to use for messages that exceed their ack timeout
+     * @return the consumer builder instance
      */
     ConsumerBuilder<T> ackTimeoutRedeliveryBackoff(RedeliveryBackoff ackTimeoutRedeliveryBackoff);
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Motivation

The document states that `ackTimeoutRedeliveryBackoff` cannot be used with `consumer.negativeAcknowledge(MessageId messageId)`. However, this is confusing. The `ackTimeoutRedeliveryBackoff` should not relate to the nack.

## Modification

- Fix the doc for the `ackTimeoutRedeliveryBackoff`
- Improve the doc for `negativeAckRedeliveryBackoff` and `ackTimeoutRedeliveryBackoff`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
