### PR TITLE
[fix][broker] Fix NonDurable Subscription msgBackLog incorrect after topic unload

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1250,6 +1250,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         final long consumerEpoch = subscribe.hasConsumerEpoch() ? subscribe.getConsumerEpoch() : DEFAULT_CONSUMER_EPOCH;
         final Optional<Map<String, String>> subscriptionProperties = SubscriptionOption.getPropertiesMap(
                 subscribe.getSubscriptionPropertiesList());
+        final boolean resetIncludeHead = subscribe.isResetIncludeHead();
 
         if (log.isDebugEnabled()) {
             log.debug("Topic name = {}, subscription name = {}, schema is {}", topicName, subscriptionName,
@@ -1374,6 +1375,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                                 .subscriptionProperties(subscriptionProperties)
                                                 .consumerEpoch(consumerEpoch)
                                                 .schemaType(schema == null ? null : schema.getType())
+                                                .resetIncludeHead(resetIncludeHead)
                                                 .build();
                                         if (schema != null && schema.getType() != SchemaType.AUTO_CONSUME) {
                                             return ignoreUnrecoverableBKException

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SubscriptionOption.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SubscriptionOption.java
@@ -51,6 +51,7 @@ public class SubscriptionOption {
     private Optional<Map<String, String>> subscriptionProperties;
     private long consumerEpoch;
     private SchemaType schemaType;
+    private boolean resetIncludeHead;
 
     public static Optional<Map<String, String>> getPropertiesMap(List<KeyValue> list) {
         if (list == null) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1162,9 +1162,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 if (ledgerId >= 0 && entryId >= 0
                         && msgId instanceof BatchMessageIdImpl
                         && (msgId.getBatchIndex() >= 0 || resetIncludeHead)) {
+                    // When resetIncludeHead is true, we need to take one step back on the previous message,
+                    // to ensure the read position starts with startMessageId
+
                     // When the start message is relative to a batch, we need to take one step back on the previous
-                    // message,
-                    // because the "batch" might not have been consumed in its entirety.
+                    // message, because the "batch" might not have been consumed in its entirety.
                     // The client will then be able to discard the first messages if needed.
                     entryId = msgId.getEntryId() - 1;
                 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonDurableSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonDurableSubscriptionTest.java
@@ -257,6 +257,57 @@ public class NonDurableSubscriptionTest extends ProducerConsumerBase {
     }
 
     @Test
+    public void testNonDurableSubscriptionBackLogAfterTopicUnload() throws Exception {
+        String topicName = "persistent://my-property/my-ns/nonDurable-sub-test";
+        String subName = "test-sub";
+
+        admin.topics().createNonPartitionedTopic(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
+
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic(topicName)
+                .subscriptionName(subName)
+                .subscriptionMode(SubscriptionMode.NonDurable).subscribe();
+
+        // 1. send message
+        for (int i = 0; i < 10; i++) {
+            String message = "my-message-" + i;
+            producer.send(message.getBytes());
+        }
+        producer.close();
+
+        assertEquals(admin.topics().getStats(topicName).getSubscriptions().get(subName).getMsgBacklog(), 10);
+
+        // 2. receive the message
+        Thread t = new Thread(() -> {
+            while (true) {
+                Message<byte[]> msg;
+                try {
+                    msg = consumer.receive();
+                    consumer.acknowledge(msg);
+                } catch (PulsarClientException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        t.start();
+
+        // 3. consumed all messages and the msgBacklog is 0
+        Awaitility.await().untilAsserted(() ->
+                assertEquals(admin.topics().getStats(topicName).getSubscriptions().get(subName).getMsgBacklog(), 0));
+
+        // 4. unload the topic
+        admin.topics().unload(topicName);
+
+        // 5. wait the consumer reconnect
+        Awaitility.await().until(() -> admin.topics().getStats(topicName).getSubscriptions() != null);
+
+        // 6. the backlog should still be 0
+        Awaitility.await().untilAsserted(() -> assertEquals(admin.topics().getStats(topicName).
+                getSubscriptions().get(subName).getMsgBacklog(), 0));
+    }
+
+    @Test
     public void testFlowCountForMultiTopics() throws Exception {
         String topicName = "persistent://my-property/my-ns/test-flow-count";
         int numPartitions = 5;
@@ -464,7 +515,7 @@ public class NonDurableSubscriptionTest extends ProducerConsumerBase {
         // A middle ledger id, and entry id is "-1".
         log.info("start test s8");
         String s8 = "s8";
-        MessageIdImpl startMessageId8 = new MessageIdImpl(ledgers.get(2), 0, -1);
+        MessageIdImpl startMessageId8 = new MessageIdImpl(ledgers.get(2), -1, -1);
         Reader<String> reader8 = pulsarClient.newReader(Schema.STRING).topic(topicName).subscriptionName(s8)
                 .receiverQueueSize(0).startMessageId(startMessageId8).create();
         ManagedLedgerInternalStats.CursorStats cursor8 = admin.topics().getInternalStats(topicName).cursors.get(s8);
@@ -497,7 +548,7 @@ public class NonDurableSubscriptionTest extends ProducerConsumerBase {
         ManagedLedgerInternalStats.CursorStats cursor10 = admin.topics().getInternalStats(topicName).cursors.get(s10);
         log.info("cursor10 readPosition: {}, markDeletedPosition: {}", cursor10.readPosition, cursor10.markDeletePosition);
         Position p10 = parseReadPosition(cursor10);
-        assertEquals(p10.getLedgerId(), ledgers.get(2));
+        assertEquals(p10.getLedgerId(), ledgers.get(3));
         assertEquals(p10.getEntryId(), 0);
         reader10.close();
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -895,7 +895,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                     InitialPosition.valueOf(subscriptionInitialPosition.getValue()),
                     startMessageRollbackDuration, si, createTopicIfDoesNotExist, conf.getKeySharedPolicy(),
                     // Use the current epoch to subscribe.
-                    conf.getSubscriptionProperties(), CONSUMER_EPOCH.get(this));
+                    conf.getSubscriptionProperties(), CONSUMER_EPOCH.get(this), resetIncludeHead);
 
             cnx.sendRequestWithId(request, requestId).thenRun(() -> {
                 synchronized (ConsumerImpl.this) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -588,7 +588,7 @@ public class Commands {
         return newSubscribe(topic, subscription, consumerId, requestId, subType, priorityLevel, consumerName,
                 isDurable, startMessageId, metadata, readCompacted, isReplicated, subscriptionInitialPosition,
                 startMessageRollbackDurationInSec, schemaInfo, createTopicIfDoesNotExist, null,
-                Collections.emptyMap(), DEFAULT_CONSUMER_EPOCH);
+                Collections.emptyMap(), DEFAULT_CONSUMER_EPOCH, false);
     }
 
     public static ByteBuf newSubscribe(String topic, String subscription, long consumerId, long requestId,
@@ -596,7 +596,7 @@ public class Commands {
                Map<String, String> metadata, boolean readCompacted, boolean isReplicated,
                InitialPosition subscriptionInitialPosition, long startMessageRollbackDurationInSec,
                SchemaInfo schemaInfo, boolean createTopicIfDoesNotExist, KeySharedPolicy keySharedPolicy,
-               Map<String, String> subscriptionProperties, long consumerEpoch) {
+               Map<String, String> subscriptionProperties, long consumerEpoch, boolean resetIncludeHead) {
         BaseCommand cmd = localCmd(Type.SUBSCRIBE);
         CommandSubscribe subscribe = cmd.setSubscribe()
                 .setTopic(topic)
@@ -611,7 +611,8 @@ public class Commands {
                 .setInitialPosition(subscriptionInitialPosition)
                 .setReplicateSubscriptionState(isReplicated)
                 .setForceTopicCreation(createTopicIfDoesNotExist)
-                .setConsumerEpoch(consumerEpoch);
+                .setConsumerEpoch(consumerEpoch)
+                .setResetIncludeHead(resetIncludeHead);
 
         if (subscriptionProperties != null && !subscriptionProperties.isEmpty()) {
             List<KeyValue> keyValues = new ArrayList<>();

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -401,6 +401,8 @@ message CommandSubscribe {
 
     // The consumer epoch, when exclusive and failover consumer redeliver unack message will increase the epoch
     optional uint64 consumer_epoch = 19;
+
+    optional bool reset_include_head = 20 [default = false];
 }
 
 message CommandPartitionedTopicMetadata {


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/23239

### Motivation
#### Briefly describe the issue: 
Consumer consumed all messages and then the msgBacklog is 0, but after topic unload, the msgBacklog turned to be 1 instead of 0 which is not what we expected. The detail is in test NonDurableSubscriptionTest#testNonDurableSubscriptionBackLogAfterTopicUnload.
    
#### Root cause:
I analysed the related code, and found this issue was introduced by https://github.com/apache/pulsar/pull/4331. In the https://github.com/apache/pulsar/pull/4331, 
`if (((BatchMessageIdImpl) msgId).getBatchIndex() >= 0) {`  was deleted directly, which cause none batch message will also execute the step `entryId = msgId.getEntryId() - 1;`.  Because of this, the entryId reduced by 1, then the msgBacklog turned to be 1 instead of 0.
 
In the https://github.com/apache/pulsar/pull/4331, we added `ReaderBuilder#startMessageIdInclusive` interface to allow create Reader which read containes startMessageId, but it has not been implemented correctly. We should add the field **resetIncludeHead** in CommandSubscribe to implement it.
  
### Modifications
- CommandSubscribe add the field **resetIncludeHead**, and when use the ReaderBuilder#startMessageIdInclusive, this param is true while other is false.
- Persist#getNonDurableSubscription method add the judge condition `(msgId.getBatchIndex() >= 0 || resetIncludeHead)`, entryId -1 will execute Only **when msg is batch or the resetIncludeHead is true.**
    
```java
               if (ledgerId >= 0 && entryId >= 0
                        && msgId instanceof BatchMessageIdImpl
                        && (msgId.getBatchIndex() >= 0 || resetIncludeHead)) {
                    // When the start message is relative to a batch, we need to take one step back on the previous
                    // message,
                    // because the "batch" might not have been consumed in its entirety.
                    // The client will then be able to discard the first messages if needed.
                    entryId = msgId.getEntryId() - 1;
                }
```  
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
