### PR TITLE
[feat][meta] Bump oxia java version from 0.3.2 to 0.4.5

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -480,8 +480,8 @@ The Apache Software License, Version 2.0
   * Prometheus
     - io.prometheus-simpleclient_httpserver-0.16.0.jar
   * Oxia
-    - io.streamnative.oxia-oxia-client-api-0.3.2.jar
-    - io.streamnative.oxia-oxia-client-0.3.2.jar
+    - io.streamnative.oxia-oxia-client-api-0.4.5.jar
+    - io.streamnative.oxia-oxia-client-0.4.5.jar
   * OpenHFT
     - net.openhft-zero-allocation-hashing-0.16.jar
   * Java JSON WebTokens

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@ flexible messaging model and an intuitive client API.</description>
     <apache-http-client.version>4.5.13</apache-http-client.version>
     <apache-httpcomponents.version>4.4.15</apache-httpcomponents.version>
     <jetcd.version>0.7.7</jetcd.version>
-    <oxia.version>0.3.2</oxia.version>
+    <oxia.version>0.4.5</oxia.version>
     <snakeyaml.version>2.0</snakeyaml.version>
     <ant.version>1.10.12</ant.version>
     <seancfoley.ipaddress.version>5.5.0</seancfoley.ipaddress.version>


### PR DESCRIPTION
### Motivation

 Bump oxia java version from 0.3.2 to 0.4.5

### Modifications

-  Bump oxia java version from 0.3.2 to 0.4.5

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->


The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
