### PR TITLE
[fix][cli] Fix the pulsar-daemon parameter passthrough syntax

### DIFF
--- a/bin/pulsar-daemon
+++ b/bin/pulsar-daemon
@@ -157,7 +157,7 @@ start ()
     echo starting $command, logging to $logfile
     echo Note: Set immediateFlush to true in conf/log4j2.yaml will guarantee the logging event is flushing to disk immediately. The default behavior is switched off due to performance considerations.
     pulsar=$PULSAR_HOME/bin/pulsar
-    nohup $pulsar $command "$1" > "$out" 2>&1 < /dev/null &
+    nohup $pulsar $command $1 > "$out" 2>&1 < /dev/null &
     echo $! > $pid
     sleep 1; head $out
     sleep 2;

--- a/bin/pulsar-daemon
+++ b/bin/pulsar-daemon
@@ -157,7 +157,7 @@ start ()
     echo starting $command, logging to $logfile
     echo Note: Set immediateFlush to true in conf/log4j2.yaml will guarantee the logging event is flushing to disk immediately. The default behavior is switched off due to performance considerations.
     pulsar=$PULSAR_HOME/bin/pulsar
-    nohup $pulsar $command $1 > "$out" 2>&1 < /dev/null &
+    nohup $pulsar $command "$@" > "$out" 2>&1 < /dev/null &
     echo $! > $pid
     sleep 1; head $out
     sleep 2;
@@ -216,7 +216,7 @@ stop ()
 
 case $startStop in
   (start)
-    start "$*"
+    start "$@"
     ;;
 
   (stop)
@@ -224,21 +224,20 @@ case $startStop in
     ;;
 
   (restart)
-    forceStopFlag=$(echo "$*"|grep "\-force")
-    if [[ "$forceStopFlag" != "" ]]
+    if [[ "$1" == "-force" ]]
     then
-      stop "-force"
+      stop -force
+      # remove "-force" from the arguments
+      shift
     else
       stop
     fi
     if [ "$?" == 0 ]
     then
-       sleep 3
-       paramaters="$*"
-       startParamaters=${paramaters//-force/}
-       start "$startParamaters"
+      sleep 3
+      start "$@"
     else
-       echo "WARNNING :  $command failed restart, for $command is not stopped completely."
+      echo "WARNNING :  $command failed restart, for $command is not stopped completely."
     fi
     ;;
 


### PR DESCRIPTION
### Motivation

Using `bin/pulsar-daemon start standalone` can't start pulsar due to https://github.com/apache/pulsar/pull/22867 changing `bin/pulsar` parameter passthrough syntax.

### Modifications

replace `"$1"` with `"$@"` in bin/pulsar

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
