### PR TITLE
[improve][broker] GetPartitionMetadata fail also can produce messages

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -176,6 +176,7 @@ import org.apache.pulsar.common.util.collections.ConcurrentLongHashMap;
 import org.apache.pulsar.common.util.netty.NettyChannelUtil;
 import org.apache.pulsar.common.util.netty.NettyFutureUtil;
 import org.apache.pulsar.functions.utils.Exceptions;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
 import org.apache.pulsar.transaction.coordinator.exceptions.CoordinatorException;
 import org.apache.pulsar.transaction.coordinator.impl.MLTransactionMetadataStore;
@@ -663,7 +664,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                             log.warn("Failed to get Partitioned Metadata [{}] {}: {}", remoteAddress,
                                                     topicName, ex.getMessage(), ex);
                                             ServerError error = ServerError.ServiceNotReady;
-                                            if (ex instanceof RestException restException){
+                                            if (ex instanceof MetadataStoreException) {
+                                                error = ServerError.MetadataError;
+                                            } else if (ex instanceof RestException restException){
                                                 int responseCode = restException.getResponse().getStatus();
                                                 if (responseCode == NOT_FOUND.getStatusCode()){
                                                     error = ServerError.TopicNotFound;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ZKReconnectTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ZKReconnectTest.java
@@ -1,0 +1,65 @@
+package org.apache.pulsar.broker.zookeeper;
+
+import com.google.common.collect.Sets;
+import org.apache.pulsar.broker.MetadataSessionExpiredPolicy;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.apache.zookeeper.KeeperException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+
+@Test
+public class ZKReconnectTest extends MockedPulsarServiceBaseTest {
+
+    @BeforeMethod(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        this.conf.setZookeeperSessionExpiredPolicy(MetadataSessionExpiredPolicy.reconnect);
+        this.internalSetup();
+        admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.tenants().createTenant("public",
+                new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
+        admin.namespaces().createNamespace("public/default");
+        admin.namespaces().setNamespaceReplicationClusters("public/default", Sets.newHashSet("test"));
+    }
+
+    @Test
+    public void testGetPartitionMetadataFailAlsoCanProduceMessage() throws Exception {
+
+        pulsarClient = PulsarClient.builder().
+                serviceUrl(pulsar.getBrokerServiceUrl())
+                .build();
+
+        String topic = "testGetPartitionMetadataFailAlsoCanProduceMessage";
+        admin.topics().createPartitionedTopic(topic, 5);
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .autoUpdatePartitionsInterval(1, TimeUnit.SECONDS).topic(topic).create();
+
+        this.mockZooKeeper.setAlwaysFail(KeeperException.Code.SESSIONEXPIRED);
+
+        // clear cache
+        pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                .getCache().delete("/admin/partitioned-topics/public/default/persistent"
+                        + "/testGetPartitionMetadataFailAlsoCanProduceMessage");
+        pulsar.getNamespaceService().getOwnershipCache().invalidateLocalOwnerCache();
+        TimeUnit.SECONDS.sleep(3);
+        producer.send("test".getBytes());
+        this.mockZooKeeper.unsetAlwaysFail();
+        producer.send("test".getBytes());
+        producer.close();
+    }
+
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        this.internalCleanup();
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ZKReconnectTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ZKReconnectTest.java
@@ -49,7 +49,11 @@ public class ZKReconnectTest extends MockedPulsarServiceBaseTest {
                 .getCache().delete("/admin/partitioned-topics/public/default/persistent"
                         + "/testGetPartitionMetadataFailAlsoCanProduceMessage");
         pulsar.getNamespaceService().getOwnershipCache().invalidateLocalOwnerCache();
+
+        // autoUpdatePartitions 1 second
         TimeUnit.SECONDS.sleep(3);
+
+        // also can send message
         producer.send("test".getBytes());
         this.mockZooKeeper.unsetAlwaysFail();
         producer.send("test".getBytes());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ZKReconnectTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ZKReconnectTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.broker.zookeeper;
 
 import com.google.common.collect.Sets;


### PR DESCRIPTION
### Motivation

GetPartitionMetadata fail also can produce messages

- 'autoUpdatePartitionsInterval' will get partition metadata and will regularly detect partition changes

- if GetPartitionMetadata will return ServiceNotReady, client receive ServiceNotReady will close cnx

- if close the current cnx, all producers and consumers witch use this cnx will close and reconnect

(https://github.com/apache/pulsar/blob/5c6602cbb3660a696bf960f2847aac1a2ae037d2/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java#L323-L345)
- this will influence a lot of producers and consumers and if current time the zk not available and bundle cache not exist the topic's bundle metadata, the client can't send messages to broker because the producer lookup will fail

### Modifications

GetPartitionMetadata return MetadataError when throw MetadataStoreException

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
