### PR TITLE
[fix][broker] support peek-message for compressed and encrypted messages

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -2712,11 +2712,16 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         Producer<byte[]> cryptoProducer = pulsarClient.newProducer()
                 .topic(topicName).addEncryptionKey("client-ecdsa.pem")
+                .compressionType(CompressionType.LZ4)
                 .cryptoKeyReader(new EncKeyReader()).create();
         for (int i = 0; i < totalMsg; i++) {
             String message = "my-message-" + i;
             cryptoProducer.send(message.getBytes());
         }
+
+        // admin api should be able to fetch compressed and encrypted message
+        List<Message<byte[]>> msgs = admin.topics().peekMessages(topicName, "my-subscriber-name", 1);
+        assertNotNull(msgs);
 
         Message<byte[]> msg;
 


### PR DESCRIPTION


Fixes #23233


### Motivation

It fixes this issue: https://github.com/apache/pulsar/issues/23233

Currently `peek-message` CLI/API returns encrypted or compressed message , and user can use this CLI/API to retrieve message and metadata information for any kind of debugging. For example, if encrypted messages is failing to decrypt in consumer application and if user wants to know the encryption keys name then peek-message will help to retrieve such information.
But peek-message api/cli fails if message is encrypted and compressed , and failed with below error because broker is trying to decompress invalid message payload as client first compress and encrypt the message, and broker tried to uncompress already encrypted message.

```
Reason: 
--- An unexpected error occurred in the server ---

Message: offset outside destination buffer: offset=10

Stacktrace:

io.airlift.compress.MalformedInputException: offset outside destination buffer: offset=10
	at io.airlift.compress.lz4.Lz4RawDecompressor.decompress(Lz4RawDecompressor.java:112)
	at io.airlift.compress.lz4.Lz4Decompressor.decompress(Lz4Decompressor.java:93)
	at org.apache.pulsar.common.compression.CompressionCodecLZ4.decode(CompressionCodecLZ4.java:98)
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.generateResponseWithEntry(PersistentTopicsBase.java:2927)
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.internalPeekNthMessage(PersistentTopicsBase.java:2740)
	at org.apache.pulsar.broker.admin.v1.PersistentTopics.peekNthMessage(PersistentTopics.java:707)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)

```

### Modifications

Avoid decompressing invalid payload if message is already encrypted.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
