### PR TITLE
[improve][broker] Decouple ManagedLedger interfaces from the current implementation

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/AsyncCallbacks.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/AsyncCallbacks.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
-import org.apache.bookkeeper.mledger.impl.ReadOnlyManagedLedgerImpl;
 
 /**
  * Definition of all the callbacks used for the ManagedLedger asynchronous API.
@@ -48,7 +47,7 @@ public interface AsyncCallbacks {
     }
 
     interface OpenReadOnlyManagedLedgerCallback {
-        void openReadOnlyManagedLedgerComplete(ReadOnlyManagedLedgerImpl managedLedger, Object ctx);
+        void openReadOnlyManagedLedgerComplete(ReadOnlyManagedLedger managedLedger, Object ctx);
 
         void openReadOnlyManagedLedgerFailed(ManagedLedgerException exception, Object ctx);
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
@@ -34,6 +34,7 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.MarkDeleteCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.SkipEntriesCallback;
+import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats;
 
 /**
  * A ManagedCursor is a persisted cursor inside a ManagedLedger.
@@ -44,6 +45,8 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.SkipEntriesCallback;
 @InterfaceAudience.LimitedPrivate
 @InterfaceStability.Stable
 public interface ManagedCursor {
+
+    String CURSOR_INTERNAL_PROPERTY_PREFIX = "#pulsar.internal.";
 
     @SuppressWarnings("checkstyle:javadoctype")
     enum FindPositionConstraint {
@@ -885,4 +888,16 @@ public interface ManagedCursor {
     default ManagedCursorAttributes getManagedCursorAttributes() {
         return new ManagedCursorAttributes(this);
     }
+
+    ManagedLedgerInternalStats.CursorStats getCursorStats();
+
+    boolean isMessageDeleted(Position position);
+
+    ManagedCursor duplicateNonDurableCursor(String nonDurableCursorName) throws ManagedLedgerException;
+
+    long[] getBatchPositionAckSet(Position position);
+
+    int applyMaxSizeCap(int maxEntries, long maxSizeBytes);
+
+    void updateReadStats(int readEntriesCount, long readEntriesSize);
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -18,8 +18,10 @@
  */
 package org.apache.bookkeeper.mledger;
 
+import com.google.common.collect.Range;
 import io.netty.buffer.ByteBuf;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
@@ -374,6 +376,8 @@ public interface ManagedLedger {
      */
     long getNumberOfEntries();
 
+    long getNumberOfEntries(Range<Position> range);
+
     /**
      * Get the total number of active entries for this managed ledger.
      *
@@ -703,4 +707,30 @@ public interface ManagedLedger {
     default ManagedLedgerAttributes getManagedLedgerAttributes() {
         return new ManagedLedgerAttributes(this);
     }
+
+    void asyncReadEntry(Position position, AsyncCallbacks.ReadEntryCallback callback, Object ctx);
+
+    /**
+     * Get all the managed ledgers.
+     */
+    NavigableMap<Long, LedgerInfo> getLedgersInfo();
+
+    Position getNextValidPosition(Position position);
+
+    Position getPreviousPosition(Position position);
+
+    long getEstimatedBacklogSize(Position position);
+
+    Position getPositionAfterN(Position startPosition, long n, PositionBound startRange);
+
+    int getPendingAddEntriesCount();
+
+    long getCacheSize();
+
+    default CompletableFuture<Position> getLastDispatchablePosition(final Predicate<Entry> predicate,
+                                                                    final Position startPosition) {
+        return CompletableFuture.completedFuture(PositionFactory.EARLIEST);
+    }
+
+    Position getFirstPosition();
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
@@ -28,6 +28,8 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.ManagedLedgerInfoCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenLedgerCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenReadOnlyCursorCallback;
 import org.apache.bookkeeper.mledger.impl.cache.EntryCacheManager;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.PersistentOfflineTopicStats;
 
 /**
  * A factory to open/create managed ledgers and delete them.
@@ -233,4 +235,14 @@ public interface ManagedLedgerFactory {
      * @return properties of this managedLedger.
      */
     CompletableFuture<Map<String, String>> getManagedLedgerPropertiesAsync(String name);
+
+    Map<String, ManagedLedger> getManagedLedgers();
+
+    ManagedLedgerFactoryMXBean getCacheStats();
+
+
+    void estimateUnloadedTopicBacklog(PersistentOfflineTopicStats offlineTopicStats, TopicName topicName,
+                                              boolean accurate, Object ctx) throws Exception;
+
+    ManagedLedgerFactoryConfig getConfig();
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
@@ -242,7 +242,7 @@ public interface ManagedLedgerFactory {
 
 
     void estimateUnloadedTopicBacklog(PersistentOfflineTopicStats offlineTopicStats, TopicName topicName,
-                                              boolean accurate, Object ctx) throws Exception;
+                                      boolean accurate, Object ctx) throws Exception;
 
     ManagedLedgerFactoryConfig getConfig();
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/PositionBound.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/PositionBound.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger;
+
+public enum PositionBound {
+    // define boundaries for position based seeks and searches
+        startIncluded, startExcluded
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/PositionBound.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/PositionBound.java
@@ -20,5 +20,5 @@ package org.apache.bookkeeper.mledger;
 
 public enum PositionBound {
     // define boundaries for position based seeks and searches
-        startIncluded, startExcluded
+    startIncluded, startExcluded
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ReadOnlyManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ReadOnlyManagedLedger.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger;
+
+import java.util.Map;
+
+public interface ReadOnlyManagedLedger {
+
+    void asyncReadEntry(Position position, AsyncCallbacks.ReadEntryCallback callback, Object ctx);
+
+    long getNumberOfEntries();
+
+    ReadOnlyCursor createReadOnlyCursor(Position position);
+
+    Map<String, String> getProperties();
+
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ReadOnlyManagedLedgerImplWrapper.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ReadOnlyManagedLedgerImplWrapper.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.common.util.OrderedScheduler;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
+import org.apache.bookkeeper.mledger.impl.MetaStore;
+import org.apache.bookkeeper.mledger.impl.ReadOnlyManagedLedgerImpl;
+
+public class ReadOnlyManagedLedgerImplWrapper implements ReadOnlyManagedLedger {
+
+    private final ReadOnlyManagedLedgerImpl readOnlyManagedLedger;
+
+    public ReadOnlyManagedLedgerImplWrapper(ManagedLedgerFactoryImpl factory, BookKeeper bookKeeper, MetaStore store,
+                                            ManagedLedgerConfig config, OrderedScheduler scheduledExecutor,
+                                            String name) {
+        this.readOnlyManagedLedger =
+                new ReadOnlyManagedLedgerImpl(factory, bookKeeper, store, config, scheduledExecutor, name);
+    }
+
+    public CompletableFuture<Void> initialize() {
+        return readOnlyManagedLedger.initialize();
+    }
+
+    @Override
+    public void asyncReadEntry(Position position, AsyncCallbacks.ReadEntryCallback callback, Object ctx) {
+        readOnlyManagedLedger.asyncReadEntry(position, callback, ctx);
+    }
+
+    @Override
+    public long getNumberOfEntries() {
+        return readOnlyManagedLedger.getNumberOfEntries();
+    }
+
+    @Override
+    public ReadOnlyCursor createReadOnlyCursor(Position position) {
+        return readOnlyManagedLedger.createReadOnlyCursor(position);
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return readOnlyManagedLedger.getProperties();
+    }
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerOfflineBacklog.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerOfflineBacklog.java
@@ -20,29 +20,16 @@ package org.apache.bookkeeper.mledger.impl;
 
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
-import com.google.protobuf.InvalidProtocolBufferException;
-import java.util.Enumeration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.NavigableMap;
-import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import org.apache.bookkeeper.client.AsyncCallback;
-import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
-import org.apache.bookkeeper.client.BookKeeperAdmin;
-import org.apache.bookkeeper.client.LedgerEntry;
-import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.api.DigestType;
-import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.Position;
-import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
-import org.apache.bookkeeper.mledger.util.Errors;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.PersistentOfflineTopicStats;
-import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
-import org.apache.pulsar.metadata.api.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,369 +89,28 @@ public class ManagedLedgerOfflineBacklog {
         }
     }
 
-    public PersistentOfflineTopicStats getEstimatedUnloadedTopicBacklog(ManagedLedgerFactoryImpl factory,
+    public PersistentOfflineTopicStats getEstimatedUnloadedTopicBacklog(ManagedLedgerFactory factory,
             String managedLedgerName) throws Exception {
         return estimateUnloadedTopicBacklog(factory, TopicName.get("persistent://" + managedLedgerName));
     }
 
-    public PersistentOfflineTopicStats estimateUnloadedTopicBacklog(ManagedLedgerFactoryImpl factory,
-            TopicName topicName) throws Exception {
+    public PersistentOfflineTopicStats estimateUnloadedTopicBacklog(ManagedLedgerFactory factory,
+                                                                    TopicName topicName) throws Exception {
         String managedLedgerName = topicName.getPersistenceNamingEncoding();
-        long numberOfEntries = 0;
-        long totalSize = 0;
-        final NavigableMap<Long, MLDataFormats.ManagedLedgerInfo.LedgerInfo> ledgers = new ConcurrentSkipListMap<>();
         final PersistentOfflineTopicStats offlineTopicStats = new PersistentOfflineTopicStats(managedLedgerName,
                 brokerName);
-
-        // calculate total managed ledger size and number of entries without loading the topic
-        readLedgerMeta(factory, topicName, ledgers);
-        for (MLDataFormats.ManagedLedgerInfo.LedgerInfo ls : ledgers.values()) {
-            numberOfEntries += ls.getEntries();
-            totalSize += ls.getSize();
-            if (accurate) {
-                offlineTopicStats.addLedgerDetails(ls.getEntries(), ls.getTimestamp(), ls.getSize(), ls.getLedgerId());
-            }
-        }
-        offlineTopicStats.totalMessages = numberOfEntries;
-        offlineTopicStats.storageSize = totalSize;
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Total number of entries - {} and size - {}", managedLedgerName, numberOfEntries, totalSize);
+        if (factory instanceof ManagedLedgerFactoryImpl) {
+            List<Object> ctx = new ArrayList<>();
+            ctx.add(digestType);
+            ctx.add(password);
+            factory.estimateUnloadedTopicBacklog(offlineTopicStats, topicName, accurate, ctx);
+        } else {
+            Object ctx = null;
+            factory.estimateUnloadedTopicBacklog(offlineTopicStats, topicName, accurate, ctx);
         }
 
-        // calculate per cursor message backlog
-        calculateCursorBacklogs(factory, topicName, ledgers, offlineTopicStats);
-        offlineTopicStats.statGeneratedAt.setTime(System.currentTimeMillis());
 
         return offlineTopicStats;
-    }
-
-    private void readLedgerMeta(final ManagedLedgerFactoryImpl factory, final TopicName topicName,
-            final NavigableMap<Long, MLDataFormats.ManagedLedgerInfo.LedgerInfo> ledgers) throws Exception {
-        String managedLedgerName = topicName.getPersistenceNamingEncoding();
-        MetaStore store = factory.getMetaStore();
-
-        final CountDownLatch mlMetaCounter = new CountDownLatch(1);
-
-        store.getManagedLedgerInfo(managedLedgerName, false /* createIfMissing */,
-                new MetaStore.MetaStoreCallback<MLDataFormats.ManagedLedgerInfo>() {
-                    @Override
-                    public void operationComplete(MLDataFormats.ManagedLedgerInfo mlInfo, Stat stat) {
-                        for (MLDataFormats.ManagedLedgerInfo.LedgerInfo ls : mlInfo.getLedgerInfoList()) {
-                            ledgers.put(ls.getLedgerId(), ls);
-                        }
-
-                        // find no of entries in last ledger
-                        if (!ledgers.isEmpty()) {
-                            final long id = ledgers.lastKey();
-                            AsyncCallback.OpenCallback opencb = (rc, lh, ctx1) -> {
-                                if (log.isDebugEnabled()) {
-                                    log.debug("[{}] Opened ledger {}: {}", managedLedgerName, id,
-                                            BKException.getMessage(rc));
-                                }
-                                if (rc == BKException.Code.OK) {
-                                    MLDataFormats.ManagedLedgerInfo.LedgerInfo info =
-                                        MLDataFormats.ManagedLedgerInfo.LedgerInfo
-                                            .newBuilder().setLedgerId(id).setEntries(lh.getLastAddConfirmed() + 1)
-                                            .setSize(lh.getLength()).setTimestamp(System.currentTimeMillis()).build();
-                                    ledgers.put(id, info);
-                                    mlMetaCounter.countDown();
-                                } else if (Errors.isNoSuchLedgerExistsException(rc)) {
-                                    log.warn("[{}] Ledger not found: {}", managedLedgerName, ledgers.lastKey());
-                                    ledgers.remove(ledgers.lastKey());
-                                    mlMetaCounter.countDown();
-                                } else {
-                                    log.error("[{}] Failed to open ledger {}: {}", managedLedgerName, id,
-                                            BKException.getMessage(rc));
-                                    mlMetaCounter.countDown();
-                                }
-                            };
-
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] Opening ledger {}", managedLedgerName, id);
-                            }
-
-                            factory.getBookKeeper()
-                                    .thenAccept(bk -> {
-                                        bk.asyncOpenLedgerNoRecovery(id, digestType, password, opencb, null);
-                                    }).exceptionally(ex -> {
-                                        log.warn("[{}] Failed to open ledger {}: {}", managedLedgerName, id, ex);
-                                        opencb.openComplete(-1, null, null);
-                                        mlMetaCounter.countDown();
-                                        return null;
-                                    });
-                        } else {
-                            log.warn("[{}] Ledger list empty", managedLedgerName);
-                            mlMetaCounter.countDown();
-                        }
-                    }
-
-                    @Override
-                    public void operationFailed(ManagedLedgerException.MetaStoreException e) {
-                        log.warn("[{}] Unable to obtain managed ledger metadata - {}", managedLedgerName, e);
-                        mlMetaCounter.countDown();
-                    }
-                });
-
-        if (accurate) {
-            // block until however long it takes for operation to complete
-            mlMetaCounter.await();
-        } else {
-            mlMetaCounter.await(META_READ_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-
-        }
-    }
-
-    private void calculateCursorBacklogs(final ManagedLedgerFactoryImpl factory, final TopicName topicName,
-            final NavigableMap<Long, MLDataFormats.ManagedLedgerInfo.LedgerInfo> ledgers,
-            final PersistentOfflineTopicStats offlineTopicStats) throws Exception {
-
-        if (ledgers.isEmpty()) {
-            return;
-        }
-        String managedLedgerName = topicName.getPersistenceNamingEncoding();
-        MetaStore store = factory.getMetaStore();
-        BookKeeper bk = factory.getBookKeeper().get();
-        final CountDownLatch allCursorsCounter = new CountDownLatch(1);
-        final long errorInReadingCursor = -1;
-        ConcurrentOpenHashMap<String, Long> ledgerRetryMap =
-                ConcurrentOpenHashMap.<String, Long>newBuilder().build();
-
-        final MLDataFormats.ManagedLedgerInfo.LedgerInfo ledgerInfo = ledgers.lastEntry().getValue();
-        final Position lastLedgerPosition =
-                PositionFactory.create(ledgerInfo.getLedgerId(), ledgerInfo.getEntries() - 1);
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Last ledger position {}", managedLedgerName, lastLedgerPosition);
-        }
-
-        store.getCursors(managedLedgerName, new MetaStore.MetaStoreCallback<List<String>>() {
-            @Override
-            public void operationComplete(List<String> cursors, Stat v) {
-                // Load existing cursors
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Found {} cursors", managedLedgerName, cursors.size());
-                }
-
-                if (cursors.isEmpty()) {
-                    allCursorsCounter.countDown();
-                    return;
-                }
-
-                final CountDownLatch cursorCounter = new CountDownLatch(cursors.size());
-
-                for (final String cursorName : cursors) {
-                    // determine subscription position from cursor ledger
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Loading cursor {}", managedLedgerName, cursorName);
-                    }
-
-                    AsyncCallback.OpenCallback cursorLedgerOpenCb = (rc, lh, ctx1) -> {
-                        long ledgerId = lh.getId();
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] Opened cursor ledger {} for cursor {}. rc={}", managedLedgerName, ledgerId,
-                                    cursorName, rc);
-                        }
-                        if (rc != BKException.Code.OK) {
-                            log.warn("[{}] Error opening metadata ledger {} for cursor {}: {}", managedLedgerName,
-                                    ledgerId, cursorName, BKException.getMessage(rc));
-                            cursorCounter.countDown();
-                            return;
-                        }
-                        long lac = lh.getLastAddConfirmed();
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] Cursor {} LAC {} read from ledger {}", managedLedgerName, cursorName, lac,
-                                    ledgerId);
-                        }
-
-                        if (lac == LedgerHandle.INVALID_ENTRY_ID) {
-                            // save the ledger id and cursor to retry outside of this call back
-                            // since we are trying to read the same cursor ledger, we will block until
-                            // this current callback completes, since an attempt to read the entry
-                            // will block behind this current operation to complete
-                            ledgerRetryMap.put(cursorName, ledgerId);
-                            log.info("[{}] Cursor {} LAC {} read from ledger {}", managedLedgerName, cursorName, lac,
-                                    ledgerId);
-                            cursorCounter.countDown();
-                            return;
-                        }
-                        final long entryId = lac;
-                        // read last acked message position for subscription
-                        lh.asyncReadEntries(entryId, entryId, new AsyncCallback.ReadCallback() {
-                            @Override
-                            public void readComplete(int rc, LedgerHandle lh, Enumeration<LedgerEntry> seq,
-                                    Object ctx) {
-                                try {
-                                    if (log.isDebugEnabled()) {
-                                        log.debug("readComplete rc={} entryId={}", rc, entryId);
-                                    }
-                                    if (rc != BKException.Code.OK) {
-                                        log.warn("[{}] Error reading from metadata ledger {} for cursor {}: {}",
-                                                managedLedgerName, ledgerId, cursorName, BKException.getMessage(rc));
-                                        // indicate that this cursor should be excluded
-                                        offlineTopicStats.addCursorDetails(cursorName, errorInReadingCursor,
-                                                lh.getId());
-                                    } else {
-                                        LedgerEntry entry = seq.nextElement();
-                                        MLDataFormats.PositionInfo positionInfo;
-                                        try {
-                                            positionInfo = MLDataFormats.PositionInfo.parseFrom(entry.getEntry());
-                                        } catch (InvalidProtocolBufferException e) {
-                                            log.warn(
-                                                "[{}] Error reading position from metadata ledger {} for cursor {}: {}",
-                                                managedLedgerName, ledgerId, cursorName, e);
-                                            offlineTopicStats.addCursorDetails(cursorName, errorInReadingCursor,
-                                                    lh.getId());
-                                            return;
-                                        }
-                                        final Position lastAckedMessagePosition =
-                                                PositionFactory.create(positionInfo.getLedgerId(),
-                                                        positionInfo.getEntryId());
-                                        if (log.isDebugEnabled()) {
-                                            log.debug("[{}] Cursor {} MD {} read last ledger position {}",
-                                                    managedLedgerName, cursorName, lastAckedMessagePosition,
-                                                    lastLedgerPosition);
-                                        }
-                                        // calculate cursor backlog
-                                        Range<Position> range = Range.openClosed(lastAckedMessagePosition,
-                                                lastLedgerPosition);
-                                        if (log.isDebugEnabled()) {
-                                            log.debug("[{}] Calculating backlog for cursor {} using range {}",
-                                                    managedLedgerName, cursorName, range);
-                                        }
-                                        long cursorBacklog = getNumberOfEntries(range, ledgers);
-                                        offlineTopicStats.messageBacklog += cursorBacklog;
-                                        offlineTopicStats.addCursorDetails(cursorName, cursorBacklog, lh.getId());
-                                    }
-                                } finally {
-                                    cursorCounter.countDown();
-                                }
-                            }
-                        }, null);
-
-                    }; // end of cursor meta read callback
-
-                    store.asyncGetCursorInfo(managedLedgerName, cursorName,
-                            new MetaStore.MetaStoreCallback<MLDataFormats.ManagedCursorInfo>() {
-                                @Override
-                                public void operationComplete(MLDataFormats.ManagedCursorInfo info,
-                                        Stat stat) {
-                                    long cursorLedgerId = info.getCursorsLedgerId();
-                                    if (log.isDebugEnabled()) {
-                                        log.debug("[{}] Cursor {} meta-data read ledger id {}", managedLedgerName,
-                                                cursorName, cursorLedgerId);
-                                    }
-                                    if (cursorLedgerId != -1) {
-                                        bk.asyncOpenLedgerNoRecovery(cursorLedgerId, digestType, password,
-                                                cursorLedgerOpenCb, null);
-                                    } else {
-                                        Position lastAckedMessagePosition = PositionFactory.create(
-                                                info.getMarkDeleteLedgerId(), info.getMarkDeleteEntryId());
-                                        Range<Position> range = Range.openClosed(lastAckedMessagePosition,
-                                                lastLedgerPosition);
-                                        if (log.isDebugEnabled()) {
-                                            log.debug("[{}] Calculating backlog for cursor {} using range {}",
-                                                    managedLedgerName, cursorName, range);
-                                        }
-                                        long cursorBacklog = getNumberOfEntries(range, ledgers);
-                                        offlineTopicStats.messageBacklog += cursorBacklog;
-                                        offlineTopicStats.addCursorDetails(cursorName, cursorBacklog, cursorLedgerId);
-                                        cursorCounter.countDown();
-                                    }
-
-                                }
-
-                                @Override
-                                public void operationFailed(ManagedLedgerException.MetaStoreException e) {
-                                    log.warn("[{}] Unable to obtain cursor ledger for cursor {}: {}", managedLedgerName,
-                                            cursorName, e);
-                                    cursorCounter.countDown();
-                                }
-                            });
-                } // for every cursor find backlog
-                try {
-                    if (accurate) {
-                        cursorCounter.await();
-                    } else {
-                        cursorCounter.await(META_READ_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-                    }
-                } catch (Exception e) {
-                    log.warn("[{}] Error reading subscription positions{}", managedLedgerName, e);
-                } finally {
-                    allCursorsCounter.countDown();
-                }
-            }
-
-            @Override
-            public void operationFailed(ManagedLedgerException.MetaStoreException e) {
-                log.warn("[{}] Failed to get the cursors list", managedLedgerName, e);
-                allCursorsCounter.countDown();
-            }
-        });
-        if (accurate) {
-            allCursorsCounter.await();
-        } else {
-            allCursorsCounter.await(META_READ_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        }
-
-        // go through ledgers where LAC was -1
-        if (accurate && ledgerRetryMap.size() > 0) {
-            ledgerRetryMap.forEach((cursorName, ledgerId) -> {
-                if (log.isDebugEnabled()) {
-                    log.debug("Cursor {} Ledger {} Trying to obtain MD from BkAdmin", cursorName, ledgerId);
-                }
-                Position lastAckedMessagePosition = tryGetMDPosition(bk, ledgerId, cursorName);
-                if (lastAckedMessagePosition == null) {
-                    log.warn("[{}] Cursor {} read from ledger {}. Unable to determine cursor position",
-                            managedLedgerName, cursorName, ledgerId);
-                } else {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Cursor {} read from ledger using bk admin {}. position {}", managedLedgerName,
-                                cursorName, ledgerId, lastAckedMessagePosition);
-                    }
-                    // calculate cursor backlog
-                    Range<Position> range = Range.openClosed(lastAckedMessagePosition, lastLedgerPosition);
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Calculating backlog for cursor {} using range {}", managedLedgerName,
-                                cursorName, range);
-                    }
-                    long cursorBacklog = getNumberOfEntries(range, ledgers);
-                    offlineTopicStats.messageBacklog += cursorBacklog;
-                    offlineTopicStats.addCursorDetails(cursorName, cursorBacklog, ledgerId);
-                }
-            });
-        }
-    }
-
-    private Position tryGetMDPosition(BookKeeper bookKeeper, long ledgerId, String cursorName) {
-        BookKeeperAdmin bookKeeperAdmin = null;
-        long lastEntry = LedgerHandle.INVALID_ENTRY_ID;
-        Position lastAckedMessagePosition = null;
-        try {
-            bookKeeperAdmin = new BookKeeperAdmin(bookKeeper);
-            for (LedgerEntry ledgerEntry : bookKeeperAdmin.readEntries(ledgerId, 0, lastEntry)) {
-                lastEntry = ledgerEntry.getEntryId();
-                if (log.isDebugEnabled()) {
-                    log.debug(" Read entry {} from ledger {} for cursor {}", lastEntry, ledgerId, cursorName);
-                }
-                MLDataFormats.PositionInfo positionInfo = MLDataFormats.PositionInfo.parseFrom(ledgerEntry.getEntry());
-                lastAckedMessagePosition =
-                        PositionFactory.create(positionInfo.getLedgerId(), positionInfo.getEntryId());
-                if (log.isDebugEnabled()) {
-                    log.debug("Cursor {} read position {}", cursorName, lastAckedMessagePosition);
-                }
-            }
-        } catch (Exception e) {
-            log.warn("Unable to determine LAC for ledgerId {} for cursor {}: {}", ledgerId, cursorName, e);
-        } finally {
-            if (bookKeeperAdmin != null) {
-                try {
-                    bookKeeperAdmin.close();
-                } catch (Exception e) {
-                    log.warn("Unable to close bk admin for ledgerId {} for cursor {}", ledgerId, cursorName, e);
-                }
-            }
-
-        }
-        return lastAckedMessagePosition;
     }
 
     private static final Logger log = LoggerFactory.getLogger(ManagedLedgerOfflineBacklog.class);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -45,7 +45,7 @@ import org.apache.bookkeeper.mledger.intercept.ManagedLedgerInterceptor;
  *
  */
 @Slf4j
-public class OpAddEntry implements AddCallback, CloseCallback, Runnable {
+public class OpAddEntry implements AddCallback, CloseCallback, Runnable, ManagedLedgerInterceptor.AddEntryOperation {
     protected ManagedLedgerImpl ml;
     LedgerHandle ledger;
     long entryId;
@@ -139,8 +139,8 @@ public class OpAddEntry implements AddCallback, CloseCallback, Runnable {
             lastInitTime = System.nanoTime();
             if (ml.getManagedLedgerInterceptor() != null) {
                 long originalDataLen = data.readableBytes();
-                payloadProcessorHandle = ml.getManagedLedgerInterceptor().processPayloadBeforeLedgerWrite(this,
-                        duplicateBuffer);
+                payloadProcessorHandle = ml.getManagedLedgerInterceptor()
+                        .processPayloadBeforeLedgerWrite(this.getCtx(), duplicateBuffer);
                 if (payloadProcessorHandle != null) {
                     duplicateBuffer = payloadProcessorHandle.getProcessedPayload();
                     // If data len of entry changes, correct "dataLength" and "currentLedgerSize".

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpFindNewest.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpFindNewest.java
@@ -26,7 +26,7 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntryCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.PositionBound;
+import org.apache.bookkeeper.mledger.PositionBound;
 
 @Slf4j
 class OpFindNewest implements ReadEntryCallback {
@@ -97,7 +97,7 @@ class OpFindNewest implements ReadEntryCallback {
                 searchPosition = ledger.getPositionAfterN(searchPosition, max, PositionBound.startExcluded);
                 Position lastPosition = ledger.getLastPosition();
                 searchPosition =
-                        ledger.getPositionAfterN(searchPosition, max, ManagedLedgerImpl.PositionBound.startExcluded);
+                        ledger.getPositionAfterN(searchPosition, max, PositionBound.startExcluded);
                 if (lastPosition.compareTo(searchPosition) < 0) {
                     if (log.isDebugEnabled()) {
                         log.debug("first position {} matches, last should be {}, but moving to lastPos {}", position,

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpScan.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpScan.java
@@ -29,6 +29,7 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.ScanCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.PositionBound;
 import org.apache.bookkeeper.mledger.ScanOutcome;
 
 @Slf4j
@@ -88,7 +89,7 @@ class OpScan implements ReadEntriesCallback {
                 }
             }
             searchPosition = ledger.getPositionAfterN(lastPositionForBatch, 1,
-                    ManagedLedgerImpl.PositionBound.startExcluded);
+                    PositionBound.startExcluded);
             if (log.isDebugEnabled()) {
                 log.debug("readEntryComplete {} at {} next is {}", lastPositionForBatch, searchPosition);
             }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpenTelemetryManagedCursorStats.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpenTelemetryManagedCursorStats.java
@@ -23,6 +23,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.BatchCallback;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.pulsar.opentelemetry.Constants;
 
 public class OpenTelemetryManagedCursorStats implements AutoCloseable {
@@ -98,7 +99,7 @@ public class OpenTelemetryManagedCursorStats implements AutoCloseable {
         batchCallback = meter.batchCallback(() -> factory.getManagedLedgers()
                         .values()
                         .stream()
-                        .map(ManagedLedgerImpl::getCursors)
+                        .map(ManagedLedger::getCursors)
                         .flatMap(Streams::stream)
                         .forEach(this::recordMetrics),
                 persistOperationCounter,

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpenTelemetryManagedLedgerStats.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpenTelemetryManagedLedgerStats.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.mledger.impl;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.BatchCallback;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.pulsar.opentelemetry.Constants;
 
 public class OpenTelemetryManagedLedgerStats implements AutoCloseable {
@@ -130,8 +131,8 @@ public class OpenTelemetryManagedLedgerStats implements AutoCloseable {
         batchCallback.close();
     }
 
-    private void recordMetrics(ManagedLedgerImpl ml) {
-        var stats = ml.getMbean();
+    private void recordMetrics(ManagedLedger ml) {
+        var stats = ml.getStats();
         var ledgerAttributeSet = ml.getManagedLedgerAttributes();
         var attributes = ledgerAttributeSet.getAttributes();
         var attributesSucceed = ledgerAttributeSet.getAttributesOperationSucceed();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorImpl.java
@@ -23,9 +23,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.PositionBound;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.bookkeeper.mledger.ReadOnlyCursor;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.PositionBound;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 
 @Slf4j

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
@@ -43,12 +43,12 @@ import org.apache.pulsar.metadata.api.Stat;
 public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
 
     public ReadOnlyManagedLedgerImpl(ManagedLedgerFactoryImpl factory, BookKeeper bookKeeper, MetaStore store,
-            ManagedLedgerConfig config, OrderedScheduler scheduledExecutor,
-            String name) {
+                                     ManagedLedgerConfig config, OrderedScheduler scheduledExecutor,
+                                     String name) {
         super(factory, bookKeeper, store, config, scheduledExecutor, name);
     }
 
-    CompletableFuture<Void> initialize() {
+    public CompletableFuture<Void> initialize() {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
         // Fetch the list of existing ledgers in the managed ledger
@@ -128,7 +128,7 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
         return future;
     }
 
-    ReadOnlyCursor createReadOnlyCursor(Position startPosition) {
+    public ReadOnlyCursor createReadOnlyCursor(Position startPosition) {
         if (ledgers.isEmpty()) {
             lastConfirmedEntry = PositionFactory.EARLIEST;
         } else if (ledgers.lastEntry().getValue().getEntries() > 0) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ShadowManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ShadowManagedLedgerImpl.java
@@ -131,7 +131,8 @@ public class ShadowManagedLedgerImpl extends ManagedLedgerImpl {
                         currentLedger = lh;
 
                         if (managedLedgerInterceptor != null) {
-                            managedLedgerInterceptor.onManagedLedgerLastLedgerInitialize(name, lh)
+                            managedLedgerInterceptor
+                                    .onManagedLedgerLastLedgerInitialize(name, createLastEntryHandle(lh))
                                     .thenRun(() -> ShadowManagedLedgerImpl.super.initialize(callback, ctx))
                                     .exceptionally(ex -> {
                                         callback.initializeFailed(

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/intercept/ManagedLedgerInterceptor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/intercept/ManagedLedgerInterceptor.java
@@ -24,7 +24,6 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
-import org.apache.bookkeeper.mledger.impl.OpAddEntry;
 
 /**
  * Interceptor for ManagedLedger.
@@ -32,14 +31,34 @@ import org.apache.bookkeeper.mledger.impl.OpAddEntry;
 @InterfaceAudience.LimitedPrivate
 @InterfaceStability.Stable
 public interface ManagedLedgerInterceptor {
+    /**
+     * An operation to add an entry to a ledger.
+     */
+    interface AddEntryOperation {
+        /**
+         * Get the data to be written to the ledger.
+         * @return data to be written to the ledger
+         */
+        ByteBuf getData();
+        /**
+         * Set the data to be written to the ledger.
+         * @param data data to be written to the ledger
+         */
+        void setData(ByteBuf data);
+        /**
+         * Get the operation context object.
+         * @return context the context object
+         */
+        Object getCtx();
+    }
 
     /**
-     * Intercept an OpAddEntry and return an OpAddEntry.
-     * @param op an OpAddEntry to be intercepted.
+     * Intercept adding an entry to a ledger.
+     *
+     * @param op an operation to be intercepted.
      * @param numberOfMessages
-     * @return an OpAddEntry.
      */
-    OpAddEntry beforeAddEntry(OpAddEntry op, int numberOfMessages);
+    void beforeAddEntry(AddEntryOperation op, int numberOfMessages);
 
     /**
      * Intercept When add entry failed.
@@ -93,12 +112,12 @@ public interface ManagedLedgerInterceptor {
 
     /**
      * Intercept before payload gets written to ledger.
-     * @param ledgerWriteOp OpAddEntry used to trigger ledger write.
+     * @param ctx the operation context object
      * @param dataToBeStoredInLedger data to be stored in ledger
      * @return handle to the processor
      */
-    default PayloadProcessorHandle processPayloadBeforeLedgerWrite(OpAddEntry ledgerWriteOp,
-                                                                   ByteBuf dataToBeStoredInLedger){
+    default PayloadProcessorHandle processPayloadBeforeLedgerWrite(Object ctx,
+                                                                   ByteBuf dataToBeStoredInLedger) {
         return null;
     }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/intercept/ManagedLedgerInterceptor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/intercept/ManagedLedgerInterceptor.java
@@ -20,10 +20,11 @@ package org.apache.bookkeeper.mledger.intercept;
 
 import io.netty.buffer.ByteBuf;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
+import org.apache.bookkeeper.mledger.Entry;
 
 /**
  * Interceptor for ManagedLedger.
@@ -75,11 +76,24 @@ public interface ManagedLedgerInterceptor {
     void onManagedLedgerPropertiesInitialize(Map<String, String> propertiesMap);
 
     /**
-     * Intercept when ManagedLedger is initialized.
-     * @param name name of ManagedLedger
-     * @param ledgerHandle a LedgerHandle.
+     * A handle for reading the last ledger entry.
      */
-    CompletableFuture<Void> onManagedLedgerLastLedgerInitialize(String name, LedgerHandle ledgerHandle);
+    interface LastEntryHandle {
+        /**
+         * Read the last entry from the ledger.
+         * The caller is responsible for releasing the entry.
+         * @return the last entry from the ledger, if any
+         */
+        CompletableFuture<Optional<Entry>> readLastEntryAsync();
+    }
+
+    /**
+     * Intercept when ManagedLedger is initialized.
+     *
+     * @param name            name of ManagedLedger
+     * @param lastEntryHandle a LedgerHandle.
+     */
+    CompletableFuture<Void> onManagedLedgerLastLedgerInitialize(String name, LastEntryHandle lastEntryHandle);
 
     /**
      * @param propertiesMap  map of properties.

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -47,8 +47,10 @@ import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedCursorMXBean;
 import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
+import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats;
 import org.testng.annotations.Test;
 
 public class ManagedCursorContainerTest {
@@ -408,6 +410,36 @@ public class ManagedCursorContainerTest {
         @Override
         public boolean isClosed() {
             return false;
+        }
+
+        @Override
+        public ManagedLedgerInternalStats.CursorStats getCursorStats() {
+            return null;
+        }
+
+        @Override
+        public boolean isMessageDeleted(Position position) {
+            return false;
+        }
+
+        @Override
+        public ManagedCursor duplicateNonDurableCursor(String nonDurableCursorName) throws ManagedLedgerException {
+            return null;
+        }
+
+        @Override
+        public long[] getBatchPositionAckSet(Position position) {
+            return new long[0];
+        }
+
+        @Override
+        public int applyMaxSizeCap(int maxEntries, long maxSizeBytes) {
+            return 0;
+        }
+
+        @Override
+        public void updateReadStats(int readEntriesCount, long readEntriesSize) {
+
         }
     }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorPropertiesTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorPropertiesTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
-import static org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.CURSOR_INTERNAL_PROPERTY_PREFIX;
+import static org.apache.bookkeeper.mledger.ManagedCursor.CURSOR_INTERNAL_PROPERTY_PREFIX;
 import static org.apache.bookkeeper.mledger.util.Futures.executeWithRetry;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -123,6 +123,7 @@ import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactoryConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactoryMXBean;
 import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.PositionBound;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.VoidCallback;
 import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
@@ -2178,7 +2179,9 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         ledger.addEntry("data".getBytes());
 
         // After the re-establishment, we'll be creating new ledgers
-        assertEquals(ledger.getLedgersInfoAsList().size(), 3);
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertEquals(ledger.getLedgersInfoAsList().size(), 4);
+        });
     }
 
     @Test
@@ -2595,11 +2598,11 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
         Position startPosition = PositionFactory.create(firstLedger, 0);
 
-        Position targetPosition = managedLedger.getPositionAfterN(startPosition, 1, ManagedLedgerImpl.PositionBound.startExcluded);
+        Position targetPosition = managedLedger.getPositionAfterN(startPosition, 1, PositionBound.startExcluded);
         assertEquals(targetPosition.getLedgerId(), firstLedger);
         assertEquals(targetPosition.getEntryId(), 1);
 
-        targetPosition = managedLedger.getPositionAfterN(startPosition, 4, ManagedLedgerImpl.PositionBound.startExcluded);
+        targetPosition = managedLedger.getPositionAfterN(startPosition, 4, PositionBound.startExcluded);
         assertEquals(targetPosition.getLedgerId(), firstLedger);
         assertEquals(targetPosition.getEntryId(), 4);
 
@@ -2607,25 +2610,25 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         Position searchPosition = managedLedger.getNextValidPosition(managedCursor.getMarkDeletedPosition());
         long length = managedCursor.getNumberOfEntriesInStorage();
         // return the last confirm entry position if searchPosition is exceed the last confirm entry
-        targetPosition = managedLedger.getPositionAfterN(searchPosition, length, ManagedLedgerImpl.PositionBound.startExcluded);
+        targetPosition = managedLedger.getPositionAfterN(searchPosition, length, PositionBound.startExcluded);
         log.info("Target position is {}", targetPosition);
         assertEquals(targetPosition.getLedgerId(), secondLedger);
         assertEquals(targetPosition.getEntryId(), 4);
 
         // test for n > NumberOfEntriesInStorage
         searchPosition = PositionFactory.create(secondLedger, 0);
-        targetPosition = managedLedger.getPositionAfterN(searchPosition, 100, ManagedLedgerImpl.PositionBound.startIncluded);
+        targetPosition = managedLedger.getPositionAfterN(searchPosition, 100, PositionBound.startIncluded);
         assertEquals(targetPosition.getLedgerId(), secondLedger);
         assertEquals(targetPosition.getEntryId(), 4);
 
         // test for startPosition > current ledger
         searchPosition = PositionFactory.create(999, 0);
-        targetPosition = managedLedger.getPositionAfterN(searchPosition, 0, ManagedLedgerImpl.PositionBound.startIncluded);
+        targetPosition = managedLedger.getPositionAfterN(searchPosition, 0, PositionBound.startIncluded);
         assertEquals(targetPosition.getLedgerId(), secondLedger);
         assertEquals(targetPosition.getEntryId(), 4);
 
         searchPosition = PositionFactory.create(999, 0);
-        targetPosition = managedLedger.getPositionAfterN(searchPosition, 10, ManagedLedgerImpl.PositionBound.startExcluded);
+        targetPosition = managedLedger.getPositionAfterN(searchPosition, 10, PositionBound.startExcluded);
         assertEquals(targetPosition.getLedgerId(), secondLedger);
         assertEquals(targetPosition.getEntryId(), 4);
     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImplTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImplTest.java
@@ -31,6 +31,7 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.ReadOnlyManagedLedger;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
 import org.testng.annotations.Test;
 
@@ -56,7 +57,7 @@ public class ReadOnlyManagedLedgerImplTest extends MockedBookKeeperTestCase {
         factory.asyncOpenReadOnlyManagedLedger(MANAGED_LEDGER_NAME_ATTACHED_PROPERTIES,
                 new AsyncCallbacks.OpenReadOnlyManagedLedgerCallback() {
                     @Override
-                    public void openReadOnlyManagedLedgerComplete(ReadOnlyManagedLedgerImpl managedLedger,
+                    public void openReadOnlyManagedLedgerComplete(ReadOnlyManagedLedger managedLedger,
                                                                   Object ctx) {
                         managedLedger.getProperties().forEach((key, value) -> {
                             assertEquals(key, propertiesKey);
@@ -85,7 +86,7 @@ public class ReadOnlyManagedLedgerImplTest extends MockedBookKeeperTestCase {
         factory.asyncOpenReadOnlyManagedLedger(MANAGED_LEDGER_NAME_NON_PROPERTIES,
                 new AsyncCallbacks.OpenReadOnlyManagedLedgerCallback() {
                     @Override
-                    public void openReadOnlyManagedLedgerComplete(ReadOnlyManagedLedgerImpl managedLedger,
+                    public void openReadOnlyManagedLedgerComplete(ReadOnlyManagedLedger managedLedger,
                                                                   Object ctx) {
                         assertEquals(managedLedger.getProperties().size(), 0);
                         future.complete(null);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -220,6 +221,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     private StrategicTwoPhaseCompactor strategicCompactor;
     private ResourceUsageTransportManager resourceUsageTransportManager;
     private ResourceGroupService resourceGroupServiceManager;
+    private final Clock clock;
 
     private final ScheduledExecutorService executor;
 
@@ -340,6 +342,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         PulsarConfigurationLoader.isComplete(config);
         TransactionBatchedWriteValidator.validate(config);
         this.config = config;
+        this.clock = Clock.systemUTC();
 
         this.openTelemetry = new PulsarBrokerOpenTelemetry(config, openTelemetrySdkBuilderCustomizer);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -66,8 +66,6 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.bookkeeper.mledger.ScanOutcome;
 import org.apache.bookkeeper.mledger.impl.AckSetStateUtil;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerOfflineBacklog;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -2622,7 +2620,7 @@ public class PersistentTopicsBase extends AdminResource {
                                    MessageIdImpl messageId, int batchIndex) {
         if (batchIndex >= 0) {
             try {
-                ManagedLedgerImpl ledger = (ManagedLedgerImpl) topic.getManagedLedger();
+                ManagedLedger ledger = topic.getManagedLedger();
                 ledger.asyncReadEntry(PositionFactory.create(messageId.getLedgerId(),
                         messageId.getEntryId()), new AsyncCallbacks.ReadEntryCallback() {
                     @Override
@@ -2733,8 +2731,7 @@ public class PersistentTopicsBase extends AdminResource {
         .thenCompose(__ -> getTopicReferenceAsync(topicName))
         .thenCompose(topic -> {
             CompletableFuture<Response> results = new CompletableFuture<>();
-            ManagedLedgerImpl ledger =
-                    (ManagedLedgerImpl) ((PersistentTopic) topic).getManagedLedger();
+            ManagedLedger ledger = ((PersistentTopic) topic).getManagedLedger();
             ledger.asyncReadEntry(PositionFactory.create(ledgerId, entryId),
                     new AsyncCallbacks.ReadEntryCallback() {
                         @Override
@@ -3173,7 +3170,7 @@ public class PersistentTopicsBase extends AdminResource {
                                 try {
                                     PersistentOfflineTopicStats estimateOfflineTopicStats =
                                             offlineTopicBacklog.estimateUnloadedTopicBacklog(
-                                                    (ManagedLedgerFactoryImpl) pulsar().getManagedLedgerFactory(),
+                                                    pulsar().getManagedLedgerFactory(),
                                                     topicName);
                                     pulsar().getBrokerService()
                                             .cacheOfflineTopicStats(topicName, estimateOfflineTopicStats);
@@ -3248,8 +3245,7 @@ public class PersistentTopicsBase extends AdminResource {
                         getTopicNotFoundErrorMessage(topicName.toString())));
                 return;
             }
-            ManagedLedgerImpl managedLedger =
-                    (ManagedLedgerImpl) topic.getManagedLedger();
+            ManagedLedger managedLedger = topic.getManagedLedger();
             if (messageId.getLedgerId() == -1) {
                 asyncResponse.resume(managedLedger.getTotalSize());
             } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
@@ -19,7 +19,7 @@
 package org.apache.pulsar.broker.delayed.bucket;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.CURSOR_INTERNAL_PROPERTY_PREFIX;
+import static org.apache.bookkeeper.mledger.ManagedCursor.CURSOR_INTERNAL_PROPERTY_PREFIX;
 import static org.apache.pulsar.broker.delayed.bucket.Bucket.DELIMITER;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashBasedTable;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
@@ -23,8 +23,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import org.apache.bookkeeper.client.LedgerHandle;
-import org.apache.bookkeeper.client.api.LedgerEntry;
+import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.intercept.ManagedLedgerInterceptor;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.pulsar.common.api.proto.BrokerEntryMetadata;
@@ -113,43 +112,22 @@ public class ManagedLedgerInterceptorImpl implements ManagedLedgerInterceptor {
     }
 
     @Override
-    public CompletableFuture<Void> onManagedLedgerLastLedgerInitialize(String name, LedgerHandle lh) {
-        CompletableFuture<Void> promise = new CompletableFuture<>();
-        boolean hasAppendIndexMetadataInterceptor = appendIndexMetadataInterceptor != null;
-        if (hasAppendIndexMetadataInterceptor && lh.getLastAddConfirmed() >= 0) {
-            lh.readAsync(lh.getLastAddConfirmed(), lh.getLastAddConfirmed()).whenComplete((entries, ex) -> {
-                if (ex != null) {
-                    log.error("[{}] Read last entry error.", name, ex);
-                    promise.completeExceptionally(ex);
-                } else {
-                    if (entries != null) {
-                        try {
-                            LedgerEntry ledgerEntry = entries.getEntry(lh.getLastAddConfirmed());
-                            if (ledgerEntry != null) {
-                                BrokerEntryMetadata brokerEntryMetadata =
-                                        Commands.parseBrokerEntryMetadataIfExist(ledgerEntry.getEntryBuffer());
-                                if (brokerEntryMetadata != null && brokerEntryMetadata.hasIndex()) {
-                                    appendIndexMetadataInterceptor.recoveryIndexGenerator(
-                                            brokerEntryMetadata.getIndex());
-                                }
-                            }
-                            entries.close();
-                            promise.complete(null);
-                        } catch (Exception e) {
-                            entries.close();
-                            log.error("[{}] Failed to recover the index generator from the last add confirmed entry.",
-                                    name, e);
-                            promise.completeExceptionally(e);
-                        }
-                    } else {
-                        promise.complete(null);
+    public CompletableFuture<Void> onManagedLedgerLastLedgerInitialize(String name, LastEntryHandle lh) {
+        return lh.readLastEntryAsync().thenAccept(lastEntryOptional -> {
+            if (lastEntryOptional.isPresent()) {
+                Entry lastEntry = lastEntryOptional.get();
+                try {
+                    BrokerEntryMetadata brokerEntryMetadata =
+                            Commands.parseBrokerEntryMetadataIfExist(lastEntry.getDataBuffer());
+                    if (brokerEntryMetadata != null && brokerEntryMetadata.hasIndex()) {
+                        appendIndexMetadataInterceptor.recoveryIndexGenerator(
+                                brokerEntryMetadata.getIndex());
                     }
+                } finally {
+                    lastEntry.release();
                 }
-            });
-        } else {
-            promise.complete(null);
-        }
-        return promise;
+            }
+        });
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.api.LedgerEntry;
-import org.apache.bookkeeper.mledger.impl.OpAddEntry;
 import org.apache.bookkeeper.mledger.intercept.ManagedLedgerInterceptor;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.pulsar.common.api.proto.BrokerEntryMetadata;
@@ -85,12 +84,11 @@ public class ManagedLedgerInterceptorImpl implements ManagedLedgerInterceptor {
     }
 
     @Override
-    public OpAddEntry beforeAddEntry(OpAddEntry op, int numberOfMessages) {
+    public void beforeAddEntry(AddEntryOperation op, int numberOfMessages) {
        if (op == null || numberOfMessages <= 0) {
-           return op;
+           return;
        }
         op.setData(Commands.addBrokerEntryMetadata(op.getData(), brokerEntryMetadataInterceptors, numberOfMessages));
-        return op;
     }
 
     @Override
@@ -189,11 +187,11 @@ public class ManagedLedgerInterceptorImpl implements ManagedLedgerInterceptor {
         };
     }
     @Override
-    public PayloadProcessorHandle processPayloadBeforeLedgerWrite(OpAddEntry op, ByteBuf ledgerData) {
+    public PayloadProcessorHandle processPayloadBeforeLedgerWrite(Object ctx, ByteBuf ledgerData) {
         if (this.inputProcessors == null || this.inputProcessors.size() == 0) {
             return null;
         }
-        return processPayload(this.inputProcessors, op.getCtx(), ledgerData);
+        return processPayload(this.inputProcessors, ctx, ledgerData);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -23,6 +23,7 @@ import static java.util.Objects.requireNonNull;
 import static org.apache.bookkeeper.mledger.impl.ManagedLedgerMBeanImpl.ENTRY_LATENCY_BUCKETS_USEC;
 import static org.apache.pulsar.compaction.Compactor.COMPACTION_SUBSCRIPTION;
 import com.google.common.base.MoreObjects;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -164,11 +165,13 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
     protected volatile Pair<String, List<EntryFilter>> entryFilters;
     protected volatile boolean transferring = false;
     private volatile List<PublishRateLimiter> activeRateLimiters;
+    protected final Clock clock;
 
     protected Set<String> additionalSystemCursorNames = new TreeSet<>();
 
     public AbstractTopic(String topic, BrokerService brokerService) {
         this.topic = topic;
+        this.clock = brokerService.getClock();
         this.brokerService = brokerService;
         this.producers = new ConcurrentHashMap<>();
         this.isFenced = false;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -27,10 +27,10 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedCursor.IndividualDeletedEntries;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
-import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.resources.NamespaceResources;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -132,7 +132,7 @@ public class BacklogQuotaManager {
 
         // Get estimated unconsumed size for the managed ledger associated with this topic. Estimated size is more
         // useful than the actual storage size. Actual storage size gets updated only when managed ledger is trimmed.
-        ManagedLedgerImpl mLedger = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
+        ManagedLedger mLedger = persistentTopic.getManagedLedger();
         long backlogSize = mLedger.getEstimatedBacklogSize();
 
         if (log.isDebugEnabled()) {
@@ -214,29 +214,30 @@ public class BacklogQuotaManager {
             );
         } else {
             // If disabled precise time based backlog quota check, will try to remove whole ledger from cursor's backlog
-            long currentMillis = ((ManagedLedgerImpl) persistentTopic.getManagedLedger()).getClock().millis();
-            ManagedLedgerImpl mLedger = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
+            long currentMillis = persistentTopic.getManagedLedger().getConfig().getClock().millis();
+            ManagedLedger mLedger = persistentTopic.getManagedLedger();
             try {
                 for (; ; ) {
                     ManagedCursor slowestConsumer = mLedger.getSlowestConsumer();
                     Position oldestPosition = slowestConsumer.getMarkDeletedPosition();
                     if (log.isDebugEnabled()) {
                         log.debug("[{}] slowest consumer mark delete position is [{}], read position is [{}]",
-                                slowestConsumer.getName(), oldestPosition, slowestConsumer.getReadPosition());
+                            slowestConsumer.getName(), oldestPosition, slowestConsumer.getReadPosition());
                     }
-                    ManagedLedgerInfo.LedgerInfo ledgerInfo = mLedger.getLedgerInfo(oldestPosition.getLedgerId()).get();
+                    MLDataFormats.ManagedLedgerInfo.LedgerInfo ledgerInfo =
+                        mLedger.getLedgerInfo(oldestPosition.getLedgerId()).get();
                     if (ledgerInfo == null) {
-                        Position nextPosition =
-                                PositionFactory.create(mLedger.getNextValidLedger(oldestPosition.getLedgerId()), -1);
+                        long ledgerId = mLedger.getLedgersInfo().ceilingKey(oldestPosition.getLedgerId() + 1);
+                        Position nextPosition = PositionFactory.create(ledgerId, -1);
                         slowestConsumer.markDelete(nextPosition);
                         continue;
                     }
                     // Timestamp only > 0 if ledger has been closed
                     if (ledgerInfo.getTimestamp() > 0
-                            && currentMillis - ledgerInfo.getTimestamp() > SECONDS.toMillis(quota.getLimitTime())) {
+                        && currentMillis - ledgerInfo.getTimestamp() > SECONDS.toMillis(quota.getLimitTime())) {
                         // skip whole ledger for the slowest cursor
-                        Position nextPosition =
-                                PositionFactory.create(mLedger.getNextValidLedger(ledgerInfo.getLedgerId()), -1);
+                        long ledgerId = mLedger.getLedgersInfo().ceilingKey(oldestPosition.getLedgerId() + 1);
+                        Position nextPosition = PositionFactory.create(ledgerId, -1);
                         if (!nextPosition.equals(oldestPosition)) {
                             slowestConsumer.markDelete(nextPosition);
                             continue;
@@ -246,7 +247,7 @@ public class BacklogQuotaManager {
                 }
             } catch (Exception e) {
                 log.error("[{}] Error resetting cursor for slowest consumer [{}]", persistentTopic.getName(),
-                        mLedger.getSlowestConsumer().getName(), e);
+                    mLedger.getSlowestConsumer().getName(), e);
             }
         }
     }
@@ -285,7 +286,7 @@ public class BacklogQuotaManager {
      */
     private boolean advanceSlowestSystemCursor(PersistentTopic persistentTopic) {
 
-        ManagedLedgerImpl mLedger = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
+        ManagedLedger mLedger = persistentTopic.getManagedLedger();
         ManagedCursor slowestConsumer = mLedger.getSlowestConsumer();
         if (slowestConsumer == null) {
             return false;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -288,6 +289,7 @@ public class BrokerService implements Closeable {
     private final int keepAliveIntervalSeconds;
     private final PulsarStats pulsarStats;
     private final AuthenticationService authenticationService;
+    private final Clock clock;
 
     public static final String MANAGED_LEDGER_PATH_ZNODE = "/managed-ledgers";
 
@@ -327,6 +329,7 @@ public class BrokerService implements Closeable {
 
     public BrokerService(PulsarService pulsar, EventLoopGroup eventLoopGroup) throws Exception {
         this.pulsar = pulsar;
+        this.clock = pulsar.getClock();
         this.dynamicConfigurationMap = prepareDynamicConfigurationMap();
         this.brokerPublishRateLimiter = new PublishRateLimiterImpl(pulsar.getMonotonicSnapshotClock());
         this.preciseTopicPublishRateLimitingEnable =

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
@@ -28,13 +28,12 @@ import javax.annotation.Nullable;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.FindEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.MarkDeleteCallback;
 import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.LedgerNotExistException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.NonRecoverableLedgerException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
-import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.pulsar.broker.service.MessageExpirer;
 import org.apache.pulsar.client.impl.MessageImpl;
@@ -113,27 +112,25 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
         if (messageTTLInSeconds <= 0) {
             return;
         }
-        if (cursor instanceof ManagedCursorImpl managedCursor) {
-            ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) managedCursor.getManagedLedger();
-            Position deletedPosition = managedCursor.getMarkDeletedPosition();
-            SortedMap<Long, MLDataFormats.ManagedLedgerInfo.LedgerInfo> ledgerInfoSortedMap =
-                    managedLedger.getLedgersInfo().subMap(deletedPosition.getLedgerId(), true,
-                            managedLedger.getLedgersInfo().lastKey(), true);
-            MLDataFormats.ManagedLedgerInfo.LedgerInfo info = null;
-            for (MLDataFormats.ManagedLedgerInfo.LedgerInfo ledgerInfo : ledgerInfoSortedMap.values()) {
-                if (!ledgerInfo.hasTimestamp() || ledgerInfo.getTimestamp() == 0L
-                        || !MessageImpl.isEntryExpired(messageTTLInSeconds, ledgerInfo.getTimestamp())) {
-                    break;
-                }
-                info = ledgerInfo;
+        ManagedLedger managedLedger = cursor.getManagedLedger();
+        Position deletedPosition = cursor.getMarkDeletedPosition();
+        SortedMap<Long, MLDataFormats.ManagedLedgerInfo.LedgerInfo> ledgerInfoSortedMap =
+                managedLedger.getLedgersInfo().subMap(deletedPosition.getLedgerId(), true,
+                        managedLedger.getLedgersInfo().lastKey(), true);
+        MLDataFormats.ManagedLedgerInfo.LedgerInfo info = null;
+        for (MLDataFormats.ManagedLedgerInfo.LedgerInfo ledgerInfo : ledgerInfoSortedMap.values()) {
+            if (!ledgerInfo.hasTimestamp() || ledgerInfo.getTimestamp() == 0L
+                    || !MessageImpl.isEntryExpired(messageTTLInSeconds, ledgerInfo.getTimestamp())) {
+                break;
             }
-            if (info != null && info.getLedgerId() > -1) {
-                Position position = PositionFactory.create(info.getLedgerId(), info.getEntries() - 1);
-                if (managedLedger.getLastConfirmedEntry().compareTo(position) < 0) {
-                    findEntryComplete(managedLedger.getLastConfirmedEntry(), null);
-                } else {
-                    findEntryComplete(position, null);
-                }
+            info = ledgerInfo;
+        }
+        if (info != null && info.getLedgerId() > -1) {
+            Position position = PositionFactory.create(info.getLedgerId(), info.getEntries() - 1);
+            if (managedLedger.getLastConfirmedEntry().compareTo(position) < 0) {
+                findEntryComplete(managedLedger.getLastConfirmedEntry(), null);
+            } else {
+                findEntryComplete(position, null);
             }
         }
     }
@@ -240,11 +237,12 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
                     exception.getMessage());
             if (exception instanceof LedgerNotExistException) {
                 long failedLedgerId = failedReadPosition.get().getLedgerId();
-                ManagedLedgerImpl ledger = ((ManagedLedgerImpl) cursor.getManagedLedger());
+                ManagedLedger ledger = cursor.getManagedLedger();
                 Position lastPositionInLedger = ledger.getOptionalLedgerInfo(failedLedgerId)
                         .map(ledgerInfo -> PositionFactory.create(failedLedgerId, ledgerInfo.getEntries() - 1))
                         .orElseGet(() -> {
-                            Long nextExistingLedger = ledger.getNextValidLedger(failedReadPosition.get().getLedgerId());
+                            Long nextExistingLedger =
+                                ledger.getLedgersInfo().ceilingKey(failedReadPosition.get().getLedgerId() + 1);
                             if (nextExistingLedger == null) {
                                 log.info("[{}] [{}] Couldn't find next next valid ledger for expiry monitor when find "
                                                 + "entry failed {}", ledger.getName(), ledger.getName(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -37,10 +37,10 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.BrokerServiceException;
@@ -323,7 +323,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             }
 
             if (messagesForC > 0) {
-                final ManagedLedgerImpl managedLedger = ((ManagedLedgerImpl) cursor.getManagedLedger());
+                final ManagedLedger managedLedger = cursor.getManagedLedger();
                 for (int i = 0; i < messagesForC; i++) {
                     final Entry entry = entriesWithSameKey.get(i);
                     // remove positions first from replay list first : sendMessages recycles entries
@@ -368,7 +368,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
 
         // Update the last sent position and remove ranges from individuallySentPositions if necessary
         if (!allowOutOfOrderDelivery && lastSentPosition != null) {
-            final ManagedLedgerImpl managedLedger = ((ManagedLedgerImpl) cursor.getManagedLedger());
+            final ManagedLedger managedLedger = cursor.getManagedLedger();
             com.google.common.collect.Range<Position> range = individuallySentPositions.firstRange();
 
             // If the upper bound is before the last sent position, we need to move ahead as these

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -23,6 +23,7 @@ import static org.apache.pulsar.common.naming.SystemTopicNames.isEventSystemTopi
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import io.netty.buffer.ByteBuf;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -51,8 +52,6 @@ import org.apache.bookkeeper.mledger.ManagedLedgerException.ConcurrentFindCursor
 import org.apache.bookkeeper.mledger.ManagedLedgerException.InvalidCursorPositionException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.ScanOutcome;
-import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -405,7 +404,7 @@ public class PersistentSubscription extends AbstractSubscription {
             cursor.asyncDelete(positions, deleteCallback, previousMarkDeletePosition);
             if (topic.getBrokerService().getPulsar().getConfig().isTransactionCoordinatorEnabled()) {
                 positions.forEach(position -> {
-                    if (((ManagedCursorImpl) cursor).isMessageDeleted(position)) {
+                    if ((cursor.isMessageDeleted(position))) {
                         pendingAckHandle.clearIndividualPosition(position);
                     }
                 });
@@ -552,7 +551,7 @@ public class PersistentSubscription extends AbstractSubscription {
         final String newNonDurableCursorName = "analyze-backlog-" + UUID.randomUUID();
         ManagedCursor newNonDurableCursor;
         try {
-            newNonDurableCursor = ((ManagedCursorImpl) cursor).duplicateNonDurableCursor(newNonDurableCursorName);
+            newNonDurableCursor = cursor.duplicateNonDurableCursor(newNonDurableCursorName);
         } catch (ManagedLedgerException e) {
             return CompletableFuture.failedFuture(e);
         }
@@ -1281,7 +1280,7 @@ public class PersistentSubscription extends AbstractSubscription {
         }
         subStats.msgBacklog = getNumberOfEntriesInBacklog(getStatsOptions.isGetPreciseBacklog());
         if (getStatsOptions.isSubscriptionBacklogSize()) {
-            subStats.backlogSize = ((ManagedLedgerImpl) topic.getManagedLedger())
+            subStats.backlogSize = topic.getManagedLedger()
                     .getEstimatedBacklogSize(cursor.getMarkDeletedPosition());
         } else {
             subStats.backlogSize = -1;
@@ -1331,9 +1330,9 @@ public class PersistentSubscription extends AbstractSubscription {
             return CompletableFuture.completedFuture(subStats);
         }
         if (subStats.msgBacklog > 0) {
-            ManagedLedgerImpl managedLedger = ((ManagedLedgerImpl) cursor.getManagedLedger());
+            ManagedLedger managedLedger = cursor.getManagedLedger();
             Position markDeletedPosition = cursor.getMarkDeletedPosition();
-            return managedLedger.getEarliestMessagePublishTimeOfPos(markDeletedPosition).thenApply(v -> {
+            return getEarliestMessagePublishTimeOfPos(managedLedger, markDeletedPosition).thenApply(v -> {
                 subStats.earliestMsgPublishTimeInBacklog = v;
                 return subStats;
             });
@@ -1341,6 +1340,48 @@ public class PersistentSubscription extends AbstractSubscription {
             subStats.earliestMsgPublishTimeInBacklog = -1;
             return CompletableFuture.completedFuture(subStats);
         }
+    }
+
+    private CompletableFuture<Long> getEarliestMessagePublishTimeOfPos(ManagedLedger ml, Position pos) {
+        CompletableFuture<Long> future = new CompletableFuture<>();
+        if (pos == null) {
+            future.complete(0L);
+            return future;
+        }
+        Position nextPos = ml.getNextValidPosition(pos);
+
+        if (nextPos.compareTo(ml.getLastConfirmedEntry()) > 0) {
+            return CompletableFuture.completedFuture(-1L);
+        }
+
+        ml.asyncReadEntry(nextPos, new ReadEntryCallback() {
+            @Override
+            public void readEntryComplete(Entry entry, Object ctx) {
+                try {
+                    long entryTimestamp = Commands.getEntryTimestamp(entry.getDataBuffer());
+                    future.complete(entryTimestamp);
+                } catch (IOException e) {
+                    log.error("Error deserializing message for message position {}", nextPos, e);
+                    future.completeExceptionally(e);
+                } finally {
+                    entry.release();
+                }
+            }
+
+            @Override
+            public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
+                log.error("Error read entry for position {}", nextPos, exception);
+                future.completeExceptionally(exception);
+            }
+
+            @Override
+            public String toString() {
+                return String.format("ML [%s] get earliest message publish time of pos",
+                        ml.getName());
+            }
+        }, null);
+
+        return future;
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/AbstractMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/AbstractMetrics.java
@@ -24,9 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactoryMXBean;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerMBeanImpl;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.policies.data.TopicStats;
@@ -132,7 +131,7 @@ abstract class AbstractMetrics {
      * @return
      */
     protected ManagedLedgerFactoryMXBean getManagedLedgerCacheStats() {
-        return ((ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory()).getCacheStats();
+        return pulsar.getManagedLedgerFactory().getCacheStats();
     }
 
     /**
@@ -140,8 +139,8 @@ abstract class AbstractMetrics {
      *
      * @return
      */
-    protected Map<String, ManagedLedgerImpl> getManagedLedgers() {
-        return ((ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory()).getManagedLedgers();
+    protected Map<String, ManagedLedger> getManagedLedgers() {
+        return pulsar.getManagedLedgerFactory().getManagedLedgers();
     }
 
     protected String getLocalClusterName() {
@@ -235,8 +234,8 @@ abstract class AbstractMetrics {
      * @param metrics
      * @param ledger
      */
-    protected void populateDimensionMap(Map<Metrics, List<ManagedLedgerImpl>> ledgersByDimensionMap, Metrics metrics,
-            ManagedLedgerImpl ledger) {
+    protected void populateDimensionMap(Map<Metrics, List<ManagedLedger>> ledgersByDimensionMap, Metrics metrics,
+            ManagedLedger ledger) {
         ledgersByDimensionMap.computeIfAbsent(metrics, __ -> new ArrayList<>()).add(ledger);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedCursorMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedCursorMetrics.java
@@ -25,9 +25,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedCursorMXBean;
-import org.apache.bookkeeper.mledger.impl.ManagedCursorContainer;
-import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.stats.Metrics;
 
@@ -55,16 +53,15 @@ public class ManagedCursorMetrics extends AbstractMetrics {
      */
     private List<Metrics> aggregate() {
         metricsCollection.clear();
-        for (Map.Entry<String, ManagedLedgerImpl> e : getManagedLedgers().entrySet()) {
+        for (Map.Entry<String, ManagedLedger> e : getManagedLedgers().entrySet()) {
             String ledgerName = e.getKey();
-            ManagedLedgerImpl ledger = e.getValue();
+            ManagedLedger ledger = e.getValue();
             String namespace = parseNamespaceFromLedgerName(ledgerName);
 
-            ManagedCursorContainer cursorContainer = ledger.getCursors();
-            Iterator<ManagedCursor> cursorIterator = cursorContainer.iterator();
+            Iterator<ManagedCursor> cursorIterator = ledger.getCursors().iterator();
 
             while (cursorIterator.hasNext()) {
-                ManagedCursorImpl cursor = (ManagedCursorImpl) cursorIterator.next();
+                ManagedCursor cursor = cursorIterator.next();
                 ManagedCursorMXBean cStats = cursor.getStats();
                 dimensionMap.clear();
                 dimensionMap.put("namespace", namespace);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerMetrics.java
@@ -23,16 +23,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerMXBean;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.stats.Metrics;
 
 public class ManagedLedgerMetrics extends AbstractMetrics {
 
     private List<Metrics> metricsCollection;
-    private Map<Metrics, List<ManagedLedgerImpl>> ledgersByDimensionMap;
+    private Map<Metrics, List<ManagedLedger>> ledgersByDimensionMap;
     // temp map to prepare aggregation metrics
     private Map<String, Double> tempAggregatedMetricsMap;
     private static final Buckets
@@ -53,7 +52,7 @@ public class ManagedLedgerMetrics extends AbstractMetrics {
         this.metricsCollection = new ArrayList<>();
         this.ledgersByDimensionMap = new HashMap<>();
         this.tempAggregatedMetricsMap = new HashMap<>();
-        this.statsPeriodSeconds = ((ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory())
+        this.statsPeriodSeconds = pulsar.getManagedLedgerFactory()
                 .getConfig().getStatsPeriodSeconds();
     }
 
@@ -71,20 +70,20 @@ public class ManagedLedgerMetrics extends AbstractMetrics {
      * @param ledgersByDimension
      * @return
      */
-    private List<Metrics> aggregate(Map<Metrics, List<ManagedLedgerImpl>> ledgersByDimension) {
+    private List<Metrics> aggregate(Map<Metrics, List<ManagedLedger>> ledgersByDimension) {
 
         metricsCollection.clear();
 
-        for (Entry<Metrics, List<ManagedLedgerImpl>> e : ledgersByDimension.entrySet()) {
+        for (Entry<Metrics, List<ManagedLedger>> e : ledgersByDimension.entrySet()) {
             Metrics metrics = e.getKey();
-            List<ManagedLedgerImpl> ledgers = e.getValue();
+            List<ManagedLedger> ledgers = e.getValue();
 
             // prepare aggregation map
             tempAggregatedMetricsMap.clear();
 
             // generate the collections by each metrics and then apply the aggregation
 
-            for (ManagedLedgerImpl ledger : ledgers) {
+            for (ManagedLedger ledger : ledgers) {
                 ManagedLedgerMXBean lStats = ledger.getStats();
 
                 populateAggregationMapWithSum(tempAggregatedMetricsMap, "brk_ml_AddEntryBytesRate",
@@ -151,17 +150,17 @@ public class ManagedLedgerMetrics extends AbstractMetrics {
      *
      * @return
      */
-    private Map<Metrics, List<ManagedLedgerImpl>> groupLedgersByDimension() {
+    private Map<Metrics, List<ManagedLedger>> groupLedgersByDimension() {
 
         ledgersByDimensionMap.clear();
 
         // get the current topics statistics from StatsBrokerFilter
         // Map : topic-name->dest-stat
 
-        for (Entry<String, ManagedLedgerImpl> e : getManagedLedgers().entrySet()) {
+        for (Entry<String, ManagedLedger> e : getManagedLedgers().entrySet()) {
 
             String ledgerName = e.getKey();
-            ManagedLedgerImpl ledger = e.getValue();
+            ManagedLedger ledger = e.getValue();
 
             // we want to aggregate by NS dimension
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
@@ -24,7 +24,6 @@ import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.commons.collections4.map.LinkedMap;
 import org.apache.pulsar.broker.service.SystemTopicTxnBufferSnapshotService.ReferenceCountedWriter;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -69,8 +68,8 @@ public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcesso
     //In this implementation we clear the invalid aborted txn ID one by one.
     @Override
     public void trimExpiredAbortedTxns() {
-        while (!aborts.isEmpty() && !((ManagedLedgerImpl) topic.getManagedLedger())
-                .ledgerExists(aborts.get(aborts.firstKey()).getLedgerId())) {
+        while (!aborts.isEmpty() && !topic.getManagedLedger().getLedgersInfo()
+                .containsKey(aborts.get(aborts.firstKey()).getLedgerId())) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Topic transaction buffer clear aborted transaction, TxnId : {}, Position : {}",
                         topic.getName(), aborts.firstKey(), aborts.get(aborts.firstKey()));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -38,7 +38,6 @@ import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.commons.collections4.map.LinkedMap;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.BrokerServiceException.PersistenceException;
@@ -320,7 +319,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
             ongoingTxns.put(txnId, position);
             Position firstPosition = ongoingTxns.get(ongoingTxns.firstKey());
             // max read position is less than first ongoing transaction message position
-            updateMaxReadPosition(((ManagedLedgerImpl) topic.getManagedLedger()).getPreviousPosition(firstPosition),
+            updateMaxReadPosition(topic.getManagedLedger().getPreviousPosition(firstPosition),
                     false);
         }
     }
@@ -488,7 +487,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
         ongoingTxns.remove(txnID);
         if (!ongoingTxns.isEmpty()) {
             Position position = ongoingTxns.get(ongoingTxns.firstKey());
-            updateMaxReadPosition(((ManagedLedgerImpl) topic.getManagedLedger()).getPreviousPosition(position), false);
+            updateMaxReadPosition(topic.getManagedLedger().getPreviousPosition(position), false);
         } else {
             updateMaxReadPosition(topic.getManagedLedger().getLastConfirmedEntry(), false);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStore.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStore.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
@@ -44,7 +45,6 @@ import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.bookkeeper.mledger.impl.AckSetStateUtil;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.pulsar.broker.service.BrokerServiceException.PersistenceException;
 import org.apache.pulsar.broker.transaction.pendingack.PendingAckReplyCallBack;
@@ -121,7 +121,7 @@ public class MLPendingAckStore implements PendingAckStore {
     public MLPendingAckStore(ManagedLedger managedLedger, ManagedCursor cursor,
                              ManagedCursor subManagedCursor, long transactionPendingAckLogIndexMinLag,
                              TxnLogBufferedWriterConfig bufferedWriterConfig,
-                             Timer timer, TxnLogBufferedWriterMetricsStats bufferedWriterMetrics) {
+                             Timer timer, TxnLogBufferedWriterMetricsStats bufferedWriterMetrics, Executor executor) {
         this.managedLedger = managedLedger;
         this.cursor = cursor;
         this.currentLoadPosition = this.cursor.getMarkDeletedPosition();
@@ -131,7 +131,7 @@ public class MLPendingAckStore implements PendingAckStore {
         this.subManagedCursor = subManagedCursor;
         this.logIndexBackoff = new LogIndexLagBackoff(transactionPendingAckLogIndexMinLag, Long.MAX_VALUE, 1);
         this.maxIndexLag = logIndexBackoff.next(0);
-        this.bufferedWriter = new TxnLogBufferedWriter(managedLedger, ((ManagedLedgerImpl) managedLedger).getExecutor(),
+        this.bufferedWriter = new TxnLogBufferedWriter(managedLedger, executor,
                 timer, PendingAckLogSerializer.INSTANCE,
                 bufferedWriterConfig.getBatchedWriteMaxRecords(), bufferedWriterConfig.getBatchedWriteMaxSize(),
                 bufferedWriterConfig.getBatchedWriteMaxDelayInMillis(), bufferedWriterConfig.isBatchEnabled(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreProvider.java
@@ -134,7 +134,12 @@ public class MLPendingAckStoreProvider implements TransactionPendingAckStoreProv
                                                                         .getConfiguration()
                                                                         .getTransactionPendingAckLogIndexMinLag(),
                                                                 txnLogBufferedWriterConfig,
-                                                                brokerClientSharedTimer, bufferedWriterMetrics));
+                                                                brokerClientSharedTimer, bufferedWriterMetrics,
+                                                                originPersistentTopic
+                                                                        .getBrokerService()
+                                                                        .getPulsar()
+                                                                        .getOrderedExecutor()
+                                                                        .chooseThread()));
                                                         if (log.isDebugEnabled()) {
                                                             log.debug("{},{} open MLPendingAckStore cursor success",
                                                                     originPersistentTopic.getName(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
@@ -47,7 +47,6 @@ import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.AckSetState;
 import org.apache.bookkeeper.mledger.impl.AckSetStateUtil;
-import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.commons.collections4.map.LinkedMap;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -235,8 +234,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
 
                             // If try to ack message already acked by committed transaction or
                             // normal acknowledge,throw exception.
-                            if (((ManagedCursorImpl) persistentSubscription.getCursor())
-                                    .isMessageDeleted(position)) {
+                            if (persistentSubscription.getCursor().isMessageDeleted(position)) {
                                 String errorMsg = "[" + topicName + "][" + subName + "] Transaction:" + txnID
                                         + " try to ack message:" + position + " already acked before.";
                                 log.error(errorMsg);
@@ -258,8 +256,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
                                 bitSetRecyclable.set(positionIntegerMutablePair.right, bitSetRecyclable.size());
                                 long[] ackSetOverlap = bitSetRecyclable.toLongArray();
                                 bitSetRecyclable.recycle();
-                                if (isAckSetOverlap(ackSetOverlap,
-                                        ((ManagedCursorImpl) persistentSubscription.getCursor())
+                                if (isAckSetOverlap(ackSetOverlap, persistentSubscription.getCursor()
                                                 .getBatchPositionAckSet(position))) {
                                     String errorMsg = "[" + topicName + "][" + subName + "] Transaction:"
                                             + txnID + " try to ack message:"
@@ -865,8 +862,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
 
             // If try to ack message already acked by committed transaction or
             // normal acknowledge,throw exception.
-            if (((ManagedCursorImpl) persistentSubscription.getCursor())
-                    .isMessageDeleted(position)) {
+            if (persistentSubscription.getCursor().isMessageDeleted(position)) {
                 return;
             }
 
@@ -885,8 +881,7 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
                 long[] ackSetOverlap = bitSetRecyclable.toLongArray();
                 bitSetRecyclable.recycle();
                 if (isAckSetOverlap(ackSetOverlap,
-                        ((ManagedCursorImpl) persistentSubscription.getCursor())
-                                .getBatchPositionAckSet(position))) {
+                        persistentSubscription.getCursor().getBatchPositionAckSet(position))) {
                     return;
                 }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
@@ -47,7 +47,6 @@ import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.bookkeeper.mledger.impl.EntryImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer.ReadEntriesCtx;
 import org.apache.pulsar.client.api.MessageId;
@@ -122,8 +121,7 @@ public class CompactedTopicImpl implements CompactedTopic {
                 || currentCompactionHorizon.compareTo(cursorPosition) < 0) {
                 cursor.asyncReadEntriesOrWait(maxEntries, bytesToRead, callback, readEntriesCtx, maxReadPosition);
             } else {
-                ManagedCursorImpl managedCursor = (ManagedCursorImpl) cursor;
-                int numberOfEntriesToRead = managedCursor.applyMaxSizeCap(maxEntries, bytesToRead);
+                int numberOfEntriesToRead = cursor.applyMaxSizeCap(maxEntries, bytesToRead);
 
                 compactedTopicContext.thenCompose(
                     (context) -> findStartPoint(cursorPosition, context.ledger.getLastAddConfirmed(), context.cache)
@@ -143,7 +141,7 @@ public class CompactedTopicImpl implements CompactedTopic {
                                         for (Entry entry : entries) {
                                             entriesSize += entry.getLength();
                                         }
-                                        managedCursor.updateReadStats(entries.size(), entriesSize);
+                                        cursor.updateReadStats(entries.size(), entriesSize);
 
                                         Entry lastEntry = entries.get(entries.size() - 1);
                                         // The compaction task depends on the last snapshot and the incremental

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicUtils.java
@@ -31,7 +31,6 @@ import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
-import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer;
@@ -75,8 +74,7 @@ public class CompactedTopicUtils {
                 return CompletableFuture.completedFuture(null);
             }
 
-            ManagedCursorImpl managedCursor = (ManagedCursorImpl) cursor;
-            int numberOfEntriesToRead = managedCursor.applyMaxSizeCap(maxEntries, bytesToRead);
+            int numberOfEntriesToRead = cursor.applyMaxSizeCap(maxEntries, bytesToRead);
 
             return topicCompactionService.readCompactedEntries(readPosition, numberOfEntriesToRead)
                     .thenAccept(entries -> {
@@ -94,7 +92,7 @@ public class CompactedTopicUtils {
                         for (Entry entry : entries) {
                             entriesSize += entry.getLength();
                         }
-                        managedCursor.updateReadStats(entries.size(), entriesSize);
+                        cursor.updateReadStats(entries.size(), entriesSize);
 
                         Entry lastEntry = entries.get(entries.size() - 1);
                         cursor.seek(lastEntry.getPosition().getNext(), true);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/MockManagedCursor.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/MockManagedCursor.java
@@ -32,6 +32,7 @@ import org.apache.bookkeeper.mledger.ManagedCursorMXBean;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
+import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats;
 
 public class MockManagedCursor implements ManagedCursor {
 
@@ -413,5 +414,35 @@ public class MockManagedCursor implements ManagedCursor {
     @Override
     public boolean isClosed() {
         return false;
+    }
+
+    @Override
+    public ManagedLedgerInternalStats.CursorStats getCursorStats() {
+        return null;
+    }
+
+    @Override
+    public boolean isMessageDeleted(Position position) {
+        return false;
+    }
+
+    @Override
+    public ManagedCursor duplicateNonDurableCursor(String nonDurableCursorName) throws ManagedLedgerException {
+        return null;
+    }
+
+    @Override
+    public long[] getBatchPositionAckSet(Position position) {
+        return new long[0];
+    }
+
+    @Override
+    public int applyMaxSizeCap(int maxEntries, long maxSizeBytes) {
+        return 0;
+    }
+
+    @Override
+    public void updateReadStats(int readEntriesCount, long readEntriesSize) {
+
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/MangedLedgerInterceptorImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/MangedLedgerInterceptorImplTest.java
@@ -41,7 +41,6 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
-import org.apache.bookkeeper.mledger.impl.OpAddEntry;
 import org.apache.bookkeeper.mledger.intercept.ManagedLedgerInterceptor;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
 import org.apache.pulsar.common.api.proto.BrokerEntryMetadata;
@@ -391,16 +390,15 @@ public class MangedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase {
         }
 
         @Override
-        public OpAddEntry beforeAddEntry(OpAddEntry op, int numberOfMessages) {
+        public void beforeAddEntry(AddEntryOperation op, int numberOfMessages) {
             if (op == null || numberOfMessages <= 0) {
-                return op;
+                return;
             }
             op.setData(Commands.addBrokerEntryMetadata(op.getData(), brokerEntryMetadataInterceptors,
                     numberOfMessages));
             if (op != null) {
                 throw new RuntimeException("throw exception before add entry for test");
             }
-            return op;
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/CurrentLedgerRolloverIfFullTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/CurrentLedgerRolloverIfFullTest.java
@@ -81,7 +81,9 @@ public class CurrentLedgerRolloverIfFullTest extends BrokerTestBase {
         }
 
         ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
-        Assert.assertEquals(managedLedger.getLedgersInfoAsList().size(), msgNum / 2);
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            Assert.assertEquals(managedLedger.getLedgersInfoAsList().size(), msgNum / 2 + 1);
+        });
 
         for (int i = 0; i < msgNum; i++) {
             Message<byte[]> msg = consumer.receive(2, TimeUnit.SECONDS);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/BucketDelayedDeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/BucketDelayedDeliveryTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.broker.service.persistent;
 
-import static org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.CURSOR_INTERNAL_PROPERTY_PREFIX;
+import static org.apache.bookkeeper.mledger.ManagedCursor.CURSOR_INTERNAL_PROPERTY_PREFIX;
 import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.Metric;
 import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.parseMetrics;
 import static org.testng.Assert.assertEquals;
@@ -38,7 +38,6 @@ import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.mledger.ManagedCursor;
-import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.pulsar.PrometheusMetricsTestUtil;
 import org.apache.pulsar.broker.BrokerTestUtil;
@@ -104,7 +103,7 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
         Awaitility.await().untilAsserted(() -> Assert.assertEquals(dispatcher.getNumberOfDelayedMessages(), 1000));
         List<String> bucketKeys =
                 ((PersistentDispatcherMultipleConsumers) dispatcher).getCursor().getCursorProperties().keySet().stream()
-                        .filter(x -> x.startsWith(ManagedCursorImpl.CURSOR_INTERNAL_PROPERTY_PREFIX)).toList();
+                        .filter(x -> x.startsWith(CURSOR_INTERNAL_PROPERTY_PREFIX)).toList();
 
         c1.close();
 
@@ -119,7 +118,7 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
         Dispatcher dispatcher2 = pulsar.getBrokerService().getTopicReference(topic).get().getSubscription("sub").getDispatcher();
         List<String> bucketKeys2 =
                 ((PersistentDispatcherMultipleConsumers) dispatcher2).getCursor().getCursorProperties().keySet().stream()
-                        .filter(x -> x.startsWith(ManagedCursorImpl.CURSOR_INTERNAL_PROPERTY_PREFIX)).toList();
+                        .filter(x -> x.startsWith(CURSOR_INTERNAL_PROPERTY_PREFIX)).toList();
 
         Awaitility.await().untilAsserted(() -> Assert.assertEquals(dispatcher2.getNumberOfDelayedMessages(), 1000));
         Assert.assertEquals(bucketKeys, bucketKeys2);
@@ -384,7 +383,7 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
         admin.topics().createSubscription(topic, subscriptionName, MessageId.earliest);
         pulsarClient.newConsumer().topic(topic).subscriptionName(subscriptionName)
                 .subscriptionType(subscriptionType).subscribe().close();
-        ManagedCursorImpl cursor = findCursor(topic, subscriptionName);
+        ManagedCursor cursor = findCursor(topic, subscriptionName);
         assertNotNull(cursor);
         assertTrue(cursor.getCursorProperties() == null || cursor.getCursorProperties().isEmpty());
         // Test topic deletion is successful.
@@ -404,7 +403,7 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
         admin.topics().createSubscription(topic, subscriptionName, MessageId.earliest);
         pulsarClient.newConsumer().topic(topic).subscriptionName(subscriptionName)
                 .subscriptionType(subscriptionType).subscribe().close();
-        ManagedCursorImpl cursor = findCursor(topic + "-partition-0", subscriptionName);
+        ManagedCursor cursor = findCursor(topic + "-partition-0", subscriptionName);
         assertNotNull(cursor);
         assertTrue(cursor.getCursorProperties() == null || cursor.getCursorProperties().isEmpty());
         // Test topic deletion is successful.
@@ -424,7 +423,7 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
         admin.topics().createSubscription(topic, subscriptionName, MessageId.earliest);
         pulsarClient.newConsumer().topic(topic).subscriptionName(subscriptionName)
                 .subscriptionType(subscriptionType).subscribe().close();
-        ManagedCursorImpl cursor = findCursor(topic, subscriptionName);
+        ManagedCursor cursor = findCursor(topic, subscriptionName);
         assertNotNull(cursor);
         assertTrue(cursor.getCursorProperties() == null || cursor.getCursorProperties().isEmpty());
         // Put a subscription prop.
@@ -451,7 +450,7 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
         pulsarClient.newConsumer().topic(topic).subscriptionName(subscriptionName)
                 .subscriptionType(subscriptionType).subscribe().close();
 
-        ManagedCursorImpl cursor = findCursor(topic + "-partition-0", subscriptionName);
+        ManagedCursor cursor = findCursor(topic + "-partition-0", subscriptionName);
         assertNotNull(cursor);
         assertTrue(cursor.getCursorProperties() == null || cursor.getCursorProperties().isEmpty());
         // Put a subscription prop.
@@ -464,7 +463,7 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
     }
 
 
-    private ManagedCursorImpl findCursor(String topic, String subscriptionName) {
+    private ManagedCursor findCursor(String topic, String subscriptionName) {
         PersistentTopic persistentTopic =
                 (PersistentTopic) pulsar.getBrokerService().getTopic(topic, false).join().get();
         Iterator<ManagedCursor> cursorIterator = persistentTopic.getManagedLedger().getCursors().iterator();
@@ -473,7 +472,7 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
             if (managedCursor == null || !managedCursor.getName().equals(subscriptionName)) {
                 continue;
             }
-            return (ManagedCursorImpl) managedCursor;
+            return managedCursor;
         }
         return null;
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ManagedLedgerMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ManagedLedgerMetricsTest.java
@@ -29,9 +29,9 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerMBeanImpl;
 import org.apache.bookkeeper.mledger.impl.OpenTelemetryManagedLedgerStats;
 import org.apache.pulsar.broker.BrokerTestUtil;
@@ -106,7 +106,7 @@ public class ManagedLedgerMetricsTest extends BrokerTestBase {
         }
 
         var managedLedgerFactory = (ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory();
-        for (Entry<String, ManagedLedgerImpl> ledger : managedLedgerFactory.getManagedLedgers().entrySet()) {
+        for (Entry<String, ManagedLedger> ledger : managedLedgerFactory.getManagedLedgers().entrySet()) {
             ManagedLedgerMBeanImpl stats = (ManagedLedgerMBeanImpl) ledger.getValue().getStats();
             stats.refreshStats(1, TimeUnit.SECONDS);
         }
@@ -118,7 +118,7 @@ public class ManagedLedgerMetricsTest extends BrokerTestBase {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
-        for (Entry<String, ManagedLedgerImpl> ledger : managedLedgerFactory.getManagedLedgers().entrySet()) {
+        for (Entry<String, ManagedLedger> ledger : managedLedgerFactory.getManagedLedgers().entrySet()) {
             ManagedLedgerMBeanImpl stats = (ManagedLedgerMBeanImpl) ledger.getValue().getStats();
             stats.refreshStats(1, TimeUnit.SECONDS);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
@@ -49,8 +49,8 @@ import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
+import org.apache.bookkeeper.mledger.ReadOnlyManagedLedger;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
-import org.apache.bookkeeper.mledger.impl.ReadOnlyManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.commons.collections4.map.LinkedMap;
 import org.apache.commons.lang3.RandomUtils;
@@ -796,7 +796,7 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
         AsyncCallbacks.OpenReadOnlyManagedLedgerCallback callback = new AsyncCallbacks
                 .OpenReadOnlyManagedLedgerCallback() {
             @Override
-            public void openReadOnlyManagedLedgerComplete(ReadOnlyManagedLedgerImpl readOnlyManagedLedger, Object ctx) {
+            public void openReadOnlyManagedLedgerComplete(ReadOnlyManagedLedger readOnlyManagedLedger, Object ctx) {
                 readOnlyManagedLedger.asyncReadEntry(
                         PositionFactory.create(messageId.getLedgerId(), messageId.getEntryId()),
                         new AsyncCallbacks.ReadEntryCallback() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -864,7 +864,8 @@ public class TransactionTest extends TransactionTestBase {
         doReturn(CompletableFuture.completedFuture(
                 new MLPendingAckStore(persistentTopic.getManagedLedger(), managedCursor, null,
                         500, bufferedWriterConfig, transactionTimer,
-                        DISABLED_BUFFERED_WRITER_METRICS)))
+                        DISABLED_BUFFERED_WRITER_METRICS, persistentTopic.getBrokerService().getPulsar()
+                        .getOrderedExecutor().chooseThread())))
                 .when(pendingAckStoreProvider).newPendingAckStore(any());
         doReturn(CompletableFuture.completedFuture(true)).when(pendingAckStoreProvider).checkInitializedBefore(any());
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ManagedLedgerInternalStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ManagedLedgerInternalStats.java
@@ -20,10 +20,14 @@ package org.apache.pulsar.common.policies.data;
 
 import java.util.List;
 import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
+
 
 /**
  * ManagedLedger internal statistics.
  */
+@Getter(AccessLevel.PUBLIC)
 public class ManagedLedgerInternalStats {
 
     /** Messages published since this broker loaded this managedLedger. */
@@ -82,6 +86,7 @@ public class ManagedLedgerInternalStats {
     /**
      * Pulsar cursor statistics.
      */
+    @Getter(AccessLevel.PUBLIC)
     public static class CursorStats {
         public String markDeletePosition;
         public String readPosition;

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionSequenceIdGenerator.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionSequenceIdGenerator.java
@@ -24,7 +24,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.api.LedgerEntry;
-import org.apache.bookkeeper.mledger.impl.OpAddEntry;
 import org.apache.bookkeeper.mledger.intercept.ManagedLedgerInterceptor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.pulsar.transaction.coordinator.proto.TransactionMetadataEntry;
@@ -42,8 +41,8 @@ public class MLTransactionSequenceIdGenerator implements ManagedLedgerIntercepto
     private final AtomicLong sequenceId = new AtomicLong(TC_ID_NOT_USED);
 
     @Override
-    public OpAddEntry beforeAddEntry(OpAddEntry op, int numberOfMessages) {
-        return op;
+    public void beforeAddEntry(AddEntryOperation op, int numberOfMessages) {
+        // do nothing
     }
 
     // When all of ledger have been deleted, we will generate sequenceId from managedLedger properties

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
@@ -18,8 +18,10 @@
  */
 package org.apache.bookkeeper.mledger.offload.jcloud.impl;
 
+import com.google.common.collect.Range;
 import io.netty.buffer.ByteBuf;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
@@ -32,6 +34,7 @@ import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerMXBean;
 import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.PositionBound;
 import org.apache.bookkeeper.mledger.intercept.ManagedLedgerInterceptor;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
@@ -174,6 +177,11 @@ public class MockManagedLedger implements ManagedLedger {
 
     @Override
     public long getNumberOfEntries() {
+        return 0;
+    }
+
+    @Override
+    public long getNumberOfEntries(Range<Position> range) {
         return 0;
     }
 
@@ -379,6 +387,51 @@ public class MockManagedLedger implements ManagedLedger {
     @Override
     public void checkCursorsToCacheEntries() {
         // no-op
+    }
+
+    @Override
+    public void asyncReadEntry(Position position, AsyncCallbacks.ReadEntryCallback callback, Object ctx) {
+
+    }
+
+    @Override
+    public NavigableMap<Long, LedgerInfo> getLedgersInfo() {
+        return null;
+    }
+
+    @Override
+    public Position getNextValidPosition(Position position) {
+        return null;
+    }
+
+    @Override
+    public Position getPreviousPosition(Position position) {
+        return null;
+    }
+
+    @Override
+    public long getEstimatedBacklogSize(Position position) {
+        return 0;
+    }
+
+    @Override
+    public Position getPositionAfterN(Position startPosition, long n, PositionBound startRange) {
+        return null;
+    }
+
+    @Override
+    public int getPendingAddEntriesCount() {
+        return 0;
+    }
+
+    @Override
+    public long getCacheSize() {
+        return 0;
+    }
+
+    @Override
+    public Position getFirstPosition() {
+        return null;
     }
 
     @Override


### PR DESCRIPTION
## Motivation

This PR is part of an initiative to clean up and decouple the ManagedLedger interfaces from their current implementation in preparation for Pulsar 4.0. The primary goals are:

1. To allow for alternative ManagedLedger implementations in Pulsar 4.0.
2. To improve the overall architecture by reducing coupling between core Pulsar components and specific ManagedLedger implementations.

This work stems from a community discussion on the Apache Pulsar mailing list: [Preparing for Pulsar 4.0: cleaning up the Managed Ledger interfaces](https://lists.apache.org/thread/b2f4vkql693x3frdxm75tndk686crh9k)

Since the ManagedLedger interface is not exposed externally and this PR doesn't introduce implementation changes, a formal PIP (Pulsar Improvement Proposal) is not required. The mailing list discussion and the review process for this PR are considered sufficient for proceeding with these changes.

## Scope

This PR aims to make minimal, focused changes to achieve the decoupling goal. It does not include:
- Adding comprehensive JavaDocs to the interfaces (this will be addressed in future PRs)
- Changing any external APIs or behaviors

## Modifications

1. **Decouple from `ManagedLedgerImpl`:**
   - Add required methods from `ManagedLedgerImpl` to the `ManagedLedger` interface
   - Update relevant code to use the interface instead of the implementation

2. **Decouple from `ManagedLedgerFactoryImpl`:**
   - Add necessary methods from `ManagedLedgerFactoryImpl` to the `ManagedLedgerFactory` interface
   - Refactor code to depend on the interface rather than the concrete implementation

3. **Decouple from `ManagedCursorImpl`:**
   - Enhance the `ManagedCursor` interface with required methods from `ManagedCursorImpl`
   - Update code to use the interface methods instead of implementation-specific ones

4. **Introduce `ReadOnlyManagedLedger` interface:**
   - Extract this interface to decouple from `ReadOnlyManagedLedgerImpl`
   - Adjust code to utilize the new interface where appropriate

5. **Decouple `OpAddEntry` from `ManagedLedgerInterceptor`:**
   - add interface `AddEntryOperation` to be used by the `beforeAddEntry` method
   - revisit the method return type since it should be `void`
   - Adjust code to utilize the new interface where appropriate
   - Eliminate the use of `AddEntryOperation` in `processPayloadBeforeLedgerWrite` since mutation should happen with the `PayloadProcessorHandle` in that case.

6. **Decouple `LedgerHandle` from `ManagedLedgerInterceptor`:**
   - add interface `LastEntryHandle` to be used by the `onManagedLedgerLastLedgerInitialize` method
   - Adjust code to utilize the new interface where appropriate

7. **Additional minor changes:**
   - Adjust method signatures and parameter types as needed
   - Refactor any code that directly referenced implementation classes

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->