### PR TITLE
[fix][broker] fix broker may lost rack information

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClient.java
@@ -181,8 +181,13 @@ public class PulsarRegistrationClient implements RegistrationClient {
     @Override
     public CompletableFuture<Void> watchWritableBookies(RegistrationListener registrationListener) {
         writableBookiesWatchers.add(registrationListener);
+        // trigger all listeners in writableBookiesWatchers one by one. It aims to keep a sync way
+        // to make sure the previous listener has finished when a new listener is register.
+        // Though it would bring duplicate trigger listener problem, but since watchWritableBookies
+        // is only executed when bookieClient construct, the duplicate problem is acceptable.
         return getWritableBookies()
-                .thenAcceptAsync(registrationListener::onBookiesChanged, executor);
+                .thenAcceptAsync(bookies ->
+                        writableBookiesWatchers.forEach(w -> w.onBookiesChanged(bookies)), executor);
     }
 
     @Override
@@ -193,8 +198,13 @@ public class PulsarRegistrationClient implements RegistrationClient {
     @Override
     public CompletableFuture<Void> watchReadOnlyBookies(RegistrationListener registrationListener) {
         readOnlyBookiesWatchers.add(registrationListener);
+        // trigger all listeners in readOnlyBookiesWatchers one by one. It aims to keep a sync way
+        // to make sure the previous listener has finished when a new listener is register.
+        // Though it would bring duplicate trigger listener problem, but since watchReadOnlyBookies
+        // is only executed when bookieClient construct, the duplicate problem is acceptable.
         return getReadOnlyBookies()
-                .thenAcceptAsync(registrationListener::onBookiesChanged, executor);
+                .thenAcceptAsync(bookies ->
+                        readOnlyBookiesWatchers.forEach(w -> w.onBookiesChanged(bookies)), executor);
     }
 
     @Override


### PR DESCRIPTION
Main Issue: https://github.com/apache/pulsar/issues/23330

Relevant issue: https://github.com/apache/pulsar/issues/23282, https://github.com/apache/pulsar/pull/23283



### Motivation

Fix another issue cause broker lost rack information. There is a previous issue also cause broker lost rack information.

### Modifications

This is the first potential fix, when construct bookieClient and do watchWritableBookies() to register listener, trigger each listener in writableBookiesWatchers. 

This fix can ensure multiple listeners is trigger in a sync way, but it would bring duplicate trigger problem. Since watchWritableBookies() is only executed twice when bookieClient construct. I think the duplicate trigger problem is acceptable. 

Alternative fix is to make BookieRackAffinityMapping#watchAvailableBookies become sync method. Change to registrationClient.watchWritableBookies(......).get() in BookieRackAffinityMapping#watchAvailableBookies. Now it is async. 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->


