### PR TITLE
[improve][pip] PIP-360 Add admin API to display Schema metadata

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.admin.AdminResource;
+import org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage;
 import org.apache.pulsar.broker.service.schema.SchemaRegistry.SchemaAndMetadata;
 import org.apache.pulsar.broker.service.schema.SchemaRegistryService;
 import org.apache.pulsar.broker.web.RestException;
@@ -38,6 +39,7 @@ import org.apache.pulsar.client.impl.schema.SchemaUtils;
 import org.apache.pulsar.client.internal.DefaultImplementation;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
+import org.apache.pulsar.common.policies.data.SchemaMetadata;
 import org.apache.pulsar.common.policies.data.TopicOperation;
 import org.apache.pulsar.common.protocol.schema.GetAllVersionsSchemaResponse;
 import org.apache.pulsar.common.protocol.schema.GetSchemaResponse;
@@ -103,6 +105,13 @@ public class SchemasResourceBase extends AdminResource {
                     String schemaId = getSchemaId();
                     return pulsar().getSchemaRegistryService().trimDeletedSchemaAndGetList(schemaId);
                 });
+    }
+
+    public CompletableFuture<SchemaMetadata> getSchemaMetadataAsync(boolean authoritative) {
+        String schemaId = getSchemaId();
+        BookkeeperSchemaStorage storage = (BookkeeperSchemaStorage) pulsar().getSchemaStorage();
+        return validateOwnershipAndOperationAsync(authoritative, TopicOperation.GET_METADATA)
+                .thenCompose(__ -> storage.getSchemaMetadata(schemaId));
     }
 
     public CompletableFuture<SchemaVersion> deleteSchemaAsync(boolean authoritative, boolean force) {

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Schemas.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Schemas.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.admin;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.common.policies.data.SchemaMetadata;
 import org.apache.pulsar.common.protocol.schema.IsCompatibilityResponse;
 import org.apache.pulsar.common.protocol.schema.PostSchemaPayload;
 import org.apache.pulsar.common.schema.SchemaInfo;
@@ -233,4 +234,19 @@ public interface Schemas {
      * @param topic topic name, in fully qualified format
      */
     CompletableFuture<List<SchemaInfo>> getAllSchemasAsync(String topic);
+
+    /**
+     * Get schema metadata of the <tt>topic</tt>.
+     *
+     * @param topic topic name, in fully qualified format
+     * @throws PulsarAdminException
+     */
+    SchemaMetadata getSchemaMetadata(String topic) throws PulsarAdminException;
+
+    /**
+     * Get schema metadata of the <tt>topic</tt> asynchronously.
+     *
+     * @param topic topic name, in fully qualified format
+     */
+    CompletableFuture<SchemaMetadata> getSchemaMetadataAsync(String topic);
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SchemaMetadata.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SchemaMetadata.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Schema metadata info.
+ */
+@Data
+public class SchemaMetadata {
+
+    public Entry info;
+    public List<Entry> index;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Entry {
+        private long ledgerId;
+        private long entryId;
+        private long version;
+
+        @Override
+        public String toString() {
+            return String.format("ledgerId=[%d], entryId=[%d], version=[%d]", ledgerId, entryId, version);
+        }
+    }
+}

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SchemasImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/SchemasImpl.java
@@ -31,6 +31,7 @@ import org.apache.pulsar.client.admin.Schemas;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.internal.DefaultImplementation;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.SchemaMetadata;
 import org.apache.pulsar.common.protocol.schema.DeleteSchemaResponse;
 import org.apache.pulsar.common.protocol.schema.GetAllVersionsSchemaResponse;
 import org.apache.pulsar.common.protocol.schema.GetSchemaResponse;
@@ -276,6 +277,19 @@ public class SchemasImpl extends BaseResource implements Schemas {
                         .collect(Collectors.toList()));
     }
 
+    @Override
+    public SchemaMetadata getSchemaMetadata(String topic) throws PulsarAdminException {
+        return sync(() -> getSchemaMetadataAsync(topic));
+    }
+
+    @Override
+    public CompletableFuture<SchemaMetadata> getSchemaMetadataAsync(String topic) {
+        TopicName tn = TopicName.get(topic);
+        WebTarget path = metadata(tn);
+        return asyncGetRequest(path, new FutureCallback<SchemaMetadata>(){});
+    }
+
+
     private WebTarget schemaPath(TopicName topicName) {
         return topicPath(topicName, "schema");
     }
@@ -290,6 +304,10 @@ public class SchemasImpl extends BaseResource implements Schemas {
 
     private WebTarget compatibilityPath(TopicName topicName) {
         return topicPath(topicName, "compatibility");
+    }
+
+    private WebTarget metadata(TopicName topicName) {
+        return topicPath(topicName, "metadata");
     }
 
     private WebTarget topicPath(TopicName topic, String... parts) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSchemas.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSchemas.java
@@ -44,6 +44,7 @@ public class CmdSchemas extends CmdBase {
         addCommand("delete", new DeleteSchema());
         addCommand("upload", new UploadSchema());
         addCommand("extract", new ExtractSchema());
+        addCommand("metadata", new GetSchemaMetadata());
         addCommand("compatibility", new TestCompatibility());
     }
 
@@ -74,6 +75,18 @@ public class CmdSchemas extends CmdBase {
             } else {
                 print(getAdmin().schemas().getAllSchemas(topic));
             }
+        }
+    }
+
+    @Command(description = "Get the schema for a topic")
+    private class GetSchemaMetadata extends CliCommand {
+        @Parameters(description = "persistent://tenant/namespace/topic", arity = "1")
+        private String topicName;
+
+        @Override
+        void run() throws Exception {
+            String topic = validateTopicName(topicName);
+            print(getAdmin().schemas().getSchemaMetadata(topic));
         }
     }
 

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSchema.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdSchema.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.admin.cli;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.Schemas;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class TestCmdSchema {
+
+    private PulsarAdmin pulsarAdmin;
+
+    private CmdSchemas cmdSchemas;
+
+    private Schemas schemas;
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        pulsarAdmin = mock(PulsarAdmin.class);
+        schemas = mock(Schemas.class);
+        when(pulsarAdmin.schemas()).thenReturn(schemas);
+        cmdSchemas = spy(new CmdSchemas(() -> pulsarAdmin));
+    }
+
+    @Test
+    public void testCmdClusterConfigFile() throws Exception {
+        String topic = "persistent://tenant/ns1/t1";
+        cmdSchemas.run(new String[]{"metadata", topic});
+        verify(schemas).getSchemaMetadata(eq(topic));
+    }
+}


### PR DESCRIPTION
PIP-360:  #22913 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

Schema is one of the important part of the topic because it also plays important part in topic availability and required to successfully load the topic, and if schema initialization failure is causing issue in topic loading then it is very important to get schema metadata information to understand schema related issues and perform appropriate actions to mitigate that issue to successfully load the topic and make it available for users. Therefore, similar to ledger metadata and managed-ledger metadata, Pulsar should have API to show schema metadata and related ledger info which can be used by tools or users to perform appropriate actions during topic availability issues or any other troubleshooting.

### Modifications

Adding admin API and cli to read schema metadata.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
