### PR TITLE
[fix] [meta] Oxia metadta store: Convert error to MetadataStoreException if operation failed

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/OxiaMetadataStoreErrorTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/OxiaMetadataStoreErrorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.MetadataStoreFactory;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class OxiaMetadataStoreErrorTest extends BaseMetadataStoreTest {
+
+    @Test
+    public void emptyStoreTest() throws Exception {
+        String metadataStoreUrl = "oxia://" + getOxiaServerConnectString();
+        String prefix = newKey();
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(metadataStoreUrl,
+                MetadataStoreConfig.builder().fsyncEnable(false).build());
+        oxiaServer.close();
+        try {
+            store.exists(prefix + "/non-existing-key").join();
+            fail("Expected an exception because the metadata store server has been closed.");
+        } catch (Exception ex) {
+            Throwable actEx = FutureUtil.unwrapCompletionException(ex);
+            assertTrue(actEx instanceof MetadataStoreException);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation & Modifications

Once the Oxia's operation fails to execute, you will get many kinds of errors, such as `io.grpc.StatusRuntimeException`, which is not expected, we should convert these exceptions to `MetadataStoreException`

```
Aug 12, 2024 4:52:07 PM com.github.benmanes.caffeine.cache.LocalAsyncCache lambda$handleCompletion$7
WARNING: Exception thrown during asynchronous load
java.util.concurrent.CompletionException: io.grpc.StatusRuntimeException: UNAVAILABLE: io exception
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:332)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:347)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:874)
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
	at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2162)
	at io.streamnative.oxia.client.batch.Operation.fail(Operation.java:56)
	at io.streamnative.oxia.client.batch.ReadBatch.lambda$onError$0(ReadBatch.java:80)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at io.streamnative.oxia.client.batch.ReadBatch.onError(ReadBatch.java:80)
	at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:491)
	at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:567)
	at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:71)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:735)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:716)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializeReentrantCallsDirectExecutor.execute(SerializeReentrantCallsDirectExecutor.java:49)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl.closedInternal(ClientCallImpl.java:743)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl.closed(ClientCallImpl.java:683)
	at io.grpc.internal.FailingClientStream.start(FailingClientStream.java:61)
	at io.grpc.internal.ClientCallImpl.startInternal(ClientCallImpl.java:291)
	at io.grpc.internal.ClientCallImpl.start(ClientCallImpl.java:193)
	at io.grpc.stub.ClientCalls.startCall(ClientCalls.java:345)
	at io.grpc.stub.ClientCalls.asyncUnaryRequestCall(ClientCalls.java:319)
	at io.grpc.stub.ClientCalls.asyncUnaryRequestCall(ClientCalls.java:307)
	at io.grpc.stub.ClientCalls.asyncServerStreamingCall(ClientCalls.java:91)
	at io.streamnative.oxia.proto.OxiaClientGrpc$OxiaClientStub.read(OxiaClientGrpc.java:558)
	at io.streamnative.oxia.client.batch.ReadBatch.send(ReadBatch.java:62)
	at io.streamnative.oxia.client.batch.Batcher.batcherLoop(Batcher.java:125)
	at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: io.grpc.StatusRuntimeException: UNAVAILABLE: io exception
	at io.grpc.Status.asRuntimeException(Status.java:539)
	... 21 more
```



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x