### PR TITLE
[fix][broker] Fail fast if the extensible load manager failed to start

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/PulsarServerException.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/PulsarServerException.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker;
 
 import java.io.IOException;
+import java.util.concurrent.CompletionException;
 
 public class PulsarServerException extends IOException {
     private static final long serialVersionUID = 1;
@@ -43,5 +44,21 @@ public class PulsarServerException extends IOException {
         public NotFoundException(Throwable t) {
             super(t);
         }
+    }
+
+    public static PulsarServerException from(Throwable throwable) {
+        if (throwable instanceof CompletionException) {
+            return from(throwable.getCause());
+        }
+        if (throwable instanceof PulsarServerException pulsarServerException) {
+            return pulsarServerException;
+        } else {
+            return new PulsarServerException(throwable);
+        }
+    }
+
+    // Wrap this checked exception into a specific unchecked exception
+    public static CompletionException toUncheckedException(PulsarServerException e) {
+        return new CompletionException(e);
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1080,7 +1080,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             state = State.Started;
         } catch (Exception e) {
             LOG.error("Failed to start Pulsar service: {}", e.getMessage(), e);
-            PulsarServerException startException = new PulsarServerException(e);
+            PulsarServerException startException = PulsarServerException.from(e);
             readyForIncomingRequestsFuture.completeExceptionally(startException);
             throw startException;
         } finally {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -908,8 +908,6 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
                 topBundlesLoadDataStore.close();
                 topBundlesLoadDataStore.startProducer();
                 break;
-            } catch (InterruptedException ignored) {
-                return;
             } catch (Throwable e) {
                 log.warn("The broker:{} failed to set the role. Retrying {} th ...",
                         pulsar.getBrokerId(), ++retry, e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -36,7 +36,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/LoadManagerFailFastTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/LoadManagerFailFastTest.java
@@ -28,8 +28,8 @@ import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateC
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelImpl;
 import org.apache.pulsar.common.util.PortManager;
 import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
+import org.awaitility.Awaitility;
 import org.mockito.Mockito;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/LoadManagerFailFastTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/LoadManagerFailFastTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.extensions;
+
+import java.util.Optional;
+import lombok.Cleanup;
+import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannel;
+import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelImpl;
+import org.apache.pulsar.common.util.PortManager;
+import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class LoadManagerFailFastTest {
+
+    private static final String cluster = "test";
+    private final int zkPort = PortManager.nextLockedFreePort();
+    private final LocalBookkeeperEnsemble bk = new LocalBookkeeperEnsemble(2, zkPort, PortManager::nextLockedFreePort);
+    private final ServiceConfiguration config = new ServiceConfiguration();
+
+    @BeforeClass
+    protected void setup() throws Exception {
+        bk.start();
+        config.setClusterName(cluster);
+        config.setAdvertisedAddress("localhost");
+        config.setBrokerServicePort(Optional.of(0));
+        config.setWebServicePort(Optional.of(0));
+        config.setMetadataStoreUrl("zk:localhost:" + zkPort);
+    }
+
+    @AfterClass
+    protected void cleanup() throws Exception {
+        bk.stop();
+    }
+
+    @Test(timeOut = 30000)
+    public void testBrokerRegistryFailure() throws Exception {
+        config.setLoadManagerClassName(BrokerRegistryLoadManager.class.getName());
+        @Cleanup final var pulsar = new PulsarService(config);
+        try {
+            pulsar.start();
+            Assert.fail();
+        } catch (PulsarServerException e) {
+            Assert.assertNull(e.getCause());
+            Assert.assertEquals(e.getMessage(), "Cannot start BrokerRegistry");
+        }
+    }
+
+    @Test(timeOut = 30000)
+    public void testServiceUnitStateChannelFailure() throws Exception {
+        config.setLoadManagerClassName(ChannelLoadManager.class.getName());
+        @Cleanup final var pulsar = new PulsarService(config);
+        try {
+            pulsar.start();
+            Assert.fail();
+        } catch (PulsarServerException e) {
+            Assert.assertNull(e.getCause());
+            Assert.assertEquals(e.getMessage(), "Cannot start ServiceUnitStateChannel");
+        }
+    }
+
+    private static class BrokerRegistryLoadManager extends ExtensibleLoadManagerImpl {
+
+        @Override
+        protected BrokerRegistry createBrokerRegistry(PulsarService pulsar) {
+            final var mockBrokerRegistry = Mockito.mock(BrokerRegistryImpl.class);
+            try {
+                Mockito.doThrow(new PulsarServerException("Cannot start BrokerRegistry")).when(mockBrokerRegistry)
+                        .start();
+            } catch (PulsarServerException e) {
+                throw new RuntimeException(e);
+            }
+            return mockBrokerRegistry;
+        }
+    }
+
+    private static class ChannelLoadManager extends ExtensibleLoadManagerImpl {
+
+        @Override
+        protected ServiceUnitStateChannel createServiceUnitStateChannel(PulsarService pulsar) {
+            final var channel = Mockito.mock(ServiceUnitStateChannelImpl.class);
+            try {
+                Mockito.doThrow(new PulsarServerException("Cannot start ServiceUnitStateChannel")).when(channel)
+                        .start();
+            } catch (PulsarServerException e) {
+                throw new RuntimeException(e);
+            }
+            Mockito.doAnswer(__ -> null).when(channel).listen(Mockito.any());
+            return channel;
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/LoadManagerFailFastTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/LoadManagerFailFastTest.java
@@ -23,11 +23,13 @@ import lombok.Cleanup;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.loadbalance.LoadManager;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannel;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelImpl;
 import org.apache.pulsar.common.util.PortManager;
 import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
 import org.mockito.Mockito;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -66,6 +68,8 @@ public class LoadManagerFailFastTest {
             Assert.assertNull(e.getCause());
             Assert.assertEquals(e.getMessage(), "Cannot start BrokerRegistry");
         }
+        Assert.assertTrue(pulsar.getLocalMetadataStore().getChildren(LoadManager.LOADBALANCE_BROKERS_ROOT).get()
+                .isEmpty());
     }
 
     @Test(timeOut = 30000)
@@ -79,6 +83,8 @@ public class LoadManagerFailFastTest {
             Assert.assertNull(e.getCause());
             Assert.assertEquals(e.getMessage(), "Cannot start ServiceUnitStateChannel");
         }
+        Awaitility.await().untilAsserted(() -> Assert.assertTrue(pulsar.getLocalMetadataStore()
+                .getChildren(LoadManager.LOADBALANCE_BROKERS_ROOT).get().isEmpty()));
     }
 
     private static class BrokerRegistryLoadManager extends ExtensibleLoadManagerImpl {


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/23230 tries to fix the issue that "the pulsar broker cannot catch the exception" caused by https://github.com/apache/pulsar/pull/22977. However, the fix is incorrect because even before https://github.com/apache/pulsar/pull/22977, the broker also wouldn't fail if the extensible load manager failed to start.

It's destructive to have broker running with a failed load manager. Since `BrokerRegistry#unregister` will be called for failures, the issue broker will unregister itself from the metadata store and it could not be selected as the owner broker. Besides, all lookup requests sent to this broker will fail because the load manager is not started.

### Modifications

- Revert https://github.com/apache/pulsar/pull/23230
- Implement `failStarting` correctly:
  - If it has registered, just unregister the broker from the metadata store via `BrokerRegistry#close`  and swallow the exception.
  - Complete `initWaiter` with false to tell background threads to exit directly. Otherwise, methods like `playFollower` will swallow the exception from `initWaiter` and continue the loop.
  - Propagate the exception by wrapping checked exception `PulsarServerException` into a unchecked exception `CompletionException` and unwrap it in `PulsarService#start`'s catch block.
- Add `LoadManagerFailFastTest` to verify the fail-fast behaviors and the broker will unregister itself from the metadata store.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 