### PR TITLE
[improve][client] Enhance error handling for non-exist subscription in consumer creation

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiTopicsConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiTopicsConsumerTest.java
@@ -413,8 +413,9 @@ public class MultiTopicsConsumerTest extends ProducerConsumerBase {
                     .isAckReceiptEnabled(true)
                     .subscribe();
             assertTrue(singleTopicConsumer instanceof ConsumerImpl);
+        } catch (PulsarClientException.SubscriptionNotFoundException ignore) {
         } catch (Throwable t) {
-            assertTrue(t.getCause().getCause() instanceof PulsarClientException.SubscriptionNotFoundException);
+            fail("Should throw PulsarClientException.SubscriptionNotFoundException instead");
         }
 
         try {
@@ -424,8 +425,9 @@ public class MultiTopicsConsumerTest extends ProducerConsumerBase {
                     .isAckReceiptEnabled(true)
                     .subscribe();
             assertTrue(multiTopicsConsumer instanceof MultiTopicsConsumerImpl);
+        } catch (PulsarClientException.SubscriptionNotFoundException ignore) {
         } catch (Throwable t) {
-            assertTrue(t.getCause().getCause() instanceof PulsarClientException.SubscriptionNotFoundException);
+            fail("Should throw PulsarClientException.SubscriptionNotFoundException instead");
         }
 
         pulsar.getConfiguration().setAllowAutoSubscriptionCreation(true);

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -1144,6 +1144,8 @@ public class PulsarClientException extends IOException {
             newException = new TransactionConflictException(msg);
         } else if (cause instanceof TopicDoesNotExistException) {
             newException = new TopicDoesNotExistException(msg);
+        } else if (cause instanceof SubscriptionNotFoundException) {
+            newException = new SubscriptionNotFoundException(msg);
         } else if (cause instanceof ProducerFencedException) {
             newException = new ProducerFencedException(msg);
         } else if (cause instanceof MemoryBufferIsFullError) {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

When `allowAutoSubscriptionCreation` is set to `false` on broker, creating a consumer for a subscription that does not exist does not throw a `SubscriptionNotFoundException`. Instead, it throws a `PulsarClientException`. This behavior complicates determining whether the subscription exists, requiring users to perform checks like `getRootCause(e).getMessage().matches(".*Subscription .*does not exist.*")` before #22164. Even after #22164, while the root cause becomes `SubscriptionNotFoundException`, additional handling is still necessary.
```java
try {
    Consumer<byte[]> consumer = pulsarClient.newConsumer()
            .topic("public/default/subscription-auto-creation-disabled")
            .subscriptionName("test")
            .subscriptionType(SubscriptionType.Exclusive)
            .subscribe();
} catch (PulsarClientException.SubscriptionNotFoundException e) {
    // never reached here
} catch (PulsarClientException e) {
    getRootCause(e).getMessage().matches(".*Subscription .*does not exist.*");   // before #22164
    getRootCause(e) instanceof PulsarClientException.SubscriptionNotFoundException; // after #22164, there is another approach
}
```

### Modifications

This change modifies the code to throw `SubscriptionNotFoundException` directly when attempting to create a consumer for a non-existent subscription. This exception is a subclass of `PulsarClientException`, ensuring backward compatibility and providing a clearer error handling path for users.

### Verifying this change

- [x] Ensure that the change passes the CI checks.

This PR also updates the corresponding test in `org.apache.pulsar.client.api.MultiTopicsConsumerTest#testSubscriptionNotFound`.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/Shawyeok/pulsar/pull/17

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
