### PR TITLE
[fix][broker] Fix out-of-order issues with ConsistentHashingStickyKeyConsumerSelector

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelector.java
@@ -180,9 +180,11 @@ public class ConsistentHashingStickyKeyConsumerSelector implements StickyKeyCons
             for (int i = 0; i < numberOfPoints; i++) {
                 int hash = calculateHashForConsumerAndIndex(consumer, i);
                 hashRing.compute(hash, (k, v) -> {
-                    v.removeConsumer(consumer);
-                    if (v.getSelectedConsumer() == null) {
-                        v = null;
+                    if (v != null) {
+                        v.removeConsumer(consumer);
+                        if (v.getSelectedConsumer() == null) {
+                            v = null;
+                        }
                     }
                     return v;
                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelector.java
@@ -127,6 +127,9 @@ public class ConsistentHashingStickyKeyConsumerSelector implements StickyKeyCons
         }
 
         private void changeSelectedConsumerEntry(ConsumerEntry newSelectedConsumer) {
+            if (newSelectedConsumer == selectedConsumerEntry) {
+                return;
+            }
             beforeChangingSelectedConsumerEntry();
             selectedConsumerEntry = newSelectedConsumer;
             afterChangingSelectedConsumerEntry();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelector.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.broker.service;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,10 +27,8 @@ import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.pulsar.client.api.Range;
 import org.apache.pulsar.common.util.Murmur3_32Hash;
-import org.roaringbitmap.RoaringBitmap;
 
 /**
  * This is a consumer selector based fixed hash range.
@@ -54,87 +51,6 @@ public class ConsistentHashingStickyKeyConsumerSelector implements StickyKeyCons
     public ConsistentHashingStickyKeyConsumerSelector(int numberOfPoints) {
         this.hashRing = new TreeMap<>();
         this.numberOfPoints = numberOfPoints;
-    }
-
-    private static class ConsumerIdentityWrapper {
-        final Consumer consumer;
-
-        public ConsumerIdentityWrapper(Consumer consumer) {
-            this.consumer = consumer;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (obj instanceof ConsumerIdentityWrapper) {
-                ConsumerIdentityWrapper other = (ConsumerIdentityWrapper) obj;
-                return consumer == other.consumer;
-            }
-            return false;
-        }
-
-        @Override
-        public int hashCode() {
-            return consumer.hashCode();
-        }
-
-        @Override
-        public String toString() {
-            return consumer.toString();
-        }
-    }
-
-    private static class ConsumerNameIndexTracker {
-        private final Map<String, RoaringBitmap> consumerNameCounters = new HashMap<>();
-        private final Map<ConsumerIdentityWrapper, ConsumerEntry> consumerEntries = new HashMap<>();
-        record ConsumerEntry(String consumerName, int nameIndex, MutableInt refCount) {
-        }
-
-        private RoaringBitmap getConsumerNameIndexBitmap(String consumerName) {
-            return consumerNameCounters.computeIfAbsent(consumerName,
-                    k -> new RoaringBitmap());
-        }
-
-        private int allocateConsumerNameIndex(String consumerName) {
-            RoaringBitmap bitmap = getConsumerNameIndexBitmap(consumerName);
-            // find the first index that is not set, if there is no such index, add a new one
-            int index = (int) bitmap.nextAbsentValue(0);
-            if (index == -1) {
-                index = bitmap.getCardinality();
-            }
-            bitmap.add(index);
-            return index;
-        }
-
-        private void deallocateConsumerNameIndex(String consumerName, int index) {
-            RoaringBitmap bitmap = getConsumerNameIndexBitmap(consumerName);
-            bitmap.remove(index);
-            if (bitmap.isEmpty()) {
-                consumerNameCounters.remove(consumerName);
-            }
-        }
-
-        public void removeHashRingReference(ConsumerIdentityWrapper removed) {
-            ConsumerEntry consumerEntry = consumerEntries.get(removed);
-            int refCount = consumerEntry.refCount.decrementAndGet();
-            if (refCount == 0) {
-                deallocateConsumerNameIndex(consumerEntry.consumerName, consumerEntry.nameIndex);
-                consumerEntries.remove(removed, consumerEntry);
-            }
-        }
-
-        public int addHashRingReference(ConsumerIdentityWrapper wrapper) {
-            String consumerName = wrapper.consumer.consumerName();
-            ConsumerEntry entry = consumerEntries.computeIfAbsent(wrapper,
-                    k -> new ConsumerEntry(consumerName, allocateConsumerNameIndex(consumerName),
-                            new MutableInt(0)));
-            entry.refCount.increment();
-            return entry.nameIndex;
-        }
-
-        public int getTrackedConsumerNameIndex(ConsumerIdentityWrapper wrapper) {
-            ConsumerEntry consumerEntry = consumerEntries.get(wrapper);
-            return consumerEntry != null ? consumerEntry.nameIndex : -1;
-        }
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerIdentityWrapper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerIdentityWrapper.java
@@ -22,6 +22,10 @@ package org.apache.pulsar.broker.service;
  * A wrapper class for a Consumer instance that provides custom implementations
  * of equals and hashCode methods. The equals method returns true if and only if
  * the compared instance is the same instance.
+ *
+ * <p>The reason for this class is the custom implementation of {@link Consumer#equals(Object)}.
+ * Using this wrapper class will be useful in use cases where it's necessary to match a key
+ * in a map by instance or a value in a set by instance.</p>
  */
 class ConsumerIdentityWrapper {
     final Consumer consumer;
@@ -30,6 +34,15 @@ class ConsumerIdentityWrapper {
         this.consumer = consumer;
     }
 
+    /**
+     * Compares this wrapper to the specified object. The result is true if and only if
+     * the argument is not null and is a ConsumerIdentityWrapper object that wraps
+     * the same Consumer instance.
+     *
+     * @param obj the object to compare this ConsumerIdentityWrapper against
+     * @return true if the given object represents a ConsumerIdentityWrapper
+     *         equivalent to this wrapper, false otherwise
+     */
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof ConsumerIdentityWrapper) {
@@ -39,6 +52,12 @@ class ConsumerIdentityWrapper {
         return false;
     }
 
+    /**
+     * Returns a hash code for this wrapper. The hash code is computed based on
+     * the wrapped Consumer instance.
+     *
+     * @return a hash code value for this object
+     */
     @Override
     public int hashCode() {
         return consumer.hashCode();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerIdentityWrapper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerIdentityWrapper.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+/**
+ * A wrapper class for a Consumer instance that provides custom implementations
+ * of equals and hashCode methods. The equals method returns true if and only if
+ * the compared instance is the same instance.
+ */
+class ConsumerIdentityWrapper {
+    final Consumer consumer;
+
+    public ConsumerIdentityWrapper(Consumer consumer) {
+        this.consumer = consumer;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof ConsumerIdentityWrapper) {
+            ConsumerIdentityWrapper other = (ConsumerIdentityWrapper) obj;
+            return consumer == other.consumer;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return consumer.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return consumer.toString();
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerNameIndexTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerNameIndexTracker.java
@@ -20,41 +20,90 @@ package org.apache.pulsar.broker.service;
 
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.roaringbitmap.RoaringBitmap;
 
+/**
+ * Tracks the used consumer name indexes for each consumer name.
+ * This is used by {@link ConsistentHashingStickyKeyConsumerSelector} to get a unique "consumer name index"
+ * for each consumer name. It is useful when there are multiple consumers with the same name, but they are
+ * different consumers. The purpose of the index is to prevent collisions in the hash ring.
+ *
+ * The consumer name index serves as an additional key for the hash ring assignment. The logic keeps track of
+ * used "index slots" for each consumer name and assigns the first unused index when a new consumer is added.
+ * This approach minimizes hash collisions due to using the same consumer name.
+ *
+ * An added benefit of this tracking approach is that a consumer that leaves and then rejoins immediately will get the
+ * same index and therefore the same assignments in the hash ring. This improves stability since the hash assignment
+ * changes are minimized over time, although a better solution would be to avoid reusing the same consumer name
+ * in the first place.
+ *
+ * When a consumer is removed, the index is deallocated. RoaringBitmap is used to keep track of the used indexes.
+ * The data structure to track a consumer name is removed when the reference count of the consumer name is zero.
+ *
+ * This class is not thread-safe and should be used in a synchronized context in the caller.
+ */
+@NotThreadSafe
 class ConsumerNameIndexTracker {
-    private final Map<String, RoaringBitmap> consumerNameCounters = new HashMap<>();
+    // tracks the used index slots for each consumer name
+    private final Map<String, ConsumerNameIndexSlots> consumerNameIndexSlotsMap = new HashMap<>();
+    // tracks the active consumer entries
     private final Map<ConsumerIdentityWrapper, ConsumerEntry> consumerEntries = new HashMap<>();
 
+    // Represents a consumer entry in the tracker, including the consumer name, index, and reference count.
     record ConsumerEntry(String consumerName, int nameIndex, MutableInt refCount) {
     }
 
-    private RoaringBitmap getConsumerNameIndexBitmap(String consumerName) {
-        return consumerNameCounters.computeIfAbsent(consumerName,
-                k -> new RoaringBitmap());
+    /*
+     * Tracks the used indexes for a consumer name using a RoaringBitmap.
+     * A specific index slot is used when the bit is set.
+     * When all bits are cleared, the customer name can be removed from tracking.
+     */
+    static class ConsumerNameIndexSlots {
+        private RoaringBitmap indexSlots = new RoaringBitmap();
+
+        public int allocateIndexSlot() {
+            // find the first index that is not set, if there is no such index, add a new one
+            int index = (int) indexSlots.nextAbsentValue(0);
+            if (index == -1) {
+                index = indexSlots.getCardinality();
+            }
+            indexSlots.add(index);
+            return index;
+        }
+
+        public boolean deallocateIndexSlot(int index) {
+            indexSlots.remove(index);
+            return indexSlots.isEmpty();
+        }
+    }
+
+    /*
+     * Adds a reference to the consumer and returns the index assigned to this consumer.
+     */
+    public int increaseConsumerRefCountAndReturnIndex(ConsumerIdentityWrapper wrapper) {
+        ConsumerEntry entry = consumerEntries.computeIfAbsent(wrapper, k -> {
+            String consumerName = wrapper.consumer.consumerName();
+            return new ConsumerEntry(consumerName, allocateConsumerNameIndex(consumerName), new MutableInt(0));
+        });
+        entry.refCount.increment();
+        return entry.nameIndex;
     }
 
     private int allocateConsumerNameIndex(String consumerName) {
-        RoaringBitmap bitmap = getConsumerNameIndexBitmap(consumerName);
-        // find the first index that is not set, if there is no such index, add a new one
-        int index = (int) bitmap.nextAbsentValue(0);
-        if (index == -1) {
-            index = bitmap.getCardinality();
-        }
-        bitmap.add(index);
-        return index;
+        return getConsumerNameIndexBitmap(consumerName).allocateIndexSlot();
     }
 
-    private void deallocateConsumerNameIndex(String consumerName, int index) {
-        RoaringBitmap bitmap = getConsumerNameIndexBitmap(consumerName);
-        bitmap.remove(index);
-        if (bitmap.isEmpty()) {
-            consumerNameCounters.remove(consumerName);
-        }
+    private ConsumerNameIndexSlots getConsumerNameIndexBitmap(String consumerName) {
+        return consumerNameIndexSlotsMap.computeIfAbsent(consumerName, k -> new ConsumerNameIndexSlots());
     }
 
-    public void removeHashRingReference(ConsumerIdentityWrapper removed) {
+    /*
+     * Decreases the reference count of the consumer and removes the consumer name from tracking if the ref count is
+     * zero.
+     */
+    public void decreaseConsumerRefCount(ConsumerIdentityWrapper removed) {
         ConsumerEntry consumerEntry = consumerEntries.get(removed);
         int refCount = consumerEntry.refCount.decrementAndGet();
         if (refCount == 0) {
@@ -63,17 +112,25 @@ class ConsumerNameIndexTracker {
         }
     }
 
-    public int addHashRingReference(ConsumerIdentityWrapper wrapper) {
-        String consumerName = wrapper.consumer.consumerName();
-        ConsumerEntry entry = consumerEntries.computeIfAbsent(wrapper,
-                k -> new ConsumerEntry(consumerName, allocateConsumerNameIndex(consumerName),
-                        new MutableInt(0)));
-        entry.refCount.increment();
-        return entry.nameIndex;
+    private void deallocateConsumerNameIndex(String consumerName, int index) {
+        if (getConsumerNameIndexBitmap(consumerName).deallocateIndexSlot(index)) {
+            consumerNameIndexSlotsMap.remove(consumerName);
+        }
     }
 
-    public int getTrackedConsumerNameIndex(ConsumerIdentityWrapper wrapper) {
+    /*
+     * Returns the currently tracked index for the consumer.
+     */
+    public int getTrackedIndex(ConsumerIdentityWrapper wrapper) {
         ConsumerEntry consumerEntry = consumerEntries.get(wrapper);
         return consumerEntry != null ? consumerEntry.nameIndex : -1;
+    }
+
+    int getTrackedConsumerNamesCount() {
+        return consumerNameIndexSlotsMap.size();
+    }
+
+    int getTrackedConsumersCount() {
+        return consumerEntries.size();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerNameIndexTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerNameIndexTracker.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.roaringbitmap.RoaringBitmap;
+
+class ConsumerNameIndexTracker {
+    private final Map<String, RoaringBitmap> consumerNameCounters = new HashMap<>();
+    private final Map<ConsumerIdentityWrapper, ConsumerEntry> consumerEntries = new HashMap<>();
+
+    record ConsumerEntry(String consumerName, int nameIndex, MutableInt refCount) {
+    }
+
+    private RoaringBitmap getConsumerNameIndexBitmap(String consumerName) {
+        return consumerNameCounters.computeIfAbsent(consumerName,
+                k -> new RoaringBitmap());
+    }
+
+    private int allocateConsumerNameIndex(String consumerName) {
+        RoaringBitmap bitmap = getConsumerNameIndexBitmap(consumerName);
+        // find the first index that is not set, if there is no such index, add a new one
+        int index = (int) bitmap.nextAbsentValue(0);
+        if (index == -1) {
+            index = bitmap.getCardinality();
+        }
+        bitmap.add(index);
+        return index;
+    }
+
+    private void deallocateConsumerNameIndex(String consumerName, int index) {
+        RoaringBitmap bitmap = getConsumerNameIndexBitmap(consumerName);
+        bitmap.remove(index);
+        if (bitmap.isEmpty()) {
+            consumerNameCounters.remove(consumerName);
+        }
+    }
+
+    public void removeHashRingReference(ConsumerIdentityWrapper removed) {
+        ConsumerEntry consumerEntry = consumerEntries.get(removed);
+        int refCount = consumerEntry.refCount.decrementAndGet();
+        if (refCount == 0) {
+            deallocateConsumerNameIndex(consumerEntry.consumerName, consumerEntry.nameIndex);
+            consumerEntries.remove(removed, consumerEntry);
+        }
+    }
+
+    public int addHashRingReference(ConsumerIdentityWrapper wrapper) {
+        String consumerName = wrapper.consumer.consumerName();
+        ConsumerEntry entry = consumerEntries.computeIfAbsent(wrapper,
+                k -> new ConsumerEntry(consumerName, allocateConsumerNameIndex(consumerName),
+                        new MutableInt(0)));
+        entry.refCount.increment();
+        return entry.nameIndex;
+    }
+
+    public int getTrackedConsumerNameIndex(ConsumerIdentityWrapper wrapper) {
+        ConsumerEntry consumerEntry = consumerEntries.get(wrapper);
+        return consumerEntry != null ? consumerEntry.nameIndex : -1;
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
@@ -18,9 +18,9 @@
  */
 package org.apache.pulsar.broker.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.pulsar.broker.service.BrokerServiceException.ConsumerAssignException;
 import org.apache.pulsar.client.api.Range;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -54,7 +55,7 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
         selector.addConsumer(consumer2);
 
         final int N = 1000;
-        final double PERCENT_ERROR = 0.20; // 20 %
+        final double PERCENT_ERROR = 0.25; // 25 %
 
         Map<String, Integer> selectionMap = new HashMap<>();
         for (int i = 0; i < N; i++) {
@@ -146,12 +147,17 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
         ConsistentHashingStickyKeyConsumerSelector selector = new ConsistentHashingStickyKeyConsumerSelector(3);
         List<String> consumerName = Arrays.asList("consumer1", "consumer2", "consumer3");
         List<Consumer> consumers = new ArrayList<>();
+        long id=0;
         for (String s : consumerName) {
-            Consumer consumer = mock(Consumer.class);
-            when(consumer.consumerName()).thenReturn(s);
+            Consumer consumer = createMockConsumer(s, s, id++);
             selector.addConsumer(consumer);
             consumers.add(consumer);
         }
+
+        // check that results are the same when called multiple times
+        assertThat(selector.getConsumerKeyHashRanges())
+                .containsExactlyEntriesOf(selector.getConsumerKeyHashRanges());
+
         Map<Consumer, List<Range>> expectedResult = new HashMap<>();
         expectedResult.put(consumers.get(0), Arrays.asList(
                 Range.of(119056335, 242013991),
@@ -160,17 +166,47 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
         expectedResult.put(consumers.get(1), Arrays.asList(
                 Range.of(0, 90164503),
                 Range.of(90164504, 119056334),
-                Range.of(382436668, 722195656)));
+                Range.of(382436668, 722195656),
+                Range.of(1914695767, 2147483646)));
         expectedResult.put(consumers.get(2), Arrays.asList(
                 Range.of(242013992, 242377547),
                 Range.of(242377548, 382436667),
                 Range.of(1656011843, 1707482097)));
-        for (Map.Entry<Consumer, List<Range>> entry : selector.getConsumerKeyHashRanges().entrySet()) {
-            System.out.println(entry.getValue());
-            Assert.assertEquals(entry.getValue(), expectedResult.get(entry.getKey()));
-            expectedResult.remove(entry.getKey());
+        assertThat(selector.getConsumerKeyHashRanges()).containsExactlyInAnyOrderEntriesOf(expectedResult);
+    }
+
+    @Test
+    public void testConsumersGetEvenlyMappedWhenThereAreCollisions()
+            throws BrokerServiceException.ConsumerAssignException {
+        ConsistentHashingStickyKeyConsumerSelector selector = new ConsistentHashingStickyKeyConsumerSelector(5);
+        List<Consumer> consumers = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            // use the same name for all consumers
+            Consumer consumer = createMockConsumer("consumer", "index " + i, i);
+            selector.addConsumer(consumer);
+            consumers.add(consumer);
         }
-        Assert.assertEquals(expectedResult.size(), 0);
+        // check that results are the same when called multiple times
+        assertThat(selector.getConsumerKeyHashRanges())
+                .containsExactlyEntriesOf(selector.getConsumerKeyHashRanges());
+
+        Map<Consumer, List<Range>> expectedResult = new HashMap<>();
+        expectedResult.put(consumers.get(0), List.of(Range.of(306176209, 365902830)));
+        expectedResult.put(consumers.get(1), List.of(Range.of(216056714, 306176208)));
+        expectedResult.put(consumers.get(2), List.of(Range.of(365902831, 1240826377)));
+        expectedResult.put(consumers.get(3), List.of(Range.of(1240826378, 1862045174)));
+        expectedResult.put(consumers.get(4), List.of(Range.of(0, 216056713), Range.of(1862045175, 2147483646)));
+        assertThat(selector.getConsumerKeyHashRanges()).containsExactlyInAnyOrderEntriesOf(expectedResult);
+    }
+
+    private static Consumer createMockConsumer(String consumerName, String toString, long id) {
+        // without stubOnly, the mock will record method invocations and run into OOME
+        Consumer consumer =  mock(Consumer.class, Mockito.withSettings().stubOnly());
+        when(consumer.consumerName()).thenReturn(consumerName);
+        when(consumer.getPriorityLevel()).thenReturn(0);
+        when(consumer.toString()).thenReturn(toString);
+        when(consumer.consumerId()).thenReturn(id);
+        return consumer;
     }
 
     // reproduces https://github.com/apache/pulsar/issues/22050
@@ -215,5 +251,47 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
         consumers.forEach(selector::removeConsumer);
         // then there should be no mapping remaining
         Assert.assertEquals(selector.getConsumerKeyHashRanges().size(), 0);
+    }
+
+    @Test
+    public void testShouldNotChangeSelectedConsumerWhenConsumerIsRemoved() {
+        final ConsistentHashingStickyKeyConsumerSelector selector = new ConsistentHashingStickyKeyConsumerSelector(25);
+        final String consumerName = "consumer";
+        final int numOfInitialConsumers = 25;
+        List<Consumer> consumers = new ArrayList<>();
+        for (int i = 0; i < numOfInitialConsumers; i++) {
+            final Consumer consumer = createMockConsumer(consumerName, "index " + i, i);
+            consumers.add(consumer);
+            selector.addConsumer(consumer);
+        }
+
+        int hashRangeSize = Integer.MAX_VALUE;
+        int validationPointCount = 100;
+        int increment = hashRangeSize / validationPointCount;
+        List<Consumer> selectedConsumerBeforeRemoval = new ArrayList<>();
+
+        for (int i = 0; i < validationPointCount; i++) {
+            selectedConsumerBeforeRemoval.add(selector.select(i * increment));
+        }
+
+        for (int i = 0; i < validationPointCount; i++) {
+            Consumer selected = selector.select(i * increment);
+            Consumer expected = selectedConsumerBeforeRemoval.get(i);
+            assertThat(selected.consumerId()).as("validationPoint %d", i).isEqualTo(expected.consumerId());
+        }
+
+        /*
+        TODO: failing test case
+        for (Consumer removedConsumer : consumers) {
+            selector.removeConsumer(removedConsumer);
+            for (int i = 0; i < validationPointCount; i++) {
+                Consumer selected = selector.select(i * increment);
+                Consumer expected = selectedConsumerBeforeRemoval.get(i);
+                if (expected != removedConsumer) {
+                    assertThat(selected.consumerId()).as("validationPoint %d", i).isEqualTo(expected.consumerId());
+                }
+            }
+        }
+         */
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
@@ -165,19 +165,22 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
                 .containsExactlyEntriesOf(selector.getConsumerKeyHashRanges());
 
         Map<Consumer, List<Range>> expectedResult = new HashMap<>();
+        assertThat(consumers.get(0).consumerName()).isEqualTo("consumer1");
         expectedResult.put(consumers.get(0), Arrays.asList(
-                Range.of(119056335, 242013991),
-                Range.of(722195657, 1656011842),
-                Range.of(1707482098, 1914695766)));
+                Range.of(95615213, 440020355),
+                Range.of(440020356, 455987436),
+                Range.of(1189794593, 1264144431)));
+        assertThat(consumers.get(1).consumerName()).isEqualTo("consumer2");
         expectedResult.put(consumers.get(1), Arrays.asList(
-                Range.of(0, 90164503),
-                Range.of(90164504, 119056334),
-                Range.of(382436668, 722195656),
-                Range.of(1914695767, 2147483646)));
+                Range.of(939655188, 1189794592),
+                Range.of(1314727625, 1977451233),
+                Range.of(1977451234, 2016237253)));
+        assertThat(consumers.get(2).consumerName()).isEqualTo("consumer3");
         expectedResult.put(consumers.get(2), Arrays.asList(
-                Range.of(242013992, 242377547),
-                Range.of(242377548, 382436667),
-                Range.of(1656011843, 1707482097)));
+                Range.of(0, 95615212),
+                Range.of(455987437, 939655187),
+                Range.of(1264144432, 1314727624),
+                Range.of(2016237255, 2147483646)));
         assertThat(selector.getConsumerKeyHashRanges()).containsExactlyInAnyOrderEntriesOf(expectedResult);
     }
 
@@ -205,7 +208,7 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
         printSelectionCountStats(consumerSelectionCount);
 
         int averageCount = totalSelections / consumers.size();
-        int allowedVariance = (int) (0.5d * averageCount);
+        int allowedVariance = (int) (0.2d * averageCount);
         System.out.println("averageCount: " + averageCount + " allowedVariance: " + allowedVariance);
 
         for (Map.Entry<Consumer, MutableInt> entry : consumerSelectionCount.entrySet()) {
@@ -213,6 +216,8 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
                     .isCloseTo(averageCount, Offset.offset(allowedVariance));
         }
 
+        consumers.forEach(selector::removeConsumer);
+        assertThat(selector.getConsumerKeyHashRanges()).isEmpty();
     }
 
     private static void printSelectionCountStats(Map<Consumer, MutableInt> consumerSelectionCount) {
@@ -348,7 +353,7 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
         }
 
         Map<Consumer, List<Range>> expected = selector.getConsumerKeyHashRanges();
-        assertThat(selector.getConsumerKeyHashRanges()).as("sanity check").isEqualTo(expected);
+        assertThat(selector.getConsumerKeyHashRanges()).as("sanity check").containsExactlyInAnyOrderEntriesOf(expected);
         System.out.println(expected);
 
         for (Consumer removedConsumer : consumers) {
@@ -384,7 +389,7 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
         }
 
         Map<Consumer, List<Range>> expected = selector.getConsumerKeyHashRanges();
-        assertThat(selector.getConsumerKeyHashRanges()).as("sanity check").isEqualTo(expected);
+        assertThat(selector.getConsumerKeyHashRanges()).as("sanity check").containsExactlyInAnyOrderEntriesOf(expected);
 
         for (int i = numOfInitialConsumers; i < numOfInitialConsumers * 2; i++) {
             final Consumer addedConsumer = createMockConsumer(consumerName, "index " + i, i);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
@@ -294,6 +294,32 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
     }
 
     @Test
+    public void testShouldNotChangeSelectedConsumerWhenConsumerIsRemovedCheckHashRanges() {
+        final ConsistentHashingStickyKeyConsumerSelector selector = new ConsistentHashingStickyKeyConsumerSelector(5);
+        final String consumerName = "consumer";
+        final int numOfInitialConsumers = 10;
+        List<Consumer> consumers = new ArrayList<>();
+        for (int i = 0; i < numOfInitialConsumers; i++) {
+            final Consumer consumer = createMockConsumer(consumerName, "index " + i, i);
+            consumers.add(consumer);
+            selector.addConsumer(consumer);
+        }
+
+        int hashRangeSize = Integer.MAX_VALUE;
+
+        Map<Consumer, List<Range>> expected = selector.getConsumerKeyHashRanges();
+        assertThat(selector.getConsumerKeyHashRanges()).as("sanity check").isEqualTo(expected);
+
+        for (Consumer removedConsumer : consumers) {
+            selector.removeConsumer(removedConsumer);
+            Map<Consumer, List<Range>> actual = selector.getConsumerKeyHashRanges();
+            expected.remove(removedConsumer);
+            assertThat(actual).as("removed %s", removedConsumer.toString())
+                    .containsExactlyInAnyOrderEntriesOf(expected);
+        }
+    }
+
+    @Test
     public void testShouldNotChangeSelectedConsumerWhenConsumerIsAdded() {
         final ConsistentHashingStickyKeyConsumerSelector selector = new ConsistentHashingStickyKeyConsumerSelector(100);
         final String consumerName = "consumer";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
@@ -191,10 +191,10 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
                 .containsExactlyEntriesOf(selector.getConsumerKeyHashRanges());
 
         Map<Consumer, List<Range>> expectedResult = new HashMap<>();
-        expectedResult.put(consumers.get(0), List.of(Range.of(306176209, 365902830)));
-        expectedResult.put(consumers.get(1), List.of(Range.of(216056714, 306176208)));
-        expectedResult.put(consumers.get(2), List.of(Range.of(365902831, 1240826377)));
-        expectedResult.put(consumers.get(3), List.of(Range.of(1240826378, 1862045174)));
+        expectedResult.put(consumers.get(0), List.of(Range.of(216056714, 306176208)));
+        expectedResult.put(consumers.get(1), List.of(Range.of(365902831, 1240826377)));
+        expectedResult.put(consumers.get(2), List.of(Range.of(1240826378, 1862045174)));
+        expectedResult.put(consumers.get(3), List.of(Range.of(306176209, 365902830)));
         expectedResult.put(consumers.get(4), List.of(Range.of(0, 216056713), Range.of(1862045175, 2147483646)));
         assertThat(selector.getConsumerKeyHashRanges()).containsExactlyInAnyOrderEntriesOf(expectedResult);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
@@ -47,7 +47,7 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
     @Test
     public void testConsumerSelect() throws ConsumerAssignException {
 
-        ConsistentHashingStickyKeyConsumerSelector selector = new ConsistentHashingStickyKeyConsumerSelector(100);
+        ConsistentHashingStickyKeyConsumerSelector selector = new ConsistentHashingStickyKeyConsumerSelector(200);
         String key1 = "anyKey";
         Assert.assertNull(selector.select(key1.getBytes()));
 
@@ -61,7 +61,7 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
         selector.addConsumer(consumer2);
 
         final int N = 1000;
-        final double PERCENT_ERROR = 0.25; // 25 %
+        final double PERCENT_ERROR = 0.20; // 20 %
 
         Map<String, Integer> selectionMap = new HashMap<>();
         for (int i = 0; i < N; i++) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
@@ -458,4 +458,26 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
         }
     }
 
+    @Test
+    public void testShouldNotChangeMappingWhenConsumerLeavesAndRejoins() {
+        final ConsistentHashingStickyKeyConsumerSelector selector = new ConsistentHashingStickyKeyConsumerSelector(100);
+        final String consumerName = "consumer";
+        final int numOfInitialConsumers = 25;
+        List<Consumer> consumers = new ArrayList<>();
+        for (int i = 0; i < numOfInitialConsumers; i++) {
+            final Consumer consumer = createMockConsumer(consumerName, "index " + i, i);
+            consumers.add(consumer);
+            selector.addConsumer(consumer);
+        }
+
+        Map<Consumer, List<Range>> expected = selector.getConsumerKeyHashRanges();
+        assertThat(selector.getConsumerKeyHashRanges()).as("sanity check").containsExactlyInAnyOrderEntriesOf(expected);
+
+        selector.removeConsumer(consumers.get(0));
+        selector.removeConsumer(consumers.get(numOfInitialConsumers / 2));
+        selector.addConsumer(consumers.get(0));
+        selector.addConsumer(consumers.get(numOfInitialConsumers / 2));
+
+        assertThat(selector.getConsumerKeyHashRanges()).as("ranges shouldn't change").containsExactlyInAnyOrderEntriesOf(expected);
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
@@ -283,11 +283,12 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
         for (Consumer removedConsumer : consumers) {
             selector.removeConsumer(removedConsumer);
             for (int i = 0; i < validationPointCount; i++) {
-                Consumer selected = selector.select(i * increment);
+                int hash = i * increment;
+                Consumer selected = selector.select(hash);
                 Consumer expected = selectedConsumerBeforeRemoval.get(i);
                 if (expected != removedConsumer) {
-                    assertThat(selected.consumerId()).as("validationPoint %d, removed %s", i,
-                            removedConsumer.toString()).isEqualTo(expected.consumerId());
+                    assertThat(selected.consumerId()).as("validationPoint %d, removed %s, hash %d", i,
+                            removedConsumer.toString(), hash).isEqualTo(expected.consumerId());
                 }
             }
         }
@@ -399,10 +400,11 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
             final Consumer addedConsumer = createMockConsumer(consumerName, "index " + i, i);
             selector.addConsumer(addedConsumer);
             for (int j = 0; j < validationPointCount; j++) {
-                Consumer selected = selector.select(j * increment);
+                int hash = j * increment;
+                Consumer selected = selector.select(hash);
                 Consumer expected = selectedConsumerBeforeRemoval.get(j);
                 if (expected != addedConsumer) {
-                    assertThat(selected.consumerId()).as("validationPoint %d", j).isEqualTo(expected.consumerId());
+                    assertThat(selected.consumerId()).as("validationPoint %d, hash %d", j, hash).isEqualTo(expected.consumerId());
                 }
             }
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
@@ -286,7 +286,8 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
                 Consumer selected = selector.select(i * increment);
                 Consumer expected = selectedConsumerBeforeRemoval.get(i);
                 if (expected != removedConsumer) {
-                    assertThat(selected.consumerId()).as("validationPoint %d", i).isEqualTo(expected.consumerId());
+                    assertThat(selected.consumerId()).as("validationPoint %d, removed %s", i,
+                            removedConsumer.toString()).isEqualTo(expected.consumerId());
                 }
             }
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
@@ -180,8 +180,21 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
                 Range.of(0, 95615212),
                 Range.of(455987437, 939655187),
                 Range.of(1264144432, 1314727624),
-                Range.of(2016237255, 2147483646)));
-        assertThat(selector.getConsumerKeyHashRanges()).containsExactlyInAnyOrderEntriesOf(expectedResult);
+                Range.of(2016237254, 2147483646)));
+        Map<Consumer, List<Range>> consumerKeyHashRanges = selector.getConsumerKeyHashRanges();
+        assertThat(consumerKeyHashRanges).containsExactlyInAnyOrderEntriesOf(expectedResult);
+
+        // check that ranges are continuous and cover the whole range
+        List<Range> allRanges =
+                consumerKeyHashRanges.values().stream().flatMap(List::stream).sorted().collect(Collectors.toList());
+        Range previousRange = null;
+        for (Range range : allRanges) {
+            if (previousRange != null) {
+                assertThat(range.getStart()).isEqualTo(previousRange.getEnd() + 1);
+            }
+            previousRange = range;
+        }
+        assertThat(allRanges.stream().mapToInt(r -> r.getEnd() - r.getStart() + 1).sum()).isEqualTo(Integer.MAX_VALUE);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
@@ -253,6 +253,8 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
         consumers.forEach(selector::removeConsumer);
         // then there should be no mapping remaining
         Assert.assertEquals(selector.getConsumerKeyHashRanges().size(), 0);
+        // when consumers are removed again, should not fail
+        consumers.forEach(selector::removeConsumer);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
@@ -316,10 +316,13 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
                     continue;
                 }
                 for (Range range : entry.getValue()) {
-                    assertThat(selector.select(range.getStart())).as("removed %s, range %s", removedConsumer, range)
+                    Consumer rangeStartConsumer = selector.select(range.getStart());
+                    assertThat(rangeStartConsumer).as("removed %s, range %s", removedConsumer, range)
                             .isEqualTo(entry.getKey());
-                    assertThat(selector.select(range.getEnd())).as("removed %s, range %s", removedConsumer, range)
+                    Consumer rangeEndConsumer = selector.select(range.getEnd());
+                    assertThat(rangeEndConsumer).as("removed %s, range %s", removedConsumer, range)
                             .isEqualTo(entry.getKey());
+                    assertThat(rangeStartConsumer).isSameAs(rangeEndConsumer);
                 }
             }
             expected = selector.getConsumerKeyHashRanges();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumerIdentityWrapperTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumerIdentityWrapperTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class ConsumerIdentityWrapperTest {
+    private static Consumer mockConsumer() {
+        return mockConsumer("consumer");
+    }
+
+    private static Consumer mockConsumer(String consumerName) {
+        Consumer consumer = mock(Consumer.class);
+        when(consumer.consumerName()).thenReturn(consumerName);
+        return consumer;
+    }
+
+    @Test
+    public void testEquals() {
+        Consumer consumer = mockConsumer();
+        assertEquals(new ConsumerIdentityWrapper(consumer), new ConsumerIdentityWrapper(consumer));
+    }
+
+    @Test
+    public void testHashCode() {
+        Consumer consumer = mockConsumer();
+        assertEquals(new ConsumerIdentityWrapper(consumer).hashCode(),
+                new ConsumerIdentityWrapper(consumer).hashCode());
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        Consumer consumer1 = mockConsumer();
+        Consumer consumer2 = mockConsumer();
+        ConsumerIdentityWrapper wrapper1 = new ConsumerIdentityWrapper(consumer1);
+        ConsumerIdentityWrapper wrapper2 = new ConsumerIdentityWrapper(consumer1);
+        ConsumerIdentityWrapper wrapper3 = new ConsumerIdentityWrapper(consumer2);
+
+        // Test equality
+        assertEquals(wrapper1, wrapper2);
+        assertNotEquals(wrapper1, wrapper3);
+
+        // Test hash code
+        assertEquals(wrapper1.hashCode(), wrapper2.hashCode());
+        assertNotEquals(wrapper1.hashCode(), wrapper3.hashCode());
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumerNameIndexTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumerNameIndexTrackerTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class ConsumerNameIndexTrackerTest {
+    private ConsumerNameIndexTracker tracker;
+
+    @BeforeMethod
+    public void setUp() {
+        tracker = new ConsumerNameIndexTracker();
+    }
+
+    private static Consumer mockConsumer() {
+        return mockConsumer("consumer");
+    }
+
+
+    private static Consumer mockConsumer(String consumerName) {
+        Consumer consumer = mock(Consumer.class);
+        when(consumer.consumerName()).thenReturn(consumerName);
+        return consumer;
+    }
+
+    @Test
+    public void testIncreaseConsumerRefCountAndReturnIndex() {
+        Consumer consumer1 = mockConsumer();
+        Consumer consumer2 = mockConsumer();
+        ConsumerIdentityWrapper wrapper1 = new ConsumerIdentityWrapper(consumer1);
+        ConsumerIdentityWrapper wrapper2 = new ConsumerIdentityWrapper(consumer2);
+        int index1 = tracker.increaseConsumerRefCountAndReturnIndex(wrapper1);
+        int index2 = tracker.increaseConsumerRefCountAndReturnIndex(wrapper2);
+        assertNotEquals(index1, index2);
+        assertEquals(index1, tracker.getTrackedIndex(wrapper1));
+        assertEquals(index2, tracker.getTrackedIndex(wrapper2));
+    }
+
+    @Test
+    public void testTrackingReturnsStableIndexWhenRemovedAndAddedInSameOrder() {
+        List<ConsumerIdentityWrapper> consumerIdentityWrappers =
+                IntStream.range(0, 100).mapToObj(i -> mockConsumer()).map(ConsumerIdentityWrapper::new).toList();
+        Map<ConsumerIdentityWrapper, Integer> trackedIndexes =
+                consumerIdentityWrappers.stream().collect(Collectors.toMap(
+                        wrapper -> wrapper, wrapper -> tracker.increaseConsumerRefCountAndReturnIndex(wrapper)));
+        // stop tracking every other consumer
+        for (int i = 0; i < consumerIdentityWrappers.size(); i++) {
+            if (i % 2 == 0) {
+                tracker.decreaseConsumerRefCount(consumerIdentityWrappers.get(i));
+            }
+        }
+        // check that others are tracked
+        for (int i = 0; i < consumerIdentityWrappers.size(); i++) {
+            ConsumerIdentityWrapper wrapper = consumerIdentityWrappers.get(i);
+            int trackedIndex = tracker.getTrackedIndex(wrapper);
+            assertEquals(trackedIndex, i % 2 == 0 ? -1 : trackedIndexes.get(wrapper));
+        }
+        // check that new consumers are tracked with the same index
+        for (int i = 0; i < consumerIdentityWrappers.size(); i++) {
+            ConsumerIdentityWrapper wrapper = consumerIdentityWrappers.get(i);
+            if (i % 2 == 0) {
+                int trackedIndex = tracker.increaseConsumerRefCountAndReturnIndex(wrapper);
+                assertEquals(trackedIndex, trackedIndexes.get(wrapper));
+            }
+        }
+        // check that all consumers are tracked with the original indexes
+        for (int i = 0; i < consumerIdentityWrappers.size(); i++) {
+            ConsumerIdentityWrapper wrapper = consumerIdentityWrappers.get(i);
+            int trackedIndex = tracker.getTrackedIndex(wrapper);
+            assertEquals(trackedIndex, trackedIndexes.get(wrapper));
+        }
+    }
+
+    @Test
+    public void testTrackingMultipleTimes() {
+        List<ConsumerIdentityWrapper> consumerIdentityWrappers =
+                IntStream.range(0, 100).mapToObj(i -> mockConsumer()).map(ConsumerIdentityWrapper::new).toList();
+        Map<ConsumerIdentityWrapper, Integer> trackedIndexes =
+                consumerIdentityWrappers.stream().collect(Collectors.toMap(
+                        wrapper -> wrapper, wrapper -> tracker.increaseConsumerRefCountAndReturnIndex(wrapper)));
+        Map<ConsumerIdentityWrapper, Integer> trackedIndexes2 =
+                consumerIdentityWrappers.stream().collect(Collectors.toMap(
+                        wrapper -> wrapper, wrapper -> tracker.increaseConsumerRefCountAndReturnIndex(wrapper)));
+        assertThat(tracker.getTrackedConsumerNamesCount()).isEqualTo(1);
+        assertThat(trackedIndexes).containsExactlyInAnyOrderEntriesOf(trackedIndexes2);
+        consumerIdentityWrappers.forEach(wrapper -> tracker.decreaseConsumerRefCount(wrapper));
+        for (ConsumerIdentityWrapper wrapper : consumerIdentityWrappers) {
+            int trackedIndex = tracker.getTrackedIndex(wrapper);
+            assertEquals(trackedIndex, trackedIndexes.get(wrapper));
+        }
+        consumerIdentityWrappers.forEach(wrapper -> tracker.decreaseConsumerRefCount(wrapper));
+        assertThat(tracker.getTrackedConsumersCount()).isEqualTo(0);
+        assertThat(tracker.getTrackedConsumerNamesCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testDecreaseConsumerRefCount() {
+        Consumer consumer1 = mockConsumer();
+        ConsumerIdentityWrapper wrapper1 = new ConsumerIdentityWrapper(consumer1);
+        int index1 = tracker.increaseConsumerRefCountAndReturnIndex(wrapper1);
+        assertNotEquals(index1, -1);
+        tracker.decreaseConsumerRefCount(wrapper1);
+        assertEquals(tracker.getTrackedIndex(wrapper1), -1);
+    }
+
+    @Test
+    public void testGetTrackedIndex() {
+        Consumer consumer1 = mockConsumer();
+        Consumer consumer2 = mockConsumer();
+        ConsumerIdentityWrapper wrapper1 = new ConsumerIdentityWrapper(consumer1);
+        ConsumerIdentityWrapper wrapper2 = new ConsumerIdentityWrapper(consumer2);
+        int index1 = tracker.increaseConsumerRefCountAndReturnIndex(wrapper1);
+        int index2 = tracker.increaseConsumerRefCountAndReturnIndex(wrapper2);
+        assertEquals(index1, tracker.getTrackedIndex(wrapper1));
+        assertEquals(index2, tracker.getTrackedIndex(wrapper2));
+    }
+
+    @Test
+    public void testTrackingMultipleNames() {
+        List<ConsumerIdentityWrapper> consumerIdentityWrappers =
+                IntStream.range(0, 100).mapToObj(i -> mockConsumer("consumer" + i)).map(ConsumerIdentityWrapper::new)
+                        .toList();
+        consumerIdentityWrappers.forEach(wrapper -> tracker.increaseConsumerRefCountAndReturnIndex(wrapper));
+        assertThat(tracker.getTrackedConsumerNamesCount()).isEqualTo(100);
+        assertThat(tracker.getTrackedConsumersCount()).isEqualTo(100);
+        consumerIdentityWrappers.forEach(wrapper -> tracker.decreaseConsumerRefCount(wrapper));
+        assertThat(tracker.getTrackedConsumersCount()).isEqualTo(0);
+        assertThat(tracker.getTrackedConsumerNamesCount()).isEqualTo(0);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.service.persistent;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.pulsar.common.protocol.Commands.serializeMetadataAndPayload;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
@@ -326,7 +327,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumersTest {
         redeliverEntries.add(EntryImpl.create(1, 1, createMessage("message1", 1, "key1")));
         final List<Entry> readEntries = new ArrayList<>();
         readEntries.add(EntryImpl.create(1, 2, createMessage("message2", 2, "key1")));
-        readEntries.add(EntryImpl.create(1, 3, createMessage("message3", 3, "key22")));
+        readEntries.add(EntryImpl.create(1, 3, createMessage("message3", 3, "key2")));
 
         try {
             Field totalAvailablePermitsField = PersistentDispatcherMultipleConsumers.class.getDeclaredField("totalAvailablePermits");
@@ -417,7 +418,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumersTest {
 
         // Messages with key1 are routed to consumer1 and messages with key2 are routed to consumer2
         final List<Entry> allEntries = new ArrayList<>();
-        allEntries.add(EntryImpl.create(1, 1, createMessage("message1", 1, "key22")));
+        allEntries.add(EntryImpl.create(1, 1, createMessage("message1", 1, "key2")));
         allEntries.add(EntryImpl.create(1, 2, createMessage("message2", 2, "key1")));
         allEntries.add(EntryImpl.create(1, 3, createMessage("message3", 3, "key1")));
         allEntries.forEach(entry -> ((EntryImpl) entry).retain());
@@ -518,8 +519,8 @@ public class PersistentStickyKeyDispatcherMultipleConsumersTest {
             persistentDispatcher.readMoreEntries();
         }
 
-        assertEquals(actualEntriesToConsumer1, expectedEntriesToConsumer1);
-        assertEquals(actualEntriesToConsumer2, expectedEntriesToConsumer2);
+        assertThat(actualEntriesToConsumer1).containsExactlyElementsOf(expectedEntriesToConsumer1);
+        assertThat(actualEntriesToConsumer2).containsExactlyElementsOf(expectedEntriesToConsumer2);
 
         allEntries.forEach(entry -> entry.release());
     }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Range.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Range.java
@@ -27,7 +27,7 @@ import org.apache.pulsar.common.classification.InterfaceStability;
  */
 @InterfaceAudience.Public
 @InterfaceStability.Stable
-public class Range {
+public class Range implements Comparable<Range> {
 
     private final int start;
     private final int end;
@@ -83,5 +83,14 @@ public class Range {
     @Override
     public String toString() {
         return "[" + start + ", " + end + "]";
+    }
+
+    @Override
+    public int compareTo(Range o) {
+        int result = Integer.compare(start, o.start);
+        if (result == 0) {
+            result = Integer.compare(end, o.end);
+        }
+        return result;
     }
 }


### PR DESCRIPTION
Fixes #23315
Fixes #23321

### Motivation

See #23315 and #23321. This PR fixes a bug in ConsistentHashingStickyKeyConsumerSelector where the selected consumer for a hash could change across 2 existing consumers when a consumer was removed or when a new consumer was added.
In addition it fixes the problem that ConsistentHashingStickyKeyConsumerSelector.getConsumerKeyHashRanges() returned invalid information. These are fixed together since they are in the same code area and fixing getConsumerKeyHashRanges is required for testing the consistent selection of a consumer when there are hash collisions.

### Modifications

In PR #8396 a solution was added to fix a problem where all hash ring points were assigned to the last arrived consumer when there were hash collisions, for example when the consumers had the same name:
https://github.com/apache/pulsar/blob/4f96146f13b136644a4eb0cf4ec36699e0431929/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelector.java#L127

That solution causes problems since it causes the bug #23315. A different solution is needed to distribute the consumers evenly when there are hash collisions.

The solution in this PR is to assign a consumer with a "consumer name index". When there are multiple consumers with the same name, the name index will be unique. Since any consumer name could be potentially used by consumers arriving later, it is necessary to track all consumer names. When all consumers have been removed for a specific consumer name, it shouldn't result in a memory leak. This is the reason why tracking reference counts is handled in the implementation. 

The implementation contains a solution where a consumer leaving and joining immediately will get assigned with the same "consumer name index". This improves stability since the hash assignment changes are minimized over time, although a better solution would be to avoid reusing the same consumer name in the first place.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->