### PR TITLE
[fix][broker] Support advertised listeners when gracefully transferring topics (ExtensibleLoadManagerImpl only)

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -29,7 +29,6 @@ import static org.apache.pulsar.broker.service.persistent.PersistentTopic.getMig
 import static org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage.ignoreUnrecoverableBKException;
 import static org.apache.pulsar.common.api.proto.ProtocolVersion.v5;
 import static org.apache.pulsar.common.protocol.Commands.DEFAULT_CONSUMER_EPOCH;
-import static org.apache.pulsar.common.protocol.Commands.newCloseConsumer;
 import static org.apache.pulsar.common.protocol.Commands.newLookupErrorResponse;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -71,6 +70,7 @@ import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.TransactionMetadataStoreService;
@@ -82,6 +82,7 @@ import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import org.apache.pulsar.broker.limiter.ConnectionController;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
+import org.apache.pulsar.broker.namespace.LookupOptions;
 import org.apache.pulsar.broker.resources.NamespaceResources;
 import org.apache.pulsar.broker.resources.TopicResources;
 import org.apache.pulsar.broker.service.BrokerServiceException.ConsumerBusyException;
@@ -149,6 +150,7 @@ import org.apache.pulsar.common.api.proto.TxnAction;
 import org.apache.pulsar.common.compression.CompressionCodec;
 import org.apache.pulsar.common.compression.CompressionCodecProvider;
 import org.apache.pulsar.common.intercept.InterceptException;
+import org.apache.pulsar.common.lookup.data.LookupData;
 import org.apache.pulsar.common.naming.Metadata;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.SystemTopicNames;
@@ -3186,15 +3188,28 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         closeProducer(producer.getProducerId(), producer.getEpoch(), assignedBrokerLookupData);
     }
 
+    private LookupData getLookupData(BrokerLookupData lookupData) {
+        LookupOptions.LookupOptionsBuilder builder = LookupOptions.builder();
+        if (StringUtils.isNotBlank((listenerName))) {
+            builder.advertisedListenerName(listenerName);
+        }
+        try {
+            return lookupData.toLookupResult(builder.build()).getLookupData();
+        } catch (PulsarServerException e) {
+            log.error("Failed to get lookup data", e);
+            throw new RuntimeException(e);
+        }
+    }
+
     private void closeProducer(long producerId, long epoch, Optional<BrokerLookupData> assignedBrokerLookupData) {
         if (getRemoteEndpointProtocolVersion() >= v5.getValue()) {
-            if (assignedBrokerLookupData.isPresent()) {
-                writeAndFlush(Commands.newCloseProducer(producerId, -1L,
-                        assignedBrokerLookupData.get().pulsarServiceUrl(),
-                        assignedBrokerLookupData.get().pulsarServiceUrlTls()));
-            } else {
-                writeAndFlush(Commands.newCloseProducer(producerId, -1L));
-            }
+            assignedBrokerLookupData.ifPresentOrElse(lookup -> {
+                        LookupData lookupData = getLookupData(lookup);
+                        writeAndFlush(Commands.newCloseProducer(producerId, -1L,
+                                lookupData.getBrokerUrl(),
+                                lookupData.getBrokerUrlTls()));
+                    },
+                    () -> writeAndFlush(Commands.newCloseProducer(producerId, -1L)));
 
             // The client does not necessarily know that the producer is closed, but the connection is still
             // active, and there could be messages in flight already. We want to ignore these messages for a time
@@ -3220,9 +3235,13 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     private void closeConsumer(long consumerId, Optional<BrokerLookupData> assignedBrokerLookupData) {
         if (getRemoteEndpointProtocolVersion() >= v5.getValue()) {
-            writeAndFlush(newCloseConsumer(consumerId, -1L,
-                    assignedBrokerLookupData.map(BrokerLookupData::pulsarServiceUrl).orElse(null),
-                    assignedBrokerLookupData.map(BrokerLookupData::pulsarServiceUrlTls).orElse(null)));
+            assignedBrokerLookupData.ifPresentOrElse(lookup -> {
+                        LookupData lookupData = getLookupData(lookup);
+                        writeAndFlush(Commands.newCloseConsumer(consumerId, -1L,
+                                lookupData.getBrokerUrl(),
+                                lookupData.getBrokerUrlTls()));
+                    },
+                    () -> writeAndFlush(Commands.newCloseConsumer(consumerId, -1L, null, null)));
         } else {
             close();
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -237,9 +237,14 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
     protected void doInitConf() throws Exception {
         this.conf.setBrokerShutdownTimeoutMs(0L);
         this.conf.setLoadBalancerOverrideBrokerNicSpeedGbps(Optional.of(1.0d));
-        this.conf.setBrokerServicePort(Optional.of(0));
+        if (!conf.getBrokerServicePort().isPresent()) {
+            this.conf.setBrokerServicePort(Optional.of(0));
+        }
+
         this.conf.setAdvertisedAddress("localhost");
-        this.conf.setWebServicePort(Optional.of(0));
+        if (!conf.getWebServicePort().isPresent()) {
+            this.conf.setWebServicePort(Optional.of(0));
+        }
         this.conf.setNumExecutorThreadPoolSize(5);
         this.conf.setExposeBundlesMetricsInPrometheus(true);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -237,14 +237,9 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
     protected void doInitConf() throws Exception {
         this.conf.setBrokerShutdownTimeoutMs(0L);
         this.conf.setLoadBalancerOverrideBrokerNicSpeedGbps(Optional.of(1.0d));
-        if (!conf.getBrokerServicePort().isPresent()) {
-            this.conf.setBrokerServicePort(Optional.of(0));
-        }
-
+        this.conf.setBrokerServicePort(Optional.of(0));
         this.conf.setAdvertisedAddress("localhost");
-        if (!conf.getWebServicePort().isPresent()) {
-            this.conf.setWebServicePort(Optional.of(0));
-        }
+        this.conf.setWebServicePort(Optional.of(0));
         this.conf.setNumExecutorThreadPoolSize(5);
         this.conf.setExposeBundlesMetricsInPrometheus(true);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplBaseTest.java
@@ -64,7 +64,14 @@ public abstract class ExtensibleLoadManagerImplBaseTest extends MockedPulsarServ
         this.defaultTestNamespace = defaultTestNamespace;
     }
 
-    protected ServiceConfiguration initConfig(ServiceConfiguration conf) {
+    @Override
+    protected void doInitConf() throws Exception {
+        super.doInitConf();
+        updateConfig(conf);
+    }
+
+
+    protected ServiceConfiguration updateConfig(ServiceConfiguration conf) {
         conf.setForceDeleteNamespaceAllowed(true);
         conf.setLoadManagerClassName(ExtensibleLoadManagerImpl.class.getName());
         conf.setLoadBalancerLoadSheddingStrategy(TransferShedder.class.getName());
@@ -78,10 +85,9 @@ public abstract class ExtensibleLoadManagerImplBaseTest extends MockedPulsarServ
     @Override
     @BeforeClass(alwaysRun = true)
     protected void setup() throws Exception {
-        initConfig(conf);
         super.internalSetup(conf);
         pulsar1 = pulsar;
-        var conf2 = initConfig(getDefaultConf());
+        var conf2 = updateConfig(getDefaultConf());
         additionalPulsarTestContext = createAdditionalPulsarTestContext(conf2);
         pulsar2 = additionalPulsarTestContext.getPulsarService();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplBaseTest.java
@@ -20,14 +20,9 @@ package org.apache.pulsar.broker.loadbalance.extensions;
 
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 import com.google.common.collect.Sets;
-
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.PulsarService;
@@ -37,8 +32,6 @@ import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateC
 import org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedder;
 import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.LookupService;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.SystemTopicNames;
@@ -171,37 +164,5 @@ public abstract class ExtensibleLoadManagerImplBaseTest extends MockedPulsarServ
             }
             i++;
         }
-    }
-
-    protected static LookupService spyLookupService(PulsarClient client) throws IllegalAccessException {
-        LookupService svc = (LookupService) FieldUtils.readDeclaredField(client, "lookup", true);
-        var lookup = spy(svc);
-        FieldUtils.writeDeclaredField(client, "lookup", lookup, true);
-        return lookup;
-    }
-
-    protected static void checkOwnershipState(String broker, NamespaceBundle bundle,
-                                              ExtensibleLoadManager primaryLoadManager,
-                                              ExtensibleLoadManager secondaryLoadManager, PulsarService pulsar1)
-            throws ExecutionException, InterruptedException {
-        var targetLoadManager = secondaryLoadManager;
-        var otherLoadManager = primaryLoadManager;
-        if (broker.equals(pulsar1.getBrokerServiceUrl())) {
-            targetLoadManager = primaryLoadManager;
-            otherLoadManager = secondaryLoadManager;
-        }
-        assertTrue(targetLoadManager.checkOwnershipAsync(Optional.empty(), bundle).get());
-        assertFalse(otherLoadManager.checkOwnershipAsync(Optional.empty(), bundle).get());
-    }
-    protected void checkOwnershipState(String broker, NamespaceBundle bundle)
-            throws ExecutionException, InterruptedException {
-        checkOwnershipState(broker, bundle, primaryLoadManager, secondaryLoadManager, pulsar1);
-    }
-
-    protected static PulsarClient pulsarClient(String url, int intervalInSecs) throws PulsarClientException {
-        return
-                PulsarClient.builder()
-                        .serviceUrl(url)
-                        .statsInterval(intervalInSecs, TimeUnit.SECONDS).build();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplBaseTest.java
@@ -20,10 +20,14 @@ package org.apache.pulsar.broker.loadbalance.extensions;
 
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import com.google.common.collect.Sets;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.PulsarService;
@@ -33,6 +37,8 @@ import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateC
 import org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedder;
 import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.LookupService;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.SystemTopicNames;
@@ -147,7 +153,7 @@ public abstract class ExtensibleLoadManagerImplBaseTest extends MockedPulsarServ
                 FieldUtils.readField(secondaryLoadManager, "serviceUnitStateChannel", true);
     }
 
-    protected CompletableFuture<NamespaceBundle> getBundleAsync(PulsarService pulsar, TopicName topic) {
+    protected static CompletableFuture<NamespaceBundle> getBundleAsync(PulsarService pulsar, TopicName topic) {
         return pulsar.getNamespaceService().getBundleAsync(topic);
     }
 
@@ -165,5 +171,37 @@ public abstract class ExtensibleLoadManagerImplBaseTest extends MockedPulsarServ
             }
             i++;
         }
+    }
+
+    protected static LookupService spyLookupService(PulsarClient client) throws IllegalAccessException {
+        LookupService svc = (LookupService) FieldUtils.readDeclaredField(client, "lookup", true);
+        var lookup = spy(svc);
+        FieldUtils.writeDeclaredField(client, "lookup", lookup, true);
+        return lookup;
+    }
+
+    protected static void checkOwnershipState(String broker, NamespaceBundle bundle,
+                                              ExtensibleLoadManager primaryLoadManager,
+                                              ExtensibleLoadManager secondaryLoadManager, PulsarService pulsar1)
+            throws ExecutionException, InterruptedException {
+        var targetLoadManager = secondaryLoadManager;
+        var otherLoadManager = primaryLoadManager;
+        if (broker.equals(pulsar1.getBrokerServiceUrl())) {
+            targetLoadManager = primaryLoadManager;
+            otherLoadManager = secondaryLoadManager;
+        }
+        assertTrue(targetLoadManager.checkOwnershipAsync(Optional.empty(), bundle).get());
+        assertFalse(otherLoadManager.checkOwnershipAsync(Optional.empty(), bundle).get());
+    }
+    protected void checkOwnershipState(String broker, NamespaceBundle bundle)
+            throws ExecutionException, InterruptedException {
+        checkOwnershipState(broker, bundle, primaryLoadManager, secondaryLoadManager, pulsar1);
+    }
+
+    protected static PulsarClient pulsarClient(String url, int intervalInSecs) throws PulsarClientException {
+        return
+                PulsarClient.builder()
+                        .serviceUrl(url)
+                        .statsInterval(intervalInSecs, TimeUnit.SECONDS).build();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -111,6 +111,7 @@ import org.apache.pulsar.broker.namespace.NamespaceBundleSplitListener;
 import org.apache.pulsar.broker.namespace.NamespaceEphemeralData;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.BrokerServiceException;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -434,6 +435,19 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
     @Test(timeOut = 30_000, dataProvider = "isPersistentTopicSubscriptionTypeTest")
     public void testTransferClientReconnectionWithoutLookup(TopicDomain topicDomain, SubscriptionType subscriptionType)
             throws Exception {
+        testTransferClientReconnectionWithoutLookup(topicDomain, subscriptionType, defaultTestNamespace, admin,
+                lookupUrl.toString(), pulsar1, pulsar2, primaryLoadManager, secondaryLoadManager);
+    }
+
+    @Test(enabled = false)
+    public static void testTransferClientReconnectionWithoutLookup(TopicDomain topicDomain,
+                                                                   SubscriptionType subscriptionType,
+                                                                   String defaultTestNamespace,
+                                                                   PulsarAdmin admin, String brokerServiceUrl,
+                                                                   PulsarService pulsar1, PulsarService pulsar2,
+                                                                   ExtensibleLoadManager primaryLoadManager,
+                                                                   ExtensibleLoadManager secondaryLoadManager)
+            throws Exception {
         var id = String.format("test-tx-client-reconnect-%s-%s", subscriptionType, UUID.randomUUID());
         var topic = String.format("%s://%s/%s", topicDomain.toString(), defaultTestNamespace, id);
         var topicName = TopicName.get(topic);
@@ -443,7 +457,8 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
         var consumers = new ArrayList<Consumer<String>>();
         try {
             var lookups = new ArrayList<LookupService>();
-
+            var pulsarClient = pulsarClient(brokerServiceUrl, 0);
+            clients.add(pulsarClient);
             @Cleanup
             var producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
             lookups.add(spyLookupService(pulsarClient));
@@ -451,7 +466,7 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
             var consumerCount = subscriptionType == SubscriptionType.Exclusive ? 1 : 3;
 
             for (int i = 0; i < consumerCount; i++) {
-                var client = newPulsarClient(lookupUrl.toString(), 0);
+                var client = pulsarClient(brokerServiceUrl, 0);
                 clients.add(client);
                 var consumer = client.newConsumer(Schema.STRING).
                         subscriptionName(id).
@@ -478,7 +493,7 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
                 dstBrokerUrl = pulsar1.getBrokerId();
                 dstBrokerServiceUrl = pulsar1.getBrokerServiceUrl();
             }
-            checkOwnershipState(broker, bundle);
+            checkOwnershipState(broker, bundle, primaryLoadManager, secondaryLoadManager, pulsar1);
 
             var messageCountBeforeUnloading = 100;
             var messageCountAfterUnloading = 100;
@@ -572,6 +587,17 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
     @Test(timeOut = 30 * 1000, dataProvider = "isPersistentTopicSubscriptionTypeTest")
     public void testUnloadClientReconnectionWithLookup(TopicDomain topicDomain,
                                                        SubscriptionType subscriptionType) throws Exception {
+        testUnloadClientReconnectionWithLookup(topicDomain, subscriptionType, defaultTestNamespace, admin,
+                lookupUrl.toString(), pulsar1);
+    }
+
+    @Test(enabled = false)
+    public static void testUnloadClientReconnectionWithLookup(TopicDomain topicDomain,
+                                                              SubscriptionType subscriptionType,
+                                                              String defaultTestNamespace,
+                                                              PulsarAdmin admin,
+                                                              String brokerServiceUrl,
+                                                              PulsarService pulsar1) throws Exception {
         var id = String.format("test-unload-%s-client-reconnect-%s-%s",
                 topicDomain, subscriptionType, UUID.randomUUID());
         var topic = String.format("%s://%s/%s", topicDomain, defaultTestNamespace, id);
@@ -580,6 +606,7 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
         var consumers = new ArrayList<Consumer<String>>();
         try {
             @Cleanup
+            var pulsarClient = pulsarClient(brokerServiceUrl, 0);
             var producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
 
             var consumerCount = subscriptionType == SubscriptionType.Exclusive ? 1 : 3;
@@ -651,12 +678,25 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
 
     @Test(timeOut = 30 * 1000, dataProvider = "isPersistentTopicTest")
     public void testOptimizeUnloadDisable(TopicDomain topicDomain) throws Exception {
+        testOptimizeUnloadDisable(topicDomain, defaultTestNamespace, admin, lookupUrl.toString(), pulsar1, pulsar2);
+    }
+
+    @Test(enabled = false)
+    public static void testOptimizeUnloadDisable(TopicDomain topicDomain,
+                                                 String defaultTestNamespace,
+                                                 PulsarAdmin admin,
+                                                 String brokerServiceUrl,
+                                                 PulsarService pulsar1,
+                                                 PulsarService pulsar2) throws Exception {
         var id = String.format("test-optimize-unload-disable-%s-%s", topicDomain, UUID.randomUUID());
         var topic = String.format("%s://%s/%s", topicDomain, defaultTestNamespace, id);
         var topicName = TopicName.get(topic);
 
         pulsar1.getConfig().setLoadBalancerMultiPhaseBundleUnload(false);
         pulsar2.getConfig().setLoadBalancerMultiPhaseBundleUnload(false);
+
+        @Cleanup
+        var pulsarClient = pulsarClient(brokerServiceUrl, 0);
 
         @Cleanup
         var producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
@@ -719,23 +759,7 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
         verify(lookup, times(2)).getBroker(topicName);
     }
 
-    private LookupService spyLookupService(PulsarClient client) throws IllegalAccessException {
-        LookupService svc = (LookupService) FieldUtils.readDeclaredField(client, "lookup", true);
-        var lookup = spy(svc);
-        FieldUtils.writeDeclaredField(client, "lookup", lookup, true);
-        return lookup;
-    }
-    private void checkOwnershipState(String broker, NamespaceBundle bundle)
-            throws ExecutionException, InterruptedException {
-        var targetLoadManager = secondaryLoadManager;
-        var otherLoadManager = primaryLoadManager;
-        if (broker.equals(pulsar1.getBrokerServiceUrl())) {
-            targetLoadManager = primaryLoadManager;
-            otherLoadManager = secondaryLoadManager;
-        }
-        assertTrue(targetLoadManager.checkOwnershipAsync(Optional.empty(), bundle).get());
-        assertFalse(otherLoadManager.checkOwnershipAsync(Optional.empty(), bundle).get());
-    }
+
 
     @Test(timeOut = 30 * 1000)
     public void testSplitBundleAdminAPI() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplWithAdvertisedListenersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplWithAdvertisedListenersTest.java
@@ -39,8 +39,10 @@ public class ExtensibleLoadManagerImplWithAdvertisedListenersTest extends Extens
     public ExtensibleLoadManagerImplWithAdvertisedListenersTest() {
         super("public/test");
     }
-    protected ServiceConfiguration initConfig(ServiceConfiguration conf) {
-        super.initConfig(conf);
+
+    @Override
+    protected ServiceConfiguration updateConfig(ServiceConfiguration conf) {
+        super.updateConfig(conf);
         int privatePulsarPort = nextLockedFreePort();
         int publicPulsarPort = nextLockedFreePort();
         conf.setInternalListenerName("internal");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplWithAdvertisedListenersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplWithAdvertisedListenersTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.extensions;
+
+import static org.apache.pulsar.common.util.PortManager.nextLockedFreePort;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for {@link ExtensibleLoadManagerImpl with AdvertisedListeners broker configs}.
+ */
+@Slf4j
+@Test(groups = "flaky")
+@SuppressWarnings("unchecked")
+public class ExtensibleLoadManagerImplWithAdvertisedListenersTest extends ExtensibleLoadManagerImplBaseTest {
+
+    public String brokerServiceUrl;
+    public ExtensibleLoadManagerImplWithAdvertisedListenersTest() {
+        super("public/test");
+    }
+    protected ServiceConfiguration initConfig(ServiceConfiguration conf) {
+        super.initConfig(conf);
+        int privatePulsarPort = nextLockedFreePort();
+        int publicPulsarPort = nextLockedFreePort();
+        conf.setInternalListenerName("internal");
+        conf.setBindAddresses("external:pulsar://localhost:" + publicPulsarPort);
+        conf.setAdvertisedListeners(
+                "external:pulsar://localhost:" + publicPulsarPort +
+                        ",internal:pulsar://localhost:" + privatePulsarPort);
+        conf.setWebServicePortTls(Optional.empty());
+        conf.setBrokerServicePortTls(Optional.empty());
+        conf.setBrokerServicePort(Optional.of(privatePulsarPort));
+        conf.setWebServicePort(Optional.of(0));
+        brokerServiceUrl = conf.getBindAddresses().replaceAll("external:", "");
+        return conf;
+    }
+
+    @DataProvider(name = "isPersistentTopicSubscriptionTypeTest")
+    public Object[][] isPersistentTopicSubscriptionTypeTest() {
+        return new Object[][]{
+                {TopicDomain.non_persistent, SubscriptionType.Exclusive},
+                {TopicDomain.persistent, SubscriptionType.Key_Shared}
+        };
+    }
+
+    @Test(timeOut = 30_000, dataProvider = "isPersistentTopicSubscriptionTypeTest")
+    public void testTransferClientReconnectionWithoutLookup(TopicDomain topicDomain, SubscriptionType subscriptionType)
+            throws Exception {
+        ExtensibleLoadManagerImplTest.testTransferClientReconnectionWithoutLookup(topicDomain, subscriptionType,
+                defaultTestNamespace, admin,
+                brokerServiceUrl,
+                pulsar1, pulsar2, primaryLoadManager, secondaryLoadManager);
+    }
+
+    @Test(timeOut = 30 * 1000, dataProvider = "isPersistentTopicSubscriptionTypeTest")
+    public void testUnloadClientReconnectionWithLookup(TopicDomain topicDomain,
+                                                       SubscriptionType subscriptionType) throws Exception {
+        ExtensibleLoadManagerImplTest.testUnloadClientReconnectionWithLookup(topicDomain, subscriptionType,
+                defaultTestNamespace, admin,
+                brokerServiceUrl,
+                pulsar1);
+    }
+
+    @DataProvider(name = "isPersistentTopicTest")
+    public Object[][] isPersistentTopicTest() {
+        return new Object[][]{{TopicDomain.persistent}, {TopicDomain.non_persistent}};
+    }
+
+    @Test(timeOut = 30 * 1000, dataProvider = "isPersistentTopicTest")
+    public void testOptimizeUnloadDisable(TopicDomain topicDomain) throws Exception {
+        ExtensibleLoadManagerImplTest.testOptimizeUnloadDisable(topicDomain, defaultTestNamespace, admin,
+                brokerServiceUrl, pulsar1, pulsar2);
+    }
+
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplWithTransactionCoordinatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplWithTransactionCoordinatorTest.java
@@ -31,8 +31,8 @@ public class ExtensibleLoadManagerImplWithTransactionCoordinatorTest extends Ext
     }
 
     @Override
-    protected ServiceConfiguration initConfig(ServiceConfiguration conf) {
-        conf = super.initConfig(conf);
+    protected ServiceConfiguration updateConfig(ServiceConfiguration conf) {
+        conf = super.updateConfig(conf);
         conf.setTransactionCoordinatorEnabled(true);
         return conf;
     }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: https://github.com/apache/pulsar/blob/master/pip/pip-307.md

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

- PIP-307 does not cover advertised listeners. This PR is trying to support advertised listeners when gracefully transferring topics (ExtensibleLoadManagerImpl only)

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

By utilizing serverCnx.listenerName, added by https://github.com/apache/pulsar/pull/12056, brokers return advertised listener broker urls in the producer|consumer close commands, if the connection is through the listenerName.
```
if(serverCnx.listenerName != null){
  listener =  lookup.getAdvertisedListener(serverCnx.listenerName)
  return listener's brokerServiceUrl and brokerServiceUrlTls
} else {
  return  lookup.pulsarServiceUrl and lookup.pulsarServiceUrlTls
}
```
### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/heesung-sn/pulsar/pull/68

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
