### PR TITLE
[fix][broker] Fix incomplete NAR file extraction which prevents broker from starting

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarUnpacker.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarUnpacker.java
@@ -32,7 +32,9 @@ import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
@@ -86,19 +88,32 @@ public class NarUnpacker {
             try (FileChannel channel = new RandomAccessFile(lockFile, "rw").getChannel();
                  FileLock lock = channel.lock()) {
                 File narWorkingDirectory = new File(parentDirectory, md5Sum);
-                if (narWorkingDirectory.mkdir()) {
+                if (!narWorkingDirectory.exists()) {
+                    File narExtractionTempDirectory = new File(parentDirectory, md5Sum + ".tmp");
+                    if (narExtractionTempDirectory.exists()) {
+                        FileUtils.deleteFile(narExtractionTempDirectory, true);
+                    }
+                    if (!narExtractionTempDirectory.mkdir()) {
+                        throw new IOException("Cannot create " + narExtractionTempDirectory);
+                    }
                     try {
-                        log.info("Extracting {} to {}", nar, narWorkingDirectory);
+                        log.info("Extracting {} to {}", nar, narExtractionTempDirectory);
                         if (extractCallback != null) {
                             extractCallback.run();
                         }
-                        unpack(nar, narWorkingDirectory);
+                        unpack(nar, narExtractionTempDirectory);
                     } catch (IOException e) {
                         log.error("There was a problem extracting the nar file. Deleting {} to clean up state.",
-                                narWorkingDirectory, e);
-                        FileUtils.deleteFile(narWorkingDirectory, true);
+                                narExtractionTempDirectory, e);
+                        try {
+                            FileUtils.deleteFile(narExtractionTempDirectory, true);
+                        } catch (IOException e2) {
+                            log.error("Failed to delete temporary directory {}", narExtractionTempDirectory, e2);
+                        }
                         throw e;
                     }
+                    Files.move(narExtractionTempDirectory.toPath(), narWorkingDirectory.toPath(),
+                            StandardCopyOption.ATOMIC_MOVE);
                 }
                 return narWorkingDirectory;
             }
@@ -166,7 +181,7 @@ public class NarUnpacker {
      * @throws IOException
      *             if cannot read file
      */
-    private static byte[] calculateMd5sum(final File file) throws IOException {
+    protected static byte[] calculateMd5sum(final File file) throws IOException {
         try (final FileInputStream inputStream = new FileInputStream(file)) {
             // codeql[java/weak-cryptographic-algorithm] - md5 is sufficient for this use case
             final MessageDigest md5 = MessageDigest.getInstance("md5");

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/nar/NarUnpackerTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/nar/NarUnpackerTest.java
@@ -119,24 +119,13 @@ public class NarUnpackerTest {
     }
 
     @Test
-    void shouldReExtractWhenUnpackedDirectoryIsMissing() throws InterruptedException {
-        CountDownLatch countDownLatch = new CountDownLatch(1);
-        AtomicInteger exceptionCounter = new AtomicInteger();
+    void shouldReExtractWhenUnpackedDirectoryIsMissing() throws IOException {
         AtomicInteger extractCounter = new AtomicInteger();
 
-        try {
-            File narWorkingDirectory = NarUnpacker.doUnpackNar(sampleZipFile, extractDirectory, extractCounter::incrementAndGet);
-            FileUtils.deleteFile(narWorkingDirectory, true);
-            NarUnpacker.doUnpackNar(sampleZipFile, extractDirectory, extractCounter::incrementAndGet);
-        } catch (Exception e) {
-            log.error("Unpacking failed", e);
-            exceptionCounter.incrementAndGet();
-        } finally {
-            countDownLatch.countDown();
-        }
+        File narWorkingDirectory = NarUnpacker.doUnpackNar(sampleZipFile, extractDirectory, extractCounter::incrementAndGet);
+        FileUtils.deleteFile(narWorkingDirectory, true);
+        NarUnpacker.doUnpackNar(sampleZipFile, extractDirectory, extractCounter::incrementAndGet);
 
-        assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
-        assertEquals(exceptionCounter.get(), 0);
         assertEquals(extractCounter.get(), 2);
     }
 

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/nar/NarUnpackerTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/nar/NarUnpackerTest.java
@@ -124,18 +124,16 @@ public class NarUnpackerTest {
         AtomicInteger exceptionCounter = new AtomicInteger();
         AtomicInteger extractCounter = new AtomicInteger();
 
-        new Thread(() -> {
-            try {
-                File narWorkingDirectory = NarUnpacker.doUnpackNar(sampleZipFile, extractDirectory, extractCounter::incrementAndGet);
-                FileUtils.deleteFile(narWorkingDirectory, true);
-                NarUnpacker.doUnpackNar(sampleZipFile, extractDirectory, extractCounter::incrementAndGet);
-            } catch (Exception e) {
-                log.error("Unpacking failed", e);
-                exceptionCounter.incrementAndGet();
-            } finally {
-                countDownLatch.countDown();
-            }
-        }).start();
+        try {
+            File narWorkingDirectory = NarUnpacker.doUnpackNar(sampleZipFile, extractDirectory, extractCounter::incrementAndGet);
+            FileUtils.deleteFile(narWorkingDirectory, true);
+            NarUnpacker.doUnpackNar(sampleZipFile, extractDirectory, extractCounter::incrementAndGet);
+        } catch (Exception e) {
+            log.error("Unpacking failed", e);
+            exceptionCounter.incrementAndGet();
+        } finally {
+            countDownLatch.countDown();
+        }
 
         assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
         assertEquals(exceptionCounter.get(), 0);


### PR DESCRIPTION
Fixes [23273](https://github.com/apache/pulsar/issues/23273)

### Motivation
This PR addresses an issue where the Pulsar broker fails to restart due to incomplete NAR file extraction. The broker attempts to reuse an incomplete directory in the `/tmp` folder, leading to a `NoSuchFileException`. This occurs when the broker is stopped during the extraction process, causing the NAR files to remain in an inconsistent state, which affects future restarts.


### Modifications

* extract to a temporary directory which is renamed to the target directory in the last step. This ensures the consistency of the extracted files.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

* Adding new tests that simulate an incomplete NAR extraction, followed by a broker restart to ensure it handles incomplete extractions.


### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [x] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/cognitree/pulsar/pull/15