### PR TITLE
[fix] Bump io.grpc from 1.56.0 to 1.56.1

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -429,22 +429,22 @@ The Apache Software License, Version 2.0
      - org.jetbrains.kotlin-kotlin-stdlib-jdk8-1.8.20.jar
      - org.jetbrains-annotations-13.0.jar
  * gRPC
-    - io.grpc-grpc-all-1.56.0.jar
-    - io.grpc-grpc-auth-1.56.0.jar
-    - io.grpc-grpc-context-1.56.0.jar
-    - io.grpc-grpc-core-1.56.0.jar
-    - io.grpc-grpc-protobuf-1.56.0.jar
-    - io.grpc-grpc-protobuf-lite-1.56.0.jar
-    - io.grpc-grpc-stub-1.56.0.jar
-    - io.grpc-grpc-alts-1.56.0.jar
-    - io.grpc-grpc-api-1.56.0.jar
-    - io.grpc-grpc-grpclb-1.56.0.jar
-    - io.grpc-grpc-netty-shaded-1.56.0.jar
-    - io.grpc-grpc-services-1.56.0.jar
-    - io.grpc-grpc-xds-1.56.0.jar
-    - io.grpc-grpc-rls-1.56.0.jar
-    - io.grpc-grpc-servlet-1.56.0.jar
-    - io.grpc-grpc-servlet-jakarta-1.56.0.jar
+    - io.grpc-grpc-all-1.56.1.jar
+    - io.grpc-grpc-auth-1.56.1.jar
+    - io.grpc-grpc-context-1.56.1.jar
+    - io.grpc-grpc-core-1.56.1.jar
+    - io.grpc-grpc-protobuf-1.56.1.jar
+    - io.grpc-grpc-protobuf-lite-1.56.1.jar
+    - io.grpc-grpc-stub-1.56.1.jar
+    - io.grpc-grpc-alts-1.56.1.jar
+    - io.grpc-grpc-api-1.56.1.jar
+    - io.grpc-grpc-grpclb-1.56.1.jar
+    - io.grpc-grpc-netty-shaded-1.56.1.jar
+    - io.grpc-grpc-services-1.56.1.jar
+    - io.grpc-grpc-xds-1.56.1.jar
+    - io.grpc-grpc-rls-1.56.1.jar
+    - io.grpc-grpc-servlet-1.56.1.jar
+    - io.grpc-grpc-servlet-jakarta-1.56.1.jar
     - io.grpc-grpc-util-1.60.0.jar
   * Perfmark
     - io.perfmark-perfmark-api-0.26.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@ flexible messaging model and an intuitive client API.</description>
     <zt-zip.version>1.17</zt-zip.version>
     <protobuf3.version>3.22.3</protobuf3.version>
     <protoc3.version>${protobuf3.version}</protoc3.version>
-    <grpc.version>1.56.0</grpc.version>
+    <grpc.version>1.56.1</grpc.version>
     <google-http-client.version>1.41.0</google-http-client.version>
     <perfmark.version>0.26.0</perfmark.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>


### PR DESCRIPTION
### Motivation

Bump io.grpc from 1.56.0 to 1.56.1 to address this important fix. https://github.com/grpc/grpc-java/pull/10328

### Modifications

- Bump io.grpc from 1.56.0 to 1.56.1

### Verifying this change

- [x] Make sure that the change passes the CI checks.
### Documentation

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->