### PR TITLE
[fix][broker] Fix brokerId npe problem

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -338,6 +338,12 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         // the advertised address is defined as the host component of the broker's canonical name.
         this.advertisedAddress = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress());
 
+        // the broker id is used in the load manager to identify the broker
+        // it should not be used for making connections to the broker
+        this.brokerId =
+                String.format("%s:%s", advertisedAddress, config.getWebServicePort()
+                        .or(config::getWebServicePortTls).orElseThrow());
+
         // use `internalListenerName` listener as `advertisedAddress`
         this.bindAddress = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getBindAddress());
         this.brokerVersion = PulsarVersion.getVersion();
@@ -917,12 +923,6 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             this.webServiceAddressTls = webAddressTls(config);
             this.brokerServiceUrl = brokerUrl(config);
             this.brokerServiceUrlTls = brokerUrlTls(config);
-
-            // the broker id is used in the load manager to identify the broker
-            // it should not be used for making connections to the broker
-            this.brokerId =
-                    String.format("%s:%s", advertisedAddress, config.getWebServicePort()
-                            .or(config::getWebServicePortTls).orElseThrow());
 
             if (this.compactionServiceFactory == null) {
                 this.compactionServiceFactory = loadCompactionServiceFactory();


### PR DESCRIPTION
### Motivation

As shown in https://github.com/apache/pulsar/issues/22975. 


### Modifications

generate brokerId when construct PulsarService, instead of in PulsarService.start(). 


### Verifying this change

- [ ] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->


