### PR TITLE
[cleanup][misc] Remove classifier from netty-transport-native-unix-common dependency

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -312,7 +312,6 @@ The Apache Software License, Version 2.0
     - io.netty-netty-transport-native-epoll-4.1.111.Final-linux-aarch_64.jar
     - io.netty-netty-transport-native-epoll-4.1.111.Final-linux-x86_64.jar
     - io.netty-netty-transport-native-unix-common-4.1.111.Final.jar
-    - io.netty-netty-transport-native-unix-common-4.1.111.Final-linux-x86_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.65.Final.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.65.Final-linux-aarch_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.65.Final-linux-x86_64.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -363,7 +363,6 @@ The Apache Software License, Version 2.0
     - netty-transport-native-epoll-4.1.111.Final-linux-aarch_64.jar
     - netty-transport-native-epoll-4.1.111.Final-linux-x86_64.jar
     - netty-transport-native-unix-common-4.1.111.Final.jar
-    - netty-transport-native-unix-common-4.1.111.Final-linux-x86_64.jar
     - netty-tcnative-boringssl-static-2.0.65.Final.jar
     - netty-tcnative-boringssl-static-2.0.65.Final-linux-aarch_64.jar
     - netty-tcnative-boringssl-static-2.0.65.Final-linux-x86_64.jar

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -107,7 +107,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-unix-common</artifactId>
-      <classifier>linux-x86_64</classifier>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Motivation

- explained in https://github.com/netty/netty/blob/217df76/transport-native-epoll/pom.xml#L208-L218: 
> The unix-common with classifier dependency is optional because it is not a runtime dependency, but a build time dependency to get the static library which is built directly into the shared library generated by this project.

### Modifications

- remove classifier from netty-transport-native-unix-common dependency

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->