### PR TITLE
[improve][broker] Use RoaringBitmap in tracking individual acks to reduce memory usage

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -513,7 +513,7 @@ The Apache Software License, Version 2.0
   * RxJava
     - io.reactivex.rxjava3-rxjava-3.0.1.jar
   * RoaringBitmap
-    - org.roaringbitmap-RoaringBitmap-1.1.0.jar
+    - org.roaringbitmap-RoaringBitmap-1.2.0.jar
   * OpenTelemetry
     - io.opentelemetry-opentelemetry-api-1.38.0.jar
     - io.opentelemetry-opentelemetry-api-incubator-1.38.0-alpha.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -513,7 +513,7 @@ The Apache Software License, Version 2.0
   * RxJava
     - io.reactivex.rxjava3-rxjava-3.0.1.jar
   * RoaringBitmap
-    - org.roaringbitmap-RoaringBitmap-1.0.6.jar
+    - org.roaringbitmap-RoaringBitmap-1.1.0.jar
   * OpenTelemetry
     - io.opentelemetry-opentelemetry-api-1.38.0.jar
     - io.opentelemetry-opentelemetry-api-incubator-1.38.0-alpha.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -382,6 +382,8 @@ The Apache Software License, Version 2.0
     - simpleclient_tracer_common-0.16.0.jar
     - simpleclient_tracer_otel-0.16.0.jar
     - simpleclient_tracer_otel_agent-0.16.0.jar
+ * RoaringBitmap
+    - RoaringBitmap-1.1.0.jar
  * Log4J
     - log4j-api-2.23.1.jar
     - log4j-core-2.23.1.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -383,7 +383,7 @@ The Apache Software License, Version 2.0
     - simpleclient_tracer_otel-0.16.0.jar
     - simpleclient_tracer_otel_agent-0.16.0.jar
  * RoaringBitmap
-    - RoaringBitmap-1.1.0.jar
+    - RoaringBitmap-1.2.0.jar
  * Log4J
     - log4j-api-2.23.1.jar
     - log4j-core-2.23.1.jar

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/RangeSetWrapper.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/RangeSetWrapper.java
@@ -55,7 +55,7 @@ public class RangeSetWrapper<T extends Comparable<T>> implements LongPairRangeSe
         this.config = managedCursor.getManagedLedger().getConfig();
         this.rangeConverter = rangeConverter;
         this.rangeSet = config.isUnackedRangesOpenCacheSetEnabled()
-                ? new OpenLongPairRangeSet<>(4096, rangeConverter)
+                ? new OpenLongPairRangeSet<>(rangeConverter)
                 : new LongPairRangeSet.DefaultRangeSet<>(rangeConverter, rangeBoundConsumer);
         this.enableMultiEntry = config.isPersistentUnackedRangesWithMultipleEntriesEnabled();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@ flexible messaging model and an intuitive client API.</description>
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
     <dependency-check-maven.version>10.0.1</dependency-check-maven.version>
-    <roaringbitmap.version>1.1.0</roaringbitmap.version>
+    <roaringbitmap.version>1.2.0</roaringbitmap.version>
     <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
     <oshi.version>6.4.0</oshi.version>
     <checkerframework.version>3.33.0</checkerframework.version>

--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@ flexible messaging model and an intuitive client API.</description>
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
     <dependency-check-maven.version>10.0.1</dependency-check-maven.version>
-    <roaringbitmap.version>1.0.6</roaringbitmap.version>
+    <roaringbitmap.version>1.1.0</roaringbitmap.version>
     <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
     <oshi.version>6.4.0</oshi.version>
     <checkerframework.version>3.33.0</checkerframework.version>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -252,6 +252,11 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.roaringbitmap</groupId>
+      <artifactId>RoaringBitmap</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/OpenLongPairRangeSet.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/OpenLongPairRangeSet.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.commons.lang.mutable.MutableInt;
+import org.roaringbitmap.RoaringBitSet;
 
 /**
  * A Concurrent set comprising zero or more ranges of type {@link LongPair}. This can be alternative of
@@ -46,8 +47,6 @@ import org.apache.commons.lang.mutable.MutableInt;
 public class OpenLongPairRangeSet<T extends Comparable<T>> implements LongPairRangeSet<T> {
 
     protected final NavigableMap<Long, BitSet> rangeBitSetMap = new ConcurrentSkipListMap<>();
-    private boolean threadSafe = true;
-    private final int bitSetSize;
     private final LongPairConsumer<T> consumer;
 
     // caching place-holder for cpu-optimization to avoid calculating ranges again
@@ -57,16 +56,6 @@ public class OpenLongPairRangeSet<T extends Comparable<T>> implements LongPairRa
     private volatile boolean updatedAfterCachedForToString = true;
 
     public OpenLongPairRangeSet(LongPairConsumer<T> consumer) {
-        this(1024, true, consumer);
-    }
-
-    public OpenLongPairRangeSet(int size, LongPairConsumer<T> consumer) {
-        this(size, true, consumer);
-    }
-
-    public OpenLongPairRangeSet(int size, boolean threadSafe, LongPairConsumer<T> consumer) {
-        this.threadSafe = threadSafe;
-        this.bitSetSize = size;
         this.consumer = consumer;
     }
 
@@ -416,7 +405,7 @@ public class OpenLongPairRangeSet<T extends Comparable<T>> implements LongPairRa
     }
 
     private BitSet createNewBitSet() {
-        return this.threadSafe ? new ConcurrentBitSet(bitSetSize) : new BitSet(bitSetSize);
+        return new RoaringBitSet();
     }
 
 }


### PR DESCRIPTION
Fixes #22866

### Motivation

There has been a previous attempt to address #22866 in #22908 which caused regressions and this PR was reverted by #22968. 
After that, PR #22966 made ConcurrentOpenLongPairRangeSet thread safe and renamed the class to OpenLongPairRangeSet. The PR makes changes to the class to properly and consistently use the existing ReadWriteLock for all accesses. 
This PR contains the next step to use the RoaringBitSet class that @dao-jun has contributed to RoaringBitmap 1.1.0. The usage of RoaringBitmap reduces memory usage compared to java.util.BitSet and presumable addresses issue #22866.

### Modifications

- Upgrade RoaringBitmap to 1.2.0
- Remove unnecessary options from OpenLongPairRangeSet class
- Use RoaringBitSet in OpenLongPairRangeSet as the BitSet implementation

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->