### PR TITLE
[fix][client] Fix orphan consumer when reconnection and closing are concurrency executing

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1088,7 +1088,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     }
 
     @Override
-    public CompletableFuture<Void> closeAsync() {
+    public synchronized CompletableFuture<Void> closeAsync() {
         CompletableFuture<Void> closeFuture = new CompletableFuture<>();
 
         if (getState() == State.Closing || getState() == State.Closed) {


### PR DESCRIPTION
### Motivation

| `time`| `thread: ConsumerImpl.connectionOpened` | `thread: ConsumerImpl.closeAsync` |
| --- | --- | --- |
| 1 | check connect state: <br> - reconnectiong <br> - `cnx` is `null` | |
| 2 | | Change state to `ready` |
| 3 | | Reconnected |
| 4 | Change state to `closed` and skip sending <br> requests to remove consumer in broker memory | |

After the above steps, there is an orphan consumer in the broker memory, which will cause the error `Exclusive consumer is already connected` and other errors.

BTW, this issue may cause the compaction task stuck, because the new reader can not be created successfully due to the previous consumer has not been removed.

You can reproduce the issue by the test `testConcurrencyClose` in the PR https://github.com/apache/pulsar/pull/22959

### Modifications

Fix the issue.



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
