### PR TITLE
[improve][broker] Optimize high CPU usage when consuming from topics with ongoing txn

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -953,7 +953,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
         int numberOfEntriesToRead = applyMaxSizeCap(maxEntries, maxSizeBytes);
 
-        if (hasMoreEntries()) {
+        if (hasMoreEntries() && maxPosition.compareTo(readPosition) > 0) {
             // If we have available entries, we can read them immediately
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] Read entries immediately", ledger.getName(), name);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -953,7 +953,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
         int numberOfEntriesToRead = applyMaxSizeCap(maxEntries, maxSizeBytes);
 
-        if (hasMoreEntries() && maxPosition.compareTo(readPosition) > 0) {
+        if (hasMoreEntries() && maxPosition.compareTo(readPosition) >= 0) {
             // If we have available entries, we can read them immediately
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] Read entries immediately", ledger.getName(), name);


### PR DESCRIPTION
### Motivation

We found the CPU of the broker busy with calling `ManagedLedgerImpl.internalReadFromLedger` and broker checked the `readPosition > maxPosition` and then triggered the `readMoreEntries` call again leading to the broker looping to call readMoreEntries. But in `ManagedCursorImpl.asyncReadEntriesWithSkipOrWait` we have checked no more data to read via hasMoreEntries(). I think this case may be caused by `maxReadPosition < lastConfirmedPosition` when the topic exists ongoing Txn. So I think `maxPosition <= readPosition` we should not read entries immediately, instead, we delay calling read entries.

<img width="1373" alt="image" src="https://github.com/user-attachments/assets/74a43e6e-74e5-4db0-938e-4b82b70f7bd7">

### Modifications

If `maxPosition < readPosition` then delayed trigger readEntries.

Test Code:
```java
    @Test
    public void testSlowTxn() throws Exception {
        String topic = NAMESPACE1 + "/testSlowTxn";
        @Cleanup
        ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) pulsarClient.newProducer()
                .topic(topic)
                .sendTimeout(1, TimeUnit.SECONDS)
                .create();

        @Cleanup
        Consumer<byte[]> consumer = pulsarClient.newConsumer()
                .topic(topic)
                .subscriptionName("test")
                .subscriptionType(SubscriptionType.Shared)
                .subscribe();

        Transaction transaction = pulsarClient.newTransaction().withTransactionTimeout(10, TimeUnit.MINUTES)
                .build().get();

        producer.newMessage(transaction).value("Hello Pulsar!".getBytes()).send();

        Thread.sleep(10 * 60 * 1000);

        transaction.commit().get();
        producer.close();
        admin.topics().delete(topic, true);
    }
```

**CPU usage before applying this change:**
<img width="1025" alt="image" src="https://github.com/user-attachments/assets/fe3589ac-624b-4e49-b114-8e58fd3de526">

flamegraph: https://drive.google.com/file/d/1nNb4MOdbZB7mO4fWitts2UpjzutdT22O/view?usp=sharing

**CPU usage after applying this change**:
<img width="1223" alt="image" src="https://github.com/user-attachments/assets/75dda040-952c-413b-8cbf-d5714207359b">


flamegraph: https://drive.google.com/file/d/1AndMJuSMXhOImf3T0hg_E7YeCyslTaNI/view?usp=sharing

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
