### PR TITLE
[fix] [broker] broker log a full thread dump when a deadlock is detected in healthcheck every time

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -88,7 +88,7 @@ public class BrokersBase extends AdminResource {
     private static final Duration HEALTH_CHECK_READ_TIMEOUT = Duration.ofSeconds(58);
     private static final TimeoutException HEALTH_CHECK_TIMEOUT_EXCEPTION =
             FutureUtil.createTimeoutException("Timeout", BrokersBase.class, "healthCheckRecursiveReadNext(...)");
-    private volatile long threadDumpLoggedTimestamp;
+    private static volatile long threadDumpLoggedTimestamp;
 
     @GET
     @Path("/{cluster}")
@@ -395,8 +395,9 @@ public class BrokersBase extends AdminResource {
             String threadNames = Arrays.stream(threadInfos)
                     .map(threadInfo -> threadInfo.getThreadName() + "(tid=" + threadInfo.getThreadId() + ")").collect(
                             Collectors.joining(", "));
-            if (System.currentTimeMillis() - threadDumpLoggedTimestamp
-                    > LOG_THREADDUMP_INTERVAL_WHEN_DEADLOCK_DETECTED) {
+            if ((System.currentTimeMillis() - threadDumpLoggedTimestamp
+                    > LOG_THREADDUMP_INTERVAL_WHEN_DEADLOCK_DETECTED) ||
+                    threadDumpLoggedTimestamp == 0) {
                 threadDumpLoggedTimestamp = System.currentTimeMillis();
                 LOG.error("Deadlocked threads detected. {}\n{}", threadNames,
                         ThreadDumpUtil.buildThreadDiagnosticString());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -395,9 +395,8 @@ public class BrokersBase extends AdminResource {
             String threadNames = Arrays.stream(threadInfos)
                     .map(threadInfo -> threadInfo.getThreadName() + "(tid=" + threadInfo.getThreadId() + ")").collect(
                             Collectors.joining(", "));
-            if ((System.currentTimeMillis() - threadDumpLoggedTimestamp
-                    > LOG_THREADDUMP_INTERVAL_WHEN_DEADLOCK_DETECTED) ||
-                    threadDumpLoggedTimestamp == 0) {
+            if (System.currentTimeMillis() - threadDumpLoggedTimestamp
+                    > LOG_THREADDUMP_INTERVAL_WHEN_DEADLOCK_DETECTED) {
                 threadDumpLoggedTimestamp = System.currentTimeMillis();
                 LOG.error("Deadlocked threads detected. {}\n{}", threadNames,
                         ThreadDumpUtil.buildThreadDiagnosticString());


### PR DESCRIPTION
Fixes #22915

### Motivation

Broker log a full thread dump when a deadlock is detected in healthcheck every time.

**Our expectation is：**
First detection of deadlock printing full thread dump, then printing at the interval between parameter settings in 
```java
// org.apache.pulsar.broker.admin.impl.BrokersBase.java
private static final long LOG_THREADDUMP_INTERVAL_WHEN_DEADLOCK_DETECTED = 600000L;
```
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

1. class：`org.apache.pulsar.broker.admin.impl.BrokersBase.java ` Variable `threadDumpLoggedTimestamp ` decorated with `static` keyword. Avoid initializing parameters with a value of 0 every time the interface is called.

2. Method `checkDeadlockedThreads` comparison before and after modification:

(1) before:
```java
private void checkDeadlockedThreads() {
        ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
        long[] threadIds = threadBean.findDeadlockedThreads();
        if (threadIds != null && threadIds.length > 0) {
            ThreadInfo[] threadInfos = threadBean.getThreadInfo(threadIds, false, false);
            String threadNames = Arrays.stream(threadInfos)
                    .map(threadInfo -> threadInfo.getThreadName() + "(tid=" + threadInfo.getThreadId() + ")").collect(
                            Collectors.joining(", "));
            if (System.currentTimeMillis() - threadDumpLoggedTimestamp
                    > LOG_THREADDUMP_INTERVAL_WHEN_DEADLOCK_DETECTED) {
                threadDumpLoggedTimestamp = System.currentTimeMillis();
                LOG.error("Deadlocked threads detected. {}\n{}", threadNames,
                        ThreadDumpUtil.buildThreadDiagnosticString());
            } else {
                LOG.error("Deadlocked threads detected. {}", threadNames);
            }
            throw new IllegalStateException("Deadlocked threads detected. " + threadNames);
        }
    }
```
(2)after:
```java
private void checkDeadlockedThreads() {
        ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
        long[] threadIds = threadBean.findDeadlockedThreads();
        if (threadIds != null && threadIds.length > 0) {
            ThreadInfo[] threadInfos = threadBean.getThreadInfo(threadIds, false, false);
            String threadNames = Arrays.stream(threadInfos)
                    .map(threadInfo -> threadInfo.getThreadName() + "(tid=" + threadInfo.getThreadId() + ")").collect(
                            Collectors.joining(", "));
            if ((System.currentTimeMillis() - threadDumpLoggedTimestamp
                    > LOG_THREADDUMP_INTERVAL_WHEN_DEADLOCK_DETECTED) ||
                    threadDumpLoggedTimestamp == 0) {
                threadDumpLoggedTimestamp = System.currentTimeMillis();
                LOG.error("Deadlocked threads detected. {}\n{}", threadNames,
                        ThreadDumpUtil.buildThreadDiagnosticString());
            } else {
                LOG.error("Deadlocked threads detected. {}", threadNames);
            }
            throw new IllegalStateException("Deadlocked threads detected. " + threadNames);
        }
    }
```

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
https://github.com/yyj8/pulsar/pull/9

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
