### PR TITLE
[fix][build] Add re2/j dependency to pulsar-common and client shading

### DIFF
--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -122,6 +122,7 @@
                   <include>com.google.protobuf:protobuf-java</include>
                   <include>com.google.guava:guava</include>
                   <include>com.google.code.gson:gson</include>
+                  <include>com.google.re2j:re2j</include>
                   <include>com.fasterxml.jackson.*:*</include>
                   <include>io.netty:*</include>
                   <include>io.netty.incubator:*</include>

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -166,6 +166,7 @@
                   <include>com.google.errorprone:*</include>
                   <include>com.google.j2objc:*</include>
                   <include>com.google.code.gson:gson</include>
+                  <include>com.google.re2j:re2j</include>
                   <include>com.fasterxml.jackson.*:*</include>
                   <include>io.netty:netty</include>
                   <include>io.netty:netty-all</include>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -144,6 +144,7 @@
                   <include>com.google.errorprone:*</include>
                   <include>com.google.j2objc:*</include>
                   <include>com.google.code.gson:gson</include>
+                  <include>com.google.re2j:re2j</include>
                   <include>com.fasterxml.jackson.*:*</include>
                   <include>io.netty:*</include>
                   <include>io.netty.incubator:*</include>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -206,6 +206,11 @@
 	  <artifactId>protobuf-java</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.re2j</groupId>
+      <artifactId>re2j</artifactId>
+    </dependency>
+
     <!-- test -->
     <dependency>
       <groupId>org.bouncycastle</groupId>

--- a/pulsar-common/src/main/java-templates/org/apache/pulsar/PulsarVersion.java
+++ b/pulsar-common/src/main/java-templates/org/apache/pulsar/PulsarVersion.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pulsar;
 
-import com.google.re2j.Matcher;
-import com.google.re2j.Pattern;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class PulsarVersion {
 


### PR DESCRIPTION
Follow up on #22829 changes

### Motivation

I noticed that pulsar-common didn't have an explicit re2/j dependency and client shading configs were missing. I also noticed that PulsarVersion should continue to use plain `java.util.regex.Pattern`.

### Modifications

- add explicit dependency to `com.google.re2j:re2j` to pulsar-common module
  - relying on an external transient dependency isn't recommended
- add shading configs for `com.google.re2j:re2j` to pulsar-client-admin-shaded, pulsar-client-all and pulsar-client-shaded
- revert changes to PulsarVersion since it doesn't contain user provided regex

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->