### PR TITLE
[draft] Fix setting cursor position on NonDurable subcription

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1203,7 +1203,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 long entryId = msgId.getEntryId();
                 // Ensure that the start message id starts from a valid entry.
                 if (ledgerId >= 0 && entryId >= 0
-                        && msgId instanceof BatchMessageIdImpl) {
+                        && msgId instanceof BatchMessageIdImpl
+                        && startMessageId != null) {
                     // When the start message is relative to a batch, we need to take one step back on the previous
                     // message,
                     // because the "batch" might not have been consumed in its entirety.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1203,8 +1203,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 long entryId = msgId.getEntryId();
                 // Ensure that the start message id starts from a valid entry.
                 if (ledgerId >= 0 && entryId >= 0
-                        && msgId instanceof BatchMessageIdImpl
-                        && startMessageId != null) {
+                        && msgId instanceof BatchMessageIdImpl) {
                     // When the start message is relative to a batch, we need to take one step back on the previous
                     // message,
                     // because the "batch" might not have been consumed in its entirety.


### PR DESCRIPTION
PR is a draft and contains only failing test.

### Motivation

After re-creating NonDurable subscription, the cursor was moved back by 1 position.
This should only happen when there is no startMessageId provided (see tests in the original PR).
Broker does not store batch index information, therefore it has to be provided while subscription initialization.

Before this fix, the backlog is incorrect, and the batch message later ignored by the client. 

### Modifications

Added `startMessageId != null` check, to ensure that the we only set relative position in a batch, when we have this information.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


This change is already covered by existing tests, such as *(please describe tests)*.
- Broker tests where covering the original case. I've added one more test to cover this case.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
