### PR TITLE
[improve][build] Move docker-push profile to submodule

### DIFF
--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -75,12 +75,5 @@
         </plugins>
       </build>
     </profile>
-    <profile>
-      <id>docker-push</id>
-      <properties>
-        <docker.skip.push>false</docker.skip.push>
-        <docker.platforms>linux/amd64,linux/arm64</docker.platforms>
-      </properties>
-    </profile>
   </profiles>
 </project>

--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -177,5 +177,12 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>docker-push</id>
+      <properties>
+        <docker.skip.push>false</docker.skip.push>
+        <docker.platforms>linux/amd64,linux/arm64</docker.platforms>
+      </properties>
+    </profile>
   </profiles>
 </project>

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -122,5 +122,12 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>docker-push</id>
+      <properties>
+        <docker.skip.push>false</docker.skip.push>
+        <docker.platforms>linux/amd64,linux/arm64</docker.platforms>
+      </properties>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
### Motivation

The profile refactoring breaks the pulsar release in the #23091.

### Modifications

- Move docker-push profile to docker/pulsar and docker/pulsar-all modules

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->