### PR TITLE
[improve][broker] Reduce the CPU pressure from the transaction buffer in rolling restarts

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -124,7 +124,6 @@ import org.apache.pulsar.broker.stats.prometheus.PrometheusRawMetricsProvider;
 import org.apache.pulsar.broker.stats.prometheus.PulsarPrometheusMetricsServlet;
 import org.apache.pulsar.broker.storage.ManagedLedgerStorage;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBufferProvider;
-import org.apache.pulsar.broker.transaction.buffer.impl.SnapshotTableView;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferClientImpl;
 import org.apache.pulsar.broker.transaction.pendingack.TransactionPendingAckStoreProvider;
 import org.apache.pulsar.broker.transaction.pendingack.impl.MLPendingAckStoreProvider;
@@ -286,7 +285,6 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     private PulsarMetadataEventSynchronizer localMetadataSynchronizer;
     private CoordinationService coordinationService;
     private TransactionBufferSnapshotServiceFactory transactionBufferSnapshotServiceFactory;
-    private SnapshotTableView snapshotTableView;
     private MetadataStore configurationMetadataStore;
     private PulsarMetadataEventSynchronizer configMetadataSynchronizer;
     private boolean shouldShutdownConfigurationMetadataStore;
@@ -994,8 +992,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 MLTransactionMetadataStoreProvider.initBufferedWriterMetrics(getAdvertisedAddress());
                 MLPendingAckStoreProvider.initBufferedWriterMetrics(getAdvertisedAddress());
 
-                this.transactionBufferSnapshotServiceFactory = new TransactionBufferSnapshotServiceFactory(getClient());
-                this.snapshotTableView = new SnapshotTableView(this);
+                this.transactionBufferSnapshotServiceFactory = new TransactionBufferSnapshotServiceFactory(this);
 
                 this.transactionTimer =
                         new HashedWheelTimer(new DefaultThreadFactory("pulsar-transaction-timer"));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -995,10 +995,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 MLPendingAckStoreProvider.initBufferedWriterMetrics(getAdvertisedAddress());
 
                 this.transactionBufferSnapshotServiceFactory = new TransactionBufferSnapshotServiceFactory(getClient());
-                this.snapshotTableView = new SnapshotTableView(
-                        transactionBufferSnapshotServiceFactory.getTxnBufferSnapshotService(),
-                        executor, Long.parseLong(config.getProperties().getProperty(
-                                "brokerClient_operationTimeoutMs", "30000")));
+                this.snapshotTableView = new SnapshotTableView(this);
 
                 this.transactionTimer =
                         new HashedWheelTimer(new DefaultThreadFactory("pulsar-transaction-timer"));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -124,6 +124,7 @@ import org.apache.pulsar.broker.stats.prometheus.PrometheusRawMetricsProvider;
 import org.apache.pulsar.broker.stats.prometheus.PulsarPrometheusMetricsServlet;
 import org.apache.pulsar.broker.storage.ManagedLedgerStorage;
 import org.apache.pulsar.broker.transaction.buffer.TransactionBufferProvider;
+import org.apache.pulsar.broker.transaction.buffer.impl.SnapshotTableView;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferClientImpl;
 import org.apache.pulsar.broker.transaction.pendingack.TransactionPendingAckStoreProvider;
 import org.apache.pulsar.broker.transaction.pendingack.impl.MLPendingAckStoreProvider;
@@ -285,6 +286,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     private PulsarMetadataEventSynchronizer localMetadataSynchronizer;
     private CoordinationService coordinationService;
     private TransactionBufferSnapshotServiceFactory transactionBufferSnapshotServiceFactory;
+    private SnapshotTableView snapshotTableView;
     private MetadataStore configurationMetadataStore;
     private PulsarMetadataEventSynchronizer configMetadataSynchronizer;
     private boolean shouldShutdownConfigurationMetadataStore;
@@ -993,6 +995,10 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 MLPendingAckStoreProvider.initBufferedWriterMetrics(getAdvertisedAddress());
 
                 this.transactionBufferSnapshotServiceFactory = new TransactionBufferSnapshotServiceFactory(getClient());
+                this.snapshotTableView = new SnapshotTableView(
+                        transactionBufferSnapshotServiceFactory.getTxnBufferSnapshotService(),
+                        executor, Long.parseLong(config.getProperties().getProperty(
+                                "brokerClient_operationTimeoutMs", "30000")));
 
                 this.transactionTimer =
                         new HashedWheelTimer(new DefaultThreadFactory("pulsar-transaction-timer"));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TransactionBufferSnapshotServiceFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TransactionBufferSnapshotServiceFactory.java
@@ -18,12 +18,15 @@
  */
 package org.apache.pulsar.broker.service;
 
+import lombok.Getter;
+import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.transaction.buffer.metadata.TransactionBufferSnapshot;
 import org.apache.pulsar.broker.transaction.buffer.metadata.v2.TransactionBufferSnapshotIndexes;
 import org.apache.pulsar.broker.transaction.buffer.metadata.v2.TransactionBufferSnapshotSegment;
-import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.events.EventType;
 
+@Getter
 public class TransactionBufferSnapshotServiceFactory {
 
     private SystemTopicTxnBufferSnapshotService<TransactionBufferSnapshot> txnBufferSnapshotService;
@@ -33,27 +36,14 @@ public class TransactionBufferSnapshotServiceFactory {
 
     private SystemTopicTxnBufferSnapshotService<TransactionBufferSnapshotIndexes> txnBufferSnapshotIndexService;
 
-    public TransactionBufferSnapshotServiceFactory(PulsarClient pulsarClient) {
-        this.txnBufferSnapshotSegmentService = new SystemTopicTxnBufferSnapshotService<>(pulsarClient,
+    public TransactionBufferSnapshotServiceFactory(PulsarService pulsar) throws PulsarServerException {
+        this.txnBufferSnapshotSegmentService = new SystemTopicTxnBufferSnapshotService<>(pulsar,
                 EventType.TRANSACTION_BUFFER_SNAPSHOT_SEGMENTS,
                 TransactionBufferSnapshotSegment.class);
-        this.txnBufferSnapshotIndexService = new SystemTopicTxnBufferSnapshotService<>(pulsarClient,
+        this.txnBufferSnapshotIndexService = new SystemTopicTxnBufferSnapshotService<>(pulsar,
                 EventType.TRANSACTION_BUFFER_SNAPSHOT_INDEXES, TransactionBufferSnapshotIndexes.class);
-        this.txnBufferSnapshotService = new SystemTopicTxnBufferSnapshotService<>(pulsarClient,
+        this.txnBufferSnapshotService = new SystemTopicTxnBufferSnapshotService<>(pulsar,
                 EventType.TRANSACTION_BUFFER_SNAPSHOT, TransactionBufferSnapshot.class);
-    }
-
-    public SystemTopicTxnBufferSnapshotService<TransactionBufferSnapshotIndexes> getTxnBufferSnapshotIndexService() {
-        return this.txnBufferSnapshotIndexService;
-    }
-
-    public SystemTopicTxnBufferSnapshotService<TransactionBufferSnapshotSegment>
-    getTxnBufferSnapshotSegmentService() {
-        return this.txnBufferSnapshotSegmentService;
-    }
-
-    public SystemTopicTxnBufferSnapshotService<TransactionBufferSnapshot> getTxnBufferSnapshotService() {
-        return this.txnBufferSnapshotService;
     }
 
     public void close() throws Exception {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
@@ -90,7 +90,8 @@ public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcesso
         final var pulsar = topic.getBrokerService().getPulsar();
         pulsar.getTransactionExecutorProvider().getExecutor(this).execute(() -> {
             try {
-                final var snapshot = pulsar.getSnapshotTableView().readLatest(topic.getName());
+                final var snapshot = pulsar.getTransactionBufferSnapshotServiceFactory().getTxnBufferSnapshotService()
+                        .getTableView().readLatest(topic.getName());
                 if (snapshot != null) {
                     handleSnapshot(snapshot);
                     final var startReadCursorPosition = PositionFactory.create(snapshot.getMaxReadPositionLedgerId(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
@@ -21,26 +21,19 @@ package org.apache.pulsar.broker.transaction.buffer.impl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.commons.collections4.map.LinkedMap;
-import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.SystemTopicTxnBufferSnapshotService.ReferenceCountedWriter;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
-import org.apache.pulsar.broker.systopic.SystemTopicClient;
 import org.apache.pulsar.broker.transaction.buffer.AbortedTxnProcessor;
 import org.apache.pulsar.broker.transaction.buffer.metadata.AbortTxnMetadata;
 import org.apache.pulsar.broker.transaction.buffer.metadata.TransactionBufferSnapshot;
-import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.transaction.TxnID;
-import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.TransactionBufferStats;
-import org.apache.pulsar.common.util.FutureUtil;
 
 @Slf4j
 public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcessor {
@@ -91,48 +84,26 @@ public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcesso
         return aborts.containsKey(txnID);
     }
 
-    private long getSystemClientOperationTimeoutMs() throws Exception {
-        PulsarClientImpl pulsarClient = (PulsarClientImpl) topic.getBrokerService().getPulsar().getClient();
-        return pulsarClient.getConfiguration().getOperationTimeoutMs();
-    }
-
     @Override
     public CompletableFuture<Position> recoverFromSnapshot() {
-        return topic.getBrokerService().getPulsar().getTransactionBufferSnapshotServiceFactory()
-                .getTxnBufferSnapshotService()
-                .createReader(TopicName.get(topic.getName())).thenComposeAsync(reader -> {
-                    try {
-                    Position startReadCursorPosition = null;
-                        while (reader.hasMoreEvents()) {
-                            Message<TransactionBufferSnapshot> message = reader.readNextAsync()
-                                    .get(getSystemClientOperationTimeoutMs(), TimeUnit.MILLISECONDS);
-                            if (topic.getName().equals(message.getKey())) {
-                                TransactionBufferSnapshot transactionBufferSnapshot = message.getValue();
-                                if (transactionBufferSnapshot != null) {
-                                    handleSnapshot(transactionBufferSnapshot);
-                                    startReadCursorPosition = PositionFactory.create(
-                                            transactionBufferSnapshot.getMaxReadPositionLedgerId(),
-                                            transactionBufferSnapshot.getMaxReadPositionEntryId());
-                                }
-                            }
-                        }
-                        return CompletableFuture.completedFuture(startReadCursorPosition);
-                    } catch (TimeoutException ex) {
-                        Throwable t = FutureUtil.unwrapCompletionException(ex);
-                        String errorMessage = String.format("[%s] Transaction buffer recover fail by read "
-                                + "transactionBufferSnapshot timeout!", topic.getName());
-                        log.error(errorMessage, t);
-                        return FutureUtil.failedFuture(
-                                new BrokerServiceException.ServiceUnitNotReadyException(errorMessage, t));
-                    } catch (Exception ex) {
-                        log.error("[{}] Transaction buffer recover fail when read "
-                                + "transactionBufferSnapshot!", topic.getName(), ex);
-                        return FutureUtil.failedFuture(ex);
-                    } finally {
-                        closeReader(reader);
-                    }
-                },  topic.getBrokerService().getPulsar().getTransactionExecutorProvider()
-                        .getExecutor(this));
+        final var future = new CompletableFuture<Position>();
+        final var pulsar = topic.getBrokerService().getPulsar();
+        pulsar.getTransactionExecutorProvider().getExecutor(this).execute(() -> {
+            try {
+                final var snapshot = pulsar.getSnapshotTableView().readLatest(topic.getName());
+                if (snapshot != null) {
+                    handleSnapshot(snapshot);
+                    final var startReadCursorPosition = PositionFactory.create(snapshot.getMaxReadPositionLedgerId(),
+                            snapshot.getMaxReadPositionEntryId());
+                    future.complete(startReadCursorPosition);
+                } else {
+                    future.complete(null);
+                }
+            } catch (Throwable e) {
+                future.completeExceptionally(e);
+            }
+        });
+        return future;
     }
 
     @Override
@@ -189,13 +160,6 @@ public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcesso
             takeSnapshotWriter.release();
         }
         return CompletableFuture.completedFuture(null);
-    }
-
-    private void closeReader(SystemTopicClient.Reader<TransactionBufferSnapshot> reader) {
-        reader.closeAsync().exceptionally(e -> {
-            log.error("[{}]Transaction buffer reader close error!", topic.getName(), e);
-            return null;
-        });
     }
 
     private void handleSnapshot(TransactionBufferSnapshot snapshot) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -24,11 +24,11 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Supplier;
@@ -54,7 +54,6 @@ import org.apache.pulsar.broker.transaction.buffer.metadata.v2.TransactionBuffer
 import org.apache.pulsar.broker.transaction.buffer.metadata.v2.TransactionBufferSnapshotIndexesMetadata;
 import org.apache.pulsar.broker.transaction.buffer.metadata.v2.TransactionBufferSnapshotSegment;
 import org.apache.pulsar.broker.transaction.buffer.metadata.v2.TxnIDData;
-import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.MessageIdImpl;
@@ -228,220 +227,129 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
 
     @Override
     public CompletableFuture<Position> recoverFromSnapshot() {
-        return topic.getBrokerService().getPulsar().getTransactionBufferSnapshotServiceFactory()
-                .getTxnBufferSnapshotIndexService()
-                .createReader(TopicName.get(topic.getName())).thenComposeAsync(reader -> {
-                    Position startReadCursorPosition = null;
-                    TransactionBufferSnapshotIndexes persistentSnapshotIndexes = null;
-                    try {
-                        /*
-                          Read the transaction snapshot segment index.
-                          <p>
-                              The processor can get the sequence ID, unsealed transaction IDs,
-                              segment index list and max read position in the snapshot segment index.
-                              Then we can traverse the index list to read all aborted transaction IDs
-                              in segments to aborts.
-                          </p>
-                         */
-                        while (reader.hasMoreEvents()) {
-                            Message<TransactionBufferSnapshotIndexes> message = reader.readNextAsync()
-                                    .get(getSystemClientOperationTimeoutMs(), TimeUnit.MILLISECONDS);
-                            if (topic.getName().equals(message.getKey())) {
-                                TransactionBufferSnapshotIndexes transactionBufferSnapshotIndexes = message.getValue();
-                                if (transactionBufferSnapshotIndexes != null) {
-                                    persistentSnapshotIndexes = transactionBufferSnapshotIndexes;
-                                    startReadCursorPosition = PositionFactory.create(
-                                            transactionBufferSnapshotIndexes.getSnapshot().getMaxReadPositionLedgerId(),
-                                            transactionBufferSnapshotIndexes.getSnapshot().getMaxReadPositionEntryId());
-                                }
-                            }
-                        }
-                    } catch (TimeoutException ex) {
-                        Throwable t = FutureUtil.unwrapCompletionException(ex);
-                        String errorMessage = String.format("[%s] Transaction buffer recover fail by read "
-                                + "transactionBufferSnapshot timeout!", topic.getName());
-                        log.error(errorMessage, t);
-                        return FutureUtil.failedFuture(
-                                new BrokerServiceException.ServiceUnitNotReadyException(errorMessage, t));
-                    } catch (Exception ex) {
-                        log.error("[{}] Transaction buffer recover fail when read "
-                                + "transactionBufferSnapshot!", topic.getName(), ex);
-                        return FutureUtil.failedFuture(ex);
-                    } finally {
-                        closeReader(reader);
-                    }
-                    Position finalStartReadCursorPosition = startReadCursorPosition;
-                    TransactionBufferSnapshotIndexes finalPersistentSnapshotIndexes = persistentSnapshotIndexes;
-                    if (persistentSnapshotIndexes == null) {
-                        return recoverOldSnapshot();
-                    } else {
-                        this.unsealedTxnIds = convertTypeToTxnID(persistentSnapshotIndexes
-                                .getSnapshot().getAborts());
-                    }
-                    //Read snapshot segment to recover aborts.
-                    ArrayList<CompletableFuture<Void>> completableFutures = new ArrayList<>();
-                    CompletableFuture<Void> openManagedLedgerAndHandleSegmentsFuture = new CompletableFuture<>();
-                    AtomicBoolean hasInvalidIndex = new AtomicBoolean(false);
-                    AsyncCallbacks.OpenReadOnlyManagedLedgerCallback callback = new AsyncCallbacks
-                            .OpenReadOnlyManagedLedgerCallback() {
-                        @Override
-                        public void openReadOnlyManagedLedgerComplete(ReadOnlyManagedLedgerImpl readOnlyManagedLedger,
-                                                                      Object ctx) {
-                            finalPersistentSnapshotIndexes.getIndexList().forEach(index -> {
-                                CompletableFuture<Void> handleSegmentFuture = new CompletableFuture<>();
-                                completableFutures.add(handleSegmentFuture);
-                                readOnlyManagedLedger.asyncReadEntry(
-                                        PositionFactory.create(index.getSegmentLedgerID(),
-                                                index.getSegmentEntryID()),
-                                        new AsyncCallbacks.ReadEntryCallback() {
-                                            @Override
-                                            public void readEntryComplete(Entry entry, Object ctx) {
-                                                handleSnapshotSegmentEntry(entry);
-                                                indexes.put(PositionFactory.create(
-                                                                index.abortedMarkLedgerID,
-                                                                index.abortedMarkEntryID),
-                                                        index);
-                                                entry.release();
-                                                handleSegmentFuture.complete(null);
-                                            }
+        final var pulsar = topic.getBrokerService().getPulsar();
+        final var future = new CompletableFuture<Position>();
+        pulsar.getTransactionExecutorProvider().getExecutor(this).execute(() -> {
+            try {
+                final var indexes = pulsar.getTransactionBufferSnapshotServiceFactory()
+                        .getTxnBufferSnapshotIndexService().getTableView().readLatest(topic.getName());
+                if (indexes == null) {
+                    // Try recovering from the old format snapshot
+                    future.complete(recoverOldSnapshot());
+                    return;
+                }
+                final var snapshot = indexes.getSnapshot();
+                final var startReadCursorPosition = PositionFactory.create(snapshot.getMaxReadPositionLedgerId(),
+                        snapshot.getMaxReadPositionEntryId());
+                this.unsealedTxnIds = convertTypeToTxnID(snapshot.getAborts());
+                // Read snapshot segment to recover aborts
+                final var snapshotSegmentTopicName = TopicName.get(TopicDomain.persistent.toString(),
+                        TopicName.get(topic.getName()).getNamespaceObject(),
+                        SystemTopicNames.TRANSACTION_BUFFER_SNAPSHOT_SEGMENTS);
+                readSegmentEntries(snapshotSegmentTopicName, indexes);
+                if (!this.indexes.isEmpty()) {
+                    // If there is no segment index, the persistent worker will write segment begin from 0.
+                    persistentWorker.sequenceID.set(this.indexes.get(this.indexes.lastKey()).sequenceID + 1);
+                }
+                unsealedTxnIds.forEach(txnID -> aborts.put(txnID, txnID));
+                future.complete(startReadCursorPosition);
+            } catch (Throwable throwable) {
+                future.completeExceptionally(throwable);
+            }
+        });
+        return future;
+    }
 
-                                            @Override
-                                            public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
-                                                /*
-                                                  The logic flow of deleting expired segment is:
-                                                  <p>
-                                                      1. delete segment
-                                                      2. update segment index
-                                                  </p>
-                                                  If the worker delete segment successfully
-                                                  but failed to update segment index,
-                                                  the segment can not be read according to the index.
-                                                  We update index again if there are invalid indexes.
-                                                 */
-                                                if (((ManagedLedgerImpl) topic.getManagedLedger())
-                                                        .ledgerExists(index.getAbortedMarkLedgerID())) {
-                                                    log.error("[{}] Failed to read snapshot segment [{}:{}]",
-                                                            topic.getName(), index.segmentLedgerID,
-                                                            index.segmentEntryID, exception);
-                                                    handleSegmentFuture.completeExceptionally(exception);
-                                                } else {
-                                                    hasInvalidIndex.set(true);
-                                                }
-                                            }
+    private void readSegmentEntries(TopicName topicName, TransactionBufferSnapshotIndexes indexes) throws Exception {
+        final var managedLedger = openReadOnlyManagedLedger(topicName);
+        boolean hasInvalidIndex = false;
+        for (var index : indexes.getIndexList()) {
+            final var position = PositionFactory.create(index.getSegmentLedgerID(), index.getSegmentEntryID());
+            final var abortedPosition = PositionFactory.create(index.abortedMarkLedgerID, index.abortedMarkEntryID);
+            try {
+                final var entry = readEntry(managedLedger, position);
+                try {
+                    handleSnapshotSegmentEntry(entry);
+                    this.indexes.put(abortedPosition, index);
+                } finally {
+                    entry.release();
+                }
+            } catch (Throwable throwable) {
+                if (((ManagedLedgerImpl) topic.getManagedLedger())
+                        .ledgerExists(index.getAbortedMarkLedgerID())) {
+                    log.error("[{}] Failed to read snapshot segment [{}:{}]",
+                            topic.getName(), index.segmentLedgerID,
+                            index.segmentEntryID, throwable);
+                    throw throwable;
+                } else {
+                    hasInvalidIndex = true;
+                }
+            }
+        }
+        if (hasInvalidIndex) {
+            // Update the snapshot segment index if there exist invalid indexes.
+            persistentWorker.appendTask(PersistentWorker.OperationType.UpdateIndex,
+                    () -> persistentWorker.updateSnapshotIndex(indexes.getSnapshot()));
+        }
+    }
 
-                                            @Override
-                                            public String toString() {
-                                                return String.format("Transaction buffer [%s] recover from snapshot",
-                                                        SnapshotSegmentAbortedTxnProcessorImpl.this.topic.getName());
-                                            }
-                                        }, null);
-                            });
-                            openManagedLedgerAndHandleSegmentsFuture.complete(null);
-                        }
+    private ReadOnlyManagedLedgerImpl openReadOnlyManagedLedger(TopicName topicName) throws Exception {
+        final var future = new CompletableFuture<ReadOnlyManagedLedgerImpl>();
+        final var callback = new AsyncCallbacks.OpenReadOnlyManagedLedgerCallback() {
+            @Override
+            public void openReadOnlyManagedLedgerComplete(ReadOnlyManagedLedgerImpl managedLedger, Object ctx) {
+                future.complete(managedLedger);
+            }
 
-                        @Override
-                        public void openReadOnlyManagedLedgerFailed(ManagedLedgerException exception, Object ctx) {
-                            log.error("[{}] Failed to open readOnly managed ledger", topic, exception);
-                            openManagedLedgerAndHandleSegmentsFuture.completeExceptionally(exception);
-                        }
-                    };
+            @Override
+            public void openReadOnlyManagedLedgerFailed(ManagedLedgerException exception, Object ctx) {
+                future.completeExceptionally(exception);
+            }
 
-                    TopicName snapshotSegmentTopicName = TopicName.get(TopicDomain.persistent.toString(),
-                            TopicName.get(topic.getName()).getNamespaceObject(),
-                            SystemTopicNames.TRANSACTION_BUFFER_SNAPSHOT_SEGMENTS);
-                    this.topic.getBrokerService().getPulsar().getManagedLedgerFactory()
-                            .asyncOpenReadOnlyManagedLedger(snapshotSegmentTopicName
-                                            .getPersistenceNamingEncoding(), callback,
-                                    topic.getManagedLedger().getConfig(),
-                                    null);
-                    /*
-                       Wait the processor recover completely and then allow TB
-                       to recover the messages after the startReadCursorPosition.
-                     */
-                    return openManagedLedgerAndHandleSegmentsFuture
-                            .thenCompose((ignore) -> FutureUtil.waitForAll(completableFutures))
-                            .thenCompose((i) -> {
-                                /*
-                                  Update the snapshot segment index if there exist invalid indexes.
-                                 */
-                                if (hasInvalidIndex.get()) {
-                                    persistentWorker.appendTask(PersistentWorker.OperationType.UpdateIndex,
-                                            () -> persistentWorker.updateSnapshotIndex(
-                                                    finalPersistentSnapshotIndexes.getSnapshot()));
-                                }
-                                /*
-                                   If there is no segment index, the persistent worker will write segment begin from 0.
-                                 */
-                                if (indexes.size() != 0) {
-                                    persistentWorker.sequenceID.set(indexes.get(indexes.lastKey()).sequenceID + 1);
-                                }
-                                /*
-                                  Append the aborted txn IDs in the index metadata
-                                  can keep the order of the aborted txn in the aborts.
-                                  So that we can trim the expired snapshot segment in aborts
-                                  according to the latest transaction IDs in the segmentIndex.
-                                 */
-                                unsealedTxnIds.forEach(txnID -> aborts.put(txnID, txnID));
-                                return CompletableFuture.completedFuture(finalStartReadCursorPosition);
-                            }).exceptionally(ex -> {
-                                log.error("[{}] Failed to recover snapshot segment", this.topic.getName(), ex);
-                                return null;
-                            });
+            @Override
+            public String toString() {
+                return String.format("Transaction buffer [%s] recover from snapshot",
+                        SnapshotSegmentAbortedTxnProcessorImpl.this.topic.getName());
+            }
+        };
+        topic.getBrokerService().getPulsar().getManagedLedgerFactory().asyncOpenReadOnlyManagedLedger(
+                topicName.getPersistenceNamingEncoding(), callback, topic.getManagedLedger().getConfig(), null);
+        return wait(future, "open read only ml for " + topicName);
+    }
 
-                    },  topic.getBrokerService().getPulsar().getTransactionExecutorProvider()
-                        .getExecutor(this));
+    private Entry readEntry(ReadOnlyManagedLedgerImpl managedLedger, Position position) throws Exception {
+        final var future = new CompletableFuture<Entry>();
+        managedLedger.asyncReadEntry(position, new AsyncCallbacks.ReadEntryCallback() {
+            @Override
+            public void readEntryComplete(Entry entry, Object ctx) {
+                future.complete(entry);
+            }
+
+            @Override
+            public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
+                future.completeExceptionally(exception);
+            }
+        }, null);
+        return wait(future, "read entry from " + position);
     }
 
     // This method will be deprecated and removed in version 4.x.0
-    private CompletableFuture<Position> recoverOldSnapshot() {
-        return topic.getBrokerService().getPulsar().getPulsarResources().getTopicResources()
-                .listPersistentTopicsAsync(NamespaceName.get(TopicName.get(topic.getName()).getNamespace()))
-                .thenCompose(topics -> {
-                    if (!topics.contains(TopicDomain.persistent + "://"
-                            + TopicName.get(topic.getName()).getNamespace() + "/"
-                            + SystemTopicNames.TRANSACTION_BUFFER_SNAPSHOT)) {
-                        return CompletableFuture.completedFuture(null);
-                    } else {
-                        return topic.getBrokerService().getPulsar().getTransactionBufferSnapshotServiceFactory()
-                                .getTxnBufferSnapshotService()
-                                .createReader(TopicName.get(topic.getName())).thenComposeAsync(snapshotReader -> {
-                                    Position startReadCursorPositionInOldSnapshot = null;
-                                    try {
-                                        while (snapshotReader.hasMoreEvents()) {
-                                            Message<TransactionBufferSnapshot> message = snapshotReader.readNextAsync()
-                                                    .get(getSystemClientOperationTimeoutMs(), TimeUnit.MILLISECONDS);
-                                            if (topic.getName().equals(message.getKey())) {
-                                                TransactionBufferSnapshot transactionBufferSnapshot =
-                                                        message.getValue();
-                                                if (transactionBufferSnapshot != null) {
-                                                    handleOldSnapshot(transactionBufferSnapshot);
-                                                    startReadCursorPositionInOldSnapshot = PositionFactory.create(
-                                                            transactionBufferSnapshot.getMaxReadPositionLedgerId(),
-                                                            transactionBufferSnapshot.getMaxReadPositionEntryId());
-                                                }
-                                            }
-                                        }
-                                    } catch (TimeoutException ex) {
-                                        Throwable t = FutureUtil.unwrapCompletionException(ex);
-                                        String errorMessage = String.format("[%s] Transaction buffer recover fail by "
-                                                + "read transactionBufferSnapshot timeout!", topic.getName());
-                                        log.error(errorMessage, t);
-                                        return FutureUtil.failedFuture(new BrokerServiceException
-                                                .ServiceUnitNotReadyException(errorMessage, t));
-                                    } catch (Exception ex) {
-                                        log.error("[{}] Transaction buffer recover fail when read "
-                                                + "transactionBufferSnapshot!", topic.getName(), ex);
-                                        return FutureUtil.failedFuture(ex);
-                                    } finally {
-                                        assert snapshotReader != null;
-                                        closeReader(snapshotReader);
-                                    }
-                                    return CompletableFuture.completedFuture(startReadCursorPositionInOldSnapshot);
-                                },
-                                        topic.getBrokerService().getPulsar().getTransactionExecutorProvider()
-                                                .getExecutor(this));
-                    }
-                });
+    private Position recoverOldSnapshot() throws Exception {
+        final var pulsar = topic.getBrokerService().getPulsar();
+        final var topicName = TopicName.get(topic.getName());
+        final var topics = wait(pulsar.getPulsarResources().getTopicResources().listPersistentTopicsAsync(
+                NamespaceName.get(topicName.getNamespace())), "list persistent topics");
+        if (!topics.contains(TopicDomain.persistent + "://" + topicName.getNamespace() + "/"
+                + SystemTopicNames.TRANSACTION_BUFFER_SNAPSHOT)) {
+            return null;
+        }
+        final var snapshot = pulsar.getTransactionBufferSnapshotServiceFactory().getTxnBufferSnapshotService()
+                .getTableView().readLatest(topic.getName());
+        if (snapshot == null) {
+            return null;
+        }
+        handleOldSnapshot(snapshot);
+        return PositionFactory.create(snapshot.getMaxReadPositionLedgerId(), snapshot.getMaxReadPositionEntryId());
     }
 
     // This method will be deprecated and removed in version 4.x.0
@@ -509,9 +417,17 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
         return pulsarClient.getConfiguration().getOperationTimeoutMs();
     }
 
-    private <T> void  closeReader(SystemTopicClient.Reader<T> reader) {
+    private <R> R wait(CompletableFuture<R> future, String msg) throws Exception {
+        try {
+            return future.get(getSystemClientOperationTimeoutMs(), TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw new CompletionException("Failed to " + msg, e.getCause());
+        }
+    }
+
+    private <T> void closeReader(SystemTopicClient.Reader<T> reader) {
         reader.closeAsync().exceptionally(e -> {
-            log.error("[{}]Transaction buffer snapshot reader close error!", topic.getName(), e);
+            log.warn("[{}] Failed to close reader: {}", topic.getName(), e.getMessage());
             return null;
         });
     }
@@ -838,25 +754,37 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
          * </p>
          */
         private CompletableFuture<Void> clearAllSnapshotSegments() {
-            return topic.getBrokerService().getPulsar().getTransactionBufferSnapshotServiceFactory()
-                    .getTxnBufferSnapshotSegmentService()
-                    .createReader(TopicName.get(topic.getName())).thenComposeAsync(reader -> {
-                        try {
-                            while (reader.hasMoreEvents()) {
-                                Message<TransactionBufferSnapshotSegment> message = reader.readNextAsync()
-                                        .get(getSystemClientOperationTimeoutMs(), TimeUnit.MILLISECONDS);
-                                if (topic.getName().equals(message.getValue().getTopicName())) {
-                                   snapshotSegmentsWriter.getFuture().get().write(message.getKey(), null);
-                                }
+            final var future = new CompletableFuture<Void>();
+            final var pulsar = topic.getBrokerService().getPulsar();
+            pulsar.getTransactionExecutorProvider().getExecutor(this).execute(() -> {
+                try {
+                    final var reader = wait(pulsar.getTransactionBufferSnapshotServiceFactory()
+                            .getTxnBufferSnapshotSegmentService().createReader(TopicName.get(topic.getName()))
+                            , "create reader");
+                    try {
+                        while (wait(reader.hasMoreEventsAsync(), "has more events")) {
+                            final var message = wait(reader.readNextAsync(), "read next");
+                            if (topic.getName().equals(message.getValue().getTopicName())) {
+                                snapshotSegmentsWriter.getFuture().get().write(message.getKey(), null);
                             }
-                            return CompletableFuture.completedFuture(null);
-                        } catch (Exception ex) {
-                            log.error("[{}] Transaction buffer clear snapshot segments fail!", topic.getName(), ex);
-                            return FutureUtil.failedFuture(ex);
-                        } finally {
-                            closeReader(reader);
                         }
-           });
+                        future.complete(null);
+                    } finally {
+                        closeReader(reader);
+                    }
+                } catch (Throwable throwable) {
+                    future.completeExceptionally(throwable);
+                }
+            });
+            return future;
+        }
+
+        private <R> R wait(CompletableFuture<R> future, String msg) throws Exception {
+            try {
+                return future.get(getSystemClientOperationTimeoutMs(), TimeUnit.MILLISECONDS);
+            } catch (ExecutionException e) {
+                throw new CompletionException("Failed to " + msg, e.getCause());
+            }
         }
 
         synchronized CompletableFuture<Void> closeAsync() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotTableView.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotTableView.java
@@ -70,7 +70,11 @@ public class SnapshotTableView {
         while (wait(reader.hasMoreEventsAsync(), "has more events")) {
             final var msg = wait(reader.readNextAsync(), "read message");
             if (msg.getKey() != null) {
-                snapshots.put(msg.getKey(), msg.getValue());
+                if (msg.getValue() != null) {
+                    snapshots.put(msg.getKey(), msg.getValue());
+                } else {
+                    snapshots.remove(msg.getKey());
+                }
             }
         }
         return snapshots.get(topic);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotTableView.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotTableView.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction.buffer.impl;
+
+import static org.apache.pulsar.broker.systopic.SystemTopicClient.Reader;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.service.SystemTopicTxnBufferSnapshotService;
+import org.apache.pulsar.broker.transaction.buffer.metadata.TransactionBufferSnapshot;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.utils.SimpleCache;
+
+/**
+ * Compared with the more generic {@link org.apache.pulsar.client.api.TableView}, this table view
+ * - Provides just a single public method that reads the latest value synchronously.
+ * - Maintains multiple long-lived readers that will be expired after some time (1 minute by default).
+ */
+@Slf4j
+public class SnapshotTableView {
+
+    // Remove the cached reader and snapshots if there is no refresh request in 1 minute
+    private static final long CACHE_EXPIRE_TIMEOUT_MS = 60 * 1000L;
+    private final Map<String, TransactionBufferSnapshot> snapshots = new ConcurrentHashMap<>();
+    private final SystemTopicTxnBufferSnapshotService<TransactionBufferSnapshot> snapshotService;
+    private final long blockTimeoutMs;
+    private final SimpleCache<NamespaceName, Reader<TransactionBufferSnapshot>> readers;
+
+    public SnapshotTableView(SystemTopicTxnBufferSnapshotService<TransactionBufferSnapshot> snapshotService,
+                             ScheduledExecutorService executor, long blockTimeoutMs) {
+        this.snapshotService = snapshotService;
+        this.blockTimeoutMs = blockTimeoutMs;
+        this.readers = new SimpleCache<>(executor, CACHE_EXPIRE_TIMEOUT_MS);
+    }
+
+    public TransactionBufferSnapshot readLatest(String topic) throws Exception {
+        final var topicName = TopicName.get(topic);
+        final var namespace = topicName.getNamespaceObject();
+        final var reader = readers.get(namespace, () -> {
+            try {
+                return wait(snapshotService.createReader(topicName), "create reader");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }, __ -> __.closeAsync().exceptionally(e -> {
+            log.warn("Failed to close reader {}", e.getMessage());
+            return null;
+        }));
+        while (wait(reader.hasMoreEventsAsync(), "has more events")) {
+            final var msg = wait(reader.readNextAsync(), "read message");
+            if (msg.getKey() != null) {
+                snapshots.put(msg.getKey(), msg.getValue());
+            }
+        }
+        return snapshots.get(topic);
+    }
+
+    private <T> T wait(CompletableFuture<T> future, String msg) throws Exception {
+        try {
+            return future.get(blockTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            throw new ExecutionException("Failed to " + msg, e.getCause());
+        }
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TableView.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TableView.java
@@ -43,6 +43,7 @@ public class TableView<T> {
 
     // Remove the cached reader and snapshots if there is no refresh request in 1 minute
     private static final long CACHE_EXPIRE_TIMEOUT_MS = 60 * 1000L;
+    private static final long CACHE_EXPIRE_CHECK_FREQUENCY_MS = 3000L;
     @VisibleForTesting
     protected final Function<TopicName, CompletableFuture<Reader<T>>> readerCreator;
     private final Map<String, T> snapshots = new ConcurrentHashMap<>();
@@ -53,7 +54,7 @@ public class TableView<T> {
                      ScheduledExecutorService executor) {
         this.readerCreator = readerCreator;
         this.clientOperationTimeoutMs = clientOperationTimeoutMs;
-        this.readers = new SimpleCache<>(executor, CACHE_EXPIRE_TIMEOUT_MS);
+        this.readers = new SimpleCache<>(executor, CACHE_EXPIRE_TIMEOUT_MS, CACHE_EXPIRE_CHECK_FREQUENCY_MS);
     }
 
     public T readLatest(String topic) throws Exception {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -632,7 +632,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                         this, topic.getName());
                 return;
             }
-            abortedTxnProcessor.recoverFromSnapshot().thenAcceptAsync(startReadCursorPosition -> {
+            abortedTxnProcessor.recoverFromSnapshot().thenAccept(startReadCursorPosition -> {
                 //Transaction is not use for this topic, so just make maxReadPosition as LAC.
                 if (startReadCursorPosition == null) {
                     callBack.noNeedToRecover();
@@ -678,8 +678,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
                 closeCursor(SUBSCRIPTION_NAME);
                 callBack.recoverComplete();
-            }, topic.getBrokerService().getPulsar().getTransactionExecutorProvider()
-                    .getExecutor(this)).exceptionally(e -> {
+            }).exceptionally(e -> {
                 callBack.recoverExceptionally(e.getCause());
                 log.error("[{}]Transaction buffer failed to recover snapshot!", topic.getName(), e);
                 return null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/utils/SimpleCache.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/utils/SimpleCache.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SimpleCache<K, V> {
+
+    private final Map<K, V> cache = new HashMap<>();
+    private final Map<K, ScheduledFuture<?>> futures = new HashMap<>();
+    private final ScheduledExecutorService executor;
+    private final long timeoutMs;
+
+    public synchronized V get(final K key, final Supplier<V> valueSupplier, final Consumer<V> expireCallback) {
+        final V value;
+        V existingValue = cache.get(key);
+        if (existingValue != null) {
+            value = existingValue;
+        } else {
+            value = valueSupplier.get();
+            cache.put(key, value);
+        }
+        final var future = futures.remove(key);
+        if (future != null) {
+            future.cancel(true);
+        }
+        futures.put(key, executor.schedule(() -> {
+            synchronized (SimpleCache.this) {
+                futures.remove(key);
+                final var removedValue = cache.remove(key);
+                if (removedValue != null) {
+                    expireCallback.accept(removedValue);
+                }
+            }
+        }, timeoutMs, TimeUnit.MILLISECONDS));
+        return value;
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
@@ -90,7 +90,6 @@ import org.apache.pulsar.client.impl.transaction.TransactionImpl;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.events.EventType;
 import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
@@ -682,25 +681,6 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
 
         producer.newMessage(txn).value("test".getBytes()).send();
         txn.commit().get();
-    }
-
-
-    @Test
-    public void testTransactionBufferNoSnapshotCloseReader() throws Exception{
-        String topic = NAMESPACE1 + "/test";
-        @Cleanup
-        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).producerName("testTxnTimeOut_producer")
-                .topic(topic).sendTimeout(0, TimeUnit.SECONDS).enableBatching(false).create();
-
-        admin.topics().unload(topic);
-
-        // unload success, all readers have been closed except for the compaction sub
-        producer.send("test");
-        TopicStats stats = admin.topics().getStats(NAMESPACE1 + "/" + TRANSACTION_BUFFER_SNAPSHOT);
-
-        // except for the compaction sub
-        assertEquals(stats.getSubscriptions().size(), 1);
-        assertTrue(stats.getSubscriptions().keySet().contains("__compaction"));
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/utils/SimpleCacheTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/utils/SimpleCacheTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.utils;
+
+import java.util.Collections;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+public class SimpleCacheTest {
+
+    private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+
+    @AfterClass
+    public void shutdown() {
+        executor.shutdown();
+    }
+
+    @Test
+    public void testConcurrentUpdate() throws Exception {
+        final var cache = new SimpleCache<Integer, Integer>(executor, 10000L);
+        final var pool = Executors.newFixedThreadPool(2);
+        final var latch = new CountDownLatch(2);
+        for (int i = 0; i < 2; i++) {
+            final var value = i + 100;
+            pool.execute(() -> {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ignored) {
+                }
+                cache.get(0, () -> value, __ -> {});
+                latch.countDown();
+            });
+        }
+        latch.await();
+        final var value = cache.get(0, () -> -1, __ -> {});
+        Assert.assertTrue(value == 100 || value == 101);
+        pool.shutdown();
+    }
+
+    @Test
+    public void testExpire() throws InterruptedException {
+        final var cache = new SimpleCache<Integer, Integer>(executor, 500L);
+        final var expiredValues = new CopyOnWriteArrayList<Integer>();
+        cache.get(0, () -> 100, expiredValues::add);
+        for (int i = 0; i < 100; i++) {
+            cache.get(1, () -> 101, expiredValues::add);
+            Thread.sleep(10);
+        }
+        Assert.assertEquals(cache.get(0, () -> -1, __ -> {}), -1); // the value is expired
+        Assert.assertEquals(cache.get(1, () -> -1, __ -> {}), 101);
+        Assert.assertEquals(expiredValues, Collections.singletonList(100));
+    }
+}


### PR DESCRIPTION
### Motivation

During the rolling restarts, the namespace bundle ownerships will change. Assuming there is a producer created on a single topic, and the ownership was transferred to the new broker. Assuming the namespace bundle has N topics and the namespace is `tenant/ns`,
1. All N topics in the same bundle of that topic will be loaded.
2. For each topic, the managed ledger will be initialized, when the transaction coordinator is enabled, a `TopicTransactionBuffer` will be created. A Pulsar reader will be created on `tenant/ns/__transaction_buffer_snapshot` concurrently.
3. Once all N readers are created, the owner of the snapshot topic will start dispatching messages to N readers. Each dispatcher will read messages from BookKeeper concurrently and might fail with too many requests error because BK can only have `maxPendingReadRequestsPerThread` pending read requests (default: 10000).

We have a `numTransactionReplayThreadPoolSize` config to limit the concurrency of transaction snapshot readers. However, it only limits the read loop. For example, if it's configured with 1, only 1 reader could read messages at the same time. However, N readers will be created concurrently. Each when one of these reader explicitly calls `readNext`, all N dispatchers at brokers side will dispatch messages to N readers.

The behaviors above brings much CPU pressure on the owner broker, especially for a small cluster with only two brokers.

### Modifications

Synchronize the reader creation, read loop and the following process on its result. Maintain only one reader for each namespace. The reader is now not closed unless there is no snapshot read request in 1 minute.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/BewareMyPower/pulsar/pull/32

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
