### PR TITLE
[fix][test] Update OpenTelemetry receiver endpoint in integration test

### DIFF
--- a/tests/integration/src/test/resources/containers/otel-collector-config.yaml
+++ b/tests/integration/src/test/resources/containers/otel-collector-config.yaml
@@ -21,6 +21,7 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
 
 exporters:
   prometheus:


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/22995

### Motivation

OpenTelemetry integration tests are broken due to an upstream change in the OTel receiver. The receiver had a breaking change in v0.104.0, where the listener binds to localhost unless otherwise instructed ([ref](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.104.0)).

### Modifications

Bind the receiver to `0.0.0.0:4317` for the integration tests.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `org.apache.pulsar.tests.integration.metrics.OpenTelemetrySanityTest#testOpenTelemetryMetricsOtlpExport`

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

