### PR TITLE
[fix][broker] Fix NPE calling PulsarService.getBrokerId() in checkTopicNsOwnership method during broker startup

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2208,9 +2208,9 @@ public class BrokerService implements Closeable {
                     if (ownedByThisInstance) {
                         return CompletableFuture.completedFuture(null);
                     } else {
-                        String msg = String.format("Namespace bundle for topic (%s) not served by this instance:%s. "
+                        String msg = String.format("Namespace bundle for topic (%s) not served by this instance. "
                                         + "Please redo the lookup. Request is denied: namespace=%s",
-                                topic, pulsar.getBrokerId(), topicName.getNamespace());
+                                topic, topicName.getNamespace());
                         log.warn(msg);
                         return FutureUtil.failedFuture(new ServiceUnitNotReadyException(msg));
                     }


### PR DESCRIPTION
Fixes #22975

### Motivation

PulsarService.getBrokerId() will fail with NPE if it's called before the broker has been started.

### Modifications

- don't use brokerId in log message in `org.apache.pulsar.broker.service.BrokerService#checkTopicNsOwnership` method since the method might get called in the startup sequence, before brokerId is available.

### Additional Context

There's a more complete fix to address the root cause, that's #22977.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
