### PR TITLE
[fix][broker] Execute the pending callbacks in order before ready for incoming requests

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -298,6 +298,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     private final DefaultMonotonicSnapshotClock monotonicSnapshotClock;
     private String brokerId;
     private final CompletableFuture<Void> readyForIncomingRequestsFuture = new CompletableFuture<>();
+    private final List<Runnable> pendingTasksBeforeReadyForIncomingRequests = new ArrayList<>();
 
     public enum State {
         Init, Started, Closing, Closed
@@ -1023,7 +1024,11 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             this.metricsGenerator = new MetricsGenerator(this);
 
             // the broker is ready to accept incoming requests by Pulsar binary protocol and http/https
-            readyForIncomingRequestsFuture.complete(null);
+            synchronized (pendingTasksBeforeReadyForIncomingRequests) {
+                pendingTasksBeforeReadyForIncomingRequests.forEach(Runnable::run);
+                pendingTasksBeforeReadyForIncomingRequests.clear();
+                readyForIncomingRequestsFuture.complete(null);
+            }
 
             // Initialize the message protocol handlers.
             // start the protocol handlers only after the broker is ready,
@@ -1082,7 +1087,16 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     }
 
     public void runWhenReadyForIncomingRequests(Runnable runnable) {
-        readyForIncomingRequestsFuture.thenRun(runnable);
+        // Here we don't call the thenRun() methods because CompletableFuture maintains a stack for pending callbacks,
+        // not a queue. Once the future is complete, the pending callbacks will be executed in reverse order of
+        // when they were added.
+        synchronized (pendingTasksBeforeReadyForIncomingRequests) {
+            if (readyForIncomingRequestsFuture.isDone()) {
+                runnable.run();
+            } else {
+                pendingTasksBeforeReadyForIncomingRequests.add(runnable);
+            }
+        }
     }
 
     public void waitUntilReadyForIncomingRequests() throws ExecutionException, InterruptedException {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1090,12 +1090,17 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         // Here we don't call the thenRun() methods because CompletableFuture maintains a stack for pending callbacks,
         // not a queue. Once the future is complete, the pending callbacks will be executed in reverse order of
         // when they were added.
+        final boolean addedToPendingTasks;
         synchronized (pendingTasksBeforeReadyForIncomingRequests) {
             if (readyForIncomingRequestsFuture.isDone()) {
-                runnable.run();
+                addedToPendingTasks = false;
             } else {
                 pendingTasksBeforeReadyForIncomingRequests.add(runnable);
+                addedToPendingTasks = true;
             }
+        }
+        if (!addedToPendingTasks) {
+            runnable.run();
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1024,11 +1024,13 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             this.metricsGenerator = new MetricsGenerator(this);
 
             // the broker is ready to accept incoming requests by Pulsar binary protocol and http/https
+            final List<Runnable> runnables;
             synchronized (pendingTasksBeforeReadyForIncomingRequests) {
-                pendingTasksBeforeReadyForIncomingRequests.forEach(Runnable::run);
+                runnables = new ArrayList<>(pendingTasksBeforeReadyForIncomingRequests);
                 pendingTasksBeforeReadyForIncomingRequests.clear();
                 readyForIncomingRequestsFuture.complete(null);
             }
+            runnables.forEach(Runnable::run);
 
             // Initialize the message protocol handlers.
             // start the protocol handlers only after the broker is ready,


### PR DESCRIPTION
### Background Knowledge

CompletableFuture has an intuitive behavior

```java
        final var future = new CompletableFuture<Integer>();
        future.thenRun(() -> System.out.println("A"));
        future.thenRun(() -> System.out.println("B"));
        future.thenRun(() -> System.out.println("C"));
        future.complete(0);
```

The outputs of the code above are:

```
C
B
A
```

That's because it maintains callbacks in the LIFO stack, not FIFO queue.

### Motivation

https://github.com/apache/pulsar/pull/22977 breaks the order of some events during extensible load manager's start by adding the runnable objects via `thenRun()`. The previous events order of `ExtensibleLoadManagerImpl`:
1. `playLeader()` or `playFollower()`
2. `serviceUnitStateChannel.start()`
3. Schedule some tasks (`brokerLoadDataReportTask`, `topBundlesLoadDataReportTask`, etc.) and set `started` with true.

Now, since they will be executed in reverse order, `started` will first be set true and then event 1 and 2 happened. It might cause unexpected issues 

### Modifications

Add a synchronized list to queue the pending tasks and execute them in order before the future is complete.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 