### PR TITLE
[improve] [pip] PIP-358: let resource weight work for OverloadShedder, LeastLongTermMessageRate, ModularLoadManagerImpl.

### DIFF
--- a/pip/pip-358.md
+++ b/pip/pip-358.md
@@ -1,0 +1,37 @@
+
+# PIP-358: let resource weight work for OverloadShedder, LeastLongTermMessageRate, ModularLoadManagerImpl.
+
+# Background knowledge
+
+Initially, we introduce `loadBalancerCPUResourceWeight`, `loadBalancerBandwidthInResourceWeight`, `loadBalancerBandwidthOutResourceWeight`, 
+`loadBalancerMemoryResourceWeight`, `loadBalancerDirectMemoryResourceWeight` in `ThresholdShedder` to control the resource weight for 
+different resources when calculating the load of the broker. 
+Then we let it work for `LeastResourceUsageWithWeight` for better bundle placement policy.
+
+But https://github.com/apache/pulsar/pull/19559 and https://github.com/apache/pulsar/pull/21168 have point out that the actual load of 
+the broker is not related to the memory usage and direct memory usage, thus we have changed the default value of
+`loadBalancerMemoryResourceWeight`, `loadBalancerDirectMemoryResourceWeight` to 0.0.
+
+There are still some places where memory usage and direct memory usage are used to calculate the load of the broker, such as
+`OverloadShedder`, `LeastLongTermMessageRate`, `ModularLoadManagerImpl`. We should let the resource weight work for these places
+so that we can set the resource weight to 0.0 to avoid the impact of memory usage and direct memory usage on the load of the broker.
+
+# Motivation
+
+The actual load of the broker is not related to the memory usage and direct memory usage, thus we should let the resource weight work for
+`OverloadShedder`, `LeastLongTermMessageRate`, `ModularLoadManagerImpl` so that we can set the resource weight to 0.0 to avoid the impact of
+memory usage and direct memory usage on the load of the broker.
+
+
+# Detailed Design
+
+- Let resource weight work for `OverloadShedder`, `LeastLongTermMessageRate`, `ModularLoadManagerImpl`.
+
+
+# Backward & Forward Compatibility
+
+
+# Links
+
+* Mailing List discussion thread:
+* Mailing List voting thread:

--- a/pip/pip-358.md
+++ b/pip/pip-358.md
@@ -35,4 +35,4 @@ Let resource weight work for `OverloadShedder`, `LeastLongTermMessageRate`, `Mod
 # Links
 
 * Mailing List discussion thread: https://lists.apache.org/thread/lj34s3vmjbzlwmy8d66d0bsb25vnq9ky
-* Mailing List voting thread:
+* Mailing List voting thread: https://lists.apache.org/thread/b7dzm0yz6l40pkxmxhto5mro7brmz57r

--- a/pip/pip-358.md
+++ b/pip/pip-358.md
@@ -8,8 +8,8 @@ Initially, we introduce `loadBalancerCPUResourceWeight`, `loadBalancerBandwidthI
 different resources when calculating the load of the broker. 
 Then we let it work for `LeastResourceUsageWithWeight` for better bundle placement policy.
 
-But https://github.com/apache/pulsar/pull/19559 and https://github.com/apache/pulsar/pull/21168 have point out that the actual load of 
-the broker is not related to the memory usage and direct memory usage, thus we have changed the default value of
+But https://github.com/apache/pulsar/pull/19559 and https://github.com/apache/pulsar/pull/21168 have pointed out that the actual load 
+of the broker is not related to the memory usage and direct memory usage, thus we have changed the default value of
 `loadBalancerMemoryResourceWeight`, `loadBalancerDirectMemoryResourceWeight` to 0.0.
 
 There are still some places where memory usage and direct memory usage are used to calculate the load of the broker, such as
@@ -33,5 +33,5 @@ memory usage and direct memory usage on the load of the broker.
 
 # Links
 
-* Mailing List discussion thread:
+* Mailing List discussion thread: https://lists.apache.org/thread/lj34s3vmjbzlwmy8d66d0bsb25vnq9ky
 * Mailing List voting thread:

--- a/pip/pip-358.md
+++ b/pip/pip-358.md
@@ -25,8 +25,9 @@ memory usage and direct memory usage on the load of the broker.
 
 # Detailed Design
 
-- Let resource weight work for `OverloadShedder`, `LeastLongTermMessageRate`, `ModularLoadManagerImpl`.
-
+Let resource weight work for `OverloadShedder`, `LeastLongTermMessageRate`, `ModularLoadManagerImpl`.
+- For `OverloadShedder`, `LeastLongTermMessageRate`, we replace `getMaxResourceUsage()` with `getMaxResourceUsageWithWeight()` in the calculation of the load of the broker.
+- For `ModularLoadManagerImpl`, we replace `getMaxResourceUsage()` with `getMaxResourceUsageWithWeight()` when checking if the broker is overloaded and decide whether to update the broker data to metadata store.
 
 # Backward & Forward Compatibility
 


### PR DESCRIPTION
Implementation PR: https://github.com/apache/pulsar/pull/22888

### Motivation

Initially, we introduce `loadBalancerCPUResourceWeight`, `loadBalancerBandwidthInResourceWeight`, `loadBalancerBandwidthOutResourceWeight`, `loadBalancerMemoryResourceWeight`, `loadBalancerDirectMemoryResourceWeight` in `ThresholdShedder` to control the resource weight for different resources when calculating the load of the broker. 

Then we let it work for `LeastResourceUsageWithWeight` for better bundle placement policy.

But https://github.com/apache/pulsar/pull/19559 and https://github.com/apache/pulsar/pull/21168 have point out that the actual load of the broker is not related to the memory usage and direct memory usage, thus we have changed the default value of `loadBalancerMemoryResourceWeight`, `loadBalancerDirectMemoryResourceWeight` to 0.0.


There are still some places where memory usage and direct memory usage are used to calculate the load of the broker, such as `OverloadShedder`, `LeastLongTermMessageRate`, `ModularLoadManagerImpl`. We should let the resource weight work for these places so that we can set the resource weight to 0.0 to avoid the impact of memory usage and direct memory usage on the load of the broker.


### Modifications

- Let resource weight work for `OverloadShedder`, `LeastLongTermMessageRate`, `ModularLoadManagerImpl`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 