### PR TITLE
[improve][admin] Improve BrokerStats.allocatorStats

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/AllocatorStatsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/AllocatorStatsGenerator.java
@@ -54,6 +54,8 @@ public class AllocatorStatsGenerator {
         stats.numDirectArenas = allocator.metric().numDirectArenas();
         stats.numHeapArenas = allocator.metric().numHeapArenas();
         stats.numThreadLocalCaches = allocator.metric().numThreadLocalCaches();
+        stats.usedHeapMemory = allocator.metric().usedHeapMemory();
+        stats.usedDirectMemory = allocator.metric().usedDirectMemory();
         stats.normalCacheSize = allocator.metric().normalCacheSize();
         stats.smallCacheSize = allocator.metric().smallCacheSize();
         return stats;

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/stats/AllocatorStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/stats/AllocatorStats.java
@@ -29,6 +29,8 @@ public class AllocatorStats {
     public int numThreadLocalCaches;
     public int normalCacheSize;
     public int smallCacheSize;
+    public long usedDirectMemory;
+    public long usedHeapMemory;
 
     public List<PoolArenaStats> directArenas;
     public List<PoolArenaStats> heapArenas;

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -199,6 +199,10 @@ public class PulsarAdminToolTest {
         doReturn("null").when(mockBrokerStats).getMetrics();
         brokerStats.run(split("monitoring-metrics"));
         verify(mockBrokerStats).getMetrics();
+
+        doReturn(null).when(mockBrokerStats).getAllocatorStats("default");
+        brokerStats.run(split("allocator-stats default"));
+        verify(mockBrokerStats).getAllocatorStats("default");
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Expose `usedDirectMemory` and `usedHeapMemory` to track the heap/direct memory usage of ByteBufAllocator.

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
