### PR TITLE
[fix][misc] Correct the comment of tlsAllowInsecureConnection in ClusterDataImpl class.

### DIFF
--- a/conf/client.conf
+++ b/conf/client.conf
@@ -41,7 +41,7 @@ authPlugin=
 # authParams=tlsCertFile:/path/to/client-cert.pem,tlsKeyFile:/path/to/client-key.pem
 authParams=
 
-# Allow TLS connections to servers whose certificate cannot be
+# Allow TLS connections to servers whose certificate cannot
 # be verified to have been signed by a trusted certificate
 # authority.
 tlsAllowInsecureConnection=false

--- a/deployment/terraform-ansible/templates/client.conf
+++ b/deployment/terraform-ansible/templates/client.conf
@@ -41,7 +41,7 @@ authPlugin=
 # authParams=tlsCertFile:/path/to/client-cert.pem,tlsKeyFile:/path/to/client-key.pem
 authParams=
 
-# Allow TLS connections to servers whose certificate cannot be
+# Allow TLS connections to servers whose certificate cannot
 # be verified to have been signed by a trusted certificate
 # authority.
 tlsAllowInsecureConnection=false

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterDataImpl.java
@@ -107,7 +107,7 @@ public final class ClusterDataImpl implements  ClusterData, Cloneable {
     private boolean brokerClientTlsEnabled;
     @ApiModelProperty(
         name = "tlsAllowInsecureConnection",
-        value = "Allow TLS connections to servers whose certificate cannot be"
+        value = "Allow TLS connections to servers whose certificate cannot"
                 + " be verified to have been signed by a trusted certificate"
                 + " authority."
     )


### PR DESCRIPTION
### Motivation

Correct the comment of tlsAllowInsecureConnection in ClusterDataImpl class.

### Modifications

Remove duplicated 'be'.

`Allow TLS connections to servers whose certificate cannot be be` -> 
`Allow TLS connections to servers whose certificate cannot be`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
