### PR TITLE
[feat][misc] PIP-264: Add OpenTelemetry messaging rate limit metrics

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -213,7 +213,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                 compressionConfigForManagedCursorInfo);
         this.config = config;
         this.mbean = new ManagedLedgerFactoryMBeanImpl(this);
-        this.entryCacheManager = new RangeEntryCacheManagerImpl(this);
+        this.entryCacheManager = new RangeEntryCacheManagerImpl(this, openTelemetry);
         this.statsTask = scheduledExecutor.scheduleWithFixedDelay(catchingAndLoggingThrowables(this::refreshStats),
                 0, config.getStatsPeriodSeconds(), TimeUnit.SECONDS);
         this.flushCursorsTask = scheduledExecutor.scheduleAtFixedRate(catchingAndLoggingThrowables(this::flushCursors),

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
@@ -19,20 +19,45 @@
 package org.apache.bookkeeper.mledger.impl.cache;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.ObservableLongCounter;
 import io.prometheus.client.Gauge;
 import lombok.AllArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.opentelemetry.Constants;
+import org.apache.pulsar.opentelemetry.annotations.PulsarDeprecatedMetric;
 
 @Slf4j
-public class InflightReadsLimiter {
+public class InflightReadsLimiter implements AutoCloseable {
 
+    public static final AttributeKey<String> MANAGED_LEDGER_READ_INFLIGHT_USAGE =
+            AttributeKey.stringKey("pulsar.managed_ledger.inflight.read.utilization");
+    public enum InflightReadLimiterUtilization {
+        USED,
+        FREE,
+        TOTAL;
+        private final Attributes attributes = Attributes.of(MANAGED_LEDGER_READ_INFLIGHT_USAGE, name().toLowerCase());
+    }
+
+    public static final String INFLIGHT_READS_LIMITER_LIMIT_METRIC_NAME = "pulsar_ml_reads_inflight_bytes";
+    private final ObservableLongCounter inflightReadsLimitCounter;
+
+    @PulsarDeprecatedMetric(newMetricName = INFLIGHT_READS_LIMITER_LIMIT_METRIC_NAME)
+    @Deprecated
     private static final Gauge PULSAR_ML_READS_BUFFER_SIZE = Gauge
             .build()
             .name("pulsar_ml_reads_inflight_bytes")
             .help("Estimated number of bytes retained by data read from storage or cache")
             .register();
 
+    public static final String INFLIGHT_READS_LIMITER_USAGE_METRIC_NAME = "pulsar_ml_reads_inflight_usage_bytes";
+    private final ObservableLongCounter inflightReadsUsageCounter;
+
+    @PulsarDeprecatedMetric(newMetricName = INFLIGHT_READS_LIMITER_USAGE_METRIC_NAME)
+    @Deprecated
     private static final Gauge PULSAR_ML_READS_AVAILABLE_BUFFER_SIZE = Gauge
             .build()
             .name("pulsar_ml_reads_available_inflight_bytes")
@@ -42,7 +67,7 @@ public class InflightReadsLimiter {
     private final long maxReadsInFlightSize;
     private long remainingBytes;
 
-    public InflightReadsLimiter(long maxReadsInFlightSize) {
+    public InflightReadsLimiter(long maxReadsInFlightSize, OpenTelemetry openTelemetry) {
         if (maxReadsInFlightSize <= 0) {
             // set it to -1 in order to show in the metrics that the metric is not available
             PULSAR_ML_READS_BUFFER_SIZE.set(-1);
@@ -50,11 +75,34 @@ public class InflightReadsLimiter {
         }
         this.maxReadsInFlightSize = maxReadsInFlightSize;
         this.remainingBytes = maxReadsInFlightSize;
+
+        var meter = openTelemetry.getMeter(Constants.BROKER_INSTRUMENTATION_SCOPE_NAME);
+        inflightReadsLimitCounter = meter.counterBuilder(INFLIGHT_READS_LIMITER_LIMIT_METRIC_NAME)
+                .buildWithCallback(measurement -> {
+                    if (!isDisabled()) {
+                        measurement.record(maxReadsInFlightSize);
+                    }
+                });
+        inflightReadsUsageCounter = meter.counterBuilder(INFLIGHT_READS_LIMITER_USAGE_METRIC_NAME)
+                .buildWithCallback(measurement -> {
+                    if (!isDisabled()) {
+                        var freeBytes = getRemainingBytes();
+                        var usedBytes = maxReadsInFlightSize - freeBytes;
+                        measurement.record(freeBytes, InflightReadLimiterUtilization.FREE.attributes);
+                        measurement.record(usedBytes, InflightReadLimiterUtilization.USED.attributes);
+                    }
+                });
     }
 
     @VisibleForTesting
     public synchronized long getRemainingBytes() {
         return remainingBytes;
+    }
+
+    @Override
+    public void close() {
+        inflightReadsLimitCounter.close();
+        inflightReadsUsageCounter.close();
     }
 
     @AllArgsConstructor

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
@@ -37,9 +37,8 @@ public class InflightReadsLimiter implements AutoCloseable {
             AttributeKey.stringKey("pulsar.managed_ledger.inflight.read.utilization");
     public enum InflightReadLimiterUtilization {
         USED,
-        FREE,
-        TOTAL;
-        private final Attributes attributes = Attributes.of(MANAGED_LEDGER_READ_INFLIGHT_USAGE, name().toLowerCase());
+        FREE;
+        public final Attributes attributes = Attributes.of(MANAGED_LEDGER_READ_INFLIGHT_USAGE, name().toLowerCase());
     }
 
     public static final String INFLIGHT_READS_LIMITER_LIMIT_METRIC_NAME = "pulsar_ml_reads_inflight_bytes";

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheManagerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheManagerImpl.java
@@ -20,6 +20,7 @@ package org.apache.bookkeeper.mledger.impl.cache;
 
 import com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
+import io.opentelemetry.api.OpenTelemetry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -56,10 +57,10 @@ public class RangeEntryCacheManagerImpl implements EntryCacheManager {
     private static final double evictionTriggerThresholdPercent = 0.98;
 
 
-    public RangeEntryCacheManagerImpl(ManagedLedgerFactoryImpl factory) {
+    public RangeEntryCacheManagerImpl(ManagedLedgerFactoryImpl factory, OpenTelemetry openTelemetry) {
         this.maxSize = factory.getConfig().getMaxCacheSize();
         this.inflightReadsLimiter = new InflightReadsLimiter(
-                factory.getConfig().getManagedLedgerMaxReadsInFlightSize());
+                factory.getConfig().getManagedLedgerMaxReadsInFlightSize(), openTelemetry);
         this.evictionTriggerThreshold = (long) (maxSize * evictionTriggerThresholdPercent);
         this.cacheEvictionWatermark = factory.getConfig().getCacheEvictionWatermark();
         this.evictionPolicy = new EntryCacheDefaultEvictionPolicy();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
@@ -21,7 +21,7 @@ package org.apache.bookkeeper.mledger.impl.cache;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
-
+import io.opentelemetry.api.OpenTelemetry;
 import lombok.extern.slf4j.Slf4j;
 import org.testng.annotations.Test;
 
@@ -31,19 +31,19 @@ public class InflightReadsLimiterTest {
     @Test
     public void testDisabled() throws Exception {
 
-        InflightReadsLimiter limiter = new InflightReadsLimiter(0);
+        InflightReadsLimiter limiter = new InflightReadsLimiter(0, OpenTelemetry.noop());
         assertTrue(limiter.isDisabled());
 
-        limiter = new InflightReadsLimiter(-1);
+        limiter = new InflightReadsLimiter(-1, OpenTelemetry.noop());
         assertTrue(limiter.isDisabled());
 
-        limiter = new InflightReadsLimiter(1);
+        limiter = new InflightReadsLimiter(1, OpenTelemetry.noop());
         assertFalse(limiter.isDisabled());
     }
 
     @Test
     public void testBasicAcquireRelease() throws Exception {
-        InflightReadsLimiter limiter = new InflightReadsLimiter(100);
+        InflightReadsLimiter limiter = new InflightReadsLimiter(100, OpenTelemetry.noop());
         assertEquals(100, limiter.getRemainingBytes());
         InflightReadsLimiter.Handle handle = limiter.acquire(100, null);
         assertEquals(0, limiter.getRemainingBytes());
@@ -56,7 +56,7 @@ public class InflightReadsLimiterTest {
 
     @Test
     public void testNotEnoughPermits() throws Exception {
-        InflightReadsLimiter limiter = new InflightReadsLimiter(100);
+        InflightReadsLimiter limiter = new InflightReadsLimiter(100, OpenTelemetry.noop());
         assertEquals(100, limiter.getRemainingBytes());
         InflightReadsLimiter.Handle handle = limiter.acquire(100, null);
         assertEquals(0, limiter.getRemainingBytes());
@@ -86,7 +86,7 @@ public class InflightReadsLimiterTest {
 
     @Test
     public void testPartialAcquire() throws Exception {
-        InflightReadsLimiter limiter = new InflightReadsLimiter(100);
+        InflightReadsLimiter limiter = new InflightReadsLimiter(100, OpenTelemetry.noop());
         assertEquals(100, limiter.getRemainingBytes());
 
         InflightReadsLimiter.Handle handle = limiter.acquire(30, null);
@@ -116,7 +116,7 @@ public class InflightReadsLimiterTest {
 
     @Test
     public void testTooManyTrials() throws Exception {
-        InflightReadsLimiter limiter = new InflightReadsLimiter(100);
+        InflightReadsLimiter limiter = new InflightReadsLimiter(100, OpenTelemetry.noop());
         assertEquals(100, limiter.getRemainingBytes());
 
         InflightReadsLimiter.Handle handle = limiter.acquire(30, null);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
@@ -19,8 +19,8 @@
 package org.apache.bookkeeper.mledger.impl.cache;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
-import static org.apache.bookkeeper.mledger.impl.cache.InflightReadsLimiter.InflightReadLimiterUtilization.FREE;
-import static org.apache.bookkeeper.mledger.impl.cache.InflightReadsLimiter.InflightReadLimiterUtilization.USED;
+import static org.apache.pulsar.opentelemetry.OpenTelemetryAttributes.InflightReadLimiterUtilization.FREE;
+import static org.apache.pulsar.opentelemetry.OpenTelemetryAttributes.InflightReadLimiterUtilization.USED;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -38,7 +38,7 @@ import org.testng.annotations.Test;
 public class InflightReadsLimiterTest {
 
     @DataProvider
-    public static Object[][] isDisabled() {
+    private static Object[][] isDisabled() {
         return new Object[][] {
             {0, true},
             {-1, true},

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
@@ -18,49 +18,75 @@
  */
 package org.apache.bookkeeper.mledger.impl.cache;
 
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static org.apache.bookkeeper.mledger.impl.cache.InflightReadsLimiter.InflightReadLimiterUtilization.FREE;
+import static org.apache.bookkeeper.mledger.impl.cache.InflightReadsLimiter.InflightReadLimiterUtilization.USED;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Slf4j
 public class InflightReadsLimiterTest {
 
-    @Test
-    public void testDisabled() throws Exception {
-        @Cleanup
-        var reader = InMemoryMetricReader.create();
+    @DataProvider
+    public static Object[][] isDisabled() {
+        return new Object[][] {
+            {0, true},
+            {-1, true},
+            {1, false},
+        };
+    }
 
-        @Cleanup
-        var openTelemetry = OpenTelemetrySdk.builder().build();
+    @Test(dataProvider = "isDisabled")
+    public void testDisabled(long maxReadsInFlightSize, boolean shouldBeDisabled) throws Exception {
+        var otel = buildOpenTelemetryAndReader();
+        @Cleanup var openTelemetry = otel.getLeft();
+        @Cleanup var metricReader = otel.getRight();
 
-        InflightReadsLimiter limiter = new InflightReadsLimiter(0, OpenTelemetry.noop());
-        assertTrue(limiter.isDisabled());
+        var limiter = new InflightReadsLimiter(maxReadsInFlightSize, openTelemetry);
+        assertEquals(limiter.isDisabled(), shouldBeDisabled);
 
-        limiter = new InflightReadsLimiter(-1, OpenTelemetry.noop());
-        assertTrue(limiter.isDisabled());
-
-        limiter = new InflightReadsLimiter(1, OpenTelemetry.noop());
-        assertFalse(limiter.isDisabled());
+        if (shouldBeDisabled) {
+            // Verify metrics are not present
+            var metrics = metricReader.collectAllMetrics();
+            assertThat(metrics).noneSatisfy(metricData -> assertThat(metricData)
+                    .hasName(InflightReadsLimiter.INFLIGHT_READS_LIMITER_LIMIT_METRIC_NAME));
+            assertThat(metrics).noneSatisfy(metricData -> assertThat(metricData)
+                    .hasName(InflightReadsLimiter.INFLIGHT_READS_LIMITER_USAGE_METRIC_NAME));
+        }
     }
 
     @Test
     public void testBasicAcquireRelease() throws Exception {
-        InflightReadsLimiter limiter = new InflightReadsLimiter(100, OpenTelemetry.noop());
+        var otel = buildOpenTelemetryAndReader();
+        @Cleanup var openTelemetry = otel.getLeft();
+        @Cleanup var metricReader = otel.getRight();
+
+        InflightReadsLimiter limiter = new InflightReadsLimiter(100, openTelemetry);
         assertEquals(100, limiter.getRemainingBytes());
+        assertLimiterMetrics(metricReader, 100, 0, 100);
+
         InflightReadsLimiter.Handle handle = limiter.acquire(100, null);
         assertEquals(0, limiter.getRemainingBytes());
         assertTrue(handle.success);
         assertEquals(handle.acquiredPermits, 100);
         assertEquals(1, handle.trials);
+        assertLimiterMetrics(metricReader, 100, 100, 0);
+
         limiter.release(handle);
         assertEquals(100, limiter.getRemainingBytes());
+        assertLimiterMetrics(metricReader, 100, 0, 100);
     }
+
 
     @Test
     public void testNotEnoughPermits() throws Exception {
@@ -177,4 +203,25 @@ public class InflightReadsLimiterTest {
 
     }
 
+    private Pair<OpenTelemetrySdk, InMemoryMetricReader> buildOpenTelemetryAndReader() {
+        var metricReader = InMemoryMetricReader.create();
+        var openTelemetry = AutoConfiguredOpenTelemetrySdk.builder()
+                .addMeterProviderCustomizer((builder, __) -> builder.registerMetricReader(metricReader))
+                .build()
+                .getOpenTelemetrySdk();
+        return Pair.of(openTelemetry, metricReader);
+    }
+
+    private void assertLimiterMetrics(InMemoryMetricReader metricReader,
+                                      long expectedLimit, long expectedUsed, long expectedFree) {
+        var metrics = metricReader.collectAllMetrics();
+        assertThat(metrics).anySatisfy(metricData -> assertThat(metricData)
+                .hasName(InflightReadsLimiter.INFLIGHT_READS_LIMITER_LIMIT_METRIC_NAME)
+                .hasLongSumSatisfying(longSum -> longSum.hasPointsSatisfying(point -> point.hasValue(expectedLimit))));
+        assertThat(metrics).anySatisfy(metricData -> assertThat(metricData)
+                .hasName(InflightReadsLimiter.INFLIGHT_READS_LIMITER_USAGE_METRIC_NAME)
+                .hasLongSumSatisfying(longSum -> longSum.hasPointsSatisfying(
+                        point -> point.hasValue(expectedFree).hasAttributes(FREE.attributes),
+                        point -> point.hasValue(expectedUsed).hasAttributes(USED.attributes))));
+    }
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
@@ -22,6 +22,9 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.testng.annotations.Test;
 
@@ -30,6 +33,11 @@ public class InflightReadsLimiterTest {
 
     @Test
     public void testDisabled() throws Exception {
+        @Cleanup
+        var reader = InMemoryMetricReader.create();
+
+        @Cleanup
+        var openTelemetry = OpenTelemetrySdk.builder().build();
 
         InflightReadsLimiter limiter = new InflightReadsLimiter(0, OpenTelemetry.noop());
         assertTrue(limiter.isDisabled());

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/PendingReadsManagerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/PendingReadsManagerTest.java
@@ -18,32 +18,6 @@
  */
 package org.apache.bookkeeper.mledger.impl.cache;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.bookkeeper.client.api.ReadHandle;
-import org.apache.bookkeeper.mledger.AsyncCallbacks;
-import org.apache.bookkeeper.mledger.Entry;
-import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
-import org.apache.bookkeeper.mledger.ManagedLedgerException;
-import org.apache.bookkeeper.mledger.Position;
-import org.apache.bookkeeper.mledger.impl.EntryImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
-
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -54,6 +28,30 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.AssertJUnit.assertNotSame;
 import static org.testng.AssertJUnit.assertSame;
+import io.opentelemetry.api.OpenTelemetry;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.client.api.ReadHandle;
+import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.impl.EntryImpl;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 @Slf4j
 public class PendingReadsManagerTest  {
@@ -93,7 +91,7 @@ public class PendingReadsManagerTest  {
         config.setReadEntryTimeoutSeconds(10000);
         when(rangeEntryCache.getName()).thenReturn("my-topic");
         when(rangeEntryCache.getManagedLedgerConfig()).thenReturn(config);
-        inflighReadsLimiter = new InflightReadsLimiter(0);
+        inflighReadsLimiter = new InflightReadsLimiter(0, OpenTelemetry.noop());
         when(rangeEntryCache.getPendingReadsLimiter()).thenReturn(inflighReadsLimiter);
         pendingReadsManager = new PendingReadsManager(rangeEntryCache);
         doAnswer(new Answer() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -858,6 +858,7 @@ public class BrokerService implements Closeable {
                                 pulsarStats.close();
                                 pendingTopicLoadOperationsCounter.close();
                                 pendingLookupOperationsCounter.close();
+                                throttledConnectionsCounter.close();
                                 try {
                                     delayedDeliveryTrackerFactory.close();
                                 } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -184,7 +184,7 @@ import org.apache.pulsar.compaction.Compactor;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.Notification;
 import org.apache.pulsar.metadata.api.NotificationType;
-import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
+import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes.ConnectionRateLimitOperationName;
 import org.apache.pulsar.opentelemetry.annotations.PulsarDeprecatedMetric;
 import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
 import org.apache.pulsar.transaction.coordinator.TransactionMetadataStore;
@@ -3709,20 +3709,20 @@ public class BrokerService implements Closeable {
     }
 
     public void recordConnectionPaused() {
-        rateLimitedConnectionsCounter.add(1, OpenTelemetryAttributes.ConnectionRateLimitState.PAUSED.attributes);
+        rateLimitedConnectionsCounter.add(1, ConnectionRateLimitOperationName.PAUSED.attributes);
     }
 
     public void recordConnectionResumed() {
-        rateLimitedConnectionsCounter.add(1, OpenTelemetryAttributes.ConnectionRateLimitState.RESUMED.attributes);
+        rateLimitedConnectionsCounter.add(1, ConnectionRateLimitOperationName.RESUMED.attributes);
     }
 
     public void recordConnectionThrottled() {
-        rateLimitedConnectionsCounter.add(1, OpenTelemetryAttributes.ConnectionRateLimitState.THROTTLED.attributes);
+        rateLimitedConnectionsCounter.add(1, ConnectionRateLimitOperationName.THROTTLED.attributes);
         throttledConnectionsGauge.inc();
     }
 
     public void recordConnectionUnthrottled() {
-        rateLimitedConnectionsCounter.add(1, OpenTelemetryAttributes.ConnectionRateLimitState.UNTHROTTLED.attributes);
+        rateLimitedConnectionsCounter.add(1, ConnectionRateLimitOperationName.UNTHROTTLED.attributes);
         throttledConnectionsGauge.dec();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -297,8 +297,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         Start, Connected, Failed, Connecting
     }
 
-    private final ServerCnxThrottleTracker throttleTracker = new ServerCnxThrottleTracker(this);
-
+    private final ServerCnxThrottleTracker throttleTracker;
 
     public ServerCnx(PulsarService pulsar) {
         this(pulsar, null);
@@ -347,6 +346,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         this.topicListService = new TopicListService(pulsar, this,
                 enableSubscriptionPatternEvaluation, maxSubscriptionPatternLength);
         this.brokerInterceptor = this.service != null ? this.service.getInterceptor() : null;
+        this.throttleTracker = new ServerCnxThrottleTracker(this);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnxThrottleTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnxThrottleTracker.java
@@ -90,10 +90,10 @@ final class ServerCnxThrottleTracker {
         }
         // update the metrics that track throttling
         if (autoRead) {
-            serverCnx.getBrokerService().resumedConnections(1);
+            serverCnx.getBrokerService().recordConnectionResumed();
         } else if (isChannelActive()) {
             serverCnx.increasePublishLimitedTimesForTopics();
-            serverCnx.getBrokerService().pausedConnections(1);
+            serverCnx.getBrokerService().recordConnectionPaused();
         }
     }
 
@@ -109,7 +109,11 @@ final class ServerCnxThrottleTracker {
         boolean changed = changeThrottlingFlag(PENDING_SEND_REQUESTS_EXCEEDED_UPDATER, throttlingEnabled);
         if (changed) {
             // update the metrics that track throttling due to pending send requests
-            serverCnx.getBrokerService().updateThrottledConnectionCount(throttlingEnabled ? 1 : -1);
+            if (throttlingEnabled) {
+                serverCnx.getBrokerService().recordConnectionThrottled();
+            } else {
+                serverCnx.getBrokerService().recordConnectionUnthrottled();
+            }
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnxThrottleTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnxThrottleTracker.java
@@ -123,6 +123,7 @@ final class ServerCnxThrottleTracker {
                 throttledConnections.dec();
             }
             serverCnx.getBrokerService().updateThrottledConnectionCount(throttlingEnabled);
+            throw new RuntimeException("DMISCA: backtrace");
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/MessagePublishBufferThrottleTest.java
@@ -29,7 +29,7 @@ import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes.ConnectionRateLimitState;
+import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes.ConnectionRateLimitOperationName;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -64,8 +64,8 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
                 .topic(topic)
                 .producerName("producer-name")
                 .create();
-        assertRateLimitCounter(ConnectionRateLimitState.PAUSED, 0);
-        assertRateLimitCounter(ConnectionRateLimitState.RESUMED, 0);
+        assertRateLimitCounter(ConnectionRateLimitOperationName.PAUSED, 0);
+        assertRateLimitCounter(ConnectionRateLimitOperationName.RESUMED, 0);
 
         pulsarTestContext.getMockBookKeeper().addEntryDelay(1, TimeUnit.SECONDS);
 
@@ -76,8 +76,8 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
         }
         producer.flush();
 
-        assertRateLimitCounter(ConnectionRateLimitState.PAUSED, 0);
-        assertRateLimitCounter(ConnectionRateLimitState.RESUMED, 0);
+        assertRateLimitCounter(ConnectionRateLimitOperationName.PAUSED, 0);
+        assertRateLimitCounter(ConnectionRateLimitOperationName.RESUMED, 0);
     }
 
     @Test
@@ -91,8 +91,8 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
                 .producerName("producer-name")
                 .create();
 
-        assertRateLimitCounter(ConnectionRateLimitState.PAUSED, 0);
-        assertRateLimitCounter(ConnectionRateLimitState.RESUMED, 0);
+        assertRateLimitCounter(ConnectionRateLimitOperationName.PAUSED, 0);
+        assertRateLimitCounter(ConnectionRateLimitOperationName.RESUMED, 0);
 
         pulsarTestContext.getMockBookKeeper().addEntryDelay(1, TimeUnit.SECONDS);
 
@@ -102,15 +102,15 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
         }
 
         Awaitility.await().untilAsserted(() -> {
-            assertRateLimitCounter(ConnectionRateLimitState.PAUSED, 0);
-            assertRateLimitCounter(ConnectionRateLimitState.RESUMED, 0);
+            assertRateLimitCounter(ConnectionRateLimitOperationName.PAUSED, 0);
+            assertRateLimitCounter(ConnectionRateLimitOperationName.RESUMED, 0);
         });
 
         producer.flush();
 
         Awaitility.await().untilAsserted(() -> {
-            assertRateLimitCounter(ConnectionRateLimitState.PAUSED, 0);
-            assertRateLimitCounter(ConnectionRateLimitState.RESUMED, 0);
+            assertRateLimitCounter(ConnectionRateLimitOperationName.PAUSED, 0);
+            assertRateLimitCounter(ConnectionRateLimitOperationName.RESUMED, 0);
         });
     }
 
@@ -119,8 +119,8 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
         conf.setMaxMessagePublishBufferSizeInMB(1);
         super.baseSetup();
 
-        assertRateLimitCounter(ConnectionRateLimitState.PAUSED, 0);
-        assertRateLimitCounter(ConnectionRateLimitState.RESUMED, 0);
+        assertRateLimitCounter(ConnectionRateLimitOperationName.PAUSED, 0);
+        assertRateLimitCounter(ConnectionRateLimitOperationName.RESUMED, 0);
 
         final String topic = "persistent://prop/ns-abc/testBlockByPublishRateLimiting";
         Producer<byte[]> producer = pulsarClient.newProducer()
@@ -129,8 +129,8 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
                 .create();
         Topic topicRef = pulsar.getBrokerService().getTopicReference(topic).get();
         Assert.assertNotNull(topicRef);
-        assertRateLimitCounter(ConnectionRateLimitState.PAUSED, 0);
-        assertRateLimitCounter(ConnectionRateLimitState.RESUMED, 0);
+        assertRateLimitCounter(ConnectionRateLimitOperationName.PAUSED, 0);
+        assertRateLimitCounter(ConnectionRateLimitOperationName.RESUMED, 0);
 
         pulsarTestContext.getMockBookKeeper().addEntryDelay(5, TimeUnit.SECONDS);
 
@@ -140,14 +140,14 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
             producer.sendAsync(payload);
         }
 
-        Awaitility.await().untilAsserted(() -> assertRateLimitCounter(ConnectionRateLimitState.PAUSED, 1));
+        Awaitility.await().untilAsserted(() -> assertRateLimitCounter(ConnectionRateLimitOperationName.PAUSED, 1));
 
         CompletableFuture<Void> flushFuture = producer.flushAsync();
 
         // Block by publish rate.
         // After 1 second, the message buffer throttling will be lifted, but the rate limiting will still be in place.
-        assertRateLimitCounter(ConnectionRateLimitState.PAUSED, 1);
-        assertRateLimitCounter(ConnectionRateLimitState.RESUMED, 0);
+        assertRateLimitCounter(ConnectionRateLimitOperationName.PAUSED, 1);
+        assertRateLimitCounter(ConnectionRateLimitOperationName.RESUMED, 0);
 
         try {
             flushFuture.get(2, TimeUnit.SECONDS);
@@ -159,8 +159,8 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
         flushFuture.join();
 
         Awaitility.await().untilAsserted(() -> {
-            assertRateLimitCounter(ConnectionRateLimitState.PAUSED, 10);
-            assertRateLimitCounter(ConnectionRateLimitState.RESUMED, 10);
+            assertRateLimitCounter(ConnectionRateLimitOperationName.PAUSED, 10);
+            assertRateLimitCounter(ConnectionRateLimitOperationName.RESUMED, 10);
         });
     }
 
@@ -170,8 +170,8 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
 
         var topic = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/testSendThrottled");
 
-        assertRateLimitCounter(ConnectionRateLimitState.THROTTLED, 0);
-        assertRateLimitCounter(ConnectionRateLimitState.UNTHROTTLED, 0);
+        assertRateLimitCounter(ConnectionRateLimitOperationName.THROTTLED, 0);
+        assertRateLimitCounter(ConnectionRateLimitOperationName.UNTHROTTLED, 0);
 
         @Cleanup
         var producer = pulsarClient.newProducer(Schema.STRING)
@@ -188,13 +188,13 @@ public class MessagePublishBufferThrottleTest extends BrokerTestBase {
         Awaitility.await().untilAsserted(() -> {
             var metrics = pulsarTestContext.getOpenTelemetryMetricReader().collectAllMetrics();
             assertMetricLongSumValue(metrics, BrokerService.CONNECTION_RATE_LIMIT_COUNT_METRIC_NAME,
-                    ConnectionRateLimitState.THROTTLED.attributes, value -> assertThat(value).isPositive());
+                    ConnectionRateLimitOperationName.THROTTLED.attributes, value -> assertThat(value).isPositive());
             assertMetricLongSumValue(metrics, BrokerService.CONNECTION_RATE_LIMIT_COUNT_METRIC_NAME,
-                    ConnectionRateLimitState.UNTHROTTLED.attributes, value -> assertThat(value).isPositive());
+                    ConnectionRateLimitOperationName.UNTHROTTLED.attributes, value -> assertThat(value).isPositive());
         });
     }
 
-    private void assertRateLimitCounter(ConnectionRateLimitState connectionRateLimitState, int expectedCount) {
+    private void assertRateLimitCounter(ConnectionRateLimitOperationName connectionRateLimitState, int expectedCount) {
         var metrics = pulsarTestContext.getOpenTelemetryMetricReader().collectAllMetrics();
         if (expectedCount == 0) {
             assertThat(metrics).noneSatisfy(metricData -> assertThat(metricData)

--- a/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
+++ b/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
@@ -116,7 +116,9 @@ public interface OpenTelemetryAttributes {
             AttributeKey.stringKey("pulsar.connection.rate_limit.state");
     enum ConnectionRateLimitState {
         PAUSED,
-        THROTTLED;
+        RESUMED,
+        THROTTLED,
+        UNTHROTTLED;
         public final Attributes attributes = Attributes.of(PULSAR_CONNECTION_RATE_LIMIT_STATE, name().toLowerCase());
     }
 

--- a/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
+++ b/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
@@ -112,6 +112,14 @@ public interface OpenTelemetryAttributes {
      */
     AttributeKey<String> PULSAR_CLIENT_VERSION = AttributeKey.stringKey("pulsar.client.version");
 
+    AttributeKey<String> PULSAR_CONNECTION_RATE_LIMIT_STATE =
+            AttributeKey.stringKey("pulsar.connection.rate_limit.state");
+    enum ConnectionRateLimitState {
+        PAUSED,
+        THROTTLED;
+        public final Attributes attributes = Attributes.of(PULSAR_CONNECTION_RATE_LIMIT_STATE, name().toLowerCase());
+    }
+
     /**
      * The status of the Pulsar transaction.
      */

--- a/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
+++ b/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
@@ -207,6 +207,14 @@ public interface OpenTelemetryAttributes {
         public final Attributes attributes = Attributes.of(ML_CURSOR_OPERATION_STATUS, name().toLowerCase());
     }
 
+    AttributeKey<String> MANAGED_LEDGER_READ_INFLIGHT_USAGE =
+            AttributeKey.stringKey("pulsar.managed_ledger.inflight.read.usage.state");
+    enum InflightReadLimiterUtilization {
+        USED,
+        FREE;
+        public final Attributes attributes = Attributes.of(MANAGED_LEDGER_READ_INFLIGHT_USAGE, name().toLowerCase());
+    }
+
     /**
      * The name of the remote cluster for a Pulsar replicator.
      */

--- a/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
+++ b/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryAttributes.java
@@ -112,14 +112,15 @@ public interface OpenTelemetryAttributes {
      */
     AttributeKey<String> PULSAR_CLIENT_VERSION = AttributeKey.stringKey("pulsar.client.version");
 
-    AttributeKey<String> PULSAR_CONNECTION_RATE_LIMIT_STATE =
-            AttributeKey.stringKey("pulsar.connection.rate_limit.state");
-    enum ConnectionRateLimitState {
+    AttributeKey<String> PULSAR_CONNECTION_RATE_LIMIT_OPERATION_NAME =
+            AttributeKey.stringKey("pulsar.connection.rate_limit.operation.name");
+    enum ConnectionRateLimitOperationName {
         PAUSED,
         RESUMED,
         THROTTLED,
         UNTHROTTLED;
-        public final Attributes attributes = Attributes.of(PULSAR_CONNECTION_RATE_LIMIT_STATE, name().toLowerCase());
+        public final Attributes attributes =
+                Attributes.of(PULSAR_CONNECTION_RATE_LIMIT_OPERATION_NAME, name().toLowerCase());
     }
 
     /**


### PR DESCRIPTION
[PIP-264](https://github.com/apache/pulsar/blob/master/pip/pip-264.md)

### Motivation

Adds messaging rate limit metrics, currently exposed in classes `InflightReadsLimiter` and `ServerCnxThrottleTracker`, to the OpenTelemetry pipeline.

### Modifications

- Added metrics, as described by https://github.com/apache/pulsar-site/pull/943, to the OpenTelemetry pipeline.
- The metrics differ slightly from the existing ones:
  - Connection throttling metrics are cumulative totals, instead of the instantaneous value in the existing Prometheus metric `pulsar_broker_throttled_connections`. This gives better visibility into the frequency of rate limiting operations.
  - Connection throttling metrics are exposed for pause/resume operations too.
  - Managed ledger inflight reads metrics expose both the hard-wired limit and current usage, for increased visibility.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - Updated tests `InflightReadsLimiterTest#testDisabled` and `InflightReadsLimiterTest#testBasicAcquireRelease` to cover the changes to the `InflightReadsLimiter` metrics
  - Updated tests in `MessagePublishBufferThrottleTest` to verify connection pause/unpause metrics
  - Added test `MessagePublishBufferThrottleTest#testConnectionThrottled` to verify connection throttle/unthrottle metrics

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics: _As described in https://github.com/apache/pulsar-site/pull/943_
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` https://github.com/apache/pulsar-site/pull/943
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dragosvictor/pulsar/pull/41