### PR TITLE
[fix] [broker] Fix compatibility issues for PIP-344

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1498,18 +1498,20 @@ public class NamespaceService implements AutoCloseable {
                                 return CompletableFuture.completedFuture(false);
                             } else if (actEx instanceof PulsarClientException.FeatureNotSupportedException fe){
                                 if (fe.getFailedFeatureCheck() == SupportsGetPartitionedMetadataWithoutAutoCreation) {
-                                    // Since the feature PIP-344 was not supported, just rollback the behavior to the
-                                    // original as before the fix https://github.com/apache/pulsar/pull/22838.
-                                    log.info("{} Checking if a non-persistent non-partitioned topic exists was"
-                                            + " fall-backed to the previous behavior before #22838, because a broker"
-                                            + " does not support a new API. see more detail #23136", topic);
+                                    // Since the feature PIP-344 isn't supported, restore the behavior to previous
+                                    // before before https://github.com/apache/pulsar/pull/22838 changes.
+                                    log.info("{} Checking the existence of a non-persistent non-partitioned topic "
+                                                    + "was performed using the behavior prior to PIP-344 changes, "
+                                                    + "because the broker does not support the PIP-344 feature "
+                                                    + "'supports_get_partitioned_metadata_without_auto_creation'.",
+                                            topic);
                                     return CompletableFuture.completedFuture(false);
                                 } else {
-                                    log.error("{} Failed to get partition metadata due to redirecting fails", topic, ex);
+                                    log.error("{} Failed to get partition metadata", topic, ex);
                                     return CompletableFuture.failedFuture(ex);
                                 }
                             } else {
-                                log.error("{} Failed to get partition metadata due to redirecting fails", topic, ex);
+                                log.error("{} Failed to get partition metadata", topic, ex);
                                 return CompletableFuture.failedFuture(ex);
                             }
                         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1487,7 +1487,7 @@ public class NamespaceService implements AutoCloseable {
                         brokerUrl = lookupData.getBrokerUrl();
                     }
                     return pulsarClient.getLookup(brokerUrl)
-                        .getPartitionedTopicMetadata(topicName, false, false)
+                        .getPartitionedTopicMetadata(topicName, false)
                         .thenApply(metadata -> true)
                         .exceptionallyCompose(ex -> {
                             Throwable actEx = FutureUtil.unwrapCompletionException(ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1498,7 +1498,7 @@ public class NamespaceService implements AutoCloseable {
                             } else if (actEx instanceof PulsarClientException.FeatureNotSupportedException fe){
                                 if (fe.getFailedFeatureCheck() == SupportsGetPartitionedMetadataWithoutAutoCreation) {
                                     // Since the feature PIP-344 isn't supported, restore the behavior to previous
-                                    // before before https://github.com/apache/pulsar/pull/22838 changes.
+                                    // behavior before https://github.com/apache/pulsar/pull/22838 changes.
                                     log.info("{} Checking the existence of a non-persistent non-partitioned topic "
                                                     + "was performed using the behavior prior to PIP-344 changes, "
                                                     + "because the broker does not support the PIP-344 feature "

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1501,8 +1501,8 @@ public class NamespaceService implements AutoCloseable {
                                     // Since the feature PIP-344 was not supported, just rollback the behavior to the
                                     // original as before the fix https://github.com/apache/pulsar/pull/22838.
                                     log.info("{} Checking if a non-persistent non-partitioned topic exists was"
-                                            + " roll-backed to the original before #22838, because a broker does not"
-                                            + " support a new API. see more detail #23136", topic);
+                                            + " fall-backed to the previous behavior before #22838, because a broker"
+                                            + " does not support a new API. see more detail #23136", topic);
                                     return CompletableFuture.completedFuture(false);
                                 } else {
                                     log.error("{} Failed to get partition metadata due to redirecting fails", topic, ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -23,9 +23,8 @@ import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.pulsar.client.api.PulsarClientException.FailedFeatureCheck.SupportsGetPartitionedMetadataWithoutAutoCreation;
 import static org.apache.pulsar.common.naming.NamespaceName.SYSTEM_NAMESPACE;
-import static org.apache.pulsar.client.api.PulsarClientException.FailedFeatureCheck
-        .SupportsGetPartitionedMetadataWithoutAutoCreation;
 import com.google.common.hash.Hashing;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -58,7 +58,6 @@ import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.pulsar.client.impl.BinaryProtoLookupService;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -1498,7 +1497,8 @@ public class NamespaceService implements AutoCloseable {
                             } else if (actEx instanceof PulsarClientException.NotSupportedException){
                                 /**
                                  * Summary: For compatibility of
-                                 * {@link BinaryProtoLookupService#getPartitionedTopicMetadata(TopicName, boolean)}.
+                                 * {@link org.apache.pulsar.client.impl.BinaryProtoLookupService
+                                 *        #getPartitionedTopicMetadata(TopicName, boolean)}.
                                  *
                                  * Explanation:
                                  * 1. Reason of why getting the error here.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1517,6 +1517,10 @@ public class NamespaceService implements AutoCloseable {
                                  *   there is an issue that may cause a non-partitioned non-persistent topic and
                                  *   a partitioned non-persistent topic with the same name to exist at the same time.
                                  */
+                                log.warn("{} The versions of the brokers in the same cluster are different( some are"
+                                        + " less than 3.0.6), rollback to the original behavior before the bug fix that"
+                                        + " may cause a non-partitioned non-persistent topic and a partitioned"
+                                        + " non-persistent topic with the same name to exist at the same time.", topic);
                                 return CompletableFuture.completedFuture(false);
                             } else {
                                 log.error("{} Failed to get partition metadata due to redirecting fails", topic, ex);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataMultiBrokerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataMultiBrokerTest.java
@@ -247,9 +247,6 @@ public class GetPartitionMetadataMultiBrokerTest extends GetPartitionMetadataTes
         };
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Test(dataProvider = "autoCreationParamsAllForNonPersistentTopic")
     public void testCompatibilityDifferentBrokersForNonPersistentTopic(boolean configAllowAutoTopicCreation,
                                                   boolean paramMetadataAutoCreationEnabled,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataMultiBrokerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataMultiBrokerTest.java
@@ -18,20 +18,32 @@
  */
 package org.apache.pulsar.broker.admin;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import java.lang.reflect.Field;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.ClientCnx;
+import org.apache.pulsar.client.impl.ConnectionPool;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.TopicType;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.awaitility.Awaitility;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker-admin")
@@ -218,5 +230,74 @@ public class GetPartitionMetadataMultiBrokerTest extends GetPartitionMetadataTes
                                                   boolean isUsingHttpLookup) throws Exception {
         super.testGetMetadataIfNotAllowedCreateOfNonPersistentTopic(configAllowAutoTopicCreation,
                 paramMetadataAutoCreationEnabled, isUsingHttpLookup);
+    }
+
+    @DataProvider(name = "autoCreationParamsAllForNonPersistentTopic")
+    public Object[][] autoCreationParamsAllForNonPersistentTopic(){
+        return new Object[][]{
+                // configAllowAutoTopicCreation, paramCreateIfAutoCreationEnabled, isUsingHttpLookup.
+                {true, true, true},
+                {true, true, false},
+                {true, false, true},
+                {true, false, false},
+                {false, true, true},
+                {false, true, false},
+                {false, false, true},
+                {false, false, false}
+        };
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Test(dataProvider = "autoCreationParamsAllForNonPersistentTopic")
+    public void testCompatibilityDifferentBrokersForNonPersistentTopic(boolean configAllowAutoTopicCreation,
+                                                  boolean paramMetadataAutoCreationEnabled,
+                                                  boolean isUsingHttpLookup) throws Exception {
+        modifyTopicAutoCreation(configAllowAutoTopicCreation, TopicType.PARTITIONED, 3);
+
+        // Initialize the connections of internal Pulsar Client.
+        PulsarClientImpl client1 = (PulsarClientImpl) pulsar1.getClient();
+        PulsarClientImpl client2 = (PulsarClientImpl) pulsar2.getClient();
+        client1.getLookup(pulsar2.getBrokerServiceUrl()).getBroker(TopicName.get(DEFAULT_NS + "/tp1"));
+        client2.getLookup(pulsar1.getBrokerServiceUrl()).getBroker(TopicName.get(DEFAULT_NS + "/tp1"));
+
+        // Inject a not support flag into the connections initialized.
+        Field field = ClientCnx.class.getDeclaredField("supportsGetPartitionedMetadataWithoutAutoCreation");
+        field.setAccessible(true);
+        for (PulsarClientImpl client : Arrays.asList(client1, client2)) {
+            ConnectionPool pool = client.getCnxPool();
+            for (CompletableFuture<ClientCnx> connectionFuture : pool.getConnections()) {
+                ClientCnx clientCnx = connectionFuture.join();
+                clientCnx.isSupportsGetPartitionedMetadataWithoutAutoCreation();
+                field.set(clientCnx, false);
+            }
+        }
+        // Verify: the method "getPartitionsForTopic(topic, false, true)" will be roll-backed
+        //   to "getPartitionsForTopic(topic, true)".
+        int lookupPermitsBefore = getLookupRequestPermits();
+
+        // Verify: we will not get an un-support error.
+        PulsarClientImpl[] clientArray = getClientsToTest(isUsingHttpLookup);
+        for (PulsarClientImpl client : clientArray) {
+            final String topicNameStr = BrokerTestUtil.newUniqueName("non-persistent://" + DEFAULT_NS + "/tp");
+            try {
+                PartitionedTopicMetadata topicMetadata = client
+                        .getPartitionedTopicMetadata(topicNameStr, paramMetadataAutoCreationEnabled, false)
+                        .join();
+                log.info("Get topic metadata: {}", topicMetadata.partitions);
+            } catch (Exception ex) {
+                Throwable unwrapEx = FutureUtil.unwrapCompletionException(ex);
+                assertTrue(unwrapEx instanceof PulsarClientException.TopicDoesNotExistException
+                        || unwrapEx instanceof PulsarClientException.NotFoundException);
+                assertFalse(ex.getMessage().contains("getting partitions without auto-creation is not supported from"
+                        + " the broker"));
+            }
+        }
+
+        // Verify: lookup semaphore has been releases.
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(getLookupRequestPermits(), lookupPermitsBefore);
+        });
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataMultiBrokerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataMultiBrokerTest.java
@@ -296,5 +296,15 @@ public class GetPartitionMetadataMultiBrokerTest extends GetPartitionMetadataTes
         Awaitility.await().untilAsserted(() -> {
             assertEquals(getLookupRequestPermits(), lookupPermitsBefore);
         });
+
+        // reset clients.
+        for (PulsarClientImpl client : Arrays.asList(client1, client2)) {
+            ConnectionPool pool = client.getCnxPool();
+            for (CompletableFuture<ClientCnx> connectionFuture : pool.getConnections()) {
+                ClientCnx clientCnx = connectionFuture.join();
+                clientCnx.isSupportsGetPartitionedMetadataWithoutAutoCreation();
+                field.set(clientCnx, false);
+            }
+        }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataMultiBrokerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataMultiBrokerTest.java
@@ -270,8 +270,8 @@ public class GetPartitionMetadataMultiBrokerTest extends GetPartitionMetadataTes
                 field.set(clientCnx, false);
             }
         }
-        // Verify: the method "getPartitionsForTopic(topic, false, true)" will be roll-backed
-        //   to "getPartitionsForTopic(topic, true)".
+        // Verify: the method "getPartitionsForTopic(topic, false, true)" will fallback
+        //   to "getPartitionsForTopic(topic, true)" behavior.
         int lookupPermitsBefore = getLookupRequestPermits();
 
         // Verify: we will not get an un-support error.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataMultiBrokerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataMultiBrokerTest.java
@@ -247,7 +247,7 @@ public class GetPartitionMetadataMultiBrokerTest extends GetPartitionMetadataTes
         };
     }
 
-    @Test(dataProvider = "autoCreationParamsAllForNonPersistentTopic")
+    @Test(dataProvider = "autoCreationParamsAllForNonPersistentTopic", priority = Integer.MAX_VALUE)
     public void testCompatibilityDifferentBrokersForNonPersistentTopic(boolean configAllowAutoTopicCreation,
                                                   boolean paramMetadataAutoCreationEnabled,
                                                   boolean isUsingHttpLookup) throws Exception {
@@ -303,7 +303,7 @@ public class GetPartitionMetadataMultiBrokerTest extends GetPartitionMetadataTes
             for (CompletableFuture<ClientCnx> connectionFuture : pool.getConnections()) {
                 ClientCnx clientCnx = connectionFuture.join();
                 clientCnx.isSupportsGetPartitionedMetadataWithoutAutoCreation();
-                field.set(clientCnx, false);
+                field.set(clientCnx, true);
             }
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
@@ -271,6 +271,16 @@ public class GetPartitionMetadataTest {
             // Cleanup.
             admin1.topics().deletePartitionedTopic(tp, false);
         }
+
+        // reset clients.
+        for (PulsarClientImpl client : clients) {
+            ConnectionPool pool = client.getCnxPool();
+            for (CompletableFuture<ClientCnx> connectionFuture : pool.getConnections()) {
+                ClientCnx clientCnx = connectionFuture.join();
+                clientCnx.isSupportsGetPartitionedMetadataWithoutAutoCreation();
+                field.set(clientCnx, true);
+            }
+        }
     }
 
     @DataProvider(name = "autoCreationParamsAll")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
@@ -23,10 +23,12 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.common.collect.Sets;
+import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.PulsarService;
@@ -34,6 +36,8 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.ClientCnx;
+import org.apache.pulsar.client.impl.ConnectionPool;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
@@ -225,6 +229,50 @@ public class GetPartitionMetadataTest {
         }
     }
 
+    @Test(dataProvider = "topicDomains")
+    public void testCompatibilityForNewClientAndOldBroker(TopicDomain topicDomain) throws Exception {
+        modifyTopicAutoCreation(true, TopicType.PARTITIONED, 3);
+        // Initialize connections.
+        String pulsarUrl = pulsar1.getBrokerServiceUrl();
+        PulsarClientImpl[] clients = getClientsToTest(false);
+        for (PulsarClientImpl client : clients) {
+            client.getLookup(pulsarUrl).getBroker(TopicName.get(DEFAULT_NS + "/tp1"));
+        }
+        // Inject a not support flag into the connections initialized.
+        Field field = ClientCnx.class.getDeclaredField("supportsGetPartitionedMetadataWithoutAutoCreation");
+        field.setAccessible(true);
+        for (PulsarClientImpl client : clients) {
+            ConnectionPool pool = client.getCnxPool();
+            for (CompletableFuture<ClientCnx> connectionFuture : pool.getConnections()) {
+                ClientCnx clientCnx = connectionFuture.join();
+                clientCnx.isSupportsGetPartitionedMetadataWithoutAutoCreation();
+                field.set(clientCnx, false);
+            }
+        }
+
+        // Verify: the method "getPartitionsForTopic(topic, false, true)" will be roll-backed to
+        // "getPartitionsForTopic(topic)".
+        int lookupPermitsBefore = getLookupRequestPermits();
+        for (PulsarClientImpl client : clients) {
+            // Verify: the behavior of topic creation.
+            final String tp = BrokerTestUtil.newUniqueName(topicDomain.value() + "://" + DEFAULT_NS + "/tp");
+            client.getPartitionedTopicMetadata(tp, false, true).join();
+            Optional<PartitionedTopicMetadata> metadata1 = pulsar1.getPulsarResources().getNamespaceResources()
+                    .getPartitionedTopicResources()
+                    .getPartitionedTopicMetadataAsync(TopicName.get(tp), true).join();
+            assertTrue(metadata1.isPresent());
+            assertEquals(metadata1.get().partitions, 3);
+
+            // Verify: lookup semaphore has been releases.
+            Awaitility.await().untilAsserted(() -> {
+                assertEquals(getLookupRequestPermits(), lookupPermitsBefore);
+            });
+
+            // Cleanup.
+            admin1.topics().deletePartitionedTopic(tp, false);
+        }
+    }
+
     @DataProvider(name = "autoCreationParamsAll")
     public Object[][] autoCreationParamsAll(){
         return new Object[][]{
@@ -265,7 +313,7 @@ public class GetPartitionMetadataTest {
         for (PulsarClientImpl client : clientArray) {
             // Verify: the result of get partitioned topic metadata.
             PartitionedTopicMetadata response =
-                    client.getPartitionedTopicMetadata(topicNameStr, paramMetadataAutoCreationEnabled).join();
+                    client.getPartitionedTopicMetadata(topicNameStr, paramMetadataAutoCreationEnabled, false).join();
             assertEquals(response.partitions, 0);
             List<String> partitionedTopics = admin1.topics().getPartitionedTopicList("public/default");
             assertFalse(partitionedTopics.contains(topicNameStr));
@@ -298,7 +346,7 @@ public class GetPartitionMetadataTest {
         for (PulsarClientImpl client : clientArray) {
             // Verify: the result of get partitioned topic metadata.
             PartitionedTopicMetadata response =
-                    client.getPartitionedTopicMetadata(topicNameStr, paramMetadataAutoCreationEnabled).join();
+                    client.getPartitionedTopicMetadata(topicNameStr, paramMetadataAutoCreationEnabled, false).join();
             assertEquals(response.partitions, 3);
             verifyNonPartitionedTopicNeverCreated(topicNameStr);
 
@@ -332,7 +380,7 @@ public class GetPartitionMetadataTest {
             // Case-1: normal topic.
             final String topicNameStr = BrokerTestUtil.newUniqueName(topicDomain.value() + "://" + DEFAULT_NS + "/tp");
             // Verify: the result of get partitioned topic metadata.
-            PartitionedTopicMetadata response = client.getPartitionedTopicMetadata(topicNameStr, true).join();
+            PartitionedTopicMetadata response = client.getPartitionedTopicMetadata(topicNameStr, true, false).join();
             assertEquals(response.partitions, 3);
             // Verify: the behavior of topic creation.
             List<String> partitionedTopics = admin1.topics().getPartitionedTopicList("public/default");
@@ -347,7 +395,7 @@ public class GetPartitionMetadataTest {
                     topicDomain.value() + "://" + DEFAULT_NS + "/tp") + "-partition-1";
             // Verify: the result of get partitioned topic metadata.
             PartitionedTopicMetadata response2 =
-                    client.getPartitionedTopicMetadata(topicNameStrWithSuffix, true).join();
+                    client.getPartitionedTopicMetadata(topicNameStrWithSuffix, true, false).join();
             assertEquals(response2.partitions, 0);
             // Verify: the behavior of topic creation.
             List<String> partitionedTopics2 =
@@ -380,7 +428,7 @@ public class GetPartitionMetadataTest {
             // Case 1: normal topic.
             final String topicNameStr = BrokerTestUtil.newUniqueName(topicDomain.value() + "://" + DEFAULT_NS + "/tp");
             // Verify: the result of get partitioned topic metadata.
-            PartitionedTopicMetadata response = client.getPartitionedTopicMetadata(topicNameStr, true).join();
+            PartitionedTopicMetadata response = client.getPartitionedTopicMetadata(topicNameStr, true, false).join();
             assertEquals(response.partitions, 0);
             // Verify: the behavior of topic creation.
             List<String> partitionedTopics = admin1.topics().getPartitionedTopicList("public/default");
@@ -392,7 +440,7 @@ public class GetPartitionMetadataTest {
                     topicDomain.value() + "://" + DEFAULT_NS + "/tp") + "-partition-1";
             // Verify: the result of get partitioned topic metadata.
             PartitionedTopicMetadata response2 =
-                    client.getPartitionedTopicMetadata(topicNameStrWithSuffix, true).join();
+                    client.getPartitionedTopicMetadata(topicNameStrWithSuffix, true, false).join();
             assertEquals(response2.partitions, 0);
             // Verify: the behavior of topic creation.
             List<String> partitionedTopics2 =
@@ -443,7 +491,7 @@ public class GetPartitionMetadataTest {
             final TopicName topicName = TopicName.get(topicNameStr);
             // Verify: the result of get partitioned topic metadata.
             try {
-                client.getPartitionedTopicMetadata(topicNameStr, paramMetadataAutoCreationEnabled)
+                client.getPartitionedTopicMetadata(topicNameStr, paramMetadataAutoCreationEnabled, false)
                         .join();
                 fail("Expect a not found exception");
             } catch (Exception e) {
@@ -496,7 +544,7 @@ public class GetPartitionMetadataTest {
             // Verify: the result of get partitioned topic metadata.
             try {
                 PartitionedTopicMetadata topicMetadata = client
-                        .getPartitionedTopicMetadata(topicNameStr, paramMetadataAutoCreationEnabled)
+                        .getPartitionedTopicMetadata(topicNameStr, paramMetadataAutoCreationEnabled, false)
                         .join();
                 log.info("Get topic metadata: {}", topicMetadata.partitions);
                 fail("Expected a not found ex");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
@@ -229,7 +229,7 @@ public class GetPartitionMetadataTest {
         }
     }
 
-    @Test(dataProvider = "topicDomains")
+    @Test(dataProvider = "topicDomains", priority = Integer.MAX_VALUE)
     public void testCompatibilityForNewClientAndOldBroker(TopicDomain topicDomain) throws Exception {
         modifyTopicAutoCreation(true, TopicType.PARTITIONED, 3);
         // Initialize connections.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
@@ -250,8 +250,8 @@ public class GetPartitionMetadataTest {
             }
         }
 
-        // Verify: the method "getPartitionsForTopic(topic, false, true)" will be roll-backed to
-        // "getPartitionsForTopic(topic)".
+        // Verify: the method "getPartitionsForTopic(topic, false, true)" will fallback to
+        // "getPartitionsForTopic(topic)" behavior.
         int lookupPermitsBefore = getLookupRequestPermits();
         for (PulsarClientImpl client : clients) {
             // Verify: the behavior of topic creation.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAutoCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAutoCreationTest.java
@@ -134,6 +134,8 @@ public class TopicAutoCreationTest extends ProducerConsumerBase {
             // we want to skip the "lookup" phase, because it is blocked by the HTTP API
             LookupService mockLookup = mock(LookupService.class);
             ((PulsarClientImpl) pulsarClient).setLookup(mockLookup);
+            when(mockLookup.getPartitionedTopicMetadata(any(), anyBoolean())).thenAnswer(
+                    i -> CompletableFuture.completedFuture(new PartitionedTopicMetadata(0)));
             when(mockLookup.getPartitionedTopicMetadata(any(), anyBoolean(), anyBoolean())).thenAnswer(
                     i -> CompletableFuture.completedFuture(new PartitionedTopicMetadata(0)));
             when(mockLookup.getBroker(any())).thenAnswer(ignored -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAutoCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAutoCreationTest.java
@@ -134,7 +134,7 @@ public class TopicAutoCreationTest extends ProducerConsumerBase {
             // we want to skip the "lookup" phase, because it is blocked by the HTTP API
             LookupService mockLookup = mock(LookupService.class);
             ((PulsarClientImpl) pulsarClient).setLookup(mockLookup);
-            when(mockLookup.getPartitionedTopicMetadata(any(), anyBoolean())).thenAnswer(
+            when(mockLookup.getPartitionedTopicMetadata(any(), anyBoolean(), anyBoolean())).thenAnswer(
                     i -> CompletableFuture.completedFuture(new PartitionedTopicMetadata(0)));
             when(mockLookup.getBroker(any())).thenAnswer(ignored -> {
                 InetSocketAddress brokerAddress =

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionLowWaterMarkTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionLowWaterMarkTest.java
@@ -148,7 +148,7 @@ public class TransactionLowWaterMarkTest extends TransactionTestBase {
 
         PartitionedTopicMetadata partitionedTopicMetadata =
                 ((PulsarClientImpl) pulsarClient).getLookup()
-                        .getPartitionedTopicMetadata(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN, false, false)
+                        .getPartitionedTopicMetadata(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN, false)
                         .get();
         Transaction lowWaterMarkTxn = null;
         for (int i = 0; i < partitionedTopicMetadata.partitions; i++) {
@@ -254,7 +254,7 @@ public class TransactionLowWaterMarkTest extends TransactionTestBase {
 
         PartitionedTopicMetadata partitionedTopicMetadata =
                 ((PulsarClientImpl) pulsarClient).getLookup()
-                        .getPartitionedTopicMetadata(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN, false, false)
+                        .getPartitionedTopicMetadata(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN, false)
                         .get();
         Transaction lowWaterMarkTxn = null;
         for (int i = 0; i < partitionedTopicMetadata.partitions; i++) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionLowWaterMarkTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionLowWaterMarkTest.java
@@ -148,7 +148,8 @@ public class TransactionLowWaterMarkTest extends TransactionTestBase {
 
         PartitionedTopicMetadata partitionedTopicMetadata =
                 ((PulsarClientImpl) pulsarClient).getLookup()
-                        .getPartitionedTopicMetadata(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN, false).get();
+                        .getPartitionedTopicMetadata(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN, false, false)
+                        .get();
         Transaction lowWaterMarkTxn = null;
         for (int i = 0; i < partitionedTopicMetadata.partitions; i++) {
             lowWaterMarkTxn = pulsarClient.newTransaction()
@@ -253,7 +254,8 @@ public class TransactionLowWaterMarkTest extends TransactionTestBase {
 
         PartitionedTopicMetadata partitionedTopicMetadata =
                 ((PulsarClientImpl) pulsarClient).getLookup()
-                        .getPartitionedTopicMetadata(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN, false).get();
+                        .getPartitionedTopicMetadata(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN, false, false)
+                        .get();
         Transaction lowWaterMarkTxn = null;
         for (int i = 0; i < partitionedTopicMetadata.partitions; i++) {
             lowWaterMarkTxn = pulsarClient.newTransaction()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -933,7 +933,7 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         // Verify the request is works after merge the requests.
         List<CompletableFuture<PartitionedTopicMetadata>> futures = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
-            futures.add(lookupService.getPartitionedTopicMetadata(TopicName.get(tpName), false));
+            futures.add(lookupService.getPartitionedTopicMetadata(TopicName.get(tpName), false, false));
         }
         for (CompletableFuture<PartitionedTopicMetadata> future : futures) {
             assertEquals(future.join().partitions, topicPartitions);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -933,7 +933,7 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         // Verify the request is works after merge the requests.
         List<CompletableFuture<PartitionedTopicMetadata>> futures = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
-            futures.add(lookupService.getPartitionedTopicMetadata(TopicName.get(tpName), false, false));
+            futures.add(lookupService.getPartitionedTopicMetadata(TopicName.get(tpName), false));
         }
         for (CompletableFuture<PartitionedTopicMetadata> future : futures) {
             assertEquals(future.join().partitions, topicPartitions);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ClientCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ClientCnxTest.java
@@ -208,7 +208,7 @@ public class ClientCnxTest extends MockedPulsarServiceBaseTest {
             clientWitBinaryLookup.getPartitionsForTopic(topic, false).join();
             Assert.fail("Expected an error that the broker version is too old.");
         } catch (Exception ex) {
-            Assert.assertTrue(ex.getMessage().contains("without auto-creation is not supported from the broker"));
+            Assert.assertTrue(ex.getMessage().contains("without auto-creation is not supported by the broker"));
         }
 
         // cleanup.

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import lombok.Getter;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
 
@@ -739,6 +740,30 @@ public class PulsarClientException extends IOException {
         public NotSupportedException(String msg) {
             super(msg);
         }
+    }
+
+    /**
+     * Not supported exception thrown by Pulsar client.
+     */
+    public static class FeatureNotSupportedException extends NotSupportedException {
+
+        @Getter
+        private final FailedFeatureCheck failedFeatureCheck;
+
+        public FeatureNotSupportedException(String msg, FailedFeatureCheck failedFeatureCheck) {
+            super(msg);
+            this.failedFeatureCheck = failedFeatureCheck;
+        }
+    }
+
+    /**
+     * "supports_auth_refresh" was introduced at "2.6" and is no longer supported, so skip this enum.
+     * "supports_broker_entry_metadata" was introduced at "2.8" and is no longer supported, so skip this enum.
+     * "supports_partial_producer" was introduced at "2.10" and is no longer supported, so skip this enum.
+     * "supports_topic_watchers" was introduced at "2.11" and is no longer supported, so skip this enum.
+     */
+    public enum FailedFeatureCheck {
+        SupportsGetPartitionedMetadataWithoutAutoCreation;
     }
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
@@ -260,7 +260,7 @@ public class BinaryProtoLookupService implements LookupService {
             boolean finalAutoCreationEnabled = metadataAutoCreationEnabled;
             if (!metadataAutoCreationEnabled && !clientCnx.isSupportsGetPartitionedMetadataWithoutAutoCreation()) {
                 if (acceptFallbackIfNotSupport) {
-                    log.info("{} Roll-back getPartitionedTopicMetadata(topic, false) to"
+                    log.info("{} Fall-back getPartitionedTopicMetadata(topic, false) to"
                             + " getPartitionedTopicMetadata(topic) since broker does not support.", topicName);
                     finalAutoCreationEnabled = true;
                 } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
@@ -18,9 +18,8 @@
  */
 package org.apache.pulsar.client.impl;
 
-import static org.apache.pulsar.client.api.PulsarClientException.FailedFeatureCheck
-        .SupportsGetPartitionedMetadataWithoutAutoCreation;
 import static java.lang.String.format;
+import static org.apache.pulsar.client.api.PulsarClientException.FailedFeatureCheck.SupportsGetPartitionedMetadataWithoutAutoCreation;
 import io.netty.buffer.ByteBuf;
 import io.opentelemetry.api.common.Attributes;
 import java.net.InetSocketAddress;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -122,6 +122,13 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
                     || actEx instanceof PulsarClientException.TopicDoesNotExistException
                     || actEx instanceof PulsarAdminException.NotFoundException) {
                 existsFuture.complete(false);
+            } else if (actEx instanceof PulsarClientException.NotSupportedException) {
+                existsFuture.completeExceptionally(new PulsarClientException.NotSupportedException("There is a bug that"
+                    + " the Retry/DLQ consumer will still trigger a Retry/DLQ topic with the old rule"
+                    + " ({namespace}/{subscription}-RETRY/DLQ), but the rule was changed to"
+                    + " {namespace}/{topic}-{subscription}-RETRY/DLQ after 2.8.0. Please upgrade the brokers' version"
+                    + " to >=3.0.6 or >=3.3.1; another solution is use HTTP protocol service URL instead of Binary"
+                    + " protocol service URL when building Pulsar Client"));
             } else {
                 existsFuture.completeExceptionally(ex);
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -107,7 +107,7 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
 
     private CompletableFuture<Boolean> checkDlqAlreadyExists(String topic) {
         CompletableFuture<Boolean> existsFuture = new CompletableFuture<>();
-        client.getPartitionedTopicMetadata(topic, false).thenAccept(metadata -> {
+        client.getPartitionedTopicMetadata(topic, false, true).thenAccept(metadata -> {
             TopicName topicName = TopicName.get(topic);
             if (topicName.isPersistent()) {
                 // Either partitioned or non-partitioned, it exists.
@@ -122,13 +122,6 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
                     || actEx instanceof PulsarClientException.TopicDoesNotExistException
                     || actEx instanceof PulsarAdminException.NotFoundException) {
                 existsFuture.complete(false);
-            } else if (actEx instanceof PulsarClientException.NotSupportedException) {
-                existsFuture.completeExceptionally(new PulsarClientException.NotSupportedException("There is a bug that"
-                    + " the Retry/DLQ consumer will still trigger a Retry/DLQ topic with the old rule"
-                    + " ({namespace}/{subscription}-RETRY/DLQ), but the rule was changed to"
-                    + " {namespace}/{topic}-{subscription}-RETRY/DLQ after 2.8.0. Please upgrade the brokers' version"
-                    + " to >=3.0.6 or >=3.3.1; another solution is use HTTP protocol service URL instead of Binary"
-                    + " protocol service URL when building Pulsar Client"));
             } else {
                 existsFuture.completeExceptionally(ex);
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpLookupService.java
@@ -135,9 +135,13 @@ public class HttpLookupService implements LookupService {
         });
     }
 
+    /**
+     * {@inheritDoc}
+     * @param acceptFallbackIfNotSupport HttpLookupService supports every request, so this param will be ignored.
+     */
     @Override
     public CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(
-            TopicName topicName, boolean metadataAutoCreationEnabled) {
+            TopicName topicName, boolean metadataAutoCreationEnabled, boolean acceptFallbackIfNotSupport) {
         long startTime = System.nanoTime();
 
         String format = topicName.isV2() ? "admin/v2/%s/partitions" : "admin/%s/partitions";

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpLookupService.java
@@ -137,11 +137,11 @@ public class HttpLookupService implements LookupService {
 
     /**
      * {@inheritDoc}
-     * @param acceptFallbackIfNotSupport HttpLookupService supports every request, so this param will be ignored.
+     * @param useFallbackForNonPIP344Brokers HttpLookupService ignores this parameter
      */
     @Override
     public CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(
-            TopicName topicName, boolean metadataAutoCreationEnabled, boolean acceptFallbackIfNotSupport) {
+            TopicName topicName, boolean metadataAutoCreationEnabled, boolean useFallbackForNonPIP344Brokers) {
         long startTime = System.nanoTime();
 
         String format = topicName.isV2() ? "admin/v2/%s/partitions" : "admin/%s/partitions";

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/LookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/LookupService.java
@@ -80,15 +80,15 @@ public interface LookupService extends AutoCloseable {
      * 3.When {@param metadataAutoCreationEnabled} is "true," it will trigger an auto-creation for this topic(using
      *  the default topic auto-creation strategy you set for the broker), and the corresponding result is returned.
      *  For the result, see case 1.
-     * @param acceptFallbackIfNotSupport fall-back to the original method
-     *   {@link #getPartitionedTopicMetadata(TopicName)} if brokers do not support
-     *   "getPartitionedTopicMetadata(topic, false)". This param only affects when the
-     *   {@param metadataAutoCreationEnabled} is "false".
+     * @param useFallbackForNonPIP344Brokers <p>If true, fallback to the prior behavior of the method
+     *   {@link #getPartitionedTopicMetadata(TopicName)} if the broker does not support the PIP-344 feature
+     *   'supports_get_partitioned_metadata_without_auto_creation'. This parameter only affects the behavior when
+     *   {@param metadataAutoCreationEnabled} is false.</p>
      * @version 3.3.0.
      */
     CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName,
                                                                         boolean metadataAutoCreationEnabled,
-                                                                        boolean acceptFallbackIfNotSupport);
+                                                                        boolean useFallbackForNonPIP344Brokers);
 
     /**
      * Returns current SchemaInfo {@link SchemaInfo} for a given topic.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/LookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/LookupService.java
@@ -61,11 +61,11 @@ public interface LookupService extends AutoCloseable {
     /**
      * Returns {@link PartitionedTopicMetadata} for a given topic.
      * Note: this method will try to create the topic partitioned metadata if it does not exist.
-     * @deprecated Please call {{@link #getPartitionedTopicMetadata(TopicName, boolean)}}.
+     * @deprecated Please call {{@link #getPartitionedTopicMetadata(TopicName, boolean, boolean)}}.
      */
     @Deprecated
     default CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName) {
-        return getPartitionedTopicMetadata(topicName, true);
+        return getPartitionedTopicMetadata(topicName, true, true);
     }
 
     /**
@@ -80,10 +80,15 @@ public interface LookupService extends AutoCloseable {
      * 3.When {@param metadataAutoCreationEnabled} is "true," it will trigger an auto-creation for this topic(using
      *  the default topic auto-creation strategy you set for the broker), and the corresponding result is returned.
      *  For the result, see case 1.
+     * @param acceptFallbackIfNotSupport roll-back to the original method
+     *   {@link #getPartitionedTopicMetadata(TopicName)} if brokers do not support
+     *   "getPartitionedTopicMetadata(topic, false)". This param only affects when the
+     *   {@param metadataAutoCreationEnabled} is "false".
      * @version 3.3.0.
      */
     CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName,
-                                                                            boolean metadataAutoCreationEnabled);
+                                                                        boolean metadataAutoCreationEnabled,
+                                                                        boolean acceptFallbackIfNotSupport);
 
     /**
      * Returns current SchemaInfo {@link SchemaInfo} for a given topic.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/LookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/LookupService.java
@@ -80,7 +80,7 @@ public interface LookupService extends AutoCloseable {
      * 3.When {@param metadataAutoCreationEnabled} is "true," it will trigger an auto-creation for this topic(using
      *  the default topic auto-creation strategy you set for the broker), and the corresponding result is returned.
      *  For the result, see case 1.
-     * @param acceptFallbackIfNotSupport roll-back to the original method
+     * @param acceptFallbackIfNotSupport fall-back to the original method
      *   {@link #getPartitionedTopicMetadata(TopicName)} if brokers do not support
      *   "getPartitionedTopicMetadata(topic, false)". This param only affects when the
      *   {@param metadataAutoCreationEnabled} is "false".

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/LookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/LookupService.java
@@ -69,6 +69,14 @@ public interface LookupService extends AutoCloseable {
     }
 
     /**
+     * See the doc {@link #getPartitionedTopicMetadata(TopicName, boolean, boolean)}.
+     */
+    default CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(TopicName topicName,
+                                                                                boolean metadataAutoCreationEnabled) {
+        return getPartitionedTopicMetadata(topicName, metadataAutoCreationEnabled, false);
+    }
+
+    /**
      * 1.Get the partitions if the topic exists. Return "{partition: n}" if a partitioned topic exists;
      *  return "{partition: 0}" if a non-partitioned topic exists.
      * 2. When {@param metadataAutoCreationEnabled} is "false," neither partitioned topic nor non-partitioned topic

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -957,7 +957,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
         CompletableFuture<Void> subscribeResult = new CompletableFuture<>();
 
-        client.getPartitionedTopicMetadata(topicName, true)
+        client.getPartitionedTopicMetadata(topicName, true, false)
                 .thenAccept(metadata -> subscribeTopicPartitions(subscribeResult, fullTopicName, metadata.partitions,
                     createTopicIfDoesNotExist))
                 .exceptionally(ex1 -> {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -424,7 +424,7 @@ public class PulsarClientImpl implements PulsarClient {
                  *   that may cause replication stuck and topics being created in confusion, see more details in
                  *   #22838's motivation.
                  */
-                log.error("{} {} Since the target cluster does not support to get topic's partitions without"
+                log.warn("{} {} Since the target cluster does not support to get topic's partitions without"
                         + " auto-creation, skip the partitions check. It may cause both partitioned topic and"
                         + " non-partitioned topic to exist at the same time, please upgrade clusters to the version"
                         + " that >=3.0.6 or >=3.3.1", topic, producerNameForLog);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -1132,7 +1132,7 @@ public class PulsarClientImpl implements PulsarClient {
     }
 
     /**
-     * @param acceptFallbackIfNotSupport roll-back to the original method {@link #getPartitionsForTopic(String)} if
+     * @param acceptFallbackIfNotSupport fall-back to the original method {@link #getPartitionsForTopic(String)} if
      * brokers do not support "getPartitionsForTopic(topic, false)". This param only affects when the
      * {@param metadataAutoCreationEnabled} is "false".
      */

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -410,7 +410,7 @@ public class PulsarClientImpl implements PulsarClient {
                  * {@link BinaryProtoLookupService#getPartitionedTopicMetadata(TopicName, boolean)}.
                  *
                  * Explanation:
-                 * 1. This error will only occur when using Geo-Replication, and one version of the two cluster os
+                 * 1. This error will only occur when using Geo-Replication, and one version of the two cluster is
                  *    larger or equals than "3.0.6" and "3.3.1" and another is smaller than "3.0.6" and "3.3.1".
                  * 2. Reason of why getting the error here.
                  *   The feature method above was supported at "3.0.6" and "3.3.1", before that the API

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionCoordinatorClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionCoordinatorClientImpl.java
@@ -80,7 +80,7 @@ public class TransactionCoordinatorClientImpl implements TransactionCoordinatorC
     public CompletableFuture<Void> startAsync() {
         if (STATE_UPDATER.compareAndSet(this, State.NONE, State.STARTING)) {
             return pulsarClient.getPartitionedTopicMetadata(
-                            SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN.getPartitionedTopicName(), true)
+                            SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN.getPartitionedTopicName(), true, false)
                 .thenCompose(partitionMeta -> {
                     List<CompletableFuture<Void>> connectFutureList = new ArrayList<>();
                     if (LOG.isDebugEnabled()) {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
@@ -154,7 +154,7 @@ public class MultiTopicsConsumerImplTest {
         int completionDelayMillis = 100;
         Schema<byte[]> schema = Schema.BYTES;
         PulsarClientImpl clientMock = createPulsarClientMockWithMockedClientCnx(executorProvider, internalExecutor);
-        when(clientMock.getPartitionedTopicMetadata(any(), anyBoolean()))
+        when(clientMock.getPartitionedTopicMetadata(any(), anyBoolean(), anyBoolean()))
                 .thenAnswer(invocation -> createDelayedCompletedFuture(
                 new PartitionedTopicMetadata(), completionDelayMillis));
         MultiTopicsConsumerImpl<byte[]> impl = new MultiTopicsConsumerImpl<byte[]>(
@@ -203,7 +203,7 @@ public class MultiTopicsConsumerImplTest {
         int completionDelayMillis = 10;
         Schema<byte[]> schema = Schema.BYTES;
         PulsarClientImpl clientMock = createPulsarClientMockWithMockedClientCnx(executorProvider, internalExecutor);
-        when(clientMock.getPartitionedTopicMetadata(any(), anyBoolean()))
+        when(clientMock.getPartitionedTopicMetadata(any(), anyBoolean(), anyBoolean()))
                 .thenAnswer(invocation -> createExceptionFuture(
                 new PulsarClientException.InvalidConfigurationException("a mock exception"), completionDelayMillis));
         CompletableFuture<Consumer<byte[]>> completeFuture = new CompletableFuture<>();
@@ -240,7 +240,7 @@ public class MultiTopicsConsumerImplTest {
 
         // Simulate non partitioned topics
         PartitionedTopicMetadata metadata = new PartitionedTopicMetadata(0);
-        when(clientMock.getPartitionedTopicMetadata(any(), anyBoolean()))
+        when(clientMock.getPartitionedTopicMetadata(any(), anyBoolean(), anyBoolean()))
                 .thenReturn(CompletableFuture.completedFuture(metadata));
         CompletableFuture<Consumer<byte[]>> completeFuture = new CompletableFuture<>();
 
@@ -252,7 +252,7 @@ public class MultiTopicsConsumerImplTest {
 
         // getPartitionedTopicMetadata should have been called only the first time, for each of the 3 topics,
         // but not anymore since the topics are not partitioned.
-        verify(clientMock, times(3)).getPartitionedTopicMetadata(any(), anyBoolean());
+        verify(clientMock, times(3)).getPartitionedTopicMetadata(any(), anyBoolean(), anyBoolean());
     }
 
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
@@ -108,7 +108,7 @@ public class PulsarClientImplTest {
                 nullable(String.class)))
                 .thenReturn(CompletableFuture.completedFuture(
                         new GetTopicsResult(Collections.emptyList(), null, false, true)));
-        when(lookup.getPartitionedTopicMetadata(any(TopicName.class), anyBoolean()))
+        when(lookup.getPartitionedTopicMetadata(any(TopicName.class), anyBoolean(), anyBoolean()))
                 .thenReturn(CompletableFuture.completedFuture(new PartitionedTopicMetadata()));
         when(lookup.getBroker(any()))
                 .thenReturn(CompletableFuture.completedFuture(new LookupTopicResult(

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -295,6 +295,7 @@ message CommandConnect {
     optional string proxy_version = 11; // Version of the proxy. Should only be forwarded by a proxy.
 }
 
+// Please also add a new enum for the class "PulsarClientException.FailedFeatureCheck" when adding a new feature flag.
 message FeatureFlags {
   optional bool supports_auth_refresh = 1 [default = false];
   optional bool supports_broker_entry_metadata = 2 [default = false];


### PR DESCRIPTION
### Motivation & Modifications

After [PIP-344 add a public API pulsarClient.getPartitionsForTopic(String topic, boolean metadataAutoCreationEnabled)](https://github.com/apache/pulsar/pull/22182), there are `3` compatibility issues:

---

#### 1. Using DLQ( brokers’ version is  `<3.0.6`, and clients’ version is `>=3.0.6`)
PIP-344 fixed a bug that the Retry/DLQ consumer will still trigger a Retry/DLQ topic with the old rule `{namespace}/{subscription}-RETRY/DLQ`, but the rule was changed to `{namespace}/{topic}-{subscription}-RETRY/DLQ` after `2.8.0`. This behavior has been defined in the PIP-344, so it is fine.

**Modifications for compatibility**: modify the error message to let users know what happened.

---

#### 2. Using Geo-Replication, the version of the local cluster and the remote cluster is not the same ( local clusters are `>=3.0.6` , and remote clusters are `<3.0.6` )

1. This error will only occur when using Geo-Replication, and one version of the two clusters is larger or equal to `3.0.6` and "3.3.1" and another is smaller than `3.0.6` and `3.3.1`.
2. **Reason why getting the not supported error when creating internal Replicator:** The feature method above was supported at `3.0.6` and `3.3.1`, before that the API  "getPartitionedTopicMetadata" will trigger a creation for partitioned topic metadata automatically even if you just want to query it. So the brokers whose version is less than `3.0.6` and `3.3.1` do not support the new API.
3. **Modifications for compatibility:** Skip the check of comparing of topic's partitions, and force connect to the non-partitioned topic,  it may cause both the partitioned topic and non-partitioned topic to exist at the same time. But this is still better than the behavior before fix #22983, without fix #22838, there is an issue that may cause replication stuck and topics to be created in confusion, see more details in #22838's motivation.

---

#### 3. Using non-persistent topics, the versions of the brokers in the same cluster are different( some are less than `3.0.6` )

1. **Reason why getting the not supported error when creating a non-persistent consumer/producer:** The feature method `getPartitionedTopicMetadata(topic, false)` was supported at `3.0.6` and `3.3.1`, before that the API `getPartitionedTopicMetadata(topic)` will trigger a creation for partitioned topic metadata automatically even if you just want query it. So the brokers whose version is less than `3.0.6` and `3.3.1` do not support the new API.
2. **The conditions for this error occur:** There are `2` brokers in a cluster, and the version is less than `3.0.1`, rolling upgrade brokers to `3.0.6`. After the first broker restarted, there was one broker with version `3.0.6` and another is `3.0.1`, and when the internal client tries to call `getPartitionedTopicMetadata(topic, false)` to the broker with a lower version, it will get this error.
3. **Modifications for compatibility:** Rollback to the original behavior before the fix #22838. Without fix #22838, there is an issue that may cause a non-partitioned non-persistent topic and a partitioned non-persistent topic with the same name to exist at the same time.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
