### PR TITLE
[improve][misc] Optimize TLS performance by omitting extra buffer copies

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java
@@ -116,10 +116,8 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
             } else {
                 ch.pipeline().addLast(TLS_HANDLER, sslCtxRefresher.get().newHandler(ch.alloc()));
             }
-            ch.pipeline().addLast("ByteBufPairEncoder", ByteBufPair.COPYING_ENCODER);
-        } else {
-            ch.pipeline().addLast("ByteBufPairEncoder", ByteBufPair.ENCODER);
         }
+        ch.pipeline().addLast("ByteBufPairEncoder", ByteBufPair.getEncoder(this.enableTls));
 
         if (pulsar.getConfiguration().isHaProxyProtocolEnabled()) {
             ch.pipeline().addLast(OptionalProxyProtocolDecoder.NAME, new OptionalProxyProtocolDecoder());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.impl;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
@@ -147,11 +148,12 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
         ch.pipeline().addLast("consolidation", new FlushConsolidationHandler(1024, true));
 
         // Setup channel except for the SsHandler for TLS enabled connections
-        ch.pipeline().addLast("ByteBufPairEncoder", tlsEnabled ? ByteBufPair.COPYING_ENCODER : ByteBufPair.ENCODER);
+        ch.pipeline().addLast("ByteBufPairEncoder", ByteBufPair.getEncoder(tlsEnabled));
 
         ch.pipeline().addLast("frameDecoder", new LengthFieldBasedFrameDecoder(
                 Commands.DEFAULT_MAX_MESSAGE_SIZE + Commands.MESSAGE_SIZE_FRAME_PADDING, 0, 4, 0, 4));
-        ch.pipeline().addLast("handler", clientCnxSupplier.get());
+        ChannelHandler clientCnx = clientCnxSupplier.get();
+        ch.pipeline().addLast("handler", clientCnx);
     }
 
    /**


### PR DESCRIPTION
### Motivation

In Pulsar, there has been a long time workaround (#2464) for a Netty SslHandler issue where the input ByteBuf instances get mutated. After Netty 4.1.111.Final, it's no longer necessary to make buffer copies when TLS is enabled. This change on Netty side https://github.com/netty/netty/pull/14086 contains the fix.

### Modifications

Since the Pulsar client might get used with an older Netty version, it's necessary to detect that the Netty version contains the fix. The simplest way to detect Netty 4.1.111.Final is by checking for existence of the class `io.netty.handler.ssl.SslHandlerCoalescingBufferQueue` since that class was extracted from an inner class in 4.1.111.Final.

Instead of referencing `ByteBufPair.ENCODER` and `ByteBufPair.COPYING_ENCODER` directly, use `ByteBufPair.getEncoder(tlsEnabled)` to choose the correct encoder. The COPYING_ENCODER will only be used if an older Netty version is detected. This could be the case when a client application uses the pulsar-client-original maven dependency and the application uses an older Netty version.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->