### PR TITLE
[fix][misc] Disable JFR based telemetry collection since it's not used

### DIFF
--- a/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryService.java
+++ b/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryService.java
@@ -102,6 +102,9 @@ public class OpenTelemetryService implements Closeable {
 
         // For a list of exposed metrics, see https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/
         runtimeMetricsReference.set(RuntimeMetrics.builder(openTelemetrySdkReference.get())
+                // disable JFR based telemetry and use only JMX telemetry
+                .disableAllFeatures()
+                // enable experimental JMX telemetry in addition
                 .enableExperimentalJmxTelemetry()
                 .build());
     }


### PR DESCRIPTION
### Motivation

JFR based telemetry collection consumes resources. We don't currently use the metrics for anything. 
This happens in MultiBrokerLeaderElectionTest which starts 10 embedded brokers in the test. The test JVM often fails with OOM.

<img width="1016" alt="image" src="https://github.com/apache/pulsar/assets/66864/0c1cba08-cf70-4f44-b27c-77f121fd6070">

&nbsp;

<img width="1089" alt="image" src="https://github.com/apache/pulsar/assets/66864/ac183a09-ae54-42e6-a650-d781878a9ea8">

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

- disable JFR based telemetry collection since it's not used at the moment.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->