### PR TITLE
[fix][test] Disable OpenTelemetrySanityTest 

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/metrics/OpenTelemetrySanityTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/metrics/OpenTelemetrySanityTest.java
@@ -40,7 +40,6 @@ import org.apache.pulsar.tests.integration.topologies.PulsarTestBase;
 import org.awaitility.Awaitility;
 import org.testng.annotations.Test;
 
-@Test(groups = "flaky")
 public class OpenTelemetrySanityTest {
 
     // Validate that the OpenTelemetry metrics can be exported to a remote OpenTelemetry collector.

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/metrics/OpenTelemetrySanityTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/metrics/OpenTelemetrySanityTest.java
@@ -40,6 +40,7 @@ import org.apache.pulsar.tests.integration.topologies.PulsarTestBase;
 import org.awaitility.Awaitility;
 import org.testng.annotations.Test;
 
+@Test(groups = "flaky")
 public class OpenTelemetrySanityTest {
 
     // Validate that the OpenTelemetry metrics can be exported to a remote OpenTelemetry collector.

--- a/tests/integration/src/test/resources/pulsar-metrics.xml
+++ b/tests/integration/src/test/resources/pulsar-metrics.xml
@@ -22,7 +22,7 @@
 <suite name="Pulsar Metrics Integration Tests" verbose="2" annotations="JDK">
   <test name="metrics-test-suite" preserve-order="true">
     <classes>
-      <class name="org.apache.pulsar.tests.integration.metrics.OpenTelemetrySanityTest"/>
+<!--      <class name="org.apache.pulsar.tests.integration.metrics.OpenTelemetrySanityTest"/>-->
     </classes>
   </test>
 </suite>


### PR DESCRIPTION
### Motivation

OpenTelemetrySanityTest fails for every patch and blocks merging some important fixes. 
 It takes some time to fix it, so disable it .

We will track this issue by #22995.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


