### PR TITLE
[improve] [broker] Avoid subscription fenced error with consumer.seek whenever possible

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -223,8 +223,8 @@ public class PersistentSubscription extends AbstractSubscription {
     public CompletableFuture<Void> addConsumer(Consumer consumer) {
         CompletableFuture<Void> inProgressResetCursorFuture = this.inProgressResetCursorFuture;
         if (inProgressResetCursorFuture != null) {
-            return inProgressResetCursorFuture.thenApply(ignore -> null)
-                    .exceptionally(ex -> null).thenCompose(ignore -> addConsumerInternal(consumer));
+            return inProgressResetCursorFuture.handle((ignore, ignoreEx) -> null)
+                    .thenCompose(ignore -> addConsumerInternal(consumer));
         } else {
             return addConsumerInternal(consumer);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -221,6 +221,7 @@ public class PersistentSubscription extends AbstractSubscription {
 
     @Override
     public CompletableFuture<Void> addConsumer(Consumer consumer) {
+        CompletableFuture<Void> inProgressResetCursorFuture = this.inProgressResetCursorFuture;
         if (inProgressResetCursorFuture != null) {
             return inProgressResetCursorFuture.thenCompose(ignore -> addConsumerInternal(consumer))
                     .exceptionallyCompose(ex -> addConsumerInternal(consumer));
@@ -806,15 +807,16 @@ public class PersistentSubscription extends AbstractSubscription {
 
     @Override
     public CompletableFuture<Void> resetCursor(Position finalPosition) {
-        // Lock the Subscription object before locking the Dispatcher object to avoid deadlocks
+        if (!IS_FENCED_UPDATER.compareAndSet(PersistentSubscription.this, FALSE, TRUE)) {
+            return CompletableFuture.failedFuture(new SubscriptionBusyException("Failed to fence subscription"));
+        }
+
+        final CompletableFuture<Void> future = new CompletableFuture<>();;
+        inProgressResetCursorFuture = future;
         final CompletableFuture<Void> disconnectFuture;
-        final CompletableFuture<Void> future;
+
+        // Lock the Subscription object before locking the Dispatcher object to avoid deadlocks
         synchronized (this) {
-            if (!IS_FENCED_UPDATER.compareAndSet(PersistentSubscription.this, FALSE, TRUE)) {
-                return CompletableFuture.failedFuture(new SubscriptionBusyException("Failed to fence subscription"));
-            }
-            future = new CompletableFuture<>();
-            inProgressResetCursorFuture = future;
             if (dispatcher != null && dispatcher.isConsumerConnected()) {
                 disconnectFuture = dispatcher.disconnectActiveConsumers(true);
             } else {
@@ -830,6 +832,7 @@ public class PersistentSubscription extends AbstractSubscription {
             if (throwable != null) {
                 log.error("[{}][{}] Failed to disconnect consumer from subscription", topicName, subName, throwable);
                 IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
+                inProgressResetCursorFuture = null;
                 future.completeExceptionally(
                         new SubscriptionBusyException("Failed to disconnect consumers from subscription"));
                 return;
@@ -869,6 +872,7 @@ public class PersistentSubscription extends AbstractSubscription {
                             dispatcher.afterAckMessages(null, finalPosition);
                         }
                         IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
+                        inProgressResetCursorFuture = null;
                         future.complete(null);
                     }
 
@@ -877,6 +881,7 @@ public class PersistentSubscription extends AbstractSubscription {
                         log.error("[{}][{}] Failed to reset subscription to position {}", topicName, subName,
                                 finalPosition, exception);
                         IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
+                        inProgressResetCursorFuture = null;
                         // todo - retry on InvalidCursorPositionException
                         // or should we just ask user to retry one more time?
                         if (exception instanceof InvalidCursorPositionException) {
@@ -891,6 +896,7 @@ public class PersistentSubscription extends AbstractSubscription {
             }).exceptionally((e) -> {
                 log.error("[{}][{}] Error while resetting cursor", topicName, subName, e);
                 IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
+                inProgressResetCursorFuture = null;
                 future.completeExceptionally(new BrokerServiceException(e));
                 return null;
             });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -223,8 +223,8 @@ public class PersistentSubscription extends AbstractSubscription {
     public CompletableFuture<Void> addConsumer(Consumer consumer) {
         CompletableFuture<Void> inProgressResetCursorFuture = this.inProgressResetCursorFuture;
         if (inProgressResetCursorFuture != null) {
-            return inProgressResetCursorFuture.thenCompose(ignore -> addConsumerInternal(consumer))
-                    .exceptionallyCompose(ex -> addConsumerInternal(consumer));
+            return inProgressResetCursorFuture.thenApply(ignore -> null)
+                    .exceptionally(ex -> null).thenCompose(ignore -> addConsumerInternal(consumer));
         } else {
             return addConsumerInternal(consumer);
         }
@@ -811,7 +811,7 @@ public class PersistentSubscription extends AbstractSubscription {
             return CompletableFuture.failedFuture(new SubscriptionBusyException("Failed to fence subscription"));
         }
 
-        final CompletableFuture<Void> future = new CompletableFuture<>();;
+        final CompletableFuture<Void> future = new CompletableFuture<>();
         inProgressResetCursorFuture = future;
         final CompletableFuture<Void> disconnectFuture;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
@@ -34,12 +34,14 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.InjectedClientCnxClientBuilder;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageRoutingMode;
@@ -50,7 +52,11 @@ import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
+import org.apache.pulsar.client.impl.ClientBuilderImpl;
+import org.apache.pulsar.client.impl.ClientCnx;
 import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
+import org.apache.pulsar.common.api.proto.CommandError;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.util.RelativeTimeUtil;
@@ -784,24 +790,60 @@ public class SubscriptionSeekTest extends BrokerTestBase {
 
     @Test
     public void testSeekWillNotEncounteredFencedError() throws Exception {
-        String topicName = "persistent://my-property/my-ns/my-topic2";
+        String topicName = "persistent://prop/ns-abc/my-topic2";
         admin.topics().createNonPartitionedTopic(topicName);
         admin.topicPolicies().setRetention(topicName, new RetentionPolicies(3600, 0));
-        org.apache.pulsar.client.api.Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+        // Create a pulsar client with a subscription fenced counter.
+        ClientBuilderImpl clientBuilder = (ClientBuilderImpl) PulsarClient.builder().serviceUrl(lookupUrl.toString());
+        AtomicInteger receivedFencedErrorCounter = new AtomicInteger();
+        PulsarClient client = InjectedClientCnxClientBuilder.create(clientBuilder, (conf, eventLoopGroup) ->
+                new ClientCnx(InstrumentProvider.NOOP, conf, eventLoopGroup) {
+                    protected void handleError(CommandError error) {
+                        if (error.getMessage() != null && error.getMessage().contains("Subscription is fenced")) {
+                            receivedFencedErrorCounter.incrementAndGet();
+                        }
+                        super.handleError(error);
+                    }
+                });
+
+        // publish some messages.
+        org.apache.pulsar.client.api.Consumer<String> consumer = client.newConsumer(Schema.STRING)
                 .topic(topicName)
                 .subscriptionName("s1")
                 .subscribe();
-        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+        Producer<String> producer = client.newProducer(Schema.STRING)
                 .topic(topicName).create();
         MessageIdImpl msgId1 = (MessageIdImpl) producer.send("0");
         for (int i = 1; i < 11; i++) {
             admin.topics().unload(topicName);
             producer.send(i + "");
         }
-        Message<String> msg = consumer.receive(2, TimeUnit.SECONDS);
-        consumer.acknowledge(msg);
+
+        // Inject a delay for reset-cursor.
+        mockZooKeeper.delay(3000, (op, path) -> {
+            if (path.equals("/managed-ledgers/prop/ns-abc/persistent/my-topic2/s1")) {
+                return op.toString().equalsIgnoreCase("SET");
+            }
+            return false;
+        });
+
+        // Verify: consumer will not receive "subscription fenced" error after a seek.
+        for (int i = 1; i < 11; i++) {
+            Message<String> msg = consumer.receive(2, TimeUnit.SECONDS);
+            assertNotNull(msg);
+            consumer.acknowledge(msg);
+        }
         consumer.seek(msgId1);
-        Thread.sleep(20 * 1000);
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(consumer.isConnected());
+        });
+        assertEquals(receivedFencedErrorCounter.get(), 0);
+
+        // cleanup.
+        producer.close();
+        consumer.close();
+        client.close();
+        admin.topics().delete(topicName);
     }
 
     @Test


### PR DESCRIPTION
### Motivation

After a consumer calls `seek`, the operation `reconnect` will get a fenced error, which leads to more unnecessary reconnects. The steps to produce are as follows:

- `client-side`: consumer connected
- `client-side`: calls `consumer.seek` or `seekAsync`
- `broker-side`:
  - mark subscription as `fenced`
  - remove all consumer
  - do reset the cursor internally
- `client-side`:
  - consumer tries to reconnect
  - get an error Subscription was fenced due to the task `reset cursor` not finished yet.
  - loop...
- `broker-side`: `reset cursor` is completed
- `client-side`: The consumer tries to reconnect, and it will finish at this time.


### Modifications

- This PR fixes the issue that a consumer fenced itself.
- This PR can probably fix the issue that a `consumer.seek` fenced other consumers under the same subscription.
  - This PR does not fix all scenarios in which a `consumer.seek` fenced other consumers under the same subscription. See the following example:

| time | `broker-side: consumer_1` | `broker-side: consumer_2` |
| --- | --- | --- |
| 1 | | check whether an in-progress reset cursor exists: `false` |
| 2 | | start to add `consumer_2` |
| 3 | `reset cursor` started |
| 4 | mark subscription as `fenced` |
| 5 | | get a fenced error | 

I do not want to improve the behavior above because it needs a lock. Since it does not cause critical errors, it just causes reconnection and the possibility of it occurring is low, we can leave it there.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
