### PR TITLE
[fix] [broker] Topic can never be loaded up due to broker maintains a failed topic creation future

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/OrphanPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/OrphanPersistentTopicTest.java
@@ -272,7 +272,7 @@ public class OrphanPersistentTopicTest extends ProducerConsumerBase {
     }
 
     @Test(timeOut = 60 * 1000, dataProvider = "whetherTimeoutOrNot")
-    public void testCreateLedgerFails(boolean injectTimeout) throws Exception {
+    public void testTopicLoadAndDeleteAtTheSameTime(boolean injectTimeout) throws Exception {
         if (injectTimeout) {
             pulsar.getConfig().setTopicLoadTimeoutSeconds(5);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/OrphanPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/OrphanPersistentTopicTest.java
@@ -19,13 +19,17 @@
 package org.apache.pulsar.client.api;
 
 import static org.apache.pulsar.broker.service.persistent.PersistentTopic.DEDUPLICATION_CURSOR_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -33,6 +37,7 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.TopicPoliciesService;
@@ -47,6 +52,7 @@ import org.awaitility.Awaitility;
 import org.awaitility.reflect.WhiteboxImpl;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Slf4j
@@ -218,5 +224,94 @@ public class OrphanPersistentTopicTest extends ProducerConsumerBase {
         // cleanup.
         consumer.close();
         admin.topics().delete(tpName, false);
+    }
+
+    @DataProvider(name = "whetherTimeoutOrNot")
+    public Object[][] whetherTimeoutOrNot() {
+        return new Object[][] {
+            {true},
+            {false}
+        };
+    }
+
+    @Test(timeOut = 60 * 1000, dataProvider = "whetherTimeoutOrNot")
+    public void testCheckOwnerShipFails(boolean injectTimeout) throws Exception {
+        if (injectTimeout) {
+            pulsar.getConfig().setTopicLoadTimeoutSeconds(5);
+        }
+        String ns = "public" + "/" + UUID.randomUUID().toString().replaceAll("-", "");
+        String tpName = BrokerTestUtil.newUniqueName("persistent://" + ns + "/tp");
+        admin.namespaces().createNamespace(ns);
+        admin.topics().createNonPartitionedTopic(tpName);
+        admin.namespaces().unload(ns);
+
+        // Inject an error when calling "NamespaceService.isServiceUnitActiveAsync".
+        AtomicInteger failedTimes = new AtomicInteger();
+        NamespaceService namespaceService = pulsar.getNamespaceService();
+        doAnswer(invocation -> {
+            TopicName paramTp = (TopicName) invocation.getArguments()[0];
+            if (paramTp.toString().equalsIgnoreCase(tpName) && failedTimes.incrementAndGet() <= 2) {
+                if (injectTimeout) {
+                    Thread.sleep(10 * 1000);
+                }
+                log.info("Failed {} times", failedTimes.get());
+                return CompletableFuture.failedFuture(new RuntimeException("mocked error"));
+            }
+            return invocation.callRealMethod();
+        }).when(namespaceService).isServiceUnitActiveAsync(any(TopicName.class));
+
+        // Verify: the consumer can create successfully eventually.
+        Consumer consumer = pulsarClient.newConsumer().topic(tpName).subscriptionName("s1").subscribe();
+
+        // cleanup.
+        if (injectTimeout) {
+            pulsar.getConfig().setTopicLoadTimeoutSeconds(60);
+        }
+        consumer.close();
+        admin.topics().delete(tpName);
+    }
+
+    @Test(timeOut = 60 * 1000, dataProvider = "whetherTimeoutOrNot")
+    public void testCreateLedgerFails(boolean injectTimeout) throws Exception {
+        if (injectTimeout) {
+            pulsar.getConfig().setTopicLoadTimeoutSeconds(5);
+        }
+        String ns = "public" + "/" + UUID.randomUUID().toString().replaceAll("-", "");
+        String tpName = BrokerTestUtil.newUniqueName("persistent://" + ns + "/tp");
+        admin.namespaces().createNamespace(ns);
+        admin.topics().createNonPartitionedTopic(tpName);
+        admin.namespaces().unload(ns);
+
+        // Inject a race condition: load topic and delete topic execute at the same time.
+        AtomicInteger mockRaceConditionCounter = new AtomicInteger();
+        NamespaceService namespaceService = pulsar.getNamespaceService();
+        doAnswer(invocation -> {
+            TopicName paramTp = (TopicName) invocation.getArguments()[0];
+            if (paramTp.toString().equalsIgnoreCase(tpName) && mockRaceConditionCounter.incrementAndGet() <= 1) {
+                if (injectTimeout) {
+                    Thread.sleep(10 * 1000);
+                }
+                log.info("Race condition occurs {} times", mockRaceConditionCounter.get());
+                pulsar.getManagedLedgerFactory().delete(TopicName.get(tpName).getPersistenceNamingEncoding());
+            }
+            return invocation.callRealMethod();
+        }).when(namespaceService).isServiceUnitActiveAsync(any(TopicName.class));
+
+        // Verify: the consumer create failed due to pulsar does not allow to create topic automatically.
+        try {
+            pulsar.getBrokerService().getTopic(tpName, false, Collections.emptyMap()).join();
+        } catch (Exception ex) {
+            log.warn("Expected error", ex);
+        }
+
+        // Verify: the consumer create successfully after allowing to create topic automatically.
+        Consumer consumer = pulsarClient.newConsumer().topic(tpName).subscriptionName("s1").subscribe();
+
+        // cleanup.
+        if (injectTimeout) {
+            pulsar.getConfig().setTopicLoadTimeoutSeconds(60);
+        }
+        consumer.close();
+        admin.topics().delete(tpName);
     }
 }


### PR DESCRIPTION
### Motivation

There are two scenarios that may leave a failed topic creation future in `brokerService.topics` because forgot to remove the failed future from the map, which leads to the topic never being loaded up successfully.
- Topic load and delete execute at the same time: see the test `testTopicLoadAndDeleteAtTheSameTime`
- Check ownership fails: see the test `testCheckOwnerShipFails `


### Modifications

Remove the failed future if load topic fails

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
