### PR TITLE
[fix] [log] Do not print error log if tenant/namespace does not exist when calling get topic metadata

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -714,7 +714,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 if (actEx instanceof WebApplicationException restException) {
                     if (restException.getResponse().getStatus() == Response.Status.NOT_FOUND.getStatusCode()) {
                         writeAndFlush(Commands.newPartitionMetadataResponse(ServerError.MetadataError,
-                        "Tenant or namespace does not exist: " + topicName.getNamespace() ,
+                        "Tenant or namespace or topic does not exist: " + topicName.getNamespace() ,
                                 requestId));
                         lookupSemaphore.release();
                         return null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -690,8 +690,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                                                 + "[{}] {}: {}", remoteAddress,
                                                         topicName, ex.getMessage());
                                             } else {
-                                                log.warn("Failed to get Partitioned Metadata [{}] {}: {}", remoteAddress,
-                                                        topicName, ex.getMessage(), ex);
+                                                log.warn("Failed to get Partitioned Metadata [{}] {}: {}",
+                                                        remoteAddress, topicName, ex.getMessage(), ex);
                                             }
                                             commandSender.sendPartitionMetadataResponse(error, ex.getMessage(),
                                                     requestId);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -716,6 +716,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                         writeAndFlush(Commands.newPartitionMetadataResponse(ServerError.MetadataError,
                         "Tenant or namespace does not exist: " + topicName.getNamespace() ,
                                 requestId));
+                        lookupSemaphore.release();
+                        return null;
                     }
                 }
                 final String msg = "Exception occurred while trying to authorize get Partition Metadata";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
@@ -578,4 +578,45 @@ public class GetPartitionMetadataTest {
             assertEquals(getLookupRequestPermits(), lookupPermitsBefore);
         });
     }
+
+    @Test(dataProvider = "topicDomains")
+    public void testNamespaceNotExist(TopicDomain topicDomain) throws Exception {
+        final String namespaceNotExist = BrokerTestUtil.newUniqueName("public/ns");
+        final String topicNameStr = BrokerTestUtil.newUniqueName(topicDomain.toString() + "://" + namespaceNotExist + "/tp");
+        PulsarClientImpl[] clientArray = getClientsToTest(false);
+        for (PulsarClientImpl client : clientArray) {
+            try {
+                PartitionedTopicMetadata topicMetadata = client
+                        .getPartitionedTopicMetadata(topicNameStr, true, true)
+                        .join();
+                log.info("Get topic metadata: {}", topicMetadata.partitions);
+                fail("Expected a not found ex");
+            } catch (Exception ex) {
+                Throwable unwrapEx = FutureUtil.unwrapCompletionException(ex);
+                assertTrue(unwrapEx instanceof PulsarClientException.BrokerMetadataException ||
+                        unwrapEx instanceof PulsarClientException.TopicDoesNotExistException);
+            }
+        }
+    }
+
+    @Test(dataProvider = "topicDomains")
+    public void testTenantNotExist(TopicDomain topicDomain) throws Exception {
+        final String tenantNotExist = BrokerTestUtil.newUniqueName("tenant");
+        final String namespaceNotExist = BrokerTestUtil.newUniqueName(tenantNotExist + "/default");
+        final String topicNameStr = BrokerTestUtil.newUniqueName(topicDomain.toString() + "://" + namespaceNotExist + "/tp");
+        PulsarClientImpl[] clientArray = getClientsToTest(false);
+        for (PulsarClientImpl client : clientArray) {
+            try {
+                PartitionedTopicMetadata topicMetadata = client
+                        .getPartitionedTopicMetadata(topicNameStr, true, true)
+                        .join();
+                log.info("Get topic metadata: {}", topicMetadata.partitions);
+                fail("Expected a not found ex");
+            } catch (Exception ex) {
+                Throwable unwrapEx = FutureUtil.unwrapCompletionException(ex);
+                assertTrue(unwrapEx instanceof PulsarClientException.BrokerMetadataException ||
+                        unwrapEx instanceof PulsarClientException.TopicDoesNotExistException);
+            }
+        }
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
@@ -581,6 +581,7 @@ public class GetPartitionMetadataTest {
 
     @Test(dataProvider = "topicDomains")
     public void testNamespaceNotExist(TopicDomain topicDomain) throws Exception {
+        int lookupPermitsBefore = getLookupRequestPermits();
         final String namespaceNotExist = BrokerTestUtil.newUniqueName("public/ns");
         final String topicNameStr = BrokerTestUtil.newUniqueName(topicDomain.toString() + "://" + namespaceNotExist + "/tp");
         PulsarClientImpl[] clientArray = getClientsToTest(false);
@@ -597,10 +598,15 @@ public class GetPartitionMetadataTest {
                         unwrapEx instanceof PulsarClientException.TopicDoesNotExistException);
             }
         }
+        // Verify: lookup semaphore has been releases.
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(getLookupRequestPermits(), lookupPermitsBefore);
+        });
     }
 
     @Test(dataProvider = "topicDomains")
     public void testTenantNotExist(TopicDomain topicDomain) throws Exception {
+        int lookupPermitsBefore = getLookupRequestPermits();
         final String tenantNotExist = BrokerTestUtil.newUniqueName("tenant");
         final String namespaceNotExist = BrokerTestUtil.newUniqueName(tenantNotExist + "/default");
         final String topicNameStr = BrokerTestUtil.newUniqueName(topicDomain.toString() + "://" + namespaceNotExist + "/tp");
@@ -618,5 +624,9 @@ public class GetPartitionMetadataTest {
                         unwrapEx instanceof PulsarClientException.TopicDoesNotExistException);
             }
         }
+        // Verify: lookup semaphore has been releases.
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(getLookupRequestPermits(), lookupPermitsBefore);
+        });
     }
 }


### PR DESCRIPTION
### Motivation & Modifications

If users trying to use a tenant that does not exist, the broker should not print an `error-level` log.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
