### PR TITLE
[improve][client] Don't print info logs for each schema loaded by client

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/MultiVersionAvroReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/MultiVersionAvroReader.java
@@ -44,9 +44,11 @@ public class MultiVersionAvroReader<T> extends AbstractMultiVersionAvroBaseReade
     protected SchemaReader<T> loadReader(BytesSchemaVersion schemaVersion) {
         SchemaInfo schemaInfo = getSchemaInfoByVersion(schemaVersion.get());
         if (schemaInfo != null) {
-            LOG.info("Load schema reader for version({}), schema is : {}, schemaInfo: {}",
-                    SchemaUtils.getStringSchemaVersion(schemaVersion.get()),
-                    schemaInfo.getSchemaDefinition(), schemaInfo.toString());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Load schema reader for version({}), schema is : {}, schemaInfo: {}",
+                        SchemaUtils.getStringSchemaVersion(schemaVersion.get()),
+                        schemaInfo.getSchemaDefinition(), schemaInfo);
+            }
             boolean jsr310ConversionEnabled = getJsr310ConversionEnabledFromSchemaInfo(schemaInfo);
             return new AvroReader<>(parseAvroSchema(schemaInfo.getSchemaDefinition()),
                     readerSchema, pojoClassLoader, jsr310ConversionEnabled);


### PR DESCRIPTION
### Motivation

Currently when a client loads schema from brokers, it will print the whole schema as info logs. The broker's built-in client has the same issue so schemas will be printed in broker logs, which could be very long (hundreds of lines) and might expose user info.

### Modifications

Reduce the log level to debug in `MultiVersionAvroReader`.
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
