### PR TITLE
[improve] [test] add end to end deduplication test.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeduplicationEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeduplicationEndToEndTest.java
@@ -43,7 +43,7 @@ public class DeduplicationEndToEndTest extends ProducerConsumerBase {
     @Test
     public void testProducerDuplicationWithReceiptLost() throws Exception {
         final String topic = "persistent://my-property/my-ns/deduplication-test";
-        admin.namespaces().setDeduplicationStatus("my-property/my-ns", true);
+        admin.namespaces().setDeduplicationStatus("my-property/my-ns", false);
 
         // Create producer with deduplication enabled
         String producerName = "my-producer-name";
@@ -102,6 +102,153 @@ public class DeduplicationEndToEndTest extends ProducerConsumerBase {
         consumer.close();
     }
 
+
+    /**
+     * simulate the case where the producer sends the message but doesn't receive the ack
+     * due to network issue, broker issue, etc. User receives the exception and sends the same message again.
+     * With deduplication enabled, the message is duplicated too! Because the message newly sent has a
+     * different sequence id.
+     * @throws Exception
+     */
+    @Test
+    public void testProducerDuplicationWithReceiptLostDedupEnabled() throws Exception {
+        final String topic = "persistent://my-property/my-ns/deduplication-test-dedup-enabled";
+        admin.namespaces().setDeduplicationStatus("my-property/my-ns", true);
+
+        // Create producer with deduplication enabled
+        String producerName = "my-producer-name";
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic)
+                .producerName(producerName).sendTimeout(1, TimeUnit.SECONDS).create();
+        assertEquals(producer.getLastSequenceId(), -1L);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("my-sub").subscribe();
+
+        // disable the send receipt to simulate the case where the producer sends the message but doesn't receive the ack
+        PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService()
+                .getTopic(topic, false).get().get();
+        assertNotNull(persistentTopic);
+        ServerCnx serverCnx = (ServerCnx) persistentTopic.getProducers().get(producerName).getCnx();
+
+        // use reflection to spy the commandSender
+        Field commandSenderField = ServerCnx.class.getDeclaredField("commandSender");
+        commandSenderField.setAccessible(true);
+        PulsarCommandSender commandSender = (PulsarCommandSender) commandSenderField.get(serverCnx);
+        PulsarCommandSender spyCommandSender = Mockito.spy(commandSender);
+        commandSenderField.set(serverCnx, spyCommandSender);
+
+        // disable the send receipt
+        Mockito.doNothing().when(spyCommandSender).sendSendReceiptResponse(Mockito.anyLong(), Mockito.anyLong(),
+                Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong());
+
+        // send a message
+        producer.sendAsync("test".getBytes()).thenRun(() -> {
+            // should not enter here
+            Assert.fail();
+        }).exceptionally(e -> {
+            // do not receive the ack, should enter here
+            return null;
+        }).get();
+
+
+        // set back the send receipt
+        commandSenderField.set(serverCnx, commandSender);
+
+        // user receive the exception, send the same message again
+        // though the message content is the same, the sequence id is different, so the message is duplicated
+        producer.sendAsync("test".getBytes()).exceptionally(e -> {
+            // should not enter here
+            Assert.fail();
+            return null;
+        }).get();
+
+        // consume the message, there are two messages in the topic
+        Message<byte[]> message = consumer.receive(1, TimeUnit.SECONDS);
+        assertNotNull(message);
+        assertEquals(new String(message.getData()), "test");
+        assertEquals(message.getSequenceId(), 0);
+        message = consumer.receive(1, TimeUnit.SECONDS);
+        assertNotNull(message);
+        assertEquals(new String(message.getData()), "test");
+        assertEquals(message.getSequenceId(), 1);
+
+        // clean up
+        producer.close();
+        consumer.close();
+    }
+
+
+    /**
+     * simulate the case where the producer sends the message but doesn't receive the ack
+     * due to network issue, broker issue, etc. User receives the exception and sends the same message again.
+     * With deduplication enabled, the message is duplicated too! Because the message newly sent has a
+     * different sequence id.
+     * @throws Exception
+     */
+    @Test
+    public void testProducerDuplicationWithReceiptLostDedupEnabled2() throws Exception {
+        final String topic = "persistent://my-property/my-ns/deduplication-test-dedup-enabled2";
+        admin.namespaces().setDeduplicationStatus("my-property/my-ns", true);
+
+        // Create producer with deduplication enabled
+        String producerName = "my-producer-name";
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic)
+                .producerName(producerName).sendTimeout(1, TimeUnit.SECONDS).create();
+        assertEquals(producer.getLastSequenceId(), -1L);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("my-sub").subscribe();
+
+        // disable the send receipt to simulate the case where the producer sends the message but doesn't receive the ack
+        PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService()
+                .getTopic(topic, false).get().get();
+        assertNotNull(persistentTopic);
+        ServerCnx serverCnx = (ServerCnx) persistentTopic.getProducers().get(producerName).getCnx();
+
+        // use reflection to spy the commandSender
+        Field commandSenderField = ServerCnx.class.getDeclaredField("commandSender");
+        commandSenderField.setAccessible(true);
+        PulsarCommandSender commandSender = (PulsarCommandSender) commandSenderField.get(serverCnx);
+        PulsarCommandSender spyCommandSender = Mockito.spy(commandSender);
+        commandSenderField.set(serverCnx, spyCommandSender);
+
+        // disable the send receipt
+        Mockito.doNothing().when(spyCommandSender).sendSendReceiptResponse(Mockito.anyLong(), Mockito.anyLong(),
+                Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong());
+
+        // send a message
+        TypedMessageBuilder<byte[]> typeMessages = producer.newMessage().value("test".getBytes());
+        typeMessages.sendAsync().thenRun(() -> {
+            // should not enter here
+            Assert.fail();
+        }).exceptionally(e -> {
+            // do not receive the ack, should enter here
+            return null;
+        }).get();
+
+
+        // set back the send receipt
+        commandSenderField.set(serverCnx, commandSender);
+
+        // user receive the exception, send the same message again
+        // though we use the same TypedMessageBuilder, the two messages are different!
+        // because the sequence id is different, so the message is duplicated too.
+        typeMessages.sendAsync().exceptionally(e -> {
+            // should not enter here
+            Assert.fail();
+            return null;
+        }).get();
+
+        // consume the message, there are two messages in the topic
+        Message<byte[]> message = consumer.receive(1, TimeUnit.SECONDS);
+        assertNotNull(message);
+        assertEquals(new String(message.getData()), "test");
+        assertEquals(message.getSequenceId(), 0);
+        message = consumer.receive(1, TimeUnit.SECONDS);
+        assertNotNull(message);
+        assertEquals(new String(message.getData()), "test");
+        assertEquals(message.getSequenceId(), 1);
+
+        // clean up
+        producer.close();
+        consumer.close();
+    }
 
 
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeduplicationEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeduplicationEndToEndTest.java
@@ -1,0 +1,109 @@
+package org.apache.pulsar.client.api;
+
+import org.apache.pulsar.broker.service.PulsarCommandSender;
+import org.apache.pulsar.broker.service.ServerCnx;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * This test class is used to point out cases where message duplication can occur,
+ * producer idempotency features can be used to solve which cases and can't solve which cases.
+ */
+public class DeduplicationEndToEndTest extends ProducerConsumerBase {
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    /**
+     * simulate the case where the producer sends the message but doesn't receive the ack
+     * due to network issue, broker issue, etc. User receives the exception and sends the same message again.
+     * The message is duplicated in the topic.
+     * @throws Exception
+     */
+    @Test
+    public void testProducerDuplicationWithReceiptLost() throws Exception {
+        final String topic = "persistent://my-property/my-ns/deduplication-test";
+        admin.namespaces().setDeduplicationStatus("my-property/my-ns", true);
+
+        // Create producer with deduplication enabled
+        String producerName = "my-producer-name";
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic)
+                .producerName(producerName).sendTimeout(1, TimeUnit.SECONDS).create();
+        assertEquals(producer.getLastSequenceId(), -1L);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("my-sub").subscribe();
+
+        // disable the send receipt to simulate the case where the producer sends the message but doesn't receive the ack
+        PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService()
+                .getTopic(topic, false).get().get();
+        assertNotNull(persistentTopic);
+        ServerCnx serverCnx = (ServerCnx) persistentTopic.getProducers().get(producerName).getCnx();
+
+        // use reflection to spy the commandSender
+        Field commandSenderField = ServerCnx.class.getDeclaredField("commandSender");
+        commandSenderField.setAccessible(true);
+        PulsarCommandSender commandSender = (PulsarCommandSender) commandSenderField.get(serverCnx);
+        PulsarCommandSender spyCommandSender = Mockito.spy(commandSender);
+        commandSenderField.set(serverCnx, spyCommandSender);
+
+        // disable the send receipt
+        Mockito.doNothing().when(spyCommandSender).sendSendReceiptResponse(Mockito.anyLong(), Mockito.anyLong(),
+                Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong());
+
+        // send a message
+        producer.sendAsync("test".getBytes()).thenRun(() -> {
+            // should not enter here
+            Assert.fail();
+        }).exceptionally(e -> {
+            // do not receive the ack, should enter here
+            return null;
+        }).get();
+
+
+        // set back the send receipt
+        commandSenderField.set(serverCnx, commandSender);
+
+        // user receive the exception, send the same message again
+        producer.sendAsync("test".getBytes()).exceptionally(e -> {
+            // should not enter here
+            Assert.fail();
+            return null;
+        }).get();
+
+        // consume the message, there are two messages in the topic
+        Message<byte[]> message = consumer.receive(1, TimeUnit.SECONDS);
+        assertNotNull(message);
+        assertEquals(new String(message.getData()), "test");
+        message = consumer.receive(1, TimeUnit.SECONDS);
+        assertNotNull(message);
+        assertEquals(new String(message.getData()), "test");
+
+        // clean up
+        producer.close();
+        consumer.close();
+    }
+
+
+
+
+
+}


### PR DESCRIPTION
### Motivation

Message deduplication feature has been introduced into Pulsar long time ago, but the concrete problem it solve is vague.
The info i can get from the official document is that we can enable a switch in the conf file, and then we can enjoy the message deduplication feature.
But actually, there are a lot of point that we don't clarify. 
1. How do we use it? Should user set the sequence id by api exposed or not?
2. Which concrete situation will we meet message duplication in? Can message deduplication feature handle these situations all?

I will fulfill these tests to clarify this in the next few days.

### Modifications

Add end to end deduplication test to clarify what problem message deduplication can handle, and what it can't.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is already covered by existing tests, such as *(please describe tests)*.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 