### PR TITLE
[improve][build] Upgrade docker-maven-plugin to 0.45.0

### DIFF
--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -75,5 +75,12 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>docker-push</id>
+      <properties>
+        <docker.skip.push>false</docker.skip.push>
+        <docker.platforms>linux/amd64,linux/arm64</docker.platforms>
+      </properties>
+    </profile>
   </profiles>
 </project>

--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -145,7 +145,6 @@
                 <phase>package</phase>
                 <goals>
                   <goal>build</goal>
-                  <goal>tag</goal>
                   <goal>push</goal>
                 </goals>
                 <configuration>
@@ -178,13 +177,5 @@
         </plugins>
       </build>
     </profile>
-
-    <profile>
-      <id>docker-push</id>
-      <properties>
-        <docker.skip.push>false</docker.skip.push>
-      </properties>
-    </profile>
-
   </profiles>
 </project>

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -72,7 +72,6 @@
                 <phase>package</phase>
                 <goals>
                   <goal>build</goal>
-                  <goal>tag</goal>
                   <goal>push</goal>
                 </goals>
                 <configuration>
@@ -123,13 +122,5 @@
         </plugins>
       </build>
     </profile>
-
-    <profile>
-      <id>docker-push</id>
-      <properties>
-        <docker.skip.push>false</docker.skip.push>
-      </properties>
-    </profile>
-
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@ flexible messaging model and an intuitive client API.</description>
     <reflections.version>0.10.2</reflections.version>
     <swagger.version>1.6.2</swagger.version>
     <puppycrawl.checkstyle.version>10.14.2</puppycrawl.checkstyle.version>
-    <docker-maven.version>0.43.3</docker-maven.version>
+    <docker-maven.version>0.45.0</docker-maven.version>
     <docker.verbose>true</docker.verbose>
     <typetools.version>0.5.0</typetools.version>
     <byte-buddy.version>1.14.12</byte-buddy.version>


### PR DESCRIPTION
### Motivation

docker-maven-plugin keeps up to the latest version.

### Modifications

- Improve `docker-push` profile
- Remove tag goal, because build goal includes tag feature
- Upgrade docker-maven-plugin to 0.45.0

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
