### PR TITLE
[improve][misc] Set format_version=5, checksum=kxxHash in Bookkeeper RocksDB configs

### DIFF
--- a/conf/default_rocksdb.conf
+++ b/conf/default_rocksdb.conf
@@ -24,7 +24,14 @@
  info_log_level=INFO_LEVEL
  # set by jni: options.setKeepLogFileNum
  keep_log_file_num=30
-
-[CFOptions "default"]
  # set by jni: options.setLogFileTimeToRoll
  log_file_time_to_roll=86400
+
+[CFOptions "default"]
+ #no default setting in CFOptions
+
+[TableOptions/BlockBasedTable "default"]
+ # set by jni: tableOptions.setFormatVersion
+ format_version=5
+ # set by jni: tableOptions.setChecksumType
+ checksum=kxxHash

--- a/conf/entry_location_rocksdb.conf
+++ b/conf/entry_location_rocksdb.conf
@@ -61,7 +61,7 @@
  # set by jni: tableOptions.setBlockCache
  block_cache=206150041
  # set by jni: tableOptions.setFormatVersion
- format_version=2
+ format_version=5
  # set by jni: tableOptions.setChecksumType
  checksum=kxxHash
  # set by jni: tableOptions.setFilterPolicy, bloomfilter:[bits_per_key]:[use_block_based_builder]

--- a/conf/ledger_metadata_rocksdb.conf
+++ b/conf/ledger_metadata_rocksdb.conf
@@ -24,7 +24,14 @@
  info_log_level=INFO_LEVEL
  # set by jni: options.setKeepLogFileNum
  keep_log_file_num=30
-
-[CFOptions "default"]
  # set by jni: options.setLogFileTimeToRoll
  log_file_time_to_roll=86400
+
+[CFOptions "default"]
+ #no default setting in CFOptions
+
+[TableOptions/BlockBasedTable "default"]
+ # set by jni: tableOptions.setFormatVersion
+ format_version=5
+ # set by jni: tableOptions.setChecksumType
+ checksum=kxxHash


### PR DESCRIPTION
### Motivation

RocksDB format_version 5 has been supported since RocksDB 6.6 . It's required for certain performance optimizations.
Currently the default is format_version=2 which is really old. It's better to default to a more modern version.

### Changes

- specify `format_version=5` and `checksum=kxxHash` in Bookkeeper RocksDB config files
  - Bookkeeper RocksDB config is specified in separate files since https://github.com/apache/bookkeeper/pull/3056
- fix invalid CFOptions config (fix on BK side in https://github.com/apache/bookkeeper/pull/4466)

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->