### PR TITLE
[improve][broker] Add callback parameters to the SendCallback.sendComplete

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentReplicator.java
@@ -33,6 +33,7 @@ import org.apache.pulsar.broker.service.persistent.PersistentReplicator;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.client.impl.OpSendMsgStats;
 import org.apache.pulsar.client.impl.ProducerImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.SendCallback;
@@ -173,7 +174,7 @@ public class NonPersistentReplicator extends AbstractReplicator implements Repli
         private MessageImpl msg;
 
         @Override
-        public void sendComplete(Exception exception) {
+        public void sendComplete(Throwable exception, OpSendMsgStats opSendMsgStats) {
             if (exception != null) {
                 log.error("[{}] Error producing on remote broker", replicator.replicatorId, exception);
             } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -60,6 +60,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.client.impl.OpSendMsgStats;
 import org.apache.pulsar.client.impl.ProducerImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.SendCallback;
@@ -377,7 +378,7 @@ public abstract class PersistentReplicator extends AbstractReplicator
         private MessageImpl msg;
 
         @Override
-        public void sendComplete(Exception exception) {
+        public void sendComplete(Throwable exception, OpSendMsgStats opSendMsgStats) {
             if (exception != null && !(exception instanceof PulsarClientException.InvalidMessageException)) {
                 log.error("[{}] Error producing on remote broker", replicator.replicatorId, exception);
                 // cursor should be rewinded since it was incremented when readMoreEntries

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProduceWithMessageIdTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProduceWithMessageIdTest.java
@@ -28,6 +28,7 @@ import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MockBrokerService;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
@@ -40,13 +41,20 @@ import org.testng.annotations.Test;
 
 @Test(groups = "broker-impl")
 @Slf4j
-public class ProduceWithMessageIdTest {
+public class ProduceWithMessageIdTest extends ProducerConsumerBase {
     MockBrokerService mockBrokerService;
 
     @BeforeClass(alwaysRun = true)
-    public void setup() {
+    public void setup() throws Exception {
         mockBrokerService = new MockBrokerService();
         mockBrokerService.start();
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
     }
 
     @AfterClass(alwaysRun = true)
@@ -119,22 +127,16 @@ public class ProduceWithMessageIdTest {
     }
 
     @Test
-    public void testSendWithCallBack() throws Exception {
+    public void sendWithCallBack() throws Exception {
 
         int batchSize = 10;
-        @Cleanup
-        PulsarClientImpl client = (PulsarClientImpl) PulsarClient.builder()
-                .serviceUrl(mockBrokerService.getBrokerAddress())
-                .build();
 
-        String topic = "persistent://public/default/t1";
+        String topic = "persistent://public/default/testSendWithCallBack";
         ProducerImpl<byte[]> producer =
-                (ProducerImpl<byte[]>) client.newProducer().topic(topic)
+                (ProducerImpl<byte[]>) pulsarClient.newProducer().topic(topic)
                         .enableBatching(true)
                         .batchingMaxMessages(batchSize)
                         .create();
-
-
 
         AtomicBoolean result = new AtomicBoolean(false);
         AtomicReference<OpSendMsgStats> sendMsgStats = new AtomicReference<>();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProduceWithMessageIdTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProduceWithMessageIdTest.java
@@ -18,10 +18,12 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static org.apache.pulsar.client.impl.AbstractBatchMessageContainer.INITIAL_BATCH_BUFFER_SIZE;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.MessageId;
@@ -86,7 +88,7 @@ public class ProduceWithMessageIdTest {
         AtomicBoolean result = new AtomicBoolean(false);
         producer.sendAsync(msg, new SendCallback() {
             @Override
-            public void sendComplete(Exception e) {
+            public void sendComplete(Throwable e, OpSendMsgStats opSendMsgStats) {
                 log.info("sendComplete", e);
                 result.set(e == null);
             }
@@ -114,5 +116,77 @@ public class ProduceWithMessageIdTest {
 
         // the result is true only if broker received right message id.
         Awaitility.await().untilTrue(result);
+    }
+
+    @Test
+    public void testSendWithCallBack() throws Exception {
+
+        int batchSize = 10;
+        @Cleanup
+        PulsarClientImpl client = (PulsarClientImpl) PulsarClient.builder()
+                .serviceUrl(mockBrokerService.getBrokerAddress())
+                .build();
+
+        String topic = "persistent://public/default/t1";
+        ProducerImpl<byte[]> producer =
+                (ProducerImpl<byte[]>) client.newProducer().topic(topic)
+                        .enableBatching(true)
+                        .batchingMaxMessages(batchSize)
+                        .create();
+
+
+
+        AtomicBoolean result = new AtomicBoolean(false);
+        AtomicReference<OpSendMsgStats> sendMsgStats = new AtomicReference<>();
+        SendCallback sendComplete = new SendCallback() {
+            @Override
+            public void sendComplete(Throwable e, OpSendMsgStats opSendMsgStats) {
+                log.info("sendComplete", e);
+                result.set(e == null);
+                sendMsgStats.set(opSendMsgStats);
+            }
+
+            @Override
+            public void addCallback(MessageImpl<?> msg, SendCallback scb) {
+
+            }
+
+            @Override
+            public SendCallback getNextSendCallback() {
+                return null;
+            }
+
+            @Override
+            public MessageImpl<?> getNextMessage() {
+                return null;
+            }
+
+            @Override
+            public CompletableFuture<MessageId> getFuture() {
+                return null;
+            }
+        };
+        int totalReadabled = 0;
+        int totalUncompressedSize = 0;
+        for (int i = 0; i < batchSize; i++) {
+            MessageMetadata metadata = new MessageMetadata();
+            ByteBuffer buffer = ByteBuffer.wrap("data".getBytes(StandardCharsets.UTF_8));
+            MessageImpl<byte[]> msg = MessageImpl.create(metadata, buffer, Schema.BYTES, topic);
+            msg.getDataBuffer().retain();
+            totalReadabled += msg.getDataBuffer().readableBytes();
+            totalUncompressedSize += msg.getUncompressedSize();
+            producer.sendAsync(msg, sendComplete);
+        }
+
+        Awaitility.await().untilTrue(result);
+        OpSendMsgStats opSendMsgStats = sendMsgStats.get();
+        Assert.assertEquals(opSendMsgStats.getUncompressedSize(), totalUncompressedSize + INITIAL_BATCH_BUFFER_SIZE);
+        Assert.assertEquals(opSendMsgStats.getSequenceId(), 0);
+        Assert.assertEquals(opSendMsgStats.getRetryCount(), 1);
+        Assert.assertEquals(opSendMsgStats.getBatchSizeByte(), totalReadabled);
+        Assert.assertEquals(opSendMsgStats.getNumMessagesInBatch(), batchSize);
+        Assert.assertEquals(opSendMsgStats.getHighestSequenceId(), batchSize-1);
+        Assert.assertEquals(opSendMsgStats.getTotalChunks(), 0);
+        Assert.assertEquals(opSendMsgStats.getChunkId(), -1);
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -229,7 +229,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
         try {
             // Need to protect ourselves from any exception being thrown in the future handler from the application
             if (firstCallback != null) {
-                firstCallback.sendComplete(ex);
+                firstCallback.sendComplete(ex, null);
             }
             if (batchedMessageMetadataAndPayload != null) {
                 ReferenceCountUtil.safeRelease(batchedMessageMetadataAndPayload);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/OpSendMsgStats.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/OpSendMsgStats.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+
+public interface OpSendMsgStats {
+    long getUncompressedSize();
+
+    long getSequenceId();
+
+    int getRetryCount();
+
+    long getBatchSizeByte();
+
+    int getNumMessagesInBatch();
+
+    long getHighestSequenceId();
+
+    int getTotalChunks();
+
+    int getChunkId();
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/OpSendMsgStatsImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/OpSendMsgStatsImpl.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import lombok.Builder;
+
+@Builder
+public class OpSendMsgStatsImpl implements OpSendMsgStats {
+    private long uncompressedSize;
+    private long sequenceId;
+    private int retryCount;
+    private long batchSizeByte;
+    private int numMessagesInBatch;
+    private long highestSequenceId;
+    private int totalChunks;
+    private int chunkId;
+
+    @Override
+    public long getUncompressedSize() {
+        return uncompressedSize;
+    }
+
+    @Override
+    public long getSequenceId() {
+        return sequenceId;
+    }
+
+    @Override
+    public int getRetryCount() {
+        return retryCount;
+    }
+
+    @Override
+    public long getBatchSizeByte() {
+        return batchSizeByte;
+    }
+
+    @Override
+    public int getNumMessagesInBatch() {
+        return numMessagesInBatch;
+    }
+
+    @Override
+    public long getHighestSequenceId() {
+        return highestSequenceId;
+    }
+
+    @Override
+    public int getTotalChunks() {
+        return totalChunks;
+    }
+
+    @Override
+    public int getChunkId() {
+        return chunkId;
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SendCallback.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SendCallback.java
@@ -20,10 +20,12 @@ package org.apache.pulsar.client.impl;
 
 import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.common.classification.InterfaceStability;
 
 /**
  *
  */
+@InterfaceStability.Evolving
 public interface SendCallback {
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SendCallback.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SendCallback.java
@@ -30,8 +30,9 @@ public interface SendCallback {
      * invoked when send operation completes.
      *
      * @param e
+     * @param opSendMsgStats stats associated with the send operation
      */
-    void sendComplete(Exception e);
+    void sendComplete(Throwable e, OpSendMsgStats opSendMsgStats);
 
     /**
      * used to specify a callback to be invoked on completion of a send operation for individual messages sent in a


### PR DESCRIPTION


PIP: #22940 


### Modifications

- Add `OpSendMsgStats` parameters to the `org.apache.pulsar.client.impl.SendCallback.sendComplete`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/crossoverJie/pulsar/pull/29