### PR TITLE
[improve][broker] Register the broker to metadata store without version id compare

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryImpl.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryImpl.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.loadbalance.extensions;
 import static org.apache.pulsar.broker.loadbalance.LoadManager.LOADBALANCE_BROKERS_ROOT;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -43,6 +44,7 @@ import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.Notification;
 import org.apache.pulsar.metadata.api.NotificationType;
+import org.apache.pulsar.metadata.api.extended.CreateOption;
 
 /**
  * The broker registry impl, base on the LockManager.
@@ -119,7 +121,7 @@ public class BrokerRegistryImpl implements BrokerRegistry {
     public synchronized void register() throws MetadataStoreException {
         if (this.state == State.Started) {
             try {
-                brokerLookupDataMetadataCache.put(brokerIdKeyPath, brokerLookupData)
+                brokerLookupDataMetadataCache.put(brokerIdKeyPath, brokerLookupData, EnumSet.of(CreateOption.Ephemeral))
                         .get(conf.getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
                 this.state = State.Registered;
             } catch (InterruptedException | ExecutionException | TimeoutException e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryTest.java
@@ -291,7 +291,7 @@ public class BrokerRegistryTest {
     }
 
     @Test
-    public void testRegisterFailWithSameBrokerId() throws Exception {
+    public void testRegisterWithSameBrokerId() throws Exception {
         PulsarService pulsar1 = createPulsarService();
         PulsarService pulsar2 = createPulsarService();
         pulsar1.start();
@@ -301,14 +301,10 @@ public class BrokerRegistryTest {
         BrokerRegistryImpl brokerRegistry1 = createBrokerRegistryImpl(pulsar1);
         BrokerRegistryImpl brokerRegistry2 = createBrokerRegistryImpl(pulsar2);
         brokerRegistry1.start();
-        try {
-            brokerRegistry2.start();
-            fail();
-        } catch (Exception ex) {
-            log.info("Broker registry start failed.", ex);
-            assertTrue(ex instanceof PulsarServerException);
-            assertTrue(ex.getMessage().contains("LockBusyException"));
-        }
+        brokerRegistry2.start();
+
+        pulsar1.close();
+        pulsar2.close();
     }
 
     @Test

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCache.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCache.java
@@ -129,6 +129,21 @@ public interface MetadataCache<T> {
     CompletableFuture<Void> create(String path, T value);
 
     /**
+     * Create or update the value of the given path in the metadata store without version compare.
+     * <p>
+     * This method is equivalent with {@link MetadataStore#put(String, byte[], Optional)} with `Optional.empty()` as
+     * the 3rd argument. It means if the path does not exist, it will be created. If the path already exists, the new
+     * value will override the old value.
+     * </p>
+     * @param path the path of the object in the metadata store
+     * @param value the object to put in the metadata store
+     * @return the future that indicates if this operation failed, it could fail with
+     *   {@link java.io.IOException} if the value failed to be serialized
+     *   {@link MetadataStoreException} if the metadata store operation failed
+     */
+    CompletableFuture<Void> put(String path, T value);
+
+    /**
      * Delete an object from the metadata store.
      * <p>
      * This operation will make sure to keep the cache consistent.

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCache.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCache.java
@@ -18,12 +18,14 @@
  */
 package org.apache.pulsar.metadata.api;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyExistsException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
+import org.apache.pulsar.metadata.api.extended.CreateOption;
 
 /**
  * Represent the caching layer access for a specific type of objects.
@@ -129,19 +131,22 @@ public interface MetadataCache<T> {
     CompletableFuture<Void> create(String path, T value);
 
     /**
-     * Create or update the value of the given path in the metadata store without version compare.
+     * Create or update the value of the given path in the metadata store without version comparison.
      * <p>
-     * This method is equivalent with {@link MetadataStore#put(String, byte[], Optional)} with `Optional.empty()` as
-     * the 3rd argument. It means if the path does not exist, it will be created. If the path already exists, the new
-     * value will override the old value.
+     * This method is equivalent to
+     * {@link org.apache.pulsar.metadata.api.extended.MetadataStoreExtended#put(String, byte[], Optional, EnumSet)} or
+     * {@link MetadataStore#put(String, byte[], Optional)} if the metadata store does not support this extended API,
+     * with `Optional.empty()` as the 3rd argument. It means if the path does not exist, it will be created. If the path
+     * already exists, the new value will override the old value.
      * </p>
      * @param path the path of the object in the metadata store
      * @param value the object to put in the metadata store
+     * @param options the create options if the path does not in the metadata store
      * @return the future that indicates if this operation failed, it could fail with
      *   {@link java.io.IOException} if the value failed to be serialized
      *   {@link MetadataStoreException} if the metadata store operation failed
      */
-    CompletableFuture<Void> put(String path, T value);
+    CompletableFuture<Void> put(String path, T value, EnumSet<CreateOption> options);
 
     /**
      * Delete an object from the metadata store.

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
@@ -251,7 +251,7 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
         } catch (IOException e) {
             return CompletableFuture.failedFuture(e);
         }
-        return store.put(path, bytes, Optional.empty()).thenAccept(__ -> {});
+        return store.put(path, bytes, Optional.empty()).thenAccept(__ -> refresh(path));
     }
 
     @Override

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
@@ -244,6 +244,17 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
     }
 
     @Override
+    public CompletableFuture<Void> put(String path, T value) {
+        final byte[] bytes;
+        try {
+            bytes = serde.serialize(path, value);
+        } catch (IOException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+        return store.put(path, bytes, Optional.empty()).thenAccept(__ -> {});
+    }
+
+    @Override
     public CompletableFuture<Void> delete(String path) {
         return store.delete(path, Optional.empty());
     }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -55,6 +56,7 @@ import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
 import org.apache.pulsar.metadata.api.MetadataStoreFactory;
 import org.apache.pulsar.metadata.api.NotificationType;
 import org.apache.pulsar.metadata.api.Stat;
+import org.apache.pulsar.metadata.api.extended.CreateOption;
 import org.apache.pulsar.metadata.cache.impl.MetadataCacheImpl;
 import org.awaitility.Awaitility;
 import org.testng.annotations.DataProvider;
@@ -600,21 +602,21 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
 
     @Test(dataProvider = "distributedImpl")
     public void testPut(String provider, Supplier<String> urlSupplier) throws Exception {
-        @Cleanup
-        final var store1 = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        @Cleanup final var store1 = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder()
+                .build());
         final var cache1 = store1.getMetadataCache(Integer.class);
-        @Cleanup
-        final var store2 = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        @Cleanup final var store2 = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder()
+                .build());
         final var cache2 = store2.getMetadataCache(Integer.class);
         final var key = "/testPut";
 
-        cache1.put(key, 1); // create
+        cache1.put(key, 1, EnumSet.of(CreateOption.Ephemeral)); // create
         Awaitility.await().untilAsserted(() -> {
             assertEquals(cache1.get(key).get().orElse(-1), 1);
             assertEquals(cache2.get(key).get().orElse(-1), 1);
         });
 
-        cache2.put(key, 2); // update
+        cache2.put(key, 2, EnumSet.of(CreateOption.Ephemeral)); // update
         Awaitility.await().untilAsserted(() -> {
             assertEquals(cache1.get(key).get().orElse(-1), 2);
             assertEquals(cache2.get(key).get().orElse(-1), 2);


### PR DESCRIPTION
### Motivation

It's observed in our test environment many times after restarting the only broker with the extensible load manager's broker registry service.

```
2024-09-12T14:00:20,557+0000 [main] ERROR org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl - Failed to start the extensible load balance and close broker registry org.apache.pulsar.broker.loadbalance.extensions.BrokerRegistryImpl@6d6c4775.
org.apache.pulsar.broker.PulsarServerException: org.apache.pulsar.metadata.api.MetadataStoreException$LockBusyException: Resource at /loadbalance/brokers/<broker-id>:8080 is already locked
        at org.apache.pulsar.broker.loadbalance.extensions.BrokerRegistryImpl.start(BrokerRegistryImpl.java:112) ~
        at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.start(ExtensibleLoadManagerImpl.java:370) 
        at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerWrapper.start(ExtensibleLoadManagerWrapper.java:50) 
        at org.apache.pulsar.broker.PulsarService.startLoadManagementService(PulsarService.java:1426) 
        at org.apache.pulsar.broker.PulsarService.start(PulsarService.java:986) 
        ...
Caused by: org.apache.pulsar.metadata.api.MetadataStoreException$LockBusyException: Resource at /loadbalance/brokers/<broker-id>:8080 is already locked
        at org.apache.pulsar.metadata.api.MetadataStoreException.unwrap(MetadataStoreException.java:186) ~
        at org.apache.pulsar.broker.loadbalance.extensions.BrokerRegistryImpl.register(BrokerRegistryImpl.java:131) ~
        at org.apache.pulsar.broker.loadbalance.extensions.BrokerRegistryImpl.start(BrokerRegistryImpl.java:110) ~
        ... 16 more
```

The "Resource xxx is already locked" is usually caused by a `BadVersionException`. This issue can happen when:
1. Broker somehow crashed (e.g. killed by `kill -9` or the container crashed) so it did not delete the node from the metadata store.
2. Broker restarted, but the node still existed so it failed to acquire the lock.
3. **This error can only be recovered by restarting the broker after the metadata store deleted that node (manually by operators or automatically by session timeout detected)**

Actually, it's not a good use case of  `LockManager` here. The broker registry only:
1. Put it's own broker's lookup data under the of `/loadbalance/brokers/<broker-id>` when starting (in the main thread)
2. Delete its own broker id from when closing.
3. Query any broker's lookup data from the `/loadbalance/brokers/<broker-id>`
4. List all children nodes of `/loadbalance/brokers`.

Currently, step 1 and 2 are performed by the distribution lock implemented by `LockManager`. However, there should be no race condition because the broker id is the unique identifier of a broker. There is no case that a broker starts or closes concurrently. In addition, it's meaningless to pass a version explicitly to the metadata store.

Regarding step 3 and 4, they are simply wrapping the `MetadataCache`'s methods. They are actually never related to something like "lock" though they're named `listLocks` and `readLock`.

### Modifications

- Add a `put` method to `MetadataCache`, which just calls `MetadataStore#put` with `Optional.empty()` underlying.
- Replace `LockManager` with `MetadataCache` in `BrokerRegistryImpl`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
