### PR TITLE
[improve][broker] Explicitly close LB internal topics when playing a follower (ExtensibleLoadManagerImpl only)

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -102,7 +102,6 @@ import org.apache.pulsar.broker.loadbalance.extensions.models.SplitDecision;
 import org.apache.pulsar.broker.loadbalance.extensions.models.UnloadCounter;
 import org.apache.pulsar.broker.loadbalance.extensions.reporter.BrokerLoadDataReporter;
 import org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedder;
-import org.apache.pulsar.broker.loadbalance.extensions.store.LoadDataStore;
 import org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl;
 import org.apache.pulsar.broker.lookup.LookupResult;
 import org.apache.pulsar.broker.namespace.LookupOptions;
@@ -122,7 +121,6 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.LookupService;
-import org.apache.pulsar.client.impl.TableViewImpl;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.ServiceUnitId;
@@ -134,6 +132,7 @@ import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.NamespaceOwnershipStatus;
 import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
 import org.apache.pulsar.policies.data.loadbalancer.ResourceUsage;
 import org.apache.pulsar.policies.data.loadbalancer.SystemResourceUsage;
 import org.awaitility.Awaitility;
@@ -1186,55 +1185,49 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
         assertEquals(result, expectedBrokerServiceUrl);
     }
 
-    @Test(priority = 10)
-    public void testTopBundlesLoadDataStoreTableViewFromChannelOwner() throws Exception {
-        var topBundlesLoadDataStorePrimary =
-                (LoadDataStore) FieldUtils.readDeclaredField(primaryLoadManager, "topBundlesLoadDataStore", true);
-        var serviceUnitStateChannelPrimary =
-                (ServiceUnitStateChannelImpl) FieldUtils.readDeclaredField(primaryLoadManager,
-                        "serviceUnitStateChannel", true);
-        var tvPrimary =
-                (TableViewImpl) FieldUtils.readDeclaredField(topBundlesLoadDataStorePrimary, "tableView", true);
 
-        var topBundlesLoadDataStoreSecondary =
-                (LoadDataStore) FieldUtils.readDeclaredField(secondaryLoadManager, "topBundlesLoadDataStore", true);
-        var tvSecondary =
-                (TableViewImpl) FieldUtils.readDeclaredField(topBundlesLoadDataStoreSecondary, "tableView", true);
-
-        if (serviceUnitStateChannelPrimary.isChannelOwnerAsync().get(5, TimeUnit.SECONDS)) {
-            assertNotNull(tvPrimary);
-            assertNull(tvSecondary);
-        } else {
-            assertNull(tvPrimary);
-            assertNotNull(tvSecondary);
+    private void makePrimaryAsLeader() throws Exception {
+        log.info("makePrimaryAsLeader");
+        if (channel2.isChannelOwner()) {
+            pulsar2.getLeaderElectionService().close();
+            Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+                assertTrue(channel1.isChannelOwner());
+            });
+            pulsar2.getLeaderElectionService().start();
         }
 
-        restartBroker();
-        pulsar1 = pulsar;
-        setPrimaryLoadManager();
-        admin.namespaces().setNamespaceReplicationClusters(defaultTestNamespace,
-                Sets.newHashSet(this.conf.getClusterName()));
-
-        var serviceUnitStateChannelPrimaryNew =
-                (ServiceUnitStateChannelImpl) FieldUtils.readDeclaredField(primaryLoadManager,
-                        "serviceUnitStateChannel", true);
-        var topBundlesLoadDataStorePrimaryNew =
-                (LoadDataStore) FieldUtils.readDeclaredField(primaryLoadManager, "topBundlesLoadDataStore"
-                        , true);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
-                    assertFalse(serviceUnitStateChannelPrimaryNew.isChannelOwnerAsync().get(5, TimeUnit.SECONDS));
-                    assertNotNull(FieldUtils.readDeclaredField(topBundlesLoadDataStoreSecondary, "tableView"
-                            , true));
-                    assertNull(FieldUtils.readDeclaredField(topBundlesLoadDataStorePrimaryNew, "tableView"
-                            , true));
-                }
-        );
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertTrue(channel1.isChannelOwner());
+        });
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertFalse(channel2.isChannelOwner());
+        });
     }
 
-    @Test
-    public void testRoleChange() throws Exception {
-        var topBundlesLoadDataStorePrimary = (LoadDataStore<TopBundlesLoadData>)
-                FieldUtils.readDeclaredField(primaryLoadManager, "topBundlesLoadDataStore", true);
+    private void makeSecondaryAsLeader() throws Exception {
+        log.info("makeSecondaryAsLeader");
+        if (channel1.isChannelOwner()) {
+            pulsar1.getLeaderElectionService().close();
+            Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+                assertTrue(channel2.isChannelOwner());
+            });
+            pulsar1.getLeaderElectionService().start();
+        }
+
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertTrue(channel2.isChannelOwner());
+        });
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertFalse(channel1.isChannelOwner());
+        });
+    }
+
+    @Test(timeOut = 30 * 1000)
+    public void testRoleChangeIdempotency() throws Exception {
+
+        makePrimaryAsLeader();
+
+        var topBundlesLoadDataStorePrimary = primaryLoadManager.getTopBundlesLoadDataStore();
         var topBundlesLoadDataStorePrimarySpy = spy(topBundlesLoadDataStorePrimary);
         AtomicInteger countPri = new AtomicInteger(3);
         AtomicInteger countPri2 = new AtomicInteger(3);
@@ -1255,8 +1248,7 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
             return null;
         }).when(topBundlesLoadDataStorePrimarySpy).closeTableView();
 
-        var topBundlesLoadDataStoreSecondary = (LoadDataStore<TopBundlesLoadData>)
-                FieldUtils.readDeclaredField(secondaryLoadManager, "topBundlesLoadDataStore", true);
+        var topBundlesLoadDataStoreSecondary = secondaryLoadManager.getTopBundlesLoadDataStore();
         var topBundlesLoadDataStoreSecondarySpy = spy(topBundlesLoadDataStoreSecondary);
         AtomicInteger countSec = new AtomicInteger(3);
         AtomicInteger countSec2 = new AtomicInteger(3);
@@ -1284,57 +1276,128 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
                     topBundlesLoadDataStoreSecondarySpy, true);
 
 
-            if (channel1.isChannelOwnerAsync().get(5, TimeUnit.SECONDS)) {
-                primaryLoadManager.playLeader();
-                secondaryLoadManager.playFollower();
-                verify(topBundlesLoadDataStorePrimarySpy, times(3)).startTableView();
-                verify(topBundlesLoadDataStorePrimarySpy, times(5)).closeTableView();
-                verify(topBundlesLoadDataStoreSecondarySpy, times(0)).startTableView();
-                verify(topBundlesLoadDataStoreSecondarySpy, times(3)).closeTableView();
-            } else {
-                primaryLoadManager.playFollower();
-                secondaryLoadManager.playLeader();
-                verify(topBundlesLoadDataStoreSecondarySpy, times(3)).startTableView();
-                verify(topBundlesLoadDataStoreSecondarySpy, times(5)).closeTableView();
-                verify(topBundlesLoadDataStorePrimarySpy, times(0)).startTableView();
-                verify(topBundlesLoadDataStorePrimarySpy, times(3)).closeTableView();
-            }
+
+            primaryLoadManager.playLeader();
+            secondaryLoadManager.playFollower();
+            verify(topBundlesLoadDataStorePrimarySpy, times(3)).startTableView();
+            verify(topBundlesLoadDataStorePrimarySpy, times(5)).closeTableView();
+            verify(topBundlesLoadDataStoreSecondarySpy, times(0)).startTableView();
+            verify(topBundlesLoadDataStoreSecondarySpy, times(3)).closeTableView();
+
 
             primaryLoadManager.playFollower();
             secondaryLoadManager.playFollower();
+            assertEquals(ExtensibleLoadManagerImpl.Role.Leader,
+                    primaryLoadManager.getRole());
+            assertEquals(ExtensibleLoadManagerImpl.Role.Follower,
+                    secondaryLoadManager.getRole());
 
-            if (channel1.isChannelOwnerAsync().get(5, TimeUnit.SECONDS)) {
-                assertEquals(ExtensibleLoadManagerImpl.Role.Leader,
-                        FieldUtils.readDeclaredField(primaryLoadManager, "role", true));
-                assertEquals(ExtensibleLoadManagerImpl.Role.Follower,
-                        FieldUtils.readDeclaredField(secondaryLoadManager, "role", true));
-            } else {
-                assertEquals(ExtensibleLoadManagerImpl.Role.Follower,
-                        FieldUtils.readDeclaredField(primaryLoadManager, "role", true));
-                assertEquals(ExtensibleLoadManagerImpl.Role.Leader,
-                        FieldUtils.readDeclaredField(secondaryLoadManager, "role", true));
-            }
 
             primaryLoadManager.playLeader();
             secondaryLoadManager.playLeader();
+            assertEquals(ExtensibleLoadManagerImpl.Role.Leader,
+                    primaryLoadManager.getRole());
+            assertEquals(ExtensibleLoadManagerImpl.Role.Follower,
+                    secondaryLoadManager.getRole());
 
-            if (channel1.isChannelOwnerAsync().get(5, TimeUnit.SECONDS)) {
-                assertEquals(ExtensibleLoadManagerImpl.Role.Leader,
-                        FieldUtils.readDeclaredField(primaryLoadManager, "role", true));
-                assertEquals(ExtensibleLoadManagerImpl.Role.Follower,
-                        FieldUtils.readDeclaredField(secondaryLoadManager, "role", true));
-            } else {
-                assertEquals(ExtensibleLoadManagerImpl.Role.Follower,
-                        FieldUtils.readDeclaredField(primaryLoadManager, "role", true));
-                assertEquals(ExtensibleLoadManagerImpl.Role.Leader,
-                        FieldUtils.readDeclaredField(secondaryLoadManager, "role", true));
-            }
         } finally {
             FieldUtils.writeDeclaredField(primaryLoadManager, "topBundlesLoadDataStore",
                     topBundlesLoadDataStorePrimary, true);
             FieldUtils.writeDeclaredField(secondaryLoadManager, "topBundlesLoadDataStore",
                     topBundlesLoadDataStoreSecondary, true);
         }
+    }
+    @Test(timeOut = 30 * 1000)
+    public void testRoleChange() throws Exception {
+        makePrimaryAsLeader();
+
+        var leader = primaryLoadManager;
+        var follower = secondaryLoadManager;
+
+        BrokerLoadData brokerLoadExpected = new BrokerLoadData();
+        SystemResourceUsage usage = new SystemResourceUsage();
+        var cpu = new ResourceUsage(1.0, 100.0);
+        String key = "b1";
+        usage.setCpu(cpu);
+        brokerLoadExpected.update(usage, 0, 0, 0, 0, 0, 0, conf);
+        String bundle = "public/default/0x00000000_0xffffffff";
+        TopBundlesLoadData topBundlesExpected = new TopBundlesLoadData();
+        topBundlesExpected.getTopBundlesLoadData().clear();
+        topBundlesExpected.getTopBundlesLoadData().add(new TopBundlesLoadData.BundleLoadData(bundle, new NamespaceBundleStats()));
+
+        follower.getBrokerLoadDataStore().pushAsync(key, brokerLoadExpected);
+        follower.getTopBundlesLoadDataStore().pushAsync(bundle, topBundlesExpected);
+
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+
+            assertNotNull(FieldUtils.readDeclaredField(leader.getTopBundlesLoadDataStore(), "tableView", true));
+            assertNull(FieldUtils.readDeclaredField(follower.getTopBundlesLoadDataStore(), "tableView", true));
+
+            for (String internalTopic : ExtensibleLoadManagerImpl.INTERNAL_TOPICS) {
+                assertTrue(leader.pulsar.getBrokerService().getTopicReference(internalTopic)
+                        .isPresent());
+                assertTrue(follower.pulsar.getBrokerService().getTopicReference(internalTopic)
+                        .isEmpty());
+
+                assertTrue(leader.pulsar.getNamespaceService()
+                        .isServiceUnitOwnedAsync(TopicName.get(internalTopic)).get());
+                assertFalse(follower.pulsar.getNamespaceService()
+                        .isServiceUnitOwnedAsync(TopicName.get(internalTopic)).get());
+            }
+
+            var actualBrokerLoadLeader = leader.getBrokerLoadDataStore().get(key);
+            if (actualBrokerLoadLeader.isPresent()) {
+                assertEquals(actualBrokerLoadLeader.get(), brokerLoadExpected);
+            }
+
+            var actualTopBundlesLeader = leader.getTopBundlesLoadDataStore().get(bundle);
+            if (actualTopBundlesLeader.isPresent()) {
+                assertEquals(actualTopBundlesLeader.get(), topBundlesExpected);
+            }
+
+            var actualBrokerLoadFollower = follower.getBrokerLoadDataStore().get(key);
+            if (actualBrokerLoadFollower.isPresent()) {
+                assertEquals(actualBrokerLoadFollower.get(), brokerLoadExpected);
+            }
+        });
+
+        makeSecondaryAsLeader();
+
+        var leader2 = secondaryLoadManager;
+        var follower2 = primaryLoadManager;
+
+        brokerLoadExpected.update(usage, 1, 0, 0, 0, 0, 0, conf);
+        topBundlesExpected.getTopBundlesLoadData().get(0).stats().msgRateIn = 1;
+
+        follower.getBrokerLoadDataStore().pushAsync(key, brokerLoadExpected);
+        follower.getTopBundlesLoadDataStore().pushAsync(bundle, topBundlesExpected);
+
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(() -> {
+            assertNotNull(FieldUtils.readDeclaredField(leader2.getTopBundlesLoadDataStore(), "tableView", true));
+            assertNull(FieldUtils.readDeclaredField(follower2.getTopBundlesLoadDataStore(), "tableView", true));
+
+            for (String internalTopic : ExtensibleLoadManagerImpl.INTERNAL_TOPICS) {
+                assertTrue(leader2.pulsar.getBrokerService().getTopicReference(internalTopic)
+                        .isPresent());
+                assertTrue(follower2.pulsar.getBrokerService().getTopicReference(internalTopic)
+                        .isEmpty());
+
+                assertTrue(leader2.pulsar.getNamespaceService()
+                        .isServiceUnitOwnedAsync(TopicName.get(internalTopic)).get());
+                assertFalse(follower2.pulsar.getNamespaceService()
+                        .isServiceUnitOwnedAsync(TopicName.get(internalTopic)).get());
+            }
+
+
+            var actualBrokerLoadLeader = leader2.getBrokerLoadDataStore().get(key);
+            assertEquals(actualBrokerLoadLeader.get(), brokerLoadExpected);
+
+            var actualTopBundlesLeader = leader2.getTopBundlesLoadDataStore().get(bundle);
+            assertEquals(actualTopBundlesLeader.get(), topBundlesExpected);
+
+            var actualBrokerLoadFollower = follower2.getBrokerLoadDataStore().get(key);
+            assertEquals(actualBrokerLoadFollower.get(), brokerLoadExpected);
+        });
     }
 
     @Test


### PR DESCRIPTION

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->


Internal topics ownership conflict is a concern here when the leadership changes frequently - we should make sure only the current leader owns these internal topics.

The persistent internal topic can self-resolve this topic ownership conflict by the ledger fencing logic.

However, I think the non-persistent internal topics can be a problem because the fencing logic doesn't apply to non-persistent topics.

To gracefully release the previous ownership of these internal topics, I think we better make followers explicitly close the internal topics - when leadership changes, there might be a chance that some clients reconnect to the old leader if the connected zk and the old leader's zk are slow. Then, when the old leader zk catches up(notifies a follower signal to the old leader), the old leader should make sure to close any internal topics and its client connections, if any.

### Modifications

- call closeInternalTopics() inside playFollower() 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
