### PR TITLE
[improve][broker] PIP-371: Support for request-reply model that implements RPC calls

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Producer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Producer.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.api;
 
 import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
@@ -199,4 +200,40 @@ public interface Producer<T> extends Closeable {
      * @return the number of partitions per topic.
      */
     int getNumOfPartitions();
+
+    /**
+     * Sends a message synchronously.(Request-Reply mode)
+     *
+     * <p>This call will be blocking until either consumer successfully processed and acknowledged the request
+     * message. Finally, a reply message will be returned.
+     *
+     * <p>Use {@link #newMessage()} to specify more properties than just the value on the message to be sent.
+     *
+     * @param message
+     *            request message
+     * @return the reply message from consumer
+     * @throws PulsarClientException.TimeoutException
+     *             if the message was not correctly received and processed by the system within the timeout period
+     * @throws PulsarClientException.AlreadyClosedException
+     *             if the producer was already closed
+     */
+    ReplyResult request(T message, long timeout, TimeUnit timeUnit) throws PulsarClientException;
+
+    /**
+     * Send a message asynchronously.(Request-Reply mode)
+     *
+     * <p>When the producer queue is full, by default this method will complete the future with an exception
+     * {@link PulsarClientException.ProducerQueueIsFullError}
+     *
+     * <p>See {@link ProducerBuilder#maxPendingMessages(int)} to configure the producer queue size and
+     * {@link ProducerBuilder#blockIfQueueFull(boolean)} to change the blocking behavior.
+     *
+     * <p>Use {@link #newMessage()} to specify more properties than just the value on the message to be sent.
+     *
+     * @param message
+     *            a byte array with the payload of the message
+     * @return A future that can be used to track when a request message is successfully acknowledged
+     * and returns a reply result
+     */
+    CompletableFuture<ReplyResult> requestAsync(T message, long timeout, TimeUnit timeUnit);
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ReplyResult.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ReplyResult.java
@@ -16,16 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.common.naming;
+package org.apache.pulsar.client.api;
 
-/**
- * Definition of constants.
- */
-public class Constants {
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
-    public static final String GLOBAL_CLUSTER = "global";
-    public static final String REQUEST_TIMEOUT_MILLIS = "requestTimeoutInMillis";
-    public static final String REPLY_TO_CLIENT = "replyToClient";
-
-    private Constants() {}
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+public class ReplyResult {
+    // request message MessageId
+    MessageId requestMessageId;
+    // reply result
+    byte[] replyContent;
+    boolean isErrorResult;
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TypedMessageBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TypedMessageBuilder.java
@@ -295,6 +295,56 @@ public interface TypedMessageBuilder<T> extends Serializable {
      */
     TypedMessageBuilder<T> loadConf(Map<String, Object> config);
 
+    /**
+     * Send a message synchronously.(Request-Reply mode)
+     *
+     * <p>This method will block until either consumer successfully acknowledged the message
+     * and returns a reply message.
+     * Finally, the {@link ReplyResult} returned by the Consumer is returned.
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
+     * ReplyResult replyResult = producer.newMessage()
+     *                  .key(myKey)
+     *                  .value(myValue)
+     *                  .request();
+     * System.out.println("Reply result: " + replyResult);
+     * }</pre>
+     *
+     * @return the {@link ReplyResult} returned by the Consumer
+     */
+    ReplyResult request(long timeout, TimeUnit unit) throws PulsarClientException;
+
+    /**
+     * Send a message asynchronously.(Request-Reply mode)
+     *
+     * <p>This method returns a future that can be used to track the completion of the request operation and yields the
+     * {@link ReplyResult} send by the consumer to the producer.
+     *
+     * <p>Example:
+     *
+     * <pre>
+     * <code>producer.newMessage()
+     *                  .value(myValue)
+     *                  .requestAsync().thenAccept(replyResult -> {
+     *    System.out.println("Reply result: " + replyResult);
+     * }).exceptionally(e -> {
+     *    System.out.println("Failed to publish " + e);
+     *    return null;
+     * });</code>
+     * </pre>
+     *
+     * <p>When the producer queue is full, by default this method will complete the future with an exception
+     * {@link PulsarClientException.ProducerQueueIsFullError}
+     *
+     * <p>See {@link ProducerBuilder#maxPendingMessages(int)} to configure the producer queue size and
+     * {@link ProducerBuilder#blockIfQueueFull(boolean)} to change the blocking behavior.
+     *
+     * @return a future that can be used to track when the reply message will have been returned
+     */
+    CompletableFuture<ReplyResult> requestAsync(long timeout, TimeUnit unit);
+
     String CONF_KEY = "key";
     String CONF_PROPERTIES = "properties";
     String CONF_EVENT_TIME = "eventTime";
@@ -303,4 +353,6 @@ public interface TypedMessageBuilder<T> extends Serializable {
     String CONF_DISABLE_REPLICATION = "disableReplication";
     String CONF_DELIVERY_AFTER_SECONDS = "deliverAfterSeconds";
     String CONF_DELIVERY_AT = "deliverAt";
+    String REPLY_TO_CLIENT = "replyToClient";
+    String REQUEST_TIMEOUT_MILLIS = "requestTimeoutInMillis";
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AcknowledgmentsGroupingTracker.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.impl;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.api.proto.CommandAck.AckType;
 
@@ -32,6 +33,9 @@ public interface AcknowledgmentsGroupingTracker extends AutoCloseable {
     boolean isDuplicate(MessageId messageId);
 
     CompletableFuture<Void> addAcknowledgment(MessageId msgId, AckType ackType, Map<String, Long> properties);
+
+    CompletableFuture<Void> addAcknowledgment(MessageId msgId, AckType ackType, Map<String, Long> properties,
+                                              Triple<String, byte[], Boolean> replyResult);
 
     CompletableFuture<Void> addListAcknowledgment(List<MessageId> messageIds, AckType ackType,
                                                   Map<String, Long> properties);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -596,6 +596,14 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     protected CompletableFuture<Void> doAcknowledge(MessageId messageId, AckType ackType,
                                                     Map<String, Long> properties,
                                                     TransactionImpl txn) {
+        return doAcknowledge(messageId, ackType, properties, txn, Triple.of(null, null, false));
+    }
+
+    @Override
+    protected CompletableFuture<Void> doAcknowledge(MessageId messageId, AckType ackType,
+                                                    Map<String, Long> properties,
+                                                    TransactionImpl txn,
+                                                    Triple<String, byte[], Boolean> replyResult) {
         consumerAcksCounter.increment();
 
         if (getState() != State.Ready && getState() != State.Connecting) {
@@ -613,7 +621,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             return doTransactionAcknowledgeForResponse(messageId, ackType, null, properties,
                     new TxnID(txn.getTxnIdMostBits(), txn.getTxnIdLeastBits()));
         }
-        return acknowledgmentsGroupingTracker.addAcknowledgment(messageId, ackType, properties);
+        return acknowledgmentsGroupingTracker.addAcknowledgment(messageId, ackType, properties, replyResult);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -54,6 +54,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.pulsar.client.api.BatchReceivePolicy;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerStats;
@@ -486,6 +487,13 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             return consumer.doAcknowledgeWithTxn(messageId, ackType, properties, txnImpl)
                 .thenRun(() -> unAckedMessageTracker.remove(messageId));
         }
+    }
+
+    @Override
+    protected CompletableFuture<Void> doAcknowledge(MessageId messageId, AckType ackType, Map<String, Long> properties,
+                                                    TransactionImpl txn, Triple<String, byte[], Boolean> replyResult) {
+        // no-op
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/NonPersistentAcknowledgmentGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/NonPersistentAcknowledgmentGroupingTracker.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.impl;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.api.proto.CommandAck.AckType;
 
@@ -45,6 +46,13 @@ public class NonPersistentAcknowledgmentGroupingTracker implements Acknowledgmen
 
     public CompletableFuture<Void> addAcknowledgment(MessageId msgId, AckType ackType, Map<String,
             Long> properties) {
+        // no-op
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> addAcknowledgment(MessageId msgId, AckType ackType, Map<String, Long> properties,
+                                                     Triple<String, byte[], Boolean> replyResult) {
         // no-op
         return CompletableFuture.completedFuture(null);
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -45,6 +45,7 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerAccessMode;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientException.NotSupportedException;
+import org.apache.pulsar.client.api.ReplyResult;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TopicMetadata;
 import org.apache.pulsar.client.api.transaction.Transaction;
@@ -347,6 +348,12 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
         }
 
         return closeFuture;
+    }
+
+    @Override
+    CompletableFuture<ReplyResult> internalRequestAsync(MessageId msgId, long timeout, TimeUnit unit) {
+        // no-op
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBase.java
@@ -20,10 +20,12 @@ package org.apache.pulsar.client.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.ReplyResult;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
@@ -169,6 +171,22 @@ public abstract class ProducerBase<T> extends HandlerState implements Producer<T
             interceptors.onPartitionsChange(topicName, partitions);
         }
     }
+
+    @Override
+    public ReplyResult request(T message, final long timeout, TimeUnit unit) throws PulsarClientException {
+        return newMessage().value(message).request(timeout, unit);
+    }
+
+    @Override
+    public CompletableFuture<ReplyResult> requestAsync(T message, final long timeout, TimeUnit unit) {
+        try {
+            return newMessage().value(message).requestAsync(timeout, unit);
+        } catch (Exception e) {
+            return FutureUtil.failedFuture(e);
+        }
+    }
+
+    abstract CompletableFuture<ReplyResult> internalRequestAsync(MessageId msgId, long timeout, TimeUnit unit);
 
     @Override
     public String toString() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
@@ -69,6 +69,7 @@ import org.apache.pulsar.common.api.proto.CommandProducer;
 import org.apache.pulsar.common.api.proto.CommandProducerSuccess;
 import org.apache.pulsar.common.api.proto.CommandReachedEndOfTopic;
 import org.apache.pulsar.common.api.proto.CommandRedeliverUnacknowledgedMessages;
+import org.apache.pulsar.common.api.proto.CommandRequestReceipt;
 import org.apache.pulsar.common.api.proto.CommandSeek;
 import org.apache.pulsar.common.api.proto.CommandSend;
 import org.apache.pulsar.common.api.proto.CommandSendError;
@@ -157,7 +158,11 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
             case ACK:
                 checkArgument(cmd.hasAck());
                 safeInterceptCommand(cmd);
-                handleAck(cmd.getAck());
+                if (cmd.getAck().hasReplyToClient()) {
+                    handleAck(cmd.getAck(), buffer);
+                } else {
+                    handleAck(cmd.getAck());
+                }
                 break;
 
             case ACK_RESPONSE:
@@ -478,6 +483,11 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
                 handleCommandWatchTopicListClose(cmd.getWatchTopicListClose());
                 break;
 
+            case REQUEST_RECEIPT:
+                checkArgument(cmd.hasRequestReceipt());
+                handleCommandRequestReceipt(cmd.getRequestReceipt(), buffer);
+                break;
+
             default:
                 break;
             }
@@ -554,6 +564,10 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
     }
 
     protected void handleAck(CommandAck ack) {
+        throw new UnsupportedOperationException();
+    }
+
+    protected void handleAck(CommandAck ack, ByteBuf replyPayload) {
         throw new UnsupportedOperationException();
     }
 
@@ -736,6 +750,10 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
     }
 
     protected void handleCommandWatchTopicListClose(CommandWatchTopicListClose commandWatchTopicListClose) {
+        throw new UnsupportedOperationException();
+    }
+
+    protected void handleCommandRequestReceipt(CommandRequestReceipt commandRequestReceipt, ByteBuf replyPayload) {
         throw new UnsupportedOperationException();
     }
 

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -265,6 +265,7 @@ enum ProtocolVersion {
     v19 = 19; // Add CommandTcClientConnectRequest and CommandTcClientConnectResponse
     v20 = 20; // Add client support for topic migration redirection CommandTopicMigrated
     v21 = 21; // Carry the AUTO_CONSUME schema to the Broker after this version
+    v22 = 22; // Adds support for the Request-Reply model and introduces CommandRequestReceipt
 }
 
 message CommandConnect {
@@ -582,6 +583,9 @@ message CommandAck {
     optional uint64 txnid_least_bits = 6 [default = 0];
     optional uint64 txnid_most_bits = 7 [default = 0];
     optional uint64 request_id = 8;
+
+    optional string reply_to_client = 9;
+    optional bool is_error_result = 10;
 }
 
 message CommandAckResponse {
@@ -961,6 +965,12 @@ message CommandEndTxnOnSubscriptionResponse {
     optional string message = 5;
 }
 
+message CommandRequestReceipt {
+    required string reply_to_client = 1;
+    required MessageIdData request_message_id = 2;
+    required bool is_error_result = 3;
+}
+
 message BaseCommand {
     enum Type {
         CONNECT     = 2;
@@ -1052,6 +1062,7 @@ message BaseCommand {
         WATCH_TOPIC_LIST_CLOSE = 67;
 
         TOPIC_MIGRATED = 68;
+        REQUEST_RECEIPT = 69;
     }
 
 
@@ -1135,4 +1146,5 @@ message BaseCommand {
     optional CommandWatchTopicListClose watchTopicListClose = 67;
     
     optional CommandTopicMigrated topicMigrated = 68;
+    optional CommandRequestReceipt requestReceipt = 69;
 }


### PR DESCRIPTION
<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: https://github.com/apache/pulsar/pull/23143

#### This is a native implementation of the request-reply model in pulsar.

#### Although at present, there is no support from many people in the email discussion. But I think things still have to have a result.

#### I am sorry that I am just a personal developer. I have not done pulsar-related work in the company, and I have no business scenarios to test. The implementation code is as follows, if you are interested in this request-reply synchronization model, or if you have the usage scenario of this function. Can help with internal testing.

#### This is just a simple implementation, there are many exception handling or the metrics is not perfect. You are still welcome to discuss your questions on the mailing list or pr.

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

As we known，Pulsar's current **asynchronous** publish-subscribe model serves well for decoupled message distribution, but it lacks a native mechanism for handling **synchronous** interactions typical of Remote Procedure Calls (RPC).

This request-reply model can greatly enhance the utility of Pulsar. We can then use Pulsar as RPC.

Why would we use Pulsar for this RPC call?

- This proposal to achieve the function is `request`. `Request` and existing send function of pulsar can be mixed to same topic. This means that the user can choose, and the call to the server side (consumer) can be asynchronous or synchronous, which is controlled by the user flexibly.
- Similar enhancements can be implemented in [pulsar-spring](https://github.com/spring-projects/spring-pulsar), just like [rocketmq-spring#209](https://github.com/apache/rocketmq-spring/pull/209). However, this proposal does not use the solution of storing the request and reply result topics. After the consumer processing request is message, the processing result is directly sent to the broker and finally passed to the original producer. This call of link has one less message publishing and subscription of reply result, and its performance is higher than that of other request-reply models.
- You can directly use Pulsar's own delaying messages, that is, you can execute RPC regularly.
- You can directly use Pulsar's own load balancing mechanism.
- You can directly use Pulsar's own message consumption throttling mechanism.
- You can directly use Pulsar's own expansion and contraction mechanism.
- You can directly use Pulsar's own message call tracking, monitoring, and logging mechanisms.


### Modifications

Please read the https://github.com/apache/pulsar/pull/23143/files.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
