### PR TITLE
[fix] StatsOutputStream: add string write function (#308)

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SimpleTextOutputStream.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SimpleTextOutputStream.java
@@ -56,6 +56,15 @@ public class SimpleTextOutputStream {
         return this;
     }
 
+    public SimpleTextOutputStream write(String s) {
+        if (s == null) {
+            return this;
+        }
+
+        buffer.writeCharSequence(s, CharsetUtil.UTF_8);
+        return this;
+    }
+
     public SimpleTextOutputStream write(CharSequence s) {
         if (s == null) {
             return this;


### PR DESCRIPTION
### Motivation

On a specific environment /metrics end point timed out consistently, logs contained the exception below.
Applied fix has resolved the issue. 

The fix does not make much sense as String implements CharSequence, so I suspect we hit some weird issue with JIT or jvm.
The JDK is Timurin build 17.0.12+7, I could not repro this locally but it consistently happened in the env.

```
2024-08-23T20:40:42,618+0000 [pulsar-stats-updater-OrderedScheduler-0-0] WARN  org.apache.bookkeeper.common.util.SingleThreadSafeScheduledExecutorService - Unexpected throwable from task class com.google.common.util.concurrent.MoreExecutors$ScheduledListeningDecorator$NeverSuccessfulListenableFutureTask: 'org.apache.pulsar.common.util.SimpleTextOutputStream org.apache.pulsar.common.util.SimpleTextOutputStream.write(java.lang.String)'
java.lang.NoSuchMethodError: 'org.apache.pulsar.common.util.SimpleTextOutputStream org.apache.pulsar.common.util.SimpleTextOutputStream.write(java.lang.String)'
        at org.apache.pulsar.utils.StatsOutputStream.startObject(StatsOutputStream.java:41) ~[com.datastax.oss-pulsar-broker-3.1.3.1.jar:3.1.3.1]
        at org.apache.pulsar.broker.service.PulsarStats.lambda$updateStats$4(PulsarStats.java:126) ~[com.datastax.oss-pulsar-broker-3.1.3.1.jar:3.1.3.1]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:563) ~[com.datastax.oss-pulsar-common-3.1.3.1.jar:3.1.3.1]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:277) ~[com.datastax.oss-pulsar-common-3.1.3.1.jar:3.1.3.1]
        at org.apache.pulsar.broker.service.PulsarStats.updateStats(PulsarStats.java:120) ~[com.datastax.oss-pulsar-broker-3.1.3.1.jar:3.1.3.1]
        at org.apache.pulsar.broker.service.BrokerService.updateRates(BrokerService.java:2065) ~[com.datastax.oss-pulsar-broker-3.1.3.1.jar:3.1.3.1]
        at com.google.common.util.concurrent.MoreExecutors$ScheduledListeningDecorator$NeverSuccessfulListenableFutureTask.run(MoreExecutors.java:741) ~[com.google.guava-guava-32.1.1-jre.jar:?]
        at org.apache.bookkeeper.common.util.SingleThreadSafeScheduledExecutorService$SafeRunnable.run(SingleThreadSafeScheduledExecutorService.java:46) ~[org.apache.bookkeeper-bookkeeper-common-4.16.4.jar:4.16.4]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[?:?]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.108.Final.jar:4.1.108.Final]
        at java.lang.Thread.run(Thread.java:840) ~[?:?]
```

### Modifications

Added method that takes String parameter explicitly.
Such method existed up until the change https://github.com/apache/pulsar/pull/22494

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

Verified in the env where the problem reproduces

### Does this pull request potentially affect one of the following parts:

**NO**

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/datastax/pulsar/pull/308

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
