### PR TITLE
[fix][build] Fix problem where git.commit.id.abbrev is missing in image tagging

### DIFF
--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -68,7 +68,6 @@
             <configuration>
               <skip>false</skip>
               <injectAllReactorProjects>true</injectAllReactorProjects>
-              <runOnlyOnce>true</runOnlyOnce>
               <skipPoms>false</skipPoms>
             </configuration>
           </plugin>


### PR DESCRIPTION
### Motivation

building a docker image with this command will fail. 
```
mvn package -Pdocker,-main -am -pl docker/pulsar -DskipTests
```

error message is
```
[ERROR] Failed to execute goal io.fabric8:docker-maven-plugin:0.45.0:build (default) on project pulsar-docker-image: Execution default of goal io.fabric8:docker-maven-plugin:0.45.0:build failed: Given Docker name 'apachepulsar/pulsar:4.0.0-SNAPSHOT-${git.commit.id.abbrev}' is invalid:
[ERROR]    * tag part '4.0.0-SNAPSHOT-${git.commit.id.abbrev}' doesn't match allowed pattern '^[\w][\w.-]{0,127}$'
[ERROR] See http://bit.ly/docker_image_fmt for more details
```

### Modifications

Fix the problem by revisiting the `git-commit-id-plugin` configuration in `docker/pom.xml` file.
Removing `<runOnlyOnce>true</runOnlyOnce>` fixes the problem.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->