### PR TITLE
[improve] [pip] PIP-371: Support for request-reply model that implements RPC calls

### DIFF
--- a/pip/pip-371.md
+++ b/pip/pip-371.md
@@ -35,7 +35,8 @@ This request-reply model can greatly enhance the utility of Pulsar. We can then 
 
 Why would we use Pulsar for this RPC call?
 
-- The implementation of RPC based on pulsar can unify the two systems of MQ and RPC. We only need to use Pulsar.
+- This proposal to achieve the function is `request`. `Request` and existing send function of pulsar can be mixed to same topic. This means that the user can choose, and the call to the server side (consumer) can be asynchronous or synchronous, which is controlled by the user flexibly.
+- Similar enhancements can be implemented in [pulsar-spring](https://github.com/spring-projects/spring-pulsar), just like [rocketmq-spring#209](https://github.com/apache/rocketmq-spring/pull/209). However, this proposal does not use the solution of storing the request and reply result topics. After the consumer processing request is message, the processing result is directly sent to the broker and finally passed to the original producer. This call of link has one less message publishing and subscription of reply result, and its performance is higher than that of other request-reply models.
 - You can directly use Pulsar's own load balancing mechanism.
 - You can directly use Pulsar's own message consumption throttling mechanism.
 - You can directly use Pulsar's own expansion and contraction mechanism.

--- a/pip/pip-371.md
+++ b/pip/pip-371.md
@@ -367,5 +367,5 @@ None
 
 # Links
 
-* Mailing List discussion thread: https://lists.apache.org/thread/
+* Mailing List discussion thread: https://lists.apache.org/thread/42hrf8f5r7yno05hrr6fcz6lgf4jr9f7
 * Mailing List voting thread:

--- a/pip/pip-371.md
+++ b/pip/pip-371.md
@@ -1,0 +1,371 @@
+# PIP-371: Support for request-reply model that implements RPC calls
+
+# Background knowledge
+
+## Request-Reply Synchronize Model
+
+In this model, the client sends a request and waits for a response from the server. The server receives the request, processes it, and sends back a response. This interaction pattern is fundamental in client-server communication and is crucial for synchronous operations where the client needs a response before proceeding.
+
+## Remote Procedure Call (RPC)
+
+RPC allows functions or procedures to be executed on a different machine from the client making the call, as if they were local. This method abstracts the complexities of network communication, allowing developers to focus on the business logic rather than the underlying network details.
+
+The implementation of RPC is usually based on the Request-Reply model. In this case:
+
+- The RPC client plays the role of the requester, calling a remote procedure as if it were sending a request message.
+- The RPC server plays the role of the responder, receiving the request, executing the procedure, and returning the result as a reply message.
+
+## Current behavior of sending messages in Pulsar
+
+The current sending behavior of Pulsar is when the message is successfully published, that is, successfully persisted to the storage layer. The MessageId assigned to the published message by the broker is returned.
+
+## Analogies of message flow in RPC and Pulsar
+
+- In Pulsar, producer is equivalent to RPC Client.
+- The RPC Client initiates a request like sending a message producer.
+- The RPC Server side receives this request as if the consumer receives the message and then carries out customized processing, and finally ACKs the message.
+- If this ACK request contains the result returned by the "server side" and is sent to the original Producer
+- After receiving the results returned by the consumer, the Producer directly returns the content of the results.
+
+# Motivation
+
+As we known，Pulsar's current **asynchronous** publish-subscribe model serves well for decoupled message distribution, but it lacks a native mechanism for handling **synchronous** interactions typical of Remote Procedure Calls (RPC).
+
+This request-reply model can greatly enhance the utility of Pulsar. We can then use Pulsar as RPC.
+
+Why would we use Pulsar for this RPC call?
+
+- The implementation of RPC based on pulsar can unify the two systems of MQ and RPC. We only need to use Pulsar.
+- You can directly use Pulsar's own load balancing mechanism.
+- You can directly use Pulsar's own message consumption throttling mechanism.
+- You can directly use Pulsar's own expansion and contraction mechanism.
+- You can directly use Pulsar's own message call tracking, monitoring, and logging mechanisms.
+
+# Goals
+
+## In Scope
+
+- Implement a new client api. After calling the new api, the producer needs to wait for the message to be ACK by any consumer and return the reply message set after consumer processing.
+- When consumer process and ack the request message, the reply message and which Producer sent the request are passed to the broker, and finally the broker sends the reply message to the corresponding producer.
+
+## Out of Scope
+
+None
+
+# High Level Design
+
+## Implementing RPC in Pulsar
+
+In Apache Pulsar, implementing an RPC model involves the producer sending a request message to a specified topic and waiting for a reply message. Here’s how it can be structured:
+
+1. **Producer Operations**:
+    - **(Existing functions) Sending Request Message**: The producer publishes a message to a 'request-topic'. This message includes all necessary data for the server(consumer) to process the request.
+    - **(The new function) Waiting for Reply Message**: The producer waits for the request message to be consumed by any consumer and the reply Message returned after consumer acknowledged the request message.
+
+2. **Broker Operations**:
+    - **(Existing function) Receive and persist messages normally**: The server subscribes to the 'request-topic' and listens for incoming messages.
+    - **(Existing function) Message distribution to Consumer**: Messages are sent to the consumer and received and processed by the consumer.
+    - **(The new function) Handle the ACK request from the Consumer and send the ReplyMessage payload to the given Producer(Client)**: After the ACK request from the Consumer arrives at the broker, the existing ACK logic processes it normally. However, after the processing is completed, it is confirmed by the `reply_to_client` contained in the ACK request to which client it is sent. The ReplyMessage payload included in the ACK request is also sent to the client. **Note here that the internal implementation is to send the ReplyMessage first, then the asynchronous ACK.**
+
+3. **Consumer Operations:**
+    - **(Existing function) Receive and process the request message**: The consumer side receives the message and performs custom processing.
+    - **(The new function) Initiate an ACK request and carry the content of the reply**: The Consumer initiates an ACK request, which indicates that the consumer has processed the message. This is an existing function. The place to be modified is mainly to carry the content of the reply, which is sent to the Broker and then directly to the original Producer.
+
+### Handling Timeouts
+
+- The timeout period is set through the newly added client api, which can set a different timeout period for each message. On the producer side, there will be a `requestCallBack` collection with a timeout, where the key is the `MessageId` that the producer normally publishes messages to the broker and returns. If the timeout period is exceeded, a `TimeoutException` is returned and can be processed accordingly in the application.
+- There are two cases of timeout. One is that the request task has timed out after the message is normally published to the broker and successfully persisted. This situation will allow the consumer to continue processing, but the producer will be directly returned to the application TimeoutException. When processing each message, the Consumer side will obtain the time of initiating the request (or use receivedMsg.getPublishTime()) plus the timeout in the message properties. If it is less than or equal to the current time, the normal ACK message. (This part is handled by the application) Although it has timed out, this message should be "discarded" consumer just ack normally.
+- The other is to time out when doing application customization processing on the consumer side. This part is also handled by the application. If, after processing, it is checked whether the current is greater than the time to initiate the request plus the timeout in the message properties. If it is greater than then the normal ACK message, although it has timed out, the message is "discarded", and more importantly, the application needs to implement rollback logic. Because if the status of some data on the business is changed, but the request times out, it is considered a call failure and needs to be rollback.
+
+# Detailed Design
+
+## Design & Implementation Details
+
+**Let's take a simple example to see how we can use the new API:**
+
+```java
+    @Test
+    public void testRequestReplyCallMode() throws Exception {
+        final String topic = "persistent://my-property/my-ns/testRequestReplyCallMode";
+        final long requestTTL = 3000;
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).enableBatching(false)
+                .producerName("requestClient")
+                .create();
+
+        final String REPLY_CONTENT_PREFIX = "reply message content: ";
+        final String REPLY_ERROR_PREFIX = "reply error: ";
+        @Cleanup
+        Consumer<byte[]> consumer1 = pulsarClient.newConsumer().topic(topic)
+                .subscriptionType(SubscriptionType.Shared)
+                .consumerName("consumer1")
+                .messageListener((consumer, receivedMsg) -> {
+                    if (receivedMsg.hasProperty(Constants.REQUEST_TIMEOUT_MILLIS) &&
+                            System.currentTimeMillis() >= receivedMsg.getPublishTime() +
+                            Long.parseLong(receivedMsg.getProperty(Constants.REQUEST_TIMEOUT_MILLIS))) {
+                        consumer.acknowledgeAsync(receivedMsg);
+                        return;
+                    }
+
+                    try {
+                        // Do your custom processing here.
+                        // process(receivedMsg);
+
+                        if (receivedMsg.hasProperty(Constants.REQUEST_TIMEOUT_MILLIS) &&
+                                System.currentTimeMillis() >= receivedMsg.getPublishTime() +
+                                        Long.parseLong(receivedMsg.getProperty(Constants.REQUEST_TIMEOUT_MILLIS))) {
+                            // Call your own implemented rollback here.
+                            // rollBack(receivedMsg);
+                            consumer.acknowledgeAsync(receivedMsg);
+                            return;
+                        }
+
+                        String receivedMessage = new String(receivedMsg.getData());
+                        log.info("Received message [{}] in the listener", receivedMessage);
+                        byte[] replyPayload = (REPLY_CONTENT_PREFIX + receivedMessage).getBytes(UTF_8);
+                        consumer.acknowledgeAsync(replyPayload, false, receivedMsg.getMessageId());
+                    } catch (Exception e) {
+                        byte[] replyErrorPayload = (REPLY_ERROR_PREFIX + e.getCause()).getBytes(UTF_8);
+                        consumer.acknowledgeAsync(replyErrorPayload, true, receivedMsg.getMessageId());
+                    }
+                }).subscribe();
+
+        // 1.Synchronous Send.
+        ReplyResult replyResult = producer.newMessage().value("SynchronousRequest1".getBytes(UTF_8))
+                .request(rpcTTL, TimeUnit.MILLISECONDS);
+        log.info("ReplyResult: " + replyResult);
+
+        // 2.Asynchronous Send.
+        producer.newMessage().value("AsynchronousRequest1".getBytes(UTF_8))
+                .requestAsync(rpcTTL, TimeUnit.MILLISECONDS)
+                .whenComplete((replyMessage, e) -> {
+                    if (e != null) {
+                        log.error("error", e);
+                    } else {
+                        log.info("Reply message: " + replyMessage);
+                    }
+                });
+    }
+```
+
+## Public-facing Changes
+
+### Public API
+
+We also need a replyMessage return value that initiates the request as the client side (producer) and finally gets the response:
+
+```java
+package org.apache.pulsar.client.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class ReplyResult {
+    // request message MessageId
+    MessageId requestMessageId;
+    // reply result
+    byte[] replyContent;
+    boolean isErrorResult;
+}
+```
+
+### Binary protocol
+
+Add `reply_to_client` field to the `CommandAck`.
+
+```protobuf
+message CommandAck {
+    ......
+
+    // In case of individual acks, the client can pass a list of message ids
+    repeated MessageIdData message_id = 3;
+
+    // Acks can contain a flag to indicate the consumer
+    // received an invalid message that got discarded
+    // before being passed on to the application.
+    enum ValidationError {
+        UncompressedSizeCorruption = 0;
+        DecompressionError = 1;
+        ChecksumMismatch = 2;
+        BatchDeSerializeError = 3;
+        DecryptionError = 4;
+    }
+
+    optional ValidationError validation_error = 4;
+    ......
+
+    optional string reply_to_client = 9;
+}
+```
+
+We need to send the `message_id` and `reply_to_client` to the corresponding Client in the Broker after the message is ACK, so we need a new `Response`.
+
+```protobuf
+message CommandRequestReceipt {
+    required uint64 reply_to_producer_id    = 1;
+    optional MessageIdData request_message_id = 2;
+}
+```
+
+### Configuration
+
+### CLI
+
+add api `request` to the Producer and TypedMessageBuilder, which includes synchronous and asynchronous calls.
+
+**org.apache.pulsar.client.api.Producer#request**
+
+```java
+		/**
+     * Sends a message synchronously.(Request-Reply mode)
+     *
+     * <p>This call will be blocking until either consumer successfully processed and acknowledged the request
+     * message. Finally, a reply message will be returned.
+     *
+     * <p>Use {@link #newMessage()} to specify more properties than just the value on the message to be sent.
+     *
+     * @param message
+     *            request message
+     * @return the reply message from consumer
+     * @throws PulsarClientException.TimeoutException
+     *             if the message was not correctly received and processed by the system within the timeout period
+     * @throws PulsarClientException.AlreadyClosedException
+     *             if the producer was already closed
+     */
+    ReplyResult request(T message, long timeout, TimeUnit timeUnit) throws PulsarClientException;
+
+    /**
+     * Send a message asynchronously.(Request-Reply mode)
+     *
+     * <p>When the producer queue is full, by default this method will complete the future with an exception
+     * {@link PulsarClientException.ProducerQueueIsFullError}
+     *
+     * <p>See {@link ProducerBuilder#maxPendingMessages(int)} to configure the producer queue size and
+     * {@link ProducerBuilder#blockIfQueueFull(boolean)} to change the blocking behavior.
+     *
+     * <p>Use {@link #newMessage()} to specify more properties than just the value on the message to be sent.
+     *
+     * @param message
+     *            a byte array with the payload of the message
+     * @return A future that can be used to track when a request message is successfully acknowledged
+     * and returns a reply result
+     */
+    CompletableFuture<ReplyResult> requestAsync(T message, long timeout, TimeUnit timeUnit);
+```
+
+**org.apache.pulsar.client.api.TypedMessageBuilder#request**
+
+```java
+/**
+     * Send a message synchronously.(Request-Reply mode)
+     *
+     * <p>This method will block until either consumer successfully acknowledged the message
+     * and returns a reply message.
+     * Finally, the {@link ReplyResult} returned by the Consumer is returned.
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
+     * ReplyResult replyResult = producer.newMessage()
+     *                  .key(myKey)
+     *                  .value(myValue)
+     *                  .request();
+     * System.out.println("Reply result: " + replyResult);
+     * }</pre>
+     *
+     * @return the {@link ReplyResult} returned by the Consumer
+     */
+    ReplyResult request(long timeout, TimeUnit unit) throws PulsarClientException;
+
+    /**
+     * Send a message asynchronously.(Request-Reply mode)
+     *
+     * <p>This method returns a future that can be used to track the completion of the request operation and yields the
+     * {@link ReplyResult} send by the consumer to the producer.
+     *
+     * <p>Example:
+     *
+     * <pre>
+     * <code>producer.newMessage()
+     *                  .value(myValue)
+     *                  .requestAsync().thenAccept(replyResult -> {
+     *    System.out.println("Reply result: " + replyResult);
+     * }).exceptionally(e -> {
+     *    System.out.println("Failed to publish " + e);
+     *    return null;
+     * });</code>
+     * </pre>
+     *
+     * <p>When the producer queue is full, by default this method will complete the future with an exception
+     * {@link PulsarClientException.ProducerQueueIsFullError}
+     *
+     * <p>See {@link ProducerBuilder#maxPendingMessages(int)} to configure the producer queue size and
+     * {@link ProducerBuilder#blockIfQueueFull(boolean)} to change the blocking behavior.
+     *
+     * @return a future that can be used to track when the reply message will have been returned
+     */
+    CompletableFuture<ReplyResult> requestAsync(long timeout, TimeUnit unit);
+```
+
+**org.apache.pulsar.client.api.MessageAcknowledger**
+
+```java
+		/**
+     * Acknowledge the consumption of a single message, and carry ReplyMessage content.
+     *
+     * @param replyPayload Results returned by the application after the message has been processed
+     * @param isErrorMessage Whether a reply result contains an error.
+     * @param messageId {@link MessageId} to be individual acknowledged
+     *
+     * @throws PulsarClientException.AlreadyClosedException}
+     *             if the consumer was already closed
+     * @throws PulsarClientException.NotAllowedException
+     *             if `messageId` is not a {@link TopicMessageId} when multiple topics are subscribed
+     */
+    void acknowledge(byte[] replyPayload, boolean isErrorMessage, MessageId messageId) throws PulsarClientException;
+
+    default void acknowledge(byte[] replyPayload, boolean isErrorMessage, Message<?> message) throws PulsarClientException {
+        acknowledge(replyPayload, isErrorMessage, message.getMessageId());
+    }
+
+		/**
+     * The asynchronous version of {@link #acknowledge(byte[], boolean, MessageId)} with transaction support.
+     */
+    CompletableFuture<Void> acknowledgeAsync(byte[] replyPayload, boolean isErrorMessage, MessageId messageId);
+```
+
+### Metrics
+
+# Monitoring
+
+No new metrics are added in this proposal.
+
+# Security Considerations
+
+No new security considerations are added in this proposal.
+
+# Backward & Forward Compatibility
+
+## Revert
+
+No changes are needed to revert to the previous version.
+
+## Upgrade
+
+No other changes are needed to upgrade to the new version.
+
+# Alternatives
+
+None
+
+# General Notes
+
+# Links
+
+* Mailing List discussion thread: https://lists.apache.org/thread/
+* Mailing List voting thread:

--- a/pip/pip-371.md
+++ b/pip/pip-371.md
@@ -37,6 +37,7 @@ Why would we use Pulsar for this RPC call?
 
 - This proposal to achieve the function is `request`. `Request` and existing send function of pulsar can be mixed to same topic. This means that the user can choose, and the call to the server side (consumer) can be asynchronous or synchronous, which is controlled by the user flexibly.
 - Similar enhancements can be implemented in [pulsar-spring](https://github.com/spring-projects/spring-pulsar), just like [rocketmq-spring#209](https://github.com/apache/rocketmq-spring/pull/209). However, this proposal does not use the solution of storing the request and reply result topics. After the consumer processing request is message, the processing result is directly sent to the broker and finally passed to the original producer. This call of link has one less message publishing and subscription of reply result, and its performance is higher than that of other request-reply models.
+- You can directly use Pulsar's own delaying messages, that is, you can execute RPC regularly.
 - You can directly use Pulsar's own load balancing mechanism.
 - You can directly use Pulsar's own message consumption throttling mechanism.
 - You can directly use Pulsar's own expansion and contraction mechanism.


### PR DESCRIPTION
### Motivation

As we known，Pulsar's current **asynchronous** publish-subscribe model serves well for decoupled message distribution, but it lacks a native mechanism for handling **synchronous** interactions typical of Remote Procedure Calls (RPC).

This request-reply model can greatly enhance the utility of Pulsar. We can then use Pulsar as RPC.

### Modifications

<!-- Describe the modifications you've done. -->

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
