### PR TITLE
[fix][broker] Change default behavior when ZK session expired to shutdown

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -645,7 +645,7 @@ maxNumPartitionsPerPartitionedTopic=0
 # There are two policies to apply when broker metadata session expires: session expired happens, "shutdown" or "reconnect".
 # With "shutdown", the broker will be restarted.
 # With "reconnect", the broker will keep serving the topics, while attempting to recreate a new session.
-zookeeperSessionExpiredPolicy=reconnect
+zookeeperSessionExpiredPolicy=shutdown
 
 # Enable or disable system topic
 systemTopicEnabled=true

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1414,7 +1414,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         + " With \"shutdown\", the broker will be restarted.\n\n"
         + " With \"reconnect\", the broker will keep serving the topics, while attempting to recreate a new session."
     )
-    private MetadataSessionExpiredPolicy zookeeperSessionExpiredPolicy = MetadataSessionExpiredPolicy.reconnect;
+    private MetadataSessionExpiredPolicy zookeeperSessionExpiredPolicy = MetadataSessionExpiredPolicy.shutdown;
 
     @FieldContext(
         category = CATEGORY_SERVER,


### PR DESCRIPTION
### Motivation

**background**
- Once a broker's(we call it `broker-1`) ZK session has expired, the topics it owns will be assigned to other brokers
- And the `broker-1` will get a `BadVersionException`, then the topics will be marked `fenced`.
- Other brokers will load up the topics
- At this moment there is more than one broker who owns the same topic.
  -  The clients who connected to `broker-1` will get a fenced error.

Issue: the topics on `broker-1` will not be unloaded until it restarts, so we'd better change the default behavior of the action when ZK session expires to `shutdown`, which will solve the issue automatically. We can set it back to `reconnect` after we improve the behavior to unload the topic automatically in the future.

### Modifications

Change default behavior when ZK session expired to `shutdown`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
