### PR TITLE
[improve][pip] PIP-361 Support URI, DNS, RID, IP based Token building from client X.509 Certificate SAN Extensions

### DIFF
--- a/pip/pip-361.md
+++ b/pip/pip-361.md
@@ -1,0 +1,144 @@
+# PIP-360: Support URI, DNS, RID, IP based Token building from client's X.509 Certificate SAN Extensions.
+
+# Background Knowledge
+
+Apache Pulsar supports Mutual TLS Authentication (mTLS) as one of the Authentication mechanisms.
+
+Presently, as part of establishing the Client Identity from the Client's X.509 Certificate, it uses `CommonName` from the `DistinguishedName` of the Certificate.
+
+Though it's a good start for implementing the mTLS based Authentication, X.509 Certificate offers multiple extensions that can be taken advantage of to define the client Identity.
+
+In this PIP, we propose to take advantage of the different identifiers present in the X.509v3Extensions as role token, in addition to the current default `CommonName` based identity.
+
+
+# Motivation
+
+Providing multiple options for extracting the Client Identity from the X.509 certificate would greatly benefit the diverse implementations organisations can follow according to their scale.
+
+# Goals
+
+The Goal of this PIP is to provide configuration options to extract the Client Identity (RoleToken) from its X.509 Certificate as part of the mTLS session, in addition to the current `CommonName` based identity.
+Support URI, DNS, RID, IP, EMAIL based identities. In addition to these support a SPIFFE Identifiers which are a subset of URI based names.
+
+## In Scope
+
+- Add a configuration option to pick one of the supported mechanisms to extract the client identity from the X.509 certificate.
+- Add a configuration option to filter based on a string and select the first matched entry from multiple matches from above extraction method.
+
+## High Level Design
+
+- Add new broker configuration option `mTLSIdentityMechanism` and a System property `pulsar.mtls.id.mechanism` to define multiple locations from which the Client Identity to be extracted from X.509v3Extensions portion of the X.509 certificate.
+- Add new broker configuration option `mTLSIdentityMechanismValueFilter` and a System property `pulsar.mtls.id.mechanism.value.filter` to define a filter when more than one value of a type is found in the Subject Alternative Names.
+
+These two configuration options provide the ability to extract the client identity information and also limit it to one result.
+
+# Detailed Design
+
+The following table describes the two new configuration options in the broker.conf for `mTLSIdentityMechanism` and `mTLSIdentityMechanismValueFilter`, possible inputs and
+final role token value to understand the implementation better.
+
+| mTLSIdentityMechanism | mTLSIdentityMechanismValueFilter | X.509 Certificate Field | X.509 Certificate Value                           | Final Role Token      |
+|-----------------------|----------------------------------|-------------------------|---------------------------------------------------|-----------------------|
+| (unset)               | (unset)                          | Distinguished Name      | `CN=Pulsar,O=Apache`                              | `Pulsar`              |
+| distinguished-name    | (no-impact)                      | Distinguished Name      | `CN=Pulsar,O=Apache`                              | `CN=Pulsar,O=Apache`  |
+| common-name           | (no-impact)                      | Distinguished Name      | `CN=Pulsar,O=Apache`                              | `Pulsar`              |
+| serial-no             | (no-impact)                      | Serial Number           | `12345`                                           | `12345`               |
+| san-uri               | (unset)                          | SAN's URN entries       | `URN:urn:x, URN:urn:xx, URN:urn:y`                | `urn:x`               |
+| san-uri               | x                                | SAN's URN entries       | `URN:urn:x, URN:urn:xx, URN:urn:y`                | `urn:x`               |
+| san-uri               | xx                               | SAN's URN entries       | `URN:urn:x, URN:urn:xx, URN:urn:y`                | `urn:xx`              |
+| san-dns               | (unset)                          | SAN's DNS entries       | `DNS:apache.org, DNS:*.apache.org`                | `apache.org`          |
+| san-dns               | apache.org                       | SAN's DNS entries       | `DNS:apache.org, DNS:*.apache.org`                | `apache.org`          |
+| san-dns               | *                                | SAN's DNS entries       | `DNS:apache.org, DNS:*.apache.org`                | `*.apache.org`        |
+| san-ip                | (unset)                          | SAN's IP entries        | `IP:127.0.0.1, DNS:127.0.0.2`                     | `127.0.0.1`           |
+| san-ip                | 0.2                              | SAN's IP entries        | `IP:127.0.0.1, DNS:127.0.0.2`                     | `127.0.0.2`           |
+| san-email             | (unset)                          | SAN's Email entries     | `email:dev@apache.org, email:security@apache.org` | `dev@apache.org`      |
+| san-email             | security                         | SAN's Email entries     | `email:dev@apache.org, email:security@apache.org` | `security@apache.org` |
+| spiffe                | (unset)                          | SAN's URN entries       | `URN:spiffe://x.org/x,spiffe://y.org/y`           | `spiffe://x.org/x`    |
+| spiffe                | y.org                            | SAN's URN entries       | `URN:spiffe://x.org/x,spiffe://y.org/y`           | `spiffe://y.org/y`    |
+
+## Public-facing Changes
+
+No Changes
+
+### Public API
+
+No Changes
+
+### Binary protocol
+
+No Changes
+
+### Configuration
+
+Broker will have new configuration options `mTLSIdentityMechanism` and `mTLSIdentityMechanismValueFilter` in `broker.conf`
+
+```
+#
+# The following are the valid values for the configuration option `mTLSIdentityMechanism`
+# - `distinguished-name`: Uses the distinguished name from the Client Certificate as Role Token
+# - `common-name`: Uses the common name from the Client Certificate as Role Token
+# - `serial-no`: Uses the Serial Number from the Client Certificate as Role Token
+# - `san-uri`: Uses one of the URI entries from the Client Certificate's Subject Alternative Names. By default first value will be picked, unless a matching expression is defined in `mTLSIdentityMechanismValueFilter` option
+# - `san-dns`: Uses one of the DNS entries from the Client Certificate's Subject Alternative Names. By default first value will be picked, unless a matching expression is defined in `mTLSIdentityMechanismValueFilter` option
+# - `san-ip`: Uses one of the IP entries from the Client Certificate's Subject Alternative Names. By default first value will be picked, unless a matching expression is defined in `mTLSIdentityMechanismValueFilter` option
+# - `san-email`: Uses one of the EMAIL entries from the Client Certificate's Subject Alternative Names. By default first value will be picked, unless a matching expression is defined in `mTLSIdentityMechanismValueFilter` option
+# - `spiffe`: Uses one of the URI entries from the Client Certificate's Subject Alternative Names and extracts the values that begin with `spiffe://`. By default first value will be picked, unless a matching expression is defined in `mTLSIdentityMechanismValueFilter` option
+#
+# By default there is no value set for `mTLSIdentityMechanism` which defaults to using common name from the Client Certificates's Subject/Distinguished Name.
+mTLSIdentityMechanism=
+
+#
+# Specify any substring (no regular expressions) that should be matched anywhere in the entries found by `mTLSIdentityMechanism` option to limit to the first result.
+mTLSIdentityMechanismValueFilter=
+```
+
+### CLI
+
+No Changes
+
+### Metrics
+
+No Changes
+
+# Monitoring
+
+Default would suffice
+
+# Security Considerations
+
+Default would suffice
+
+# Backward & Forward Compatibility
+
+This implementation supports Role Tokens that are based on the CommonName of the certificate by default.
+
+If the Administrators want to not use SAN based Identities for the role token and want to switch back to Common Name based. They have to do these steps
+1) Add the ACLs for the SAN based entries to Common Name based in the cluster
+2) Revert this plugin to default as described below
+
+## Revert
+
+Pulsar Deployments that use the CommonName based Role Tokens can switch back to the default class `authenticationProviders` 
+property to `org.apache.pulsar.broker.authentication.AuthenticationProviderTls`
+
+## Upgrade
+
+No Changes
+
+# Alternatives
+
+None
+
+# General Notes
+
+None
+
+# Links
+
+https://www.openssl.org/docs/manmaster/man5/x509v3_config.html lists the different SANv3 extension types.
+
+<!--
+Updated afterwards
+-->
+* Mailing List discussion thread:
+* Mailing List voting thread:

--- a/pip/pip-361.md
+++ b/pip/pip-361.md
@@ -1,4 +1,4 @@
-# PIP-360: Support URI, DNS, RID, IP based Token building from client's X.509 Certificate SAN Extensions.
+# PIP-361: Support URI, DNS, RID, IP based Token building from client's X.509 Certificate SAN Extensions.
 
 # Background Knowledge
 


### PR DESCRIPTION
### Motivation

Providing multiple options for extracting the Client Identity from the X.509 certificate would greatly benefit the diverse implementations organizations can follow according to their scale.

### Modifications

Adding a new Class that supports this PIP along with two new configurations that control how this plugin will work.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
