### PR TITLE
[Fix] Allow the content be empty when deserialize in MetadataCache

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
@@ -108,6 +108,9 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
 
                     try {
                         GetResult res = optRes.get();
+                        if (res.getValue().length == 0) {
+                            return FutureUtils.value(Optional.of(new CacheGetResult<>(null, res.getStat())));
+                        }
                         T obj = serde.deserialize(path, res.getValue(), res.getStat());
                         return FutureUtils
                                 .value(Optional.of(new CacheGetResult<>(obj, res.getStat())));
@@ -152,10 +155,14 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
                         try {
                             // Use clone and CAS zk to ensure thread safety
                             clone = serde.deserialize(path, serde.serialize(path, entry.getValue()), entry.getStat());
+                            if (clone == null) {
+                                currentValue = Optional.empty();
+                            } else {
+                                currentValue = Optional.of(clone);
+                            }
                         } catch (IOException e) {
                             return FutureUtils.exception(e);
                         }
-                        currentValue = Optional.of(clone);
                         expectedVersion = entry.getStat().getVersion();
                     } else {
                         currentValue = Optional.empty();

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
@@ -19,8 +19,10 @@
 package org.apache.pulsar.metadata;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -446,6 +448,26 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
     }
 
     @Test(dataProvider = "impl")
+    public void testReadModifyUpdateOrCreateWithEmptyValue(String provider, Supplier<String> urlSupplier) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        String path = "/testReadModifyUpdateOrCreateWithEmptyValue";
+        store.put(path, new byte[0], Optional.of(-1L)).get();
+
+        MetadataCache<Policies> objCache = store.getMetadataCache(Policies.class);
+
+        Optional<Policies> policies = objCache.get(path).get();
+        assertFalse(policies.isPresent());
+        Policies policies1 = objCache.readModifyUpdateOrCreate(path, (rp) -> {
+            Policies p = rp.orElse(new Policies());
+            p.max_unacked_messages_per_consumer = 100;
+            return p;
+        }).get();
+        assertEquals(policies1.max_unacked_messages_per_consumer.intValue(), 100);
+    }
+
+    @Test(dataProvider = "impl")
     public void readModifyUpdate(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
         MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
@@ -473,6 +495,36 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         } catch (CompletionException e) {
             assertEquals(e.getCause().getClass(), NotFoundException.class);
         }
+    }
+
+    @Test(dataProvider = "impl")
+    public void testReadModifyUpdateWithEmptyValue(String provider, Supplier<String> urlSupplier) throws Exception {
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+
+        String path = "/testReadModifyUpdateWithEmptyValue";
+        store.put(path, new byte[0], Optional.of(-1L)).get();
+
+        MetadataCache<Policies> objCache = store.getMetadataCache(Policies.class);
+
+        Optional<Policies> policies = objCache.get(path).get();
+        assertFalse(policies.isPresent());
+        Policies policies1 = objCache.readModifyUpdate(path, (rp) -> {
+            if (rp != null) {
+                rp.max_unacked_messages_per_consumer = 100;
+            }
+            return rp;
+        }).get();
+        assertNull(policies1);
+
+        Policies policies2 = objCache.readModifyUpdate(path, (rp) -> {
+            if (rp == null) {
+                rp = new Policies();
+            }
+            rp.max_unacked_messages_per_consumer = 100;
+            return rp;
+        }).get();
+        assertEquals(policies2.max_unacked_messages_per_consumer.intValue(), 100);
     }
 
     /**


### PR DESCRIPTION
---

### Motivation

When using admin to create topic, it will set the content to byte[0] then put it into the value. Sometimes we need to update the value then we will received the deserailization error.
So we need to check the value type to make it as optional empty when the value is null.

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
