### PR TITLE
[fix][build] Remove unnecessary Oracle maven repository from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2804,13 +2804,5 @@ flexible messaging model and an intuitive client API.</description>
         <enabled>false</enabled>
       </snapshots>
     </repository>
-    <!-- For the BDB JE dependency -->
-    <repository>
-      <id>oracle.releases</id>
-      <url>https://download.oracle.com/maven</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
   </repositories>
 </project>

--- a/pulsar-io/rabbitmq/pom.xml
+++ b/pulsar-io/rabbitmq/pom.xml
@@ -94,6 +94,10 @@
           <groupId>org.apache.qpid</groupId>
           <artifactId>qpid-broker-plugins-amqp-1-0-protocol-bdb-link-store</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.qpid</groupId>
+          <artifactId>qpid-broker-plugins-derby-store</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/pulsar-io/rabbitmq/pom.xml
+++ b/pulsar-io/rabbitmq/pom.xml
@@ -85,6 +85,16 @@
       <artifactId>qpid-broker</artifactId>
       <version>9.2.0</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.qpid</groupId>
+          <artifactId>qpid-bdbstore</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.qpid</groupId>
+          <artifactId>qpid-broker-plugins-amqp-1-0-protocol-bdb-link-store</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/RabbitMQBrokerManager.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/RabbitMQBrokerManager.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pulsar.io.rabbitmq;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -42,28 +40,14 @@ public class RabbitMQBrokerManager {
 
     Map<String, Object> getBrokerOptions(String port) throws Exception {
         Path tmpFolder = Files.createTempDirectory("qpidWork");
-        Path homeFolder = Files.createTempDirectory("qpidHome");
-        File etc = new File(homeFolder.toFile(), "etc");
-        etc.mkdir();
-        FileOutputStream fos = new FileOutputStream(new File(etc, "passwd"));
-        fos.write("guest:guest\n".getBytes());
-        fos.close();
-
         Map<String, Object> config = new HashMap<>();
         config.put("qpid.work_dir", tmpFolder.toAbsolutePath().toString());
         config.put("qpid.amqp_port", port);
-        config.put("qpid.home_dir", homeFolder.toAbsolutePath().toString());
-        String configPath = getFile("qpid.json").getAbsolutePath();
 
         Map<String, Object> context = new HashMap<>();
-        context.put(SystemConfig.INITIAL_CONFIGURATION_LOCATION, configPath);
+        context.put(SystemConfig.INITIAL_CONFIGURATION_LOCATION, "classpath:qpid.json");
         context.put(SystemConfig.TYPE, "Memory");
         context.put(SystemConfig.CONTEXT, config);
         return context;
-    }
-
-    private File getFile(String name) {
-        ClassLoader classLoader = getClass().getClassLoader();
-        return new File(classLoader.getResource(name).getFile());
     }
 }

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkTest.java
@@ -18,12 +18,14 @@
  */
 package org.apache.pulsar.io.rabbitmq.sink;
 
+import static org.mockito.Mockito.mock;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.instance.SinkRecord;
+import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.rabbitmq.RabbitMQBrokerManager;
 import org.apache.pulsar.io.rabbitmq.RabbitMQSink;
 import org.awaitility.Awaitility;
@@ -66,7 +68,8 @@ public class RabbitMQSinkTest {
 
         // open should success
         // rabbitmq service may need time to initialize
-        Awaitility.await().ignoreExceptions().untilAsserted(() -> sink.open(configs, null));
+        SinkContext sinkContext = mock(SinkContext.class);
+        Awaitility.await().ignoreExceptions().untilAsserted(() -> sink.open(configs, sinkContext));
 
         // write should success
         Record<byte[]> record = build("test-topic", "fakeKey", "fakeValue", "fakeRoutingKey");

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/sink/RabbitMQSinkTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.io.rabbitmq.sink;
 
 import static org.mockito.Mockito.mock;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -48,7 +49,7 @@ public class RabbitMQSinkTest {
     }
 
     @Test
-    public void TestOpenAndWriteSink() throws Exception {
+    public void testOpenAndWriteSink() throws Exception {
         Map<String, Object> configs = new HashMap<>();
         configs.put("host", "localhost");
         configs.put("port", "5673");
@@ -69,7 +70,8 @@ public class RabbitMQSinkTest {
         // open should success
         // rabbitmq service may need time to initialize
         SinkContext sinkContext = mock(SinkContext.class);
-        Awaitility.await().ignoreExceptions().untilAsserted(() -> sink.open(configs, sinkContext));
+        Awaitility.await().ignoreExceptions().pollDelay(Duration.ofSeconds(1))
+                .untilAsserted(() -> sink.open(configs, sinkContext));
 
         // write should success
         Record<byte[]> record = build("test-topic", "fakeKey", "fakeValue", "fakeRoutingKey");

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.io.rabbitmq.source;
 
+import static org.mockito.Mockito.mock;
+import org.apache.pulsar.io.core.SourceContext;
 import org.apache.pulsar.io.rabbitmq.RabbitMQBrokerManager;
 import org.apache.pulsar.io.rabbitmq.RabbitMQSource;
 import org.awaitility.Awaitility;
@@ -66,8 +68,10 @@ public class RabbitMQSourceTest {
 
         // open should success
         // rabbitmq service may need time to initialize
-        Awaitility.await().ignoreExceptions().untilAsserted(() -> source.open(configs, null));
+        SourceContext sourceContext = mock(SourceContext.class);
+        Awaitility.await().ignoreExceptions().untilAsserted(() -> source.open(configs, sourceContext));
         source.close();
     }
+
 
 }

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.io.rabbitmq.source;
 
 import static org.mockito.Mockito.mock;
+import java.time.Duration;
 import org.apache.pulsar.io.core.SourceContext;
 import org.apache.pulsar.io.rabbitmq.RabbitMQBrokerManager;
 import org.apache.pulsar.io.rabbitmq.RabbitMQSource;
@@ -46,7 +47,7 @@ public class RabbitMQSourceTest {
     }
 
     @Test
-    public void TestOpenAndWriteSink() throws Exception {
+    public void testOpenAndWriteSink() throws Exception {
         Map<String, Object> configs = new HashMap<>();
         configs.put("host", "localhost");
         configs.put("port", "5672");
@@ -69,7 +70,8 @@ public class RabbitMQSourceTest {
         // open should success
         // rabbitmq service may need time to initialize
         SourceContext sourceContext = mock(SourceContext.class);
-        Awaitility.await().ignoreExceptions().untilAsserted(() -> source.open(configs, sourceContext));
+        Awaitility.await().ignoreExceptions().pollDelay(Duration.ofSeconds(1))
+                .untilAsserted(() -> source.open(configs, sourceContext));
         source.close();
     }
 

--- a/pulsar-io/rabbitmq/src/test/resources/qpid.json
+++ b/pulsar-io/rabbitmq/src/test/resources/qpid.json
@@ -1,25 +1,57 @@
 {
-  "name": "EmbeddedBroker",
+  "name": "${broker.name}",
   "modelVersion": "2.0",
-  "storeVersion": 1,
   "authenticationproviders": [
     {
-      "name": "noPassword",
-      "type": "Anonymous",
-      "secureOnlyMechanisms": []
-    },
+      "name": "plain",
+      "type": "Plain",
+      "secureOnlyMechanisms": [],
+      "users": [
+        {
+          "name": "guest",
+          "password": "guest",
+          "type": "managed"
+        }
+      ]
+    }
+  ],
+  "brokerloggers": [
     {
-      "name": "passwordFile",
-      "type": "PlainPasswordFile",
-      "path": "${qpid.home_dir}${file.separator}etc${file.separator}passwd",
-      "secureOnlyMechanisms": []
+      "name": "console",
+      "type": "Console",
+      "brokerloginclusionrules": [
+        {
+          "name": "Root",
+          "type": "NameAndLevel",
+          "level": "WARN",
+          "loggerName": "ROOT"
+        },
+        {
+          "name": "Qpid",
+          "type": "NameAndLevel",
+          "level": "INFO",
+          "loggerName": "org.apache.qpid.*"
+        },
+        {
+          "name": "Operational",
+          "type": "NameAndLevel",
+          "level": "INFO",
+          "loggerName": "qpid.message.*"
+        },
+        {
+          "name": "Statistics",
+          "type": "NameAndLevel",
+          "level": "INFO",
+          "loggerName": "qpid.statistics.*"
+        }
+      ]
     }
   ],
   "ports": [
     {
       "name": "AMQP",
       "port": "${qpid.amqp_port}",
-      "authenticationProvider": "passwordFile",
+      "authenticationProvider": "plain",
       "protocols": [
         "AMQP_0_9_1"
       ]
@@ -28,10 +60,9 @@
   "virtualhostnodes": [
     {
       "name": "default",
-      "type": "JSON",
+      "type": "Memory",
       "defaultVirtualHostNode": "true",
-      "virtualHostInitialConfiguration": "${qpid.initial_config_virtualhost_config}",
-      "storeType": "DERBY"
+      "virtualHostInitialConfiguration": "{\"type\": \"Memory\"}"
     }
   ]
 }


### PR DESCRIPTION
### Motivation

The build stalled because the Oracle maven repository in pom.xml. There seemed to be an temporary availability issue with the repository. The repository was added in PR #22391 to test scope since qpid requires com.sleepycat:je dependency. It's better to get rid of this repository.

### Modifications

Remove the Oracle maven repository from pom.xml and configure the test Qpid broker to use memory only mode so that the com.sleepycat:je dependency isn't required.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->