### PR TITLE
[fix][broker] Do not try to clean owned bundles from inactive source brokers (ExtensibleLoadManagerImpl only)

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -1014,7 +1014,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
         }
         try {
             FutureUtil.waitForAll(futures)
-                    .get(pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
+                    .get(pulsar.getConfiguration().getNamespaceBundleUnloadingTimeoutMs(), TimeUnit.MILLISECONDS);
         } catch (Throwable e) {
             log.warn("Failed to wait for closing internal topics", e);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -124,6 +124,9 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
 
     private static final String ELECTION_ROOT = "/loadbalance/extension/leader";
 
+    private static final Set<String> INTERNAL_TOPICS =
+            Set.of(BROKER_LOAD_DATA_STORE_TOPIC, TOP_BUNDLES_LOAD_DATA_STORE_TOPIC, TOPIC);
+
     private PulsarService pulsar;
 
     private ServiceConfiguration conf;
@@ -828,7 +831,8 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
     }
 
     public static boolean isInternalTopic(String topic) {
-        return topic.startsWith(TOPIC)
+        return INTERNAL_TOPICS.contains(topic)
+                || topic.startsWith(TOPIC)
                 || topic.startsWith(BROKER_LOAD_DATA_STORE_TOPIC)
                 || topic.startsWith(TOP_BUNDLES_LOAD_DATA_STORE_TOPIC);
     }
@@ -993,5 +997,26 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
         serviceUnitStateChannel.cleanOwnerships();
         leaderElectionService.close();
         brokerRegistry.unregister();
+        // Close the internal topics (if owned any) after giving up the possible leader role,
+        // so that the subsequent lookups could hit the next leader.
+        closeInternalTopics();
+    }
+
+    private void closeInternalTopics() {
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (String name : INTERNAL_TOPICS) {
+            futures.add(pulsar.getBrokerService().getTopicIfExists(name)
+                    .thenAccept(topicOptional -> topicOptional.ifPresent(topic -> topic.close(true)))
+                    .exceptionally(__ -> {
+                        log.warn("Failed to close internal topic:{}", name);
+                        return null;
+                    }));
+        }
+        try {
+            FutureUtil.waitForAll(futures)
+                    .get(pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
+        } catch (Throwable e) {
+            log.warn("Failed to wait for closing internal topics", e);
+        }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -1306,7 +1306,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                             selectedOpt.map(selectedBroker -> {
                                 if (orphanData.state() == Splitting) {
                                     // if Splitting, set orphan.dstBroker() as dst to indicate where it was from.
-                                    // (no-op)
+                                    // (The src broker runs handleSplitEvent.)
                                     return new ServiceUnitStateData(Splitting, orphanData.dstBroker(), selectedBroker,
                                             Map.copyOf(orphanData.splitServiceUnitToDestBroker()), true, version);
                                 } else if (orphanData.state() == Owned) {
@@ -1324,6 +1324,8 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                                                     orphanData.sourceBroker(),
                                             true, version);
                                 }
+                                // If no broker is selected(available), free the ownership.
+                                // If the previous owner is still active, it will close the bundle(topic) ownership.
                             }).orElseGet(() -> new ServiceUnitStateData(Free, null,
                                     orphanData.state() == Owned ? orphanData.dstBroker() : orphanData.sourceBroker(),
                                     true,
@@ -1545,7 +1547,8 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             }
         }
 
-        // timedOutOrphanServiceUnits are the in-flight ones although their src and dst brokers are known to be active.
+        // timedOutInFlightStateServiceUnits are the in-flight ones although their src and dst brokers are known to
+        // be active.
         if (!timedOutInFlightStateServiceUnits.isEmpty()) {
             for (var etr : timedOutInFlightStateServiceUnits.entrySet()) {
                 var orphanServiceUnit = etr.getKey();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2252,8 +2252,8 @@ public class BrokerService implements Closeable {
             if (serviceUnit.includes(topicName)) {
                 if (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(pulsar)
                         && ExtensibleLoadManagerImpl.isInternalTopic(topicName.toString())) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Skip unloading ExtensibleLoadManager internal topics. Such internal topic "
+                    if (ExtensibleLoadManagerImpl.debug(pulsar.getConfiguration(), log)) {
+                        log.info("[{}] Skip unloading ExtensibleLoadManager internal topics. Such internal topic "
                                 + "should be closed when shutting down the broker.", topicName);
                     }
                     return;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2250,6 +2250,15 @@ public class BrokerService implements Closeable {
         topics.forEach((name, topicFuture) -> {
             TopicName topicName = TopicName.get(name);
             if (serviceUnit.includes(topicName)) {
+                if (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(pulsar)
+                        && ExtensibleLoadManagerImpl.isInternalTopic(topicName.toString())) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] Skip unloading ExtensibleLoadManager internal topics. Such internal topic "
+                                + "should be closed when shutting down the broker.", topicName);
+                    }
+                    return;
+                }
+
                 // Topic needs to be unloaded
                 log.info("[{}] Unloading topic", topicName);
                 if (topicFuture.isCompletedExceptionally()) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
@@ -110,6 +110,7 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
     private ServiceUnitStateChannel channel2;
     private String brokerId1;
     private String brokerId2;
+    private String brokerId3;
     private String bundle;
     private String bundle1;
     private String bundle2;
@@ -161,6 +162,7 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
                 FieldUtils.readDeclaredField(channel1, "brokerId", true);
         brokerId2 = (String)
                 FieldUtils.readDeclaredField(channel2, "brokerId", true);
+        brokerId3 = "broker-3";
 
         bundle = "public/default/0x00000000_0xffffffff";
         bundle1 = "public/default/0x00000000_0xfffffff0";
@@ -1235,7 +1237,8 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
 
 
         var leader = channel1.isChannelOwnerAsync().get() ? channel1 : channel2;
-
+        doReturn(CompletableFuture.completedFuture(Optional.of(brokerId1)))
+                .when(loadManager).selectAsync(any(), any(), any());
         waitUntilStateWithMonitor(leader, bundle, Init);
         waitUntilStateWithMonitor(channel1, bundle, Init);
         waitUntilStateWithMonitor(channel2, bundle, Init);
@@ -1426,6 +1429,8 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
                     assertEquals(3, count.get());
                 });
         var leader = channel1.isChannelOwnerAsync().get() ? channel1 : channel2;
+        doReturn(CompletableFuture.completedFuture(Optional.of(brokerId1)))
+                .when(loadManager).selectAsync(any(), any(), any());
         ((ServiceUnitStateChannelImpl) leader)
                 .monitorOwnerships(List.of(brokerId1, brokerId2));
 
@@ -1569,26 +1574,40 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         String broker = brokerId1;
 
         // test override states
-        String releasingBundle = "public/releasing/0xfffffff0_0xffffffff";
+        String releasingBundle1 = "public/releasing1/0xfffffff0_0xffffffff";
+        String releasingBundle2 = "public/releasing2/0xfffffff0_0xffffffff";
         String splittingBundle = bundle;
-        String assigningBundle = "public/assigning/0xfffffff0_0xffffffff";
+        String assigningBundle1 = "public/assigning1/0xfffffff0_0xffffffff";
+        String assigningBundle2 = "public/assigning2/0xfffffff0_0xffffffff";
         String freeBundle = "public/free/0xfffffff0_0xffffffff";
         String deletedBundle = "public/deleted/0xfffffff0_0xffffffff";
-        String ownedBundle = "public/owned/0xfffffff0_0xffffffff";
-        overrideTableViews(releasingBundle,
-                new ServiceUnitStateData(Releasing, null, broker, 1));
+        String ownedBundle1 = "public/owned1/0xfffffff0_0xffffffff";
+        String ownedBundle2 = "public/owned2SourceBundle/0xfffffff0_0xffffffff";
+        String ownedBundle3 = "public/owned3/0xfffffff0_0xffffffff";
+        String inactiveBroker = "broker-inactive-1";
+        overrideTableViews(releasingBundle1,
+                new ServiceUnitStateData(Releasing, broker, brokerId2, 1));
+        overrideTableViews(releasingBundle2,
+                new ServiceUnitStateData(Releasing, brokerId2, brokerId3, 1));
         overrideTableViews(splittingBundle,
                 new ServiceUnitStateData(Splitting, null, broker,
                         Map.of(childBundle1Range, Optional.empty(),
                                 childBundle2Range, Optional.empty()), 1));
-        overrideTableViews(assigningBundle,
+        overrideTableViews(assigningBundle1,
                 new ServiceUnitStateData(Assigning, broker, null, 1));
+        overrideTableViews(assigningBundle2,
+                new ServiceUnitStateData(Assigning, broker, brokerId2, 1));
         overrideTableViews(freeBundle,
                 new ServiceUnitStateData(Free, null, broker, 1));
         overrideTableViews(deletedBundle,
                 new ServiceUnitStateData(Deleted, null, broker, 1));
-        overrideTableViews(ownedBundle,
+        overrideTableViews(ownedBundle1,
                 new ServiceUnitStateData(Owned, broker, null, 1));
+        overrideTableViews(ownedBundle2,
+                new ServiceUnitStateData(Owned, broker, inactiveBroker, 1));
+        overrideTableViews(ownedBundle3,
+                new ServiceUnitStateData(Owned, inactiveBroker, broker, 1));
+
 
         // test stable metadata state
         doReturn(CompletableFuture.completedFuture(Optional.of(brokerId2)))
@@ -1598,16 +1617,33 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         FieldUtils.writeDeclaredField(followerChannel, "inFlightStateWaitingTimeInMillis",
                 -1, true);
         ((ServiceUnitStateChannelImpl) leaderChannel)
-                .monitorOwnerships(List.of(brokerId1, brokerId2));
+                .monitorOwnerships(List.of(brokerId1, brokerId2, "broker-3"));
 
-        waitUntilNewOwner(channel2, releasingBundle, broker);
-        waitUntilNewOwner(channel2, childBundle11, broker);
-        waitUntilNewOwner(channel2, childBundle12, broker);
-        waitUntilNewOwner(channel2, assigningBundle, brokerId2);
-        waitUntilNewOwner(channel2, ownedBundle, broker);
-        assertEquals(Optional.empty(), channel2.getOwnerAsync(freeBundle).get());
-        assertTrue(channel2.getOwnerAsync(deletedBundle).isCompletedExceptionally());
+        ServiceUnitStateChannel finalLeaderChannel = leaderChannel;
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> getCleanupJobs(finalLeaderChannel).isEmpty());
+
+
+        waitUntilNewOwner(channel2, releasingBundle1, brokerId2);
+        waitUntilNewOwner(channel2, releasingBundle2, brokerId2);
         assertTrue(channel2.getOwnerAsync(splittingBundle).get().isEmpty());
+        waitUntilNewOwner(channel2, childBundle11, brokerId2);
+        waitUntilNewOwner(channel2, childBundle12, brokerId2);
+        waitUntilNewOwner(channel2, assigningBundle1, brokerId2);
+        waitUntilNewOwner(channel2, assigningBundle2, brokerId2);
+        assertTrue(channel2.getOwnerAsync(freeBundle).get().isEmpty());
+        assertTrue(channel2.getOwnerAsync(deletedBundle).isCompletedExceptionally());
+        waitUntilNewOwner(channel2, ownedBundle1, broker);
+        waitUntilNewOwner(channel2, ownedBundle2, broker);
+        waitUntilNewOwner(channel2, ownedBundle3, brokerId2);
+
+        validateMonitorCounters(leaderChannel,
+                1,
+                0,
+                6,
+                0,
+                1,
+                0,
+                0);
 
         // clean-up
         FieldUtils.writeDeclaredField(channel1,


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

- Found a bug that the ownership monitor tries to clean owned bundles from inactive source brokers

### Modifications

<!-- Describe the modifications you've done. -->

- Fix the bug not to clean owned bundles from inactive source brokers
- Cleaned/refactored override ownership code
- Skip unloading LB internal topics. Instead, close those topics when shutting down the broker.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/heesung-sn/pulsar/pull/75

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
