### PR TITLE
[improve][broker] Optimize message payload traffic for ShadowReplicator

### DIFF
--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -80,7 +80,7 @@ function test_group_broker_group_1() {
 }
 
 function test_group_broker_group_2() {
-  mvn_test -pl pulsar-broker -Dgroups='schema,utils,functions-worker,broker-io,broker-discovery,broker-compaction,broker-naming,websocket,other'
+  mvn_test -pl pulsar-broker -Dgroups='schema,utils,functions-worker,broker-io,broker-discovery,broker-compaction,broker-naming,broker-replication,websocket,other'
 }
 
 function test_group_broker_group_3() {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -38,6 +38,7 @@ import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.bookkeeper.mledger.intercept.ManagedLedgerInterceptor;
+import org.apache.pulsar.common.protocol.Commands;
 
 
 /**
@@ -239,8 +240,12 @@ public class OpAddEntry implements AddCallback, CloseCallback, Runnable {
         ManagedLedgerImpl.TOTAL_SIZE_UPDATER.addAndGet(ml, dataLength);
 
         long ledgerId = ledger != null ? ledger.getId() : ((Position) ctx).getLedgerId();
-        // Don't insert to the entry cache for the ShadowManagedLedger
-        if (!(ml instanceof ShadowManagedLedgerImpl) && ml.hasActiveCursors()) {
+        // Don't insert to the entry cache when the entry payload is empty
+        final var duplicatedData = data.duplicate();
+        Commands.skipBrokerEntryMetadataIfExist(duplicatedData);
+        Commands.skipChecksumIfPresent(duplicatedData);
+        long metadataSize = duplicatedData.readUnsignedInt();
+        if (duplicatedData.readableBytes() > metadataSize && ml.hasActiveCursors()) {
             // Avoid caching entries if no cursor has been created
             EntryImpl entry = EntryImpl.create(ledgerId, entryId, data);
             // EntryCache.insert: duplicates entry by allocating new entry and data. so, recycle entry after calling

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -239,7 +239,8 @@ public class OpAddEntry implements AddCallback, CloseCallback, Runnable {
         ManagedLedgerImpl.TOTAL_SIZE_UPDATER.addAndGet(ml, dataLength);
 
         long ledgerId = ledger != null ? ledger.getId() : ((Position) ctx).getLedgerId();
-        if (ml.hasActiveCursors()) {
+        // Don't insert to the entry cache for the ShadowManagedLedger
+        if (!(ml instanceof ShadowManagedLedgerImpl) && ml.hasActiveCursors()) {
             // Avoid caching entries if no cursor has been created
             EntryImpl entry = EntryImpl.create(ledgerId, entryId, data);
             // EntryCache.insert: duplicates entry by allocating new entry and data. so, recycle entry after calling

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ShadowReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ShadowReplicator.java
@@ -67,7 +67,7 @@ public class ShadowReplicator extends PersistentReplicator {
                 ByteBuf headersAndPayload = entry.getDataBuffer();
                 MessageImpl msg;
                 try {
-                    msg = MessageImpl.deserializeSkipBrokerEntryMetaData(headersAndPayload);
+                    msg = MessageImpl.deserializeMetadataWithEmptyPayload(headersAndPayload);
                 } catch (Throwable t) {
                     log.error("[{}] Failed to deserialize message at {} (buffer size: {}): {}", replicatorId,
                             entry.getPosition(), length, t.getMessage(), t);
@@ -91,9 +91,9 @@ public class ShadowReplicator extends PersistentReplicator {
 
                 dispatchRateLimiter.ifPresent(rateLimiter -> rateLimiter.consumeDispatchQuota(1, entry.getLength()));
 
-                msgOut.recordEvent(headersAndPayload.readableBytes());
+                msgOut.recordEvent(msg.getDataBuffer().readableBytes());
                 stats.incrementMsgOutCounter();
-                stats.incrementBytesOutCounter(headersAndPayload.readableBytes());
+                stats.incrementBytesOutCounter(msg.getDataBuffer().readableBytes());
 
                 msg.setReplicatedFrom(localCluster);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ShadowReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ShadowReplicatorTest.java
@@ -131,7 +131,7 @@ public class ShadowReplicatorTest extends BrokerTestBase {
 
         Message<byte[]> shadowMessage = shadowConsumer.receive(5, TimeUnit.SECONDS);
 
-        Assert.assertEquals(shadowMessage.getData().length, 0);
+        Assert.assertEquals(shadowMessage.getData(), sourceMessage.getData());
         Assert.assertEquals(shadowMessage.getSequenceId(), sourceMessage.getSequenceId());
         Assert.assertEquals(shadowMessage.getEventTime(), sourceMessage.getEventTime());
         Assert.assertEquals(shadowMessage.getProperties(), sourceMessage.getProperties());
@@ -144,9 +144,6 @@ public class ShadowReplicatorTest extends BrokerTestBase {
 
         Assert.assertEquals(replicator.stats.getBytesOutCount(), 0);
 
-
-        //`replicatedFrom` is set as localClusterName in shadow topic.
-        Assert.assertNotEquals(shadowMessage.getReplicatedFrom(), sourceMessage.getReplicatedFrom());
         Assert.assertEquals(shadowMessage.getMessageId(), sourceMessage.getMessageId());
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ShadowReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ShadowReplicatorTest.java
@@ -131,7 +131,7 @@ public class ShadowReplicatorTest extends BrokerTestBase {
 
         Message<byte[]> shadowMessage = shadowConsumer.receive(5, TimeUnit.SECONDS);
 
-        Assert.assertEquals(shadowMessage.getData(), sourceMessage.getData());
+        Assert.assertEquals(shadowMessage.getData().length, 0);
         Assert.assertEquals(shadowMessage.getSequenceId(), sourceMessage.getSequenceId());
         Assert.assertEquals(shadowMessage.getEventTime(), sourceMessage.getEventTime());
         Assert.assertEquals(shadowMessage.getProperties(), sourceMessage.getProperties());
@@ -141,6 +141,9 @@ public class ShadowReplicatorTest extends BrokerTestBase {
         Assert.assertEquals(shadowMessage.getPublishTime(), sourceMessage.getPublishTime());
         Assert.assertEquals(shadowMessage.getBrokerPublishTime(), sourceMessage.getBrokerPublishTime());
         Assert.assertEquals(shadowMessage.getIndex(), sourceMessage.getIndex());
+
+        Assert.assertEquals(replicator.stats.getBytesOutCount(), 0);
+
 
         //`replicatedFrom` is set as localClusterName in shadow topic.
         Assert.assertNotEquals(shadowMessage.getReplicatedFrom(), sourceMessage.getReplicatedFrom());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ShadowTopicRealBkTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ShadowTopicRealBkTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.service.persistent;
 import com.google.common.collect.Lists;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.mledger.impl.ShadowManagedLedgerImpl;
 import org.apache.pulsar.broker.PulsarService;
@@ -74,7 +75,7 @@ public class ShadowTopicRealBkTest {
 
     @Test
     public void testReadFromStorage() throws Exception {
-        final var sourceTopic = TopicName.get("test-read-from-source").toString();
+        final var sourceTopic = TopicName.get("test-read-from-source" + UUID.randomUUID()).toString();
         final var shadowTopic = sourceTopic + "-shadow";
 
         admin.topics().createNonPartitionedTopic(sourceTopic);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -306,6 +306,13 @@ public class MessageImpl<T> implements Message<T> {
         return msg;
     }
 
+    public static MessageImpl<byte[]> deserializeMetadataWithEmptyPayload(
+            ByteBuf headersAndPayloadWithBrokerEntryMetadata) throws IOException {
+        MessageImpl<byte[]> msg = deserializeSkipBrokerEntryMetaData(headersAndPayloadWithBrokerEntryMetadata);
+        msg.payload = Unpooled.EMPTY_BUFFER;
+        return msg;
+    }
+
     public void setReplicatedFrom(String cluster) {
         msgMetadata.setReplicatedFrom(cluster);
     }


### PR DESCRIPTION
## Motivation

Currently, the ShadowReplicator syncs all message payloads from the source topic to the shadow topic (ShadowManagedLedger). This significantly increases traffic between brokers. However, the ShadowManagedLedger only requires the position information from these messages. It can retrieve the payload directly from the Bookkeeper. Therefore, the ShadowReplicator does not need to sync the message payloads between brokers.

### Modifications

- Prevent ShadowReplicator from syncing message payloads

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/RobertIndie/pulsar/pull/16

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
