### PR TITLE
[fix] [broker] Messages lost on the remote cluster when using topic level replication

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -549,7 +549,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     private CompletableFuture<Void> removeOrphanReplicationCursors() {
         List<CompletableFuture<Void>> futures = new ArrayList<>();
-        String localCluster = brokerService.pulsar().getConfiguration().getClusterName();
         List<String> replicationClusters = topicPolicies.getReplicationClusters().get();
         for (ManagedCursor cursor : ledger.getCursors()) {
             if (cursor.getName().startsWith(replicatorPrefix)) {
@@ -557,7 +556,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 if (!replicationClusters.contains(remoteCluster)) {
                     log.warn("Remove the replicator because the cluster '{}' does not exist", remoteCluster);
                     futures.add(removeReplicator(remoteCluster));
-                    continue;
                 }
             }
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -554,7 +554,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             if (cursor.getName().startsWith(replicatorPrefix)) {
                 String remoteCluster = PersistentReplicator.getRemoteCluster(cursor.getName());
                 if (!replicationClusters.contains(remoteCluster)) {
-                    log.warn("Remove the replicator because the cluster '{}' does not exist", remoteCluster);
+                    log.warn("Remove the orphan replicator because the cluster '{}' does not exist", remoteCluster);
                     futures.add(removeReplicator(remoteCluster));
                 }
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -559,9 +559,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     futures.add(removeReplicator(remoteCluster));
                     continue;
                 }
-                if (localCluster.equals(remoteCluster)) {
-                    log.warn("Remove the replicator because the cluster '{}' does not exist", remoteCluster);
-                }
             }
         }
         return FutureUtil.waitForAll(futures);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTestBase.java
@@ -350,6 +350,11 @@ public abstract class OneWayReplicatorTestBase extends TestRetrySupport {
     }
 
     protected void verifyReplicationWorks(String topic) throws Exception {
+        Awaitility.await().untilAsserted(() -> {
+            PersistentTopic persistentTopic =
+                    (PersistentTopic) pulsar1.getBrokerService().getTopic(topic, false).join().get();
+            assertTrue(persistentTopic.getReplicators().size() > 0);
+        });
         final String subscription = "__subscribe_1";
         final String msgValue = "__msg1";
         Producer<String> producer1 = client1.newProducer(Schema.STRING).topic(topic).create();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTestBase.java
@@ -350,11 +350,28 @@ public abstract class OneWayReplicatorTestBase extends TestRetrySupport {
     }
 
     protected void verifyReplicationWorks(String topic) throws Exception {
-        Awaitility.await().untilAsserted(() -> {
-            PersistentTopic persistentTopic =
-                    (PersistentTopic) pulsar1.getBrokerService().getTopic(topic, false).join().get();
-            assertTrue(persistentTopic.getReplicators().size() > 0);
+        // Wait for replicator starting.
+        Awaitility.await().until(() -> {
+            try {
+                PersistentTopic persistentTopic = (PersistentTopic) pulsar1.getBrokerService()
+                                .getTopic(topic, false).join().get();
+                if (persistentTopic.getReplicators().size() > 0) {
+                    return true;
+                }
+            } catch (Exception ex) {}
+
+            try {
+                String partition0 = TopicName.get(topic).getPartition(0).toString();
+                PersistentTopic persistentTopic = (PersistentTopic) pulsar1.getBrokerService()
+                        .getTopic(partition0, false).join().get();
+                if (persistentTopic.getReplicators().size() > 0) {
+                    return true;
+                }
+            } catch (Exception ex) {}
+
+            return false;
         });
+        // Verify: pub & sub.
         final String subscription = "__subscribe_1";
         final String msgValue = "__msg1";
         Producer<String> producer1 = client1.newProducer(Schema.STRING).topic(topic).create();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
@@ -106,7 +106,7 @@ public class OneWayReplicatorUsingGlobalZKTest extends OneWayReplicatorTest {
     }
 
     @Test(enabled = false)
-    public void testReloadWithTopicLevelGeoReplication() throws Exception {
-        super.testReloadWithTopicLevelGeoReplication();
+    public void testReloadWithTopicLevelGeoReplication(ReplicationLevel replicationLevel) throws Exception {
+        super.testReloadWithTopicLevelGeoReplication(replicationLevel);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
@@ -104,4 +104,9 @@ public class OneWayReplicatorUsingGlobalZKTest extends OneWayReplicatorTest {
     public void testExpandTopicPartitionsOnNamespaceLevelReplication() throws Exception {
         super.testExpandTopicPartitionsOnNamespaceLevelReplication();
     }
+
+    @Test(enabled = false)
+    public void testReloadWithTopicLevelGeoReplication() throws Exception {
+        super.testReloadWithTopicLevelGeoReplication();
+    }
 }


### PR DESCRIPTION
### Motivation

**Background**
1. the method `PersistentTopic.addReplicationCluster` will remove orphan replication cursors, see https://github.com/apache/pulsar/pull/19972
2. when a topic is loading up, it will initialize replicators by the cursors named `pulsar.repl.<remote cluster>`

**Issue**
- Mechanism `2` was called before topic-level policies initializing, so it will remove the replicator and cursor when a topic is loading up. 
- After the topic level policies are initialized, the broker will create a new replicator with a new cursor(start at the `latest position`), and all the messages in backlog are lost.

This issue may cause messages to be lost when using topic-level Geo-Replication. For example:
- Enable topic level Geo-Replication
- Send messages on this topic
  - There are 3 ledgers under the topic: `{L1: 0~50000, L2: 0~50000, L3: 0~5000}`
  - The replication cursor came to `L1: 10000` now.
- Unload the topic.
  - The Replication cursor was removed due to the remote cluster is not in the replicated cluster list(the topic level policies have not been loaded yet).
  - Create a new replication cursor after the topic-level policies are loaded. But the new cursor will start at the `latest` position(`L3: 50001`)
- The messages `L1: 10001 ~ L3: 50000` were lost 

### Modifications

Fix the issue: make Mechanism `2` being called after the topic-level policies were loaded.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
