### PR TITLE
[Draft] [fix] [broker] Do not record a bundle-unloading into the topic load failed metrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1259,7 +1259,11 @@ public class BrokerService implements Closeable {
     private CompletableFuture<Optional<Topic>> createNonPersistentTopic(String topic) {
         CompletableFuture<Optional<Topic>> topicFuture = new CompletableFuture<>();
         topicFuture.exceptionally(t -> {
-            pulsarStats.recordTopicLoadFailed();
+            if (t instanceof BrokerServiceException.BundleUnloadingException) {
+                pulsarStats.recordConcurrencyLoadTopicAndUnloadBundle();
+            } else {
+                pulsarStats.recordTopicLoadFailed();
+            }
             pulsar.getExecutor().execute(() -> topics.remove(topic, topicFuture));
             return null;
         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1553,7 +1553,11 @@ public class BrokerService implements Closeable {
                 () -> FAILED_TO_LOAD_TOPIC_TIMEOUT_EXCEPTION);
 
         topicFuture.exceptionally(t -> {
-            pulsarStats.recordTopicLoadFailed();
+            if (t instanceof BrokerServiceException.BundleUnloadingException) {
+                pulsarStats.recordConcurrencyLoadTopicAndUnloadBundle();
+            } else {
+                pulsarStats.recordTopicLoadFailed();
+            }
             return null;
         });
 
@@ -2226,7 +2230,7 @@ public class BrokerService implements Closeable {
                                         + "Please redo the lookup. Request is denied: namespace=%s",
                                 topic, pulsar.getBrokerId(), topicName.getNamespace());
                         log.warn(msg);
-                        return FutureUtil.failedFuture(new ServiceUnitNotReadyException(msg));
+                        return FutureUtil.failedFuture(new BrokerServiceException.BundleUnloadingException(msg));
                     }
                 });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
@@ -71,6 +71,16 @@ public class BrokerServiceException extends Exception {
         }
     }
 
+    public static class BundleUnloadingException extends ServiceUnitNotReadyException {
+        public BundleUnloadingException(String msg) {
+            super(msg);
+        }
+
+        public BundleUnloadingException(String msg, Throwable t) {
+            super(msg, t);
+        }
+    }
+
     public static class TopicClosedException extends BrokerServiceException {
         public TopicClosedException(Throwable t) {
             super(t);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarStats.java
@@ -265,6 +265,10 @@ public class PulsarStats implements Closeable {
         brokerOperabilityMetrics.recordTopicLoadFailed();
     }
 
+    public void recordConcurrencyLoadTopicAndUnloadBundle() {
+        brokerOperabilityMetrics.recordConcurrencyLoadTopicAndUnloadBundle();
+    }
+
     public void recordConnectionCreate() {
         brokerOperabilityMetrics.recordConnectionCreate();
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
@@ -35,6 +35,8 @@ import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes.ConnectionStatus;
  */
 public class BrokerOperabilityMetrics implements AutoCloseable {
     private static final Counter TOPIC_LOAD_FAILED = Counter.build("topic_load_failed", "-").register();
+    private static final Counter CONCURRENCY_LOAD_TOPIC_AND_UNLOAD_BUNDLE =
+            Counter.build("concurrency_load_topic_and_unload_bundle", "-").register();
     private final List<Metrics> metricsList;
     private final String localCluster;
     private final DimensionStats topicLoadStats;
@@ -160,6 +162,10 @@ public class BrokerOperabilityMetrics implements AutoCloseable {
 
     public void recordTopicLoadFailed() {
         this.TOPIC_LOAD_FAILED.inc();
+    }
+
+    public void recordConcurrencyLoadTopicAndUnloadBundle() {
+        this.CONCURRENCY_LOAD_TOPIC_AND_UNLOAD_BUNDLE.inc();
     }
 
     public void recordConnectionCreate() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
@@ -132,6 +132,8 @@ public class BrokerOperabilityMetrics implements AutoCloseable {
     Metrics getTopicLoadMetrics() {
         Metrics metrics = getDimensionMetrics("pulsar_topic_load_times", "topic_load", topicLoadStats);
         metrics.put("brk_topic_load_failed_count", TOPIC_LOAD_FAILED.get());
+        metrics.put("brk_concurrency_load_topic_and_unload_bundle_count",
+                CONCURRENCY_LOAD_TOPIC_AND_UNLOAD_BUNDLE.get());
         return metrics;
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -67,7 +67,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
@@ -81,7 +80,6 @@ import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.NullLedgerOffloader;
 import org.apache.bookkeeper.mledger.impl.NonAppendableLedgerOffloader;
-import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -1679,8 +1677,8 @@ public class BrokerServiceTest extends BrokerTestBase {
         admin.topics().unload(topic);
 
         // Get original counter.
-        AtomicLong failedLoadTopic1 = new AtomicLong(0);
-        AtomicLong concurrencyLoadTopicAndUnloadBundle1 = new AtomicLong(0);
+        final AtomicLong failedLoadTopic1 = new AtomicLong(0);
+        final AtomicLong concurrencyLoadTopicAndUnloadBundle1 = new AtomicLong(0);
         JerseyClient httpClient = JerseyClientBuilder.createClient();
         String response = httpClient.target(pulsar.getWebServiceAddress()).path("/metrics/")
                 .request().get(String.class);
@@ -1730,8 +1728,8 @@ public class BrokerServiceTest extends BrokerTestBase {
         admin.namespaces().unload(namespace);
 
         // Get original counter.
-        AtomicLong failedLoadTopic1 = new AtomicLong(0);
-        AtomicLong concurrencyLoadTopicAndUnloadBundle1 = new AtomicLong(0);
+        final AtomicLong failedLoadTopic1 = new AtomicLong(0);
+        final AtomicLong concurrencyLoadTopicAndUnloadBundle1 = new AtomicLong(0);
         JerseyClient httpClient = JerseyClientBuilder.createClient();
         String response = httpClient.target(pulsar.getWebServiceAddress()).path("/metrics/")
                 .request().get(String.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -67,6 +67,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
@@ -1677,16 +1679,16 @@ public class BrokerServiceTest extends BrokerTestBase {
         admin.topics().unload(topic);
 
         // Get original counter.
-        MutableInt failedLoadTopic1 = new MutableInt(0);
-        MutableInt concurrencyLoadTopicAndUnloadBundle1 = new MutableInt(0);
+        AtomicLong failedLoadTopic1 = new AtomicLong(0);
+        AtomicLong concurrencyLoadTopicAndUnloadBundle1 = new AtomicLong(0);
         JerseyClient httpClient = JerseyClientBuilder.createClient();
         String response = httpClient.target(pulsar.getWebServiceAddress()).path("/metrics/")
                 .request().get(String.class);
         long failedLoadTopic = parseLongMetric(response, "pulsar_topic_load_failed_count");
         long concurrencyLoadTopicAndUnloadBundle =
                 parseLongMetric(response, "pulsar_concurrency_load_topic_and_unload_bundle_count");
-        failedLoadTopic1.setValue(failedLoadTopic);
-        concurrencyLoadTopicAndUnloadBundle1.setValue(concurrencyLoadTopicAndUnloadBundle);
+        failedLoadTopic1.set(failedLoadTopic);
+        concurrencyLoadTopicAndUnloadBundle1.set(concurrencyLoadTopicAndUnloadBundle);
 
         // Inject an error that makes the topic load fails.
         AtomicBoolean failMarker = new AtomicBoolean(true);
@@ -1706,8 +1708,8 @@ public class BrokerServiceTest extends BrokerTestBase {
             long failedLoadTopic2 = parseLongMetric(response2, "pulsar_topic_load_failed_count");
             long concurrencyLoadTopicAndUnloadBundle2 =
                     parseLongMetric(response2, "pulsar_concurrency_load_topic_and_unload_bundle_count");
-            assertTrue(failedLoadTopic2 > failedLoadTopic1.getValue());
-            assertTrue(concurrencyLoadTopicAndUnloadBundle2 == concurrencyLoadTopicAndUnloadBundle1.getValue());
+            assertTrue(failedLoadTopic2 > failedLoadTopic1.get());
+            assertTrue(concurrencyLoadTopicAndUnloadBundle2 == concurrencyLoadTopicAndUnloadBundle1.get());
         });
 
         // Remove the injection.
@@ -1728,16 +1730,16 @@ public class BrokerServiceTest extends BrokerTestBase {
         admin.namespaces().unload(namespace);
 
         // Get original counter.
-        MutableInt failedLoadTopic1 = new MutableInt(0);
-        MutableInt concurrencyLoadTopicAndUnloadBundle1 = new MutableInt(0);
+        AtomicLong failedLoadTopic1 = new AtomicLong(0);
+        AtomicLong concurrencyLoadTopicAndUnloadBundle1 = new AtomicLong(0);
         JerseyClient httpClient = JerseyClientBuilder.createClient();
         String response = httpClient.target(pulsar.getWebServiceAddress()).path("/metrics/")
                 .request().get(String.class);
         long failedLoadTopic = parseLongMetric(response, "pulsar_topic_load_failed_count");
         long concurrencyLoadTopicAndUnloadBundle =
                 parseLongMetric(response, "pulsar_concurrency_load_topic_and_unload_bundle_count");
-        failedLoadTopic1.setValue(failedLoadTopic);
-        concurrencyLoadTopicAndUnloadBundle1.setValue(concurrencyLoadTopicAndUnloadBundle);
+        failedLoadTopic1.set(failedLoadTopic);
+        concurrencyLoadTopicAndUnloadBundle1.set(concurrencyLoadTopicAndUnloadBundle);
 
         // Inject an error that makes the topic load fails.
         AtomicBoolean failMarker = new AtomicBoolean(true);
@@ -1761,8 +1763,8 @@ public class BrokerServiceTest extends BrokerTestBase {
             long failedLoadTopic2 = parseLongMetric(response2, "pulsar_topic_load_failed_count");
             long concurrencyLoadTopicAndUnloadBundle2 =
                     parseLongMetric(response2, "pulsar_concurrency_load_topic_and_unload_bundle_count");
-            assertTrue(failedLoadTopic2 == failedLoadTopic1.getValue());
-            assertTrue(concurrencyLoadTopicAndUnloadBundle2 > concurrencyLoadTopicAndUnloadBundle1.getValue());
+            assertTrue(failedLoadTopic2 == failedLoadTopic1.get());
+            assertTrue(concurrencyLoadTopicAndUnloadBundle2 > concurrencyLoadTopicAndUnloadBundle1.get());
         });
 
         // Remove the injection.


### PR DESCRIPTION
### Motivation & Modifications

Pulsar has a metric that indicates load topic failed: `topic_load_failed_total`, it reflects something is not expected, such as 
- Not enough bookies
- Failed to connect to the Metadata store

But the topic loaded failed due to a bundle in unloading is expected, we should not record it into this metrics.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
