### PR TITLE
[fix][ci] Fix jacoco code coverage report aggregation

### DIFF
--- a/build/pulsar_ci_tool.sh
+++ b/build/pulsar_ci_tool.sh
@@ -353,6 +353,7 @@ _ci_upload_coverage_files() {
                   --transform="flags=r;s|\\(/jacoco.*\\).exec$|\\1_${testtype}_${testgroup}.exec|" \
                   --transform="flags=r;s|\\(/tmp/jacocoDir/.*\\).exec$|\\1_${testtype}_${testgroup}.exec|" \
                   --exclude="*/META-INF/bundled-dependencies/*" \
+                  --exclude="*/META-INF/versions/*" \
                   $GITHUB_WORKSPACE/target/classpath_* \
                   $(find "$GITHUB_WORKSPACE" -path "*/target/jacoco*.exec" -printf "%p\n%h/classes\n" | sort | uniq) \
                   $([ -d /tmp/jacocoDir ] && echo "/tmp/jacocoDir" ) \
@@ -494,11 +495,11 @@ ci_create_test_coverage_report() {
     local classfilesArgs="--classfiles $({
       {
         for classpathEntry in $(cat $completeClasspathFile | { grep -v -f $filterArtifactsFile || true; } | sort | uniq | { grep -v -E "$excludeJarsPattern" || true; }); do
-            if [[ -f $classpathEntry && -n "$(unzip -Z1C $classpathEntry 'META-INF/bundled-dependencies/*' 2>/dev/null)" ]]; then
-              # file must be processed by removing META-INF/bundled-dependencies
+            if [[ -f $classpathEntry && -n "$(unzip -Z1C $classpathEntry 'META-INF/bundled-dependencies/*' 'META-INF/versions/*' 2>/dev/null)" ]]; then
+              # file must be processed by removing META-INF/bundled-dependencies and META-INF/versions
               local jartempfile=$(mktemp -t jarfile.XXXX --suffix=.jar)
               cp $classpathEntry $jartempfile
-              zip -q -d $jartempfile 'META-INF/bundled-dependencies/*' &> /dev/null
+              zip -q -d $jartempfile 'META-INF/bundled-dependencies/*' 'META-INF/versions/*' &> /dev/null
               echo $jartempfile
             else
               echo $classpathEntry
@@ -560,7 +561,7 @@ ci_create_inttest_coverage_report() {
       # remove jar file that causes duplicate classes issue
       rm /tmp/jacocoDir/pulsar_lib/org.apache.pulsar-bouncy-castle* || true
       # remove any bundled dependencies as part of .jar/.nar files
-      find /tmp/jacocoDir/pulsar_lib '(' -name "*.jar" -or -name "*.nar" ')' -exec echo "Processing {}" \; -exec zip -q -d {} 'META-INF/bundled-dependencies/*' \; |grep -E -v "Nothing to do|^$" || true
+      find /tmp/jacocoDir/pulsar_lib '(' -name "*.jar" -or -name "*.nar" ')' -exec echo "Processing {}" \; -exec zip -q -d {} 'META-INF/bundled-dependencies/*' 'META-INF/versions/*' \; |grep -E -v "Nothing to do|^$" || true
     fi
     # projects that aren't considered as production code and their own src/main/java source code shouldn't be analysed
     local excludeProjectsPattern="testmocks|testclient|buildtools"

--- a/jetcd-core-shaded/pom.xml
+++ b/jetcd-core-shaded/pom.xml
@@ -100,6 +100,12 @@
                   <pattern>io.vertx</pattern>
                   <shadedPattern>org.apache.pulsar.jetcd.shaded.io.vertx</shadedPattern>
                 </relocation>
+                <!-- relocate multi-release packages -->
+                <relocation>
+                  <pattern>META-INF/versions/(\d+)/io/vertx/</pattern>
+                  <shadedPattern>META-INF/versions/$1/org/apache/pulsar/jetcd/shaded/io/vertx/</shadedPattern>
+                  <rawString>true</rawString>
+                </relocation>
                 <!-- relocate to use grpc-netty-shaded packages -->
                 <relocation>
                   <pattern>io.grpc.netty</pattern>
@@ -123,6 +129,11 @@
                 </filter>
               </filters>
               <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Multi-Release>true</Multi-Release>
+                  </manifestEntries>
+                </transformer>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.PluginXmlResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@ flexible messaging model and an intuitive client API.</description>
     <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
     <wagon-ssh-external.version>3.5.3</wagon-ssh-external.version>
     <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
-    <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <spotbugs-maven-plugin.version>4.7.3.6</spotbugs-maven-plugin.version>
     <spotbugs.version>4.7.3</spotbugs.version>
     <errorprone.version>2.24.0</errorprone.version>


### PR DESCRIPTION
### Motivation

Jacoco code coverage report aggregation is currently broken in CI.

[Example failure](https://github.com/apache/pulsar/actions/runs/9644239258/job/26599083286?pr=22962#step:10:258)
```
  Error: Exception in thread "main" java.io.IOException: Error while analyzing /tmp/jacocoDir/pulsar_lib/org.apache.pulsar-jetcd-core-shaded-3.4.0-SNAPSHOT-shaded.jar@META-INF/versions/11/io/vertx/core/DeploymentOptions.class with JaCoCo 0.8.11.202310140853/f33756c.
  	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzerError(Analyzer.java:163)
  	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeClass(Analyzer.java:135)
  	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeClass(Analyzer.java:158)
  	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:195)
  	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeZip(Analyzer.java:267)
  	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:198)
  	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:228)
  	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:223)
  	at org.jacoco.cli.internal.commands.Report.analyze(Report.java:110)
  	at org.jacoco.cli.internal.commands.Report.execute(Report.java:84)
  	at org.jacoco.cli.internal.Main.execute(Main.java:90)
  	at org.jacoco.cli.internal.Main.main(Main.java:105)
  Caused by: java.lang.IllegalStateException: Can't add different class with same name: org/apache/pulsar/jetcd/shaded/io/vertx/core/DeploymentOptions
  	at org.jacoco.cli.internal.core.analysis.CoverageBuilder.visitCoverage(CoverageBuilder.java:106)
  	at org.jacoco.cli.internal.core.analysis.Analyzer$1.visitEnd(Analyzer.java:100)
  	at org.jacoco.cli.internal.asm.ClassVisitor.visitEnd(ClassVisitor.java:395)
  	at org.jacoco.cli.internal.core.internal.flow.ClassProbesAdapter.visitEnd(ClassProbesAdapter.java:100)
  	at org.jacoco.cli.internal.asm.ClassReader.accept(ClassReader.java:749)
  	at org.jacoco.cli.internal.asm.ClassReader.accept(ClassReader.java:425)
  	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeClass(Analyzer.java:117)
  	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeClass(Analyzer.java:133)
```

### Modifications

- Jacoco doesn't support Multi-release Jar files and the classes must be excluded (https://github.com/jacoco/jacoco/issues/407)
- Fix relocation of multi-release jar in `jetcd-core-shaded/pom.xml`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
