### PR TITLE
[feat][broker] PIP-264: Enable OpenTelemetry reusable data memory mode

### DIFF
--- a/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryService.java
+++ b/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryService.java
@@ -72,7 +72,9 @@ public class OpenTelemetryService implements Closeable {
         sdkBuilder.addPropertiesSupplier(() -> Map.of(
                 OTEL_SDK_DISABLED_KEY, "true",
                 // Cardinality limit includes the overflow attribute set, so we need to add 1.
-                "otel.experimental.metrics.cardinality.limit", Integer.toString(MAX_CARDINALITY_LIMIT + 1)
+                "otel.experimental.metrics.cardinality.limit", Integer.toString(MAX_CARDINALITY_LIMIT + 1),
+                // Reduce number of allocations by using reusable data mode.
+                "otel.java.experimental.exporter.memory_mode", "reusable_data"
         ));
 
         sdkBuilder.addResourceCustomizer(

--- a/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryService.java
+++ b/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryService.java
@@ -25,6 +25,7 @@ import io.opentelemetry.instrumentation.runtimemetrics.java17.RuntimeMetrics;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
+import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.ResourceAttributes;
 import java.io.Closeable;
@@ -74,7 +75,7 @@ public class OpenTelemetryService implements Closeable {
                 // Cardinality limit includes the overflow attribute set, so we need to add 1.
                 "otel.experimental.metrics.cardinality.limit", Integer.toString(MAX_CARDINALITY_LIMIT + 1),
                 // Reduce number of allocations by using reusable data mode.
-                "otel.java.experimental.exporter.memory_mode", "reusable_data"
+                "otel.java.experimental.exporter.memory_mode", MemoryMode.REUSABLE_DATA.name()
         ));
 
         sdkBuilder.addResourceCustomizer(


### PR DESCRIPTION
PIP: https://github.com/apache/pulsar/blob/master/pip/pip-264.md

### Motivation

The recently added OpenTelemetry 'reusable data' memory mode allows the OpenTelemetry SDK to reduce the number of memory allocations in between collector runs, at the expense of parallel collection. This is a fair compromise given Pulsar's use-case, and it promises to significantly improve the performance of the metric pipeline.

### Modifications

Enables, by default, the OpenTelemetry 'reusable data' export mode. This can be overridden by the user at runtime via Java system property `otel.java.experimental.exporter.memory_mode` or environment variable `OTEL_JAVA_EXPERIMENTAL_EXPORTER_MEMORY_MODE`. See https://opentelemetry.io/docs/languages/java/configuration/#exporters for a few more details on the config.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as:

- Integration test `org.apache.pulsar.tests.integration.metrics.OpenTelemetrySanityTest`

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [x] The default values of configurations: _As described above_
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dragosvictor/pulsar/pull/32/
