### PR TITLE
[fix][broker] Fix topic status for oldestBacklogMessageAgeSeconds continuously increases even when there is no backlog.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1467,7 +1467,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     return FutureUtil.failedFuture(
                             new TopicBusyException("Topic has subscriptions: " + subscriptions.keys()));
                 } else if (failIfHasBacklogs) {
-                    if (hasBacklogs()) {
+                    if (hasBacklogs(false)) {
                         List<String> backlogSubs =
                                 subscriptions.values().stream()
                                         .filter(sub -> sub.getNumberOfEntriesInBacklog(false) > 0)
@@ -2638,12 +2638,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         stats.backlogQuotaLimitTime = getBacklogQuota(BacklogQuotaType.message_age).getLimitTime();
 
         TimeBasedBacklogQuotaCheckResult backlogQuotaCheckResult = timeBasedBacklogQuotaCheckResult;
-        stats.oldestBacklogMessageAgeSeconds = (backlogQuotaCheckResult == null)
-            ? (long) -1
-                : TimeUnit.MILLISECONDS.toSeconds(
-                Clock.systemUTC().millis() - backlogQuotaCheckResult.getPositionPublishTimestampInMillis());
-
+        stats.oldestBacklogMessageAgeSeconds = getBestEffortOldestUnacknowledgedMessageAgeSeconds();
         stats.oldestBacklogMessageSubscriptionName = (backlogQuotaCheckResult == null)
+                || !hasBacklogs(getStatsOptions.isGetPreciseBacklog())
             ? null
             : backlogQuotaCheckResult.getCursorName();
 
@@ -2906,7 +2903,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 }
                 break;
             case delete_when_subscriptions_caught_up:
-                if (hasBacklogs()) {
+                if (hasBacklogs(false)) {
                     return true;
                 }
                 break;
@@ -2919,8 +2916,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }
     }
 
-    private boolean hasBacklogs() {
-        return subscriptions.values().stream().anyMatch(sub -> sub.getNumberOfEntriesInBacklog(false) > 0);
+    private boolean hasBacklogs(boolean getPreciseBacklog) {
+        return subscriptions.values().stream().anyMatch(sub -> sub.getNumberOfEntriesInBacklog(getPreciseBacklog) > 0);
     }
 
     @Override
@@ -3466,6 +3463,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     @Override
     public long getBestEffortOldestUnacknowledgedMessageAgeSeconds() {
+        if (!hasBacklogs(false)) {
+            return 0;
+        }
         TimeBasedBacklogQuotaCheckResult result = timeBasedBacklogQuotaCheckResult;
         if (result == null) {
             return -1;
@@ -3553,6 +3553,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }
 
         if (brokerService.pulsar().getConfiguration().isPreciseTimeBasedBacklogQuotaCheck()) {
+            if (!hasBacklogs(true)) {
+                return CompletableFuture.completedFuture(false);
+            }
             CompletableFuture<Boolean> future = new CompletableFuture<>();
             // Check if first unconsumed message(first message after mark delete position)
             // for slowest cursor's has expired.
@@ -3606,6 +3609,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             return future;
         } else {
             try {
+                if (!hasBacklogs(false)) {
+                    return CompletableFuture.completedFuture(false);
+                }
                 EstimateTimeBasedBacklogQuotaCheckResult checkResult =
                         estimatedTimeBasedBacklogQuotaCheck(oldestMarkDeletePosition);
                 if (checkResult.getEstimatedOldestUnacknowledgedMessageTimestamp() != null) {


### PR DESCRIPTION
### Motivation
The #21816 introduces the `pulsar_storage_backlog_age_seconds` metrics, and refactors logic for `checkTimeBacklogExceeded`. It has two problems:

1. Even if the consumers under the topic have consumed all the data, `pulsar_storage_backlog_age_seconds` will not become **0** and will continue to increase over time. This is because its calculation: `current time - publish time of the last message`.
2. If the user has configured [BacklogQuota.message_age](https://github.com/apache/pulsar/blob/17bb3227536f891d4f2ef234da596bdb5bb46bbb/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java#L1651-L1652), it will also affect the ability of producers to continue sending messages, even if there is currently no backlog under this topic.


### Modifications
1. In `PersistentTopic.checkTimeBacklogExceeded` method, if the topic has no backlog, it should return `false` directly.
2. In `PersistentTopic.asyncGetStats` method, if the topic has no backlog, it should be set `oldestBacklogMessageAgeSeconds = 0`


### Verifying this change
- Add `backlogsStatsPreciseWithNoBacklog` unit test to cover this case with configuration: `preciseTimeBasedBacklogQuotaCheck=true, exposePreciseBacklogInPrometheus=true`
- Add `backlogsStatsNotPreciseWithNoBacklog` unit test to cover this case with configuration: `preciseTimeBasedBacklogQuotaCheck=false, exposePreciseBacklogInPrometheus=false`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
