### PR TITLE
[improve][fn] Add support for overriding additionalJavaRuntimeArguments with PF_additionalJavaRuntimeArguments env

### DIFF
--- a/docker/pulsar/scripts/gen-yml-from-env.py
+++ b/docker/pulsar/scripts/gen-yml-from-env.py
@@ -50,6 +50,9 @@ SET_KEYS = [
     'brokerClientTlsProtocols',
     'webServiceTlsCiphers',
     'webServiceTlsProtocols',
+    'additionalJavaRuntimeArguments',
+    'additionalEnabledConnectorUrlPatterns',
+    'additionalEnabledFunctionsUrlPatterns'
 ]
 
 PF_ENV_PREFIX = 'PF_'


### PR DESCRIPTION
### Motivation

Apache Pulsar Helm chart uses the gen-yml-from-env.py script to customize the function_worker.yml file so that environment variables are used to override values.
There's support missing for a few configuration keys.

### Modifications

- register `additionalJavaRuntimeArguments`, `additionalEnabledConnectorUrlPatterns` and `additionalEnabledFunctionsUrlPatterns` configuration keys as ones that take a list of values.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->