### PR TITLE
[improve] [broker] make system topic distribute evenly.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -893,7 +893,9 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                     brokerToNamespaceToBundleRange, brokerToFailureDomainMap);
 
             // distribute bundles evenly to candidate-brokers if enable
-            if (conf.isLoadBalancerDistributeBundlesEvenlyEnabled()) {
+            // or system-namespace bundles
+            if (conf.isLoadBalancerDistributeBundlesEvenlyEnabled()
+                    || serviceUnit.getNamespaceObject().equals(NamespaceName.SYSTEM_NAMESPACE)) {
                 LoadManagerShared.removeMostServicingBrokersForNamespace(bundle,
                         brokerCandidateCache,
                         brokerToNamespaceToBundleRange);


### PR DESCRIPTION
### Motivation

The loading of TC onto which broker depends on which broker the `transaction_coordinator_assign-partition-${TC ID}` is loaded onto.

In order to improve service availability, we need to distribute TC evenly across the entire cluster as much as possible, avoiding all TCs from being loaded onto a few machines.

For example, if all 16 TCs are loaded onto two or three brokers, restarting the broker during cluster rolling upgrades will result in a large number of TCs becoming unavailable simultaneously, which will significantly affect the transaction client.

All shedding algorithm pick up the bundles based on throughput or message rate from the top to the bottom. **However, the system topic has almost no traffic, which means system topic can't be re-distribute evenly with shedding algo.** Placement strategy always want to distribute bundles with the least load broker, so there is high possibility that the bundles of system topic are loaded onto few of brokers.

For example:
`count(pulsar_txn_created_total) by (instance)`
![image](https://github.com/apache/pulsar/assets/52550727/f365361f-d024-4f4f-a304-747818abded8)
One single broker serve for all 16 TCs.


### Modifications

Distribute bundles of system topic evenly forcefully.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/60