### PR TITLE
[fix][broker] Fix stuck when enable topic level replication and build remote admin fails

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -976,6 +976,10 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         } catch (Exception ex) {
             // Expected an error.
         }
+
+        // cleanup.
+        admin1.topics().deletePartitionedTopic(topic);
+        admin1.tenants().updateTenant(defaultTenant, tenantInfo);
     }
 
     @Test


### PR DESCRIPTION
### Motivation

The method `BrokerService. getClusterPulsarAdmin` will throw exceptions and the method `topics set replicated clusters` did not catch the exception, which leads to the complete future can not be completed.  Eventually, the API `enbale topic-level replication` gets stuck.

### Modifications

fix the bug

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x