### PR TITLE
[improve][build] Require Java 17 or Java 21 for building Pulsar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1979,8 +1979,8 @@ flexible messaging model and an intuitive client API.</description>
               <configuration>
                 <rules>
                   <requireJavaVersion>
-                    <version>17</version>
-                    <message>Java 17+ is required to build Pulsar.</message>
+                    <version>[17,18),[21,22)</version>
+                    <message>Java 17 or Java 21 is required to build Pulsar.</message>
                   </requireJavaVersion>
                   <requireMavenVersion>
                     <version>3.6.1</version>


### PR DESCRIPTION
Fixes #22874

### Motivation

Building Pulsar is supported with either Java 17 or Java 21. This should be enforced so that there's a clear error message when the build is run on an unsupported Java version.

### Modifications

Change the version range for enforcer plugin to allow all Java 17 versions and all Java 21 versions.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->