### PR TITLE
[improve][pip] PIP-368: Support lookup based on the lookup properties

### DIFF
--- a/pip/pip-368.md
+++ b/pip/pip-368.md
@@ -104,7 +104,7 @@ private String lookupPropertyPrefix = "lookup.";
 
 ### Binary protocol
 
-Add `properties` field to the `CommandLookupTopic`. Now the `CommandLookupTopic will look like:
+Add `properties` field to the `CommandLookupTopic`. Now the `CommandLookupTopic` will look like:
 
 ```protobuf
 message KeyValue {

--- a/pip/pip-368.md
+++ b/pip/pip-368.md
@@ -182,4 +182,4 @@ None
 # Links
 
 * Mailing List discussion thread: https://lists.apache.org/thread/7n2gncxk3c5q8dxj8fw9y5gcwg6jjg6z
-* Mailing List voting thread:
+* Mailing List voting thread: https://lists.apache.org/thread/z0t3dyqj27ldm8rs6nl5jon152ohghvw

--- a/pip/pip-368.md
+++ b/pip/pip-368.md
@@ -1,48 +1,70 @@
-# PIP-368: Support client properties for the lookup
+# PIP-368: Support lookup based on the lookup properties
 
 # Background knowledge
 
 ## How Pulsar Lookup Works
 
 Before producing or consuming messages, a Pulsar client must first find the broker responsible for the topic. This
-happens through the lookup service. The client sends a `CommandLookupTopic` request with the topic name to the lookup
-service, which then returns the responsible broker. The client then interacts with this broker to produce or consume
+happens through the lookup service. The client sends a `CommandLookupTopic` request with the topic name to the broker
+lookup service.
+
+On the broker side, the broker will register itself to the metadata store using a distributed lock with the value
+of [`BrokerLookupData`](https://github.com/apache/pulsar/blob/7fe92ac43cfd2f2de5576a023498aac8b46c7ac8/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupData.java#L34-L44)
+when starting. The lookup service will first choose the owner broker. And then retrieve the `BrokerLookupData` of the
+owner broker and finally return to the client. The client then interacts with this broker to produce or consume
 messages.
 
-On the broker side, users can customize lookup logic by setting a custom load manager in the `loadManagerClassName`
-configuration.
+Users can customize the lookup process by setting a custom load manager in the `loadManagerClassName` configuration.
 
 # Motivation
 
 Currently, the lookup process uses only the topic name as its parameter. However, to enhance this process, it's
-beneficial for clients to provide additional information. This could be done by introducing the `properties` field in
-the client configuration. The client can then send these properties to the broker during the lookup process.
+beneficial for clients to provide additional information. This could be done by introducing the `lookupProperties` field
+in the client configuration. Clients can then share these properties with the broker during lookup.
 
-Here is a scenario for using the client properties for the lookup:
-Assuming there are two brokers that broker-0 configures the "rack" property with "A" and broker-1 configures the "rack"
-property with "B". By using the lookup properties, clients can supply rack information during the lookup, enabling the
-broker to identify and connect them to the nearest broker within the same rack. If a client that configures the "rack"
-property with "A" connects to a lookup broker, the customized load manager can determine broker-0 as the owner broker
-since the broker and the client have the same rack property.
+On the broker side, the broker could also contain some properties that are used for the lookup. We can also support the
+lookupProperties for the broker. The broker can use these properties to make a better decision on which broker to
+return.
+
+Here is the rack-aware lookup scenario for using the client properties for the lookup:
+Assuming there are two brokers that broker-0 configures the lookup property "rack" with "A" and broker-1 configures the
+lookup property "rack" with "B". By using the lookup properties, clients can supply rack information during the lookup,
+enabling the broker to identify and connect them to the nearest broker within the same rack. If a client that configures
+the "rack" property with "A" connects to a lookup broker, the customized load manager can determine broker-0 as the
+owner broker since the broker and the client have the same rack property.
 
 # Goals
 
 ## In Scope
 
-- Enable clients to send additional lookup information to brokers during the lookup.
+- Enable setting up lookup properties in both client and broker configurations.
+- Allow clients to provide extra lookup information to brokers during the lookup process.
 
 ## Out of Scope
 
-None
+- The implementation of the rack-aware lookup scenario.
 
 # High Level Design
 
-Add new configuration `properties` to the client. While looking up the broker, the client will send the properties to
-the broker through `CommandLookupTopic` request.
-The `properties` will be added to the `LookupOptions`. The Load Manager implementation can retrieve the `properties`
-through `LookupOptions` to make a better decision on which broker to return.
+Add new configuration `lookupProperties` to the client. While looking up the broker, the client will send the properties
+to the broker through `CommandLookupTopic` request.
+
+The `lookupProperties` will then be added to the `LookupOptions`. The Load Manager implementation can access
+the `properties` through `LookupOptions` to make a better decision on which broker to return.
+
 The properties are used only when the protocol is the binary protocol, starting with `pulsar://` or `pulsar+ssl://`, or
 if the `loadManagerClassName` in the broker is a class that implements the `ExtensibleLoadManager` interface.
+
+To support configuring the `lookupProperties` on the broker side, introduce a new broker
+configuration `lookupPropertyPrefix`. Any broker configuration properties that start with the `lookupPropertyPrefix`
+will be included into the `BrokerLookupData` and be persisted in the metadata store. The broker can use these properties
+during the lookup.
+
+In this way, to support the rack-aware lookup scenario mentioned in the "Motivation" part, the client can set the rack
+information in the client `lookupProperties`. Similarly, the broker can also set the rack information in the broker
+configuration like `lookup.rack`. The `lookup.rack` will be stored in the `BrokerLookupData`. A customized load manager
+can then be implemented. For each lookup request, it will go through the `BrokerLookupData` for all brokers and select
+the broker in the same rack to return.
 
 # Detailed Design
 
@@ -52,20 +74,32 @@ if the `loadManagerClassName` in the broker is a class that implements the `Exte
 
 ### Configuration
 
-Add new configuration `properties` to the `ClientBuilder`.
+Add new configuration `lookupProperties` to the `ClientBuilder`.
 
 ```java
 /**
  * Set the properties used for topic lookup.
  * <p>
- * When the broker performs topic lookup, these properties will be taken into consideration in a customized load
+ * When the broker performs topic lookup, these lookup properties will be taken into consideration in a customized load
  * manager. 
  * <p>
- * Note: The properties are only used in topic lookup when:
+ * Note: The lookup properties are only used in topic lookup when:
  * - The protocol is binary protocol, i.e. the service URL starts with "pulsar://" or "pulsar+ssl://"
  * - The `loadManagerClassName` config in broker is a class that implements the `ExtensibleLoadManager` interface
  */
-ClientBuilder properties(Map<String, String> properties);
+ClientBuilder lookupProperties(Map<String, String> properties);
+```
+
+Add new broker configuration `lookupPropertyPrefix` to the `ServiceConfiguration`:
+
+```java
+
+@FieldContext(
+        category = CATEGORY_SERVER,
+        doc = "The properties whose name starts with this prefix will be uploaded to the metadata store for "
+                + " the topic lookup"
+)
+private String lookupPropertyPrefix = "lookup.";
 ```
 
 ### Binary protocol
@@ -91,6 +125,8 @@ message CommandLookupTopic {
 }
 ```
 
+When the client lookups a topic, it will set the client `lookupPorperties` to the `CommandLookupTopic.properties`.
+
 ### Public API
 
 Currently, there is a public method `assign` in the `ExtensibleLoadManager` interface that will accept
@@ -115,6 +151,7 @@ public class LookupOptions {
 }
 ```
 
+The `LookupOptions.properties` will be set to the value of `CommandLookupTopic.properties`.
 This way, the custom `ExtensibleLoadManager` implementation can retrieve the `properties` from the `LookupOptions` to
 make a better decision on which broker to return.
 
@@ -144,5 +181,5 @@ None
 
 # Links
 
-* Mailing List discussion thread:
+* Mailing List discussion thread: https://lists.apache.org/thread/7n2gncxk3c5q8dxj8fw9y5gcwg6jjg6z
 * Mailing List voting thread:

--- a/pip/pip-368.md
+++ b/pip/pip-368.md
@@ -1,0 +1,148 @@
+# PIP-368: Support client properties for the lookup
+
+# Background knowledge
+
+## How Pulsar Lookup Works
+
+Before producing or consuming messages, a Pulsar client must first find the broker responsible for the topic. This
+happens through the lookup service. The client sends a `CommandLookupTopic` request with the topic name to the lookup
+service, which then returns the responsible broker. The client then interacts with this broker to produce or consume
+messages.
+
+On the broker side, users can customize lookup logic by setting a custom load manager in the `loadManagerClassName`
+configuration.
+
+# Motivation
+
+Currently, the lookup process uses only the topic name as its parameter. However, to enhance this process, it's
+beneficial for clients to provide additional information. This could be done by introducing the `properties` field in
+the client configuration. The client can then send these properties to the broker during the lookup process.
+
+Here is a scenario for using the client properties for the lookup:
+Assuming there are two brokers that broker-0 configures the "rack" property with "A" and broker-1 configures the "rack"
+property with "B". By using the lookup properties, clients can supply rack information during the lookup, enabling the
+broker to identify and connect them to the nearest broker within the same rack. If a client that configures the "rack"
+property with "A" connects to a lookup broker, the customized load manager can determine broker-0 as the owner broker
+since the broker and the client have the same rack property.
+
+# Goals
+
+## In Scope
+
+- Enable clients to send additional lookup information to brokers during the lookup.
+
+## Out of Scope
+
+None
+
+# High Level Design
+
+Add new configuration `properties` to the client. While looking up the broker, the client will send the properties to
+the broker through `CommandLookupTopic` request.
+The `properties` will be added to the `LookupOptions`. The Load Manager implementation can retrieve the `properties`
+through `LookupOptions` to make a better decision on which broker to return.
+The properties are used only when the protocol is the binary protocol, starting with `pulsar://` or `pulsar+ssl://`, or
+if the `loadManagerClassName` in the broker is a class that implements the `ExtensibleLoadManager` interface.
+
+# Detailed Design
+
+## Design & Implementation Details
+
+## Public-facing Changes
+
+### Configuration
+
+Add new configuration `properties` to the `ClientBuilder`.
+
+```java
+/**
+ * Set the properties used for topic lookup.
+ * <p>
+ * When the broker performs topic lookup, these properties will be taken into consideration in a customized load
+ * manager. 
+ * <p>
+ * Note: The properties are only used in topic lookup when:
+ * - The protocol is binary protocol, i.e. the service URL starts with "pulsar://" or "pulsar+ssl://"
+ * - The `loadManagerClassName` config in broker is a class that implements the `ExtensibleLoadManager` interface
+ */
+ClientBuilder properties(Map<String, String> properties);
+```
+
+### Binary protocol
+
+Add `properties` field to the `CommandLookupTopic`. Now the `CommandLookupTopic will look like:
+
+```protobuf
+message KeyValue {
+  required string key = 1;
+  required string value = 2;
+}
+
+message CommandLookupTopic {
+  required string topic = 1;
+  required uint64 request_id = 2;
+  optional bool authoritative = 3 [default = false];
+  optional string original_principal = 4;
+  optional string original_auth_data = 5;
+  optional string original_auth_method = 6;
+  optional string advertised_listener_name = 7;
+  // The properties used for topic lookup
+  repeated KeyValue properties = 8;
+}
+```
+
+### Public API
+
+Currently, there is a public method `assign` in the `ExtensibleLoadManager` interface that will accept
+the `LookupOptions` to lookup the topic.
+
+```java
+public interface ExtensibleLoadManager {
+    CompletableFuture<Optional<BrokerLookupData>> assign(Optional<ServiceUnitId> topic,
+                                                         ServiceUnitId serviceUnit,
+                                                         LookupOptions options);
+}
+```
+
+In this proposal, the `properties` will be added to the `LookupOptions`:
+
+```java
+public class LookupOptions {
+    // Other fields are omitted ...
+
+    // The properties used for topic lookup
+    private final Map<String, String> properties;
+}
+```
+
+This way, the custom `ExtensibleLoadManager` implementation can retrieve the `properties` from the `LookupOptions` to
+make a better decision on which broker to return.
+
+# Monitoring
+
+No new metrics are added in this proposal.
+
+# Security Considerations
+
+No new security considerations are added in this proposal.
+
+# Backward & Forward Compatibility
+
+## Revert
+
+No changes are needed to revert to the previous version.
+
+## Upgrade
+
+No other changes are needed to upgrade to the new version.
+
+# Alternatives
+
+None
+
+# General Notes
+
+# Links
+
+* Mailing List discussion thread:
+* Mailing List voting thread:


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


### Motivation

Currently, the lookup process uses only the topic name as its parameter. However, to enhance this process, it's
beneficial for clients to provide additional information. This could be done by introducing the `lookupProperties` field
in the client configuration. Clients can then share these properties with the broker during lookup.

On the broker side, the broker could also contain some properties that are used for the lookup. We can also support the
lookupProperties for the broker. The broker can use these properties to make a better decision on which broker to
return.

Here is the rack-aware lookup scenario for using the client properties for the lookup:
Assuming there are two brokers that broker-0 configures the lookup property "rack" with "A" and broker-1 configures the
lookup property "rack" with "B". By using the lookup properties, clients can supply rack information during the lookup,
enabling the broker to identify and connect them to the nearest broker within the same rack. If a client that configures
the "rack" property with "A" connects to a lookup broker, the customized load manager can determine broker-0 as the
owner broker since the broker and the client have the same rack property.

### Modifications

Add new configuration `lookupProperties` to the client. While looking up the broker, the client will send the properties
to the broker through `CommandLookupTopic` request.

The `lookupProperties` will then be added to the `LookupOptions`. The Load Manager implementation can access
the `properties` through `LookupOptions` to make a better decision on which broker to return.

The properties are used only when the protocol is the binary protocol, starting with `pulsar://` or `pulsar+ssl://`, or
if the `loadManagerClassName` in the broker is a class that implements the `ExtensibleLoadManager` interface.

To support configuring the `lookupProperties` on the broker side, introduce a new broker
configuration `lookupPropertyPrefix`. Any broker configuration properties that start with the `lookupPropertyPrefix`
will be included into the `BrokerLookupData` and be persisted in the metadata store. The broker can use these properties
during the lookup.

In this way, to support the rack-aware lookup scenario mentioned in the "Motivation" part, the client can set the rack
information in the client `lookupProperties`. Similarly, the broker can also set the rack information in the broker
configuration like `lookup.rack`. The `lookup.rack` will be stored in the `BrokerLookupData`. A customized load manager
can then be implemented. For each lookup request, it will go through the `BrokerLookupData` for all brokers and select
the broker in the same rack to return.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
