### PR TITLE
[fix][broker] Fix authenticate order in AuthenticationProviderList

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderList.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderList.java
@@ -120,7 +120,8 @@ public class AuthenticationProviderList implements AuthenticationProvider {
                             if (log.isDebugEnabled()) {
                                 log.debug("Authentication failed for auth provider " + authState.getClass() + ": ", ex);
                             }
-                            authenticateRemainingAuthStates(authChallengeFuture, authData, ex, states.size() - 1);
+                            authenticateRemainingAuthStates(authChallengeFuture, authData, ex,
+                                    states.isEmpty() ? -1 : 0);
                         }
                     });
             return authChallengeFuture;
@@ -130,7 +131,7 @@ public class AuthenticationProviderList implements AuthenticationProvider {
                                                      AuthData clientAuthData,
                                                      Throwable previousException,
                                                      int index) {
-            if (index < 0) {
+            if (index < 0 || index >= states.size()) {
                 if (previousException == null) {
                     previousException = new AuthenticationException("Authentication required");
                 }
@@ -142,7 +143,7 @@ public class AuthenticationProviderList implements AuthenticationProvider {
             AuthenticationState state = states.get(index);
             if (state == authState) {
                 // Skip the current auth state
-                authenticateRemainingAuthStates(authChallengeFuture, clientAuthData, null, index - 1);
+                authenticateRemainingAuthStates(authChallengeFuture, clientAuthData, null, index + 1);
             } else {
                 state.authenticateAsync(clientAuthData)
                         .whenComplete((authChallenge, ex) -> {
@@ -155,7 +156,7 @@ public class AuthenticationProviderList implements AuthenticationProvider {
                                     log.debug("Authentication failed for auth provider "
                                             + authState.getClass() + ": ", ex);
                                 }
-                                authenticateRemainingAuthStates(authChallengeFuture, clientAuthData, ex, index - 1);
+                                authenticateRemainingAuthStates(authChallengeFuture, clientAuthData, ex, index + 1);
                             }
                         });
             }
@@ -228,7 +229,7 @@ public class AuthenticationProviderList implements AuthenticationProvider {
     @Override
     public CompletableFuture<String> authenticateAsync(AuthenticationDataSource authData) {
         CompletableFuture<String> roleFuture = new CompletableFuture<>();
-        authenticateRemainingAuthProviders(roleFuture, authData, null, providers.size() - 1);
+        authenticateRemainingAuthProviders(roleFuture, authData, null, providers.isEmpty() ? -1 : 0);
         return roleFuture;
     }
 
@@ -236,7 +237,7 @@ public class AuthenticationProviderList implements AuthenticationProvider {
                                                     AuthenticationDataSource authData,
                                                     Throwable previousException,
                                                     int index) {
-        if (index < 0) {
+        if (index < 0 || index >= providers.size()) {
             if (previousException == null) {
                 previousException = new AuthenticationException("Authentication required");
             }
@@ -254,7 +255,7 @@ public class AuthenticationProviderList implements AuthenticationProvider {
                         if (log.isDebugEnabled()) {
                             log.debug("Authentication failed for auth provider " + provider.getClass() + ": ", ex);
                         }
-                        authenticateRemainingAuthProviders(roleFuture, authData, ex, index - 1);
+                        authenticateRemainingAuthProviders(roleFuture, authData, ex, index + 1);
                     }
                 });
         }


### PR DESCRIPTION
### Motivation

If we configure multiple AuthenticationProvider, we should authenticate in configuration order, but authenticate from back to front now in AuthenticationListState#authenticateAsync and AuthenticationProviderList#authenticateAsync.

### Modifications

Fix authenticate order in AuthenticationProviderList

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
