### PR TITLE
[fix][misc] Rename netty native libraries in pulsar-client-admin-shaded

### DIFF
--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -304,6 +304,31 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <!-- This plugin is used to run a script after the package phase in order to rename
+            libnetty_transport_native_epoll_x86_64.so from Netty into
+            liborg_apache_pulsar_shade_netty_transport_native_epoll_x86_64.so
+            to reflect the shade that is being applied.
+         -->
+        <artifactId>exec-maven-plugin</artifactId>
+        <groupId>org.codehaus.mojo</groupId>
+        <executions>
+          <execution>
+            <id>rename-epoll-library</id>
+            <phase>package</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>${project.parent.basedir}/src/${rename.netty.native.libs}</executable>
+              <arguments>
+                <argument>${project.artifactId}</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
### Motivation

It's necessary to rename the bundled Netty native libraries in the shaded jar file.
This has been done for pulsar-client and pulsar-client-all. Netty is also included in pulsar-client-admin-shaded and the renaming has been missing.

### Modifications

- add similar renaming to `pulsar-client-admin-shaded/pom.xml`

### Additional information

Using pulsar-client-admin dependency might cause applications to crash if the application uses an older version of Netty or Netty Tcnative. The workaround to this issue (before the fix in this PR is released) is to use the shaded pulsar-client-all dependency (which includes both the Java client and the Admin client) instead of using pulsar-client-admin dependency.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->