### PR TITLE
[fix][sql][branch-3.0] Fix UUID convert failed for JSON schema

### DIFF
--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/decoder/json/PulsarJsonFieldDecoder.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/decoder/json/PulsarJsonFieldDecoder.java
@@ -64,6 +64,7 @@ import io.trino.spi.type.VarcharType;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.commons.lang3.tuple.Pair;
 
 /**
@@ -275,6 +276,10 @@ public class PulsarJsonFieldDecoder
 
         private static Slice getSlice(JsonNode value, Type type, String columnName) {
             String textValue = value.isValueNode() ? value.asText() : value.toString();
+
+            if (type instanceof UuidType) {
+                return UuidType.javaUuidToTrinoUuid(UUID.fromString(textValue));
+            }
 
             Slice slice = utf8Slice(textValue);
             if (type instanceof VarcharType) {

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/decoder/json/TestJsonDecoder.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/decoder/json/TestJsonDecoder.java
@@ -144,7 +144,7 @@ public class TestJsonDecoder extends AbstractDecoderTester {
 
         PulsarColumnHandle uuidHandle = new PulsarColumnHandle(getPulsarConnectorId().toString(),
                 "uuidField", UuidType.UUID, false, false, "uuidField", null, null, PulsarColumnHandle.HandleKeyValueType.NONE);
-        checkValue(decodedRow, uuidHandle, message.uuidField.toString());
+        checkValue(decodedRow, uuidHandle, UuidType.javaUuidToTrinoUuid(message.uuidField));
     }
 
     @Test


### PR DESCRIPTION
### Motivation
If using JSON schema and UUID type, will receive error when use trino.

```
java.lang.IllegalStateException: Expected entry size to be exactly 16 but was 36
	at io.trino.spi.type.UuidType.writeSlice(UuidType.java:143)
	at io.trino.spi.connector.RecordPageSource.getNextPage(RecordPageSource.java:113)
	at io.trino.operator.TableScanOperator.getOutput(TableScanOperator.java:311)
	at io.trino.operator.Driver.processInternal(Driver.java:388)
	at io.trino.operator.Driver.lambda$processFor$9(Driver.java:292)
	at io.trino.operator.Driver.tryWithLock(Driver.java:685)
	at io.trino.operator.Driver.processFor(Driver.java:285)
	at io.trino.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1076)
	at io.trino.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:163)
	at io.trino.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:488)
	at io.trino.$gen.Trino_368____20240912_093830_2.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

#21267 supported UUID type, but for JSON schema not convert to UUID type of trino.


### Modifications
- For JSON schema,convert to UUID type of trino.


### Verifying this change
- Change TestJsonDecoder to cover it.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

