### PR TITLE
[improve][build] Use eclipse-temurin:17 image instead of apt installation

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -50,6 +50,20 @@ RUN for SUBDIRECTORY in conf data download logs; do \
 # to create those log directories. This should be removed when Trino is removed.
 RUN chmod g+w /pulsar/trino
 
+FROM eclipse-temurin:17 as jre-build
+
+# Create a custom Java runtime
+RUN $JAVA_HOME/bin/jlink \
+         --add-modules ALL-MODULE-PATH \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
+RUN echo networkaddress.cache.ttl=1 >> /javaruntime/conf/security/java.security
+RUN echo networkaddress.cache.negative.ttl=1 >> /javaruntime/conf/security/java.security
+
 ### Create 2nd stage from Ubuntu image
 ### and add OpenJDK and Python dependencies (for Pulsar functions)
 
@@ -68,26 +82,17 @@ RUN sed -i -e "s|http://archive\.ubuntu\.com/ubuntu/|${UBUNTU_MIRROR:-mirror://m
      && apt-get -y dist-upgrade \
      && apt-get -y install netcat dnsutils less procps iputils-ping \
                  curl ca-certificates wget apt-transport-https \
-     && apt-get -y install --no-install-recommends python3 python3-kazoo python3-pip
-
-# Install Eclipse Temurin Package
-RUN mkdir -p /etc/apt/keyrings \
-     && wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc \
-     && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
-     && apt-get update \
-     && apt-get -y dist-upgrade \
-     && apt-get -y install temurin-17-jdk \
-     && export ARCH=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1') \
-     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$ARCH/conf/security/java.security \
-     && echo networkaddress.cache.negative.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$ARCH/conf/security/java.security
-
-# Cleanup apt
-RUN apt-get -y --purge autoremove \
+     && apt-get -y install --no-install-recommends python3 python3-kazoo python3-pip \
+     && apt-get -y --purge autoremove \
      && apt-get autoclean \
      && apt-get clean \
-     && rm -rf /var/lib/apt/lists/*
+     && rm -rf /var/lib/apt/lists/* \
+     && pip3 install pyyaml==6.0.1
 
-RUN pip3 install pyyaml==6.0.1
+# Copy Eclipse Temurin Package
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH="$PATH:$JAVA_HOME/bin"
+COPY --from=jre-build /javaruntime $JAVA_HOME
 
 # Pulsar currently writes to the below directories, assuming the default configuration.
 # Note that number 4 is the reason that pulsar components need write access to the /pulsar directory.


### PR DESCRIPTION
### Motivation

Reduce the docker image size by https://adoptium.net/zh-CN/blog/2021/08/using-jlink-in-dockerfiles/

```
apachepulsar/pulsar 3.0.7-SNAPSHOT-new e35b177e267a 623MB
apachepulsar/pulsar 3.0.7-SNAPSHOT-old fd1e1113514d 943MB
```

It was reduced by 320MB.

We already improved the 4.0.0: https://github.com/apache/pulsar/pull/22973

### Modifications

- Use eclipse-temurin:17 image instead of apt installation.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->