### PR TITLE
[improve][broker] Add retry for start service unit state channel (ExtensibleLoadManagerImpl only)

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -420,7 +420,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
                         log.warn("The broker:{} failed to start service unit state channel. Retrying {} th ...",
                                 pulsar.getBrokerId(), ++retry, e);
                         try {
-                            TimeUnit.SECONDS.sleep(backoff.next());
+                            Thread.sleep(backoff.next());
                         } catch (InterruptedException ex) {
                             log.warn("Interrupted while sleeping.");
                             // preserve thread's interrupt status

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -125,6 +125,8 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
 
     public static final long COMPACTION_THRESHOLD = 5 * 1024 * 1024;
 
+    public static final int STARTUP_TIMEOUT_SECONDS = 30;
+
     public static final int MAX_RETRY = 5;
 
     private static final String ELECTION_ROOT = "/loadbalance/extension/leader";
@@ -408,7 +410,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
             pulsar.runWhenReadyForIncomingRequests(() -> {
                 Backoff backoff = new BackoffBuilder()
                         .setInitialTime(100, TimeUnit.MILLISECONDS)
-                        .setMax(conf.getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS)
+                        .setMax(STARTUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                         .create();
                 int retry = 0;
                 while (!Thread.currentThread().isInterrupted()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -427,6 +427,12 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
                             log.warn("Interrupted while sleeping.");
                             // preserve thread's interrupt status
                             Thread.currentThread().interrupt();
+                            try {
+                                pulsar.close();
+                            } catch (PulsarServerException exc) {
+                                log.error("Failed to close pulsar service.", exc);
+                            }
+                            return;
                         }
                         failStarting(e);
                         if (retry >= MAX_RETRY) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -879,6 +879,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                                 k -> ConcurrentOpenHashMap.<String,
                                         ConcurrentOpenHashSet<String>>newBuilder()
                                         .build());
+        Set<String> myConcurrentSet = ConcurrentHashMap.newKeySet();
         synchronized (namespaceToBundleRange) {
             namespaceToBundleRange.computeIfAbsent(namespaceName,
                     k -> ConcurrentOpenHashSet.<String>newBuilder().build())

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -879,7 +879,6 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                                 k -> ConcurrentOpenHashMap.<String,
                                         ConcurrentOpenHashSet<String>>newBuilder()
                                         .build());
-        Set<String> myConcurrentSet = ConcurrentHashMap.newKeySet();
         synchronized (namespaceToBundleRange) {
             namespaceToBundleRange.computeIfAbsent(namespaceName,
                     k -> ConcurrentOpenHashSet.<String>newBuilder().build())


### PR DESCRIPTION
### Motivation

When the service unit state channel fails to start, it will throw an exception, and after the PR https://github.com/apache/pulsar/pull/22977 , it will fail forever, because the pulsar broker cannot catch the exception, and it won't have any retry mechanism

### Modifications

Add retry for start service unit state channel

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->