### PR TITLE
[feat][ws]Add support for initialSubscriptionPosition in Websocket Consumer

### DIFF
--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -433,9 +433,11 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
         }
 
         if (queryParams.containsKey("subscriptionInitialPosition")) {
-            checkArgument(Enums.getIfPresent(SubscriptionInitialPosition.class, queryParams.get("subscriptionInitialPosition")).isPresent(),
-                    "Invalid subscriptionInitialPosition %s", queryParams.get("subscriptionInitialPosition"));
-            builder.subscriptionInitialPosition(SubscriptionInitialPosition.valueOf(queryParams.get("subscriptionInitialPosition")));
+            final String subscriptionInitialPosition = queryParams.get("subscriptionInitialPosition");
+            checkArgument(
+                    Enums.getIfPresent(SubscriptionInitialPosition.class, subscriptionInitialPosition).isPresent(),
+                    "Invalid subscriptionInitialPosition %s", subscriptionInitialPosition);
+            builder.subscriptionInitialPosition(SubscriptionInitialPosition.valueOf(subscriptionInitialPosition));
         }
 
         if (queryParams.containsKey("receiverQueueSize")) {

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -44,6 +44,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientException.AlreadyClosedException;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.ConsumerBuilderImpl;
@@ -429,6 +430,12 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
             checkArgument(Enums.getIfPresent(SubscriptionMode.class, queryParams.get("subscriptionMode")).isPresent(),
                     "Invalid subscriptionMode %s", queryParams.get("subscriptionMode"));
             builder.subscriptionMode(SubscriptionMode.valueOf(queryParams.get("subscriptionMode")));
+        }
+
+        if (queryParams.containsKey("subscriptionInitialPosition")) {
+            checkArgument(Enums.getIfPresent(SubscriptionInitialPosition.class, queryParams.get("subscriptionInitialPosition")).isPresent(),
+                    "Invalid subscriptionInitialPosition %s", queryParams.get("subscriptionInitialPosition"));
+            builder.subscriptionInitialPosition(SubscriptionInitialPosition.valueOf(queryParams.get("subscriptionInitialPosition")));
         }
 
         if (queryParams.containsKey("receiverQueueSize")) {


### PR DESCRIPTION

<!-- Either this PR fixes an issue, -->

Fixes #22969

### Motivation

As a websocket client, I need to subscribe to a persistent topic that has existing messages.
I need to consume all messages, starting from the first (earliest) one, and keep consuming messages as they become available.
Persistent subscription cursor is needed, hence the use of consumer api.

There is no parameter available for this setting shown in the documentation, or in the code that creates the subscription.

There is a similar setting messageId for the Reader endpoint.
But not for the Consumer endpoint.

### Modifications

Passthru the SubscriptionInitialPosition query parameter to the Consumer java API.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
