### PR TITLE
[fix][test] Fix flaky UnloadSubscriptionTest.testMultiConsumer

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/UnloadSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/UnloadSubscriptionTest.java
@@ -60,6 +60,7 @@ public class UnloadSubscriptionTest extends ProducerConsumerBase {
         super.doInitConf();
         conf.setSystemTopicEnabled(false);
         conf.setTransactionCoordinatorEnabled(false);
+        conf.setAcknowledgmentAtBatchIndexLevelEnabled(true);
     }
 
     @AfterClass(alwaysRun = true)
@@ -242,6 +243,7 @@ public class UnloadSubscriptionTest extends ProducerConsumerBase {
                 .subscriptionName(subName)
                 .subscriptionType(subType)
                 .isAckReceiptEnabled(true)
+                .enableBatchIndexAcknowledgment(true)
                 .subscribe();
         return consumer;
     }


### PR DESCRIPTION
### Motivation

Fixes https://github.com/apache/pulsar/issues/19508#issuecomment-1733497179
This problem still exists. The root cause is that `BatchIndexAcknowledgment` is not enabled.

### Modifications

enable batch index acknowledgment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->