### PR TITLE
[fix] [broker] Let Pending ack handler can retry to init when encounters a metadata store error

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
@@ -41,6 +41,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.client.api.BKException;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
@@ -69,6 +70,7 @@ import org.apache.pulsar.common.util.Backoff;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.RecoverTimeRecord;
 import org.apache.pulsar.common.util.collections.BitSetRecyclable;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.transaction.common.exception.TransactionConflictException;
 
 /**
@@ -989,7 +991,9 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
                 && !(realCause instanceof ManagedLedgerException.NonRecoverableLedgerException))
                 || realCause instanceof PulsarClientException.BrokerPersistenceException
                 || realCause instanceof PulsarClientException.LookupException
-                || realCause instanceof PulsarClientException.ConnectException;
+                || realCause instanceof PulsarClientException.ConnectException
+                || realCause instanceof MetadataStoreException
+                || realCause instanceof BKException;
     }
 
     @Override


### PR DESCRIPTION
### Motivation

The Pending Ack handler can not recover after encountering a `MetadataStoreException` even the metadata store has been re-established.

```
2024-07-24T02:56:11,347+0000 [pulsar-transaction-executor-5-1] ERROR org.apache.pulsar.broker.transaction.pendingack.impl.PendingAckHandleImpl - [persistent://{tenant}/{ns}/{topic}] [multiTopicsReader-5c010a1ec8] PendingAckHandleImpl init fail!
org.apache.pulsar.metadata.api.MetadataStoreException: org.apache.zookeeper.KeeperException$ConnectionLossException: KeeperErrorCode = ConnectionLoss for /managed-ledgers/{tenant}/{namespace}/persistent/{topic}-multiTopicsReader-5c010a1ec8__transaction_pending_ack
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.108.Final.jar:4.1.108.Final]
	at org.apache.zookeeper.KeeperException.create(KeeperException.java:101)
	at org.apache.pulsar.broker.transaction.pendingack.impl.PendingAckHandleImpl.lambda$init$1(PendingAckHandleImpl.java:185) ~[io.streamnative-pulsar-broker-3.0.4.6.jar:3.0.4.6]
        ...
```

### Modifications

Add `MetadataStoreException` and `BKException` into the retriable error list

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x