### PR TITLE
[fix][broker] Asynchronously return brokerRegistry.lookupAsync when checking if broker is active(ExtensibleLoadManagerImpl only)

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
@@ -1620,32 +1620,63 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
     @Test(priority = 19)
     public void testActiveGetOwner() throws Exception {
 
-
-        // set the bundle owner is the broker
+        // case 1: the bundle owner is empty
         String broker = brokerId2;
         String bundle = "public/owned/0xfffffff0_0xffffffff";
+        overrideTableViews(bundle, null);
+        assertEquals(Optional.empty(), channel1.getOwnerAsync(bundle).get());
+
+        // case 2: the bundle ownership is transferring, and the dst broker is not the channel owner
+        overrideTableViews(bundle,
+                new ServiceUnitStateData(Releasing, broker, brokerId1, 1));
+        assertEquals(Optional.of(broker), channel1.getOwnerAsync(bundle).get());
+
+
+        // case 3: the bundle ownership is transferring, and the dst broker is the channel owner
+        overrideTableViews(bundle,
+                new ServiceUnitStateData(Assigning, brokerId1, brokerId2, 1));
+        assertTrue(!channel1.getOwnerAsync(bundle).isDone());
+
+        // case 4: the bundle ownership is found
         overrideTableViews(bundle,
                 new ServiceUnitStateData(Owned, broker, null, 1));
         var owner = channel1.getOwnerAsync(bundle).get(5, TimeUnit.SECONDS).get();
         assertEquals(owner, broker);
 
-        // simulate the owner is inactive
+        // case 5: the owner lookup gets delayed
         var spyRegistry = spy(new BrokerRegistryImpl(pulsar));
-        doReturn(CompletableFuture.completedFuture(Optional.empty()))
-                .when(spyRegistry).lookupAsync(eq(broker));
         FieldUtils.writeDeclaredField(channel1,
                 "brokerRegistry", spyRegistry , true);
         FieldUtils.writeDeclaredField(channel1,
                 "inFlightStateWaitingTimeInMillis", 1000, true);
+        var delayedFuture = new CompletableFuture();
+        doReturn(delayedFuture).when(spyRegistry).lookupAsync(eq(broker));
+        CompletableFuture.runAsync(() -> {
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();;
+            }
+            delayedFuture.complete(Optional.of(broker));
+        });
 
-
-        // verify getOwnerAsync times out because the owner is inactive now.
+        // verify the owner eventually returns in inFlightStateWaitingTimeInMillis.
         long start = System.currentTimeMillis();
+        assertEquals(broker, channel1.getOwnerAsync(bundle).get().get());
+        long elapsed = System.currentTimeMillis() - start;
+        assertTrue(elapsed < 1000);
+
+        // case 6: the owner is inactive
+        doReturn(CompletableFuture.completedFuture(Optional.empty()))
+                .when(spyRegistry).lookupAsync(eq(broker));
+
+        // verify getOwnerAsync times out
+        start = System.currentTimeMillis();
         var ex = expectThrows(ExecutionException.class, () -> channel1.getOwnerAsync(bundle).get());
         assertTrue(ex.getCause() instanceof IllegalStateException);
         assertTrue(System.currentTimeMillis() - start >= 1000);
 
-        // simulate ownership cleanup(no selected owner) by the leader channel
+        // case 7: the ownership cleanup(no new owner) by the leader channel
         doReturn(CompletableFuture.completedFuture(Optional.empty()))
                 .when(loadManager).selectAsync(any(), any(), any());
         var leaderChannel = channel1;
@@ -1669,7 +1700,8 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         waitUntilState(channel2, bundle, Init);
 
         assertTrue(System.currentTimeMillis() - start < 20_000);
-        // simulate ownership cleanup(brokerId1 selected owner) by the leader channel
+
+        // case 8: simulate ownership cleanup(brokerId1 as the new owner) by the leader channel
         overrideTableViews(bundle,
                 new ServiceUnitStateData(Owned, broker, null, 1));
         doReturn(CompletableFuture.completedFuture(Optional.of(brokerId1)))
@@ -1693,6 +1725,7 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         cleanTableViews();
 
     }
+
 
     private static ConcurrentHashMap<String, CompletableFuture<Optional<String>>> getOwnerRequests(
             ServiceUnitStateChannel channel) throws IllegalAccessException {


### PR DESCRIPTION


<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation
- The broker could falsely return that brokers were inactive too soon if the broker registry cache was empty. 

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications
- Asynchronously return `brokerRegistry.lookupAsync` instead of using `future.getNow`.

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
