### PR TITLE
[fix][misc] Add proper nslookup (included in bind-tools) to docker image

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -81,7 +81,7 @@ FROM apachepulsar/glibc-base:2.38 as glibc
 FROM alpine:3.19.1
 ENV LANG C.UTF-8
 
-# Install some utilities
+# Install some utilities, some are required by Pulsar scripts
 RUN apk add --no-cache \
             bash \
             python3 \
@@ -91,7 +91,8 @@ RUN apk add --no-cache \
             gcompat \
             ca-certificates \
             procps \
-            curl
+            curl \
+            bind-utils
 
 # Upgrade all packages to get latest versions with security fixes
 RUN apk upgrade --no-cache

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -92,7 +92,7 @@ RUN apk add --no-cache \
             ca-certificates \
             procps \
             curl \
-            bind-utils
+            bind-tools
 
 # Upgrade all packages to get latest versions with security fixes
 RUN apk upgrade --no-cache


### PR DESCRIPTION
Fixes: #22877 

### Motivation

The default `nslookup` in Alpine is based on busybox and it isn't compatible with Kubernetes. See #22877 for more details.

### Modifications

Install `bind-tools` package to get proper `nslookup`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->