### PR TITLE
[fix][broker] Fix thread unsafe access on the bundle range cache for load manager

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleRangeCache.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleRangeCache.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.impl;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+public class BundleRangeCache {
+
+    // Map from brokers to namespaces to the bundle ranges in that namespace assigned to that broker.
+    // Used to distribute bundles within a namespace evenly across brokers.
+    private final Map<String, Map<String, Set<String>>> data = new ConcurrentHashMap<>();
+
+    public void reloadFromBundles(String broker, Stream<String> bundles) {
+        final var namespaceToBundleRange = new ConcurrentHashMap<String, Set<String>>();
+        bundles.forEach(bundleName -> {
+            final String namespace = LoadManagerShared.getNamespaceNameFromBundleName(bundleName);
+            final String bundleRange = LoadManagerShared.getBundleRangeFromBundleName(bundleName);
+            initConcurrentHashSet(namespaceToBundleRange, namespace).add(bundleRange);
+        });
+        data.put(broker, namespaceToBundleRange);
+    }
+
+    public void addBundleRange(String broker, String namespace, String bundleRange) {
+        getBundleRangeSet(broker, namespace).add(bundleRange);
+    }
+
+    public int getBundles(String broker, String namespace) {
+        return getBundleRangeSet(broker, namespace).size();
+    }
+
+    public List<CompletableFuture<Void>> runTasks(
+            BiFunction<String/* broker */, String/* namespace */, CompletableFuture<Void>> task) {
+        return data.entrySet().stream().flatMap(e -> {
+            final var broker = e.getKey();
+            return e.getValue().entrySet().stream().filter(__ -> !__.getValue().isEmpty()).map(Map.Entry::getKey)
+                    .map(namespace -> task.apply(broker, namespace));
+        }).toList();
+    }
+
+    private Set<String> getBundleRangeSet(String broker, String namespace) {
+        return initConcurrentHashSet(data.computeIfAbsent(broker, __ -> new ConcurrentHashMap<>()), namespace);
+    }
+
+    private static Set<String> initConcurrentHashSet(Map<String, Set<String>> namespaceToBundleRangeSet,
+                                                     String namespace) {
+        return namespaceToBundleRangeSet.computeIfAbsent(namespace, __ -> ConcurrentHashMap.newKeySet());
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
@@ -46,8 +46,6 @@ import org.apache.pulsar.common.naming.ServiceUnitId;
 import org.apache.pulsar.common.policies.data.FailureDomainImpl;
 import org.apache.pulsar.common.util.DirectMemoryUtils;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
-import org.apache.pulsar.common.util.collections.ConcurrentOpenHashSet;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.policies.data.loadbalancer.BrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.ResourceUsage;
@@ -282,24 +280,6 @@ public class LoadManagerShared {
             return brokerCandidateCache;
         });
     }
-    /**
-     * Using the given bundles, populate the namespace to bundle range map.
-     *
-     * @param bundles
-     *            Bundles with which to populate.
-     * @param target
-     *            Map to fill.
-     */
-    public static void fillNamespaceToBundlesMap(final Set<String> bundles,
-            final ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>> target) {
-        bundles.forEach(bundleName -> {
-            final String namespaceName = getNamespaceNameFromBundleName(bundleName);
-            final String bundleRange = getBundleRangeFromBundleName(bundleName);
-            target.computeIfAbsent(namespaceName,
-                    k -> ConcurrentOpenHashSet.<String>newBuilder().build())
-                    .add(bundleRange);
-        });
-    }
 
     // From a full bundle name, extract the bundle range.
     public static String getBundleRangeFromBundleName(String bundleName) {
@@ -359,8 +339,7 @@ public class LoadManagerShared {
     public static void removeMostServicingBrokersForNamespace(
             final String assignedBundleName,
             final Set<String> candidates,
-            final ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>>
-                    brokerToNamespaceToBundleRange) {
+            final BundleRangeCache brokerToNamespaceToBundleRange) {
         if (candidates.isEmpty()) {
             return;
         }
@@ -369,13 +348,7 @@ public class LoadManagerShared {
         int leastBundles = Integer.MAX_VALUE;
 
         for (final String broker : candidates) {
-            int bundles = (int) brokerToNamespaceToBundleRange
-                    .computeIfAbsent(broker,
-                            k -> ConcurrentOpenHashMap.<String,
-                                    ConcurrentOpenHashSet<String>>newBuilder().build())
-                    .computeIfAbsent(namespaceName,
-                            k -> ConcurrentOpenHashSet.<String>newBuilder().build())
-                    .size();
+            int bundles = brokerToNamespaceToBundleRange.getBundles(broker, namespaceName);
             leastBundles = Math.min(leastBundles, bundles);
             if (leastBundles == 0) {
                 break;
@@ -386,13 +359,8 @@ public class LoadManagerShared {
         // `leastBundles` may differ from the actual value.
 
         final int finalLeastBundles = leastBundles;
-        candidates.removeIf(
-                broker -> brokerToNamespaceToBundleRange.computeIfAbsent(broker,
-                        k -> ConcurrentOpenHashMap.<String,
-                                ConcurrentOpenHashSet<String>>newBuilder().build())
-                        .computeIfAbsent(namespaceName,
-                                k -> ConcurrentOpenHashSet.<String>newBuilder().build())
-                        .size() > finalLeastBundles);
+        candidates.removeIf(broker ->
+                brokerToNamespaceToBundleRange.getBundles(broker, namespaceName) > finalLeastBundles);
     }
 
     /**
@@ -426,8 +394,7 @@ public class LoadManagerShared {
     public static void filterAntiAffinityGroupOwnedBrokers(
             final PulsarService pulsar, final String assignedBundleName,
             final Set<String> candidates,
-            final ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>>
-                    brokerToNamespaceToBundleRange,
+            final BundleRangeCache brokerToNamespaceToBundleRange,
             Map<String, String> brokerToDomainMap) {
         if (candidates.isEmpty()) {
             return;
@@ -572,8 +539,7 @@ public class LoadManagerShared {
      */
     public static CompletableFuture<Map<String, Integer>> getAntiAffinityNamespaceOwnedBrokers(
             final PulsarService pulsar, final String namespaceName,
-            final ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>>
-                    brokerToNamespaceToBundleRange) {
+            final BundleRangeCache brokerToNamespaceToBundleRange) {
 
         CompletableFuture<Map<String, Integer>> antiAffinityNsBrokersResult = new CompletableFuture<>();
         getNamespaceAntiAffinityGroupAsync(pulsar, namespaceName)
@@ -584,18 +550,11 @@ public class LoadManagerShared {
             }
             final String antiAffinityGroup = antiAffinityGroupOptional.get();
             final Map<String, Integer> brokerToAntiAffinityNamespaceCount = new ConcurrentHashMap<>();
-            final List<CompletableFuture<Void>> futures = new ArrayList<>();
-            brokerToNamespaceToBundleRange.forEach((broker, nsToBundleRange) -> {
-                nsToBundleRange.forEach((ns, bundleRange) -> {
-                    if (bundleRange.isEmpty()) {
-                        return;
-                    }
-
-                    CompletableFuture<Void> future = new CompletableFuture<>();
-                    futures.add(future);
-                    countAntiAffinityNamespaceOwnedBrokers(broker, ns, future,
-                            pulsar, antiAffinityGroup, brokerToAntiAffinityNamespaceCount);
-                });
+            final var futures = brokerToNamespaceToBundleRange.runTasks((broker, namespace) -> {
+                final var future = new CompletableFuture<Void>();
+                countAntiAffinityNamespaceOwnedBrokers(broker, namespace, future,
+                        pulsar, antiAffinityGroup, brokerToAntiAffinityNamespaceCount);
+                return future;
             });
             FutureUtil.waitForAll(futures)
                     .thenAccept(r -> antiAffinityNsBrokersResult.complete(brokerToAntiAffinityNamespaceCount));
@@ -698,7 +657,6 @@ public class LoadManagerShared {
      * by different broker.
      *
      * @param namespace
-     * @param bundle
      * @param currentBroker
      * @param pulsar
      * @param brokerToNamespaceToBundleRange
@@ -707,10 +665,9 @@ public class LoadManagerShared {
      * @throws Exception
      */
     public static boolean shouldAntiAffinityNamespaceUnload(
-            String namespace, String bundle, String currentBroker,
+            String namespace, String currentBroker,
             final PulsarService pulsar,
-            final ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>>
-                    brokerToNamespaceToBundleRange,
+            final BundleRangeCache brokerToNamespaceToBundleRange,
             Set<String> candidateBrokers) throws Exception {
 
         Map<String, Integer> brokerNamespaceCount = getAntiAffinityNamespaceOwnedBrokers(pulsar, namespace,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -43,6 +43,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
@@ -72,8 +73,6 @@ import org.apache.pulsar.common.policies.data.ResourceQuota;
 import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.Reflections;
-import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
-import org.apache.pulsar.common.util.collections.ConcurrentOpenHashSet;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
 import org.apache.pulsar.metadata.api.Notification;
@@ -116,10 +115,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
     // Broker host usage object used to calculate system resource usage.
     private BrokerHostUsage brokerHostUsage;
 
-    // Map from brokers to namespaces to the bundle ranges in that namespace assigned to that broker.
-    // Used to distribute bundles within a namespace evenly across brokers.
-    private final ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>>
-            brokerToNamespaceToBundleRange;
+    private final BundleRangeCache brokerToNamespaceToBundleRange = new BundleRangeCache();
 
     // Path to the ZNode containing the LocalBrokerData json for this broker.
     private String brokerZnodePath;
@@ -199,10 +195,6 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
      */
     public ModularLoadManagerImpl() {
         brokerCandidateCache = new HashSet<>();
-        brokerToNamespaceToBundleRange =
-                ConcurrentOpenHashMap.<String,
-                        ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>>newBuilder()
-                        .build();
         defaultStats = new NamespaceBundleStats();
         filterPipeline = new ArrayList<>();
         loadData = new LoadData();
@@ -582,17 +574,9 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
             TimeAverageBrokerData timeAverageData = new TimeAverageBrokerData();
             timeAverageData.reset(statsMap.keySet(), bundleData, defaultStats);
             brokerData.setTimeAverageData(timeAverageData);
-            final ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>> namespaceToBundleRange =
-                    brokerToNamespaceToBundleRange
-                            .computeIfAbsent(broker, k ->
-                                    ConcurrentOpenHashMap.<String,
-                                            ConcurrentOpenHashSet<String>>newBuilder()
-                                            .build());
-            synchronized (namespaceToBundleRange) {
-                namespaceToBundleRange.clear();
-                LoadManagerShared.fillNamespaceToBundlesMap(statsMap.keySet(), namespaceToBundleRange);
-                LoadManagerShared.fillNamespaceToBundlesMap(preallocatedBundleData.keySet(), namespaceToBundleRange);
-            }
+
+            brokerToNamespaceToBundleRange.reloadFromBundles(broker,
+                    Stream.of(statsMap.keySet(), preallocatedBundleData.keySet()).flatMap(Collection::stream));
         }
 
         // Remove not active bundle from loadData
@@ -736,7 +720,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                         .getBundle(namespace, bundle);
                 LoadManagerShared.applyNamespacePolicies(serviceUnit, policies, brokerCandidateCache,
                         getAvailableBrokers(), brokerTopicLoadingPredicate);
-                return LoadManagerShared.shouldAntiAffinityNamespaceUnload(namespace, bundle, currentBroker, pulsar,
+                return LoadManagerShared.shouldAntiAffinityNamespaceUnload(namespace, currentBroker, pulsar,
                         brokerToNamespaceToBundleRange, brokerCandidateCache);
             }
 
@@ -873,17 +857,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
 
         final String namespaceName = LoadManagerShared.getNamespaceNameFromBundleName(bundle);
         final String bundleRange = LoadManagerShared.getBundleRangeFromBundleName(bundle);
-        final ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>> namespaceToBundleRange =
-                brokerToNamespaceToBundleRange
-                        .computeIfAbsent(broker,
-                                k -> ConcurrentOpenHashMap.<String,
-                                        ConcurrentOpenHashSet<String>>newBuilder()
-                                        .build());
-        synchronized (namespaceToBundleRange) {
-            namespaceToBundleRange.computeIfAbsent(namespaceName,
-                    k -> ConcurrentOpenHashSet.<String>newBuilder().build())
-                    .add(bundleRange);
-        }
+        brokerToNamespaceToBundleRange.addBundleRange(broker, namespaceName, bundleRange);
     }
 
     @VisibleForTesting

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -857,7 +857,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
 
         final String namespaceName = LoadManagerShared.getNamespaceNameFromBundleName(bundle);
         final String bundleRange = LoadManagerShared.getBundleRangeFromBundleName(bundle);
-        brokerToNamespaceToBundleRange.addBundleRange(broker, namespaceName, bundleRange);
+        brokerToNamespaceToBundleRange.add(broker, namespaceName, bundleRange);
     }
 
     @VisibleForTesting

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Sets;
 import com.google.common.collect.TreeMultimap;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -47,6 +48,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.pulsar.broker.PulsarServerException;
@@ -62,8 +64,6 @@ import org.apache.pulsar.common.naming.ServiceUnitId;
 import org.apache.pulsar.common.policies.data.ResourceQuota;
 import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
-import org.apache.pulsar.common.util.collections.ConcurrentOpenHashSet;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.Notification;
@@ -107,10 +107,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
     private final Set<String> bundleGainsCache;
     private final Set<String> bundleLossesCache;
 
-    // Map from brokers to namespaces to the bundle ranges in that namespace assigned to that broker.
-    // Used to distribute bundles within a namespace evenly across brokers.
-    private final ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String,
-            ConcurrentOpenHashSet<String>>> brokerToNamespaceToBundleRange;
+    private final BundleRangeCache brokerToNamespaceToBundleRange = new BundleRangeCache();
 
     // CPU usage per msg/sec
     private double realtimeCpuLoadFactor = 0.025;
@@ -205,10 +202,6 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
         bundleLossesCache = new HashSet<>();
         brokerCandidateCache = new HashSet<>();
         availableBrokersCache = new HashSet<>();
-        brokerToNamespaceToBundleRange =
-                ConcurrentOpenHashMap.<String,
-                        ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>>newBuilder()
-                        .build();
         this.brokerTopicLoadingPredicate = new BrokerTopicLoadingPredicate() {
             @Override
             public boolean isEnablePersistentTopics(String brokerId) {
@@ -853,14 +846,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                 ResourceQuota quota = this.getResourceQuota(serviceUnitId);
                 // Add preallocated bundle range so incoming bundles from the same namespace are not assigned to the
                 // same broker.
-                brokerToNamespaceToBundleRange
-                        .computeIfAbsent(selectedRU.getResourceId(),
-                                k -> ConcurrentOpenHashMap.<String,
-                                        ConcurrentOpenHashSet<String>>newBuilder()
-                                        .build())
-                        .computeIfAbsent(namespaceName, k ->
-                                ConcurrentOpenHashSet.<String>newBuilder().build())
-                        .add(bundleRange);
+                brokerToNamespaceToBundleRange.addBundleRange(selectedRU.getResourceId(), namespaceName, bundleRange);
                 ranking.addPreAllocatedServiceUnit(serviceUnitId, quota);
                 resourceUnitRankings.put(selectedRU, ranking);
             }
@@ -1272,15 +1258,8 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
             final String broker = resourceUnit.getResourceId();
             final Set<String> loadedBundles = ranking.getLoadedBundles();
             final Set<String> preallocatedBundles = resourceUnitRankings.get(resourceUnit).getPreAllocatedBundles();
-            final ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>> namespaceToBundleRange =
-                    brokerToNamespaceToBundleRange
-                            .computeIfAbsent(broker,
-                                    k -> ConcurrentOpenHashMap.<String,
-                                            ConcurrentOpenHashSet<String>>newBuilder()
-                                            .build());
-            namespaceToBundleRange.clear();
-            LoadManagerShared.fillNamespaceToBundlesMap(loadedBundles, namespaceToBundleRange);
-            LoadManagerShared.fillNamespaceToBundlesMap(preallocatedBundles, namespaceToBundleRange);
+            brokerToNamespaceToBundleRange.reloadFromBundles(broker,
+                    Stream.of(loadedBundles, preallocatedBundles).flatMap(Collection::stream));
         });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -846,7 +846,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                 ResourceQuota quota = this.getResourceQuota(serviceUnitId);
                 // Add preallocated bundle range so incoming bundles from the same namespace are not assigned to the
                 // same broker.
-                brokerToNamespaceToBundleRange.addBundleRange(selectedRU.getResourceId(), namespaceName, bundleRange);
+                brokerToNamespaceToBundleRange.add(selectedRU.getResourceId(), namespaceName, bundleRange);
                 ranking.addPreAllocatedServiceUnit(serviceUnitId, quota);
                 resourceUnitRankings.put(selectedRU, ranking);
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
@@ -166,6 +166,10 @@ public class AntiAffinityNamespaceGroupTest extends MockedPulsarServiceBaseTest 
         }
     }
 
+    protected Object getBundleOwnershipData(){
+        return new BundleRangeCache();
+    }
+
     protected String getLoadManagerClassName() {
         return ModularLoadManagerImpl.class.getName();
     }
@@ -228,7 +232,7 @@ public class AntiAffinityNamespaceGroupTest extends MockedPulsarServiceBaseTest 
         brokerToDomainMap.put("brokerName-3", "domain-1");
 
         Set<String> candidate = new HashSet<>();
-        Object brokerToNamespaceToBundleRange = new BundleRangeCache();
+        Object brokerToNamespaceToBundleRange = getBundleOwnershipData();
 
         assertEquals(brokers.size(), totalBrokers);
 
@@ -311,7 +315,7 @@ public class AntiAffinityNamespaceGroupTest extends MockedPulsarServiceBaseTest 
 
         Set<String> brokers = new HashSet<>();
         Set<String> candidate = new HashSet<>();
-        Object brokerToNamespaceToBundleRange = new BundleRangeCache();
+        Object brokerToNamespaceToBundleRange = getBundleOwnershipData();
         brokers.add("broker-0");
         brokers.add("broker-1");
         brokers.add("broker-2");
@@ -459,7 +463,7 @@ public class AntiAffinityNamespaceGroupTest extends MockedPulsarServiceBaseTest 
 
         Set<String> brokers = new HashSet<>();
         Set<String> candidate = new HashSet<>();
-        Object brokerToNamespaceToBundleRange = new BundleRangeCache();
+        Object brokerToNamespaceToBundleRange = getBundleOwnershipData();
         brokers.add("broker-0");
         brokers.add("broker-1");
         brokers.add("broker-2");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
@@ -360,7 +360,7 @@ public class AntiAffinityNamespaceGroupTest extends MockedPulsarServiceBaseTest 
             String broker, String namespace, String assignedBundleName) {
 
         final var brokerToNamespaceToBundleRange = (BundleRangeCache) ownershipData;
-        brokerToNamespaceToBundleRange.addBundleRange(broker, namespace, assignedBundleName);
+        brokerToNamespaceToBundleRange.add(broker, namespace, assignedBundleName);
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerSharedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerSharedTest.java
@@ -18,13 +18,9 @@
  */
 package org.apache.pulsar.broker.loadbalance.impl;
 
+import com.google.common.collect.Sets;
 import java.util.HashSet;
 import java.util.Set;
-
-import com.google.common.collect.Sets;
-
-import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
-import org.apache.pulsar.common.util.collections.ConcurrentOpenHashSet;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -37,59 +33,44 @@ public class LoadManagerSharedTest {
         String assignedBundle = namespace + "/0x00000000_0x40000000";
 
         Set<String> candidates = new HashSet<>();
-        ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>> map =
-                ConcurrentOpenHashMap.<String,
-                        ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>>newBuilder()
-                        .build();
-        LoadManagerShared.removeMostServicingBrokersForNamespace(assignedBundle, candidates, map);
+        final var cache = new BundleRangeCache();
+        LoadManagerShared.removeMostServicingBrokersForNamespace(assignedBundle, candidates, cache);
         Assert.assertEquals(candidates.size(), 0);
 
         candidates = Sets.newHashSet("broker1");
-        LoadManagerShared.removeMostServicingBrokersForNamespace(assignedBundle, candidates, map);
+        LoadManagerShared.removeMostServicingBrokersForNamespace(assignedBundle, candidates, cache);
         Assert.assertEquals(candidates.size(), 1);
         Assert.assertTrue(candidates.contains("broker1"));
 
         candidates = Sets.newHashSet("broker1");
-        fillBrokerToNamespaceToBundleMap(map, "broker1", namespace, "0x40000000_0x80000000");
-        LoadManagerShared.removeMostServicingBrokersForNamespace(assignedBundle, candidates, map);
+        cache.addBundleRange("broker1", namespace, "0x40000000_0x80000000");
+        LoadManagerShared.removeMostServicingBrokersForNamespace(assignedBundle, candidates, cache);
         Assert.assertEquals(candidates.size(), 1);
         Assert.assertTrue(candidates.contains("broker1"));
 
         candidates = Sets.newHashSet("broker1", "broker2");
-        LoadManagerShared.removeMostServicingBrokersForNamespace(assignedBundle, candidates, map);
+        LoadManagerShared.removeMostServicingBrokersForNamespace(assignedBundle, candidates, cache);
         Assert.assertEquals(candidates.size(), 1);
         Assert.assertTrue(candidates.contains("broker2"));
 
         candidates = Sets.newHashSet("broker1", "broker2");
-        fillBrokerToNamespaceToBundleMap(map, "broker2", namespace, "0x80000000_0xc0000000");
-        LoadManagerShared.removeMostServicingBrokersForNamespace(assignedBundle, candidates, map);
+        cache.addBundleRange("broker2", namespace, "0x80000000_0xc0000000");
+        LoadManagerShared.removeMostServicingBrokersForNamespace(assignedBundle, candidates, cache);
         Assert.assertEquals(candidates.size(), 2);
         Assert.assertTrue(candidates.contains("broker1"));
         Assert.assertTrue(candidates.contains("broker2"));
 
         candidates = Sets.newHashSet("broker1", "broker2");
-        fillBrokerToNamespaceToBundleMap(map, "broker2", namespace, "0xc0000000_0xd0000000");
-        LoadManagerShared.removeMostServicingBrokersForNamespace(assignedBundle, candidates, map);
+        cache.addBundleRange("broker2", namespace, "0xc0000000_0xd0000000");
+        LoadManagerShared.removeMostServicingBrokersForNamespace(assignedBundle, candidates, cache);
         Assert.assertEquals(candidates.size(), 1);
         Assert.assertTrue(candidates.contains("broker1"));
 
         candidates = Sets.newHashSet("broker1", "broker2", "broker3");
-        fillBrokerToNamespaceToBundleMap(map, "broker3", namespace, "0xd0000000_0xffffffff");
-        LoadManagerShared.removeMostServicingBrokersForNamespace(assignedBundle, candidates, map);
+        cache.addBundleRange("broker3", namespace, "0xd0000000_0xffffffff");
+        LoadManagerShared.removeMostServicingBrokersForNamespace(assignedBundle, candidates, cache);
         Assert.assertEquals(candidates.size(), 2);
         Assert.assertTrue(candidates.contains("broker1"));
         Assert.assertTrue(candidates.contains("broker3"));
     }
-
-    private static void fillBrokerToNamespaceToBundleMap(
-            ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>> map,
-            String broker, String namespace, String bundle) {
-        map.computeIfAbsent(broker,
-                k -> ConcurrentOpenHashMap.<String,
-                        ConcurrentOpenHashSet<String>>newBuilder().build())
-                .computeIfAbsent(namespace,
-                        k -> ConcurrentOpenHashSet.<String>newBuilder().build())
-                .add(bundle);
-    }
-
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerSharedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerSharedTest.java
@@ -43,7 +43,7 @@ public class LoadManagerSharedTest {
         Assert.assertTrue(candidates.contains("broker1"));
 
         candidates = Sets.newHashSet("broker1");
-        cache.addBundleRange("broker1", namespace, "0x40000000_0x80000000");
+        cache.add("broker1", namespace, "0x40000000_0x80000000");
         LoadManagerShared.removeMostServicingBrokersForNamespace(assignedBundle, candidates, cache);
         Assert.assertEquals(candidates.size(), 1);
         Assert.assertTrue(candidates.contains("broker1"));
@@ -54,20 +54,20 @@ public class LoadManagerSharedTest {
         Assert.assertTrue(candidates.contains("broker2"));
 
         candidates = Sets.newHashSet("broker1", "broker2");
-        cache.addBundleRange("broker2", namespace, "0x80000000_0xc0000000");
+        cache.add("broker2", namespace, "0x80000000_0xc0000000");
         LoadManagerShared.removeMostServicingBrokersForNamespace(assignedBundle, candidates, cache);
         Assert.assertEquals(candidates.size(), 2);
         Assert.assertTrue(candidates.contains("broker1"));
         Assert.assertTrue(candidates.contains("broker2"));
 
         candidates = Sets.newHashSet("broker1", "broker2");
-        cache.addBundleRange("broker2", namespace, "0xc0000000_0xd0000000");
+        cache.add("broker2", namespace, "0xc0000000_0xd0000000");
         LoadManagerShared.removeMostServicingBrokersForNamespace(assignedBundle, candidates, cache);
         Assert.assertEquals(candidates.size(), 1);
         Assert.assertTrue(candidates.contains("broker1"));
 
         candidates = Sets.newHashSet("broker1", "broker2", "broker3");
-        cache.addBundleRange("broker3", namespace, "0xd0000000_0xffffffff");
+        cache.add("broker3", namespace, "0xd0000000_0xffffffff");
         LoadManagerShared.removeMostServicingBrokersForNamespace(assignedBundle, candidates, cache);
         Assert.assertEquals(candidates.size(), 2);
         Assert.assertTrue(candidates.contains("broker1"));


### PR DESCRIPTION
### Background Knowledge

A concurrent hash map (no matter the `ConcurrentOpenHashMap` in Pulsar or the official `ConcurrentHashMap`) is not a synchronized hash map.

For example, given a `ConcurrentHashMap<Integer, Integer>` object `m`,

```java
synchronized (m) {
    m.computeIfAbsent(1, __ -> 100); // [1]
    m.computeIfAbsent(2, __ -> 200); // [2]
}
```

```java
m.computeIfAbsent(1, __ -> 300); // [3]
```

If these two code blocks are called in two threads, `[1]->[3]->[2]` is a possible case.

### Motivation

`SimpleLoadManagerImpl` and `ModularLoadManagerImpl` both maintain the bundle range cache:

```java
// The 1st key is broker, the 2nd key is namespace
private final ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>>
    brokerToNamespaceToBundleRange;
```

However, when accessing the `namespace -> bundle` map, it still needs a synchronized code block:

https://github.com/apache/pulsar/blob/1c495e190b3c569e9dfd44acef2a697c93a1f771/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java#L591-L595

The code above is a composite operation of `clear()` and multiple `computeIfAbsent` operations on the `ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<String>>` object.

So the other place that access this map also requires the same lock even if the operation itself is thread safe:

https://github.com/apache/pulsar/blob/1c495e190b3c569e9dfd44acef2a697c93a1f771/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java#L882-L886

P.S. `SimpleLoadManagerImpl` does not apply the synchronized block.

However, when accessing `brokerToNamespaceToBundleRange` in the static methods of `LoadManagerShared`, they are not synchronized. So the access on the `Map<String, Set<String>>` value is not thread safe.

### Modifications

Add a `BundleRangeCache` abstraction to provide some methods to support required operations on the bundle range cache. Apply `synchronized` key word to access any internal map (`namespace -> bundle range set`) to guarantee thread safety.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: