### PR TITLE
[improve][broker][PIP-384] Decouple Bookkeeper client from ManagedLedgerStorage and enable multiple ManagedLedgerFactory instances

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -87,7 +87,9 @@ public class ManagedLedgerConfig {
     private int minimumBacklogEntriesForCaching = 1000;
     private int maxBacklogBetweenCursorsForCaching = 1000;
     private boolean triggerOffloadOnTopicLoad = false;
-
+    @Getter
+    @Setter
+    private String storageClassName;
     @Getter
     @Setter
     private String shadowSourceName;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -24,6 +24,8 @@ import com.google.common.annotations.VisibleForTesting;
 import io.netty.channel.EventLoopGroup;
 import io.opentelemetry.api.OpenTelemetry;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -39,16 +41,18 @@ import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.stats.StatsProvider;
 import org.apache.commons.configuration.Configuration;
 import org.apache.pulsar.broker.stats.prometheus.metrics.PrometheusMetricsProvider;
+import org.apache.pulsar.broker.storage.BookkeeperManagedLedgerStorageClass;
 import org.apache.pulsar.broker.storage.ManagedLedgerStorage;
+import org.apache.pulsar.broker.storage.ManagedLedgerStorageClass;
 import org.apache.pulsar.common.policies.data.EnsemblePlacementPolicyConfig;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
-
     private static final Logger log = LoggerFactory.getLogger(ManagedLedgerClientFactory.class);
-
+    private static final String DEFAULT_STORAGE_CLASS_NAME = "bookkeeper";
+    private BookkeeperManagedLedgerStorageClass defaultStorageClass;
     private ManagedLedgerFactory managedLedgerFactory;
     private BookKeeper defaultBkClient;
     private final AsyncCache<EnsemblePlacementPolicyConfig, BookKeeper>
@@ -119,19 +123,49 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
             defaultBkClient.close();
             throw e;
         }
+
+        defaultStorageClass = new BookkeeperManagedLedgerStorageClass() {
+            @Override
+            public String getName() {
+                return DEFAULT_STORAGE_CLASS_NAME;
+            }
+
+            @Override
+            public ManagedLedgerFactory getManagedLedgerFactory() {
+                return managedLedgerFactory;
+            }
+
+            @Override
+            public StatsProvider getStatsProvider() {
+                return statsProvider;
+            }
+
+            @Override
+            public BookKeeper getBookKeeperClient() {
+                return defaultBkClient;
+            }
+        };
     }
 
-    public ManagedLedgerFactory getManagedLedgerFactory() {
-        return managedLedgerFactory;
+    @Override
+    public Collection<ManagedLedgerStorageClass> getStorageClasses() {
+        return List.of(defaultStorageClass);
     }
 
-    public BookKeeper getBookKeeperClient() {
-        return defaultBkClient;
+    @Override
+    public Optional<ManagedLedgerStorageClass> getManagedLedgerStorageClass(String name) {
+        if (name == null || DEFAULT_STORAGE_CLASS_NAME.equals(name)) {
+            return Optional.of(defaultStorageClass);
+        } else {
+            return Optional.empty();
+        }
     }
 
-    public StatsProvider getStatsProvider() {
-        return statsProvider;
+    @Override
+    public ManagedLedgerStorageClass getDefaultStorageClass() {
+        return defaultStorageClass;
     }
+
 
     @VisibleForTesting
     public Map<EnsemblePlacementPolicyConfig, BookKeeper> getBkEnsemblePolicyToBookKeeperMap() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -149,13 +149,13 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
 
     @Override
     public Collection<ManagedLedgerStorageClass> getStorageClasses() {
-        return List.of(defaultStorageClass);
+        return List.of(getDefaultStorageClass());
     }
 
     @Override
     public Optional<ManagedLedgerStorageClass> getManagedLedgerStorageClass(String name) {
         if (name == null || DEFAULT_STORAGE_CLASS_NAME.equals(name)) {
-            return Optional.of(defaultStorageClass);
+            return Optional.of(getDefaultStorageClass());
         } else {
             return Optional.empty();
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
@@ -227,7 +227,9 @@ public class TransactionMetadataStoreService {
                 .setBatchedWriteMaxDelayInMillis(serviceConfiguration.getTransactionLogBatchedWriteMaxDelayInMillis());
 
         return pulsarService.getBrokerService().getManagedLedgerConfig(getMLTransactionLogName(tcId)).thenCompose(
-                v -> transactionMetadataStoreProvider.openStore(tcId, pulsarService.getManagedLedgerFactory(), v,
+                v -> transactionMetadataStoreProvider.openStore(tcId,
+                        pulsarService.getManagedLedgerStorage().getManagedLedgerStorageClass(v.getStorageClassName())
+                                .get().getManagedLedgerFactory(), v,
                         timeoutTracker, recoverTracker,
                         pulsarService.getConfig().getMaxActiveTransactionsPerCoordinator(), txnLogBufferedWriterConfig,
                         brokerClientSharedTimer));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -2540,7 +2540,7 @@ public abstract class NamespacesBase extends AdminResource {
         String localClusterName = pulsar().getConfiguration().getClusterName();
 
         OffloaderObjectsScannerUtils.scanOffloadedLedgers(managedLedgerOffloader,
-                localClusterName, pulsar().getManagedLedgerFactory(), sink);
+                localClusterName, pulsar().getDefaultManagedLedgerFactory(), sink);
 
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -64,6 +64,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
@@ -136,6 +137,8 @@ import org.apache.pulsar.broker.service.plugin.EntryFilterProvider;
 import org.apache.pulsar.broker.stats.ClusterReplicationMetrics;
 import org.apache.pulsar.broker.stats.prometheus.metrics.ObserverGauge;
 import org.apache.pulsar.broker.stats.prometheus.metrics.Summary;
+import org.apache.pulsar.broker.storage.ManagedLedgerStorage;
+import org.apache.pulsar.broker.storage.ManagedLedgerStorageClass;
 import org.apache.pulsar.broker.validator.BindAddressValidator;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
@@ -216,7 +219,7 @@ public class BrokerService implements Closeable {
             .register();
 
     private final PulsarService pulsar;
-    private final ManagedLedgerFactory managedLedgerFactory;
+    private final ManagedLedgerStorage managedLedgerStorage;
 
     private final Map<String, CompletableFuture<Optional<Topic>>> topics = new ConcurrentHashMap<>();
 
@@ -335,7 +338,7 @@ public class BrokerService implements Closeable {
         this.brokerPublishRateLimiter = new PublishRateLimiterImpl(pulsar.getMonotonicSnapshotClock());
         this.preciseTopicPublishRateLimitingEnable =
                 pulsar.getConfiguration().isPreciseTopicPublishRateLimiterEnable();
-        this.managedLedgerFactory = pulsar.getManagedLedgerFactory();
+        this.managedLedgerStorage = pulsar.getManagedLedgerStorage();
         this.keepAliveIntervalSeconds = pulsar.getConfiguration().getKeepAliveIntervalSeconds();
         this.pendingTopicLoadingQueue = Queues.newConcurrentLinkedQueue();
         this.pulsarStats = new PulsarStats(pulsar);
@@ -1241,21 +1244,49 @@ public class BrokerService implements Closeable {
                 return;
             }
             CompletableFuture<ManagedLedgerConfig> mlConfigFuture = getManagedLedgerConfig(topicName);
-            managedLedgerFactory.asyncDelete(tn.getPersistenceNamingEncoding(),
-                mlConfigFuture, new DeleteLedgerCallback() {
-                    @Override
-                    public void deleteLedgerComplete(Object ctx) {
-                        future.complete(null);
-                    }
+            mlConfigFuture.thenAccept(config -> {
+                getManagedLedgerFactoryForTopic(topicName, config.getStorageClassName())
+                        .asyncDelete(tn.getPersistenceNamingEncoding(),
+                                mlConfigFuture, new DeleteLedgerCallback() {
+                                    @Override
+                                    public void deleteLedgerComplete(Object ctx) {
+                                        future.complete(null);
+                                    }
 
-                    @Override
-                    public void deleteLedgerFailed(ManagedLedgerException exception, Object ctx) {
-                        future.completeExceptionally(exception);
-                    }
-                }, null);
+                                    @Override
+                                    public void deleteLedgerFailed(ManagedLedgerException exception,
+                                                                   Object ctx) {
+                                        future.completeExceptionally(exception);
+                                    }
+                                }, null);
+            }).exceptionally(ex1 -> {
+                log.error("Failed to get managed ledger config for topic {}", topic, ex1);
+                future.completeExceptionally(ex1);
+                return null;
+            });
          });
 
         return future;
+    }
+
+    public CompletableFuture<ManagedLedgerFactory> getManagedLedgerFactoryForTopic(TopicName topicName) {
+        return getManagedLedgerConfig(topicName)
+                .thenApply(config -> {
+                    String storageClassName = config.getStorageClassName();
+                    return getManagedLedgerFactoryForTopic(topicName, storageClassName);
+                });
+    }
+
+    public ManagedLedgerFactory getManagedLedgerFactoryForTopic(TopicName topicName, String storageClassName) {
+        Optional<ManagedLedgerStorageClass> managedLedgerStorageClass =
+                managedLedgerStorage.getManagedLedgerStorageClass(storageClassName);
+        if (!managedLedgerStorageClass.isPresent()) {
+            throw new CompletionException(new ManagedLedgerException(
+                    "ManagedLedgerStorageClass " + storageClassName + " not found for topic " + topicName));
+        }
+        return managedLedgerStorageClass
+                .get()
+                .getManagedLedgerFactory();
     }
 
     public void deleteTopicAuthenticationWithRetry(String topic, CompletableFuture<Void> future, int count) {
@@ -1624,14 +1655,17 @@ public class BrokerService implements Closeable {
     @VisibleForTesting
     protected CompletableFuture<Map<String, String>> fetchTopicPropertiesAsync(TopicName topicName) {
         if (!topicName.isPartitioned()) {
-            return managedLedgerFactory.getManagedLedgerPropertiesAsync(topicName.getPersistenceNamingEncoding());
+            return getManagedLedgerFactoryForTopic(topicName).thenCompose(
+                    managedLedgerFactory -> managedLedgerFactory.getManagedLedgerPropertiesAsync(
+                            topicName.getPersistenceNamingEncoding()));
         } else {
             TopicName partitionedTopicName = TopicName.get(topicName.getPartitionedTopicName());
             return fetchPartitionedTopicMetadataAsync(partitionedTopicName)
                     .thenCompose(metadata -> {
                         if (metadata.partitions == PartitionedTopicMetadata.NON_PARTITIONED) {
-                            return managedLedgerFactory.getManagedLedgerPropertiesAsync(
-                                    topicName.getPersistenceNamingEncoding());
+                            return getManagedLedgerFactoryForTopic(topicName).thenCompose(
+                                    managedLedgerFactory -> managedLedgerFactory.getManagedLedgerPropertiesAsync(
+                                            topicName.getPersistenceNamingEncoding()));
                         } else {
                             // Check if the partitioned topic is a ShadowTopic
                             if (MapUtils.getString(metadata.properties, PROPERTY_SOURCE_TOPIC_KEY) != null) {
@@ -1756,6 +1790,8 @@ public class BrokerService implements Closeable {
             topicEventsDispatcher.notifyOnCompletion(loadFuture, topic, TopicEvent.LOAD);
 
             // Once we have the configuration, we can proceed with the async open operation
+            ManagedLedgerFactory managedLedgerFactory =
+                    getManagedLedgerFactoryForTopic(topicName, managedLedgerConfig.getStorageClassName());
             managedLedgerFactory.asyncOpen(topicName.getPersistenceNamingEncoding(), managedLedgerConfig,
                     new OpenLedgerCallback() {
                         @Override
@@ -1918,6 +1954,7 @@ public class BrokerService implements Closeable {
             managedLedgerConfig.setEnsembleSize(persistencePolicies.getBookkeeperEnsemble());
             managedLedgerConfig.setWriteQuorumSize(persistencePolicies.getBookkeeperWriteQuorum());
             managedLedgerConfig.setAckQuorumSize(persistencePolicies.getBookkeeperAckQuorum());
+            managedLedgerConfig.setStorageClassName(persistencePolicies.getManagedLedgerStorageClassName());
 
             if (serviceConfig.isStrictBookieAffinityEnabled()) {
                 managedLedgerConfig.setBookKeeperEnsemblePlacementPolicyClassName(
@@ -2745,25 +2782,29 @@ public class BrokerService implements Closeable {
             });
         });
 
+
+        ManagedLedgerFactory defaultManagedLedgerFactory =
+                managedLedgerStorage.getDefaultStorageClass().getManagedLedgerFactory();
+
         //  add listener to notify broker managedLedgerCacheSizeMB dynamic config
         registerConfigurationListener("managedLedgerCacheSizeMB", (managedLedgerCacheSizeMB) -> {
-            managedLedgerFactory.getEntryCacheManager()
+            defaultManagedLedgerFactory.getEntryCacheManager()
                     .updateCacheSizeAndThreshold(((int) managedLedgerCacheSizeMB) * 1024L * 1024L);
         });
 
         //  add listener to notify broker managedLedgerCacheEvictionWatermark dynamic config
         registerConfigurationListener(
                 "managedLedgerCacheEvictionWatermark", (cacheEvictionWatermark) -> {
-            managedLedgerFactory.getEntryCacheManager()
-                    .updateCacheEvictionWatermark((double) cacheEvictionWatermark);
-        });
+                    defaultManagedLedgerFactory.getEntryCacheManager()
+                            .updateCacheEvictionWatermark((double) cacheEvictionWatermark);
+                });
 
         //  add listener to notify broker managedLedgerCacheEvictionTimeThresholdMillis dynamic config
         registerConfigurationListener(
                 "managedLedgerCacheEvictionTimeThresholdMillis", (cacheEvictionTimeThresholdMills) -> {
-            managedLedgerFactory.updateCacheEvictionTimeThreshold(MILLISECONDS
-                    .toNanos((long) cacheEvictionTimeThresholdMills));
-        });
+                    defaultManagedLedgerFactory.updateCacheEvictionTimeThreshold(MILLISECONDS
+                            .toNanos((long) cacheEvictionTimeThresholdMills));
+                });
 
 
         // add listener to update message-dispatch-rate in msg for topic

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -74,12 +74,14 @@ import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedCursor.IndividualDeletedEntries;
 import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerAlreadyClosedException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerFencedException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerTerminatedException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.MetadataNotFoundException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.NonRecoverableLedgerException;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionBound;
 import org.apache.bookkeeper.mledger.PositionFactory;
@@ -1232,26 +1234,34 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 .getTransactionPendingAckStoreSuffix(topic,
                         Codec.encode(subscriptionName)));
         if (brokerService.pulsar().getConfiguration().isTransactionCoordinatorEnabled()) {
-            getBrokerService().getManagedLedgerFactory().asyncDelete(tn.getPersistenceNamingEncoding(),
-                    getBrokerService().getManagedLedgerConfig(tn),
-                    new AsyncCallbacks.DeleteLedgerCallback() {
-                        @Override
-                        public void deleteLedgerComplete(Object ctx) {
-                            asyncDeleteCursorWithClearDelayedMessage(subscriptionName, unsubscribeFuture);
-                        }
-
-                        @Override
-                        public void deleteLedgerFailed(ManagedLedgerException exception, Object ctx) {
-                            if (exception instanceof MetadataNotFoundException) {
+            CompletableFuture<ManagedLedgerConfig> managedLedgerConfig = getBrokerService().getManagedLedgerConfig(tn);
+            managedLedgerConfig.thenAccept(config -> {
+                ManagedLedgerFactory managedLedgerFactory =
+                        getBrokerService().getManagedLedgerFactoryForTopic(tn, config.getStorageClassName());
+                managedLedgerFactory.asyncDelete(tn.getPersistenceNamingEncoding(),
+                        managedLedgerConfig,
+                        new AsyncCallbacks.DeleteLedgerCallback() {
+                            @Override
+                            public void deleteLedgerComplete(Object ctx) {
                                 asyncDeleteCursorWithClearDelayedMessage(subscriptionName, unsubscribeFuture);
-                                return;
                             }
 
-                            unsubscribeFuture.completeExceptionally(exception);
-                            log.error("[{}][{}] Error deleting subscription pending ack store",
-                                    topic, subscriptionName, exception);
-                        }
-                    }, null);
+                            @Override
+                            public void deleteLedgerFailed(ManagedLedgerException exception, Object ctx) {
+                                if (exception instanceof MetadataNotFoundException) {
+                                    asyncDeleteCursorWithClearDelayedMessage(subscriptionName, unsubscribeFuture);
+                                    return;
+                                }
+
+                                unsubscribeFuture.completeExceptionally(exception);
+                                log.error("[{}][{}] Error deleting subscription pending ack store",
+                                        topic, subscriptionName, exception);
+                            }
+                        }, null);
+            }).exceptionally(ex -> {
+                unsubscribeFuture.completeExceptionally(ex);
+                return null;
+            });
         } else {
             asyncDeleteCursorWithClearDelayedMessage(subscriptionName, unsubscribeFuture);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/AbstractMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/AbstractMetrics.java
@@ -131,7 +131,7 @@ abstract class AbstractMetrics {
      * @return
      */
     protected ManagedLedgerFactoryMXBean getManagedLedgerCacheStats() {
-        return pulsar.getManagedLedgerFactory().getCacheStats();
+        return pulsar.getDefaultManagedLedgerFactory().getCacheStats();
     }
 
     /**
@@ -140,7 +140,7 @@ abstract class AbstractMetrics {
      * @return
      */
     protected Map<String, ManagedLedger> getManagedLedgers() {
-        return pulsar.getManagedLedgerFactory().getManagedLedgers();
+        return pulsar.getDefaultManagedLedgerFactory().getManagedLedgers();
     }
 
     protected String getLocalClusterName() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/metrics/ManagedLedgerMetrics.java
@@ -52,8 +52,7 @@ public class ManagedLedgerMetrics extends AbstractMetrics {
         this.metricsCollection = new ArrayList<>();
         this.ledgersByDimensionMap = new HashMap<>();
         this.tempAggregatedMetricsMap = new HashMap<>();
-        this.statsPeriodSeconds = pulsar.getManagedLedgerFactory()
-                .getConfig().getStatsPeriodSeconds();
+        this.statsPeriodSeconds = pulsar.getDefaultManagedLedgerFactory().getConfig().getStatsPeriodSeconds();
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/storage/BookkeeperManagedLedgerStorageClass.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/storage/BookkeeperManagedLedgerStorageClass.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.storage;
+
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.stats.StatsProvider;
+
+/**
+ * ManagedLedgerStorageClass represents a configured instance of ManagedLedgerFactory for managed ledgers.
+ * This instance is backed by a bookkeeper storage.
+ */
+public interface BookkeeperManagedLedgerStorageClass extends ManagedLedgerStorageClass {
+    /**
+     * Return the bookkeeper client instance used by this instance.
+     *
+     * @return the bookkeeper client.
+     */
+    BookKeeper getBookKeeperClient();
+
+    /**
+     * Return the stats provider to expose the stats of the storage implementation.
+     *
+     * @return the stats provider.
+     */
+    StatsProvider getStatsProvider();
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/storage/ManagedLedgerStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/storage/ManagedLedgerStorage.java
@@ -21,9 +21,8 @@ package org.apache.pulsar.broker.storage;
 import io.netty.channel.EventLoopGroup;
 import io.opentelemetry.api.OpenTelemetry;
 import java.io.IOException;
-import org.apache.bookkeeper.client.BookKeeper;
-import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
-import org.apache.bookkeeper.stats.StatsProvider;
+import java.util.Collection;
+import java.util.Optional;
 import org.apache.pulsar.broker.BookKeeperClientFactory;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.classification.InterfaceAudience.Private;
@@ -33,6 +32,12 @@ import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 
 /**
  * Storage to access {@link org.apache.bookkeeper.mledger.ManagedLedger}s.
+ * <p>
+ * The interface provides the abstraction to access the storage layer for managed ledgers.
+ * The interface supports multiple storage classes, each with its own configuration. The default
+ * implementation supports a single instance of {@link BookkeeperManagedLedgerStorageClass}.
+ * Implementations can provide multiple storage classes. The default storage class is used
+ * for topics unless it is overridden by the persistency policy at topic or namespace level.
  */
 @Private
 @Unstable
@@ -52,25 +57,25 @@ public interface ManagedLedgerStorage extends AutoCloseable {
                     OpenTelemetry openTelemetry) throws Exception;
 
     /**
-     * Return the factory to create {@link ManagedLedgerFactory}.
-     *
-     * @return the factory to create {@link ManagedLedgerFactory}.
+     * Get all configured storage class instances.
+     * @return all configured storage class instances
      */
-    ManagedLedgerFactory getManagedLedgerFactory();
+    Collection<ManagedLedgerStorageClass> getStorageClasses();
 
     /**
-     * Return the stats provider to expose the stats of the storage implementation.
-     *
-     * @return the stats provider.
+     * Get the default storage class.
+     * @return default storage class
      */
-    StatsProvider getStatsProvider();
+    default ManagedLedgerStorageClass getDefaultStorageClass() {
+        return getStorageClasses().stream().findFirst().get();
+    }
 
     /**
-     * Return the default bookkeeper client.
-     *
-     * @return the default bookkeeper client.
+     * Lookup a storage class by name.
+     * @param name storage class name
+     * @return storage class instance, or empty if not found
      */
-    BookKeeper getBookKeeperClient();
+    Optional<ManagedLedgerStorageClass> getManagedLedgerStorageClass(String name);
 
     /**
      * Close the storage.
@@ -97,5 +102,4 @@ public interface ManagedLedgerStorage extends AutoCloseable {
         storage.initialize(conf, metadataStore, bkProvider, eventLoopGroup, openTelemetry);
         return storage;
     }
-
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/storage/ManagedLedgerStorageClass.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/storage/ManagedLedgerStorageClass.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.storage;
+
+import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
+import org.apache.pulsar.common.classification.InterfaceAudience;
+import org.apache.pulsar.common.classification.InterfaceStability;
+
+/**
+ * ManagedLedgerStorageClass represents a configured instance of ManagedLedgerFactory for managed ledgers.
+ * The {@link ManagedLedgerStorage} can hold multiple storage classes, and each storage class can have its own
+ * configuration.
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Unstable
+public interface ManagedLedgerStorageClass {
+    /**
+     * Return the name of the storage class.
+     *
+     * @return the name of the storage class.
+     */
+    String getName();
+    /**
+     * Return the factory to create {@link ManagedLedgerFactory}.
+     *
+     * @return the factory to create {@link ManagedLedgerFactory}.
+     */
+    ManagedLedgerFactory getManagedLedgerFactory();
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -311,8 +311,13 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                         SnapshotSegmentAbortedTxnProcessorImpl.this.topic.getName());
             }
         };
-        topic.getBrokerService().getPulsar().getManagedLedgerFactory().asyncOpenReadOnlyManagedLedger(
-                topicName.getPersistenceNamingEncoding(), callback, topic.getManagedLedger().getConfig(), null);
+        topic.getBrokerService().getManagedLedgerFactoryForTopic(topicName).thenAccept(managedLedgerFactory ->
+                        managedLedgerFactory.asyncOpenReadOnlyManagedLedger(topicName.getPersistenceNamingEncoding(),
+                                callback, topic.getManagedLedger().getConfig(), null))
+                .exceptionally(e -> {
+                    future.completeExceptionally(e);
+                    return null;
+                });
         return wait(future, "open read only ml for " + topicName);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreProvider.java
@@ -137,6 +137,12 @@ public class MLPendingAckStoreProvider implements TransactionPendingAckStoreProv
                         pendingAckStoreFuture.completeExceptionally(t);
                         return null;
                     });
+                }).exceptionally(e -> {
+                    Throwable t = FutureUtil.unwrapCompletionException(e);
+                    log.error("[{}] [{}] Failed to get managedLedger config when init pending ack store!",
+                            pendingAckTopicNameObject, subscription, t);
+                    pendingAckStoreFuture.completeExceptionally(t);
+                    return null;
                 });
         return pendingAckStoreFuture;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreProvider.java
@@ -25,9 +25,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.transaction.exception.pendingack.TransactionPendingAckException;
@@ -84,7 +86,8 @@ public class MLPendingAckStoreProvider implements TransactionPendingAckStoreProv
         }
 
         PersistentTopic originPersistentTopic = (PersistentTopic) subscription.getTopic();
-        PulsarService pulsarService = originPersistentTopic.getBrokerService().getPulsar();
+        BrokerService brokerService = originPersistentTopic.getBrokerService();
+        PulsarService pulsarService = brokerService.getPulsar();
 
         final Timer brokerClientSharedTimer =
                 pulsarService.getBrokerClientSharedTimer();
@@ -103,84 +106,110 @@ public class MLPendingAckStoreProvider implements TransactionPendingAckStoreProv
 
         String pendingAckTopicName = MLPendingAckStore
                 .getTransactionPendingAckStoreSuffix(originPersistentTopic.getName(), subscription.getName());
-        originPersistentTopic.getBrokerService().getManagedLedgerFactory()
-                .asyncExists(TopicName.get(pendingAckTopicName)
-                        .getPersistenceNamingEncoding()).thenAccept(exist -> {
-            TopicName topicName;
-            if (exist) {
-                topicName = TopicName.get(pendingAckTopicName);
-            } else {
-                topicName = TopicName.get(originPersistentTopic.getName());
-            }
-            originPersistentTopic.getBrokerService()
-                    .getManagedLedgerConfig(topicName).thenAccept(config -> {
-                config.setCreateIfMissing(true);
-                originPersistentTopic.getBrokerService().getManagedLedgerFactory()
-                        .asyncOpen(TopicName.get(pendingAckTopicName).getPersistenceNamingEncoding(),
-                                config, new AsyncCallbacks.OpenLedgerCallback() {
-                                    @Override
-                                    public void openLedgerComplete(ManagedLedger ledger, Object ctx) {
-                                        ledger.asyncOpenCursor(
-                                                MLPendingAckStore.getTransactionPendingAckStoreCursorName(),
-                                                InitialPosition.Earliest, new AsyncCallbacks.OpenCursorCallback() {
-                                                    @Override
-                                                    public void openCursorComplete(ManagedCursor cursor, Object ctx) {
-                                                        pendingAckStoreFuture.complete(new MLPendingAckStore(ledger,
+        TopicName pendingAckTopicNameObject = TopicName.get(pendingAckTopicName);
+        brokerService.getManagedLedgerFactoryForTopic(pendingAckTopicNameObject)
+                .thenAccept(managedLedgerFactory -> {
+                    managedLedgerFactory.asyncExists(pendingAckTopicNameObject
+                            .getPersistenceNamingEncoding()).thenAccept(exist -> {
+                        TopicName topicName;
+                        if (exist) {
+                            topicName = pendingAckTopicNameObject;
+                        } else {
+                            topicName = TopicName.get(originPersistentTopic.getName());
+                        }
+                        brokerService.getManagedLedgerConfig(topicName).thenAccept(config -> {
+                            internalNewPendingAckStore(subscription, config, brokerService, topicName,
+                                    pendingAckTopicNameObject, pendingAckStoreFuture, txnLogBufferedWriterConfig,
+                                    brokerClientSharedTimer, originPersistentTopic);
+                        }).exceptionally(e -> {
+                            Throwable t = FutureUtil.unwrapCompletionException(e);
+                            log.error("[{}] [{}] Failed to get managedLedger config when init pending ack "
+                                            + "store!",
+                                    originPersistentTopic, subscription, t);
+                            pendingAckStoreFuture.completeExceptionally(t);
+                            return null;
+
+                        });
+                    }).exceptionally(e -> {
+                        Throwable t = FutureUtil.unwrapCompletionException(e);
+                        log.error("[{}] [{}] Failed to check the pending ack topic exist when init pending ack store!",
+                                originPersistentTopic, subscription, t);
+                        pendingAckStoreFuture.completeExceptionally(t);
+                        return null;
+                    });
+                });
+        return pendingAckStoreFuture;
+    }
+
+    private static void internalNewPendingAckStore(PersistentSubscription subscription, ManagedLedgerConfig config,
+                                                   BrokerService brokerService, TopicName topicName,
+                                                   TopicName pendingAckTopicNameObject,
+                                                   CompletableFuture<PendingAckStore> pendingAckStoreFuture,
+                                                   TxnLogBufferedWriterConfig txnLogBufferedWriterConfig,
+                                                   Timer brokerClientSharedTimer,
+                                                   PersistentTopic originPersistentTopic) {
+        config.setCreateIfMissing(true);
+        brokerService
+                .getManagedLedgerFactoryForTopic(topicName, config.getStorageClassName())
+                .asyncOpen(pendingAckTopicNameObject.getPersistenceNamingEncoding(),
+                        config, new AsyncCallbacks.OpenLedgerCallback() {
+                            @Override
+                            public void openLedgerComplete(ManagedLedger ledger, Object ctx) {
+                                ledger.asyncOpenCursor(
+                                        MLPendingAckStore.getTransactionPendingAckStoreCursorName(),
+                                        InitialPosition.Earliest,
+                                        new AsyncCallbacks.OpenCursorCallback() {
+                                            @Override
+                                            public void openCursorComplete(ManagedCursor cursor,
+                                                                           Object ctx) {
+                                                pendingAckStoreFuture.complete(
+                                                        new MLPendingAckStore(ledger,
                                                                 cursor,
                                                                 subscription.getCursor(),
-                                                                originPersistentTopic
-                                                                        .getBrokerService()
+                                                                brokerService
                                                                         .getPulsar()
                                                                         .getConfiguration()
                                                                         .getTransactionPendingAckLogIndexMinLag(),
                                                                 txnLogBufferedWriterConfig,
-                                                                brokerClientSharedTimer, bufferedWriterMetrics,
-                                                                originPersistentTopic
-                                                                        .getBrokerService()
+                                                                brokerClientSharedTimer,
+                                                                bufferedWriterMetrics,
+                                                                brokerService
                                                                         .getPulsar()
                                                                         .getOrderedExecutor()
                                                                         .chooseThread()));
-                                                        if (log.isDebugEnabled()) {
-                                                            log.debug("{},{} open MLPendingAckStore cursor success",
-                                                                    originPersistentTopic.getName(),
-                                                                    subscription.getName());
-                                                        }
-                                                    }
+                                                if (log.isDebugEnabled()) {
+                                                    log.debug(
+                                                            "{},{} open MLPendingAckStore cursor "
+                                                                    + "success",
+                                                            originPersistentTopic.getName(),
+                                                            subscription.getName());
+                                                }
+                                            }
 
-                                                    @Override
-                                                    public void openCursorFailed(ManagedLedgerException exception,
-                                                                                 Object ctx) {
-                                                        log.error("{},{} open MLPendingAckStore cursor failed."
-                                                                , originPersistentTopic.getName(),
-                                                                subscription.getName(), exception);
-                                                        pendingAckStoreFuture.completeExceptionally(exception);
-                                                    }
-                                                }, null);
-                                    }
+                                            @Override
+                                            public void openCursorFailed(
+                                                    ManagedLedgerException exception,
+                                                    Object ctx) {
+                                                log.error(
+                                                        "{},{} open MLPendingAckStore cursor "
+                                                                + "failed."
+                                                        , originPersistentTopic.getName(),
+                                                        subscription.getName(), exception);
+                                                pendingAckStoreFuture.completeExceptionally(
+                                                        exception);
+                                            }
+                                        }, null);
+                            }
 
-                                    @Override
-                                    public void openLedgerFailed(ManagedLedgerException exception, Object ctx) {
-                                        log.error("{}, {} open MLPendingAckStore managedLedger failed."
-                                                , originPersistentTopic.getName(), subscription.getName(), exception);
-                                        pendingAckStoreFuture.completeExceptionally(exception);
-                                    }
-                                }, () -> CompletableFuture.completedFuture(true), null);
-                    }).exceptionally(e -> {
-                        Throwable t = FutureUtil.unwrapCompletionException(e);
-                        log.error("[{}] [{}] Failed to get managedLedger config when init pending ack store!",
-                                originPersistentTopic, subscription, t);
-                        pendingAckStoreFuture.completeExceptionally(t);
-                        return null;
-
-                    });
-                }).exceptionally(e -> {
-                    Throwable t = FutureUtil.unwrapCompletionException(e);
-                    log.error("[{}] [{}] Failed to check the pending ack topic exist when init pending ack store!",
-                            originPersistentTopic, subscription, t);
-                    pendingAckStoreFuture.completeExceptionally(t);
-                    return null;
-                });
-        return pendingAckStoreFuture;
+                            @Override
+                            public void openLedgerFailed(ManagedLedgerException exception,
+                                                         Object ctx) {
+                                log.error("{}, {} open MLPendingAckStore managedLedger failed."
+                                        , originPersistentTopic.getName(), subscription.getName(),
+                                        exception);
+                                pendingAckStoreFuture.completeExceptionally(exception);
+                            }
+                        }, () -> CompletableFuture.completedFuture(true), null);
     }
 
     @Override
@@ -188,8 +217,10 @@ public class MLPendingAckStoreProvider implements TransactionPendingAckStoreProv
         PersistentTopic originPersistentTopic = (PersistentTopic) subscription.getTopic();
         String pendingAckTopicName = MLPendingAckStore
                 .getTransactionPendingAckStoreSuffix(originPersistentTopic.getName(), subscription.getName());
-        return originPersistentTopic.getBrokerService().getManagedLedgerFactory()
-                .asyncExists(TopicName.get(pendingAckTopicName).getPersistenceNamingEncoding());
+        TopicName topicName = TopicName.get(pendingAckTopicName);
+        return originPersistentTopic.getBrokerService().getManagedLedgerFactoryForTopic(topicName)
+                .thenCompose(managedLedgerFactory -> managedLedgerFactory.asyncExists(
+                        topicName.getPersistenceNamingEncoding()));
     }
 
     private static class MLTxnPendingAckLogBufferedWriterMetrics extends TxnLogBufferedWriterMetricsStats{

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
@@ -135,7 +135,7 @@ public class AdminApiOffloadTest extends MockedPulsarServiceBaseTest {
             }
         }
 
-        ManagedLedgerInfo info = pulsar.getManagedLedgerFactory().getManagedLedgerInfo(mlName);
+        ManagedLedgerInfo info = pulsar.getDefaultManagedLedgerFactory().getManagedLedgerInfo(mlName);
         assertEquals(info.ledgers.size(), 2);
 
         assertEquals(admin.topics().offloadStatus(topicName).getStatus(), LongRunningProcessStatus.Status.NOT_RUN);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -588,24 +588,24 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
         // wait config to be updated
         Awaitility.await().until(() -> {
-            return pulsar.getManagedLedgerFactory().getEntryCacheManager().getMaxSize() == 1 * 1024L * 1024L
-                    && pulsar.getManagedLedgerFactory().getEntryCacheManager().getCacheEvictionWatermark() == 0.8
-                    && pulsar.getManagedLedgerFactory().getCacheEvictionTimeThreshold() == TimeUnit.MILLISECONDS
+            return pulsar.getDefaultManagedLedgerFactory().getEntryCacheManager().getMaxSize() == 1 * 1024L * 1024L
+                    && pulsar.getDefaultManagedLedgerFactory().getEntryCacheManager().getCacheEvictionWatermark() == 0.8
+                    && pulsar.getDefaultManagedLedgerFactory().getCacheEvictionTimeThreshold() == TimeUnit.MILLISECONDS
                     .toNanos(2000);
         });
 
         // verify value is updated
-        assertEquals(pulsar.getManagedLedgerFactory().getEntryCacheManager().getMaxSize(), 1 * 1024L * 1024L);
-        assertEquals(pulsar.getManagedLedgerFactory().getEntryCacheManager().getCacheEvictionWatermark(), 0.8);
-        assertEquals(pulsar.getManagedLedgerFactory().getCacheEvictionTimeThreshold(), TimeUnit.MILLISECONDS
+        assertEquals(pulsar.getDefaultManagedLedgerFactory().getEntryCacheManager().getMaxSize(), 1 * 1024L * 1024L);
+        assertEquals(pulsar.getDefaultManagedLedgerFactory().getEntryCacheManager().getCacheEvictionWatermark(), 0.8);
+        assertEquals(pulsar.getDefaultManagedLedgerFactory().getCacheEvictionTimeThreshold(), TimeUnit.MILLISECONDS
                 .toNanos(2000));
 
         restartBroker();
 
         // verify value again
-        assertEquals(pulsar.getManagedLedgerFactory().getEntryCacheManager().getMaxSize(), 1 * 1024L * 1024L);
-        assertEquals(pulsar.getManagedLedgerFactory().getEntryCacheManager().getCacheEvictionWatermark(), 0.8);
-        assertEquals(pulsar.getManagedLedgerFactory().getCacheEvictionTimeThreshold(), TimeUnit.MILLISECONDS
+        assertEquals(pulsar.getDefaultManagedLedgerFactory().getEntryCacheManager().getMaxSize(), 1 * 1024L * 1024L);
+        assertEquals(pulsar.getDefaultManagedLedgerFactory().getEntryCacheManager().getCacheEvictionWatermark(), 0.8);
+        assertEquals(pulsar.getDefaultManagedLedgerFactory().getCacheEvictionTimeThreshold(), TimeUnit.MILLISECONDS
                 .toNanos(2000));
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -708,7 +708,7 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         // partitioned topic to more than 10.
         final String nonPartitionTopicName2 = "special-topic-partition-10";
         final String partitionedTopicName = "special-topic";
-        pulsar.getBrokerService().getManagedLedgerFactory()
+        pulsar.getDefaultManagedLedgerFactory()
                 .open(TopicName.get(nonPartitionTopicName2).getPersistenceNamingEncoding());
         doAnswer(invocation -> {
             persistentTopics.namespaceName = NamespaceName.get("tenant", "namespace");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
@@ -127,7 +127,7 @@ public class BrokerBkEnsemblesTests extends BkEnsemblesTestBase {
         consumer.close();
         producer.close();
         pulsar.getBrokerService().removeTopicFromCache(topic);
-        ManagedLedgerFactoryImpl factory = (ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory();
+        ManagedLedgerFactoryImpl factory = (ManagedLedgerFactoryImpl) pulsar.getDefaultManagedLedgerFactory();
         Field field = ManagedLedgerFactoryImpl.class.getDeclaredField("ledgers");
         field.setAccessible(true);
         @SuppressWarnings("unchecked")
@@ -250,7 +250,7 @@ public class BrokerBkEnsemblesTests extends BkEnsemblesTestBase {
         // clean managed-ledger and recreate topic to clean any data from the cache
         producer.close();
         pulsar.getBrokerService().removeTopicFromCache(topic);
-        ManagedLedgerFactoryImpl factory = (ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory();
+        ManagedLedgerFactoryImpl factory = (ManagedLedgerFactoryImpl) pulsar.getDefaultManagedLedgerFactory();
         Field field = ManagedLedgerFactoryImpl.class.getDeclaredField("ledgers");
         field.setAccessible(true);
         @SuppressWarnings("unchecked")
@@ -399,7 +399,7 @@ public class BrokerBkEnsemblesTests extends BkEnsemblesTestBase {
 
     @Test
     public void testDeleteLedgerFactoryCorruptLedger() throws Exception {
-        ManagedLedgerFactoryImpl factory = (ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory();
+        ManagedLedgerFactoryImpl factory = (ManagedLedgerFactoryImpl) pulsar.getDefaultManagedLedgerFactory();
         ManagedLedgerImpl ml = (ManagedLedgerImpl) factory.open("test");
 
         // bookkeeper client

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
@@ -274,7 +274,7 @@ public class BrokerBookieIsolationTest {
         assertAffinityBookies(ledgerManager, ml4.getLedgersInfoAsList(), isolatedBookies);
 
         ManagedLedgerClientFactory mlFactory =
-            (ManagedLedgerClientFactory) pulsarService.getManagedLedgerClientFactory();
+            (ManagedLedgerClientFactory) pulsarService.getManagedLedgerStorage();
         Map<EnsemblePlacementPolicyConfig, BookKeeper> bkPlacementPolicyToBkClientMap = mlFactory
                 .getBkEnsemblePolicyToBookKeeperMap();
 
@@ -588,7 +588,7 @@ public class BrokerBookieIsolationTest {
         assertAffinityBookies(ledgerManager, ml4.getLedgersInfoAsList(), isolatedBookies);
 
         ManagedLedgerClientFactory mlFactory =
-                (ManagedLedgerClientFactory) pulsarService.getManagedLedgerClientFactory();
+                (ManagedLedgerClientFactory) pulsarService.getManagedLedgerStorage();
         Map<EnsemblePlacementPolicyConfig, BookKeeper> bkPlacementPolicyToBkClientMap = mlFactory
                 .getBkEnsemblePolicyToBookKeeperMap();
 
@@ -751,7 +751,7 @@ public class BrokerBookieIsolationTest {
         assertAffinityBookies(ledgerManager, ml3.getLedgersInfoAsList(), isolatedBookies);
 
         ManagedLedgerClientFactory mlFactory =
-            (ManagedLedgerClientFactory) pulsarService.getManagedLedgerClientFactory();
+            (ManagedLedgerClientFactory) pulsarService.getManagedLedgerStorage();
         Map<EnsemblePlacementPolicyConfig, BookKeeper> bkPlacementPolicyToBkClientMap = mlFactory
                 .getBkEnsemblePolicyToBookKeeperMap();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -76,8 +76,8 @@ import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
-import org.apache.bookkeeper.mledger.impl.NullLedgerOffloader;
 import org.apache.bookkeeper.mledger.impl.NonAppendableLedgerOffloader;
+import org.apache.bookkeeper.mledger.impl.NullLedgerOffloader;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -1451,7 +1451,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         ledgerField.setAccessible(true);
         @SuppressWarnings("unchecked")
         ConcurrentHashMap<String, CompletableFuture<ManagedLedgerImpl>> ledgers = (ConcurrentHashMap<String, CompletableFuture<ManagedLedgerImpl>>) ledgerField
-                .get(pulsar.getManagedLedgerFactory());
+                .get(pulsar.getDefaultManagedLedgerFactory());
         CompletableFuture<ManagedLedgerImpl> future = new CompletableFuture<>();
         future.completeExceptionally(new ManagedLedgerException("ledger opening failed"));
         ledgers.put(namespace + "/persistent/deadLockTestTopic", future);
@@ -1517,8 +1517,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
         PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName).get();
 
-        ManagedLedgerFactoryImpl mlFactory = (ManagedLedgerFactoryImpl) pulsar.getManagedLedgerClientFactory()
-                .getManagedLedgerFactory();
+        ManagedLedgerFactoryImpl mlFactory = (ManagedLedgerFactoryImpl) pulsar.getDefaultManagedLedgerFactory();
         Field ledgersField = ManagedLedgerFactoryImpl.class.getDeclaredField("ledgers");
         ledgersField.setAccessible(true);
         ConcurrentHashMap<String, CompletableFuture<ManagedLedgerImpl>> ledgers = (ConcurrentHashMap<String, CompletableFuture<ManagedLedgerImpl>>) ledgersField

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -187,7 +187,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         doAnswer(invocationOnMock -> {
             ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock, null);
             return null;
-        }).when(pulsarTestContext.getManagedLedgerFactory())
+        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
                 .asyncOpen(matches(".*success.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -196,7 +196,7 @@ public class PersistentDispatcherFailoverConsumerTest {
             ((OpenLedgerCallback) invocationOnMock.getArguments()[2])
                     .openLedgerFailed(new ManagedLedgerException("Managed ledger failure"), null);
             return null;
-        }).when(pulsarTestContext.getManagedLedgerFactory())
+        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
                 .asyncOpen(matches(".*fail.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -61,6 +61,7 @@ import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -184,10 +185,11 @@ public class PersistentDispatcherFailoverConsumerTest {
         doReturn("mockCursor").when(cursorMock).getName();
 
         // call openLedgerComplete with ledgerMock on ML factory asyncOpen
+        ManagedLedgerFactory managedLedgerFactory = pulsarTestContext.getDefaultManagedLedgerFactory();
         doAnswer(invocationOnMock -> {
             ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock, null);
             return null;
-        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
+        }).when(managedLedgerFactory)
                 .asyncOpen(matches(".*success.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -196,7 +198,7 @@ public class PersistentDispatcherFailoverConsumerTest {
             ((OpenLedgerCallback) invocationOnMock.getArguments()[2])
                     .openLedgerFailed(new ManagedLedgerException("Managed ledger failure"), null);
             return null;
-        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
+        }).when(managedLedgerFactory)
                 .asyncOpen(matches(".*fail.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
@@ -92,7 +92,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
         cursorMock = ledger.openCursor("c1");
         ledgerMock = ledger;
         mlFactoryMock = factory;
-        doReturn(mlFactoryMock).when(pulsar).getManagedLedgerFactory();
+        doReturn(mlFactoryMock).when(pulsar).getDefaultManagedLedgerFactory();
 
         brokerService = spyWithClassAndConstructorArgs(BrokerService.class, pulsar, eventLoopGroup);
         doReturn(brokerService).when(pulsar).getBrokerService();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
@@ -596,7 +596,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         pulsarClient.close();
 
         assertNotNull(pulsar.getBrokerService().getTopicReference(topic));
-        assertTrue(((ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory()).getManagedLedgers()
+        assertTrue(((ManagedLedgerFactoryImpl) pulsar.getDefaultManagedLedgerFactory()).getManagedLedgers()
                 .containsKey(topicName.getPersistenceNamingEncoding()));
 
         admin.namespaces().unload("prop/ns-abc");
@@ -613,7 +613,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         }
 
         // ML should have been closed as well
-        assertFalse(((ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory()).getManagedLedgers()
+        assertFalse(((ManagedLedgerFactoryImpl) pulsar.getDefaultManagedLedgerFactory()).getManagedLedgers()
                 .containsKey(topicName.getPersistenceNamingEncoding()));
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -191,12 +191,12 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         brokerService = pulsarTestContext.getBrokerService();
 
         doAnswer(invocationOnMock -> CompletableFuture.completedFuture(null))
-                .when(pulsarTestContext.getManagedLedgerFactory()).getManagedLedgerPropertiesAsync(any());
+                .when(pulsarTestContext.getDefaultManagedLedgerFactory()).getManagedLedgerPropertiesAsync(any());
         doAnswer(invocation -> {
             DeleteLedgerCallback deleteLedgerCallback = invocation.getArgument(1);
             deleteLedgerCallback.deleteLedgerComplete(null);
             return null;
-        }).when(pulsarTestContext.getManagedLedgerFactory()).asyncDelete(any(), any(), any());
+        }).when(pulsarTestContext.getDefaultManagedLedgerFactory()).asyncDelete(any(), any(), any());
         // Mock serviceCnx.
         serverCnx = spyWithClassAndConstructorArgsRecordingInvocations(ServerCnx.class,
                 pulsarTestContext.getPulsarService());
@@ -247,7 +247,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         doAnswer(invocationOnMock -> {
             ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock, null);
             return null;
-        }).when(pulsarTestContext.getManagedLedgerFactory())
+        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
                 .asyncOpen(anyString(), any(ManagedLedgerConfig.class), any(OpenLedgerCallback.class),
                         any(Supplier.class), any());
 
@@ -273,7 +273,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
                     .openLedgerFailed(new ManagedLedgerException("Managed ledger failure"), null)).start();
 
             return null;
-        }).when(pulsarTestContext.getManagedLedgerFactory())
+        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
                 .asyncOpen(anyString(), any(ManagedLedgerConfig.class), any(OpenLedgerCallback.class),
                         any(Supplier.class), any());
 
@@ -1395,7 +1395,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         doAnswer(invocationOnMock -> {
             ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock, null);
             return null;
-        }).when(pulsarTestContext.getManagedLedgerFactory())
+        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
                 .asyncOpen(matches(".*success.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -1404,7 +1404,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
             ((OpenLedgerCallback) invocationOnMock.getArguments()[2])
                     .openLedgerFailed(new ManagedLedgerException("Managed ledger failure"), null);
             return null;
-        }).when(pulsarTestContext.getManagedLedgerFactory())
+        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
                 .asyncOpen(matches(".*fail.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -90,6 +90,7 @@ import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
@@ -169,6 +170,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
     private BrokerService brokerService;
 
     private EventLoopGroup eventLoopGroup;
+    private ManagedLedgerFactory managedLedgerFactory;
 
     @BeforeMethod(alwaysRun = true)
     public void setup() throws Exception {
@@ -190,13 +192,14 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
                 .build();
         brokerService = pulsarTestContext.getBrokerService();
 
+        managedLedgerFactory = pulsarTestContext.getDefaultManagedLedgerFactory();
         doAnswer(invocationOnMock -> CompletableFuture.completedFuture(null))
-                .when(pulsarTestContext.getDefaultManagedLedgerFactory()).getManagedLedgerPropertiesAsync(any());
+                .when(managedLedgerFactory).getManagedLedgerPropertiesAsync(any());
         doAnswer(invocation -> {
             DeleteLedgerCallback deleteLedgerCallback = invocation.getArgument(1);
             deleteLedgerCallback.deleteLedgerComplete(null);
             return null;
-        }).when(pulsarTestContext.getDefaultManagedLedgerFactory()).asyncDelete(any(), any(), any());
+        }).when(managedLedgerFactory).asyncDelete(any(), any(), any());
         // Mock serviceCnx.
         serverCnx = spyWithClassAndConstructorArgsRecordingInvocations(ServerCnx.class,
                 pulsarTestContext.getPulsarService());
@@ -247,7 +250,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         doAnswer(invocationOnMock -> {
             ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock, null);
             return null;
-        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
+        }).when(managedLedgerFactory)
                 .asyncOpen(anyString(), any(ManagedLedgerConfig.class), any(OpenLedgerCallback.class),
                         any(Supplier.class), any());
 
@@ -273,7 +276,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
                     .openLedgerFailed(new ManagedLedgerException("Managed ledger failure"), null)).start();
 
             return null;
-        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
+        }).when(managedLedgerFactory)
                 .asyncOpen(anyString(), any(ManagedLedgerConfig.class), any(OpenLedgerCallback.class),
                         any(Supplier.class), any());
 
@@ -1395,7 +1398,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         doAnswer(invocationOnMock -> {
             ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock, null);
             return null;
-        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
+        }).when(managedLedgerFactory)
                 .asyncOpen(matches(".*success.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -1404,7 +1407,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
             ((OpenLedgerCallback) invocationOnMock.getArguments()[2])
                     .openLedgerFailed(new ManagedLedgerException("Managed ledger failure"), null);
             return null;
-        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
+        }).when(managedLedgerFactory)
                 .asyncOpen(matches(".*fail.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicationTxnTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicationTxnTest.java
@@ -187,14 +187,14 @@ public class ReplicationTxnTest extends OneWayReplicatorTestBase {
         for (int i = 0; i < txnLogPartitions; i++) {
             TopicName txnLog = TopicName.get(TopicDomain.persistent.value(),
                     NamespaceName.SYSTEM_NAMESPACE, TRANSACTION_LOG_PREFIX + i);
-            assertNotNull(pulsar1.getManagedLedgerFactory()
+            assertNotNull(pulsar1.getDefaultManagedLedgerFactory()
                     .getManagedLedgerInfo(txnLog.getPersistenceNamingEncoding()));
             assertFalse(broker1.getTopics().containsKey(txnLog.toString()));
         }
         // __transaction_pending_ack: it only uses ML, will not create topic.
         TopicName pendingAck = TopicName.get(
                 MLPendingAckStore.getTransactionPendingAckStoreSuffix(topic, subscription));
-        assertNotNull(pulsar1.getManagedLedgerFactory()
+        assertNotNull(pulsar1.getDefaultManagedLedgerFactory()
                 .getManagedLedgerInfo(pendingAck.getPersistenceNamingEncoding()));
         assertFalse(broker1.getTopics().containsKey(pendingAck.toString()));
         // __transaction_buffer_snapshot.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -1419,8 +1419,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         config1.setTopicLoadTimeoutSeconds(topicLoadTimeoutSeconds);
         config2.setTopicLoadTimeoutSeconds(topicLoadTimeoutSeconds);
 
-        ManagedLedgerFactoryImpl mlFactory = (ManagedLedgerFactoryImpl) pulsar1.getManagedLedgerClientFactory()
-                .getManagedLedgerFactory();
+        ManagedLedgerFactoryImpl mlFactory = (ManagedLedgerFactoryImpl) pulsar1.getDefaultManagedLedgerFactory();
         Field ledgersField = ManagedLedgerFactoryImpl.class.getDeclaredField("ledgers");
         ledgersField.setAccessible(true);
         ConcurrentHashMap<String, CompletableFuture<ManagedLedgerImpl>> ledgers = (ConcurrentHashMap<String, CompletableFuture<ManagedLedgerImpl>>) ledgersField

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -2043,7 +2043,7 @@ public class ServerCnxTest {
                     () -> ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock,
                             null));
             return null;
-        }).when(pulsarTestContext.getManagedLedgerFactory())
+        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
                 .asyncOpen(matches(".*success.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -2098,7 +2098,7 @@ public class ServerCnxTest {
                     () -> ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock,
                             null));
             return null;
-        }).when(pulsarTestContext.getManagedLedgerFactory())
+        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
                 .asyncOpen(matches(".*success.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -2165,7 +2165,7 @@ public class ServerCnxTest {
 
             ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock, null);
             return null;
-        }).when(pulsarTestContext.getManagedLedgerFactory())
+        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
                 .asyncOpen(matches(".*success.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -2244,7 +2244,7 @@ public class ServerCnxTest {
                     () -> ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock,
                             null));
             return null;
-        }).when(pulsarTestContext.getManagedLedgerFactory())
+        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
                 .asyncOpen(matches(".*fail.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -2316,7 +2316,7 @@ public class ServerCnxTest {
                             null));
 
             return null;
-        }).when(pulsarTestContext.getManagedLedgerFactory())
+        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
                 .asyncOpen(matches(".*success.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -2391,7 +2391,7 @@ public class ServerCnxTest {
                     () -> ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock,
                             null));
             return null;
-        }).when(pulsarTestContext.getManagedLedgerFactory())
+        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
                 .asyncOpen(matches(".*success.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -2400,7 +2400,7 @@ public class ServerCnxTest {
             openTopicFail.complete(() -> ((OpenLedgerCallback) invocationOnMock.getArguments()[2])
                     .openLedgerFailed(new ManagedLedgerException("Managed ledger failure"), null));
             return null;
-        }).when(pulsarTestContext.getManagedLedgerFactory())
+        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
                 .asyncOpen(matches(".*fail.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -2926,7 +2926,7 @@ public class ServerCnxTest {
             Thread.sleep(300);
             ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock, null);
             return null;
-        }).when(pulsarTestContext.getManagedLedgerFactory())
+        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
                 .asyncOpen(matches(".*success.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -2937,7 +2937,7 @@ public class ServerCnxTest {
                     .openLedgerFailed(new ManagedLedgerException("Managed ledger failure"), null)).start();
 
             return null;
-        }).when(pulsarTestContext.getManagedLedgerFactory())
+        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
                 .asyncOpen(matches(".*fail.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -83,6 +83,7 @@ import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -202,6 +203,7 @@ public class ServerCnxTest {
     private ManagedLedger ledgerMock;
     private ManagedCursor cursorMock;
     private ConcurrentHashSet<EmbeddedChannel> channelsStoppedAnswerHealthCheck = new ConcurrentHashSet<>();
+    private ManagedLedgerFactory managedLedgerFactory;
 
 
     @BeforeMethod(alwaysRun = true)
@@ -218,7 +220,7 @@ public class ServerCnxTest {
                 .spyByDefault()
                 .build();
         pulsar = pulsarTestContext.getPulsarService();
-
+        managedLedgerFactory = pulsarTestContext.getDefaultManagedLedgerFactory();
         brokerService = pulsarTestContext.getBrokerService();
 
         namespaceService = pulsar.getNamespaceService();
@@ -2043,7 +2045,7 @@ public class ServerCnxTest {
                     () -> ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock,
                             null));
             return null;
-        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
+        }).when(managedLedgerFactory)
                 .asyncOpen(matches(".*success.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -2098,7 +2100,7 @@ public class ServerCnxTest {
                     () -> ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock,
                             null));
             return null;
-        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
+        }).when(managedLedgerFactory)
                 .asyncOpen(matches(".*success.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -2165,7 +2167,7 @@ public class ServerCnxTest {
 
             ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock, null);
             return null;
-        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
+        }).when(managedLedgerFactory)
                 .asyncOpen(matches(".*success.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -2244,7 +2246,7 @@ public class ServerCnxTest {
                     () -> ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock,
                             null));
             return null;
-        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
+        }).when(managedLedgerFactory)
                 .asyncOpen(matches(".*fail.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -2316,7 +2318,7 @@ public class ServerCnxTest {
                             null));
 
             return null;
-        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
+        }).when(managedLedgerFactory)
                 .asyncOpen(matches(".*success.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -2391,7 +2393,7 @@ public class ServerCnxTest {
                     () -> ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock,
                             null));
             return null;
-        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
+        }).when(managedLedgerFactory)
                 .asyncOpen(matches(".*success.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -2400,7 +2402,7 @@ public class ServerCnxTest {
             openTopicFail.complete(() -> ((OpenLedgerCallback) invocationOnMock.getArguments()[2])
                     .openLedgerFailed(new ManagedLedgerException("Managed ledger failure"), null));
             return null;
-        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
+        }).when(managedLedgerFactory)
                 .asyncOpen(matches(".*fail.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -2926,7 +2928,7 @@ public class ServerCnxTest {
             Thread.sleep(300);
             ((OpenLedgerCallback) invocationOnMock.getArguments()[2]).openLedgerComplete(ledgerMock, null);
             return null;
-        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
+        }).when(managedLedgerFactory)
                 .asyncOpen(matches(".*success.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 
@@ -2937,7 +2939,7 @@ public class ServerCnxTest {
                     .openLedgerFailed(new ManagedLedgerException("Managed ledger failure"), null)).start();
 
             return null;
-        }).when(pulsarTestContext.getDefaultManagedLedgerFactory())
+        }).when(managedLedgerFactory)
                 .asyncOpen(matches(".*fail.*"), any(ManagedLedgerConfig.class),
                         any(OpenLedgerCallback.class), any(Supplier.class), any());
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMarkerDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionMarkerDeleteTest.java
@@ -70,7 +70,7 @@ public class TransactionMarkerDeleteTest extends TransactionTestBase {
     @Test
     public void testMarkerDeleteTimes() throws Exception {
         ManagedLedgerImpl managedLedger =
-                spy((ManagedLedgerImpl) getPulsarServiceList().get(0).getManagedLedgerFactory().open("test"));
+                spy((ManagedLedgerImpl) getPulsarServiceList().get(0).getDefaultManagedLedgerFactory().open("test"));
         PersistentTopic topic = mock(PersistentTopic.class);
         BrokerService brokerService = mock(BrokerService.class);
         PulsarService pulsarService = mock(PulsarService.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ManagedLedgerMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ManagedLedgerMetricsTest.java
@@ -105,7 +105,7 @@ public class ManagedLedgerMetricsTest extends BrokerTestBase {
             producer.send(message.getBytes());
         }
 
-        var managedLedgerFactory = (ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory();
+        var managedLedgerFactory = (ManagedLedgerFactoryImpl) pulsar.getDefaultManagedLedgerFactory();
         for (Entry<String, ManagedLedger> ledger : managedLedgerFactory.getManagedLedgers().entrySet()) {
             ManagedLedgerMBeanImpl stats = (ManagedLedgerMBeanImpl) ledger.getValue().getStats();
             stats.refreshStats(1, TimeUnit.SECONDS);
@@ -205,7 +205,7 @@ public class ManagedLedgerMetricsTest extends BrokerTestBase {
         ManagedLedgerConfig managedLedgerConfig = new ManagedLedgerConfig();
         managedLedgerConfig.setMaxEntriesPerLedger(2);
         MLTransactionLogImpl mlTransactionLog = new MLTransactionLogImpl(TransactionCoordinatorID.get(0),
-                pulsar.getManagedLedgerFactory(), managedLedgerConfig, txnLogBufferedWriterConfig,
+                pulsar.getDefaultManagedLedgerFactory(), managedLedgerConfig, txnLogBufferedWriterConfig,
                 transactionTimer, DISABLED_BUFFERED_WRITER_METRICS);
         mlTransactionLog.initialize().get(2, TimeUnit.SECONDS);
         ManagedLedgerMetrics metrics = new ManagedLedgerMetrics(pulsar);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/NonStartableTestPulsarService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/NonStartableTestPulsarService.java
@@ -71,7 +71,7 @@ class NonStartableTestPulsarService extends AbstractTestPulsarService {
         super(spyConfig, config, localMetadataStore, configurationMetadataStore, compactionServiceFactory,
                 brokerInterceptor, bookKeeperClientFactory, null);
         setPulsarResources(pulsarResources);
-        setManagedLedgerClientFactory(managedLedgerClientFactory);
+        setManagedLedgerStorage(managedLedgerClientFactory);
         try {
             setBrokerService(brokerServiceCustomizer.apply(
                     spyConfig.getBrokerService().spy(TestBrokerService.class, this, getIoEventLoopGroup())));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -56,7 +57,9 @@ import org.apache.pulsar.broker.resources.TopicResources;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.ServerCnx;
 import org.apache.pulsar.broker.stats.BrokerOpenTelemetryTestUtil;
+import org.apache.pulsar.broker.storage.BookkeeperManagedLedgerStorageClass;
 import org.apache.pulsar.broker.storage.ManagedLedgerStorage;
+import org.apache.pulsar.broker.storage.ManagedLedgerStorageClass;
 import org.apache.pulsar.common.util.GracefulExecutorServicesShutdown;
 import org.apache.pulsar.common.util.PortManager;
 import org.apache.pulsar.compaction.CompactionServiceFactory;
@@ -136,7 +139,7 @@ public class PulsarTestContext implements AutoCloseable {
 
     private final OrderedExecutor executor;
 
-    private final ManagedLedgerStorage managedLedgerClientFactory;
+    private final ManagedLedgerStorage managedLedgerStorage;
 
     private final PulsarService pulsarService;
 
@@ -167,8 +170,12 @@ public class PulsarTestContext implements AutoCloseable {
     private final boolean enableOpenTelemetry;
     private final InMemoryMetricReader openTelemetryMetricReader;
 
-    public ManagedLedgerFactory getManagedLedgerFactory() {
-        return managedLedgerClientFactory.getManagedLedgerFactory();
+    public ManagedLedgerStorage getManagedLedgerStorage() {
+        return managedLedgerStorage;
+    }
+
+    public ManagedLedgerFactory getDefaultManagedLedgerFactory() {
+        return getManagedLedgerStorage().getDefaultStorageClass().getManagedLedgerFactory();
     }
 
     public PulsarMockBookKeeper getMockBookKeeper() {
@@ -524,8 +531,8 @@ public class PulsarTestContext implements AutoCloseable {
          */
         public Builder managedLedgerClients(BookKeeper bookKeeperClient,
                                             ManagedLedgerFactory managedLedgerFactory) {
-            return managedLedgerClientFactory(
-                    PulsarTestContext.createManagedLedgerClientFactory(bookKeeperClient, managedLedgerFactory));
+            return managedLedgerStorage(
+                    PulsarTestContext.createManagedLedgerStorage(bookKeeperClient, managedLedgerFactory));
         }
 
         /**
@@ -622,7 +629,7 @@ public class PulsarTestContext implements AutoCloseable {
         }
 
         private void initializeCommonPulsarServices(SpyConfig spyConfig) {
-            if (super.bookKeeperClient == null && super.managedLedgerClientFactory == null) {
+            if (super.bookKeeperClient == null && super.managedLedgerStorage == null) {
                 if (super.executor == null) {
                     OrderedExecutor createdExecutor = OrderedExecutor.newBuilder().numThreads(1)
                             .name(PulsarTestContext.class.getSimpleName() + "-executor").build();
@@ -645,8 +652,11 @@ public class PulsarTestContext implements AutoCloseable {
                 });
                 bookKeeperClient(mockBookKeeper);
             }
-            if (super.bookKeeperClient == null && super.managedLedgerClientFactory != null) {
-                bookKeeperClient(super.managedLedgerClientFactory.getBookKeeperClient());
+            if (super.bookKeeperClient == null && super.managedLedgerStorage != null) {
+                bookKeeperClient(super.managedLedgerStorage.getStorageClasses().stream()
+                        .filter(BookkeeperManagedLedgerStorageClass.class::isInstance)
+                        .map(BookkeeperManagedLedgerStorageClass.class::cast)
+                        .map(BookkeeperManagedLedgerStorageClass::getBookKeeperClient).findFirst().get());
             }
             if (super.localMetadataStore == null || super.configurationMetadataStore == null) {
                 if (super.mockZooKeeper != null) {
@@ -725,8 +735,8 @@ public class PulsarTestContext implements AutoCloseable {
         }
 
         @Override
-        public Builder managedLedgerClientFactory(ManagedLedgerStorage managedLedgerClientFactory) {
-            throw new IllegalStateException("Cannot set managedLedgerClientFactory when startable.");
+        public Builder managedLedgerStorage(ManagedLedgerStorage managedLedgerStorage) {
+            throw new IllegalStateException("Cannot set managedLedgerStorage when startable.");
         }
 
         @Override
@@ -788,10 +798,10 @@ public class PulsarTestContext implements AutoCloseable {
 
         @Override
         protected void initializePulsarServices(SpyConfig spyConfig, Builder builder) {
-            if (builder.managedLedgerClientFactory == null) {
+            if (builder.managedLedgerStorage == null) {
                 ManagedLedgerFactory mlFactoryMock = Mockito.mock(ManagedLedgerFactory.class);
-                managedLedgerClientFactory(
-                        PulsarTestContext.createManagedLedgerClientFactory(builder.bookKeeperClient, mlFactoryMock));
+                managedLedgerStorage(
+                        PulsarTestContext.createManagedLedgerStorage(builder.bookKeeperClient, mlFactoryMock));
             }
             if (builder.pulsarResources == null) {
                 SpyConfig.SpyType spyConfigPulsarResources = spyConfig.getPulsarResources();
@@ -825,7 +835,7 @@ public class PulsarTestContext implements AutoCloseable {
                             builder.configurationMetadataStore, compactionServiceFactory,
                             builder.brokerInterceptor,
                             bookKeeperClientFactory, builder.pulsarResources,
-                            builder.managedLedgerClientFactory, builder.brokerServiceCustomizer);
+                            builder.managedLedgerStorage, builder.brokerServiceCustomizer);
             if (compactionServiceFactory != null) {
                 compactionServiceFactory.initialize(pulsarService);
             }
@@ -838,10 +848,31 @@ public class PulsarTestContext implements AutoCloseable {
     }
 
     @NotNull
-    private static ManagedLedgerStorage createManagedLedgerClientFactory(BookKeeper bookKeeperClient,
-                                                                         ManagedLedgerFactory managedLedgerFactory) {
-        return new ManagedLedgerStorage() {
+    private static ManagedLedgerStorage createManagedLedgerStorage(BookKeeper bookKeeperClient,
+                                                                   ManagedLedgerFactory managedLedgerFactory) {
+        BookkeeperManagedLedgerStorageClass managedLedgerStorageClass =
+                new BookkeeperManagedLedgerStorageClass() {
+                    @Override
+                    public String getName() {
+                        return "bookkeeper";
+                    }
 
+                    @Override
+                    public ManagedLedgerFactory getManagedLedgerFactory() {
+                        return managedLedgerFactory;
+                    }
+
+                    @Override
+                    public StatsProvider getStatsProvider() {
+                        return new NullStatsProvider();
+                    }
+
+                    @Override
+                    public BookKeeper getBookKeeperClient() {
+                        return bookKeeperClient;
+                    }
+                };
+        return new ManagedLedgerStorage() {
             @Override
             public void initialize(ServiceConfiguration conf, MetadataStoreExtended metadataStore,
                                    BookKeeperClientFactory bookkeeperProvider, EventLoopGroup eventLoopGroup,
@@ -849,18 +880,17 @@ public class PulsarTestContext implements AutoCloseable {
             }
 
             @Override
-            public ManagedLedgerFactory getManagedLedgerFactory() {
-                return managedLedgerFactory;
+            public Collection<ManagedLedgerStorageClass> getStorageClasses() {
+                return List.of(managedLedgerStorageClass);
             }
 
             @Override
-            public StatsProvider getStatsProvider() {
-                return new NullStatsProvider();
-            }
-
-            @Override
-            public BookKeeper getBookKeeperClient() {
-                return bookKeeperClient;
+            public Optional<ManagedLedgerStorageClass> getManagedLedgerStorageClass(String name) {
+                if (name == null || name.equals("bookkeeper")) {
+                    return Optional.of(managedLedgerStorageClass);
+                } else {
+                    return Optional.empty();
+                }
             }
 
             @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
@@ -576,6 +576,9 @@ public class PulsarTestContext implements AutoCloseable {
             if (configOverrideCustomizer != null) {
                 configOverrideCustomizer.accept(super.config);
             }
+            if (super.managedLedgerStorage != null && !MockUtil.isMock(super.managedLedgerStorage)) {
+                super.managedLedgerStorage = spyConfig.getManagedLedgerStorage().spy(super.managedLedgerStorage);
+            }
             initializeCommonPulsarServices(spyConfig);
             initializePulsarServices(spyConfig, this);
             if (pulsarServiceCustomizer != null) {
@@ -801,7 +804,9 @@ public class PulsarTestContext implements AutoCloseable {
             if (builder.managedLedgerStorage == null) {
                 ManagedLedgerFactory mlFactoryMock = Mockito.mock(ManagedLedgerFactory.class);
                 managedLedgerStorage(
-                        PulsarTestContext.createManagedLedgerStorage(builder.bookKeeperClient, mlFactoryMock));
+                        spyConfig.getManagedLedgerStorage()
+                                .spy(PulsarTestContext.createManagedLedgerStorage(builder.bookKeeperClient,
+                                        mlFactoryMock)));
             }
             if (builder.pulsarResources == null) {
                 SpyConfig.SpyType spyConfigPulsarResources = spyConfig.getPulsarResources();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/SpyConfig.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/SpyConfig.java
@@ -112,6 +112,8 @@ public class SpyConfig {
      */
     private final SpyType namespaceService;
 
+    private final SpyType managedLedgerStorage;
+
     /**
      * Create a builder for SpyConfig with no spies by default.
      *
@@ -141,5 +143,6 @@ public class SpyConfig {
         spyConfigBuilder.compactor(defaultSpyType);
         spyConfigBuilder.compactedServiceFactory(defaultSpyType);
         spyConfigBuilder.namespaceService(defaultSpyType);
+        spyConfigBuilder.managedLedgerStorage(defaultSpyType);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/StartableTestPulsarService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/StartableTestPulsarService.java
@@ -23,6 +23,7 @@ import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import lombok.SneakyThrows;
 import org.apache.pulsar.broker.BookKeeperClientFactory;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
@@ -30,6 +31,7 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.broker.storage.ManagedLedgerStorage;
 import org.apache.pulsar.compaction.CompactionServiceFactory;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 
@@ -61,5 +63,24 @@ class StartableTestPulsarService extends AbstractTestPulsarService {
     @Override
     public Supplier<NamespaceService> getNamespaceServiceProvider() throws PulsarServerException {
         return () -> spyConfig.getNamespaceService().spy(NamespaceService.class, this);
+    }
+
+    @SneakyThrows
+    @Override
+    public ManagedLedgerStorage getManagedLedgerStorage() {
+        // support adding spy to managedLedgerStorage in beforePulsarStart method
+        if (super.getManagedLedgerStorage() == null) {
+            setManagedLedgerStorage(createManagedLedgerStorageSpy());
+        }
+        return super.getManagedLedgerStorage();
+    }
+
+    @Override
+    protected ManagedLedgerStorage newManagedLedgerStorage() throws Exception {
+        return getManagedLedgerStorage();
+    }
+
+    private ManagedLedgerStorage createManagedLedgerStorageSpy() throws Exception {
+        return spyConfig.getManagedLedgerStorage().spy(super.newManagedLedgerStorage());
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
@@ -806,7 +806,7 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
                 //
             }
         };
-        pulsarService.getManagedLedgerFactory()
+        pulsarService.getDefaultManagedLedgerFactory()
                 .asyncOpenReadOnlyManagedLedger(snapshotSegmentTopicName.getPersistenceNamingEncoding(), callback,
                         brokerService.getManagedLedgerConfig(snapshotSegmentTopicName).get(),null);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionProduceTest.java
@@ -247,7 +247,7 @@ public class TransactionProduceTest extends TransactionTestBase {
             if (partition >= 0) {
                 topic = TopicName.get(topic).toString() + TopicName.PARTITIONED_TOPIC_SUFFIX + partition;
             }
-            return getPulsarServiceList().get(0).getManagedLedgerFactory().openReadOnlyCursor(
+            return getPulsarServiceList().get(0).getDefaultManagedLedgerFactory().openReadOnlyCursor(
                     TopicName.get(topic).getPersistenceNamingEncoding(),
                     PositionFactory.EARLIEST, new ManagedLedgerConfig());
         } catch (Exception e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -510,7 +510,7 @@ public class TransactionTest extends TransactionTestBase {
         admin.topics().createNonPartitionedTopic(topic);
         PulsarService pulsarService = super.getPulsarServiceList().get(0);
         pulsarService.getBrokerService().getTopics().clear();
-        ManagedLedgerFactory managedLedgerFactory = pulsarService.getBrokerService().getManagedLedgerFactory();
+        ManagedLedgerFactory managedLedgerFactory = pulsarService.getDefaultManagedLedgerFactory();
         Field field = ManagedLedgerFactoryImpl.class.getDeclaredField("ledgers");
         field.setAccessible(true);
         ConcurrentHashMap<String, CompletableFuture<ManagedLedgerImpl>> ledgers =

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/OrphanPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/OrphanPersistentTopicTest.java
@@ -291,7 +291,7 @@ public class OrphanPersistentTopicTest extends ProducerConsumerBase {
                     Thread.sleep(10 * 1000);
                 }
                 log.info("Race condition occurs {} times", mockRaceConditionCounter.get());
-                pulsar.getManagedLedgerFactory().delete(TopicName.get(tpName).getPersistenceNamingEncoding());
+                pulsar.getDefaultManagedLedgerFactory().delete(TopicName.get(tpName).getPersistenceNamingEncoding());
             }
             return invocation.callRealMethod();
         }).when(namespaceService).isServiceUnitActiveAsync(any(TopicName.class));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -91,8 +91,13 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.ServerCnx;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.storage.ManagedLedgerStorage;
+import org.apache.pulsar.broker.storage.ManagedLedgerStorageClass;
+import org.apache.pulsar.broker.testcontext.PulsarTestContext;
+import org.apache.pulsar.broker.testcontext.SpyConfig;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
@@ -148,6 +153,14 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     protected void setup() throws Exception {
         super.internalSetup();
         super.producerBaseSetup();
+    }
+
+    @Override
+    protected PulsarTestContext.Builder createPulsarTestContextBuilder(ServiceConfiguration conf) {
+        return super.createPulsarTestContextBuilder(conf)
+                .spyConfig(SpyConfig.builder()
+                        .managedLedgerStorage(SpyConfig.SpyType.SPY_ALSO_INVOCATIONS)
+                        .build());
     }
 
     @AfterMethod(alwaysRun = true)
@@ -1097,18 +1110,25 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
     }
 
+
     @Override
     protected void beforePulsarStart(PulsarService pulsar) throws Exception {
         super.beforePulsarStart(pulsar);
-        doAnswer(i0 -> {
-            ManagedLedgerFactory factory = (ManagedLedgerFactory) spy(i0.callRealMethod());
-            doAnswer(i1 -> {
-                EntryCacheManager manager = (EntryCacheManager) spy(i1.callRealMethod());
-                doAnswer(i2 -> spy(i2.callRealMethod())).when(manager).getEntryCache(any());
-                return manager;
-            }).when(factory).getEntryCacheManager();
-            return factory;
-        }).when(pulsar).getDefaultManagedLedgerFactory();
+        ManagedLedgerStorage managedLedgerStorage = pulsar.getManagedLedgerStorage();
+        doAnswer(invocation -> {
+            ManagedLedgerStorageClass managedLedgerStorageClass =
+                    (ManagedLedgerStorageClass) spy(invocation.callRealMethod());
+            doAnswer(i0 -> {
+                ManagedLedgerFactory factory = (ManagedLedgerFactory) spy(i0.callRealMethod());
+                doAnswer(i1 -> {
+                    EntryCacheManager manager = (EntryCacheManager) spy(i1.callRealMethod());
+                    doAnswer(i2 -> spy(i2.callRealMethod())).when(manager).getEntryCache(any());
+                    return manager;
+                }).when(factory).getEntryCacheManager();
+                return factory;
+            }).when(managedLedgerStorageClass).getManagedLedgerFactory();
+            return managedLedgerStorageClass;
+        }).when(managedLedgerStorage).getDefaultStorageClass();
     }
 
     /**
@@ -1125,6 +1145,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     @Test(timeOut = 100000)
     public void testActiveAndInActiveConsumerEntryCacheBehavior() throws Exception {
         log.info("-- Starting {} test --", methodName);
+
 
         final long batchMessageDelayMs = 100;
         final int receiverSize = 10;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -1108,7 +1108,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                 return manager;
             }).when(factory).getEntryCacheManager();
             return factory;
-        }).when(pulsar).getManagedLedgerFactory();
+        }).when(pulsar).getDefaultManagedLedgerFactory();
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionPauseOnAckStatPersistTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionPauseOnAckStatPersistTest.java
@@ -563,7 +563,7 @@ public class SubscriptionPauseOnAckStatPersistTest extends ProducerConsumerBase 
         final String subscription = "s1";
         final int msgSendCount = 100;
         // Inject a injection to record the counter of calling "cursor.isCursorDataFullyPersistable".
-        final ManagedLedgerImpl ml = (ManagedLedgerImpl) pulsar.getBrokerService().getManagedLedgerFactory().open(mlName);
+        final ManagedLedgerImpl ml = (ManagedLedgerImpl) pulsar.getDefaultManagedLedgerFactory().open(mlName);
         final ManagedCursorImpl cursor = (ManagedCursorImpl) ml.openCursor(subscription);
         final ManagedCursorImpl spyCursor = Mockito.spy(cursor);
         AtomicInteger callingIsCursorDataFullyPersistableCounter = new AtomicInteger();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerTest.java
@@ -624,7 +624,7 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
                 return manager;
             }).when(factory).getEntryCacheManager();
             return factory;
-        }).when(pulsar).getManagedLedgerFactory();
+        }).when(pulsar).getDefaultManagedLedgerFactory();
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SequenceIdWithErrorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SequenceIdWithErrorTest.java
@@ -62,7 +62,7 @@ public class SequenceIdWithErrorTest extends BkEnsemblesTestBase {
         ManagedLedgerClientFactory clientFactory = new ManagedLedgerClientFactory();
         clientFactory.initialize(pulsar.getConfiguration(), pulsar.getLocalMetadataStore(),
                 pulsar.getBookKeeperClientFactory(), eventLoopGroup, OpenTelemetry.noop());
-        ManagedLedgerFactory mlFactory = clientFactory.getManagedLedgerFactory();
+        ManagedLedgerFactory mlFactory = clientFactory.getDefaultStorageClass().getManagedLedgerFactory();
         ManagedLedger ml = mlFactory.open(TopicName.get(topicName).getPersistenceNamingEncoding());
         ml.close();
         clientFactory.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -927,7 +927,7 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
         // verify second ledger created
         String managedLedgerName = ((PersistentTopic)pulsar.getBrokerService().getTopicReference(topic).get())
             .getManagedLedger().getName();
-        ManagedLedgerInfo info = pulsar.getManagedLedgerFactory().getManagedLedgerInfo(managedLedgerName);
+        ManagedLedgerInfo info = pulsar.getDefaultManagedLedgerFactory().getManagedLedgerInfo(managedLedgerName);
         Assert.assertEquals(info.ledgers.size(), 2);
         Assert.assertTrue(ledgersOpened.isEmpty()); // no ledgers should have been opened
 
@@ -950,7 +950,7 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
                     .send();
         }
 
-        info = pulsar.getManagedLedgerFactory().getManagedLedgerInfo(managedLedgerName);
+        info = pulsar.getDefaultManagedLedgerFactory().getManagedLedgerInfo(managedLedgerName);
         Assert.assertEquals(info.ledgers.size(), 3);
 
         // should only have opened the penultimate ledger to get stat

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/PersistencePolicies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/PersistencePolicies.java
@@ -30,17 +30,24 @@ public class PersistencePolicies {
     private int bookkeeperWriteQuorum;
     private int bookkeeperAckQuorum;
     private double managedLedgerMaxMarkDeleteRate;
+    private String managedLedgerStorageClassName;
 
     public PersistencePolicies() {
-        this(2, 2, 2, 0.0);
+        this(2, 2, 2, 0.0, null);
     }
 
     public PersistencePolicies(int bookkeeperEnsemble, int bookkeeperWriteQuorum, int bookkeeperAckQuorum,
-            double managedLedgerMaxMarkDeleteRate) {
+                               double managedLedgerMaxMarkDeleteRate) {
+        this(bookkeeperEnsemble, bookkeeperWriteQuorum, bookkeeperAckQuorum, managedLedgerMaxMarkDeleteRate, null);
+    }
+
+    public PersistencePolicies(int bookkeeperEnsemble, int bookkeeperWriteQuorum, int bookkeeperAckQuorum,
+            double managedLedgerMaxMarkDeleteRate, String managedLedgerStorageClassName) {
         this.bookkeeperEnsemble = bookkeeperEnsemble;
         this.bookkeeperWriteQuorum = bookkeeperWriteQuorum;
         this.bookkeeperAckQuorum = bookkeeperAckQuorum;
         this.managedLedgerMaxMarkDeleteRate = managedLedgerMaxMarkDeleteRate;
+        this.managedLedgerStorageClassName = managedLedgerStorageClassName;
     }
 
     public int getBookkeeperEnsemble() {
@@ -59,10 +66,14 @@ public class PersistencePolicies {
         return managedLedgerMaxMarkDeleteRate;
     }
 
+    public String getManagedLedgerStorageClassName() {
+        return managedLedgerStorageClassName;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(bookkeeperEnsemble, bookkeeperWriteQuorum,
-                bookkeeperAckQuorum, managedLedgerMaxMarkDeleteRate);
+                bookkeeperAckQuorum, managedLedgerMaxMarkDeleteRate, managedLedgerStorageClassName);
     }
     @Override
     public boolean equals(Object obj) {
@@ -71,7 +82,8 @@ public class PersistencePolicies {
             return bookkeeperEnsemble == other.bookkeeperEnsemble
                     && bookkeeperWriteQuorum == other.bookkeeperWriteQuorum
                     && bookkeeperAckQuorum == other.bookkeeperAckQuorum
-                    && managedLedgerMaxMarkDeleteRate == other.managedLedgerMaxMarkDeleteRate;
+                    && managedLedgerMaxMarkDeleteRate == other.managedLedgerMaxMarkDeleteRate
+                    && managedLedgerStorageClassName == other.managedLedgerStorageClassName;
         }
 
         return false;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -1379,6 +1379,11 @@ public class CmdNamespaces extends CmdBase {
                 description = "Throttling rate of mark-delete operation (0 means no throttle)")
         private double managedLedgerMaxMarkDeleteRate = 0;
 
+        @Option(names = { "-c",
+                "--ml-storage-class" },
+                description = "Managed ledger storage class name")
+        private String managedLedgerStorageClassName;
+
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(namespaceName);
@@ -1390,7 +1395,8 @@ public class CmdNamespaces extends CmdBase {
                 throw new ParameterException("[--ml-mark-delete-max-rate] cannot less than 0.");
             }
             getAdmin().namespaces().setPersistence(namespace, new PersistencePolicies(bookkeeperEnsemble,
-                    bookkeeperWriteQuorum, bookkeeperAckQuorum, managedLedgerMaxMarkDeleteRate));
+                    bookkeeperWriteQuorum, bookkeeperAckQuorum, managedLedgerMaxMarkDeleteRate,
+                    managedLedgerStorageClassName));
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
@@ -1197,6 +1197,11 @@ public class CmdTopicPolicies extends CmdBase {
                 + "If set to true, the policy will be replicate to other clusters asynchronously", arity = "0")
         private boolean isGlobal = false;
 
+        @Option(names = { "-c",
+                "--ml-storage-class" },
+                description = "Managed ledger storage class name")
+        private String managedLedgerStorageClassName;
+
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(topicName);
@@ -1208,7 +1213,8 @@ public class CmdTopicPolicies extends CmdBase {
                 throw new ParameterException("[--ml-mark-delete-max-rate] cannot less than 0.");
             }
             getTopicPolicies(isGlobal).setPersistence(persistentTopic, new PersistencePolicies(bookkeeperEnsemble,
-                    bookkeeperWriteQuorum, bookkeeperAckQuorum, managedLedgerMaxMarkDeleteRate));
+                    bookkeeperWriteQuorum, bookkeeperAckQuorum, managedLedgerMaxMarkDeleteRate,
+                    managedLedgerStorageClassName));
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -2148,6 +2148,11 @@ public class CmdTopics extends CmdBase {
                 + "(0 means no throttle)")
         private double managedLedgerMaxMarkDeleteRate = 0;
 
+        @Option(names = { "-c",
+                "--ml-storage-class" },
+                description = "Managed ledger storage class name")
+        private String managedLedgerStorageClassName;
+
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(topicName);
@@ -2159,7 +2164,8 @@ public class CmdTopics extends CmdBase {
                 throw new ParameterException("[--ml-mark-delete-max-rate] cannot less than 0.");
             }
             getTopics().setPersistence(persistentTopic, new PersistencePolicies(bookkeeperEnsemble,
-                    bookkeeperWriteQuorum, bookkeeperAckQuorum, managedLedgerMaxMarkDeleteRate));
+                    bookkeeperWriteQuorum, bookkeeperAckQuorum, managedLedgerMaxMarkDeleteRate,
+                    managedLedgerStorageClassName));
         }
     }
 


### PR DESCRIPTION
This PR is partial implementation for "PIP-384: ManagedLedger interface decoupling", #23363.

## Motivation

This PR is part of an initiative to clean up and decouple the ManagedLedger interfaces from their current implementation in preparation for Pulsar 4.0. The primary goals are:

1. To allow for alternative ManagedLedger implementations in Pulsar 4.0.
2. To improve the overall architecture by reducing coupling between core Pulsar components and specific ManagedLedger implementations.

This work stems from a community discussion on the Apache Pulsar mailing list: [Preparing for Pulsar 4.0: cleaning up the Managed Ledger interfaces](https://lists.apache.org/thread/b2f4vkql693x3frdxm75tndk686crh9k)

This PR adds supports for multiple ManagedLedger implementations when using a custom ManagedLedgerStorage implementation. The benefit of this is that a Bookkeeper implementation can co-exist with a custom ManagedLedger implementation in the same Pulsar cluster. 

## Scope

This PR aims to make minimal, focused changes to achieve the decoupling goal. It does not include:
- Adding comprehensive JavaDocs to the interfaces (this will be addressed in future PRs)
- Changing any external APIs or behaviors

### Modifications

- add `managedLedgerStorageClassName` to `PersistencePolicies` to control the `ManagedLedgerFactory` instance that is used for a particular namespace or topic.
- add `storageClassName` to `ManagedLedgerConfig`, this field is read from `PersistencePolicies` (namespace or topic policies)
- modify `ManagedLedgerStorage` interface to support getting a `ManagedLedgerFactory` with the `storageClassName`
- change topics to use this for selecting the `ManagedLedgerFactory` instance
- for existing code that is not aware of multiple choices, use the default storage class and the default ManagedLedgerFactory instance.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->