### PR TITLE
[fix][client] Fix for early hit `beforeConsume` for MultiTopicConsumer

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -392,9 +392,10 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 decreaseIncomingMessageSize(message);
                 checkArgument(message instanceof TopicMessageImpl);
                 trackUnAckedMsgIfNoListener(message.getMessageId(), message.getRedeliveryCount());
+                message = beforeConsume(message);
             }
             resumeReceivingFromPausedConsumersIfNeeded();
-            return beforeConsume(message);
+            return message;
         } catch (Exception e) {
             ExceptionHandler.handleInterruptedException(e);
             throw PulsarClientException.unwrap(e);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.Lists;
 import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -108,6 +109,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     private final MessageIdAdv startMessageId;
     private volatile boolean duringSeek = false;
     private final long startMessageRollbackDurationInSec;
+    private final ConsumerInterceptors<T> internalConsumerInterceptors;
     MultiTopicsConsumerImpl(PulsarClientImpl client, ConsumerConfigurationData<T> conf,
             ExecutorProvider executorProvider, CompletableFuture<Consumer<T>> subscribeFuture, Schema<T> schema,
             ConsumerInterceptors<T> interceptors, boolean createTopicIfDoesNotExist) {
@@ -137,6 +139,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             long startMessageRollbackDurationInSec) {
         super(client, singleTopic, conf, Math.max(2, conf.getReceiverQueueSize()), executorProvider, subscribeFuture,
                 schema, interceptors);
+        this.internalConsumerInterceptors = getInternalConsumerInterceptors(interceptors);
 
         checkArgument(conf.getReceiverQueueSize() > 0,
             "Receiver queue size needs to be greater than 0 for Topics Consumer");
@@ -316,7 +319,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         CompletableFuture<Message<T>> receivedFuture = nextPendingReceive();
         if (receivedFuture != null) {
             unAckedMessageTracker.add(topicMessage.getMessageId(), topicMessage.getRedeliveryCount());
-            completePendingReceive(receivedFuture, topicMessage);
+            final Message<T> interceptMessage = beforeConsume(topicMessage);
+            completePendingReceive(receivedFuture, interceptMessage);
         } else if (enqueueMessageAndCheckBatchReceive(topicMessage) && hasPendingBatchReceive()) {
             notifyPendingBatchReceivedCallBack();
         }
@@ -369,7 +373,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             checkState(message instanceof TopicMessageImpl);
             unAckedMessageTracker.add(message.getMessageId(), message.getRedeliveryCount());
             resumeReceivingFromPausedConsumersIfNeeded();
-            return message;
+            return beforeConsume(message);
         } catch (Exception e) {
             ExceptionHandler.handleInterruptedException(e);
             throw PulsarClientException.unwrap(e);
@@ -390,7 +394,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 trackUnAckedMsgIfNoListener(message.getMessageId(), message.getRedeliveryCount());
             }
             resumeReceivingFromPausedConsumersIfNeeded();
-            return message;
+            return beforeConsume(message);
         } catch (Exception e) {
             ExceptionHandler.handleInterruptedException(e);
             throw PulsarClientException.unwrap(e);
@@ -447,7 +451,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 checkState(message instanceof TopicMessageImpl);
                 unAckedMessageTracker.add(message.getMessageId(), message.getRedeliveryCount());
                 resumeReceivingFromPausedConsumersIfNeeded();
-                result.complete(message);
+                result.complete(beforeConsume(message));
             }
         });
         return result;
@@ -1185,7 +1189,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         return ConsumerImpl.newConsumerImpl(client, partitionName,
                 configurationData, client.externalExecutorProvider(),
                 partitionIndex, true, listener != null, subFuture,
-                startMessageId, schema, interceptors,
+                startMessageId, schema, this.internalConsumerInterceptors,
                 createIfDoesNotExist, startMessageRollbackDurationInSec);
     }
 
@@ -1594,5 +1598,46 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             Collections.sort(list);
             return list;
         });
+    }
+
+    private ConsumerInterceptors<T> getInternalConsumerInterceptors(ConsumerInterceptors<T> interceptors) {
+        return new ConsumerInterceptors<T>(new ArrayList<>()) {
+
+            @Override
+            public Message<T> beforeConsume(Consumer<T> consumer, Message<T> message) {
+                return message;
+            }
+
+            @Override
+            public void onAcknowledge(Consumer<T> consumer, MessageId messageId, Throwable exception) {
+                interceptors.onAcknowledge(consumer, messageId, exception);
+            }
+
+            @Override
+            public void onAcknowledgeCumulative(Consumer<T> consumer,
+                                                MessageId messageId, Throwable exception) {
+                interceptors.onAcknowledgeCumulative(consumer, messageId, exception);
+            }
+
+            @Override
+            public void onNegativeAcksSend(Consumer<T> consumer, Set<MessageId> set) {
+                interceptors.onNegativeAcksSend(consumer, set);
+            }
+
+            @Override
+            public void onAckTimeoutSend(Consumer<T> consumer, Set<MessageId> set) {
+                interceptors.onAckTimeoutSend(consumer, set);
+            }
+
+            @Override
+            public void onPartitionsChange(String topicName, int partitions) {
+                interceptors.onPartitionsChange(topicName, partitions);
+            }
+
+            @Override
+            public void close() throws IOException {
+                interceptors.close();
+            }
+        };
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -1601,7 +1601,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         });
     }
 
-    private ConsumerInterceptors<T> getInternalConsumerInterceptors(ConsumerInterceptors<T> interceptors) {
+    private ConsumerInterceptors<T> getInternalConsumerInterceptors(ConsumerInterceptors<T> multiTopicInterceptors) {
         return new ConsumerInterceptors<T>(new ArrayList<>()) {
 
             @Override
@@ -1611,33 +1611,33 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
             @Override
             public void onAcknowledge(Consumer<T> consumer, MessageId messageId, Throwable exception) {
-                interceptors.onAcknowledge(consumer, messageId, exception);
+                multiTopicInterceptors.onAcknowledge(consumer, messageId, exception);
             }
 
             @Override
             public void onAcknowledgeCumulative(Consumer<T> consumer,
                                                 MessageId messageId, Throwable exception) {
-                interceptors.onAcknowledgeCumulative(consumer, messageId, exception);
+                multiTopicInterceptors.onAcknowledgeCumulative(consumer, messageId, exception);
             }
 
             @Override
             public void onNegativeAcksSend(Consumer<T> consumer, Set<MessageId> set) {
-                interceptors.onNegativeAcksSend(consumer, set);
+                multiTopicInterceptors.onNegativeAcksSend(consumer, set);
             }
 
             @Override
             public void onAckTimeoutSend(Consumer<T> consumer, Set<MessageId> set) {
-                interceptors.onAckTimeoutSend(consumer, set);
+                multiTopicInterceptors.onAckTimeoutSend(consumer, set);
             }
 
             @Override
             public void onPartitionsChange(String topicName, int partitions) {
-                interceptors.onPartitionsChange(topicName, partitions);
+                multiTopicInterceptors.onPartitionsChange(topicName, partitions);
             }
 
             @Override
             public void close() throws IOException {
-                interceptors.close();
+                multiTopicInterceptors.close();
             }
         };
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -139,7 +139,11 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             long startMessageRollbackDurationInSec) {
         super(client, singleTopic, conf, Math.max(2, conf.getReceiverQueueSize()), executorProvider, subscribeFuture,
                 schema, interceptors);
-        this.internalConsumerInterceptors = getInternalConsumerInterceptors(interceptors);
+        if (interceptors != null) {
+           this.internalConsumerInterceptors = getInternalConsumerInterceptors(interceptors);
+        } else {
+            this.internalConsumerInterceptors = null;
+        }
 
         checkArgument(conf.getReceiverQueueSize() > 0,
             "Receiver queue size needs to be greater than 0 for Topics Consumer");


### PR DESCRIPTION
### Motivation

When using MultiTopicConsumer with ConsumerInterceptor , the `beforeConsume` method was hit many times
before receiving the first message. The root cause of this is that before the MultiTopicsConsumer receives the message, MultiTopicsConsumer has already completed receiving the message from the internal consumer and executed the `beforeConsume` method, so we can let `beforeConsume` be called in MultiTopicsConsumer to avoid this issue.

https://github.com/apache/pulsar/blob/8707fbe8351fb6ac4337fbd88d86eb32aff55b04/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java#L228-L254

### Modifications

* Call `beforeConsume` method in MultiTopicsConsumer.
* Wrap ConsumerInterceptors for internal consumer the  and remove `beforeConsume` logic

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
