### PR TITLE
[improve] [broker] Check max producers/consumers limitation first before other ops to save resources

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -546,7 +546,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
         return count;
     }
 
-    protected boolean isConsumersExceededOnTopic() {
+    public boolean isConsumersExceededOnTopic() {
         if (isSystemTopic()) {
             return false;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1561,10 +1561,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     log.warn("[{}] Attempting to add producer to topic which reached max producers limit", topic);
                     String errorMsg = "Topic '" + topicName.toString() + "' reached max producers limit";
                     Throwable t = new BrokerServiceException.ProducerBusyException(errorMsg);
-                    producerFuture.completeExceptionally(t);
-                    producers.remove(producerId, producerFuture);
-                    commandSender.sendErrorResponse(requestId, BrokerServiceException.getClientErrorCode(t), errorMsg);
-                    return CompletableFuture.completedFuture(null);
+                    return CompletableFuture.failedFuture(t);
                 }
 
                 // Before creating producer, check if backlog quota exceeded

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1545,6 +1545,18 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             }
 
             service.getOrCreateTopic(topicName.toString()).thenCompose((Topic topic) -> {
+                // Check max producer limitation to avoid unnecessary ops wasting resources. For example: the new
+                // producer reached max producer limitation, but pulsar did schema check first, it would waste CPU
+                if (((AbstractTopic) topic).isProducersExceeded(producerName)) {
+                    log.warn("[{}] Attempting to add producer to topic which reached max producers limit", topic);
+                    String errorMsg = "Topic '" + topicName.toString() + "' reached max producers limit";
+                    Throwable t = new BrokerServiceException.ProducerBusyException(errorMsg);
+                    producerFuture.completeExceptionally(t);
+                    producers.remove(producerId, producerFuture);
+                    commandSender.sendErrorResponse(requestId, BrokerServiceException.getClientErrorCode(t), errorMsg);
+                    return CompletableFuture.completedFuture(null);
+                }
+
                 // Before creating producer, check if backlog quota exceeded
                 // on topic for size based limit and time based limit
                 CompletableFuture<Void> backlogQuotaCheckFuture = CompletableFuture.allOf(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1325,9 +1325,6 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                                     + " consumers limit", topic);
                                             Throwable t =
                                                     new ConsumerBusyException("Topic reached max consumers limit");
-                                            commandSender.sendErrorResponse(requestId,
-                                                    BrokerServiceException.getClientErrorCode(t),
-                                                    t.getMessage());
                                             return FutureUtil.failedFuture(t);
                                         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1320,6 +1320,16 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                                             new SubscriptionNotFoundException(
                                                                     "Subscription does not exist"));
                                         }
+                                        if (((AbstractTopic) topic).isConsumersExceededOnTopic()) {
+                                            log.warn("[{}] Attempting to add consumer to topic which reached max"
+                                                    + " consumers limit", topic);
+                                            Throwable t =
+                                                    new ConsumerBusyException("Topic reached max consumers limit");
+                                            commandSender.sendErrorResponse(requestId,
+                                                    BrokerServiceException.getClientErrorCode(t),
+                                                    t.getMessage());
+                                            return FutureUtil.failedFuture(t);
+                                        }
 
                                         SubscriptionOption option = SubscriptionOption.builder().cnx(ServerCnx.this)
                                                 .subscriptionName(subscriptionName)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -509,51 +509,6 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         topic.getProducers().values().forEach(producer -> Assert.assertEquals(producer.getEpoch(), 3));
     }
 
-    private void testMaxProducers() {
-        PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
-        topic.initialize().join();
-        String role = "appid1";
-        // 1. add producer1
-        Producer producer = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name1", role,
-                false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty(), true);
-        topic.addProducer(producer, new CompletableFuture<>());
-        assertEquals(topic.getProducers().size(), 1);
-
-        // 2. add producer2
-        Producer producer2 = new Producer(topic, serverCnx, 2 /* producer id */, "prod-name2", role,
-                false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty(), true);
-        topic.addProducer(producer2, new CompletableFuture<>());
-        assertEquals(topic.getProducers().size(), 2);
-
-        // 3. add producer3 but reached maxProducersPerTopic
-        try {
-            Producer producer3 = new Producer(topic, serverCnx, 3 /* producer id */, "prod-name3", role,
-                    false, null, SchemaVersion.Latest, 0, false, ProducerAccessMode.Shared, Optional.empty(), true);
-            topic.addProducer(producer3, new CompletableFuture<>()).join();
-            fail("should have failed");
-        } catch (Exception e) {
-            assertEquals(e.getCause().getClass(), BrokerServiceException.ProducerBusyException.class);
-        }
-    }
-
-    @Test
-    public void testMaxProducersForBroker() {
-        // set max clients
-        pulsarTestContext.getConfig().setMaxProducersPerTopic(2);
-        testMaxProducers();
-    }
-
-    @Test
-    public void testMaxProducersForNamespace() throws Exception {
-        // set max clients
-        Policies policies = new Policies();
-        policies.max_producers_per_topic = 2;
-        pulsarTestContext.getPulsarResources().getNamespaceResources()
-                .createPolicies(TopicName.get(successTopicName).getNamespaceObject(),
-                        policies);
-        testMaxProducers();
-    }
-
     private Producer getMockedProducerWithSpecificAddress(Topic topic, long producerId, InetAddress address) {
         final String producerNameBase = "producer";
         final String role = "appid1";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MaxProducerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MaxProducerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker-api")
+public class MaxProducerTest extends ProducerConsumerBase {
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Override
+    protected void doInitConf() throws Exception {
+        super.doInitConf();
+        conf.setMaxProducersPerTopic(2);
+    }
+
+    @Test
+    public void testMaxProducersForBroker() throws Exception {
+        testMaxProducers(2);
+    }
+
+    @Test
+    public void testMaxProducersForNamespace() throws Exception {
+        // set max clients
+        admin.namespaces().setMaxProducersPerTopic("public/default", 3);
+        testMaxProducers(3);
+    }
+
+    private void testMaxProducers(int maxProducerExpected) throws Exception {
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
+        admin.topics().createNonPartitionedTopic(topicName);
+
+        List<org.apache.pulsar.client.api.Producer<byte[]>> producers = new ArrayList<>();
+        for (int i = 0; i < maxProducerExpected; i++) {
+            producers.add(pulsarClient.newProducer().topic(topicName).create());
+        }
+
+        try {
+            pulsarClient.newProducer().topic(topicName).create();
+            fail("should have failed");
+        } catch (Exception e) {
+            assertTrue(e instanceof PulsarClientException.ProducerBusyException);
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MaxProducerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MaxProducerTest.java
@@ -78,5 +78,11 @@ public class MaxProducerTest extends ProducerConsumerBase {
         } catch (Exception e) {
             assertTrue(e instanceof PulsarClientException.ProducerBusyException);
         }
+
+        // cleanup.
+        for (org.apache.pulsar.client.api.Producer p : producers) {
+            p.close();
+        }
+        admin.topics().delete(topicName, false);
     }
 }


### PR DESCRIPTION
### Motivation

**Background**
- Pulsar checks compatible of schemas when adding producers/consumers
- After checking schemas, it checks the max producers/consumers count.

**Issue**
- If the clients have already reached max limitation of producers/consumers count, the client will try to register producers/consumers continuously.
- It checks schemas, then checks the max producers/consumers count. This will waste many CPU resources to check the compatibility of schemas.

### Modifications
-  Check max producers/consumers limitation first before other ops to save resources

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
