### PR TITLE
[fix][cli] Refactor scripts to detect major Java version and pass correct add-opens parameters

### DIFF
--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -69,6 +69,29 @@ else
     JAVA=$JAVA_HOME/bin/java
 fi
 
+# JAVA_MAJOR_VERSION should get set by conf/bkenv.sh, just in case it's not
+if [[ -z $JAVA_MAJOR_VERSION ]]; then
+  for token in $("$JAVA" -version 2>&1 | grep 'version "'); do
+      if [[ $token =~ \"([[:digit:]]+)\.([[:digit:]]+)(.*)\" ]]; then
+          if [[ ${BASH_REMATCH[1]} == "1" ]]; then
+            JAVA_MAJOR_VERSION=${BASH_REMATCH[2]}
+          else
+            JAVA_MAJOR_VERSION=${BASH_REMATCH[1]}
+          fi
+          break
+      elif [[ $token =~ \"([[:digit:]]+)(.*)\" ]]; then
+          # Process the java versions without dots, such as `17-internal`.
+          JAVA_MAJOR_VERSION=${BASH_REMATCH[1]}
+          break
+      fi
+  done
+fi
+
+if [[ $JAVA_MAJOR_VERSION -lt 17 ]]; then
+    echo "Error: Bookkeeper included in Pulsar requires Java 17 or later." 1>&2
+    exit 1
+fi
+
 # exclude tests jar
 RELEASE_JAR=`ls $BK_HOME/bookkeeper-server-*.jar 2> /dev/null | grep -v tests | tail -1`
 if [ $? == 0 ]; then
@@ -168,17 +191,12 @@ OPTS="$OPTS -Dlog4j.configurationFile=`basename $BOOKIE_LOG_CONF`"
 # Allow Netty to use reflection access
 OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"
 
-IS_JAVA_8=$( $JAVA -version 2>&1 | grep version | grep '"1\.8' )
-# Start --add-opens options
-# '--add-opens' option is not supported in jdk8
-if [[ -z "$IS_JAVA_8" ]]; then
-  # BookKeeper: enable posix_fadvise usage and DirectMemoryCRC32Digest (https://github.com/apache/bookkeeper/pull/3234)
-  OPTS="$OPTS --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util.zip=ALL-UNNAMED"
-  # Netty: enable java.nio.DirectByteBuffer
-  # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
-  # https://github.com/netty/netty/issues/12265
-  OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
-fi
+# BookKeeper: enable posix_fadvise usage and DirectMemoryCRC32Digest (https://github.com/apache/bookkeeper/pull/3234)
+OPTS="$OPTS --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util.zip=ALL-UNNAMED"
+# Netty: enable java.nio.DirectByteBuffer
+# https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+# https://github.com/netty/netty/issues/12265
+OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
 
 OPTS="-cp $BOOKIE_CLASSPATH $OPTS"
 

--- a/bin/function-localrunner
+++ b/bin/function-localrunner
@@ -34,21 +34,39 @@ else
     JAVA=$JAVA_HOME/bin/java
 fi
 
+for token in $("$JAVA" -version 2>&1 | grep 'version "'); do
+    if [[ $token =~ \"([[:digit:]]+)\.([[:digit:]]+)(.*)\" ]]; then
+        if [[ ${BASH_REMATCH[1]} == "1" ]]; then
+          JAVA_MAJOR_VERSION=${BASH_REMATCH[2]}
+        else
+          JAVA_MAJOR_VERSION=${BASH_REMATCH[1]}
+        fi
+        break
+    elif [[ $token =~ \"([[:digit:]]+)(.*)\" ]]; then
+        # Process the java versions without dots, such as `17-internal`.
+        JAVA_MAJOR_VERSION=${BASH_REMATCH[1]}
+        break
+    fi
+done
+
 PULSAR_MEM=${PULSAR_MEM:-"-Xmx128m -XX:MaxDirectMemorySize=128m"}
 
 # Garbage collection options
 PULSAR_GC=${PULSAR_GC:-"-XX:+UseZGC -XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch"}
 
 # Garbage collection log.
-IS_JAVA_8=$( $JAVA -version 2>&1 | grep version | grep '"1\.8' )
-if [[ -z "$IS_JAVA_8" ]]; then
-  # >= JDK 9
-  PULSAR_GC_LOG=${PULSAR_GC_LOG:-"-Xlog:gc:logs/pulsar_gc_%p.log:time,uptime:filecount=10,filesize=20M"}
-  # '--add-opens' option is not supported in JDK 1.8
-  OPTS="$OPTS --add-opens java.base/sun.net=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED"
-else
-  # == JDK 1.8
-  PULSAR_GC_LOG=${PULSAR_GC_LOG:-"-Xloggc:logs/pulsar_gc_%p.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=20M"}
+PULSAR_GC_LOG_DIR=${PULSAR_GC_LOG_DIR:-logs}
+if [[ -z "$PULSAR_GC_LOG" ]]; then
+  if [[ $JAVA_MAJOR_VERSION -gt 8 ]]; then
+    PULSAR_GC_LOG="-Xlog:gc*,safepoint:${PULSAR_GC_LOG_DIR}/pulsar_gc_%p.log:time,uptime,tags:filecount=10,filesize=20M"
+    if [[ $JAVA_MAJOR_VERSION -ge 17 ]]; then
+      # Use async logging on Java 17+ https://bugs.openjdk.java.net/browse/JDK-8264323
+      PULSAR_GC_LOG="-Xlog:async ${PULSAR_GC_LOG}"
+    fi
+  else
+    # Java 8 gc log options
+    PULSAR_GC_LOG="-Xloggc:${PULSAR_GC_LOG_DIR}/pulsar_gc_%p.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=20M"
+  fi
 fi
 
 # Extra options to be passed to the jvm
@@ -90,13 +108,16 @@ OPTS="$OPTS -Dlog4j.configurationFile=`basename $PULSAR_LOG_CONF`"
 
 # Allow Netty to use reflection access
 OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"
+OPTS="$OPTS -Dorg.apache.pulsar.shade.io.netty.tryReflectionSetAccessible=true"
 
-# Start --add-opens options
-# '--add-opens' option is not supported in jdk8
-if [[ -z "$IS_JAVA_8" ]]; then
-  # Netty: enable java.nio.DirectByteBuffer
-  # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
-  # https://github.com/netty/netty/issues/12265
+if [[ $JAVA_MAJOR_VERSION -gt 8 ]]; then
+  # Required by Pulsar client optimized checksum calculation on other than Linux x86_64 platforms
+  # reflection access to java.util.zip.CRC32C
+  OPTS="$OPTS --add-opens java.base/java.util.zip=ALL-UNNAMED"
+fi
+
+if [[ $JAVA_MAJOR_VERSION -ge 11 ]]; then
+  # Required by Netty for optimized direct byte buffer access
   OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
 fi
 

--- a/bin/pulsar
+++ b/bin/pulsar
@@ -129,6 +129,29 @@ else
     JAVA=$JAVA_HOME/bin/java
 fi
 
+# JAVA_MAJOR_VERSION should get set by conf/pulsar_env.sh, just in case it's not
+if [[ -z $JAVA_MAJOR_VERSION ]]; then
+  for token in $("$JAVA" -version 2>&1 | grep 'version "'); do
+      if [[ $token =~ \"([[:digit:]]+)\.([[:digit:]]+)(.*)\" ]]; then
+          if [[ ${BASH_REMATCH[1]} == "1" ]]; then
+            JAVA_MAJOR_VERSION=${BASH_REMATCH[2]}
+          else
+            JAVA_MAJOR_VERSION=${BASH_REMATCH[1]}
+          fi
+          break
+      elif [[ $token =~ \"([[:digit:]]+)(.*)\" ]]; then
+          # Process the java versions without dots, such as `17-internal`.
+          JAVA_MAJOR_VERSION=${BASH_REMATCH[1]}
+          break
+      fi
+  done
+fi
+
+if [[ $JAVA_MAJOR_VERSION -lt 17 ]]; then
+    echo "Error: Pulsar requires Java 17 or later." 1>&2
+    exit 1
+fi
+
 # exclude tests jar
 RELEASE_JAR=`ls $PULSAR_HOME/pulsar-*.jar 2> /dev/null | grep -v tests | tail -1`
 if [ $? == 0 ]; then
@@ -254,27 +277,21 @@ OPTS="$OPTS -Djute.maxbuffer=10485760 -Djava.net.preferIPv4Stack=true"
 # Enable TCP keepalive for all Zookeeper client connections
 OPTS="$OPTS -Dzookeeper.clientTcpKeepAlive=true"
 
+# BookKeeper: enable posix_fadvise usage and DirectMemoryCRC32Digest (https://github.com/apache/bookkeeper/pull/3234)
+OPTS="$OPTS --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util.zip=ALL-UNNAMED"
+# Required by JvmDefaultGCMetricsLogger & MBeanStatsGenerator
+OPTS="$OPTS --add-opens java.management/sun.management=ALL-UNNAMED"
+# Required by MBeanStatsGenerator
+OPTS="$OPTS --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED"
 # Allow Netty to use reflection access
 OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"
-IS_JAVA_8=$( $JAVA -version 2>&1 | grep version | grep '"1\.8' )
-# Start --add-opens options
-# '--add-opens' option is not supported in jdk8
-if [[ -z "$IS_JAVA_8" ]]; then
-  # BookKeeper: enable posix_fadvise usage and DirectMemoryCRC32Digest (https://github.com/apache/bookkeeper/pull/3234)
-  OPTS="$OPTS --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util.zip=ALL-UNNAMED"
-  # Netty: enable java.nio.DirectByteBuffer
-  # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
-  # https://github.com/netty/netty/issues/12265
-  OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
-  # netty.DnsResolverUtil
-  OPTS="$OPTS --add-opens java.base/sun.net=ALL-UNNAMED"
-  # JvmDefaultGCMetricsLogger & MBeanStatsGenerator
-  OPTS="$OPTS --add-opens java.management/sun.management=ALL-UNNAMED"
-  # MBeanStatsGenerator
-  OPTS="$OPTS --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED"
-  # LinuxInfoUtils
-  OPTS="$OPTS --add-opens java.base/jdk.internal.platform=ALL-UNNAMED"
-fi
+OPTS="$OPTS -Dorg.apache.pulsar.shade.io.netty.tryReflectionSetAccessible=true"
+# Netty: enable java.nio.DirectByteBuffer
+# https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+# https://github.com/netty/netty/issues/12265
+OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
+# Required by LinuxInfoUtils
+OPTS="$OPTS --add-opens java.base/jdk.internal.platform=ALL-UNNAMED"
 
 OPTS="-cp $PULSAR_CLASSPATH $OPTS"
 

--- a/bin/pulsar-admin.cmd
+++ b/bin/pulsar-admin.cmd
@@ -18,7 +18,7 @@
 @REM
 
 @echo off
-
+setlocal enabledelayedexpansion
 for %%i in ("%~dp0.") do SET "SCRIPT_PATH=%%~fi"
 set "PULSAR_HOME_DIR=%SCRIPT_PATH%\..\"
 for %%i in ("%PULSAR_HOME_DIR%.") do SET "PULSAR_HOME=%%~fi"
@@ -28,3 +28,4 @@ if ERRORLEVEL 1 (
 )
 cd "%PULSAR_HOME%"
 "%JAVACMD%" %OPTS% org.apache.pulsar.admin.cli.PulsarAdminTool %PULSAR_CLIENT_CONF% %*
+endlocal

--- a/bin/pulsar-client.cmd
+++ b/bin/pulsar-client.cmd
@@ -18,7 +18,7 @@
 @REM
 
 @echo off
-
+setlocal enabledelayedexpansion
 for %%i in ("%~dp0.") do SET "SCRIPT_PATH=%%~fi"
 set "PULSAR_HOME_DIR=%SCRIPT_PATH%\..\"
 for %%i in ("%PULSAR_HOME_DIR%.") do SET "PULSAR_HOME=%%~fi"
@@ -28,3 +28,4 @@ if ERRORLEVEL 1 (
 )
 cd "%PULSAR_HOME%"
 "%JAVACMD%" %OPTS% org.apache.pulsar.client.cli.PulsarClientTool %PULSAR_CLIENT_CONF% %*
+endlocal

--- a/bin/pulsar-perf
+++ b/bin/pulsar-perf
@@ -103,11 +103,20 @@ PULSAR_CLASSPATH="$PULSAR_JAR:$PULSAR_CLASSPATH:$PULSAR_EXTRA_CLASSPATH"
 PULSAR_CLASSPATH="`dirname $PULSAR_LOG_CONF`:$PULSAR_CLASSPATH"
 OPTS="$OPTS -Dlog4j.configurationFile=`basename $PULSAR_LOG_CONF` -Djava.net.preferIPv4Stack=true"
 
-IS_JAVA_8=$( $JAVA -version 2>&1 | grep version | grep '"1\.8' )
-# Start --add-opens options
-# '--add-opens' option is not supported in jdk8
-if [[ -z "$IS_JAVA_8" ]]; then
+# Allow Netty to use reflection access
+OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"
+OPTS="$OPTS -Dorg.apache.pulsar.shade.io.netty.tryReflectionSetAccessible=true"
+
+if [[ $JAVA_MAJOR_VERSION -gt 8 ]]; then
   OPTS="$OPTS --add-opens java.base/sun.net=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED"
+  # Required by Pulsar client optimized checksum calculation on other than Linux x86_64 platforms
+  # reflection access to java.util.zip.CRC32C
+  OPTS="$OPTS --add-opens java.base/java.util.zip=ALL-UNNAMED"
+fi
+
+if [[ $JAVA_MAJOR_VERSION -ge 11 ]]; then
+  # Required by Netty for optimized direct byte buffer access
+  OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
 fi
 
 OPTS="-cp $PULSAR_CLASSPATH $OPTS"

--- a/bin/pulsar-perf.cmd
+++ b/bin/pulsar-perf.cmd
@@ -18,67 +18,17 @@
 @REM
 
 @echo off
-
-if "%JAVA_HOME%" == "" (
-  for %%i in (java.exe) do set "JAVACMD=%%~$PATH:i"
-) else (
-  set "JAVACMD=%JAVA_HOME%\bin\java.exe"
-)
-
-if not exist "%JAVACMD%" (
-  echo The JAVA_HOME environment variable is not defined correctly, so Pulsar CLI cannot be started. >&2
-  echo JAVA_HOME is set to "%JAVA_HOME%", but "%JAVACMD%" does not exist. >&2
-  exit /B 1
-)
-
+setlocal enabledelayedexpansion
 for %%i in ("%~dp0.") do SET "SCRIPT_PATH=%%~fi"
 set "PULSAR_HOME_DIR=%SCRIPT_PATH%\..\"
 for %%i in ("%PULSAR_HOME_DIR%.") do SET "PULSAR_HOME=%%~fi"
-set "PULSAR_CLASSPATH=%PULSAR_CLASSPATH%;%PULSAR_HOME%\lib\*"
-
-
-if "%PULSAR_CLIENT_CONF%" == "" set "PULSAR_CLIENT_CONF=%PULSAR_HOME%\conf\client.conf"
-if "%PULSAR_LOG_CONF%" == "" set "PULSAR_LOG_CONF=%PULSAR_HOME%\conf\log4j2.yaml"
-
-set "PULSAR_LOG_CONF_DIR1=%PULSAR_LOG_CONF%\..\"
-for %%i in ("%PULSAR_LOG_CONF_DIR1%.") do SET "PULSAR_LOG_CONF_DIR=%%~fi"
-for %%a in ("%PULSAR_LOG_CONF%") do SET "PULSAR_LOG_CONF_BASENAME=%%~nxa"
-
-set "PULSAR_CLASSPATH=%PULSAR_CLASSPATH%;%PULSAR_LOG_CONF_DIR%"
-if not "%PULSAR_EXTRA_CLASSPATH%" == "" set "PULSAR_CLASSPATH=%PULSAR_CLASSPATH%;%PULSAR_EXTRA_CLASSPATH%"
-
-
-if "%PULSAR_PERFTEST_CONF%" == "" set "PULSAR_PERFTEST_CONF=%PULSAR_CLIENT_CONF%"
-
-
-set "OPTS=%OPTS% -Dlog4j.configurationFile="%PULSAR_LOG_CONF_BASENAME%""
-set "OPTS=%OPTS% -Djava.net.preferIPv4Stack=true"
-
-
-set "OPTS=-cp "%PULSAR_CLASSPATH%" %OPTS%"
-set "OPTS=%OPTS% %PULSAR_EXTRA_OPTS%"
-
-if "%PULSAR_LOG_DIR%" == "" set "PULSAR_LOG_DIR=%PULSAR_HOME%\logs"
-if "%PULSAR_LOG_FILE%" == "" set "PULSAR_LOG_FILE=pulsar-perftest.log"
 if "%PULSAR_LOG_APPENDER%" == "" set "PULSAR_LOG_APPENDER=Console"
-if "%PULSAR_LOG_LEVEL%" == "" set "PULSAR_LOG_LEVEL=info"
-if "%PULSAR_LOG_ROOT_LEVEL%" == "" set "PULSAR_LOG_ROOT_LEVEL=%PULSAR_LOG_LEVEL%"
-if "%PULSAR_LOG_IMMEDIATE_FLUSH%" == "" set "PULSAR_LOG_IMMEDIATE_FLUSH=false"
-
-
-set "OPTS=%OPTS% -Dpulsar.log.appender=%PULSAR_LOG_APPENDER%"
-set "OPTS=%OPTS% -Dpulsar.log.dir=%PULSAR_LOG_DIR%"
-set "OPTS=%OPTS% -Dpulsar.log.level=%PULSAR_LOG_LEVEL%"
-set "OPTS=%OPTS% -Dpulsar.log.root.level=%PULSAR_LOG_ROOT_LEVEL%"
-set "OPTS=%OPTS% -Dpulsar.log.immediateFlush=%PULSAR_LOG_IMMEDIATE_FLUSH%"
-
+if "%PULSAR_LOG_FILE%" == "" set "PULSAR_LOG_FILE=pulsar-perftest.log"
+call "%PULSAR_HOME%\bin\pulsar-admin-common.cmd"
+if ERRORLEVEL 1 (
+  exit /b 1
+)
+if "%PULSAR_PERFTEST_CONF%" == "" set "PULSAR_PERFTEST_CONF=%PULSAR_CLIENT_CONF%"
 "%JAVACMD%" %OPTS% org.apache.pulsar.testclient.PulsarPerfTestTool "%PULSAR_PERFTEST_CONF%" %*
-
-
-
-:error
-set ERROR_CODE=1
-goto :eof
-
-
+endlocal
 

--- a/bin/pulsar-shell.cmd
+++ b/bin/pulsar-shell.cmd
@@ -18,7 +18,7 @@
 @REM
 
 @echo off
-
+setlocal enabledelayedexpansion
 for %%i in ("%~dp0.") do SET "SCRIPT_PATH=%%~fi"
 set "PULSAR_HOME_DIR=%SCRIPT_PATH%\..\"
 for %%i in ("%PULSAR_HOME_DIR%.") do SET "PULSAR_HOME=%%~fi"
@@ -26,9 +26,9 @@ call "%PULSAR_HOME%\bin\pulsar-admin-common.cmd"
 if ERRORLEVEL 1 (
   exit /b 1
 )
-
 set "OPTS=%OPTS% -Dorg.jline.terminal.jansi=false"
 set "OPTS=%OPTS% -Dpulsar.shell.config.default=%cd%"
 set "DEFAULT_CONFIG=-Dpulsar.shell.config.default="%PULSAR_CLIENT_CONF%""
 cd "%PULSAR_HOME%"
 "%JAVACMD%" %OPTS%  %DEFAULT_CONFIG%  org.apache.pulsar.shell.PulsarShell %*
+endlocal


### PR DESCRIPTION
### Motivation

* Netty's optimized direct ByteBuffer support requires passing certain parameters to the JVM.
* The legacy solution `IS_JAVA_8` should be replaced with the JAVA_MAJOR_VERSION detection solution so that parameters could be correctly set for newer Java version.
* Pulsar server side code doesn't support JVMs before 17 version. The script should exit when an older JVM is detected.
* Many of the Windows .cmd scripts were broken

### Modifications

- refactor scripts to use JAVA_MAJOR_VERSION
- consistently pass required JVM arguments so that Netty's optimized direct ByteBuffer gets used.
- Fixed Windows .cmd scripts and made the logic match the bash scripts.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->