### PR TITLE
[improve][misc] Improve AES-GCM cipher performance

### DIFF
--- a/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
+++ b/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
@@ -92,6 +92,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
     // from assuming hardcoded value. However, it will increase the size of the message even further.
     public static final String RSA_TRANS = "RSA/NONE/OAEPWithSHA1AndMGF1Padding";
     public static final String AESGCM = "AES/GCM/NoPadding";
+    private static final String AESGCM_PROVIDER_NAME;
 
     private static KeyGenerator keyGenerator;
     private static final int tagLen = 16 * 8;
@@ -123,6 +124,15 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         // Initial seed
         secureRandom.nextBytes(new byte[IV_LEN]);
 
+        // Prefer SunJCE provider for AES-GCM for performance reason.
+        // For cases where SunJCE is not available (e.g. non-hotspot JVM), use BouncyCastle as fallback.
+        String sunJceProviderName = "SunJCE";
+        if (Security.getProvider(sunJceProviderName) != null) {
+            AESGCM_PROVIDER_NAME = sunJceProviderName;
+        } else {
+            AESGCM_PROVIDER_NAME = BouncyCastleProvider.PROVIDER_NAME;
+        }
+
         // Add provider only if it's not in the JVM
         if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
             Security.addProvider(new BouncyCastleProvider());
@@ -145,7 +155,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
 
         try {
 
-            cipher = Cipher.getInstance(AESGCM, BouncyCastleProvider.PROVIDER_NAME);
+            cipher = Cipher.getInstance(AESGCM, AESGCM_PROVIDER_NAME);
             // If keygen is not needed(e.g: consumer), data key will be decrypted from the message
             if (!keyGenNeeded) {
                 // codeql[java/weak-cryptographic-algorithm] - md5 is sufficient for this use case


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #23121 

### Motivation

- Java Pulsar client uses `BouncyCastleProvider` for AES-GCM encryption, which is known to be slow due to the lack of hardware instruction optimization.
- See #23121 for the detailed benchmark result

### Modifications

- Modify `MessageCryptoBc` to use `SunJCE` provider which comes with hardware-instruction optimization instead of `BouncyCastle` provider.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `org.apache.pulsar.tests.integration.SimpleProducerConsumerTest`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: [Pulsar CI workflow run result](https://github.com/ocadaruma/pulsar/actions/runs/10234721940)
