### PR TITLE
[fix][io] Upgrade mssql server docker tag in DebeziumMsSqlContainer

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -944,7 +944,7 @@ jobs:
 
   system-tests:
     name: CI - System - ${{ matrix.name }}
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runs-on || 'ubuntu-22.04' }}
     timeout-minutes: 60
     needs: ['preconditions', 'pulsar-test-latest-version-image']
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
@@ -978,6 +978,8 @@ jobs:
           - name: Pulsar IO
             group: PULSAR_IO
             clean_disk: true
+            # run on ubuntu-20.04 to avoid mssql server image crash
+            runs-on: ubuntu-20.04
 
     steps:
       - name: checkout

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -944,7 +944,7 @@ jobs:
 
   system-tests:
     name: CI - System - ${{ matrix.name }}
-    runs-on: ${{ matrix.runs-on || 'ubuntu-22.04' }}
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     needs: ['preconditions', 'pulsar-test-latest-version-image']
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
@@ -978,8 +978,6 @@ jobs:
           - name: Pulsar IO
             group: PULSAR_IO
             clean_disk: true
-            # run on ubuntu-20.04 to avoid mssql server image crash
-            runs-on: ubuntu-20.04
 
     steps:
       - name: checkout

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMsSqlContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMsSqlContainer.java
@@ -37,7 +37,7 @@ public class DebeziumMsSqlContainer extends ChaosContainer<DebeziumMsSqlContaine
     // "You may install and use copies of the software on any device,
     // including third party shared devices, to design, develop, test and demonstrate your programs.
     // You may not use the software on a device or server in a production environment."
-    private static final String IMAGE_NAME = "mcr.microsoft.com/mssql/server:2019-CU12-ubuntu-20.04";
+    private static final String IMAGE_NAME = "mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-20.04";
 
     public DebeziumMsSqlContainer(String clusterName) {
         super(clusterName, IMAGE_NAME);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
@@ -100,7 +100,7 @@ public class DebeziumMsSqlSourceTester extends SourceTester<DebeziumMsSqlContain
         log.info("Executing \"{}\"", cmd);
         ContainerExecResult response = this.debeziumMsSqlContainer
                 .execCmd("/bin/bash", "-c",
-                "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P \""
+                "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \""
                         + DebeziumMsSqlContainer.SA_PASSWORD + "\" -Q \""
                         + (useTestDb ? "USE TestDB; " : "")
                         + cmd

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
@@ -100,7 +100,7 @@ public class DebeziumMsSqlSourceTester extends SourceTester<DebeziumMsSqlContain
         log.info("Executing \"{}\"", cmd);
         ContainerExecResult response = this.debeziumMsSqlContainer
                 .execCmd("/bin/bash", "-c",
-                "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \""
+                "/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P \""
                         + DebeziumMsSqlContainer.SA_PASSWORD + "\" -Q \""
                         + (useTestDb ? "USE TestDB; " : "")
                         + cmd


### PR DESCRIPTION
### Motivation

Pulsar CI is currently broken. The "CI - System - Pulsar IO" build job fails due to this error:
```
  Error:  org.apache.pulsar.tests.integration.io.sources.debezium.PulsarDebeziumSourcesTest.testDebeziumMsSqlSource
  [INFO]   Run 1: PASS
  Error:    Run 2: PulsarDebeziumSourcesTest.testDebeziumMsSqlSource:79->testDebeziumMsSqlConnect:236 » ContainerLaunch Container startup failed for image mcr.microsoft.com/mssql/server:2019-CU12-ubuntu-20.04
-----
  !!!!!!!!! FAILURE-- [TestClass name=class org.apache.pulsar.tests.integration.io.sources.debezium.PulsarDebeziumSourcesTest].testDebeziumMsSqlSource([])-------
  org.testcontainers.containers.ContainerLaunchException: Container startup failed for image mcr.microsoft.com/mssql/server:2019-CU12-ubuntu-20.04
  	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:349)
  	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:322)
  	at org.apache.pulsar.tests.integration.topologies.PulsarCluster.startService(PulsarCluster.java:396)
  	at org.apache.pulsar.tests.integration.io.sources.debezium.DebeziumMsSqlSourceTester.setServiceContainer(DebeziumMsSqlSourceTester.java:73)
  	at org.apache.pulsar.tests.integration.io.sources.debezium.PulsarDebeziumSourcesTest.testDebeziumMsSqlConnect(PulsarDebeziumSourcesTest.java:236)
  	at org.apache.pulsar.tests.integration.io.sources.debezium.PulsarDebeziumSourcesTest.testDebeziumMsSqlSource(PulsarDebeziumSourcesTest.java:79)
-----
  SQL Server 2019 will run as non-root by default.
  This container is running as user mssql.
  To learn more visit https://go.microsoft.com/fwlink/?linkid=2099216.
  This program has encountered a fatal error and cannot continue running at Thu Sep 19 04:00:04 2024
  The following diagnostic information is available:
  
           Reason: 0x00000001
           Signal: SIGABRT - Aborted (6)
            Stack:
                   IP               Function
                   ---------------- --------------------------------------
                   000055e1e671655c <unknown>
                   000055e1e6715fa2 <unknown>
                   000055e1e6715541 <unknown>
                   00007f975bbf8210 killpg+0x40
                   00007f975bbf818b gsignal+0xcb
                   00007f975bbd7859 abort+0x12b
                   000055e1e66a3ed2 <unknown>
                   000055e1e6730264 <unknown>
                   000055e1e6765408 <unknown>
                   000055e1e67651ea <unknown>
                   000055e1e66afc3a <unknown>
                   000055e1e66af88f <unknown>
          Process: 9 - sqlservr
           Thread: 80 (application thread 0x134)
      Instance Id: b5c0f188-a6fc-46b0-90ac-fb30c3e0d513
         Crash Id: 547e9f38-a9d3-4b33-815f-529e301b8654
      Build stamp: a5b3f518e501405ea4b46f546834883e540d503e9aa013f894f66d70b45825d6
     Distribution: Ubuntu 20.04.2 LTS
       Processors: 4
     Total Memory: 16766771200 bytes
        Timestamp: Thu Sep 19 04:00:04 2024
       Last errno: 2
  Last errno text: No such file or directory
  Executing: /opt/mssql/bin/handle-crash.sh with parameters
       handle-crash.sh
       /opt/mssql/bin/sqlservr
       9
       /opt/mssql/bin
       /var/opt/mssql/log/
       
       b5c0f188-a6fc-46b0-90ac-fb30c3e0d513
       547e9f38-a9d3-4b33-815f-529e301b8654
```
full log: https://gist.github.com/lhotari/74c83c63fb35b8cbbaf7c7069bb34f5c
example from https://github.com/apache/pulsar/actions/runs/10929216073/job/30353613796?pr=23275#step:12:10186

It seems that crashes started with new GitHub Ubuntu Runner VM version, https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240915.1 . Linux kernel goes from 6.5.0-1025-azure to 6.8.0-1014-azure.
Another alternative is to switch to use ubuntu-20.04 runner.

### Modifications

- upgrade mssql server docker tag from `2019-CU12-ubuntu-20.04` to `2019-CU28-ubuntu-20.04` in DebeziumMsSqlContainer
  - list of tags: https://mcr.microsoft.com/en-us/product/mssql/server/tags
  - the mssql server process no longer crashes
- change `/opt/mssql-tools/bin/sqlcmd` to `/opt/mssql-tools18/bin/sqlcmd` since the path has changed in the more recent container version.
  - related issue is https://github.com/microsoft/mssql-docker/issues/892
- Pass [`-C` (trust server certificate) option](https://learn.microsoft.com/en-us/sql/tools/sqlcmd/sqlcmd-utility?view=sql-server-ver16&tabs=go%2Cwindows&pivots=cs1-bash#-c) to sqlcmd since encryption is mandatory by default.
  - change explained in [this comment](https://github.com/microsoft/mssql-docker/issues/892#issuecomment-2253179915) by a Microsoft employee.
  - passing `-C` is explained in several issue comments ([1](https://github.com/microsoft/mssql-docker/issues/892#issuecomment-2273923898), [2](https://github.com/microsoft/mssql-docker/issues/892#issuecomment-2252299939))

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->