### PR TITLE
[fix][broker] Fix AvgShedder strategy check

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -275,11 +275,11 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
             // if the placement strategy is also a load shedding strategy
             // we need to check two strategies are the same
             if (!conf.getLoadBalancerLoadSheddingStrategy().equals(
-                    conf.getLoadBalancerPlacementStrategy())) {
+                    conf.getLoadBalancerLoadPlacementStrategy())) {
                 throw new IllegalArgumentException("The load shedding strategy: "
                         + conf.getLoadBalancerLoadSheddingStrategy()
                         + " can't work with the placement strategy: "
-                        + conf.getLoadBalancerPlacementStrategy());
+                        + conf.getLoadBalancerLoadPlacementStrategy());
             }
             // bind the load shedding strategy and the placement strategy
             loadSheddingStrategy = (LoadSheddingStrategy) placementStrategy;


### PR DESCRIPTION
### Motivation

The check for AvgShedder strategy is wrong, we should use `loadBalancerLoadPlacementStrategy` instead of `loadBalancerPlacementStrategy`.

The `loadBalancerPlacementStrategy ` is used by `SimpleLoadManagerImpl`, and it is deprecated.


### Modifications

Use `loadBalancerLoadPlacementStrategy` instead of `loadBalancerPlacementStrategy` to check the `AvgShedder `strategy

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
