### PR TITLE
[fix][broker] Fix rare race condition in removing topic watcher

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicListService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicListService.java
@@ -254,10 +254,13 @@ public class TopicListService {
             return;
         }
 
-        // Proceed with normal watcher close
-        topicResources.deregisterPersistentTopicListener(watcherFuture.getNow(null));
+        watcherFuture.thenApply(watcher -> {
+            topicResources.deregisterPersistentTopicListener(watcher);
+            log.info("[{}] Deregistered watcher, watcherId={}", connection.toString(), watcherId);
+            return null;
+        });
         watchers.remove(watcherId);
-        log.info("[{}] Closed watcher, watcherId={}", connection.toString(), watcherId);
+        log.info("[{}] Removed watcher, watcherId={}", connection.toString(), watcherId);
     }
 
     /**


### PR DESCRIPTION
### Motivation

While reviewing code in org.apache.pulsar.broker.service.TopicListService#deleteTopicListWatcher, a race condition was detected.

https://github.com/apache/pulsar/blob/9aed73653e1f706e3517072cce4a352d0838f8d7/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicListService.java#L231-L261

### Modifications

- replace usage of `.getNow(null)` with `.thenApply(watcher -> ...` to prevent a rare race condition.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->