### PR TITLE
[fix][ci] Replace removed macos-11 with macos-latest in GitHub Actions

### DIFF
--- a/.github/workflows/ci-maven-cache-update.yaml
+++ b/.github/workflows/ci-maven-cache-update.yaml
@@ -64,7 +64,7 @@ jobs:
             mvn_arguments: ''
 
           - name: all modules - macos
-            runs-on: macos-11
+            runs-on: macos-latest
             cache_name: 'm2-dependencies-all'
 
           - name: core-modules

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -1319,7 +1319,7 @@ jobs:
 
   macos-build:
     name: Build Pulsar on MacOS
-    runs-on: macos-11
+    runs-on: macos-latest
     timeout-minutes: 120
     needs: ['preconditions', 'integration-tests']
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}


### PR DESCRIPTION
### Motivation

macos-11 runner has been deprecated since January and it will be completely removed in GitHub Actions on June 28th 2024. Jobs are currently failing intentionally by GitHub to raise awareness of the deprecation.
Details are explained [in the GitHub blog post](https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/).

### Modifications

replace `macos-11` with `macos-latest`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->