### PR TITLE
[improve][broker] Add ServiceUnitStateTableView (ExtensibleLoadManagerImpl only)

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1563,6 +1563,9 @@ loadBalancerNamespaceBundleSplitConditionHitCountThreshold=3
 # (only used in load balancer extension logics)
 loadBalancerServiceUnitStateTombstoneDelayTimeInSeconds=3600
 
+# Name of ServiceUnitStateTableView implementation class to use
+loadManagerServiceUnitStateTableViewClassName=org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateTableViewImpl
+
 
 ### --- Replication --- ###
 

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1566,6 +1566,12 @@ loadBalancerServiceUnitStateTombstoneDelayTimeInSeconds=3600
 # Name of ServiceUnitStateTableView implementation class to use
 loadManagerServiceUnitStateTableViewClassName=org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateTableViewImpl
 
+# Specify ServiceUnitTableViewSyncer to sync service unit(bundle) states between metadata store and
+# system topic table views during migration from one to the other. One could enable this
+# syncer before migration and disable it after the migration finishes.
+# It accepts `MetadataStoreToSystemTopicSyncer` or `SystemTopicToMetadataStoreSyncer` to
+# enable it. It accepts `None` to disable it."
+loadBalancerServiceUnitTableViewSyncer=None
 
 ### --- Replication --- ###
 

--- a/pip/pip-378.md
+++ b/pip/pip-378.md
@@ -30,7 +30,7 @@ Add `ServiceUnitStateTableView` abstraction and make it pluggable, so users can 
 - Introduce `MetadataStoreTableView` interface to support `ServiceUnitStateMetadataStoreTableViewImpl` implementation.
 - `MetadataStoreTableViewImpl` will use shadow hashmap to maintain the metadata tableview. It will initially fill the local tableview by scanning all existing items in the metadata store path. Also, new items will be updated to the tableview via metadata watch notifications.
 - Add `BiConsumer<String, Optional<CacheGetResult<T>>> asyncReloadConsumer` in MetadataCacheConfig to listen the automatic cache async reload. This can be useful to re-sync the the shadow hashmap in MetadataStoreTableViewImpl in case it is out-dated in the worst case(e.g. network or metadata issues).
-- Introduce `ServiceUnitStateTableViewSyncer` to sync system topic and metadata store table views to migrate to one from the other. This syncer can be enabled by a dynamic config, `loadBalancerServiceUnitTableViewSyncerEnabled`.
+- Introduce `ServiceUnitStateTableViewSyncer` to sync system topic and metadata store table views to migrate to one from the other. This syncer can be enabled by a dynamic config, `loadBalancerServiceUnitTableViewSyncer`.
 
 ## Detailed Design
 
@@ -243,56 +243,15 @@ public class MetadataCacheConfig<T> {
  */
 @Slf4j
 public class ServiceUnitStateTableViewSyncer implements Cloneable {
-    private static final int SYNC_TIMEOUT_IN_SECS = 30;
-    private volatile ServiceUnitStateTableView systemTopicTableView;
-    private volatile ServiceUnitStateTableView metadataStoreTableView;
-
+    ...
 
     public void start(PulsarService pulsar) throws IOException {
-        if (!pulsar.getConfiguration().isLoadBalancerServiceUnitTableViewSyncerEnabled()) {
-            return;
-        }
-        try {
-            if (systemTopicTableView == null) {
-                systemTopicTableView = new ServiceUnitStateTableViewImpl();
-                systemTopicTableView.start(
-                        pulsar,
-                        this::syncToMetadataStore,
-                        this::syncToMetadataStore);
-                log.info("Successfully started ServiceUnitStateTableViewSyncer::systemTopicTableView");
-            }
-
-            if (metadataStoreTableView == null) {
-                metadataStoreTableView = new ServiceUnitStateMetadataStoreTableViewImpl();
-                metadataStoreTableView.start(
-                        pulsar,
-                        this::syncToSystemTopic,
-                        this::syncToSystemTopic);
-                log.info("Successfully started ServiceUnitStateTableViewSyncer::metadataStoreTableView");
-            }
-
-        } catch (Throwable e) {
-            log.error("Failed to start ServiceUnitStateTableViewSyncer", e);
-            throw e;
-        }
+        ... // sync  SystemTopicTableView and MetadataStoreTableView
     }
 
-    private void syncToSystemTopic(String key, ServiceUnitStateData data) {
-        try {
-            systemTopicTableView.put(key, data).get(SYNC_TIMEOUT_IN_SECS, TimeUnit.SECONDS);
-        } catch (Throwable e) {
-            log.error("SystemTopicTableView failed to sync key:{}, data:{}", key, data, e);
-            throw new IllegalStateException(e);
-        }
-    }
 
-    private void syncToMetadataStore(String key, ServiceUnitStateData data) {
-        try {
-            metadataStoreTableView.put(key, data).get(SYNC_TIMEOUT_IN_SECS, TimeUnit.SECONDS);
-        } catch (Throwable e) {
-            log.error("metadataStoreTableView failed to sync key:{}, data:{}", key, data, e);
-            throw new IllegalStateException(e);
-        }
+    public void close() throws IOException {
+        ... // stop syncer
     }
 ...
 }
@@ -302,14 +261,14 @@ public class ServiceUnitStateTableViewSyncer implements Cloneable {
 
 ### Configuration
 
-- Add a `loadManagerServiceUnitStateTableViewClassName` configuration to specify `ServiceUnitStateTableView` implementation class name.
-- Add a `loadBalancerServiceUnitTableViewSyncerEnabled` configuration to to enable ServiceUnitTableViewSyncer to sync metadata store and system topic ServiceUnitStateTableView during migration.
+- Add a `loadManagerServiceUnitStateTableViewClassName` static configuration to specify `ServiceUnitStateTableView` implementation class name.
+- Add a `loadBalancerServiceUnitTableViewSyncer` dynamic configuration to enable ServiceUnitTableViewSyncer to sync metadata store and system topic ServiceUnitStateTableView during migration.
 
 ## Backward & Forward Compatibility
 
 It will ba Backward & Forward compatible as `loadManagerServiceUnitStateTableViewClassName` will be `ServiceUnitStateTableViewImpl`(system topic implementation) by default.
 
-We will introduce `ServiceUnitStateTableViewSyncer` to sync system topic and metadata store table views when migrating to ServiceUnitStateMetadataStoreTableViewImpl from ServiceUnitStateTableViewImpl and vice versa. This syncer can be enabled/disabled by a dynamic config, `loadBalancerServiceUnitTableViewSyncerEnabled`. The admin could enable this syncer before migration and disable it after it is finished.
+We will introduce `ServiceUnitStateTableViewSyncer` dynamic config to sync system topic and metadata store table views when migrating to ServiceUnitStateMetadataStoreTableViewImpl from ServiceUnitStateTableViewImpl and vice versa. The admin could enable this syncer before migration and disable it after it is finished.
 
 ## Alternatives
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2912,6 +2912,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private boolean loadBalancerMultiPhaseBundleUnload = true;
 
+    @FieldContext(
+            dynamic = false,
+            category = CATEGORY_LOAD_BALANCER,
+            doc = "Name of ServiceUnitStateTableView implementation class to use"
+    )
+    private String loadManagerServiceUnitStateTableViewClassName =
+            "org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateTableViewImpl";
+
     /**** --- Replication. --- ****/
     @FieldContext(
         category = CATEGORY_REPLICATION,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2927,9 +2927,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
                     + "system topic table views during migration from one to the other. One could enable this"
                     + " syncer before migration and disable it after the migration finishes. "
                     + "It accepts `MetadataStoreToSystemTopicSyncer` or `SystemTopicToMetadataStoreSyncer` to "
-                    + "enable it. Null value disables it."
+                    + "enable it. It accepts `None` to disable it."
     )
-    private ServiceUnitTableViewSyncerType loadBalancerServiceUnitTableViewSyncer = null;
+    private ServiceUnitTableViewSyncerType loadBalancerServiceUnitTableViewSyncer = ServiceUnitTableViewSyncerType.None;
 
     /**** --- Replication. --- ****/
     @FieldContext(
@@ -3831,10 +3831,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
     }
 
     public boolean isLoadBalancerServiceUnitTableViewSyncerEnabled() {
-        return loadBalancerServiceUnitTableViewSyncer != null;
+        return loadBalancerServiceUnitTableViewSyncer != ServiceUnitTableViewSyncerType.None;
     }
 
     public enum ServiceUnitTableViewSyncerType {
+        None,
         MetadataStoreToSystemTopicSyncer,
         SystemTopicToMetadataStoreSyncer;
     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2920,6 +2920,15 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String loadManagerServiceUnitStateTableViewClassName =
             "org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateTableViewImpl";
 
+    @FieldContext(
+            dynamic = true,
+            category = CATEGORY_LOAD_BALANCER,
+            doc = "Enable ServiceUnitTableViewSyncer to sync service unit(bundle) states between metadata store and "
+                    + "system topic table views during migration from one to the other. One could enable this"
+                    + " syncer before migration and disable it after the migration finishes."
+    )
+    private boolean loadBalancerServiceUnitTableViewSyncerEnabled = false;
+
     /**** --- Replication. --- ****/
     @FieldContext(
         category = CATEGORY_REPLICATION,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2923,11 +2923,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
             dynamic = true,
             category = CATEGORY_LOAD_BALANCER,
-            doc = "Enable ServiceUnitTableViewSyncer to sync service unit(bundle) states between metadata store and "
+            doc = "Specify ServiceUnitTableViewSyncer to sync service unit(bundle) states between metadata store and "
                     + "system topic table views during migration from one to the other. One could enable this"
-                    + " syncer before migration and disable it after the migration finishes."
+                    + " syncer before migration and disable it after the migration finishes. "
+                    + "It accepts `MetadataStoreToSystemTopicSyncer` or `SystemTopicToMetadataStoreSyncer` to "
+                    + "enable it. Null value disables it."
     )
-    private boolean loadBalancerServiceUnitTableViewSyncerEnabled = false;
+    private ServiceUnitTableViewSyncerType loadBalancerServiceUnitTableViewSyncer = null;
 
     /**** --- Replication. --- ****/
     @FieldContext(
@@ -3826,5 +3828,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
             }
         });
         return map;
+    }
+
+    public boolean isLoadBalancerServiceUnitTableViewSyncerEnabled() {
+        return loadBalancerServiceUnitTableViewSyncer != null;
+    }
+
+    public enum ServiceUnitTableViewSyncerType {
+        MetadataStoreToSystemTopicSyncer,
+        SystemTopicToMetadataStoreSyncer;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -288,14 +288,14 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
         createSystemTopic(pulsar, TOP_BUNDLES_LOAD_DATA_STORE_TOPIC);
     }
 
-    private static boolean configureSystemTopics(PulsarService pulsar) {
+    public static boolean configureSystemTopics(PulsarService pulsar, long target) {
         try {
             if (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(pulsar)
                     && pulsar.getConfiguration().isTopicLevelPoliciesEnabled()) {
                 Long threshold = pulsar.getAdminClient().topicPolicies().getCompactionThreshold(TOPIC);
-                if (threshold == null || COMPACTION_THRESHOLD != threshold.longValue()) {
-                    pulsar.getAdminClient().topicPolicies().setCompactionThreshold(TOPIC, COMPACTION_THRESHOLD);
-                    log.info("Set compaction threshold: {} bytes for system topic {}.", COMPACTION_THRESHOLD, TOPIC);
+                if (threshold == null || target != threshold.longValue()) {
+                    pulsar.getAdminClient().topicPolicies().setCompactionThreshold(TOPIC, target);
+                    log.info("Set compaction threshold: {} bytes for system topic {}.", target, TOPIC);
                 }
             } else {
                 log.warn("System topic or topic level policies is disabled. "
@@ -954,7 +954,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
                 // System topic config might fail due to the race condition
                 // with topic policy init(Topic policies cache have not init).
                 if (!configuredSystemTopics) {
-                    configuredSystemTopics = configureSystemTopics(pulsar);
+                    configuredSystemTopics = configureSystemTopics(pulsar, COMPACTION_THRESHOLD);
                 }
                 if (role != Leader) {
                     log.warn("Current role:{} does not match with the channel ownership:{}. "

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannel.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannel.java
@@ -24,13 +24,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.loadbalance.extensions.manager.StateChangeListener;
 import org.apache.pulsar.broker.loadbalance.extensions.models.Split;
 import org.apache.pulsar.broker.loadbalance.extensions.models.Unload;
+import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.stats.Metrics;
-import org.apache.pulsar.metadata.api.NotificationType;
-import org.apache.pulsar.metadata.api.extended.SessionEvent;
 
 /**
  * Defines the ServiceUnitStateChannel interface.
@@ -56,92 +57,39 @@ public interface ServiceUnitStateChannel extends Closeable {
     void close() throws PulsarServerException;
 
     /**
-     * Asynchronously gets the current owner broker of the system topic in this channel.
-     * @return the service url without the protocol prefix, 'http://'. e.g. broker-xyz:abcd
-     *
-     * ServiceUnitStateChannel elects the separate leader as the owner broker of the system topic in this channel.
+     * Asynchronously gets the current owner broker of this channel.
+     * @return a future of owner brokerId to track the completion of the operation
      */
     CompletableFuture<Optional<String>> getChannelOwnerAsync();
 
     /**
-     * Asynchronously checks if the current broker is the owner broker of the system topic in this channel.
-     * @return True if the current broker is the owner. Otherwise, false.
+     * Asynchronously checks if the current broker is the owner broker of this channel.
+     * @return a future of check result to track the completion of the operation
      */
     CompletableFuture<Boolean> isChannelOwnerAsync();
 
     /**
-     * Checks if the current broker is the owner broker of the system topic in this channel.
+     * Checks if the current broker is the owner broker of this channel.
      * @return True if the current broker is the owner. Otherwise, false.
+     * @throws ExecutionException
+     * @throws InterruptedException
+     * @throws TimeoutException
      */
-    boolean isChannelOwner();
-
-    /**
-     * Handles the metadata session events to track
-     * if the connection between the broker and metadata store is stable or not.
-     * This will be registered as a metadata SessionEvent listener.
-     *
-     * The stability of the metadata connection is important
-     * to determine how to handle the broker deletion(unavailable) event notified from the metadata store.
-     *
-     * Please refer to handleBrokerRegistrationEvent(String broker, NotificationType type) for more details.
-     *
-     * @param event metadata session events
-     */
-    void handleMetadataSessionEvent(SessionEvent event);
-
-    /**
-     * Handles the broker registration event from the broker registry.
-     * This will be registered as a broker registry listener.
-     *
-     * Case 1: If NotificationType is Deleted,
-     *         it will schedule a clean-up operation to release the ownerships of the deleted broker.
-     *
-     *      Sub-case1: If the metadata connection has been stable for long time,
-     *                 it will immediately execute the cleanup operation to guarantee high-availability.
-     *
-     *      Sub-case2: If the metadata connection has been stable only for short time,
-     *                 it will defer the clean-up operation for some time and execute it.
-     *                 This is to gracefully handle the case when metadata connection is flaky --
-     *                 If the deleted broker comes back very soon,
-     *                 we better cancel the clean-up operation for high-availability.
-     *
-     *      Sub-case3: If the metadata connection is unstable,
-     *                 it will not schedule the clean-up operation, as the broker-metadata connection is lost.
-     *                 The brokers will continue to serve existing topics connections,
-     *                 and we better not to interrupt the existing topic connections for high-availability.
-     *
-     *
-     * Case 2: If NotificationType is Created,
-     *         it will cancel any scheduled clean-up operation if still not executed.
-     *
-     * @param broker notified broker
-     * @param type notification type
-     */
-    void handleBrokerRegistrationEvent(String broker, NotificationType type);
+    boolean isChannelOwner() throws ExecutionException, InterruptedException, TimeoutException;
 
     /**
      * Asynchronously gets the current owner broker of the service unit.
      *
-     *
      * @param serviceUnit (e.g. bundle)
-     * @return the future object of the owner broker
-     *
-     * Case 1: If the service unit is owned, it returns the completed future object with the current owner.
-     * Case 2: If the service unit's assignment is ongoing, it returns the non-completed future object.
-     *      Sub-case1: If the assigned broker is available and finally takes the ownership,
-     *                 the future object will complete and return the owner broker.
-     *      Sub-case2: If the assigned broker does not take the ownership in time,
-     *                 the future object will time out.
-     * Case 3: If none of them, it returns Optional.empty().
+     * @return a future of owner brokerId to track the completion of the operation
      */
     CompletableFuture<Optional<String>> getOwnerAsync(String serviceUnit);
 
     /**
-     *  Gets the assigned broker of the service unit.
-     *
+     * Asynchronously gets the assigned broker of the service unit.
      *
      * @param serviceUnit (e.g. bundle))
-     * @return the future object of the assigned broker
+     * @return assigned brokerId
      */
     Optional<String> getAssigned(String serviceUnit);
 
@@ -149,16 +97,14 @@ public interface ServiceUnitStateChannel extends Closeable {
     /**
      * Checks if the target broker is the owner of the service unit.
      *
-     *
      * @param serviceUnit (e.g. bundle)
-     * @param targetBroker
-     * @return true if the target broker is the owner. false if unknown.
+     * @param targetBrokerId
+     * @return true if the target brokerId is the owner brokerId. false if unknown.
      */
-    boolean isOwner(String serviceUnit, String targetBroker);
+    boolean isOwner(String serviceUnit, String targetBrokerId);
 
     /**
      * Checks if the current broker is the owner of the service unit.
-     *
      *
      * @param serviceUnit (e.g. bundle))
      * @return true if the current broker is the owner. false if unknown.
@@ -166,30 +112,24 @@ public interface ServiceUnitStateChannel extends Closeable {
     boolean isOwner(String serviceUnit);
 
     /**
-     * Asynchronously publishes the service unit assignment event to the system topic in this channel.
-     * It de-duplicates assignment events if there is any ongoing assignment event for the same service unit.
+     * Asynchronously publishes the service unit assignment event to this channel.
      * @param serviceUnit (e.g bundle)
-     * @param broker the assigned broker
-     * @return the completable future object with the owner broker
-     * case 1: If the assigned broker is available and takes the ownership,
-     *         the future object will complete and return the owner broker.
-     *         The returned owner broker could be different from the input broker (due to assignment race-condition).
-     * case 2: If the assigned broker does not take the ownership in time,
-     *         the future object will time out.
+     * @param brokerId the assigned brokerId
+     * @return a future of owner brokerId to track the completion of the operation
      */
-    CompletableFuture<String> publishAssignEventAsync(String serviceUnit, String broker);
+    CompletableFuture<String> publishAssignEventAsync(String serviceUnit, String brokerId);
 
     /**
-     * Asynchronously publishes the service unit unload event to the system topic in this channel.
+     * Asynchronously publishes the service unit unload event to this channel.
      * @param unload (unload specification object)
-     * @return the completable future object staged from the event message sendAsync.
+     * @return a future to track the completion of the operation
      */
     CompletableFuture<Void> publishUnloadEventAsync(Unload unload);
 
     /**
-     * Asynchronously publishes the bundle split event to the system topic in this channel.
+     * Asynchronously publishes the bundle split event to this channel.
      * @param split (split specification object)
-     * @return the completable future object staged from the event message sendAsync.
+     * @return a future to track the completion of the operation
      */
     CompletableFuture<Void> publishSplitEventAsync(Split split);
 
@@ -200,17 +140,23 @@ public interface ServiceUnitStateChannel extends Closeable {
     List<Metrics> getMetrics();
 
     /**
-     * Add a state change listener.
+     * Adds a state change listener.
      *
      * @param listener State change listener.
      */
     void listen(StateChangeListener listener);
 
     /**
-     * Returns service unit ownership entry set.
-     * @return a set of service unit ownership entries
+     * Asynchronously returns service unit ownership entry set.
+     * @return a set of service unit ownership entries to track the completion of the operation
      */
     Set<Map.Entry<String, ServiceUnitStateData>> getOwnershipEntrySet();
+
+    /**
+     * Asynchronously returns service units owned by this broker.
+     * @return a set of owned service units to track the completion of the operation
+     */
+    Set<NamespaceBundle> getOwnedServiceUnits();
 
     /**
      * Schedules ownership monitor to periodically check and correct invalid ownership states.
@@ -223,7 +169,7 @@ public interface ServiceUnitStateChannel extends Closeable {
     void cancelOwnershipMonitor();
 
     /**
-     * Cleans the service unit ownerships from the current broker's channel.
+     * Cleans(gives up) any service unit ownerships from this broker.
      */
     void cleanOwnerships();
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateData.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateData.java
@@ -75,4 +75,19 @@ public record ServiceUnitStateData(
     public static ServiceUnitState state(ServiceUnitStateData data) {
         return data == null ? ServiceUnitState.Init : data.state();
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ServiceUnitStateData that = (ServiceUnitStateData) o;
+
+        return versionId == that.versionId;
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateMetadataStoreTableViewImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateMetadataStoreTableViewImpl.java
@@ -108,7 +108,7 @@ public class ServiceUnitStateMetadataStoreTableViewImpl extends ServiceUnitState
     @Override
     public ServiceUnitStateData get(String key) {
         if (!isValidState()) {
-            new IllegalStateException(INVALID_STATE_ERROR_MSG);
+            throw new IllegalStateException(INVALID_STATE_ERROR_MSG);
         }
         return tableview.get(key);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateMetadataStoreTableViewImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateMetadataStoreTableViewImpl.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.broker.loadbalance.extensions.channel;
+
+import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.StorageType.MetadataStore;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.MetadataStoreTableView;
+import org.apache.pulsar.metadata.tableview.impl.MetadataStoreTableViewImpl;
+
+@Slf4j
+public class ServiceUnitStateMetadataStoreTableViewImpl extends ServiceUnitStateTableViewBase {
+    public static final String PATH_PREFIX = "/service_unit_state";
+    private static final String VALID_PATH_REG_EX = "^\\/service_unit_state\\/.*\\/0x[0-9a-fA-F]{8}_0x[0-9a-fA-F]{8}$";
+    private static final Pattern VALID_PATH_PATTERN;
+
+    static {
+        try {
+            VALID_PATH_PATTERN = Pattern.compile(VALID_PATH_REG_EX);
+        } catch (PatternSyntaxException error) {
+            log.error("Invalid regular expression {}", VALID_PATH_REG_EX, error);
+            throw new IllegalArgumentException(error);
+        }
+    }
+    private ServiceUnitStateDataConflictResolver conflictResolver;
+    private volatile MetadataStoreTableView<ServiceUnitStateData> tableview;
+
+    public void start(PulsarService pulsar,
+                      BiConsumer<String, ServiceUnitStateData> tailItemListener,
+                      BiConsumer<String, ServiceUnitStateData> existingItemListener)
+            throws MetadataStoreException {
+        init(pulsar);
+        conflictResolver = new ServiceUnitStateDataConflictResolver();
+        conflictResolver.setStorageType(MetadataStore);
+        tableview = new MetadataStoreTableViewImpl<>(ServiceUnitStateData.class,
+                pulsar.getBrokerId(),
+                pulsar.getLocalMetadataStore(),
+                PATH_PREFIX,
+                this::resolveConflict,
+                this::validateServiceUnitPath,
+                List.of(this::updateOwnedServiceUnits, tailItemListener),
+                List.of(this::updateOwnedServiceUnits, existingItemListener),
+                TimeUnit.SECONDS.toMillis(pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds())
+        );
+        tableview.start();
+
+    }
+
+    protected boolean resolveConflict(ServiceUnitStateData prev, ServiceUnitStateData cur) {
+        return !conflictResolver.shouldKeepLeft(prev, cur);
+    }
+
+
+    protected boolean validateServiceUnitPath(String path) {
+        try {
+            var matcher = VALID_PATH_PATTERN.matcher(path);
+            return matcher.matches();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+
+    @Override
+    public void close() throws IOException {
+        if (tableview != null) {
+            tableview = null;
+            log.info("Successfully closed the channel tableview.");
+        }
+    }
+
+    private boolean isValidState() {
+        if (tableview == null) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public ServiceUnitStateData get(String key) {
+        if (!isValidState()) {
+            new IllegalStateException(INVALID_STATE_ERROR_MSG);
+        }
+        return tableview.get(key);
+    }
+
+    @Override
+    public CompletableFuture<Void> put(String key, @NonNull ServiceUnitStateData value) {
+        if (!isValidState()) {
+            return CompletableFuture.failedFuture(new IllegalStateException(INVALID_STATE_ERROR_MSG));
+        }
+        return tableview.put(key, value).exceptionally(e -> {
+            if (e.getCause() instanceof MetadataStoreTableView.ConflictException) {
+                return null;
+            }
+            throw FutureUtil.wrapToCompletionException(e);
+        });
+    }
+
+    @Override
+    public void flush(long waitDurationInMillis) {
+        // no-op
+    }
+
+    @Override
+    public CompletableFuture<Void> delete(String key) {
+        if (!isValidState()) {
+            return CompletableFuture.failedFuture(new IllegalStateException(INVALID_STATE_ERROR_MSG));
+        }
+        return tableview.delete(key).exceptionally(e -> {
+            if (e.getCause() instanceof MetadataStoreException.NotFoundException) {
+                return null;
+            }
+            throw FutureUtil.wrapToCompletionException(e);
+        });
+    }
+
+
+    @Override
+    public Set<Map.Entry<String, ServiceUnitStateData>> entrySet() {
+        if (!isValidState()) {
+            throw new IllegalStateException(INVALID_STATE_ERROR_MSG);
+        }
+        return tableview.entrySet();
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableView.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableView.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.extensions.channel;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.common.naming.NamespaceBundle;
+
+/**
+ * Given that the ServiceUnitStateChannel event-sources service unit (bundle) ownership states via a persistent store
+ * and reacts to ownership changes, the ServiceUnitStateTableView provides an interface to the
+ * ServiceUnitStateChannel's persistent store and its locally replicated ownership view (tableview) with listener
+ * registration. It initially populates its local table view by scanning existing items in the remote store. The
+ * ServiceUnitStateTableView receives notifications whenever ownership states are updated in the remote store, and
+ * upon notification, it applies the updates to its local tableview with the listener logic.
+ */
+public interface ServiceUnitStateTableView extends Closeable {
+
+    /**
+     * Starts the tableview.
+     * It initially populates its local table view by scanning existing items in the remote store, and it starts
+     * listening to service unit ownership changes from the remote store.
+     * @param pulsar pulsar service reference
+     * @param tailItemListener listener to listen tail(newly updated) items
+     * @param existingItemListener listener to listen existing items
+     * @throws IOException if it fails to init the tableview.
+     */
+    void start(PulsarService pulsar,
+               BiConsumer<String, ServiceUnitStateData> tailItemListener,
+               BiConsumer<String, ServiceUnitStateData> existingItemListener) throws IOException;
+
+
+    /**
+     * Closes the tableview.
+     * @throws IOException if it fails to close the tableview.
+     */
+    void close() throws IOException;
+
+    /**
+     * Gets one item from the local tableview.
+     * @param key the key to get
+     * @return value if exists. Otherwise, null.
+     */
+    ServiceUnitStateData get(String key);
+
+    /**
+     * Tries to put the item in the persistent store.
+     * If it completes, all peer tableviews (including the local one) will be notified and be eventually consistent
+     * with this put value.
+     *
+     * It ignores put operation if the input value conflicts with the existing one in the persistent store.
+     *
+     * @param key the key to put
+     * @param value the value to put
+     * @return a future to track the completion of the operation
+     */
+    CompletableFuture<Void> put(String key, ServiceUnitStateData value);
+
+    /**
+     * Tries to delete the item from the persistent store.
+     * All peer tableviews (including the local one) will be notified and be eventually consistent with this deletion.
+     *
+     * It ignores delete operation if the key is not present in the persistent store.
+     *
+     * @param key the key to delete
+     * @return a future to track the completion of the operation
+     */
+    CompletableFuture<Void> delete(String key);
+
+    /**
+     * Returns the entry set of the items in the local tableview.
+     * @return entry set
+     */
+    Set<Map.Entry<String, ServiceUnitStateData>> entrySet();
+
+    /**
+     * Returns service units (namespace bundles) owned by this broker.
+     * @return a set of owned service units (namespace bundles)
+     */
+    Set<NamespaceBundle> ownedServiceUnits();
+
+    /**
+     * Tries to flush any batched or buffered updates.
+     * @param waitDurationInMillis time to wait until complete.
+     * @throws ExecutionException
+     * @throws InterruptedException
+     * @throws TimeoutException
+     */
+    void flush(long waitDurationInMillis) throws ExecutionException, InterruptedException, TimeoutException;
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableViewBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableViewBase.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.broker.loadbalance.extensions.channel;
+
+import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Owned;
+import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Splitting;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared;
+import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.common.naming.NamespaceBundle;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+
+/**
+ * ServiceUnitStateTableView base class.
+ */
+@Slf4j
+abstract class ServiceUnitStateTableViewBase implements ServiceUnitStateTableView {
+    protected static final String INVALID_STATE_ERROR_MSG = "The tableview has not been started.";
+    private final Map<NamespaceBundle, Boolean> ownedServiceUnitsMap = new ConcurrentHashMap<>();
+    private final Set<NamespaceBundle> ownedServiceUnits = Collections.unmodifiableSet(ownedServiceUnitsMap.keySet());
+    private String brokerId;
+    private PulsarService pulsar;
+    protected void init(PulsarService pulsar) throws MetadataStoreException {
+        this.pulsar = pulsar;
+        this.brokerId = pulsar.getBrokerId();
+        // Add heartbeat and SLA monitor namespace bundle.
+        NamespaceName heartbeatNamespace =
+                NamespaceService.getHeartbeatNamespace(brokerId, pulsar.getConfiguration());
+        NamespaceName heartbeatNamespaceV2 = NamespaceService
+                .getHeartbeatNamespaceV2(brokerId, pulsar.getConfiguration());
+        NamespaceName slaMonitorNamespace = NamespaceService
+                .getSLAMonitorNamespace(brokerId, pulsar.getConfiguration());
+        try {
+            pulsar.getNamespaceService().getNamespaceBundleFactory()
+                    .getFullBundleAsync(heartbeatNamespace)
+                    .thenAccept(fullBundle -> ownedServiceUnitsMap.put(fullBundle, true))
+                    .thenCompose(__ -> pulsar.getNamespaceService().getNamespaceBundleFactory()
+                            .getFullBundleAsync(heartbeatNamespaceV2))
+                    .thenAccept(fullBundle -> ownedServiceUnitsMap.put(fullBundle, true))
+                    .thenCompose(__ -> pulsar.getNamespaceService().getNamespaceBundleFactory()
+                            .getFullBundleAsync(slaMonitorNamespace))
+                    .thenAccept(fullBundle -> ownedServiceUnitsMap.put(fullBundle, true))
+                    .thenApply(__ -> null).get(pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds(),
+                            TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new MetadataStoreException(e);
+        }
+    }
+
+    @Override
+    public Set<NamespaceBundle> ownedServiceUnits() {
+        return ownedServiceUnits;
+    }
+
+    protected void updateOwnedServiceUnits(String key, ServiceUnitStateData val) {
+        NamespaceBundle namespaceBundle = LoadManagerShared.getNamespaceBundle(pulsar, key);
+        var state = ServiceUnitStateData.state(val);
+        ownedServiceUnitsMap.compute(namespaceBundle, (k, v) -> {
+            if (state == Owned && brokerId.equals(val.dstBroker())) {
+                return true;
+            } else if (state == Splitting && brokerId.equals(val.sourceBroker())) {
+                return true;
+            } else {
+                return null;
+            }
+        });
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableViewImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableViewImpl.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.broker.loadbalance.extensions.channel;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.pulsar.common.naming.NamespaceName.SYSTEM_NAMESPACE;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
+import org.apache.pulsar.client.api.CompressionType;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.TableView;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
+
+@Slf4j
+public class ServiceUnitStateTableViewImpl extends ServiceUnitStateTableViewBase {
+
+    public static final String TOPIC = TopicName.get(
+            TopicDomain.persistent.value(),
+            SYSTEM_NAMESPACE,
+            "loadbalancer-service-unit-state").toString();
+    private static final int MAX_OUTSTANDING_PUB_MESSAGES = 500;
+    public static final CompressionType MSG_COMPRESSION_TYPE = CompressionType.ZSTD;
+    private volatile Producer<ServiceUnitStateData> producer;
+    private volatile TableView<ServiceUnitStateData> tableview;
+
+    public void start(PulsarService pulsar,
+                      BiConsumer<String, ServiceUnitStateData> tailItemListener,
+                      BiConsumer<String, ServiceUnitStateData> existingItemListener) throws IOException {
+        boolean debug = ExtensibleLoadManagerImpl.debug(pulsar.getConfiguration(), log);
+
+        init(pulsar);
+
+        var schema = Schema.JSON(ServiceUnitStateData.class);
+
+        ExtensibleLoadManagerImpl.createSystemTopic(pulsar, TOPIC);
+
+        if (producer != null) {
+            producer.close();
+            if (debug) {
+                log.info("Closed the channel producer.");
+            }
+        }
+
+        producer = pulsar.getClient().newProducer(schema)
+                .enableBatching(true)
+                .compressionType(MSG_COMPRESSION_TYPE)
+                .maxPendingMessages(MAX_OUTSTANDING_PUB_MESSAGES)
+                .blockIfQueueFull(true)
+                .topic(TOPIC)
+                .create();
+
+        if (debug) {
+            log.info("Successfully started the channel producer.");
+        }
+
+        if (tableview != null) {
+            tableview.close();
+            if (debug) {
+                log.info("Closed the channel tableview.");
+            }
+        }
+
+        tableview = pulsar.getClient().newTableViewBuilder(schema)
+                .topic(TOPIC)
+                .loadConf(Map.of(
+                        "topicCompactionStrategyClassName",
+                        ServiceUnitStateDataConflictResolver.class.getName()))
+                .create();
+        tableview.listen(this::updateOwnedServiceUnits);
+        tableview.listen(tailItemListener);
+        tableview.forEach(this::updateOwnedServiceUnits);
+        tableview.forEach(existingItemListener);
+
+    }
+
+    private boolean isValidState() {
+        if (tableview == null || producer == null) {
+            return false;
+        }
+        return true;
+    }
+
+
+    @Override
+    public void close() throws IOException {
+
+        if (tableview != null) {
+            tableview.close();
+            tableview = null;
+            log.info("Successfully closed the channel tableview.");
+        }
+
+        if (producer != null) {
+            producer.close();
+            producer = null;
+            log.info("Successfully closed the channel producer.");
+        }
+    }
+
+    @Override
+    public ServiceUnitStateData get(String key) {
+        if (!isValidState()) {
+            throw new IllegalStateException(INVALID_STATE_ERROR_MSG);
+        }
+        return tableview.get(key);
+    }
+
+    @Override
+    public CompletableFuture<Void> put(String key, ServiceUnitStateData value) {
+        if (!isValidState()) {
+            return CompletableFuture.failedFuture(new IllegalStateException(INVALID_STATE_ERROR_MSG));
+        }
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        producer.newMessage()
+                .key(key)
+                .value(value)
+                .sendAsync()
+                .whenComplete((messageId, e) -> {
+                    if (e != null) {
+                        log.error("Failed to publish the message: serviceUnit:{}, data:{}",
+                                key, value, e);
+                        future.completeExceptionally(e);
+                    } else {
+                        future.complete(null);
+                    }
+                });
+        return future;
+    }
+
+    @Override
+    public void flush(long waitDurationInMillis) throws InterruptedException, TimeoutException, ExecutionException {
+        if (!isValidState()) {
+            throw new IllegalStateException(INVALID_STATE_ERROR_MSG);
+        }
+        producer.flushAsync().get(waitDurationInMillis, MILLISECONDS);
+    }
+
+    @Override
+    public CompletableFuture<Void> delete(String key) {
+        return put(key, null);
+    }
+
+    @Override
+    public Set<Map.Entry<String, ServiceUnitStateData>> entrySet() {
+        if (!isValidState()) {
+            throw new IllegalStateException(INVALID_STATE_ERROR_MSG);
+        }
+        return tableview.entrySet();
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableViewSyncer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableViewSyncer.java
@@ -19,6 +19,7 @@
 
 package org.apache.pulsar.broker.loadbalance.extensions.channel;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,7 +41,7 @@ import org.apache.pulsar.common.util.ObjectMapperFactory;
  * One could enable this syncer before migration from one to the other and disable it after the migration finishes.
  */
 @Slf4j
-public class ServiceUnitStateTableViewSyncer implements Cloneable {
+public class ServiceUnitStateTableViewSyncer implements Closeable {
     private static final int MAX_CONCURRENT_SYNC_COUNT = 100;
     private volatile ServiceUnitStateTableView systemTopicTableView;
     private volatile ServiceUnitStateTableView metadataStoreTableView;
@@ -147,6 +148,7 @@ public class ServiceUnitStateTableViewSyncer implements Cloneable {
         return metadataStoreTableView.put(key, data);
     }
 
+    @Override
     public void close() throws IOException {
         if (!isActive) {
             return;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableViewSyncer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableViewSyncer.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.broker.loadbalance.extensions.channel;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+
+/**
+ * Defines ServiceUnitTableViewSyncer.
+ * It syncs service unit(bundle) states between metadata store and system topic table views.
+ * One could enable this syncer before migration from one to the other and disable it after the migration finishes.
+ */
+@Slf4j
+public class ServiceUnitStateTableViewSyncer implements Cloneable {
+    private static final int MAX_CONCURRENT_SYNC_COUNT = 100;
+    private volatile ServiceUnitStateTableView systemTopicTableView;
+    private volatile ServiceUnitStateTableView metadataStoreTableView;
+    private volatile boolean isActive = false;
+
+    public void start(PulsarService pulsar)
+            throws IOException, TimeoutException, InterruptedException, ExecutionException {
+        if (!pulsar.getConfiguration().isLoadBalancerServiceUnitTableViewSyncerEnabled()) {
+            return;
+        }
+
+        if (isActive) {
+            return;
+        }
+
+        try {
+            long started = System.currentTimeMillis();
+
+            if (metadataStoreTableView != null) {
+                metadataStoreTableView.close();
+                metadataStoreTableView = null;
+            }
+            metadataStoreTableView = new ServiceUnitStateMetadataStoreTableViewImpl();
+            metadataStoreTableView.start(
+                    pulsar,
+                    this::syncToSystemTopic,
+                    (k, v) -> {}
+            );
+            log.info("Started MetadataStoreTableView");
+
+            if (systemTopicTableView != null) {
+                systemTopicTableView.close();
+                systemTopicTableView = null;
+            }
+            systemTopicTableView = new ServiceUnitStateTableViewImpl();
+            systemTopicTableView.start(
+                    pulsar,
+                    this::syncToMetadataStore,
+                    (k, v) -> {}
+            );
+            log.info("Started SystemTopicTableView");
+
+            Map<String, ServiceUnitStateData> merged = new HashMap<>();
+            metadataStoreTableView.entrySet().forEach(e -> merged.put(e.getKey(), e.getValue()));
+            systemTopicTableView.entrySet().forEach(e -> merged.put(e.getKey(), e.getValue()));
+
+            List<CompletableFuture<Void>> futures = new ArrayList<>();
+            var opTimeout = pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds();
+
+            // Directly use store to sync existing items to metadataStoreTableView(otherwise, they are conflicted out)
+            var store = pulsar.getLocalMetadataStore();
+            var writer = ObjectMapperFactory.getMapper().writer();
+            for (var e : merged.entrySet()) {
+                futures.add(store.put(ServiceUnitStateMetadataStoreTableViewImpl.PATH_PREFIX + "/" + e.getKey(),
+                        writer.writeValueAsBytes(e.getValue()), Optional.empty()).thenApply(__ -> null));
+                if (futures.size() == MAX_CONCURRENT_SYNC_COUNT) {
+                    FutureUtil.waitForAll(futures).get(opTimeout, TimeUnit.SECONDS);
+                    futures.clear();
+                }
+            }
+            FutureUtil.waitForAll(futures).get(opTimeout, TimeUnit.SECONDS);
+            futures.clear();
+
+            for (var e : merged.entrySet()) {
+                futures.add(syncToSystemTopic(e.getKey(), e.getValue()));
+                if (futures.size() == MAX_CONCURRENT_SYNC_COUNT) {
+                    FutureUtil.waitForAll(futures).get(opTimeout, TimeUnit.SECONDS);
+                    futures.clear();
+                }
+            }
+            FutureUtil.waitForAll(futures).get(opTimeout, TimeUnit.SECONDS);
+            futures.clear();
+
+            int size = merged.size();
+            int syncTimeout = opTimeout * size;
+            while (metadataStoreTableView.entrySet().size() != size || systemTopicTableView.entrySet().size() != size) {
+                if (TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - started) > syncTimeout) {
+                    throw new TimeoutException(
+                            "Failed to sync tableviews. MetadataStoreTableView.size: "
+                                    + metadataStoreTableView.entrySet().size()
+                                    + ", SystemTopicTableView.size: " + systemTopicTableView.entrySet().size() + " in "
+                                    + syncTimeout + " secs");
+                }
+                Thread.sleep(100);
+            }
+
+            log.info("Successfully started ServiceUnitStateTableViewSyncer MetadataStoreTableView.size:{} , "
+                            + "SystemTopicTableView.size: {} in {} secs",
+                    metadataStoreTableView.entrySet().size(), systemTopicTableView.entrySet().size(),
+                    TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - started));
+            isActive = true;
+
+        } catch (Throwable e) {
+            log.error("Failed to start ServiceUnitStateTableViewSyncer", e);
+            throw e;
+        }
+    }
+
+    private CompletableFuture<Void> syncToSystemTopic(String key, ServiceUnitStateData data) {
+        return systemTopicTableView.put(key, data);
+    }
+
+    private CompletableFuture<Void>  syncToMetadataStore(String key, ServiceUnitStateData data) {
+        return metadataStoreTableView.put(key, data);
+    }
+
+    public void close() throws IOException {
+        if (!isActive) {
+            return;
+        }
+
+        try {
+            if (systemTopicTableView != null) {
+                systemTopicTableView.close();
+                systemTopicTableView = null;
+                log.info("Closed SystemTopicTableView");
+            }
+        } catch (Exception e) {
+            log.error("Failed to close SystemTopicTableView", e);
+            throw e;
+        }
+
+        try {
+            if (metadataStoreTableView != null) {
+                metadataStoreTableView.close();
+                metadataStoreTableView = null;
+                log.info("Closed MetadataStoreTableView");
+            }
+        } catch (Exception e) {
+            log.error("Failed to close MetadataStoreTableView", e);
+            throw e;
+        }
+
+        log.info("Successfully closed ServiceUnitStateTableViewSyncer.");
+        isActive = false;
+    }
+
+    public boolean isActive() {
+        return isActive;
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableViewSyncer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableViewSyncer.java
@@ -19,17 +19,20 @@
 
 package org.apache.pulsar.broker.loadbalance.extensions.channel;
 
+import static org.apache.pulsar.broker.ServiceConfiguration.ServiceUnitTableViewSyncerType.SystemTopicToMetadataStoreSyncer;
+import static org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.COMPACTION_THRESHOLD;
+import static org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.configureSystemTopics;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.util.FutureUtil;
@@ -43,10 +46,12 @@ import org.apache.pulsar.common.util.ObjectMapperFactory;
 @Slf4j
 public class ServiceUnitStateTableViewSyncer implements Closeable {
     private static final int MAX_CONCURRENT_SYNC_COUNT = 100;
-    private static final int MAX_SYNC_WAIT_TIME_IN_SECS = 300;
+    private static final int SYNC_WAIT_TIME_IN_SECS = 300;
+    private PulsarService pulsar;
     private volatile ServiceUnitStateTableView systemTopicTableView;
     private volatile ServiceUnitStateTableView metadataStoreTableView;
     private volatile boolean isActive = false;
+
 
     public void start(PulsarService pulsar)
             throws IOException, TimeoutException, InterruptedException, ExecutionException {
@@ -57,82 +62,17 @@ public class ServiceUnitStateTableViewSyncer implements Closeable {
         if (isActive) {
             return;
         }
+        this.pulsar = pulsar;
 
         try {
-            long started = System.currentTimeMillis();
 
-            if (metadataStoreTableView != null) {
-                metadataStoreTableView.close();
-                metadataStoreTableView = null;
+            syncExistingItems();
+            // disable compaction
+            if (!configureSystemTopics(pulsar, 0)) {
+                throw new IllegalStateException("Failed to disable compaction");
             }
-            metadataStoreTableView = new ServiceUnitStateMetadataStoreTableViewImpl();
-            metadataStoreTableView.start(
-                    pulsar,
-                    this::syncToSystemTopic,
-                    (k, v) -> {}
-            );
-            log.info("Started MetadataStoreTableView");
+            syncTailItems();
 
-            if (systemTopicTableView != null) {
-                systemTopicTableView.close();
-                systemTopicTableView = null;
-            }
-            systemTopicTableView = new ServiceUnitStateTableViewImpl();
-            systemTopicTableView.start(
-                    pulsar,
-                    this::syncToMetadataStore,
-                    (k, v) -> {}
-            );
-            log.info("Started SystemTopicTableView");
-
-            Map<String, ServiceUnitStateData> merged = new HashMap<>();
-            metadataStoreTableView.entrySet().forEach(e -> merged.put(e.getKey(), e.getValue()));
-            systemTopicTableView.entrySet().forEach(e -> merged.put(e.getKey(), e.getValue()));
-
-            List<CompletableFuture<Void>> futures = new ArrayList<>();
-            var opTimeout = pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds();
-
-            // Directly use store to sync existing items to metadataStoreTableView(otherwise, they are conflicted out)
-            var store = pulsar.getLocalMetadataStore();
-            var writer = ObjectMapperFactory.getMapper().writer();
-            for (var e : merged.entrySet()) {
-                futures.add(store.put(ServiceUnitStateMetadataStoreTableViewImpl.PATH_PREFIX + "/" + e.getKey(),
-                        writer.writeValueAsBytes(e.getValue()), Optional.empty()).thenApply(__ -> null));
-                if (futures.size() == MAX_CONCURRENT_SYNC_COUNT) {
-                    FutureUtil.waitForAll(futures).get(opTimeout, TimeUnit.SECONDS);
-                    futures.clear();
-                }
-            }
-            FutureUtil.waitForAll(futures).get(opTimeout, TimeUnit.SECONDS);
-            futures.clear();
-
-            for (var e : merged.entrySet()) {
-                futures.add(syncToSystemTopic(e.getKey(), e.getValue()));
-                if (futures.size() == MAX_CONCURRENT_SYNC_COUNT) {
-                    FutureUtil.waitForAll(futures).get(opTimeout, TimeUnit.SECONDS);
-                    futures.clear();
-                }
-            }
-            FutureUtil.waitForAll(futures).get(opTimeout, TimeUnit.SECONDS);
-            futures.clear();
-
-            int size = merged.size();
-            while (metadataStoreTableView.entrySet().size() != size || systemTopicTableView.entrySet().size() != size) {
-                if (TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - started)
-                        > MAX_SYNC_WAIT_TIME_IN_SECS) {
-                    throw new TimeoutException(
-                            "Failed to sync tableviews. MetadataStoreTableView.size: "
-                                    + metadataStoreTableView.entrySet().size()
-                                    + ", SystemTopicTableView.size: " + systemTopicTableView.entrySet().size() + " in "
-                                    + MAX_SYNC_WAIT_TIME_IN_SECS + " secs");
-                }
-                Thread.sleep(100);
-            }
-
-            log.info("Successfully started ServiceUnitStateTableViewSyncer MetadataStoreTableView.size:{} , "
-                            + "SystemTopicTableView.size: {} in {} secs",
-                    metadataStoreTableView.entrySet().size(), systemTopicTableView.entrySet().size(),
-                    TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - started));
             isActive = true;
 
         } catch (Throwable e) {
@@ -149,10 +89,165 @@ public class ServiceUnitStateTableViewSyncer implements Closeable {
         return metadataStoreTableView.put(key, data);
     }
 
+    private CompletableFuture<Void> dummy(String key, ServiceUnitStateData data) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    private void syncExistingItems()
+            throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        long started = System.currentTimeMillis();
+        @Cleanup
+        ServiceUnitStateTableView metadataStoreTableView = new ServiceUnitStateMetadataStoreTableViewImpl();
+        metadataStoreTableView.start(
+                pulsar,
+                this::dummy,
+                this::dummy
+        );
+
+        @Cleanup
+        ServiceUnitStateTableView systemTopicTableView = new ServiceUnitStateTableViewImpl();
+        systemTopicTableView.start(
+                pulsar,
+                this::dummy,
+                this::dummy
+        );
+
+
+        var syncer = pulsar.getConfiguration().getLoadBalancerServiceUnitTableViewSyncer();
+        if (syncer == SystemTopicToMetadataStoreSyncer) {
+            clean(metadataStoreTableView);
+            syncExistingItemsToMetadataStore(systemTopicTableView);
+        } else {
+            clean(systemTopicTableView);
+            syncExistingItemsToSystemTopic(metadataStoreTableView, systemTopicTableView);
+        }
+
+        if (!waitUntilSynced(metadataStoreTableView, systemTopicTableView, started)) {
+            throw new TimeoutException(
+                    syncer + " failed to sync existing items in tableviews. MetadataStoreTableView.size: "
+                            + metadataStoreTableView.entrySet().size()
+                            + ", SystemTopicTableView.size: " + systemTopicTableView.entrySet().size() + " in "
+                            + SYNC_WAIT_TIME_IN_SECS + " secs");
+        }
+
+        log.info("Synced existing items MetadataStoreTableView.size:{} , "
+                        + "SystemTopicTableView.size: {} in {} secs",
+                metadataStoreTableView.entrySet().size(), systemTopicTableView.entrySet().size(),
+                TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - started));
+    }
+
+    private void syncTailItems() throws InterruptedException, IOException, TimeoutException {
+        long started = System.currentTimeMillis();
+
+        if (metadataStoreTableView != null) {
+            metadataStoreTableView.close();
+            metadataStoreTableView = null;
+        }
+
+        if (systemTopicTableView != null) {
+            systemTopicTableView.close();
+            systemTopicTableView = null;
+        }
+
+        this.metadataStoreTableView = new ServiceUnitStateMetadataStoreTableViewImpl();
+        this.metadataStoreTableView.start(
+                pulsar,
+                this::syncToSystemTopic,
+                this::dummy
+        );
+        log.info("Started MetadataStoreTableView");
+
+        this.systemTopicTableView = new ServiceUnitStateTableViewImpl();
+        this.systemTopicTableView.start(
+                pulsar,
+                this::syncToMetadataStore,
+                this::dummy
+        );
+        log.info("Started SystemTopicTableView");
+
+        var syncer = pulsar.getConfiguration().getLoadBalancerServiceUnitTableViewSyncer();
+        if (!waitUntilSynced(metadataStoreTableView, systemTopicTableView, started)) {
+            throw new TimeoutException(
+                    syncer + " failed to sync tableviews. MetadataStoreTableView.size: "
+                            + metadataStoreTableView.entrySet().size()
+                            + ", SystemTopicTableView.size: " + systemTopicTableView.entrySet().size() + " in "
+                            + SYNC_WAIT_TIME_IN_SECS + " secs");
+        }
+
+
+        log.info("Successfully started ServiceUnitStateTableViewSyncer MetadataStoreTableView.size:{} , "
+                        + "SystemTopicTableView.size: {} in {} secs",
+                metadataStoreTableView.entrySet().size(), systemTopicTableView.entrySet().size(),
+                TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - started));
+    }
+
+    private void syncExistingItemsToMetadataStore(ServiceUnitStateTableView src)
+            throws JsonProcessingException, ExecutionException, InterruptedException, TimeoutException {
+        // Directly use store to sync existing items to metadataStoreTableView(otherwise, they are conflicted out)
+        var store = pulsar.getLocalMetadataStore();
+        var writer = ObjectMapperFactory.getMapper().writer();
+        var opTimeout = pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds();
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        var srcIter = src.entrySet().iterator();
+        while (srcIter.hasNext()) {
+            var e = srcIter.next();
+            futures.add(store.put(ServiceUnitStateMetadataStoreTableViewImpl.PATH_PREFIX + "/" + e.getKey(),
+                    writer.writeValueAsBytes(e.getValue()), Optional.empty()).thenApply(__ -> null));
+            if (futures.size() == MAX_CONCURRENT_SYNC_COUNT || !srcIter.hasNext()) {
+                FutureUtil.waitForAll(futures).get(opTimeout, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    private void syncExistingItemsToSystemTopic(ServiceUnitStateTableView src,
+                                                ServiceUnitStateTableView dst)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        var opTimeout = pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds();
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        var srcIter = src.entrySet().iterator();
+        while (srcIter.hasNext()) {
+            var e = srcIter.next();
+            futures.add(dst.put(e.getKey(), e.getValue()));
+            if (futures.size() == MAX_CONCURRENT_SYNC_COUNT || !srcIter.hasNext()) {
+                FutureUtil.waitForAll(futures).get(opTimeout, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    private void clean(ServiceUnitStateTableView dst)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        var opTimeout = pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds();
+        var dstIter = dst.entrySet().iterator();
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        while (dstIter.hasNext()) {
+            var e = dstIter.next();
+            futures.add(dst.delete(e.getKey()));
+            if (futures.size() == MAX_CONCURRENT_SYNC_COUNT || !dstIter.hasNext()) {
+                FutureUtil.waitForAll(futures).get(opTimeout, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    private boolean waitUntilSynced(ServiceUnitStateTableView srt, ServiceUnitStateTableView dst, long started)
+            throws InterruptedException {
+        while (srt.entrySet().size() != dst.entrySet().size()) {
+            if (TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - started)
+                    > SYNC_WAIT_TIME_IN_SECS) {
+                return false;
+            }
+            Thread.sleep(100);
+        }
+        return true;
+    }
+
     @Override
     public void close() throws IOException {
         if (!isActive) {
             return;
+        }
+
+        if (!configureSystemTopics(pulsar, COMPACTION_THRESHOLD)) {
+            throw new IllegalStateException("Failed to enable compaction");
         }
 
         try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableViewSyncer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableViewSyncer.java
@@ -89,8 +89,7 @@ public class ServiceUnitStateTableViewSyncer implements Closeable {
         return metadataStoreTableView.put(key, data);
     }
 
-    private CompletableFuture<Void> dummy(String key, ServiceUnitStateData data) {
-        return CompletableFuture.completedFuture(null);
+    private void dummy(String key, ServiceUnitStateData data) {
     }
 
     private void syncExistingItems()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/store/LoadDataStore.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/store/LoadDataStore.java
@@ -103,4 +103,10 @@ public interface LoadDataStore<T> extends Closeable {
      */
     void startProducer() throws LoadDataStoreException;
 
+    /**
+     * Shutdowns the data store.
+     */
+    default void shutdown() throws IOException {
+        close();
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/store/TableViewLoadDataStoreImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/store/TableViewLoadDataStoreImpl.java
@@ -43,20 +43,17 @@ import org.apache.pulsar.client.api.TableView;
 public class TableViewLoadDataStoreImpl<T> implements LoadDataStore<T> {
 
     private static final long LOAD_DATA_REPORT_UPDATE_MAX_INTERVAL_MULTIPLIER_BEFORE_RESTART = 2;
+    private static final String SHUTDOWN_ERR_MSG = "This load store tableview has been shutdown";
     private static final long INIT_TIMEOUT_IN_SECS = 5;
-
     private volatile TableView<T> tableView;
     private volatile long tableViewLastUpdateTimestamp;
-
+    private volatile long producerLastPublishTimestamp;
     private volatile Producer<T> producer;
-
     private final ServiceConfiguration conf;
-
     private final PulsarClient client;
-
     private final String topic;
-
     private final Class<T> clazz;
+    private volatile boolean isShutdown;
 
     public TableViewLoadDataStoreImpl(PulsarService pulsar, String topic, Class<T> clazz)
             throws LoadDataStoreException {
@@ -65,6 +62,7 @@ public class TableViewLoadDataStoreImpl<T> implements LoadDataStore<T> {
             this.client = pulsar.getClient();
             this.topic = topic;
             this.clazz = clazz;
+            this.isShutdown = false;
         } catch (Exception e) {
             throw new LoadDataStoreException(e);
         }
@@ -72,41 +70,76 @@ public class TableViewLoadDataStoreImpl<T> implements LoadDataStore<T> {
 
     @Override
     public synchronized CompletableFuture<Void> pushAsync(String key, T loadData) {
-        validateProducer();
-        return producer.newMessage().key(key).value(loadData).sendAsync().thenAccept(__ -> {});
+        String msg = validateProducer();
+        if (StringUtils.isNotBlank(msg)) {
+            return CompletableFuture.failedFuture(new IllegalStateException(msg));
+        }
+        return producer.newMessage().key(key).value(loadData).sendAsync()
+                .thenAccept(__ -> producerLastPublishTimestamp = System.currentTimeMillis());
     }
 
     @Override
     public synchronized CompletableFuture<Void> removeAsync(String key) {
-        validateProducer();
-        return producer.newMessage().key(key).value(null).sendAsync().thenAccept(__ -> {});
+        String msg = validateProducer();
+        if (StringUtils.isNotBlank(msg)) {
+            return CompletableFuture.failedFuture(new IllegalStateException(msg));
+        }
+        return producer.newMessage().key(key).value(null).sendAsync()
+                .thenAccept(__ -> producerLastPublishTimestamp = System.currentTimeMillis());
     }
 
     @Override
     public synchronized Optional<T> get(String key) {
-        validateTableView();
+        String msg = validateTableView();
+        if (StringUtils.isNotBlank(msg)) {
+            throw new IllegalStateException(msg);
+        }
         return Optional.ofNullable(tableView.get(key));
     }
 
     @Override
     public synchronized void forEach(BiConsumer<String, T> action) {
-        validateTableView();
+        String msg = validateTableView();
+        if (StringUtils.isNotBlank(msg)) {
+            throw new IllegalStateException(msg);
+        }
         tableView.forEach(action);
     }
 
     public synchronized Set<Map.Entry<String, T>> entrySet() {
-        validateTableView();
+        String msg = validateTableView();
+        if (StringUtils.isNotBlank(msg)) {
+            throw new IllegalStateException(msg);
+        }
         return tableView.entrySet();
     }
 
     @Override
     public synchronized int size() {
-        validateTableView();
+        String msg = validateTableView();
+        if (StringUtils.isNotBlank(msg)) {
+            throw new IllegalStateException(msg);
+        }
         return tableView.size();
+    }
+
+    private void validateState() {
+        if (isShutdown) {
+            throw new IllegalStateException(SHUTDOWN_ERR_MSG);
+        }
+    }
+
+
+    @Override
+    public synchronized void init() throws IOException {
+        validateState();
+        close();
+        start();
     }
 
     @Override
     public synchronized void closeTableView() throws IOException {
+        validateState();
         if (tableView != null) {
             tableView.close();
             tableView = null;
@@ -115,16 +148,26 @@ public class TableViewLoadDataStoreImpl<T> implements LoadDataStore<T> {
 
     @Override
     public synchronized void start() throws LoadDataStoreException {
+        validateState();
         startProducer();
         startTableView();
     }
 
+    private synchronized void closeProducer() throws IOException {
+        validateState();
+        if (producer != null) {
+            producer.close();
+            producer = null;
+        }
+    }
     @Override
     public synchronized void startTableView() throws LoadDataStoreException {
+        validateState();
         if (tableView == null) {
             try {
                 tableView = client.newTableViewBuilder(Schema.JSON(clazz)).topic(topic).createAsync()
                         .get(INIT_TIMEOUT_IN_SECS, TimeUnit.SECONDS);
+                tableViewLastUpdateTimestamp = System.currentTimeMillis();
                 tableView.forEachAndListen((k, v) ->
                         tableViewLastUpdateTimestamp = System.currentTimeMillis());
             } catch (Exception e) {
@@ -133,13 +176,14 @@ public class TableViewLoadDataStoreImpl<T> implements LoadDataStore<T> {
             }
         }
     }
-
     @Override
     public synchronized void startProducer() throws LoadDataStoreException {
+        validateState();
         if (producer == null) {
             try {
                 producer = client.newProducer(Schema.JSON(clazz)).topic(topic).createAsync()
                         .get(INIT_TIMEOUT_IN_SECS, TimeUnit.SECONDS);
+                producerLastPublishTimestamp = System.currentTimeMillis();
             } catch (Exception e) {
                 producer = null;
                 throw new LoadDataStoreException(e);
@@ -149,38 +193,63 @@ public class TableViewLoadDataStoreImpl<T> implements LoadDataStore<T> {
 
     @Override
     public synchronized void close() throws IOException {
-        if (producer != null) {
-            producer.close();
-            producer = null;
-        }
+        validateState();
+        closeProducer();
         closeTableView();
     }
 
     @Override
-    public synchronized void init() throws IOException {
+    public synchronized void shutdown() throws IOException {
         close();
-        start();
+        isShutdown = true;
     }
 
-    private void validateProducer() {
-        if (producer == null) {
+    private String validateProducer() {
+        if (isShutdown) {
+            return SHUTDOWN_ERR_MSG;
+        }
+        String restartReason = getRestartReason(producer, producerLastPublishTimestamp);
+        if (StringUtils.isNotBlank(restartReason)) {
             try {
+                closeProducer();
                 startProducer();
-                log.info("Restarted producer on {}", topic);
+                log.info("Restarted producer on {}, {}", topic, restartReason);
             } catch (Exception e) {
-                log.error("Failed to restart producer on {}", topic, e);
-                throw new RuntimeException(e);
+                String msg = "Failed to restart producer on " + topic + ", restart reason: " + restartReason;
+                log.error(msg, e);
+                return msg;
             }
         }
+        return null;
     }
 
-    private void validateTableView() {
+    private String validateTableView() {
+        if (isShutdown) {
+            return SHUTDOWN_ERR_MSG;
+        }
+        String restartReason = getRestartReason(tableView, tableViewLastUpdateTimestamp);
+        if (StringUtils.isNotBlank(restartReason)) {
+            try {
+                closeTableView();
+                startTableView();
+                log.info("Restarted tableview on {}, {}", topic, restartReason);
+            } catch (Exception e) {
+                String msg = "Failed to tableview on " + topic + ", restart reason: " + restartReason;
+                log.error(msg, e);
+                return msg;
+            }
+        }
+        return null;
+    }
+
+    private String getRestartReason(Object obj, long lastUpdateTimestamp) {
+
         String restartReason = null;
 
-        if (tableView == null) {
-            restartReason = "table view is null";
+        if (obj == null) {
+            restartReason = "object is null";
         } else {
-            long inactiveDuration = System.currentTimeMillis() - tableViewLastUpdateTimestamp;
+            long inactiveDuration = System.currentTimeMillis() - lastUpdateTimestamp;
             long threshold = TimeUnit.MINUTES.toMillis(conf.getLoadBalancerReportUpdateMaxIntervalMinutes())
                     * LOAD_DATA_REPORT_UPDATE_MAX_INTERVAL_MULTIPLIER_BEFORE_RESTART;
             if (inactiveDuration > threshold) {
@@ -189,17 +258,6 @@ public class TableViewLoadDataStoreImpl<T> implements LoadDataStore<T> {
                         TimeUnit.MILLISECONDS.toSeconds(threshold));
             }
         }
-
-        if (StringUtils.isNotBlank(restartReason)) {
-            tableViewLastUpdateTimestamp = 0;
-            try {
-                closeTableView();
-                startTableView();
-                log.info("Restarted tableview on {}, {}", topic, restartReason);
-            } catch (Exception e) {
-                log.error("Failed to restart tableview on {}", topic, e);
-                throw new RuntimeException(e);
-            }
-        }
+        return restartReason;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.service.persistent;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateTableViewImpl.TOPIC;
 import static org.apache.pulsar.broker.service.persistent.SubscribeRateLimiter.isSubscribeRateEnabled;
 import static org.apache.pulsar.common.naming.SystemTopicNames.isEventSystemTopic;
 import static org.apache.pulsar.common.protocol.Commands.DEFAULT_CONSUMER_EPOCH;
@@ -91,8 +92,7 @@ import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.delayed.BucketDelayedDeliveryTrackerFactory;
 import org.apache.pulsar.broker.delayed.DelayedDeliveryTrackerFactory;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
-import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelImpl;
-import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateCompactionStrategy;
+import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateDataConflictResolver;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.resources.NamespaceResources.PartitionedTopicResources;
 import org.apache.pulsar.broker.service.AbstractReplicator;
@@ -247,8 +247,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     // TODO: Create compaction strategy from topic policy when exposing strategic compaction to users.
     private static Map<String, TopicCompactionStrategy> strategicCompactionMap = Map.of(
-            ServiceUnitStateChannelImpl.TOPIC,
-            new ServiceUnitStateCompactionStrategy());
+            TOPIC,
+            new ServiceUnitStateDataConflictResolver());
 
     private CompletableFuture<MessageIdImpl> currentOffload = CompletableFuture.completedFuture(
             (MessageIdImpl) MessageId.earliest);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplBaseTest.java
@@ -169,7 +169,11 @@ public abstract class ExtensibleLoadManagerImplBaseTest extends MockedPulsarServ
             additionalPulsarTestContext = null;
         }
         super.internalCleanup();
-        FutureUtil.waitForAll(futures).join();
+        try {
+            FutureUtil.waitForAll(futures).join();
+        } catch (Throwable e) {
+            // skip error
+        }
         pulsar1 = pulsar2 = null;
         primaryLoadManager = secondaryLoadManager = null;
         channel1 = channel2 = null;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplWithAdvertisedListenersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplWithAdvertisedListenersTest.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 /**
@@ -36,8 +37,10 @@ import org.testng.annotations.Test;
 public class ExtensibleLoadManagerImplWithAdvertisedListenersTest extends ExtensibleLoadManagerImplBaseTest {
 
     public String brokerServiceUrl;
-    public ExtensibleLoadManagerImplWithAdvertisedListenersTest() {
-        super("public/test");
+
+    @Factory(dataProvider = "serviceUnitStateTableViewClassName")
+    public ExtensibleLoadManagerImplWithAdvertisedListenersTest(String serviceUnitStateTableViewClassName) {
+        super("public/test", serviceUnitStateTableViewClassName);
     }
 
     @Override
@@ -69,7 +72,9 @@ public class ExtensibleLoadManagerImplWithAdvertisedListenersTest extends Extens
     @Test(timeOut = 30_000, dataProvider = "isPersistentTopicSubscriptionTypeTest")
     public void testTransferClientReconnectionWithoutLookup(TopicDomain topicDomain, SubscriptionType subscriptionType)
             throws Exception {
-        ExtensibleLoadManagerImplTest.testTransferClientReconnectionWithoutLookup(topicDomain, subscriptionType,
+        ExtensibleLoadManagerImplTest.testTransferClientReconnectionWithoutLookup(
+                clients,
+                topicDomain, subscriptionType,
                 defaultTestNamespace, admin,
                 brokerServiceUrl,
                 pulsar1, pulsar2, primaryLoadManager, secondaryLoadManager);
@@ -78,7 +83,9 @@ public class ExtensibleLoadManagerImplWithAdvertisedListenersTest extends Extens
     @Test(timeOut = 30 * 1000, dataProvider = "isPersistentTopicSubscriptionTypeTest")
     public void testUnloadClientReconnectionWithLookup(TopicDomain topicDomain,
                                                        SubscriptionType subscriptionType) throws Exception {
-        ExtensibleLoadManagerImplTest.testUnloadClientReconnectionWithLookup(topicDomain, subscriptionType,
+        ExtensibleLoadManagerImplTest.testUnloadClientReconnectionWithLookup(
+                clients,
+                topicDomain, subscriptionType,
                 defaultTestNamespace, admin,
                 brokerServiceUrl,
                 pulsar1);
@@ -91,7 +98,9 @@ public class ExtensibleLoadManagerImplWithAdvertisedListenersTest extends Extens
 
     @Test(timeOut = 30 * 1000, dataProvider = "isPersistentTopicTest")
     public void testOptimizeUnloadDisable(TopicDomain topicDomain) throws Exception {
-        ExtensibleLoadManagerImplTest.testOptimizeUnloadDisable(topicDomain, defaultTestNamespace, admin,
+        ExtensibleLoadManagerImplTest.testOptimizeUnloadDisable(
+                clients,
+                topicDomain, defaultTestNamespace, admin,
                 brokerServiceUrl, pulsar1, pulsar2);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplWithTransactionCoordinatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplWithTransactionCoordinatorTest.java
@@ -21,13 +21,15 @@ package org.apache.pulsar.broker.loadbalance.extensions;
 import static org.testng.Assert.assertEquals;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.awaitility.Awaitility;
+import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker")
 public class ExtensibleLoadManagerImplWithTransactionCoordinatorTest extends ExtensibleLoadManagerImplBaseTest {
 
-    public ExtensibleLoadManagerImplWithTransactionCoordinatorTest() {
-        super("public/test-elb-with-tx");
+    @Factory(dataProvider = "serviceUnitStateTableViewClassName")
+    public ExtensibleLoadManagerImplWithTransactionCoordinatorTest(String serviceUnitStateTableViewClassName) {
+        super("public/test-elb-with-tx", serviceUnitStateTableViewClassName);
     }
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTest.java
@@ -25,6 +25,8 @@ import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUni
 import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Owned;
 import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Releasing;
 import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Splitting;
+import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.StorageType.MetadataStore;
+import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.StorageType.SystemTopic;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import org.testng.annotations.Test;
@@ -54,63 +56,123 @@ public class ServiceUnitStateTest {
     }
 
     @Test
-    public void testTransitions() {
+    public void testTransitionsOverSystemTopic() {
 
-        assertFalse(ServiceUnitState.isValidTransition(Init, Init));
-        assertTrue(ServiceUnitState.isValidTransition(Init, Free));
-        assertTrue(ServiceUnitState.isValidTransition(Init, Owned));
-        assertTrue(ServiceUnitState.isValidTransition(Init, Assigning));
-        assertTrue(ServiceUnitState.isValidTransition(Init, Releasing));
-        assertTrue(ServiceUnitState.isValidTransition(Init, Splitting));
-        assertTrue(ServiceUnitState.isValidTransition(Init, Deleted));
+        assertFalse(ServiceUnitState.isValidTransition(Init, Init, SystemTopic));
+        assertTrue(ServiceUnitState.isValidTransition(Init, Free, SystemTopic));
+        assertTrue(ServiceUnitState.isValidTransition(Init, Owned, SystemTopic));
+        assertTrue(ServiceUnitState.isValidTransition(Init, Assigning, SystemTopic));
+        assertTrue(ServiceUnitState.isValidTransition(Init, Releasing, SystemTopic));
+        assertTrue(ServiceUnitState.isValidTransition(Init, Splitting, SystemTopic));
+        assertTrue(ServiceUnitState.isValidTransition(Init, Deleted, SystemTopic));
 
-        assertTrue(ServiceUnitState.isValidTransition(Free, Init));
-        assertFalse(ServiceUnitState.isValidTransition(Free, Free));
-        assertFalse(ServiceUnitState.isValidTransition(Free, Owned));
-        assertTrue(ServiceUnitState.isValidTransition(Free, Assigning));
-        assertFalse(ServiceUnitState.isValidTransition(Free, Releasing));
-        assertFalse(ServiceUnitState.isValidTransition(Free, Splitting));
-        assertFalse(ServiceUnitState.isValidTransition(Free, Deleted));
+        assertTrue(ServiceUnitState.isValidTransition(Free, Init, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Free, Free, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Free, Owned, SystemTopic));
+        assertTrue(ServiceUnitState.isValidTransition(Free, Assigning, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Free, Releasing, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Free, Splitting, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Free, Deleted, SystemTopic));
 
-        assertFalse(ServiceUnitState.isValidTransition(Assigning, Init));
-        assertFalse(ServiceUnitState.isValidTransition(Assigning, Free));
-        assertFalse(ServiceUnitState.isValidTransition(Assigning, Assigning));
-        assertTrue(ServiceUnitState.isValidTransition(Assigning, Owned));
-        assertFalse(ServiceUnitState.isValidTransition(Assigning, Releasing));
-        assertFalse(ServiceUnitState.isValidTransition(Assigning, Splitting));
-        assertFalse(ServiceUnitState.isValidTransition(Assigning, Deleted));
+        assertFalse(ServiceUnitState.isValidTransition(Assigning, Init, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Assigning, Free, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Assigning, Assigning, SystemTopic));
+        assertTrue(ServiceUnitState.isValidTransition(Assigning, Owned, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Assigning, Releasing, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Assigning, Splitting, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Assigning, Deleted, SystemTopic));
 
-        assertFalse(ServiceUnitState.isValidTransition(Owned, Init));
-        assertFalse(ServiceUnitState.isValidTransition(Owned, Free));
-        assertFalse(ServiceUnitState.isValidTransition(Owned, Assigning));
-        assertFalse(ServiceUnitState.isValidTransition(Owned, Owned));
-        assertTrue(ServiceUnitState.isValidTransition(Owned, Releasing));
-        assertTrue(ServiceUnitState.isValidTransition(Owned, Splitting));
-        assertFalse(ServiceUnitState.isValidTransition(Owned, Deleted));
+        assertFalse(ServiceUnitState.isValidTransition(Owned, Init, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Owned, Free, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Owned, Assigning, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Owned, Owned, SystemTopic));
+        assertTrue(ServiceUnitState.isValidTransition(Owned, Releasing, SystemTopic));
+        assertTrue(ServiceUnitState.isValidTransition(Owned, Splitting, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Owned, Deleted, SystemTopic));
 
-        assertFalse(ServiceUnitState.isValidTransition(Releasing, Init));
-        assertTrue(ServiceUnitState.isValidTransition(Releasing, Free));
-        assertTrue(ServiceUnitState.isValidTransition(Releasing, Assigning));
-        assertFalse(ServiceUnitState.isValidTransition(Releasing, Owned));
-        assertFalse(ServiceUnitState.isValidTransition(Releasing, Releasing));
-        assertFalse(ServiceUnitState.isValidTransition(Releasing, Splitting));
-        assertFalse(ServiceUnitState.isValidTransition(Releasing, Deleted));
+        assertFalse(ServiceUnitState.isValidTransition(Releasing, Init, SystemTopic));
+        assertTrue(ServiceUnitState.isValidTransition(Releasing, Free, SystemTopic));
+        assertTrue(ServiceUnitState.isValidTransition(Releasing, Assigning, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Releasing, Owned, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Releasing, Releasing, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Releasing, Splitting, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Releasing, Deleted, SystemTopic));
 
-        assertFalse(ServiceUnitState.isValidTransition(Splitting, Init));
-        assertFalse(ServiceUnitState.isValidTransition(Splitting, Free));
-        assertFalse(ServiceUnitState.isValidTransition(Splitting, Assigning));
-        assertFalse(ServiceUnitState.isValidTransition(Splitting, Owned));
-        assertFalse(ServiceUnitState.isValidTransition(Splitting, Releasing));
-        assertFalse(ServiceUnitState.isValidTransition(Splitting, Splitting));
-        assertTrue(ServiceUnitState.isValidTransition(Splitting, Deleted));
+        assertFalse(ServiceUnitState.isValidTransition(Splitting, Init, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Splitting, Free, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Splitting, Assigning, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Splitting, Owned, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Splitting, Releasing, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Splitting, Splitting, SystemTopic));
+        assertTrue(ServiceUnitState.isValidTransition(Splitting, Deleted, SystemTopic));
 
-        assertTrue(ServiceUnitState.isValidTransition(Deleted, Init));
-        assertFalse(ServiceUnitState.isValidTransition(Deleted, Free));
-        assertFalse(ServiceUnitState.isValidTransition(Deleted, Assigning));
-        assertFalse(ServiceUnitState.isValidTransition(Deleted, Owned));
-        assertFalse(ServiceUnitState.isValidTransition(Deleted, Releasing));
-        assertFalse(ServiceUnitState.isValidTransition(Deleted, Splitting));
-        assertFalse(ServiceUnitState.isValidTransition(Deleted, Deleted));
+        assertTrue(ServiceUnitState.isValidTransition(Deleted, Init, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Deleted, Free, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Deleted, Assigning, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Deleted, Owned, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Deleted, Releasing, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Deleted, Splitting, SystemTopic));
+        assertFalse(ServiceUnitState.isValidTransition(Deleted, Deleted, SystemTopic));
+    }
+
+    @Test
+    public void testTransitionsOverMetadataStore() {
+
+        assertFalse(ServiceUnitState.isValidTransition(Init, Init, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Init, Free, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Init, Owned, MetadataStore));
+        assertTrue(ServiceUnitState.isValidTransition(Init, Assigning, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Init, Releasing, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Init, Splitting, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Init, Deleted, MetadataStore));
+
+        assertFalse(ServiceUnitState.isValidTransition(Free, Init, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Free, Free, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Free, Owned, MetadataStore));
+        assertTrue(ServiceUnitState.isValidTransition(Free, Assigning, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Free, Releasing, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Free, Splitting, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Free, Deleted, MetadataStore));
+
+        assertFalse(ServiceUnitState.isValidTransition(Assigning, Init, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Assigning, Free, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Assigning, Assigning, MetadataStore));
+        assertTrue(ServiceUnitState.isValidTransition(Assigning, Owned, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Assigning, Releasing, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Assigning, Splitting, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Assigning, Deleted, MetadataStore));
+
+        assertFalse(ServiceUnitState.isValidTransition(Owned, Init, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Owned, Free, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Owned, Assigning, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Owned, Owned, MetadataStore));
+        assertTrue(ServiceUnitState.isValidTransition(Owned, Releasing, MetadataStore));
+        assertTrue(ServiceUnitState.isValidTransition(Owned, Splitting, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Owned, Deleted, MetadataStore));
+
+        assertFalse(ServiceUnitState.isValidTransition(Releasing, Init, MetadataStore));
+        assertTrue(ServiceUnitState.isValidTransition(Releasing, Free, MetadataStore));
+        assertTrue(ServiceUnitState.isValidTransition(Releasing, Assigning, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Releasing, Owned, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Releasing, Releasing, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Releasing, Splitting, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Releasing, Deleted, MetadataStore));
+
+        assertFalse(ServiceUnitState.isValidTransition(Splitting, Init, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Splitting, Free, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Splitting, Assigning, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Splitting, Owned, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Splitting, Releasing, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Splitting, Splitting, MetadataStore));
+        assertTrue(ServiceUnitState.isValidTransition(Splitting, Deleted, MetadataStore));
+
+        assertTrue(ServiceUnitState.isValidTransition(Deleted, Init, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Deleted, Free, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Deleted, Assigning, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Deleted, Owned, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Deleted, Releasing, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Deleted, Splitting, MetadataStore));
+        assertFalse(ServiceUnitState.isValidTransition(Deleted, Deleted, MetadataStore));
     }
 
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/store/LoadDataStoreTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/store/LoadDataStoreTest.java
@@ -18,8 +18,12 @@
  */
 package org.apache.pulsar.broker.loadbalance.extensions.store;
 
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
 import static org.testng.AssertJUnit.assertTrue;
 
 import com.google.common.collect.Sets;
@@ -33,6 +37,7 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.awaitility.Awaitility;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -75,8 +80,6 @@ public class LoadDataStoreTest extends MockedPulsarServiceBaseTest {
         @Cleanup
         LoadDataStore<MyClass> loadDataStore =
                 LoadDataStoreFactory.create(pulsar, topic, MyClass.class);
-        loadDataStore.startProducer();
-        loadDataStore.startTableView();
         MyClass myClass1 = new MyClass("1", 1);
         loadDataStore.pushAsync("key1", myClass1).get();
 
@@ -109,8 +112,6 @@ public class LoadDataStoreTest extends MockedPulsarServiceBaseTest {
         @Cleanup
         LoadDataStore<Integer> loadDataStore =
                 LoadDataStoreFactory.create(pulsar, topic, Integer.class);
-        loadDataStore.startProducer();
-        loadDataStore.startTableView();
 
         Map<String, Integer> map = new HashMap<>();
         for (int i = 0; i < 10; i++) {
@@ -134,9 +135,6 @@ public class LoadDataStoreTest extends MockedPulsarServiceBaseTest {
         String topic = TopicDomain.persistent + "://" + NamespaceName.SYSTEM_NAMESPACE + "/" + UUID.randomUUID();
         LoadDataStore<Integer> loadDataStore =
                 LoadDataStoreFactory.create(pulsar, topic, Integer.class);
-        loadDataStore.startProducer();
-
-        loadDataStore.startTableView();
         loadDataStore.pushAsync("1", 1).get();
         Awaitility.await().untilAsserted(() -> assertEquals(loadDataStore.size(), 1));
         assertEquals(loadDataStore.get("1").get(), 1);
@@ -148,6 +146,31 @@ public class LoadDataStoreTest extends MockedPulsarServiceBaseTest {
         loadDataStore.pushAsync("1", 3).get();
         FieldUtils.writeField(loadDataStore, "tableViewLastUpdateTimestamp", 0 , true);
         Awaitility.await().untilAsserted(() -> assertEquals(loadDataStore.get("1").get(), 3));
+    }
+
+    @Test
+    public void testProducerRestart() throws Exception {
+        String topic = TopicDomain.persistent + "://" + NamespaceName.SYSTEM_NAMESPACE + "/" + UUID.randomUUID();
+        var loadDataStore =
+                (TableViewLoadDataStoreImpl) spy(LoadDataStoreFactory.create(pulsar, topic, Integer.class));
+
+        // happy case
+        loadDataStore.pushAsync("1", 1).get();
+        Awaitility.await().untilAsserted(() -> assertEquals(loadDataStore.size(), 1));
+        assertEquals(loadDataStore.get("1").get(), 1);
+        verify(loadDataStore, times(1)).startProducer();
+
+        // loadDataStore will restart producer if null.
+        FieldUtils.writeField(loadDataStore, "producer", null, true);
+        loadDataStore.pushAsync("1", 2).get();
+        Awaitility.await().untilAsserted(() -> assertEquals(loadDataStore.get("1").get(), 2));
+        verify(loadDataStore, times(2)).startProducer();
+
+        // loadDataStore will restart producer if too slow.
+        FieldUtils.writeField(loadDataStore, "producerLastPublishTimestamp", 0 , true);
+        loadDataStore.pushAsync("1", 3).get();
+        Awaitility.await().untilAsserted(() -> assertEquals(loadDataStore.get("1").get(), 3));
+        verify(loadDataStore, times(3)).startProducer();
     }
 
     @Test
@@ -163,6 +186,28 @@ public class LoadDataStoreTest extends MockedPulsarServiceBaseTest {
 
         loadDataStore.pushAsync("2", 2).get();
         loadDataStore.removeAsync("2").get();
+    }
+
+    @Test
+    public void testShutdown() throws Exception {
+        String topic = TopicDomain.persistent + "://" + NamespaceName.SYSTEM_NAMESPACE + "/" + UUID.randomUUID();
+        LoadDataStore<Integer> loadDataStore =
+                LoadDataStoreFactory.create(pulsar, topic, Integer.class);
+        loadDataStore.start();
+        loadDataStore.shutdown();
+
+        Assert.assertTrue(loadDataStore.pushAsync("2", 2).isCompletedExceptionally());
+        Assert.assertTrue(loadDataStore.removeAsync("2").isCompletedExceptionally());
+        assertThrows(IllegalStateException.class, () -> loadDataStore.get("2"));
+        assertThrows(IllegalStateException.class, loadDataStore::size);
+        assertThrows(IllegalStateException.class, loadDataStore::entrySet);
+        assertThrows(IllegalStateException.class, () -> loadDataStore.forEach((k, v) -> {}));
+        assertThrows(IllegalStateException.class, loadDataStore::init);
+        assertThrows(IllegalStateException.class, loadDataStore::start);
+        assertThrows(IllegalStateException.class, loadDataStore::startProducer);
+        assertThrows(IllegalStateException.class, loadDataStore::startTableView);
+        assertThrows(IllegalStateException.class, loadDataStore::close);
+        assertThrows(IllegalStateException.class, loadDataStore::closeTableView);
     }
 
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service;
 
+import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateTableViewImpl.TOPIC;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -32,7 +33,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
-import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelImpl;
 import org.apache.pulsar.client.admin.ListNamespaceTopicsOptions;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.MessageId;
@@ -547,7 +547,7 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         tenantInfo.setAllowedClusters(Set.of(configClusterName));
         admin.tenants().createTenant("pulsar", tenantInfo);
         admin.namespaces().createNamespace(namespaceName);
-        admin.topics().createNonPartitionedTopic(ServiceUnitStateChannelImpl.TOPIC);
+        admin.topics().createNonPartitionedTopic(TOPIC);
         admin.topics().createNonPartitionedTopic(ExtensibleLoadManagerImpl.BROKER_LOAD_DATA_STORE_TOPIC);
         admin.topics().createNonPartitionedTopic(ExtensibleLoadManagerImpl.TOP_BUNDLES_LOAD_DATA_STORE_TOPIC);
 
@@ -560,7 +560,7 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
 
         // The created persistent topic correctly can be found by
         // pulsar.getPulsarResources().getTopicResources().persistentTopicExists(topic);
-        Producer producer = pulsarClient.newProducer().topic(ServiceUnitStateChannelImpl.TOPIC).create();
+        Producer producer = pulsarClient.newProducer().topic(TOPIC).create();
 
         // The created non-persistent topics cannot be found, as we did topics.clear()
         try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service;
 
+import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateTableViewImpl.TOPIC;
 import static org.apache.pulsar.common.naming.SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN;
 import static org.apache.pulsar.common.naming.SystemTopicNames.TRANSACTION_COORDINATOR_LOG;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -82,7 +83,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.pulsar.broker.PulsarService;
-import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelImpl;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.BrokerServiceException.PersistenceException;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
@@ -1759,7 +1759,7 @@ public class BrokerServiceTest extends BrokerTestBase {
     public void testIsSystemTopicAllowAutoTopicCreationAsync() throws Exception {
         BrokerService brokerService = pulsar.getBrokerService();
         assertFalse(brokerService.isAllowAutoTopicCreationAsync(
-                ServiceUnitStateChannelImpl.TOPIC).get());
+                TOPIC).get());
         assertTrue(brokerService.isAllowAutoTopicCreationAsync(
                 "persistent://pulsar/system/my-system-topic").get());
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/ServiceUnitStateCompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/ServiceUnitStateCompactionTest.java
@@ -24,9 +24,10 @@ import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUni
 import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Assigning;
 import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Releasing;
 import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Splitting;
+import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.StorageType.SystemTopic;
 import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.isValidTransition;
-import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelImpl.MSG_COMPRESSION_TYPE;
 import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateData.state;
+import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateTableViewImpl.MSG_COMPRESSION_TYPE;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
@@ -61,7 +62,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelImpl;
-import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateCompactionStrategy;
+import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateDataConflictResolver;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateData;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
@@ -92,7 +93,7 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
     private ScheduledExecutorService compactionScheduler;
     private BookKeeper bk;
     private Schema<ServiceUnitStateData> schema;
-    private ServiceUnitStateCompactionStrategy strategy;
+    private ServiceUnitStateDataConflictResolver strategy;
 
     private ServiceUnitState testState = Init;
 
@@ -118,7 +119,7 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
 
     private ServiceUnitState nextValidState(ServiceUnitState from) {
         List<ServiceUnitState> candidates = Arrays.stream(ServiceUnitState.values())
-                .filter(to -> isValidTransition(from, to))
+                .filter(to -> isValidTransition(from, to, SystemTopic))
                 .collect(Collectors.toList());
         var state=  candidates.get(RANDOM.nextInt(candidates.size()));
         return state;
@@ -127,7 +128,7 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
     private ServiceUnitState nextValidStateNonSplit(ServiceUnitState from) {
         List<ServiceUnitState> candidates = Arrays.stream(ServiceUnitState.values())
                 .filter(to -> to != Init && to != Splitting && to != Deleted
-                        && isValidTransition(from, to))
+                        && isValidTransition(from, to, SystemTopic))
                 .collect(Collectors.toList());
         var state=  candidates.get(RANDOM.nextInt(candidates.size()));
         return state;
@@ -135,7 +136,7 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
 
     private ServiceUnitState nextInvalidState(ServiceUnitState from) {
         List<ServiceUnitState> candidates = Arrays.stream(ServiceUnitState.values())
-                .filter(to -> !isValidTransition(from, to))
+                .filter(to -> !isValidTransition(from, to, SystemTopic))
                 .collect(Collectors.toList());
         if (candidates.size() == 0) {
             return Init;
@@ -157,7 +158,7 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
                 new ThreadFactoryBuilder().setNameFormat("compaction-%d").setDaemon(true).build());
         bk = pulsar.getBookKeeperClientFactory().create(this.conf, null, null, Optional.empty(), null).get();
         schema = Schema.JSON(ServiceUnitStateData.class);
-        strategy = new ServiceUnitStateCompactionStrategy();
+        strategy = new ServiceUnitStateDataConflictResolver();
         strategy.checkBrokers(false);
 
         testState = Init;
@@ -329,10 +330,10 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
                 .topic("persistent://my-property/use/my-ns/my-topic1")
                 .loadConf(Map.of(
                         "topicCompactionStrategyClassName",
-                        ServiceUnitStateCompactionStrategy.class.getName()))
+                        ServiceUnitStateDataConflictResolver.class.getName()))
                 .create();
 
-        ((ServiceUnitStateCompactionStrategy)
+        ((ServiceUnitStateDataConflictResolver)
                 FieldUtils.readDeclaredField(tv, "compactionStrategy", true))
                 .checkBrokers(false);
         TestData testData = generateTestData();
@@ -364,7 +365,7 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
                 .topic(topic)
                 .loadConf(Map.of(
                         "topicCompactionStrategyClassName",
-                        ServiceUnitStateCompactionStrategy.class.getName()))
+                        ServiceUnitStateDataConflictResolver.class.getName()))
                 .create();
 
         for(var etr : tableview.entrySet()){
@@ -531,7 +532,7 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
                 .subscriptionName("fastTV")
                 .loadConf(Map.of(
                         strategyClassName,
-                        ServiceUnitStateCompactionStrategy.class.getName()))
+                        ServiceUnitStateDataConflictResolver.class.getName()))
                 .create();
 
         var defaultConf = getDefaultConf();
@@ -544,7 +545,7 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
                 .subscriptionName("slowTV")
                 .loadConf(Map.of(
                         strategyClassName,
-                        ServiceUnitStateCompactionStrategy.class.getName()))
+                        ServiceUnitStateDataConflictResolver.class.getName()))
                 .create();
 
         var semaphore = new Semaphore(0);
@@ -616,7 +617,7 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
                     .topic(topic)
                     .loadConf(Map.of(
                             strategyClassName,
-                            ServiceUnitStateCompactionStrategy.class.getName()))
+                            ServiceUnitStateDataConflictResolver.class.getName()))
                     .create();
             Awaitility.await()
                     .pollInterval(200, TimeUnit.MILLISECONDS)
@@ -651,7 +652,7 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
                 .subscriptionName("slowTV")
                 .loadConf(Map.of(
                         strategyClassName,
-                        ServiceUnitStateCompactionStrategy.class.getName()))
+                        ServiceUnitStateDataConflictResolver.class.getName()))
                 .create();
 
         // Configure retention to ensue data is retained for reader

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.compaction;
 
-import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelImpl.MSG_COMPRESSION_TYPE;
+import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateTableViewImpl.MSG_COMPRESSION_TYPE;
 import static org.testng.Assert.assertEquals;
 
 import java.util.ArrayList;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCacheConfig.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCacheConfig.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pulsar.metadata.api;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -29,7 +31,7 @@ import lombok.ToString;
 @Builder
 @Getter
 @ToString
-public class MetadataCacheConfig {
+public class MetadataCacheConfig<T> {
     private static final long DEFAULT_CACHE_REFRESH_TIME_MILLIS = TimeUnit.MINUTES.toMillis(5);
 
     /**
@@ -47,4 +49,12 @@ public class MetadataCacheConfig {
      */
     @Builder.Default
     private final long expireAfterWriteMillis = 2 * DEFAULT_CACHE_REFRESH_TIME_MILLIS;
+
+    /**
+     * Specifies cache reload consumer behavior when the cache is refreshed automatically at refreshAfterWriteMillis
+     * frequency.
+     */
+    @Builder.Default
+    private final BiConsumer<String, Optional<CacheGetResult<T>>> asyncReloadConsumer = null;
+
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreTableView.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreTableView.java
@@ -19,11 +19,9 @@
 
 package org.apache.pulsar.metadata.api;
 
-import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.BiConsumer;
 
 /**
  * Defines metadata store tableview.
@@ -43,14 +41,6 @@ public interface MetadataStoreTableView<T> {
      * Starts the tableview by filling existing items to its local tableview from the remote metadata store.
      */
     void start() throws MetadataStoreException;
-
-    /**
-     * Reads whether a specific key exists in the local tableview.
-     *
-     * @param key the key to check
-     * @return true if exists. Otherwise, false.
-     */
-    boolean exists(String key);
 
     /**
      * Gets one item from the local tableview.
@@ -89,38 +79,9 @@ public interface MetadataStoreTableView<T> {
     CompletableFuture<Void> delete(String key);
 
     /**
-     * Returns the size of the items in the local tableview.
-     * @return size
-     */
-    int size();
-
-    /**
-     * Reads whether the local tableview is empty or not.
-     * @return true if empty. Otherwise, false
-     */
-    boolean isEmpty();
-
-    /**
      * Returns the entry set of the items in the local tableview.
      * @return entry set
      */
     Set<Map.Entry<String, T>> entrySet();
-
-    /**
-     * Returns the key set of the items in the local tableview.
-     * @return key set
-     */
-    Set<String> keySet();
-
-    /**
-     * Returns the values of the items in the local tableview.
-     * @return values
-     */
-    Collection<T> values();
-
-    /**
-     * Runs the action for each item in the local tableview.
-     */
-    void forEach(BiConsumer<String, T> action);
 }
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreTableView.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreTableView.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.metadata.api;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+
+/**
+ * Defines metadata store tableview.
+ * MetadataStoreTableView initially fills existing items to its local tableview and eventually
+ * synchronize remote updates to its local tableview from the remote metadata store.
+ * This abstraction can help replicate metadata in memory from metadata store.
+ */
+public interface MetadataStoreTableView<T> {
+
+    class ConflictException extends RuntimeException {
+        public ConflictException(String msg) {
+            super(msg);
+        }
+    }
+
+    /**
+     * Starts the tableview by filling existing items to its local tableview from the remote metadata store.
+     */
+    void start() throws MetadataStoreException;
+
+    /**
+     * Reads whether a specific key exists in the local tableview.
+     *
+     * @param key the key to check
+     * @return true if exists. Otherwise, false.
+     */
+    boolean exists(String key);
+
+    /**
+     * Gets one item from the local tableview.
+     * <p>
+     * If the key is not found, return null.
+     *
+     * @param key the key to check
+     * @return value if exists. Otherwise, null.
+     */
+    T get(String key);
+
+    /**
+     * Tries to put the item in the persistent store.
+     * All peer tableviews (including the local one) will be notified and be eventually consistent with this put value.
+     * <p>
+     * This operation can fail if the input value conflicts with the existing one.
+     *
+     * @param key the key to check on the tableview
+     * @return a future to track the completion of the operation
+     * @throws MetadataStoreTableView.ConflictException
+     *             if the input value conflicts with the existing one.
+     */
+    CompletableFuture<Void> put(String key, T value);
+
+    /**
+     * Tries to delete the item from the persistent store.
+     * All peer tableviews (including the local one) will be notified and be eventually consistent with this deletion.
+     * <p>
+     * This can fail if the item is not present in the metadata store.
+     *
+     * @param key the key to check on the tableview
+     * @return a future to track the completion of the operation
+     * @throws MetadataStoreException.NotFoundException
+     *             if the key is not present in the metadata store.
+     */
+    CompletableFuture<Void> delete(String key);
+
+    /**
+     * Returns the size of the items in the local tableview.
+     * @return size
+     */
+    int size();
+
+    /**
+     * Reads whether the local tableview is empty or not.
+     * @return true if empty. Otherwise, false
+     */
+    boolean isEmpty();
+
+    /**
+     * Returns the entry set of the items in the local tableview.
+     * @return entry set
+     */
+    Set<Map.Entry<String, T>> entrySet();
+
+    /**
+     * Returns the key set of the items in the local tableview.
+     * @return key set
+     */
+    Set<String> keySet();
+
+    /**
+     * Returns the values of the items in the local tableview.
+     * @return values
+     */
+    Collection<T> values();
+
+    /**
+     * Runs the action for each item in the local tableview.
+     */
+    void forEach(BiConsumer<String, T> action);
+}
+

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/tableview/impl/MetadataStoreTableViewImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/tableview/impl/MetadataStoreTableViewImpl.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.metadata.tableview.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.mutable.MutableBoolean;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.metadata.api.CacheGetResult;
+import org.apache.pulsar.metadata.api.MetadataCache;
+import org.apache.pulsar.metadata.api.MetadataCacheConfig;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.MetadataStoreTableView;
+import org.apache.pulsar.metadata.api.NotificationType;
+
+@Slf4j
+public class MetadataStoreTableViewImpl<T> implements MetadataStoreTableView<T> {
+    private static final int MAX_CONCURRENT_METADATA_OPS_DURING_FILL = 50;
+    private static final long CACHE_REFRESH_FREQUENCY_IN_MILLIS = 600_000;
+    private final ConcurrentMap<String, T> data;
+    private final Map<String, T> immutableData;
+    private final String name;
+    private final MetadataStore store;
+    private final MetadataCache<T> cache;
+    private final Predicate<String> listenPathValidator;
+    private final BiPredicate<T, T> conflictResolver;
+    private final List<BiConsumer<String, T>> tailItemListeners;
+    private final List<BiConsumer<String, T>> existingItemListeners;
+    private final long timeoutInMillis;
+    private final String pathPrefix;
+
+    /**
+     * Construct MetadataStoreTableViewImpl.
+     *
+     * @param clazz                 clazz of the value type
+     * @param name                  metadata store tableview name
+     * @param store                 metadata store
+     * @param pathPrefix            metadata store path prefix
+     * @param listenPathValidator   path validator to listen
+     * @param conflictResolver      resolve conflicts for concurrent puts
+     * @param tailItemListeners     listener for tail item(recently updated) notifications
+     * @param existingItemListeners listener for existing items in metadata store
+     * @param timeoutInMillis       timeout duration for each sync operation.
+     * @throws MetadataStoreException if init fails.
+     */
+    @Builder
+    public MetadataStoreTableViewImpl(@NonNull Class<T> clazz,
+                                      @NonNull String name,
+                                      @NonNull MetadataStore store,
+                                      @NonNull String pathPrefix,
+                                      @NonNull BiPredicate<T, T> conflictResolver,
+                                      Predicate<String> listenPathValidator,
+                                      List<BiConsumer<String, T>> tailItemListeners,
+                                      List<BiConsumer<String, T>> existingItemListeners,
+                                      long timeoutInMillis) {
+        this.name = name;
+        this.data = new ConcurrentHashMap<>();
+        this.immutableData = Collections.unmodifiableMap(data);
+        this.pathPrefix = pathPrefix;
+        this.conflictResolver = conflictResolver;
+        this.listenPathValidator = listenPathValidator;
+        this.tailItemListeners = new ArrayList<>();
+        if (tailItemListeners != null) {
+            this.tailItemListeners.addAll(tailItemListeners);
+        }
+        this.existingItemListeners = new ArrayList<>();
+        if (existingItemListeners != null) {
+            this.existingItemListeners.addAll(existingItemListeners);
+        }
+        this.timeoutInMillis = timeoutInMillis;
+        this.store = store;
+        this.cache = store.getMetadataCache(clazz,
+                MetadataCacheConfig.<T>builder()
+                        .expireAfterWriteMillis(-1)
+                        .refreshAfterWriteMillis(CACHE_REFRESH_FREQUENCY_IN_MILLIS)
+                        .asyncReloadConsumer(this::consumeAsyncReload)
+                        .build());
+        store.registerListener(this::handleNotification);
+    }
+
+    public void start() throws MetadataStoreException {
+        fill();
+    }
+
+    private void consumeAsyncReload(String path, Optional<CacheGetResult<T>> cached) {
+        if (!isValidPath(path)) {
+            return;
+        }
+        String key = getKey(path);
+        var val = getValue(cached);
+        handleTailItem(key, val);
+    }
+
+    private boolean isValidPath(String path) {
+        if (listenPathValidator != null && !listenPathValidator.test(path)) {
+            return false;
+        }
+        return true;
+    }
+
+    private T getValue(Optional<CacheGetResult<T>> cached) {
+        return cached.map(CacheGetResult::getValue).orElse(null);
+    }
+
+    boolean updateData(String key, T cur) {
+        MutableBoolean updated = new MutableBoolean();
+        data.compute(key, (k, prev) -> {
+            if (Objects.equals(prev, cur)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("{} skipped item key={} value={} prev={}",
+                            name, key, cur, prev);
+                }
+                updated.setValue(false);
+                return prev;
+            } else {
+                updated.setValue(true);
+                return cur;
+            }
+        });
+        return updated.booleanValue();
+    }
+
+    private void handleTailItem(String key, T val) {
+        if (updateData(key, val)) {
+            if (log.isDebugEnabled()) {
+                log.debug("{} applying item key={} value={}",
+                        name,
+                        key,
+                        val);
+            }
+            for (var listener : tailItemListeners) {
+                try {
+                    listener.accept(key, val);
+                } catch (Throwable e) {
+                    log.error("{} failed to listen tail item key:{}, val:{}",
+                            name,
+                            key, val, e);
+                }
+            }
+        }
+
+    }
+
+    private CompletableFuture<Void> doHandleNotification(String path) {
+        if (!isValidPath(path)) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return cache.get(path).thenAccept(valOpt -> {
+            String key = getKey(path);
+            var val = valOpt.orElse(null);
+            handleTailItem(key, val);
+        }).exceptionally(e -> {
+            log.error("{} failed to handle notification for path:{}", name, path, e);
+            return null;
+        });
+    }
+
+    private void handleNotification(org.apache.pulsar.metadata.api.Notification notification) {
+
+        if (notification.getType() == NotificationType.ChildrenChanged) {
+            return;
+        }
+
+        String path = notification.getPath();
+
+        doHandleNotification(path);
+    }
+
+
+    private CompletableFuture<Void> handleExisting(String path) {
+        if (!isValidPath(path)) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return cache.get(path)
+                .thenAccept(valOpt -> {
+                    valOpt.ifPresent(val -> {
+                        String key = getKey(path);
+                        updateData(key, val);
+                        if (log.isDebugEnabled()) {
+                            log.debug("{} applying existing item key={} value={}",
+                                    name,
+                                    key,
+                                    val);
+                        }
+                        for (var listener : existingItemListeners) {
+                            try {
+                                listener.accept(key, val);
+                            } catch (Throwable e) {
+                                log.error("{} failed to listen existing item key:{}, val:{}", name, key, val,
+                                        e);
+                                throw e;
+                            }
+                        }
+                    });
+                });
+    }
+
+    private void fill() throws MetadataStoreException {
+        log.info("{} start filling existing items under the pathPrefix:{}", name, pathPrefix);
+        ConcurrentLinkedDeque<String> q = new ConcurrentLinkedDeque<>();
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        q.add(pathPrefix);
+        LongAdder count = new LongAdder();
+        while (!q.isEmpty()) {
+            int size = Math.min(MAX_CONCURRENT_METADATA_OPS_DURING_FILL, q.size());
+            for (int i = 0; i < size; i++) {
+                String path = q.poll();
+                futures.add(store.getChildren(path)
+                        .thenCompose(children -> {
+                            // The path is leaf
+                            if (children.isEmpty()) {
+                                count.increment();
+                                return handleExisting(path);
+                            } else {
+                                for (var child : children) {
+                                    q.add(path + "/" + child);
+                                }
+                                return CompletableFuture.completedFuture(null);
+                            }
+                        }));
+            }
+            try {
+                FutureUtil.waitForAll(futures).get(timeoutInMillis * size, TimeUnit.MILLISECONDS);
+            } catch (Throwable e) {
+                Throwable c = FutureUtil.unwrapCompletionException(e);
+                log.error("{} failed to fill existing items", name, c);
+                throw new MetadataStoreException(c);
+            }
+            futures.clear();
+        }
+        log.info("{} completed filling existing items with size:{}", name, count.sum());
+    }
+
+
+    private String getPath(String key) {
+        return pathPrefix + "/" + key;
+    }
+
+    private String getKey(String path) {
+        return path.replaceFirst(pathPrefix + "/", "");
+    }
+
+    public boolean exists(String key) {
+        return immutableData.containsKey(key);
+    }
+
+    public T get(String key) {
+        return data.get(key);
+    }
+
+    public CompletableFuture<Void> put(String key, T value) {
+        String path = getPath(key);
+        return cache.readModifyUpdateOrCreate(path, (old) -> {
+            if (conflictResolver.test(old.orElse(null), value)) {
+                return value;
+            } else {
+                throw new ConflictException(
+                        String.format("Failed to update from old:%s to value:%s", old, value));
+            }
+        }).thenCompose(__ -> doHandleNotification(path)); // immediately notify local tableview
+    }
+
+    public CompletableFuture<Void> delete(String key) {
+        String path = getPath(key);
+        return cache.delete(path)
+                .thenCompose(__ -> doHandleNotification(path)); // immediately notify local tableview
+    }
+
+    public int size() {
+        return immutableData.size();
+    }
+
+    public boolean isEmpty() {
+        return immutableData.isEmpty();
+    }
+
+    public Set<Map.Entry<String, T>> entrySet() {
+        return immutableData.entrySet();
+    }
+
+    public Set<String> keySet() {
+        return immutableData.keySet();
+    }
+
+    public Collection<T> values() {
+        return immutableData.values();
+    }
+
+    public void forEach(BiConsumer<String, T> action) {
+        immutableData.forEach(action);
+    }
+
+}

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/tableview/impl/package-info.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/tableview/impl/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.tableview.impl;

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTableViewTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTableViewTest.java
@@ -1,0 +1,499 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import lombok.Cleanup;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
+import org.apache.pulsar.metadata.cache.impl.JSONMetadataSerdeSimpleType;
+import org.apache.pulsar.metadata.impl.MetadataStoreFactoryImpl;
+import org.apache.pulsar.metadata.tableview.impl.MetadataStoreTableViewImpl;
+import org.awaitility.Awaitility;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class MetadataStoreTableViewTest extends BaseMetadataStoreTest {
+
+    LinkedBlockingDeque<Pair<String, Integer>> tails;
+    LinkedBlockingDeque<Pair<String, Integer>> existings;
+
+    @BeforeMethod
+    void init(){
+        tails = new LinkedBlockingDeque<>();
+        existings = new LinkedBlockingDeque<>();
+    }
+
+    private void tailListener(String k, Integer v){
+        tails.add(Pair.of(k, v));
+    }
+
+    private void existingListener(String k, Integer v){
+        existings.add(Pair.of(k, v));
+    }
+
+    MetadataStoreTableViewImpl<Integer> createTestTableView(MetadataStore store, String prefix,
+                                                            Supplier<String> urlSupplier)
+            throws Exception {
+        var tv = MetadataStoreTableViewImpl.<Integer>builder()
+                .name("test")
+                .clazz(Integer.class)
+                .store(store)
+                .pathPrefix(prefix)
+                .conflictResolver((old, cur) -> {
+                    if (old == null || cur == null) {
+                        return true;
+                    }
+                    return old < cur;
+                })
+                .listenPathValidator((path) -> path.startsWith(prefix) && path.contains("my"))
+                .tailItemListeners(List.of(this::tailListener))
+                .existingItemListeners(List.of(this::existingListener))
+                .timeoutInMillis(5_000)
+                .build();
+        tv.start();
+        return tv;
+    }
+
+    private void assertGet(MetadataStoreTableViewImpl<Integer> tv, String path, Integer expected) {
+        assertEquals(tv.get(path), expected);
+        //Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(tv.get(path), expected));
+    }
+
+
+    @Test(dataProvider = "impl")
+    public void emptyTableViewTest(String provider, Supplier<String> urlSupplier) throws Exception {
+        String prefix = newKey();
+        @Cleanup
+        MetadataStore store = MetadataStoreFactoryImpl.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        MetadataStoreTableViewImpl<Integer> tv = createTestTableView(store, prefix, urlSupplier);
+
+        assertFalse(tv.exists("non-existing-key"));
+        assertFalse(tv.exists("non-existing-key/child"));
+        assertNull(tv.get("non-existing-key"));
+        assertNull(tv.get("non-existing-key/child"));
+
+        try {
+            tv.delete("non-existing-key").join();
+            fail("Should have failed");
+        } catch (CompletionException e) {
+            assertException(e, NotFoundException.class);
+        }
+
+    }
+
+    @Test(dataProvider = "impl")
+    public void concurrentPutTest(String provider, Supplier<String> urlSupplier) throws Exception {
+        String prefix = newKey();
+        @Cleanup
+        MetadataStore store = MetadataStoreFactoryImpl.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        MetadataStoreTableViewImpl<Integer> tv = createTestTableView(store, prefix, urlSupplier);
+
+        int data = 1;
+        String path = "my";
+        int concurrent = 50;
+        List<CompletableFuture<Void>> futureList = new ArrayList<>();
+        for (int i = 0; i < concurrent; i++) {
+            futureList.add(tv.put(path, data).exceptionally(ex -> {
+                if (!(ex.getCause() instanceof MetadataStoreTableViewImpl.ConflictException)) {
+                    fail("fail to execute concurrent put", ex);
+                }
+                return null;
+            }));
+        }
+        FutureUtil.waitForAll(futureList).join();
+
+        assertGet(tv, path, data);
+    }
+
+    @Test(dataProvider = "impl")
+    public void conflictResolverTest(String provider, Supplier<String> urlSupplier) throws Exception {
+        String prefix = newKey();
+        @Cleanup
+        MetadataStore store = MetadataStoreFactoryImpl.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        MetadataStoreTableViewImpl<Integer> tv = createTestTableView(store, prefix, urlSupplier);
+
+        String key1 = "my";
+
+        tv.put(key1, 0).join();
+        tv.put(key1, 0).exceptionally(ex -> {
+            if (!(ex.getCause() instanceof MetadataStoreTableViewImpl.ConflictException)) {
+                fail("fail to execute concurrent put", ex);
+            }
+            return null;
+        }).join();
+        assertGet(tv, key1, 0);
+        tv.put(key1, 1).join();
+        assertGet(tv, key1, 1);
+        tv.put(key1, 0).exceptionally(ex -> {
+            if (!(ex.getCause() instanceof MetadataStoreTableViewImpl.ConflictException)) {
+                fail("fail to execute concurrent put", ex);
+            }
+            return null;
+        }).join();
+        assertGet(tv, key1, 1);
+    }
+
+    @Test(dataProvider = "impl")
+    public void deleteTest(String provider, Supplier<String> urlSupplier) throws Exception {
+        String prefix = newKey();
+        @Cleanup
+        MetadataStore store = MetadataStoreFactoryImpl.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        MetadataStoreTableViewImpl<Integer> tv = createTestTableView(store, prefix, urlSupplier);
+
+        String key1 = "key";
+        tv.put(key1, 0).join();
+        tv.delete(key1).join();
+        assertNull(tv.get(key1));
+    }
+
+    @Test(dataProvider = "impl")
+    public void mapApiTest(String provider, Supplier<String> urlSupplier) throws Exception {
+        String prefix = newKey();
+        @Cleanup
+        MetadataStore store = MetadataStoreFactoryImpl.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        MetadataStoreTableViewImpl<Integer> tv = createTestTableView(store, prefix, urlSupplier);
+
+        assertTrue(tv.isEmpty());
+        assertEquals(tv.size(), 0);
+
+        String key1 = "my1";
+        String key2 = "my2";
+
+        int val1 = 1;
+        int val2 = 2;
+
+        tv.put(key1, val1).join();
+        tv.put(key2, val2).join();
+        assertGet(tv, key1, 1);
+        assertGet(tv, key2, 2);
+
+        assertFalse(tv.isEmpty());
+        assertEquals(tv.size(), 2);
+
+        List<String> actual = new ArrayList<>();
+        tv.forEach((k, v) -> {
+            actual.add(k + "," + v);
+        });
+        assertEquals(actual, List.of(key1 + "," + val1, key2 + "," + val2));
+
+        var values = tv.values();
+        assertEquals(values.size(), 2);
+        assertTrue(values.containsAll(List.of(val1, val2)));
+
+        var keys = tv.keySet();
+        assertEquals(keys.size(), 2);
+        assertTrue(keys.containsAll(List.of(key1, key2)));
+
+        var entries = tv.entrySet();
+        assertEquals(entries.size(), 2);
+        assertTrue(entries.containsAll(Map.of(key1, val1, key2, val2).entrySet()));
+    }
+
+    @Test(dataProvider = "impl")
+    public void notificationListeners(String provider, Supplier<String> urlSupplier) throws Exception {
+        String prefix = newKey();
+        @Cleanup
+        MetadataStore store = MetadataStoreFactoryImpl.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        MetadataStoreTableViewImpl<Integer> tv = createTestTableView(store, prefix, urlSupplier);
+
+        String keyPrefix = "tenant/ns";
+        String key1 = keyPrefix + "/my-1";
+        int val1 = 1;
+
+        assertGet(tv, key1, null);
+
+        // listen on put
+        tv.put(key1, val1).join();
+        var kv = tails.poll(3, TimeUnit.SECONDS);
+        assertEquals(kv, Pair.of(key1, val1));
+        assertEquals(tv.get(key1), val1);
+
+        // listen on modified
+        int val2 = 2;
+        tv.put(key1, val2).join();
+        kv = tails.poll(3, TimeUnit.SECONDS);
+        assertEquals(kv, Pair.of(key1, val2));
+        assertEquals(tv.get(key1), val2);
+
+        // no listen on the parent
+        int val0 = 0;
+        String childKey = key1 + "/my-child-1";
+        tv.put(childKey, val0).join();
+        kv = tails.poll(3, TimeUnit.SECONDS);
+        assertEquals(kv, Pair.of(childKey, val0));
+        kv = tails.poll(3, TimeUnit.SECONDS);
+        assertNull(kv);
+        assertEquals(tv.get(key1), val2);
+        assertEquals(tv.get(childKey), val0);
+
+        tv.put(childKey, val1).join();
+        kv = tails.poll(3, TimeUnit.SECONDS);
+        assertEquals(kv, Pair.of(childKey, val1));
+        kv = tails.poll(3, TimeUnit.SECONDS);
+        assertNull(kv);
+        assertEquals(tv.get(key1), val2);
+        assertEquals(tv.get(childKey), val1);
+
+        tv.delete(childKey).join();
+        kv = tails.poll(3, TimeUnit.SECONDS);
+        assertEquals(kv, Pair.of(childKey, null));
+        kv = tails.poll(3, TimeUnit.SECONDS);
+        assertNull(kv);
+        assertEquals(tv.get(key1), val2);
+        assertNull(tv.get(childKey));
+
+        // No listen on the filtered key
+        String noListenKey = keyPrefix + "/to-be-filtered";
+        tv.put(noListenKey, val0).join();
+        kv = tails.poll(3, TimeUnit.SECONDS);
+        assertNull(kv);
+        assertEquals(tv.get(key1), val2);
+        assertNull(tv.get(noListenKey));
+
+        // Trigger deleted notification
+        tv.delete(key1).join();
+        kv = tails.poll(3, TimeUnit.SECONDS);
+        assertEquals(kv, Pair.of(key1, null));
+        assertNull(tv.get(key1));
+    }
+
+    @Test(dataProvider = "impl")
+    public void testConcurrentPutGetOneKey(String provider, Supplier<String> urlSupplier) throws Exception {
+        String prefix = newKey();
+        @Cleanup
+        MetadataStore store = MetadataStoreFactoryImpl.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        MetadataStoreTableViewImpl<Integer> tv = createTestTableView(store, prefix, urlSupplier);
+
+        String key = "my";
+        int val = 0;
+        int maxValue = 50;
+        tv.put(key, val).join();
+
+        AtomicInteger successWrites = new AtomicInteger(0);
+        Runnable task = new Runnable() {
+            @SneakyThrows
+            @Override
+            public void run() {
+                for (int k = 0; k < 1000; k++) {
+                    var kv = tails.poll(3, TimeUnit.SECONDS);
+                    if (kv == null) {
+                        break;
+                    }
+                    Integer val = kv.getRight() + 1;
+                    if (val <= maxValue) {
+                        CompletableFuture<Void> putResult =
+                                tv.put(key, val).thenRun(successWrites::incrementAndGet);
+                        try {
+                            putResult.get();
+                        } catch (Exception ignore) {
+                        }
+                        log.info("Put value {} success:{}. ", val, !putResult.isCompletedExceptionally());
+                    } else {
+                        break;
+                    }
+                }
+            }
+        };
+        CompletableFuture<Void> t1 = CompletableFuture.completedFuture(null).thenRunAsync(task);
+        CompletableFuture<Void> t2 = CompletableFuture.completedFuture(null).thenRunAsync(task);
+        task.run();
+        t1.join();
+        t2.join();
+        assertFalse(t1.isCompletedExceptionally());
+        assertFalse(t2.isCompletedExceptionally());
+
+        assertEquals(successWrites.get(), maxValue);
+        assertEquals(tv.get(key), maxValue);
+    }
+
+    @Test(dataProvider = "impl")
+    public void testConcurrentPut(String provider, Supplier<String> urlSupplier) throws Exception {
+        String prefix = newKey();
+        @Cleanup
+        MetadataStore store = MetadataStoreFactoryImpl.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        MetadataStoreTableViewImpl<Integer> tv = createTestTableView(store, prefix, urlSupplier);
+
+        String k = "my";
+        int v = 0;
+        CompletableFuture<Void> f1 =
+                CompletableFuture.runAsync(() -> tv.put(k, v).join());
+        CompletableFuture<Void> f2 =
+                CompletableFuture.runAsync(() -> tv.put(k, v).join());
+        Awaitility.await().until(() -> f1.isDone() && f2.isDone());
+        assertTrue(f1.isCompletedExceptionally() && !f2.isCompletedExceptionally() ||
+                ! f1.isCompletedExceptionally() && f2.isCompletedExceptionally());
+    }
+
+    @Test(dataProvider = "impl")
+    public void testConcurrentDelete(String provider, Supplier<String> urlSupplier) throws Exception {
+        String prefix = newKey();
+        @Cleanup
+        MetadataStore store = MetadataStoreFactoryImpl.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        MetadataStoreTableViewImpl<Integer> tv = createTestTableView(store, prefix, urlSupplier);
+
+        String k = "my";
+        tv.put(k, 0).join();
+        CompletableFuture<Void> f1 =
+                CompletableFuture.runAsync(() -> tv.delete(k).join());
+        CompletableFuture<Void> f2 =
+                CompletableFuture.runAsync(() -> tv.delete(k).join());
+        Awaitility.await().until(() -> f1.isDone() && f2.isDone());
+        assertTrue(f1.isCompletedExceptionally() && !f2.isCompletedExceptionally() ||
+                ! f1.isCompletedExceptionally() && f2.isCompletedExceptionally());
+    }
+
+    @Test(dataProvider = "impl")
+    public void testClosedMetadataStore(String provider, Supplier<String> urlSupplier) throws Exception {
+        String prefix = newKey();
+        String k = "my";
+        @Cleanup
+        MetadataStore store = MetadataStoreFactoryImpl.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        MetadataStoreTableViewImpl<Integer> tv = createTestTableView(store, prefix, urlSupplier);
+        store.close();
+        try {
+            tv.put(k, 0).get();
+            fail();
+        } catch (Exception e) {
+            assertTrue(e.getCause() instanceof MetadataStoreException.AlreadyClosedException);
+        }
+        try {
+            tv.delete(k).get();
+            fail();
+        } catch (Exception e) {
+            assertTrue(e.getCause() instanceof MetadataStoreException.AlreadyClosedException);
+        }
+
+    }
+
+
+    @Test(dataProvider = "distributedImpl")
+    public void testGetIfCachedDistributed(String provider, Supplier<String> urlSupplier) throws Exception {
+
+        String prefix = newKey();
+        String k = "my";
+        @Cleanup
+        MetadataStore store1 = MetadataStoreFactoryImpl.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        MetadataStoreTableViewImpl<Integer> tv1 = createTestTableView(store1, prefix, urlSupplier);
+        @Cleanup
+        MetadataStore store2 = MetadataStoreFactoryImpl.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        MetadataStoreTableViewImpl<Integer> tv2 = createTestTableView(store2, prefix, urlSupplier);
+
+
+        assertNull(tv1.get(k));
+        assertNull(tv2.get(k));
+
+        tv1.put(k, 0).join();
+        assertGet(tv1, k, 0);
+        Awaitility.await()
+                .untilAsserted(() -> assertEquals(tv2.get(k), 0));
+
+        tv2.put(k, 1).join();
+        assertGet(tv2, k, 1);
+        Awaitility.await()
+                .untilAsserted(() -> assertEquals(tv1.get(k), 1));
+
+        tv1.delete(k).join();
+        assertGet(tv1, k, null);
+        Awaitility.await()
+                .untilAsserted(() -> assertNull(tv2.get(k)));
+    }
+
+    @Test(dataProvider = "distributedImpl")
+    public void testInitialFill(String provider, Supplier<String> urlSupplier) throws Exception {
+
+        String prefix = newKey();
+        String k1 = "tenant-1/ns-1/my-1";
+        String k2 = "tenant-1/ns-1/my-2";
+        String k3 = "tenant-1/ns-2/my-3";
+        String k4 = "tenant-2/ns-3/my-4";
+        String k5 = "tenant-2/ns-3/your-1";
+        @Cleanup
+        MetadataStore store = MetadataStoreFactoryImpl.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        MetadataStoreTableViewImpl<Integer> btv = createTestTableView(store, prefix, urlSupplier);
+
+        assertFalse(btv.exists(k1));
+
+        var serde = new JSONMetadataSerdeSimpleType<>(
+                TypeFactory.defaultInstance().constructSimpleType(Integer.class, null));
+        store.put(prefix + "/" + k1, serde.serialize(prefix + "/" + k1, 0), Optional.empty()).join();
+        store.put(prefix + "/" + k2, serde.serialize(prefix + "/" + k2, 1), Optional.empty()).join();
+        store.put(prefix + "/" + k3, serde.serialize(prefix + "/" + k3, 2), Optional.empty()).join();
+        store.put(prefix + "/" + k4, serde.serialize(prefix + "/" + k4, 3), Optional.empty()).join();
+        store.put(prefix + "/" + k5, serde.serialize(prefix + "/" + k5, 4), Optional.empty()).join();
+
+        var expected = new HashSet<>(Set.of(Pair.of(k1, 0), Pair.of(k2, 1), Pair.of(k3, 2), Pair.of(k4, 3)));
+        var tailExpected = new HashSet<>(expected);
+
+        for (int i = 0; i < 4; i++) {
+            var kv = tails.poll(3, TimeUnit.SECONDS);
+            assertTrue(tailExpected.remove(kv));
+        }
+        assertNull(tails.poll(3, TimeUnit.SECONDS));
+        assertTrue(tailExpected.isEmpty());
+
+        @Cleanup
+        MetadataStore store2 = MetadataStoreFactoryImpl.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
+        MetadataStoreTableViewImpl<Integer> tv = createTestTableView(store2, prefix, urlSupplier);
+
+        var existingExpected = new HashSet<>(Set.of(Pair.of(k1, 0), Pair.of(k2, 1), Pair.of(k3, 2), Pair.of(k4, 3)));
+        var entrySetExpected = expected.stream().collect(Collectors.toMap(Pair::getLeft, Pair::getRight)).entrySet();
+
+
+        for (int i = 0; i < 4; i++) {
+            var kv = existings.poll(3, TimeUnit.SECONDS);
+            assertTrue(existingExpected.remove(kv));
+        }
+        assertNull(existings.poll(3, TimeUnit.SECONDS));
+        assertTrue(existingExpected.isEmpty());
+
+        assertEquals(tv.get(k1), 0);
+        assertEquals(tv.get(k2), 1);
+        assertEquals(tv.get(k3), 2);
+        assertEquals(tv.get(k4), 3);
+        assertNull(tv.get(k5));
+
+        assertEquals(tv.entrySet(), entrySetExpected);
+    }
+}


### PR DESCRIPTION


<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


PIP: https://github.com/apache/pulsar/pull/23300 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Implements the PIP: https://github.com/apache/pulsar/pull/23300

### Modifications
- Add ServiceUnitStateTableView interface
- Add ServiceUnitStateTableViewImpl implementation that uses Pulsar System topic (compatible with existing behavior)
- Add ServiceUnitStateMetadataStoreTableViewImpl implementation that uses Pulsar Metadata Store (new behavior)
- Refactor ExtensibleLoadMangerImpl and ServiceUnitStateChannelImpl to accept ServiceUnitStateTableView.
- Add time-based producer restart logic in LoadDataTableView and improved its shutdown logic.
- Improve ownership release logic to be more graceful upon broker shutdown
- Refactor related tests code
- ServiceUnitStateTableViewSyncer to sync the two table views during migration.


### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/heesung-sn/pulsar/pull/81

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
