### PR TITLE
[fix][client] Fix client handle unknown exception during message-decryption and apply decryption action accordingly

### DIFF
--- a/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
+++ b/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
@@ -521,13 +521,8 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
 
             keyDigest = digest.digest(encryptedDataKey);
 
-        } catch (IllegalBlockSizeException | BadPaddingException | NoSuchAlgorithmException | NoSuchProviderException
-                | NoSuchPaddingException | InvalidKeyException | InvalidAlgorithmParameterException e) {
-            log.error("{} Failed to decrypt data key {} to decrypt messages {}", logCtx, keyName, e.getMessage());
-            return false;
         } catch (Exception e) {
-            log.error("{} Failed with unknwon error to decrypt data key {} to decrypt messages {}", logCtx, keyName,
-                    e.getMessage());
+            log.error("{} Failed to decrypt data key {} to decrypt messages {}", logCtx, keyName, e.getMessage());
             return false;
         }
         dataKey = new SecretKeySpec(dataKeyValue, "AES");
@@ -554,12 +549,8 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
             targetBuffer.limit(decryptedSize);
             return true;
 
-        } catch (InvalidKeyException | InvalidAlgorithmParameterException | IllegalBlockSizeException
-                | BadPaddingException | ShortBufferException e) {
-            log.error("{} Failed to decrypt message {}", logCtx, e.getMessage());
-            return false;
         } catch (Exception e) {
-            log.error("{} Failed due to unknown error to decrypt message {}", logCtx, e.getMessage());
+            log.error("{} Failed to decrypt message {}", logCtx, e.getMessage());
             return false;
         }
     }

--- a/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
+++ b/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
@@ -525,6 +525,10 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
                 | NoSuchPaddingException | InvalidKeyException | InvalidAlgorithmParameterException e) {
             log.error("{} Failed to decrypt data key {} to decrypt messages {}", logCtx, keyName, e.getMessage());
             return false;
+        } catch (Exception e) {
+            log.error("{} Failed with unknwon error to decrypt data key {} to decrypt messages {}", logCtx, keyName,
+                    e.getMessage());
+            return false;
         }
         dataKey = new SecretKeySpec(dataKeyValue, "AES");
         dataKeyCache.put(ByteBuffer.wrap(keyDigest), dataKey);
@@ -553,6 +557,9 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         } catch (InvalidKeyException | InvalidAlgorithmParameterException | IllegalBlockSizeException
                 | BadPaddingException | ShortBufferException e) {
             log.error("{} Failed to decrypt message {}", logCtx, e.getMessage());
+            return false;
+        } catch (Exception e) {
+            log.error("{} Failed due to unknown error to decrypt message {}", logCtx, e.getMessage());
             return false;
         }
     }


### PR DESCRIPTION
### Motivation

Currently if Pulsar client fails to decrypt data-key due to corruption and fails with bc error then pulsar-client doesn't handle it correctly and client doesn't apply decryption failure action correctly.
For example, due to some reason, Pulsar-client fails to decrypt data-key and it throws `org.bouncycastle.crypto.DataLengthException` which is not caught by client lib and that makes client lib to keep closing connection and consumer is not able to consume any further message even if consumer application has configured FAILURE_ACTION as `DISCARD`.
```
2024-08-29 16:05:54 WARN  ClientCnx:271 - [broker1-use1/1.1.1.1:6651] Got exception org.bouncycastle.crypto.DataLengthException: input too large for RSA cipher.
        at org.bouncycastle.crypto.engines.RSACoreEngine.convertInput(Unknown Source)
        at org.bouncycastle.crypto.engines.RSABlindedEngine.processBlock(Unknown Source)
        at org.bouncycastle.crypto.encodings.OAEPEncoding.decodeBlock(Unknown Source)
        at org.bouncycastle.crypto.encodings.OAEPEncoding.processBlock(Unknown Source)
        at org.bouncycastle.jcajce.provider.asymmetric.rsa.CipherSpi.engineDoFinal(Unknown Source)
        at javax.crypto.Cipher.doFinal(Cipher.java:2168)
        at org.apache.pulsar.client.impl.crypto.MessageCryptoBc.decryptDataKey(MessageCryptoBc.java:498)
        at org.apache.pulsar.client.impl.crypto.MessageCryptoBc.lambda$decrypt$2(MessageCryptoBc.java:606)
        at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:174)
        at java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1361)
        at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126)
        at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:499)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:486)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
        at java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:152)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:531)
        at org.apache.pulsar.client.impl.crypto.MessageCryptoBc.decrypt(MessageCryptoBc.java:608)
        at org.apache.pulsar.client.impl.ConsumerImpl.decryptPayloadIfNeeded(ConsumerImpl.java:1621)
        at org.apache.pulsar.client.impl.ConsumerImpl.messageReceived(ConsumerImpl.java:1176)
        at org.apache.pulsar.client.impl.ClientCnx.handleMessage(ClientCnx.java:425)
        at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:209)
        at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
        at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324)
        at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:311)
        at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:432)
        at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:276)
        at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
        at org.apache.pulsar.shade.io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1406)
        at org.apache.pulsar.shade.io.netty.handler.ssl.SslHandler.decodeNonJdkCompatible(SslHandler.java:1295)
        at org.apache.pulsar.shade.io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1332)
        at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:508)
        at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:447)
        at org.apache.pulsar.shade.io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:276)
        at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
        at org.apache.pulsar.shade.io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
        at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at org.apache.pulsar.shade.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at org.apache.pulsar.shade.io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
        at org.apache.pulsar.shade.io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:795)
        at org.apache.pulsar.shade.io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:480)
        at org.apache.pulsar.shade.io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378)
        at org.apache.pulsar.shade.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
        at org.apache.pulsar.shade.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at org.apache.pulsar.shade.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.lang.Thread.run(Thread.java:748)


2024-08-29 16:05:54 INFO  ClientCnx:239 - [id: 0x9e98aad0, L:/10.227.222.179:57512 ! R:broker1-use1/1.1.1.1:6651] Disconnected
2024-08-29 16:05:54 INFO  ConnectionHandler:123 - [persistent://t1/c1/n1/t1-partition-0] [my-subscriber] Closed connection [id: 0x9e98aad0, L:/2.2.2.2:
57512 ! R:broker1-use1/1.1.1.1:6651] -- Will try again in 0.1 s

```

### Modifications

Pulsar-client lib must handle any unknown/Runtime Exception and apply crypot-failure-action as per configuration.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
