### PR TITLE
[improve][broker] Reuse topic OpenTelemetry attributes

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PersistentTopicAttributes.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PersistentTopicAttributes.java
@@ -20,7 +20,7 @@ package org.apache.pulsar.broker.service;
 
 import io.opentelemetry.api.common.Attributes;
 import lombok.Getter;
-import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
 
 @Getter
@@ -36,8 +36,8 @@ public class PersistentTopicAttributes extends TopicAttributes {
     private final Attributes transactionCommittedAttributes;
     private final Attributes transactionAbortedAttributes;
 
-    public PersistentTopicAttributes(PersistentTopic topic) {
-        super(topic);
+    public PersistentTopicAttributes(TopicName topicName) {
+        super(topicName);
 
         timeBasedQuotaAttributes = Attributes.builder()
                 .putAll(commonAttributes)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PersistentTopicAttributes.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PersistentTopicAttributes.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import io.opentelemetry.api.common.Attributes;
+import lombok.Getter;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
+
+@Getter
+public class PersistentTopicAttributes extends TopicAttributes {
+
+    private final Attributes timeBasedQuotaAttributes;
+    private final Attributes sizeBasedQuotaAttributes;
+
+    private final Attributes compactionSuccessAttributes;
+    private final Attributes compactionFailureAttributes;
+
+    private final Attributes transactionActiveAttributes;
+    private final Attributes transactionCommittedAttributes;
+    private final Attributes transactionAbortedAttributes;
+
+    public PersistentTopicAttributes(PersistentTopic topic) {
+        super(topic);
+
+        timeBasedQuotaAttributes = Attributes.builder()
+                .putAll(commonAttributes)
+                .put(OpenTelemetryAttributes.PULSAR_BACKLOG_QUOTA_TYPE, "time")
+                .build();
+        sizeBasedQuotaAttributes = Attributes.builder()
+                .putAll(commonAttributes)
+                .put(OpenTelemetryAttributes.PULSAR_BACKLOG_QUOTA_TYPE, "size")
+                .build();
+
+        transactionActiveAttributes =  Attributes.builder()
+                .putAll(commonAttributes)
+                .put(OpenTelemetryAttributes.PULSAR_TRANSACTION_STATUS, "active")
+                .build();
+        transactionCommittedAttributes =  Attributes.builder()
+                .putAll(commonAttributes)
+                .put(OpenTelemetryAttributes.PULSAR_TRANSACTION_STATUS, "committed")
+                .build();
+        transactionAbortedAttributes =  Attributes.builder()
+                .putAll(commonAttributes)
+                .put(OpenTelemetryAttributes.PULSAR_TRANSACTION_STATUS, "aborted")
+                .build();
+
+        compactionSuccessAttributes = Attributes.builder()
+                .putAll(commonAttributes)
+                .put(OpenTelemetryAttributes.PULSAR_COMPACTION_STATUS, "success")
+                .build();
+        compactionFailureAttributes = Attributes.builder()
+                .putAll(commonAttributes)
+                .put(OpenTelemetryAttributes.PULSAR_COMPACTION_STATUS, "failure")
+                .build();
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PersistentTopicAttributes.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PersistentTopicAttributes.java
@@ -41,33 +41,33 @@ public class PersistentTopicAttributes extends TopicAttributes {
 
         timeBasedQuotaAttributes = Attributes.builder()
                 .putAll(commonAttributes)
-                .put(OpenTelemetryAttributes.PULSAR_BACKLOG_QUOTA_TYPE, "time")
+                .putAll(OpenTelemetryAttributes.BacklogQuotaType.TIME.attributes)
                 .build();
         sizeBasedQuotaAttributes = Attributes.builder()
                 .putAll(commonAttributes)
-                .put(OpenTelemetryAttributes.PULSAR_BACKLOG_QUOTA_TYPE, "size")
+                .putAll(OpenTelemetryAttributes.BacklogQuotaType.SIZE.attributes)
                 .build();
 
         transactionActiveAttributes =  Attributes.builder()
                 .putAll(commonAttributes)
-                .put(OpenTelemetryAttributes.PULSAR_TRANSACTION_STATUS, "active")
+                .putAll(OpenTelemetryAttributes.TransactionStatus.ACTIVE.attributes)
                 .build();
         transactionCommittedAttributes =  Attributes.builder()
                 .putAll(commonAttributes)
-                .put(OpenTelemetryAttributes.PULSAR_TRANSACTION_STATUS, "committed")
+                .putAll(OpenTelemetryAttributes.TransactionStatus.COMMITTED.attributes)
                 .build();
         transactionAbortedAttributes =  Attributes.builder()
                 .putAll(commonAttributes)
-                .put(OpenTelemetryAttributes.PULSAR_TRANSACTION_STATUS, "aborted")
+                .putAll(OpenTelemetryAttributes.TransactionStatus.ABORTED.attributes)
                 .build();
 
         compactionSuccessAttributes = Attributes.builder()
                 .putAll(commonAttributes)
-                .put(OpenTelemetryAttributes.PULSAR_COMPACTION_STATUS, "success")
+                .putAll(OpenTelemetryAttributes.CompactionStatus.SUCCESS.attributes)
                 .build();
         compactionFailureAttributes = Attributes.builder()
                 .putAll(commonAttributes)
-                .put(OpenTelemetryAttributes.PULSAR_COMPACTION_STATUS, "failure")
+                .putAll(OpenTelemetryAttributes.CompactionStatus.FAILURE.attributes)
                 .build();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -384,4 +384,9 @@ public interface Topic {
      */
     HierarchyTopicPolicies getHierarchyTopicPolicies();
 
+    /**
+     * Get OpenTelemetry attribute set.
+     * @return
+     */
+    TopicAttributes getTopicAttributes();
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicAttributes.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicAttributes.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service;
 
 import io.opentelemetry.api.common.Attributes;
+import java.util.Objects;
 import lombok.Getter;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
@@ -28,8 +29,8 @@ public class TopicAttributes {
 
     protected final Attributes commonAttributes;
 
-    public TopicAttributes(Topic topic) {
-        var topicName = TopicName.get(topic.getName());
+    public TopicAttributes(TopicName topicName) {
+        Objects.requireNonNull(topicName);
         var builder = Attributes.builder()
                 .put(OpenTelemetryAttributes.PULSAR_DOMAIN, topicName.getDomain().toString())
                 .put(OpenTelemetryAttributes.PULSAR_TENANT, topicName.getTenant())

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicAttributes.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicAttributes.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import io.opentelemetry.api.common.Attributes;
+import lombok.Getter;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
+
+@Getter
+public class TopicAttributes {
+
+    protected final Attributes commonAttributes;
+
+    public TopicAttributes(Topic topic) {
+        var topicName = TopicName.get(topic.getName());
+        var builder = Attributes.builder()
+                .put(OpenTelemetryAttributes.PULSAR_DOMAIN, topicName.getDomain().toString())
+                .put(OpenTelemetryAttributes.PULSAR_TENANT, topicName.getTenant())
+                .put(OpenTelemetryAttributes.PULSAR_NAMESPACE, topicName.getNamespace())
+                .put(OpenTelemetryAttributes.PULSAR_TOPIC, topicName.getPartitionedTopicName());
+        if (topicName.isPartitioned()) {
+                builder.put(OpenTelemetryAttributes.PULSAR_PARTITION_INDEX, topicName.getPartitionIndex());
+        }
+        commonAttributes = builder.build();
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -36,6 +36,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -62,6 +63,7 @@ import org.apache.pulsar.broker.service.StreamingStats;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.SubscriptionOption;
 import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.broker.service.TopicAttributes;
 import org.apache.pulsar.broker.service.TopicPolicyListener;
 import org.apache.pulsar.broker.service.TransportCnx;
 import org.apache.pulsar.broker.stats.ClusterReplicationMetrics;
@@ -116,6 +118,11 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             return new TopicStats();
         }
     };
+
+    private volatile TopicAttributes topicAttributes = null;
+    private static final AtomicReferenceFieldUpdater<NonPersistentTopic, TopicAttributes>
+            TOPIC_ATTRIBUTES_FIELD_UPDATER = AtomicReferenceFieldUpdater.newUpdater(
+                    NonPersistentTopic.class, TopicAttributes.class, "topicAttributes");
 
     private static class TopicStats {
         public double averageMsgSize;
@@ -1267,5 +1274,14 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
     @Override
     public long getBestEffortOldestUnacknowledgedMessageAgeSeconds() {
         return -1;
+    }
+
+    @Override
+    public TopicAttributes getTopicAttributes() {
+        if (topicAttributes != null) {
+            return topicAttributes;
+        }
+        return TOPIC_ATTRIBUTES_FIELD_UPDATER.updateAndGet(this,
+                old -> old != null ? old : new TopicAttributes(NonPersistentTopic.this));
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -1282,6 +1282,6 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             return topicAttributes;
         }
         return TOPIC_ATTRIBUTES_FIELD_UPDATER.updateAndGet(this,
-                old -> old != null ? old : new TopicAttributes(NonPersistentTopic.this));
+                old -> old != null ? old : new TopicAttributes(TopicName.get(topic)));
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -4367,6 +4367,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             return persistentTopicAttributes;
         }
         return PERSISTENT_TOPIC_ATTRIBUTES_FIELD_UPDATER.updateAndGet(this,
-                old -> old != null ? old : new PersistentTopicAttributes(PersistentTopic.this));
+                old -> old != null ? old : new PersistentTopicAttributes(TopicName.get(topic)));
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -123,6 +123,7 @@ import org.apache.pulsar.broker.service.BrokerServiceException.UnsupportedVersio
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.Dispatcher;
 import org.apache.pulsar.broker.service.GetStatsOptions;
+import org.apache.pulsar.broker.service.PersistentTopicAttributes;
 import org.apache.pulsar.broker.service.Producer;
 import org.apache.pulsar.broker.service.Replicator;
 import org.apache.pulsar.broker.service.StreamingStats;
@@ -290,6 +291,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     @Getter
     private final PersistentTopicMetrics persistentTopicMetrics = new PersistentTopicMetrics();
+
+    private volatile PersistentTopicAttributes persistentTopicAttributes = null;
+    private static final AtomicReferenceFieldUpdater<PersistentTopic, PersistentTopicAttributes>
+            PERSISTENT_TOPIC_ATTRIBUTES_FIELD_UPDATER = AtomicReferenceFieldUpdater.newUpdater(
+                    PersistentTopic.class, PersistentTopicAttributes.class, "persistentTopicAttributes");
 
     private volatile TimeBasedBacklogQuotaCheckResult timeBasedBacklogQuotaCheckResult;
     private static final AtomicReferenceFieldUpdater<PersistentTopic, TimeBasedBacklogQuotaCheckResult>
@@ -4355,4 +4361,12 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return false;
     }
 
+    @Override
+    public PersistentTopicAttributes getTopicAttributes() {
+        if (persistentTopicAttributes != null) {
+            return persistentTopicAttributes;
+        }
+        return PERSISTENT_TOPIC_ATTRIBUTES_FIELD_UPDATER.updateAndGet(this,
+                old -> old != null ? old : new PersistentTopicAttributes(PersistentTopic.this));
+    }
 }

--- a/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
+++ b/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.opentelemetry;
 
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import java.util.List;
 
 /**
@@ -100,14 +101,30 @@ public interface OpenTelemetryAttributes {
      * The status of the Pulsar transaction.
      */
     AttributeKey<String> PULSAR_TRANSACTION_STATUS = AttributeKey.stringKey("pulsar.transaction.status");
+    enum TransactionStatus {
+        ACTIVE,
+        COMMITTED,
+        ABORTED;
+        public final Attributes attributes = Attributes.of(PULSAR_TRANSACTION_STATUS, name().toLowerCase());
+    }
 
     /**
      * The status of the Pulsar compaction operation.
      */
     AttributeKey<String> PULSAR_COMPACTION_STATUS = AttributeKey.stringKey("pulsar.compaction.status");
+    enum CompactionStatus {
+        SUCCESS,
+        FAILURE;
+        public final Attributes attributes = Attributes.of(PULSAR_COMPACTION_STATUS, name().toLowerCase());
+    }
 
     /**
      * The type of the backlog quota.
      */
     AttributeKey<String> PULSAR_BACKLOG_QUOTA_TYPE = AttributeKey.stringKey("pulsar.backlog.quota.type");
+    enum BacklogQuotaType {
+        SIZE,
+        TIME;
+        public final Attributes attributes = Attributes.of(PULSAR_BACKLOG_QUOTA_TYPE, name().toLowerCase());
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/22817

### Motivation

Successive collections of OpenTelemetry metrics re-allocate all attribute sets related to a topic. Since topics are a high-cardinality object in Pulsar, this puts pressure on the GC. This PR proposes caching these attribute sets.

### Modifications

- Adds classes `TopicAttributes` and `PersistentTopicAttributes` to store all attribute sets relevant for a topic.
- Add and lazily initialize these attribute fields in the `NonPersistentTopic` and `PersistentTopic` objects. If OpenTelemetry is not enabled, these objects never get created, saving memory.
- Modify `OpenTelemetryTopicStats` to use the cached objects instead of re-allocating them every run.
- Relocate some of the attributes into interface `OpenTelemetryAttributes`, for a cleaner design.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `org.apache.pulsar.broker.stats.OpenTelemetryTopicStatsTest`.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dragosvictor/pulsar/pull/31
