### PR TITLE
[fix][broker]A failed consumer/producer future in ServerCnx can never be removed

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -3635,22 +3635,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             log.warn("[{}] Connection check timed out. Closing connection.", this.toString());
                             ctx.close();
                         } else {
-                            /**
-                             * Scenarios that changing {@link #connectionCheckInProgress}.
-                             *   1. {@link #connectionCheckInProgress} will be changed to "null" after a successful
-                             *     "Ping & Pong"
-                             *   2. {@link #connectionCheckInProgress} will be set to a new future the next time
-                             *     {@link #checkConnectionLiveness()} when it is null.
-                             *
-                             * Once {@link #connectionCheckInProgress} is not equal to
-                             *   {@link #finalConnectionCheckInProgress}, it means Scenario 1 occurred before. If
-                             *   "receiving Pong" and "the current scheduled task" are executing at the same time,
-                             *   this log will be printed. Since the two events will be executing at the same thread,
-                             *   the concurrency scenario can not occur, so this log's level is "ERROR".
-                             */
-                            log.error("[{}] Connection check might be success, because the variable"
-                                    + " connectionCheckInProgress has been override by the following check. But this"
-                                    + " scenario is not expected",
+                            log.error("[{}] Reached unexpected code block. Completing connection check.",
                                     this.toString());
                             finalConnectionCheckInProgress.complete(Optional.of(true));
                         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -3605,8 +3605,14 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     @Override
     public CompletableFuture<Optional<Boolean>> checkConnectionLiveness() {
+        if (!isActive()) {
+            return CompletableFuture.completedFuture(Optional.of(false));
+        }
         if (connectionLivenessCheckTimeoutMillis > 0) {
             return NettyFutureUtil.toCompletableFuture(ctx.executor().submit(() -> {
+                if (!isActive()) {
+                    return CompletableFuture.completedFuture(Optional.of(false));
+                }
                 if (connectionCheckInProgress != null) {
                     return connectionCheckInProgress;
                 } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -3628,10 +3628,15 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                 && !finalConnectionCheckInProgress.isDone()) {
                             log.warn("[{}] Connection check timed out. Closing connection.", this.toString());
                             ctx.close();
-                        } else {
+                        } else if (finalConnectionCheckInProgress != connectionCheckInProgress){
                             log.info("[{}] Connection check might be success, because the variable"
-                                    + " connectionCheckInProgress has been changed.", this.toString());
-                            finalConnectionCheckInProgress.complete(Optional.of(false));
+                                    + " connectionCheckInProgress has been override by the following check.",
+                                    this.toString());
+                            finalConnectionCheckInProgress.complete(Optional.of(true));
+                        } else {
+                            log.warn("[{}] Connection check might is still in progress after {} millis, increasing the"
+                                        + "param connectionLivenessCheckTimeoutMillis is better",
+                                    this.toString(), connectionLivenessCheckTimeoutMillis);
                         }
                     }, connectionLivenessCheckTimeoutMillis, TimeUnit.MILLISECONDS);
                     sendPing();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -3649,7 +3649,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                              *   occur, so this log's level is `ERROR`) this log will be printed.
                              */
                             log.error("[{}] Connection check might be success, because the variable"
-                                    + " connectionCheckInProgress has been override by the following check.",
+                                    + " connectionCheckInProgress has been override by the following check. But this"
+                                    + " scenario is not expected",
                                     this.toString());
                             finalConnectionCheckInProgress.complete(Optional.of(true));
                         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -3644,9 +3644,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                              *
                              * Once {@link #connectionCheckInProgress} is not equal to
                              *   {@link #finalConnectionCheckInProgress}, it means Scenario 1 occurred before. If
-                             *   "receiving Pong" and "the current scheduled task" are executing at the same time
-                             *   (since they will be executing at the same thread, the concurrency scenario can not
-                             *   occur, so this log's level is `ERROR`) this log will be printed.
+                             *   "receiving Pong" and "the current scheduled task" are executing at the same time,
+                             *   this log will be printed. Since the two events will be executing at the same thread,
+                             *   the concurrency scenario can not occur, so this log's level is "ERROR".
                              */
                             log.error("[{}] Connection check might be success, because the variable"
                                     + " connectionCheckInProgress has been override by the following check. But this"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -3624,19 +3624,19 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             finalConnectionCheckInProgress.complete(Optional.of(false));
                             return;
                         }
-                        if (finalConnectionCheckInProgress == connectionCheckInProgress
-                                && !finalConnectionCheckInProgress.isDone()) {
+                        if (finalConnectionCheckInProgress.isDone()) {
+                            return;
+                        }
+                        if (finalConnectionCheckInProgress == connectionCheckInProgress) {
+                            // finalConnectionCheckInProgress will be completed when channel.inactive event occurs.
+                            // So skip set it here.
                             log.warn("[{}] Connection check timed out. Closing connection.", this.toString());
                             ctx.close();
-                        } else if (finalConnectionCheckInProgress != connectionCheckInProgress){
+                        } else {
                             log.info("[{}] Connection check might be success, because the variable"
                                     + " connectionCheckInProgress has been override by the following check.",
                                     this.toString());
                             finalConnectionCheckInProgress.complete(Optional.of(true));
-                        } else {
-                            log.warn("[{}] Connection check might is still in progress after {} millis, increasing the"
-                                        + "param connectionLivenessCheckTimeoutMillis is better",
-                                    this.toString(), connectionLivenessCheckTimeoutMillis);
                         }
                     }, connectionLivenessCheckTimeoutMillis, TimeUnit.MILLISECONDS);
                     sendPing();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxNonInjectionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxNonInjectionTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.broker.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.Schema;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker")
+public class ServerCnxNonInjectionTest extends ProducerConsumerBase {
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test(timeOut = 60 * 1000)
+    public void testCheckConnectionLivenessAfterClosed() throws Exception {
+        // Create a ServerCnx
+        final String tp = BrokerTestUtil.newUniqueName("public/default/tp");
+        Producer<String> p = pulsarClient.newProducer(Schema.STRING).topic(tp).create();
+        ServerCnx serverCnx = (ServerCnx) pulsar.getBrokerService().getTopic(tp, false).join().get()
+                        .getProducers().values().iterator().next().getCnx();
+        // Call "CheckConnectionLiveness" after serverCnx is closed. The resulted future should be done eventually.
+        p.close();
+        serverCnx.close();
+        Thread.sleep(1000);
+        serverCnx.checkConnectionLiveness().join();
+    }
+
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -67,11 +67,11 @@ import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.PulsarMockBookKeeper;
 import org.apache.bookkeeper.client.PulsarMockLedgerHandle;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
+import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.namespace.OwnershipCache;
 import org.apache.pulsar.broker.resources.BaseResources;
 import org.apache.pulsar.broker.service.AbstractDispatcherSingleActiveConsumer;
-import org.apache.pulsar.broker.service.ServerCnx;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -1008,28 +1008,36 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
 
         int numMessages = 100;
         final CountDownLatch latch = new CountDownLatch(numMessages);
-        String topic = "persistent://my-property/my-ns/closed-cnx-topic";
+        String topic = BrokerTestUtil.newUniqueName("persistent://my-property/my-ns/closed-cnx-topic");
+        admin.topics().createNonPartitionedTopic(topic);
         String sub = "my-subscriber-name";
         @Cleanup
         PulsarClient pulsarClient = newPulsarClient(lookupUrl.toString(), 0);
-        pulsarClient.newConsumer().topic(topic).subscriptionName(sub).messageListener((c1, msg) -> {
-            Assert.assertNotNull(msg, "Message cannot be null");
-            String receivedMessage = new String(msg.getData());
-            log.debug("Received message [{}] in the listener", receivedMessage);
-            c1.acknowledgeAsync(msg);
-            latch.countDown();
-        }).subscribe();
-
+        ConsumerImpl c =
+            (ConsumerImpl) pulsarClient.newConsumer().topic(topic).subscriptionName(sub).messageListener((c1, msg) -> {
+                Assert.assertNotNull(msg, "Message cannot be null");
+                String receivedMessage = new String(msg.getData());
+                log.debug("Received message [{}] in the listener", receivedMessage);
+                c1.acknowledgeAsync(msg);
+                latch.countDown();
+            }).subscribe();
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic).get();
-
         AbstractDispatcherSingleActiveConsumer dispatcher = (AbstractDispatcherSingleActiveConsumer) topicRef
                 .getSubscription(sub).getDispatcher();
-        ServerCnx cnx = (ServerCnx) dispatcher.getActiveConsumer().cnx();
-        Field field = ServerCnx.class.getDeclaredField("isActive");
-        field.setAccessible(true);
-        field.set(cnx, false);
-
         assertNotNull(dispatcher.getActiveConsumer());
+
+        // Inject an blocker to make the "ping & pong" does not work.
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        ConnectionHandler connectionHandler = c.getConnectionHandler();
+        ClientCnx clientCnx = connectionHandler.cnx();
+        clientCnx.ctx().executor().submit(() -> {
+            try {
+                countDownLatch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
         @Cleanup
         PulsarClient pulsarClient2 = newPulsarClient(lookupUrl.toString(), 0);
         Consumer<byte[]> consumer = null;
@@ -1042,15 +1050,19 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
                     c1.acknowledgeAsync(msg);
                     latch.countDown();
                 }).subscribe();
-                if (i == 0) {
-                    fail("Should failed with ConsumerBusyException!");
-                }
             } catch (PulsarClientException.ConsumerBusyException ignore) {
                // It's ok.
             }
         }
         assertNotNull(consumer);
         log.info("-- Exiting {} test --", methodName);
+
+        // cleanup.
+        countDownLatch.countDown();
+        consumer.close();
+        pulsarClient.close();
+        pulsarClient2.close();
+        admin.topics().delete(topic, false);
     }
 
     @Test


### PR DESCRIPTION
### Motivation

**Conditions under which problems occur**
- `Failover/Exclusive` subscription
- Sockets of Pulsar IO are not stable
- `ServerCnx` thread is busy.


| time | `registering consumer 1st` | `registering consumer 2nd` |
| --- | --- | --- |
| 1 | Registered |
| 2 | Socket is unstable |
| 3 | Closing `ServerCnx` |
| 4 | | Retry to subscribe |
| 5 | | Check whether the previous consumer is still active<sup>[1]</sup>, if not,  override it by the current registering |
| 6 | `ServerCnx` is closed |
| 7 | | Call `serverCnx.checkConnectionLiveness`, the Completable Future returned will never be completed |
| 8 | | Client-side: call `ClientCnx.removeConsumer` after the subscribing is timeout |
| 9 | | There is a failed future in `ServerCnx.consumers` |

**[1]**: `AbstractDispatcherSingleActiveConsumer.java`

```java
 public synchronized CompletableFuture<Void> addConsumer(Consumer consumer) {

  if (getActiveConsumer() != null) {
      return actConsumer.cnx().checkConnectionLiveness().thenCompose(actConsumerStillAlive -> {
          if (actConsumerStillAlive.isEmpty() || actConsumerStillAlive.get()) {
              return FutureUtil.failedFuture(new ConsumerBusyException("Exclusive consumer is already"
                      + " connected"));
          } else {
              return addConsumer(consumer);
          }
      });
  }
}
```

### Affects

It leads to the following subscribing can never succeed due to the ServerCnx maintaining a failed future and it can never be removed.

### Error logs

```
2024-07-25T09:28:00,109+0000 [pulsar-io-4-30] WARN  org.apache.pulsar.broker.service.ServerCnx - [/127.0.0.2:48345][persistent://{tenant}/{namespace}/__change_events-partition-0][multiTopicsReader-381f38cdef] A failed consumer with id is already present on the connection, consumerId=7425
2024-07-25T09:28:00,109+0000 [pulsar-io-4-30] ERROR org.apache.pulsar.broker.service.ServerCnx - A failed consumer with id is already present on the connection. consumerId: 7425, remoteAddress: /127.0.0.2:48345, subscription: multiTopicsReader-381f38cdef
...
...
...
// loop
```

### Modifications

Fix the bug.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x