### PR TITLE
[feat][misc] PIP-264: Add OpenTelemetry HTTP rate limiting filter metric

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/RateLimitingFilter.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/RateLimitingFilter.java
@@ -19,8 +19,8 @@
 package org.apache.pulsar.broker.web;
 
 import com.google.common.util.concurrent.RateLimiter;
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
 import io.prometheus.client.Counter;
 import java.io.IOException;
 import javax.servlet.Filter;
@@ -44,9 +44,8 @@ public class RateLimitingFilter implements Filter {
             .help("Counter of HTTP requests rejected by rate limiting")
             .register();
 
-    public RateLimitingFilter(double rateLimit, OpenTelemetry openTelemetry) {
+    public RateLimitingFilter(double rateLimit, Meter meter) {
         limiter = RateLimiter.create(rateLimit);
-        var meter = openTelemetry.getMeter("org.apache.pulsar");
         httpRejectedRequestsCounter = meter.counterBuilder(HTTP_REJECTED_REQUESTS_COUNTER_METRIC_NAME)
                 .setDescription("Counter of HTTP requests rejected by rate limiting")
                 .setUnit("{request}")

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/RateLimitingFilter.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/RateLimitingFilter.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.broker.web;
 
 import com.google.common.util.concurrent.RateLimiter;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.prometheus.client.Counter;
@@ -38,6 +40,14 @@ public class RateLimitingFilter implements Filter {
     public static final String HTTP_REJECTED_REQUESTS_COUNTER_METRIC_NAME = "pulsar.broker.http.rejected_requests";
     private final LongCounter httpRejectedRequestsCounter;
 
+    public static final AttributeKey<String> RATE_LIMITING_RESULT =
+            AttributeKey.stringKey("pulsar.http.rate_limiter.result");
+    public enum Result {
+        ACCEPTED,
+        REJECTED;
+        public final Attributes attributes = Attributes.of(RATE_LIMITING_RESULT, name().toLowerCase());
+    }
+
     @Deprecated
     private static final Counter httpRejectedRequests = Counter.build()
             .name("pulsar_broker_http_rejected_requests")
@@ -47,7 +57,7 @@ public class RateLimitingFilter implements Filter {
     public RateLimitingFilter(double rateLimit, Meter meter) {
         limiter = RateLimiter.create(rateLimit);
         httpRejectedRequestsCounter = meter.counterBuilder(HTTP_REJECTED_REQUESTS_COUNTER_METRIC_NAME)
-                .setDescription("Counter of HTTP requests rejected by rate limiting")
+                .setDescription("Counter of HTTP requests processed by rate limiting")
                 .setUnit("{request}")
                 .build();
     }
@@ -60,10 +70,11 @@ public class RateLimitingFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
         if (limiter.tryAcquire()) {
+            httpRejectedRequestsCounter.add(1, Result.ACCEPTED.attributes);
             chain.doFilter(request, response);
         } else {
             httpRejectedRequests.inc();
-            httpRejectedRequestsCounter.add(1);
+            httpRejectedRequestsCounter.add(1, Result.REJECTED.attributes);
             HttpServletResponse httpResponse = (HttpServletResponse) response;
             httpResponse.sendError(429, "Too Many Requests");
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -251,7 +251,7 @@ public class WebService implements AutoCloseable {
             if (config.isHttpRequestsLimitEnabled()) {
                 filterHolders.add(new FilterHolder(
                         new RateLimitingFilter(config.getHttpRequestsMaxPerSecond(),
-                                pulsarService.getOpenTelemetry().getOpenTelemetryService().getOpenTelemetry())));
+                                pulsarService.getOpenTelemetry().getMeter())));
             }
 
             // wait until the PulsarService is ready to serve incoming requests

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -250,7 +250,8 @@ public class WebService implements AutoCloseable {
 
             if (config.isHttpRequestsLimitEnabled()) {
                 filterHolders.add(new FilterHolder(
-                        new RateLimitingFilter(config.getHttpRequestsMaxPerSecond())));
+                        new RateLimitingFilter(config.getHttpRequestsMaxPerSecond(),
+                                pulsarService.getOpenTelemetry().getOpenTelemetryService().getOpenTelemetry())));
             }
 
             // wait until the PulsarService is ready to serve incoming requests

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
@@ -273,10 +273,10 @@ public class WebServiceTest {
 
         // setupEnv makes a HTTP call to create the cluster.
         var metrics = pulsarTestContext.getOpenTelemetryMetricReader().collectAllMetrics();
-        assertMetricLongSumValue(metrics, RateLimitingFilter.HTTP_REJECTED_REQUESTS_COUNTER_METRIC_NAME,
+        assertMetricLongSumValue(metrics, RateLimitingFilter.RATE_LIMIT_REQUEST_COUNT_METRIC_NAME,
                 Result.ACCEPTED.attributes, 1);
         assertThat(metrics).noneSatisfy(metricData -> assertThat(metricData)
-                .hasName(RateLimitingFilter.HTTP_REJECTED_REQUESTS_COUNTER_METRIC_NAME)
+                .hasName(RateLimitingFilter.RATE_LIMIT_REQUEST_COUNT_METRIC_NAME)
                 .hasLongSumSatisfying(
                         sum -> sum.hasPointsSatisfying(point -> point.hasAttributes(Result.REJECTED.attributes))));
 
@@ -287,10 +287,10 @@ public class WebServiceTest {
         }
 
         metrics = pulsarTestContext.getOpenTelemetryMetricReader().collectAllMetrics();
-        assertMetricLongSumValue(metrics, RateLimitingFilter.HTTP_REJECTED_REQUESTS_COUNTER_METRIC_NAME,
+        assertMetricLongSumValue(metrics, RateLimitingFilter.RATE_LIMIT_REQUEST_COUNT_METRIC_NAME,
                 Result.ACCEPTED.attributes, 6);
         assertThat(metrics).noneSatisfy(metricData -> assertThat(metricData)
-                .hasName(RateLimitingFilter.HTTP_REJECTED_REQUESTS_COUNTER_METRIC_NAME)
+                .hasName(RateLimitingFilter.RATE_LIMIT_REQUEST_COUNT_METRIC_NAME)
                 .hasLongSumSatisfying(
                         sum -> sum.hasPointsSatisfying(point -> point.hasAttributes(Result.REJECTED.attributes))));
 
@@ -305,9 +305,9 @@ public class WebServiceTest {
         }
 
         metrics = pulsarTestContext.getOpenTelemetryMetricReader().collectAllMetrics();
-        assertMetricLongSumValue(metrics, RateLimitingFilter.HTTP_REJECTED_REQUESTS_COUNTER_METRIC_NAME,
+        assertMetricLongSumValue(metrics, RateLimitingFilter.RATE_LIMIT_REQUEST_COUNT_METRIC_NAME,
                 Result.ACCEPTED.attributes, value -> assertThat(value).isGreaterThan(6));
-        assertMetricLongSumValue(metrics, RateLimitingFilter.HTTP_REJECTED_REQUESTS_COUNTER_METRIC_NAME,
+        assertMetricLongSumValue(metrics, RateLimitingFilter.RATE_LIMIT_REQUEST_COUNT_METRIC_NAME,
                 Result.REJECTED.attributes, value -> assertThat(value).isPositive());
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/WebServiceTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.pulsar.broker.web;
 
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static org.apache.pulsar.broker.stats.BrokerOpenTelemetryTestUtil.assertMetricLongSumValue;
 import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.Metric;
 import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.parseMetrics;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -61,6 +61,7 @@ import org.apache.pulsar.PrometheusMetricsTestUtil;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.testcontext.PulsarTestContext;
+import org.apache.pulsar.broker.web.RateLimitingFilter.Result;
 import org.apache.pulsar.broker.web.WebExecutorThreadPoolStats.LimitType;
 import org.apache.pulsar.broker.web.WebExecutorThreadPoolStats.UsageType;
 import org.apache.pulsar.client.admin.PulsarAdmin;
@@ -270,11 +271,28 @@ public class WebServiceTest {
     public void testRateLimiting() throws Exception {
         setupEnv(false, false, false, false, 10.0, false);
 
+        // setupEnv makes a HTTP call to create the cluster.
+        var metrics = pulsarTestContext.getOpenTelemetryMetricReader().collectAllMetrics();
+        assertMetricLongSumValue(metrics, RateLimitingFilter.HTTP_REJECTED_REQUESTS_COUNTER_METRIC_NAME,
+                Result.ACCEPTED.attributes, 1);
+        assertThat(metrics).noneSatisfy(metricData -> assertThat(metricData)
+                .hasName(RateLimitingFilter.HTTP_REJECTED_REQUESTS_COUNTER_METRIC_NAME)
+                .hasLongSumSatisfying(
+                        sum -> sum.hasPointsSatisfying(point -> point.hasAttributes(Result.REJECTED.attributes))));
+
         // Make requests without exceeding the max rate
         for (int i = 0; i < 5; i++) {
             makeHttpRequest(false, false);
             Thread.sleep(200);
         }
+
+        metrics = pulsarTestContext.getOpenTelemetryMetricReader().collectAllMetrics();
+        assertMetricLongSumValue(metrics, RateLimitingFilter.HTTP_REJECTED_REQUESTS_COUNTER_METRIC_NAME,
+                Result.ACCEPTED.attributes, 6);
+        assertThat(metrics).noneSatisfy(metricData -> assertThat(metricData)
+                .hasName(RateLimitingFilter.HTTP_REJECTED_REQUESTS_COUNTER_METRIC_NAME)
+                .hasLongSumSatisfying(
+                        sum -> sum.hasPointsSatisfying(point -> point.hasAttributes(Result.REJECTED.attributes))));
 
         try {
             for (int i = 0; i < 500; i++) {
@@ -285,6 +303,12 @@ public class WebServiceTest {
         } catch (IOException e) {
             assertTrue(e.getMessage().contains("429"));
         }
+
+        metrics = pulsarTestContext.getOpenTelemetryMetricReader().collectAllMetrics();
+        assertMetricLongSumValue(metrics, RateLimitingFilter.HTTP_REJECTED_REQUESTS_COUNTER_METRIC_NAME,
+                Result.ACCEPTED.attributes, value -> assertThat(value).isGreaterThan(6));
+        assertMetricLongSumValue(metrics, RateLimitingFilter.HTTP_REJECTED_REQUESTS_COUNTER_METRIC_NAME,
+                Result.REJECTED.attributes, value -> assertThat(value).isPositive());
     }
 
     @Test

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerOpenTelemetry.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/PulsarWorkerOpenTelemetry.java
@@ -27,6 +27,8 @@ import org.apache.pulsar.opentelemetry.OpenTelemetryService;
 public class PulsarWorkerOpenTelemetry implements Closeable {
 
     public static final String SERVICE_NAME = "pulsar-function-worker";
+    public static final String INSTRUMENTATION_SCOPE_NAME = "org.apache.pulsar.function_worker";
+
     private final OpenTelemetryService openTelemetryService;
 
     @Getter
@@ -38,7 +40,7 @@ public class PulsarWorkerOpenTelemetry implements Closeable {
                 .serviceName(SERVICE_NAME)
                 .serviceVersion(PulsarVersion.getVersion())
                 .build();
-        meter = openTelemetryService.getOpenTelemetry().getMeter("org.apache.pulsar.function_worker");
+        meter = openTelemetryService.getOpenTelemetry().getMeter(INSTRUMENTATION_SCOPE_NAME);
     }
 
     @Override

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.functions.worker.rest;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.prometheus.client.jetty.JettyStatisticsCollector;
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -219,7 +220,7 @@ public class WorkerServer {
 
             if (config.isHttpRequestsLimitEnabled()) {
                 filterHolders.add(new FilterHolder(
-                        new RateLimitingFilter(config.getHttpRequestsMaxPerSecond())));
+                        new RateLimitingFilter(config.getHttpRequestsMaxPerSecond(), OpenTelemetry.noop())));
             }
 
             if (config.isAuthenticationEnabled()) {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
@@ -31,6 +31,7 @@ import org.apache.pulsar.broker.web.AuthenticationFilter;
 import org.apache.pulsar.broker.web.JettyRequestLogFactory;
 import org.apache.pulsar.broker.web.RateLimitingFilter;
 import org.apache.pulsar.broker.web.WebExecutorThreadPool;
+import org.apache.pulsar.functions.worker.PulsarWorkerOpenTelemetry;
 import org.apache.pulsar.functions.worker.WorkerConfig;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.rest.api.v2.WorkerApiV2Resource;
@@ -220,7 +221,8 @@ public class WorkerServer {
 
             if (config.isHttpRequestsLimitEnabled()) {
                 filterHolders.add(new FilterHolder(
-                        new RateLimitingFilter(config.getHttpRequestsMaxPerSecond(), OpenTelemetry.noop())));
+                        new RateLimitingFilter(config.getHttpRequestsMaxPerSecond(),
+                                OpenTelemetry.noop().getMeter(PulsarWorkerOpenTelemetry.INSTRUMENTATION_SCOPE_NAME))));
             }
 
             if (config.isAuthenticationEnabled()) {

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
@@ -38,6 +38,7 @@ import org.apache.pulsar.broker.web.JsonMapperProvider;
 import org.apache.pulsar.broker.web.RateLimitingFilter;
 import org.apache.pulsar.broker.web.WebExecutorThreadPool;
 import org.apache.pulsar.jetty.tls.JettySslContextFactory;
+import org.apache.pulsar.proxy.stats.PulsarProxyOpenTelemetry;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.ConnectionLimit;
 import org.eclipse.jetty.server.Connector;
@@ -192,7 +193,8 @@ public class WebServer {
 
             if (config.isHttpRequestsLimitEnabled()) {
                 filterHolders.add(new FilterHolder(
-                        new RateLimitingFilter(config.getHttpRequestsMaxPerSecond(), OpenTelemetry.noop())));
+                        new RateLimitingFilter(config.getHttpRequestsMaxPerSecond(),
+                                OpenTelemetry.noop().getMeter(PulsarProxyOpenTelemetry.INSTRUMENTATION_SCOPE_NAME))));
             }
 
             if (config.isAuthenticationEnabled()) {

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.proxy.server;
 
 import static org.apache.pulsar.proxy.server.AdminProxyHandler.INIT_PARAM_REQUEST_BUFFER_SIZE;
+import io.opentelemetry.api.OpenTelemetry;
 import io.prometheus.client.jetty.JettyStatisticsCollector;
 import java.io.IOException;
 import java.net.URI;
@@ -191,7 +192,7 @@ public class WebServer {
 
             if (config.isHttpRequestsLimitEnabled()) {
                 filterHolders.add(new FilterHolder(
-                        new RateLimitingFilter(config.getHttpRequestsMaxPerSecond())));
+                        new RateLimitingFilter(config.getHttpRequestsMaxPerSecond(), OpenTelemetry.noop())));
             }
 
             if (config.isAuthenticationEnabled()) {

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/stats/PulsarProxyOpenTelemetry.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/stats/PulsarProxyOpenTelemetry.java
@@ -28,6 +28,8 @@ import org.apache.pulsar.proxy.server.ProxyConfiguration;
 public class PulsarProxyOpenTelemetry implements Closeable {
 
     public static final String SERVICE_NAME = "pulsar-proxy";
+    public static final String INSTRUMENTATION_SCOPE_NAME = "org.apache.pulsar.proxy";
+
     private final OpenTelemetryService openTelemetryService;
 
     @Getter
@@ -39,7 +41,7 @@ public class PulsarProxyOpenTelemetry implements Closeable {
                 .serviceName(SERVICE_NAME)
                 .serviceVersion(PulsarVersion.getVersion())
                 .build();
-        meter = openTelemetryService.getOpenTelemetry().getMeter("org.apache.pulsar.proxy");
+        meter = openTelemetryService.getOpenTelemetry().getMeter(INSTRUMENTATION_SCOPE_NAME);
     }
 
     @Override


### PR DESCRIPTION
[PIP-264](https://github.com/apache/pulsar/blob/master/pip/pip-264.md)

### Motivation

Adds metrics for the HTTP `RateLimitingFilter` class, currently exposed as Prometheus metric `pulsar_broker_http_rejected_requests` ([ref](https://github.com/apache/pulsar/blob/23163f97b7e971e8e6cc07a6e20899c49e435bef/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/RateLimitingFilter.java#L40)).

### Modifications

- Added metrics, as described by https://github.com/apache/pulsar-site/pull/944, to the OpenTelemetry pipeline.
- Deviating from the exiting design, the new metric exposes counters for both accepted and rejected requests. The cost for doing this is very small, and we get increased visibility into the server.
- Note this PR only exposes these values for the broker. The proxy and function worker integration will be done separately.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - Updated tests `WebServiceTest#testRateLimiting` to validate the metric counts.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics: _As described in https://github.com/apache/pulsar-site/pull/944_
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` https://github.com/apache/pulsar-site/pull/944
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dragosvictor/pulsar/pull/43