### PR TITLE
[fix][broker] PulsarStandalone started with error if --stream-storage-port is not 4181

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -360,7 +360,7 @@ public class LocalBookkeeperEnsemble {
         // create a default namespace
         try (StorageAdminClient admin = StorageClientBuilder.newBuilder()
              .withSettings(StorageClientSettings.newBuilder()
-                 .serviceUri("bk://localhost:4181")
+                 .serviceUri("bk://localhost:" + streamStoragePort)
                  .backoffPolicy(Backoff.Jitter.of(
                      Type.EXPONENTIAL,
                      1000,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsembleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsembleTest.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.zookeeper;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+
+import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -53,5 +55,19 @@ public class LocalBookkeeperEnsembleTest {
         assertFalse(ensemble.getZkServer().isRunning());
         assertFalse(ensemble.getZkClient().getState().isConnected());
         assertFalse(ensemble.getBookies()[0].isRunning());
+    }
+
+    @Test(timeOut = 10_000)
+    public void testStartWithSpecifiedStreamStoragePort() throws Exception {
+        LocalBookkeeperEnsemble ensemble = null;
+        try {
+            ensemble =
+                    new LocalBookkeeperEnsemble(1, 0, 0, 4182, null, null, true, null);
+            ensemble.startStandalone(new ServerConfiguration(), true);
+        } finally {
+            if (ensemble != null) {
+                ensemble.stop();
+            }
+        }
     }
 }


### PR DESCRIPTION
### Motivation
Fixes #22992

### Modifications
Replace hard coded port with `streamStoragePort` field in `LocalBookkeeperEnsemble`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

- [x] This change added tests and can also be verified with command `PULSAR_STANDALONE_USE_ZOOKEEPER=1 bin/pulsar standalone --stream-storage-port 4182`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

NO

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/zhouyifan279/pulsar/pull/1

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
