### PR TITLE
[fix][broker] Fix broker OOM when upload a large package.

### DIFF
--- a/pulsar-package-management/bookkeeper-storage/src/main/java/org/apache/pulsar/packages/management/storage/bookkeeper/DLOutputStream.java
+++ b/pulsar-package-management/bookkeeper-storage/src/main/java/org/apache/pulsar/packages/management/storage/bookkeeper/DLOutputStream.java
@@ -36,6 +36,7 @@ class DLOutputStream {
 
     private final DistributedLogManager distributedLogManager;
     private final AsyncLogWriter writer;
+    private final byte[] readBuffer = new byte[8192];
     private long offset = 0L;
 
     private DLOutputStream(DistributedLogManager distributedLogManager, AsyncLogWriter writer) {
@@ -49,7 +50,6 @@ class DLOutputStream {
     }
 
     private void writeAsyncHelper(InputStream is, CompletableFuture<DLOutputStream> result) {
-        byte[] readBuffer = new byte[8192];
         try {
             int read = is.read(readBuffer);
             if (read != -1) {
@@ -75,7 +75,7 @@ class DLOutputStream {
      * Write all input stream data to the distribute log.
      *
      * @param inputStream the data we need to write
-     * @return
+     * @return CompletableFuture<DLOutputStream>
      */
     CompletableFuture<DLOutputStream> writeAsync(InputStream inputStream) {
         CompletableFuture<DLOutputStream> result = new CompletableFuture<>();

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/DLOutputStreamTest.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/DLOutputStreamTest.java
@@ -21,17 +21,18 @@ package org.apache.pulsar.packages.management.storage.bookkeeper;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.distributedlog.DLSN;
+import org.apache.distributedlog.LogRecord;
 import org.apache.distributedlog.api.AsyncLogWriter;
 import org.apache.distributedlog.api.DistributedLogManager;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.anyList;
@@ -53,9 +54,8 @@ public class DLOutputStreamTest {
         when(dlm.asyncClose()).thenReturn(CompletableFuture.completedFuture(null));
         when(writer.markEndOfStream()).thenReturn(CompletableFuture.completedFuture(null));
         when(writer.asyncClose()).thenReturn(CompletableFuture.completedFuture(null));
-        when(writer.writeBulk(anyList()))
-                .thenReturn(CompletableFuture.completedFuture(
-                        Collections.singletonList(CompletableFuture.completedFuture(DLSN.InitialDLSN))));
+        when(writer.write(any(LogRecord.class)))
+                .thenReturn(CompletableFuture.completedFuture(DLSN.InitialDLSN));
     }
 
     @AfterMethod(alwaysRun = true)
@@ -75,7 +75,7 @@ public class DLOutputStreamTest {
             .thenCompose(w -> w.writeAsync(new ByteArrayInputStream(data))
                 .thenCompose(DLOutputStream::closeAsync)).get();
 
-        verify(writer, times(1)).writeBulk(anyList());
+        verify(writer, times(1)).write(any(LogRecord.class));
         verify(writer, times(1)).markEndOfStream();
         verify(writer, times(1)).asyncClose();
         verify(dlm, times(1)).asyncClose();
@@ -91,7 +91,7 @@ public class DLOutputStreamTest {
             .thenCompose(w -> w.writeAsync(new ByteArrayInputStream(data))
                 .thenCompose(DLOutputStream::closeAsync)).get();
 
-        verify(writer, times(1)).writeBulk(anyList());
+        verify(writer, times(1)).write(any(LogRecord.class));
         verify(writer, times(1)).markEndOfStream();
         verify(writer, times(1)).asyncClose();
         verify(dlm, times(1)).asyncClose();
@@ -104,7 +104,7 @@ public class DLOutputStreamTest {
                 .thenCompose(w -> w.writeAsync(new ByteArrayInputStream(data))
                         .thenCompose(DLOutputStream::closeAsync)).get();
 
-        verify(writer, times(1)).writeBulk(anyList());
+        verify(writer, times(4)).write(any(LogRecord.class));
         verify(writer, times(1)).markEndOfStream();
         verify(writer, times(1)).asyncClose();
         verify(dlm, times(1)).asyncClose();


### PR DESCRIPTION
### Motivation
Using package API to upload a large package may cause broker OOM.

Because in the current implementation, will copy all data to the heap.

https://github.com/apache/pulsar/blob/2c6fcc7eb8343583ffb48dec937334a5f05afbae/pulsar-package-management/bookkeeper-storage/src/main/java/org/apache/pulsar/packages/management/storage/bookkeeper/DLOutputStream.java#L60-L65


### Modifications
Each time, only copy the size of one record and then upload it directly. 

There is no need to worry about batching, as the `distributedlog client` will handle the batching.


### Verifying this change
- All related to package management test will pass.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
