### PR TITLE
[fix][cli] Fix healthcheck script pulsar-zookeeper-ruok.sh

### DIFF
--- a/docker/pulsar/scripts/pulsar-zookeeper-ruok.sh
+++ b/docker/pulsar/scripts/pulsar-zookeeper-ruok.sh
@@ -20,7 +20,7 @@
 
 # Check ZK server status
 
-status=$(echo ruok | nc -q 1 localhost 2181)
+status=$({ echo ruok; sleep 1; } | nc 127.0.0.1 2181)
 if [ "$status" == "imok" ]; then
     exit 0
 else


### PR DESCRIPTION
Fixes #22872 

### Motivation

pulsar-zookeeper-ruok.sh script doesn't work in the latest apachepulsar/pulsar:3.3.0 image.

### Modifications

- make the script compatible with Alpine's default busybox nc (so that it isn't necessary to install `netcat-openbsd`)
  - replace "-q 1" with "sleep 1" in the input
  - replace "localhost" with "127.0.0.1" (so that IPv4 gets selected?)

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->