### PR TITLE
[improve][broker] Reducing the parse of MessageMetadata in compaction

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
@@ -59,6 +59,8 @@ public class RawBatchConverter {
         ByteBuf payload = msg.getHeadersAndPayload();
         if (metadata == null) {
             metadata = Commands.parseMessageMetadata(payload);
+        } else {
+            Commands.skipMessageMetadata(payload);
         }
         int batchSize = metadata.getNumMessagesInBatch();
 
@@ -137,6 +139,8 @@ public class RawBatchConverter {
         }
         if (metadata == null) {
             metadata = Commands.parseMessageMetadata(payload);
+        } else {
+            Commands.skipMessageMetadata(payload);
         }
         ByteBuf batchBuffer = PulsarByteBufAllocator.DEFAULT.buffer(payload.capacity());
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
@@ -52,12 +52,14 @@ public class RawBatchConverter {
         return metadata.hasNumMessagesInBatch() && metadata.getEncryptionKeysCount() == 0;
     }
 
-    public static List<MessageCompactionData> extractMessageCompactionData(RawMessage msg)
+    public static List<MessageCompactionData> extractMessageCompactionData(RawMessage msg, MessageMetadata metadata)
         throws IOException {
         checkArgument(msg.getMessageIdData().getBatchIndex() == -1);
 
         ByteBuf payload = msg.getHeadersAndPayload();
-        MessageMetadata metadata = Commands.parseMessageMetadata(payload);
+        if (metadata == null) {
+            metadata = Commands.parseMessageMetadata(payload);
+        }
         int batchSize = metadata.getNumMessagesInBatch();
 
         CompressionType compressionType = metadata.getCompression();
@@ -91,7 +93,16 @@ public class RawBatchConverter {
         RawMessage msg)
         throws IOException {
         List<ImmutableTriple<MessageId, String, Integer>> idsAndKeysAndSize = new ArrayList<>();
-        for (MessageCompactionData mcd : extractMessageCompactionData(msg)) {
+        for (MessageCompactionData mcd : extractMessageCompactionData(msg, null)) {
+            idsAndKeysAndSize.add(ImmutableTriple.of(mcd.messageId(), mcd.key(), mcd.payloadSize()));
+        }
+        return idsAndKeysAndSize;
+    }
+
+    public static List<ImmutableTriple<MessageId, String, Integer>> extractIdsAndKeysAndSize(
+            RawMessage msg, MessageMetadata metadata) throws IOException {
+        List<ImmutableTriple<MessageId, String, Integer>> idsAndKeysAndSize = new ArrayList<>();
+        for (MessageCompactionData mcd : extractMessageCompactionData(msg, metadata)) {
             idsAndKeysAndSize.add(ImmutableTriple.of(mcd.messageId(), mcd.key(), mcd.payloadSize()));
         }
         return idsAndKeysAndSize;
@@ -99,7 +110,7 @@ public class RawBatchConverter {
 
     public static Optional<RawMessage> rebatchMessage(RawMessage msg,
                                                       BiPredicate<String, MessageId> filter) throws IOException {
-        return rebatchMessage(msg, filter, true);
+        return rebatchMessage(msg, null, filter, true);
     }
 
     /**
@@ -109,6 +120,7 @@ public class RawBatchConverter {
      *  NOTE: this message does not alter the reference count of the RawMessage argument.
      */
     public static Optional<RawMessage> rebatchMessage(RawMessage msg,
+                                                      MessageMetadata metadata,
                                                       BiPredicate<String, MessageId> filter,
                                                       boolean retainNullKey)
             throws IOException {
@@ -123,7 +135,9 @@ public class RawBatchConverter {
             payload.readerIndex(readerIndex);
             brokerMeta = payload.readSlice(brokerEntryMetadataSize + Short.BYTES + Integer.BYTES);
         }
-        MessageMetadata metadata = Commands.parseMessageMetadata(payload);
+        if (metadata == null) {
+            metadata = Commands.parseMessageMetadata(payload);
+        }
         ByteBuf batchBuffer = PulsarByteBufAllocator.DEFAULT.buffer(payload.capacity());
 
         CompressionType compressionType = metadata.getCompression();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/EventTimeOrderCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/EventTimeOrderCompactor.java
@@ -34,7 +34,6 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.RawMessage;
 import org.apache.pulsar.client.impl.RawBatchConverter;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
-import org.apache.pulsar.common.protocol.Commands;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/PublishingOrderCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/PublishingOrderCompactor.java
@@ -53,10 +53,10 @@ public class PublishingOrderCompactor extends AbstractTwoPhaseCompactor<MessageI
 
     @Override
     protected boolean compactMessage(String topic, Map<String, MessageId> latestForKey,
-        RawMessage m, MessageId id) {
+        RawMessage m, MessageMetadata metadata, MessageId id) {
         boolean deletedMessage = false;
         boolean replaceMessage = false;
-        Pair<String, Integer> keyAndSize = extractKeyAndSize(m);
+        Pair<String, Integer> keyAndSize = extractKeyAndSize(m, metadata);
         if (keyAndSize != null) {
             if (keyAndSize.getRight() > 0) {
                 MessageId old = latestForKey.put(keyAndSize.getLeft(), id);
@@ -84,7 +84,7 @@ public class PublishingOrderCompactor extends AbstractTwoPhaseCompactor<MessageI
             int numMessagesInBatch = metadata.getNumMessagesInBatch();
             int deleteCnt = 0;
             for (ImmutableTriple<MessageId, String, Integer> e : extractIdsAndKeysAndSizeFromBatch(
-                m)) {
+                m, metadata)) {
                 if (e != null) {
                     if (e.getMiddle() == null) {
                         if (!topicCompactionRetainNullKey) {
@@ -119,9 +119,9 @@ public class PublishingOrderCompactor extends AbstractTwoPhaseCompactor<MessageI
     }
 
     protected List<ImmutableTriple<MessageId, String, Integer>> extractIdsAndKeysAndSizeFromBatch(
-        RawMessage msg)
+        RawMessage msg, MessageMetadata metadata)
         throws IOException {
-        return RawBatchConverter.extractIdsAndKeysAndSize(msg);
+        return RawBatchConverter.extractIdsAndKeysAndSize(msg, metadata);
     }
 
 }


### PR DESCRIPTION
### Motivation

There are many redundant parses of MessageMetadata in topic compaction, including phase one and phase two

### Modifications

reuse the MessageMetadata object  in topic compaction

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->


### Matching PR in forked repository

PR in forked repository:  https://github.com/aloyszhang/pulsar/pull/23

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
