### PR TITLE
[improve][txn] Add admin api getOwnedTransactions

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
@@ -484,4 +484,24 @@ public class Transactions extends TransactionsBase {
             resumeAsyncResponseExceptionally(asyncResponse, e);
         }
     }
+
+    @GET
+    @Path("/ownedTransactions/{owner}")
+    @ApiOperation(value = "Get owned transactions.", response = TransactionMetadata.class, responseContainer = "Map")
+    @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Tenant or cluster or namespace or topic "
+                    + "or coordinator or transaction doesn't exist"),
+            @ApiResponse(code = 503, message = "This Broker is not configured "
+                    + "with transactionCoordinatorEnabled=true."),
+            @ApiResponse(code = 307, message = "Topic don't owner by this broker!"),
+            @ApiResponse(code = 400, message = "Topic is not a persistent topic!"),
+            @ApiResponse(code = 409, message = "Concurrent modification")})
+    public void getOwnedTransactions(@Suspended final AsyncResponse asyncResponse,
+                                     @QueryParam("authoritative")
+                                     @DefaultValue("false") boolean authoritative,
+                                     @PathParam("owner") String owner,
+                                     @QueryParam("coordinatorId") Integer coordinatorId) {
+        checkTransactionCoordinatorEnabled();
+        internalGetOwnedTransactions(asyncResponse, authoritative, coordinatorId, owner);
+    }
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Transactions.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Transactions.java
@@ -414,4 +414,36 @@ public interface Transactions {
      * @param txnID the txnId
      */
     CompletableFuture<Void> abortTransactionAsync(TxnID txnID);
+
+    /**
+     * Get owned transactions by coordinator id.
+     * @param coordinatorId the coordinator id
+     * @param owner the owner
+     * @return the metadata of slow transactions.
+     */
+    CompletableFuture<Map<String, TransactionMetadata>> getOwnedTransactionsByCoordinatorIdAsync(Integer coordinatorId,
+                                                                                                 String owner);
+
+    /**
+     * Get owned transactions by coordinator id.
+     * @param coordinatorId the coordinator id
+     * @param owner the owner
+     * @return the metadata of slow transactions.
+     */
+    Map<String, TransactionMetadata> getOwnedTransactionsByCoordinatorId(Integer coordinatorId,
+                                                                         String owner) throws PulsarAdminException;
+
+    /**
+     * Get owned transactions.
+     * @param owner the owner
+     * @return the metadata of slow transactions.
+     */
+    CompletableFuture<Map<String, TransactionMetadata>> getOwnedTransactionsAsync(String owner);
+
+    /**
+     * Get owned transactions.
+     * @param owner the owner
+     * @return the metadata of slow transactions.
+     */
+    Map<String, TransactionMetadata> getOwnedTransactions(String owner) throws PulsarAdminException;
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TransactionsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TransactionsImpl.java
@@ -296,4 +296,31 @@ public class TransactionsImpl extends BaseResource implements Transactions {
     public void abortTransaction(TxnID txnID) throws PulsarAdminException {
         sync(() -> abortTransactionAsync(txnID));
     }
+
+    @Override
+    public CompletableFuture<Map<String, TransactionMetadata>> getOwnedTransactionsByCoordinatorIdAsync(
+            Integer coordinatorId, String owner) {
+        WebTarget path = adminV3Transactions.path("ownedTransactions");
+        path = path.path(owner);
+        if (coordinatorId != null) {
+            path = path.queryParam("coordinatorId", coordinatorId);
+        }
+        return asyncGetRequest(path, new FutureCallback<Map<String, TransactionMetadata>>(){});
+    }
+
+    @Override
+    public Map<String, TransactionMetadata> getOwnedTransactionsByCoordinatorId(Integer coordinatorId, String owner)
+            throws PulsarAdminException {
+        return sync(() -> getOwnedTransactionsByCoordinatorIdAsync(coordinatorId, owner));
+    }
+
+    @Override
+    public CompletableFuture<Map<String, TransactionMetadata>> getOwnedTransactionsAsync(String owner) {
+        return getOwnedTransactionsByCoordinatorIdAsync(null, owner);
+    }
+
+    @Override
+    public Map<String, TransactionMetadata> getOwnedTransactions(String owner) throws PulsarAdminException {
+        return sync(() -> getOwnedTransactionsAsync(owner));
+    }
 }

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -2438,6 +2438,14 @@ public class PulsarAdminToolTest {
         cmdTransactions = new CmdTransactions(() -> admin);
         cmdTransactions.run(split("abort-transaction -m 1 -l 2"));
         verify(transactions).abortTransaction(new TxnID(1, 2));
+
+        cmdTransactions = new CmdTransactions(() -> admin);
+        cmdTransactions.run(split("owned-transactions -c 1 -o user"));
+        verify(transactions).getOwnedTransactionsByCoordinatorId(1, "user");
+
+        cmdTransactions = new CmdTransactions(() -> admin);
+        cmdTransactions.run(split("owned-transactions -o user"));
+        verify(transactions).getOwnedTransactions("user");
     }
 
     @Test

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTransactions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTransactions.java
@@ -264,6 +264,24 @@ public class CmdTransactions extends CmdBase {
         }
     }
 
+    @Command(description = "Get owned transactions.")
+    private class GetOwnedTransactions extends CliCommand {
+        @Option(names = {"-c", "--coordinator-id"}, description = "The coordinator id", required = false)
+        private Integer coordinatorId;
+
+        @Option(names = {"-o", "--owner"}, description = "The owner", required = true)
+        private String owner;
+
+        @Override
+        void run() throws Exception {
+            if (coordinatorId != null) {
+                print(getAdmin().transactions().getOwnedTransactionsByCoordinatorId(coordinatorId, owner));
+            } else {
+                print(getAdmin().transactions().getOwnedTransactions(owner));
+            }
+        }
+    }
+
     public CmdTransactions(Supplier<PulsarAdmin> admin) {
         super("transactions", admin);
         addCommand("coordinator-internal-stats", new GetCoordinatorInternalStats());
@@ -280,6 +298,6 @@ public class CmdTransactions extends CmdBase {
         addCommand("position-stats-in-pending-ack", new GetPositionStatsInPendingAck());
         addCommand("coordinators-list", new ListTransactionCoordinators());
         addCommand("abort-transaction", new AbortTransaction());
-
+        addCommand("owned-transactions", new GetOwnedTransactions());
     }
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStore.java
@@ -139,4 +139,11 @@ public interface TransactionMetadataStore {
      * @return {@link TxnMeta} the txnMetas of slow transactions
      */
     List<TxnMeta> getSlowTransactions(long timeout);
+
+    /**
+     * Get the transactions owned by the given owner
+     *
+     * @return {@link TxnMeta} the txnMetas of transactions
+     */
+    List<TxnMeta> getOwnedTransactions(String owner);
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/InMemTransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/InMemTransactionMetadataStore.java
@@ -165,4 +165,9 @@ class InMemTransactionMetadataStore implements TransactionMetadataStore {
     public List<TxnMeta> getSlowTransactions(long timeout) {
         return null;
     }
+
+    @Override
+    public List<TxnMeta> getOwnedTransactions(String owner) {
+        return null;
+    }
 }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
@@ -521,6 +521,17 @@ public class MLTransactionMetadataStore
         return txnMetas;
     }
 
+    @Override
+    public List<TxnMeta> getOwnedTransactions(String owner) {
+        List<TxnMeta> txnMetas = new ArrayList<>();
+        txnMetaMap.forEach((k, v) -> {
+            if (v.getLeft().getOwner() != null && v.getLeft().getOwner().equals(owner)) {
+                txnMetas.add(v.getLeft());
+            }
+        });
+        return txnMetas;
+    }
+
     public static List<Subscription> txnSubscriptionToSubscription(List<TransactionSubscription> tnxSubscriptions) {
         List<Subscription> subscriptions = new ArrayList<>(tnxSubscriptions.size());
         for (TransactionSubscription transactionSubscription : tnxSubscriptions) {


### PR DESCRIPTION
### Motivation
Add an admin API getOwnedTransactions to get the transactions created by a specific user.

### Modifications
Add an admin API getOwnedTransactions to get the transactions created by a specific user.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Added test in: `org.apache.pulsar.broker.admin.v3.AdminApiTransactionTest#testGetOwnedTransactions`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [x] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/hrzzzz/pulsar/pull/9

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
