### PR TITLE
[improve][log] Improve replicator's log when partitions count between two clusters is not the same

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -152,6 +152,12 @@ public abstract class PersistentReplicator extends AbstractReplicator
         Pair<Boolean, State> changeStateRes;
         changeStateRes = compareSetAndGetState(Starting, Started);
         if (changeStateRes.getLeft()) {
+            if (!(producer instanceof ProducerImpl)) {
+                log.error("[{}] The partitions count between two clusters is not the same, the replicator can not be"
+                        + " created successfully: {}", replicatorId, state);
+                doCloseProducerAsync(producer, () -> {});
+                throw new ClassCastException(producer.getClass().getName() + " can not be cast to ProducerImpl");
+            }
             this.producer = (ProducerImpl) producer;
             HAVE_PENDING_READ_UPDATER.set(this, FALSE);
             // Trigger a new read.


### PR DESCRIPTION
### Motivation

The steps of the issue
- Load up the topic `public/default/tp1` on the cluster `c1`
  - Start the replicator, but the topic on the remote cluster is a partitioned topic `partitions: 1`
  - A partitioned producer was created, but it may cause a `ClassCastException`<sup>pic-1</sup>.
  - The partitioned producer newly created is an orphan due to the `ClassCastException`. And it will never be closed, which will lead to the following producer creation fails.
- Retry to start replicator for `public/default/tp1`
  - Start the replicator, but the topic on the remote cluster is a partitioned topic `partitions: 1`
  - The partitioned producer can not be created successfully due to `Producer with name 'pulsar.repl.c1-->c2' is already connected to the topic persistent://public/default/tp1-partition-0`
- The replicator will never be started successfully.
 
---
**pic-1**:
<img width="1030" alt="Screenshot 2024-06-27 at 00 20 45" src="https://github.com/apache/pulsar/assets/25195800/68a0bf0f-c223-496f-9e7c-b24d8b6931f8">


### Modifications

Improve the logs: `Producer is already connected to the topic` -> `The partitions count between two clusters is not the same`



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x