### PR TITLE
[fix][client] TransactionCoordinatorClient support retry

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionCoordinatorClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionCoordinatorClientTest.java
@@ -24,14 +24,18 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import lombok.Cleanup;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.TransactionMetadataStoreService;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferClientImpl;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.transaction.TransactionBufferClient;
+import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClient;
 import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClient.State;
 import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClientException;
 import org.apache.pulsar.client.api.transaction.TxnID;
+import org.apache.pulsar.client.impl.transaction.TransactionCoordinatorClientImpl;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -106,5 +110,27 @@ public class TransactionCoordinatorClientTest extends TransactionMetaStoreTestBa
             Assert.assertTrue(TransactionCoordinatorClientException.unwrap(exception)
                     instanceof TransactionCoordinatorClientException.InvalidTxnStatusException);
         }
+    }
+
+    @Test
+    public void testClientStartWithRetry() throws Exception{
+
+        String validBrokerServiceUrl = pulsarServices[0].getBrokerServiceUrl();
+        String invalidBrokerServiceUrl = "localhost:0";
+        String brokerServiceUrl = validBrokerServiceUrl + "," + invalidBrokerServiceUrl;
+
+        @Cleanup
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(brokerServiceUrl).build();
+
+        @Cleanup
+        TransactionCoordinatorClient transactionCoordinatorClient = new TransactionCoordinatorClientImpl(pulsarClient);
+
+        try {
+            transactionCoordinatorClient.start();
+        }catch (TransactionCoordinatorClientException e) {
+            Assert.fail("Shouldn't have exception at here", e);
+        }
+
+        Assert.assertEquals(transactionCoordinatorClient.getState(), State.READY);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionCoordinatorClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionCoordinatorClientTest.java
@@ -114,14 +114,12 @@ public class TransactionCoordinatorClientTest extends TransactionMetaStoreTestBa
 
     @Test
     public void testClientStartWithRetry() throws Exception{
-
         String validBrokerServiceUrl = pulsarServices[0].getBrokerServiceUrl();
         String invalidBrokerServiceUrl = "localhost:0";
         String brokerServiceUrl = validBrokerServiceUrl + "," + invalidBrokerServiceUrl;
 
         @Cleanup
         PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(brokerServiceUrl).build();
-
         @Cleanup
         TransactionCoordinatorClient transactionCoordinatorClient = new TransactionCoordinatorClientImpl(pulsarClient);
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
@@ -132,10 +132,8 @@ public class TransactionMetaStoreHandler extends HandlerState
                     LOG.error("Transaction meta handler with transaction coordinator id {} connection failed.",
                             transactionCoordinatorId, exception);
                 } else {
-                    LOG.error(
-                            "Transaction meta handler with transaction coordinator id {} connection failed after "
-                                    + "timeout",
-                            transactionCoordinatorId, exception);
+                    LOG.error("Transaction meta handler with transaction coordinator id {} connection failed after "
+                            + "timeout", transactionCoordinatorId, exception);
                 }
                 setState(State.Failed);
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionCoordinatorClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionCoordinatorClientImpl.java
@@ -79,34 +79,34 @@ public class TransactionCoordinatorClientImpl implements TransactionCoordinatorC
     @Override
     public CompletableFuture<Void> startAsync() {
         if (STATE_UPDATER.compareAndSet(this, State.NONE, State.STARTING)) {
-            return pulsarClient.getLookup()
-                .getPartitionedTopicMetadata(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN, true)
-                .thenCompose(partitionMeta -> {
-                    List<CompletableFuture<Void>> connectFutureList = new ArrayList<>();
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Transaction meta store assign partition is {}.", partitionMeta.partitions);
-                    }
-                    if (partitionMeta.partitions > 0) {
-                        handlers = new TransactionMetaStoreHandler[partitionMeta.partitions];
-                        for (int i = 0; i < partitionMeta.partitions; i++) {
-                            CompletableFuture<Void> connectFuture = new CompletableFuture<>();
-                            connectFutureList.add(connectFuture);
-                            TransactionMetaStoreHandler handler = new TransactionMetaStoreHandler(
-                                    i, pulsarClient, getTCAssignTopicName(i), connectFuture);
-                            handlers[i] = handler;
-                            handlerMap.put(i, handler);
-                            handler.start();
+            return pulsarClient.getPartitionedTopicMetadata(
+                            SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN.getPartitionedTopicName(), true)
+                    .thenCompose(partitionMeta -> {
+                        List<CompletableFuture<Void>> connectFutureList = new ArrayList<>();
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Transaction meta store assign partition is {}.", partitionMeta.partitions);
                         }
-                    } else {
-                        return FutureUtil.failedFuture(new TransactionCoordinatorClientException(
-                                "The broker doesn't enable the transaction coordinator, "
-                                        + "or the transaction coordinator has not initialized"));
-                    }
+                        if (partitionMeta.partitions > 0) {
+                            handlers = new TransactionMetaStoreHandler[partitionMeta.partitions];
+                            for (int i = 0; i < partitionMeta.partitions; i++) {
+                                CompletableFuture<Void> connectFuture = new CompletableFuture<>();
+                                connectFutureList.add(connectFuture);
+                                TransactionMetaStoreHandler handler = new TransactionMetaStoreHandler(
+                                        i, pulsarClient, getTCAssignTopicName(i), connectFuture);
+                                handlers[i] = handler;
+                                handlerMap.put(i, handler);
+                                handler.start();
+                            }
+                        } else {
+                            return FutureUtil.failedFuture(new TransactionCoordinatorClientException(
+                                    "The broker doesn't enable the transaction coordinator, "
+                                            + "or the transaction coordinator has not initialized"));
+                        }
 
-                    STATE_UPDATER.set(TransactionCoordinatorClientImpl.this, State.READY);
+                        STATE_UPDATER.set(TransactionCoordinatorClientImpl.this, State.READY);
 
-                    return FutureUtil.waitForAll(connectFutureList);
-                });
+                        return FutureUtil.waitForAll(connectFutureList);
+                    });
         } else {
             return FutureUtil.failedFuture(
                     new CoordinatorClientStateException("Can not start while current state is " + state));


### PR DESCRIPTION
### Motivation
we have two brokerUrls(one is dead) in PulsarClient serviceUrl, it is working well without enabling transactions.

```
            # broker test.pulsar.com:6651 is dead
            PulsarClient client = PulsarClient.builder()
                    //.enableTransaction(true)
                    .serviceUrl("pulsar://test.pulsar.com:6650,test.pulsar.com:6651")
                    .build();
```

If  enabling transactions
```
            # broker test.pulsar.com:6651 is dead
            PulsarClient client = PulsarClient.builder()
                    .enableTransaction(true)
                    .serviceUrl("pulsar://test.pulsar.com:6650,test.pulsar.com:6651")
                    .build();
```
the following error occurs and the `PulsarClient` init fails, It will not retry the other brokerUrl

```
2024-07-27T00:52:27,787 - ERROR - [pulsar-client-io-1-1:TransactionMetaStoreHandler@120] - Transaction meta handler with transaction coordinator id 14 connection failed.
org.apache.pulsar.client.api.PulsarClientException: java.util.concurrent.CompletionException: io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: test.pulsar.com/127.0.0.1:6651
	at org.apache.pulsar.client.impl.ConnectionPool.lambda$createConnection$14(ConnectionPool.java:311) ~[classes/:?]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:566) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: java.util.concurrent.CompletionException: io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: test.pulsar.com/127.0.0.1:6651
	at java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:368) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:377) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1097) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2162) ~[?:?]
	at org.apache.pulsar.common.util.netty.ChannelFutures.lambda$toCompletableFuture$0(ChannelFutures.java:58) ~[classes/:?]
	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:590) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListeners0(DefaultPromise.java:583) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:559) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:492) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:636) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.setFailure0(DefaultPromise.java:629) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.tryFailure(DefaultPromise.java:118) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.fulfillConnectPromise(AbstractNioChannel.java:326) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.finishConnect(AbstractNioChannel.java:342) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:776) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	... 4 more
Caused by: io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: test.pulsar.com/127.0.0.1:6651
Caused by: java.net.ConnectException: Connection refused
	at sun.nio.ch.Net.pollConnect(Native Method) ~[?:?]
	at sun.nio.ch.Net.pollConnectNow(Net.java:672) ~[?:?]
	at sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:946) ~[?:?]
	at io.netty.channel.socket.nio.NioSocketChannel.doFinishConnect(NioSocketChannel.java:337) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.finishConnect(AbstractNioChannel.java:339) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:776) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	... 4 more
```

The root cause is that the `TransactionCoordinatorClient` doesn't support retry.

### Modifications
support retry in `TransactionCoordinatorClient`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
