### PR TITLE
[fix][broker] Fix topic policies cannot be queried with extensible load manager

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -267,7 +267,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
 
     @Override
     public synchronized boolean started() {
-        return validateChannelState(LeaderElectionServiceStarted, false);
+        return validateChannelState(Started, true);
     }
 
     public synchronized void start() throws PulsarServerException {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -3601,6 +3601,9 @@ public class BrokerService implements Closeable {
     public @Nonnull CompletableFuture<Boolean> isAllowAutoSubscriptionCreationAsync(@Nonnull TopicName tpName) {
         requireNonNull(tpName);
         // Policies priority: topic level -> namespace level -> broker level
+        if (ExtensibleLoadManagerImpl.isInternalTopic(tpName.toString())) {
+            return CompletableFuture.completedFuture(true);
+        }
         return pulsar.getTopicPoliciesService()
                 .getTopicPoliciesAsync(tpName, TopicPoliciesService.GetType.LOCAL_ONLY)
                 .thenCompose(optionalTopicPolicies -> {


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/23319 brings a regression that topic policies cannot be queried with extensible load manager.  `compactionScheduleTest` could not succeed now.

In `SystemTopicBasedTopicPoliciesService#getTopicPoliciesAsync`, it skips getting events from `__change_events` because the reader will fail to create if the load manager does not start.

https://github.com/apache/pulsar/blob/4b3b273c1c57741f9f9da2118eb4ec5dfeee2220/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java#L253-L259

However, the state validation in `ServiceUnitStateChannelImpl` here is wrong: https://github.com/apache/pulsar/blob/4b3b273c1c57741f9f9da2118eb4ec5dfeee2220/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java#L270

The method above returns true when the state is `Closed`, `Constructed` or `LeaderElectionServiceStarted`, which is the opposite of the expected result (`Started`).

### Modifications

Fix the `ServiceUnitStateChannelImpl#started()` method with the correct state validation.

However, if only with this simple fix, the extensible load manager would fail to start. It's because after the table view creation for `loadbalancer-broker-load-data` and `loadbalancer-top-bundles-load-data` topics happen after the load manager start. In `isAllowAutoSubscriptionCreationAsync`, it will wait until the future of `getTopicPoliciesAsync` on these topics is done, while the reader creation on `__change_events` will fail.

Therefore, to fix this start failure, just return true for internal topics in `isAllowAutoSubscriptionCreationAsync`.

### Verifying this change

`ExtensibleLoadManagerImplTest#compactionScheduleTest` will pass now.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: