### PR TITLE
[fix] [client] Fix memory leak when using API pulsarClient.getLookup(url)

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PulsarClientImplMultiBrokersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PulsarClientImplMultiBrokersTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin;
+
+import static org.testng.Assert.fail;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.MultiBrokerBaseTest;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.client.impl.LookupService;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.awaitility.reflect.WhiteboxImpl;
+import org.testng.annotations.Test;
+
+/**
+ * Test multi-broker admin api.
+ */
+@Slf4j
+@Test(groups = "broker-admin")
+public class PulsarClientImplMultiBrokersTest extends MultiBrokerBaseTest {
+    @Override
+    protected int numberOfAdditionalBrokers() {
+        return 3;
+    }
+
+    @Override
+    protected void doInitConf() throws Exception {
+        super.doInitConf();
+        this.conf.setManagedLedgerMaxEntriesPerLedger(10);
+    }
+
+    @Override
+    protected void onCleanup() {
+        super.onCleanup();
+    }
+
+    @Test(timeOut = 30 * 1000)
+    public void testReleaseUrlLookupServices() throws Exception {
+        PulsarClientImpl pulsarClient = (PulsarClientImpl) additionalBrokerClients.get(0);
+        Map<String, LookupService> urlLookupMap = WhiteboxImpl.getInternalState(pulsarClient, "urlLookupMap");
+        assertEquals(urlLookupMap.size(), 0);
+        for (PulsarService pulsar : additionalBrokers) {
+            pulsarClient.getLookup(pulsar.getBrokerServiceUrl());
+            pulsarClient.getLookup(pulsar.getWebServiceAddress());
+        }
+        assertEquals(urlLookupMap.size(), additionalBrokers.size() * 2);
+        // Verify: lookup services will be release.
+        pulsarClient.close();
+        assertEquals(urlLookupMap.size(), 0);
+        try {
+            for (PulsarService pulsar : additionalBrokers) {
+                pulsarClient.getLookup(pulsar.getBrokerServiceUrl());
+                pulsarClient.getLookup(pulsar.getWebServiceAddress());
+            }
+            fail("Expected a error when calling pulsarClient.getLookup if getLookup was closed");
+        } catch (IllegalStateException illegalArgumentException) {
+            assertTrue(illegalArgumentException.getMessage().contains("has been closed"));
+        }
+        assertEquals(urlLookupMap.size(), 0);
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -33,6 +33,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -744,6 +745,21 @@ public class PulsarClientImpl implements PulsarClient {
         }
     }
 
+    private void closeUrlLookupMap() {
+        Map<String, LookupService> closedUrlLookupServices = new HashMap(urlLookupMap.size());
+        urlLookupMap.entrySet().forEach(e -> {
+            try {
+                e.getValue().close();
+            } catch (Exception ex) {
+                log.error("Error closing lookup service {}", e.getKey(), ex);
+            }
+            closedUrlLookupServices.put(e.getKey(), e.getValue());
+        });
+        closedUrlLookupServices.entrySet().forEach(e -> {
+            urlLookupMap.remove(e.getKey(), e.getValue());
+        });
+    }
+
     @Override
     public CompletableFuture<Void> closeAsync() {
         log.info("Client closing. URL: {}", lookup.getServiceUrl());
@@ -753,6 +769,8 @@ public class PulsarClientImpl implements PulsarClient {
 
         final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
         List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+        closeUrlLookupMap();
 
         producers.forEach(p -> futures.add(p.closeAsync().handle((__, t) -> {
             if (t != null) {
@@ -982,6 +1000,10 @@ public class PulsarClientImpl implements PulsarClient {
 
     public LookupService getLookup(String serviceUrl) {
         return urlLookupMap.computeIfAbsent(serviceUrl, url -> {
+            if (isClosed()) {
+                throw new IllegalStateException("Pulsar client has been closed, can not build LookupService when"
+                        + " calling get lookup with an url");
+            }
             try {
                 return createLookup(serviceUrl);
             } catch (PulsarClientException e) {


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/21356 added a resource map `urlLookupMap` in `PulsarClientImpl.class`, but did not release the lookup services when closing PulsarClient.

### Modifications

Release `urlLookupMap` when closing PulsarClient


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x