### PR TITLE
[fix] FIx ArrayIndexOutOfBoundsException when using SameAuthParamsLookupAutoClusterFailover

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailover.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailover.java
@@ -71,29 +71,36 @@ public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvid
         this.executor = EventLoopUtil.newEventLoopGroup(1, false,
                 new ExecutorProvider.ExtendedThreadFactory("broker-service-url-check"));
         scheduledCheckTask = executor.scheduleAtFixedRate(() -> {
-            if (closed) {
-                return;
-            }
-            checkPulsarServices();
-            int firstHealthyPulsarService = firstHealthyPulsarService();
-            if (firstHealthyPulsarService == currentPulsarServiceIndex) {
-                return;
-            }
-            if (firstHealthyPulsarService < 0) {
-                int failoverTo = findFailoverTo();
-                if (failoverTo < 0) {
-                    // No healthy pulsar service to connect.
-                    log.error("Failed to choose a pulsar service to connect, no one pulsar service is healthy. Current"
-                            + " pulsar service: [{}] {}. States: {}, Counters: {}", currentPulsarServiceIndex,
-                            pulsarServiceUrlArray[currentPulsarServiceIndex], Arrays.toString(pulsarServiceStateArray),
-                            Arrays.toString(checkCounterArray));
-                } else {
-                    // Failover to low priority pulsar service.
-                    updateServiceUrl(failoverTo);
+            try {
+                if (closed) {
+                    return;
                 }
-            } else {
-                // Back to high priority pulsar service.
-                updateServiceUrl(firstHealthyPulsarService);
+                checkPulsarServices();
+                int firstHealthyPulsarService = firstHealthyPulsarService();
+                if (firstHealthyPulsarService == currentPulsarServiceIndex) {
+                    return;
+                }
+                if (firstHealthyPulsarService < 0) {
+                    int failoverTo = findFailoverTo();
+                    if (failoverTo < 0) {
+                        // No healthy pulsar service to connect.
+                        log.error(
+                                "Failed to choose a pulsar service to connect, no one pulsar service is healthy."
+                                        + " Current pulsar service: [{}] {}. States: {}, Counters: {}",
+                                currentPulsarServiceIndex,
+                                pulsarServiceUrlArray[currentPulsarServiceIndex],
+                                Arrays.toString(pulsarServiceStateArray),
+                                Arrays.toString(checkCounterArray));
+                    } else {
+                        // Failover to low priority pulsar service.
+                        updateServiceUrl(failoverTo);
+                    }
+                } else {
+                    // Back to high priority pulsar service.
+                    updateServiceUrl(firstHealthyPulsarService);
+                }
+            } catch (Exception ex) {
+                log.error("Failed to re-check cluster status", ex);
             }
         }, checkHealthyIntervalMs, checkHealthyIntervalMs, TimeUnit.MILLISECONDS);
     }
@@ -123,7 +130,7 @@ public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvid
     }
 
     private int findFailoverTo() {
-        for (int i = currentPulsarServiceIndex + 1; i <= pulsarServiceUrlArray.length; i++) {
+        for (int i = currentPulsarServiceIndex + 1; i < pulsarServiceUrlArray.length; i++) {
             if (probeAvailable(i)) {
                 return i;
             }


### PR DESCRIPTION
### Motivation

There is a [mistake](https://github.com/apache/pulsar/pull/23336/files#diff-d1cfc9f5db8cc65b6f7ec1b04a3bfda01230a2f16610069c776714dc67134eefR133) in `SameAuthParamsLookupAutoClusterFailover.class`, which may cause a `ArrayIndexOutOfBoundsException`, but it affects nothing because it only happens when no server is available.


### Modifications

- Fix the mistake
- Add an log

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x