### PR TITLE
[fix] [txn] do not take snapshot when no txn.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1584,7 +1584,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
                     schemaVersionFuture.thenAccept(schemaVersion -> {
                         topic.checkIfTransactionBufferRecoverCompletely(isTxnEnabled)
-                                .thenCompose(future -> topic.takeFirstSnapshotIfNeed())
+                                .thenCompose(future -> topic.takeFirstSnapshotIfNeed(isTxnEnabled))
                                 .thenAccept(future -> {
                                     CompletionStage<Subscription> createInitSubFuture;
                                     if (!Strings.isNullOrEmpty(initialSubscriptionName)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -155,9 +155,10 @@ public interface Topic {
 
     /**
      * Take snapshot if needed.
+     * @param isTxnEnabled isTxnEnabled
      * @return a future represents the result of take snapshot operation.
      */
-    CompletableFuture<Void> takeFirstSnapshotIfNeed();
+    CompletableFuture<Void> takeFirstSnapshotIfNeed(boolean isTxnEnabled);
 
     /**
      * record add-latency.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -154,6 +154,12 @@ public interface Topic {
     CompletableFuture<Void> checkIfTransactionBufferRecoverCompletely(boolean isTxnEnabled);
 
     /**
+     * Take snapshot if needed.
+     * @return a future represents the result of take snapshot operation.
+     */
+    CompletableFuture<Void> takeFirstSnapshotIfNeed();
+
+    /**
      * record add-latency.
      */
     void recordAddLatency(long latency, TimeUnit unit);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -262,6 +262,11 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
     }
 
     @Override
+    public CompletableFuture<Void> takeFirstSnapshotIfNeed() {
+        return  CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public CompletableFuture<Consumer> subscribe(SubscriptionOption option) {
         return internalSubscribe(option.getCnx(), option.getSubscriptionName(), option.getConsumerId(),
                 option.getSubType(), option.getPriorityLevel(), option.getConsumerName(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -262,7 +262,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
     }
 
     @Override
-    public CompletableFuture<Void> takeFirstSnapshotIfNeed() {
+    public CompletableFuture<Void> takeFirstSnapshotIfNeed(boolean enableTxn) {
         return  CompletableFuture.completedFuture(null);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -846,8 +846,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     @Override
-    public CompletableFuture<Void> takeFirstSnapshotIfNeed() {
-        return getTransactionBuffer().takeFirstSnapshotIfNeed();
+    public CompletableFuture<Void> takeFirstSnapshotIfNeed(boolean isTxnEnabled) {
+        return getTransactionBuffer().takeFirstSnapshotIfNeed(isTxnEnabled);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -846,6 +846,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     @Override
+    public CompletableFuture<Void> takeFirstSnapshotIfNeed() {
+        return getTransactionBuffer().takeFirstSnapshotIfNeed();
+    }
+
+    @Override
     protected CompletableFuture<Long> incrementTopicEpoch(Optional<Long> currentEpoch) {
         long newEpoch = currentEpoch.orElse(-1L) + 1;
         return setTopicEpoch(newEpoch);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
@@ -196,9 +196,10 @@ public interface TransactionBuffer {
 
     /**
      * Take snapshot if needed.
+     * @param enableTxn
      * @return a future represents the result of take snapshot operation.
      */
-    CompletableFuture<Void> takeFirstSnapshotIfNeed();
+    CompletableFuture<Void> takeFirstSnapshotIfNeed(boolean enableTxn);
 
     long getOngoingTxnCount();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
@@ -194,7 +194,11 @@ public interface TransactionBuffer {
      */
     CompletableFuture<Void> checkIfTBRecoverCompletely(boolean isTxn);
 
-
+    /**
+     * Take snapshot if needed.
+     * @return a future represents the result of take snapshot operation.
+     */
+    CompletableFuture<Void> takeFirstSnapshotIfNeed();
 
     long getOngoingTxnCount();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBuffer.java
@@ -416,6 +416,11 @@ class InMemTransactionBuffer implements TransactionBuffer {
     }
 
     @Override
+    public CompletableFuture<Void> takeFirstSnapshotIfNeed(boolean enableTxn) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public long getOngoingTxnCount() {
         return this.buffers.values().stream()
                 .filter(txnBuffer -> txnBuffer.status.equals(TxnStatus.OPEN)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -221,6 +221,9 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
             transactionBufferFuture.thenRun(() -> {
                 if (checkIfNoSnapshot() || checkIfReady()) {
                     completableFuture.complete(null);
+                } else {
+                    completableFuture.completeExceptionally(new BrokerServiceException
+                            .ServiceUnitNotReadyException("TransactionBuffer recover failed"));
                 }
             }).exceptionally(exception -> {
                 log.error("Topic {}: TransactionBuffer recover failed", this.topic.getName(), exception.getCause());
@@ -428,7 +431,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
     }
 
     private void takeAbortedTxnSnapshot(Position maxReadPosition) {
-        this.snapshotAbortedTxnProcessor.takeAbortedTxnsSnapshot(this.maxReadPosition)
+        this.snapshotAbortedTxnProcessor.takeAbortedTxnsSnapshot(maxReadPosition)
                 .thenRun(() -> {
                     if (checkIfNoSnapshot()) {
                         changeToReadyStateFromNoSnapshot();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -235,9 +235,9 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
     }
 
     @Override
-    public CompletableFuture<Void> takeFirstSnapshotIfNeed() {
+    public CompletableFuture<Void> takeFirstSnapshotIfNeed(boolean enableTxn) {
         CompletableFuture<Void> completableFuture = new CompletableFuture<>();
-        if (checkIfNoSnapshot()) {
+        if (enableTxn && checkIfNoSnapshot()) {
             this.snapshotAbortedTxnProcessor.takeAbortedTxnsSnapshot(maxReadPosition)
                     .thenRun(() -> changeToReadyStateFromNoSnapshot())
                     .thenAccept(__ -> completableFuture.complete(null));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -256,6 +256,9 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                     + "Please use a new transaction to send message."));
             return completableFuture;
         }
+        if (checkIfNoSnapshot()) {
+            takeAbortedTxnSnapshot(this.maxReadPosition);
+        }
         topic.getManagedLedger().asyncAddEntry(buffer, new AsyncCallbacks.AddEntryCallback() {
             @Override
             public void addComplete(Position position, ByteBuf entryData, Object ctx) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferDisable.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferDisable.java
@@ -137,6 +137,11 @@ public class TransactionBufferDisable implements TransactionBuffer {
     }
 
     @Override
+    public CompletableFuture<Void> takeFirstSnapshotIfNeed(boolean enableTxn) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public long getOngoingTxnCount() {
         return 0;
     }


### PR DESCRIPTION
### Motivation

When broker enable txn, but client don't use txn feature, we expect that the tb would't take snapshot. But it did.

### Modifications

Guarantee that tb would''t take snapshot.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository:  https://github.com/thetumbled/pulsar/pull/61