### PR TITLE
[improve][admin] PIP-369 Change default value of `unload-scope` in `ns-isolation-policy set`

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
@@ -826,7 +826,7 @@ public class ClustersBase extends AdminResource {
             Set<String> commonNamespaces = new HashSet<>(policyData.getNamespaces());
             commonNamespaces.retainAll(oldNamespaces);
 
-            log.debug("combined regexes: {}; common regexes:{}", combinedNamespaces, combinedNamespaces);
+            log.debug("combined regexes: {}; common regexes:{}", combinedNamespaces, commonNamespaces);
 
             if (!unloadAllNamespaces) {
                 // Find the changed regexes ((new U old) - (new ∩ old)).

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaceIsolationPolicy.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaceIsolationPolicy.java
@@ -75,12 +75,12 @@ public class CmdNamespaceIsolationPolicy extends CmdBase {
         private Map<String, String> autoFailoverPolicyParams;
 
         @Option(names = "--unload-scope", description = "configure the type of unload to do -"
-                + " ['all_matching', 'none', 'changed'] namespaces. By default, all namespaces matching the namespaces"
-                + " regex will be unloaded and placed again. You can choose to not unload any namespace while setting"
-                + " this new policy by choosing `none` or choose to unload only the namespaces whose placement will"
-                + " actually change. If you chose 'none', you will need to manually unload the namespaces for them to"
-                + " be placed correctly, or wait till some namespaces get load balanced automatically based on load"
-                + " shedding configurations.")
+                + " ['all_matching', 'none', 'changed'] namespaces. By default, only namespaces whose placement will"
+                + " actually change would be unloaded and placed again. You can choose to not unload any namespace"
+                + " while setting this new policy by choosing `none` or choose to unload all namespaces matching"
+                + " old (if any) and new namespace regex. If you chose 'none', you will need to manually unload the"
+                + " namespaces for them to be placed correctly, or wait till some namespaces get load balanced"
+                + " automatically based on load shedding configurations.")
         private NamespaceIsolationPolicyUnloadScope unloadScope;
 
         void run() throws PulsarAdminException {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/NamespaceIsolationDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/NamespaceIsolationDataImpl.java
@@ -78,8 +78,8 @@ public class NamespaceIsolationDataImpl implements NamespaceIsolationData {
     @ApiModelProperty(
             name = "unload_scope",
             value = "The type of unload to perform while applying the new isolation policy.",
-            example = "'all_matching' (default) for unloading all matching namespaces. 'none' for not unloading "
-                    + "any namespace. 'changed' for unloading only the namespaces whose placement is actually changing"
+            example = "'changed' (default) for unloading only the namespaces whose placement is actually changing. "
+                    + "'all_matching' for unloading all matching namespaces. 'none' for not unloading any namespaces."
     )
     @JsonProperty("unload_scope")
     private NamespaceIsolationPolicyUnloadScope unloadScope;


### PR DESCRIPTION
This PR is a followup to #23120 to make the backward incompatible change to:
* Make the default value of `unload-scope` to `changed`
* Change behavior of all_matching to cover both removed and added regexes

PIP: #23116 

This change is only meant for pulsar 4.x release

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - Added test case to validate behavior of `all_matching` flag
  - Added test case to verify default changed to `changed`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [x] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [x] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/grssam/pulsar/pull/3

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
