### PR TITLE
[improve][misc] Set Alpine base image to 3.20 instead of 3.19.1

### DIFF
--- a/docker/glibc-package/Dockerfile
+++ b/docker/glibc-package/Dockerfile
@@ -19,6 +19,7 @@
 
 
 ARG GLIBC_VERSION=2.38
+ARG ALPINE_VERSION=3.20
 
 FROM ubuntu:22.04 as build
 ARG GLIBC_VERSION
@@ -51,7 +52,7 @@ RUN tar --dereference --hard-dereference -zcf /glibc-bin.tar.gz /usr/glibc-compa
 
 ################################################
 ## Build the APK package
-FROM alpine:3.19 as apk
+FROM alpine:$ALPINE_VERSION as apk
 ARG GLIBC_VERSION
 
 RUN apk add abuild sudo build-base

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -17,8 +17,10 @@
 # under the License.
 #
 
+ARG ALPINE_VERSION=3.20
+
 # First create a stage with just the Pulsar tarball and scripts
-FROM alpine as pulsar
+FROM alpine:$ALPINE_VERSION as pulsar
 
 RUN apk add zip
 
@@ -52,7 +54,7 @@ RUN chmod -R o+rx /pulsar
 RUN echo 'OPTS="$OPTS -Dorg.xerial.snappy.use.systemlib=true"' >> /pulsar/conf/bkenv.sh
 
 ###  Create one stage to include JVM distribution
-FROM alpine AS jvm
+FROM alpine:$ALPINE_VERSION AS jvm
 
 RUN wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub
 RUN echo "https://apk.corretto.aws" >> /etc/apk/repositories
@@ -68,7 +70,7 @@ RUN echo networkaddress.cache.negative.ttl=1 >> /opt/jvm/conf/security/java.secu
 # Fix the issue when using snappy-java in x86 arch alpine
 # See https://github.com/xerial/snappy-java/issues/181 https://github.com/xerial/snappy-java/issues/579
 # We need to ensure that the version of the native library matches the version of snappy-java imported via Maven
-FROM alpine AS snappy-java
+FROM alpine:$ALPINE_VERSION AS snappy-java
 
 ARG SNAPPY_VERSION
 RUN apk add git alpine-sdk util-linux cmake autoconf automake libtool openjdk17 maven curl bash tar
@@ -78,7 +80,7 @@ FROM apachepulsar/glibc-base:2.38 as glibc
 
 ## Create final stage from Alpine image
 ## and add OpenJDK and Python dependencies (for Pulsar functions)
-FROM alpine:3.19.1
+FROM alpine:$ALPINE_VERSION
 ENV LANG C.UTF-8
 
 # Install some utilities, some are required by Pulsar scripts


### PR DESCRIPTION
### Motivation

The base image was set to 3.19.1 . It's better to use a top level version so that an updated base image is used for builds.
The version tag wasn't set for intermediate build images and 3.20 was already used. Instead of sticking to 3.19, it's better to migrate to use 3.20 since it's already stable. 

### Modifications

- consistently use alpine:3.20 as the base image

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
