### PR TITLE
[improve][broker] Log warning when chunked messages appear with Key_Shared subscriptions

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -854,7 +854,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         return true;
     }
 
-    private boolean sendChunkedMessagesToConsumers(ReadType readType,
+    protected boolean sendChunkedMessagesToConsumers(ReadType readType,
                                                    List<Entry> entries,
                                                    MessageMetadata[] metadataArray) {
         final List<EntryAndMetadata> originalEntryAndMetadataList = new ArrayList<>(metadataArray.length);


### PR DESCRIPTION
### Motivation

Chunked messages aren't currently handled properly in Key_Shared subscriptions. They are silently dispatched to consumers.

### Modifications

Log a warning when chunked messages appear with Key_Shared subscriptions so that the problem becomes visible.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->