### PR TITLE
[fix][cli] Fix Pulsar standalone "--wipe-data"

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -18,12 +18,14 @@
  */
 package org.apache.pulsar;
 
+import static org.apache.commons.io.FileUtils.cleanDirectory;
 import static org.apache.pulsar.common.naming.NamespaceName.SYSTEM_NAMESPACE;
 import static org.apache.pulsar.common.naming.SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import io.netty.util.internal.PlatformDependent;
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -446,7 +448,12 @@ public class PulsarStandalone implements AutoCloseable {
     void startBookieWithMetadataStore() throws Exception {
         if (StringUtils.isBlank(metadataStoreUrl)){
             log.info("Starting BK with RocksDb metadata store");
-            metadataStoreUrl = "rocksdb://" + Paths.get(metadataDir).toAbsolutePath();
+            Path metadataDirPath = Paths.get(metadataDir);
+            metadataStoreUrl = "rocksdb://" + metadataDirPath.toAbsolutePath();
+            if (wipeData && Files.exists(metadataDirPath)) {
+                log.info("Wiping RocksDb metadata store at {}", metadataStoreUrl);
+                cleanDirectory(metadataDirPath.toFile());
+            }
         } else {
             log.info("Starting BK with metadata store: {}", metadataStoreUrl);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -194,6 +194,7 @@ public class LocalBookkeeperEnsemble {
                 : createTempDirectory("zktest");
 
         if (this.clearOldData) {
+            LOG.info("Wiping Zookeeper data directory at {}", zkDataDir.getAbsolutePath());
             cleanDirectory(zkDataDir);
         }
 
@@ -291,6 +292,7 @@ public class LocalBookkeeperEnsemble {
                     : createTempDirectory("bk" + i + "test");
 
             if (this.clearOldData) {
+                LOG.info("Wiping Bookie data directory at {}", bkDataDir.getAbsolutePath());
                 cleanDirectory(bkDataDir);
             }
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BKCluster.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/BKCluster.java
@@ -232,6 +232,7 @@ public class BKCluster implements AutoCloseable {
         }
 
         if (clusterConf.clearOldData && dataDir.exists()) {
+            log.info("Wiping Bookie data directory at {}", dataDir.getAbsolutePath());
             cleanDirectory(dataDir);
         }
 


### PR DESCRIPTION
Fixes #22881

### Motivation

See #22881. The issue wasn't fully addressed in the previous fix for #16741 in #16744. That fix only deletes Bookie data, but not the RocksDB based metadata store.

### Modifications

- Handle deleting the RocksDB metadata store
- Add logging to all locations when data is wiped

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->