### PR TITLE
[fix][sec] Upgrade vertx to 4.5.10 to address CVE-2024-8391

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -491,11 +491,11 @@ The Apache Software License, Version 2.0
   * JCTools - Java Concurrency Tools for the JVM
     - org.jctools-jctools-core-2.1.2.jar
   * Vertx
-    - io.vertx-vertx-auth-common-4.5.8.jar
-    - io.vertx-vertx-bridge-common-4.5.8.jar
-    - io.vertx-vertx-core-4.5.8.jar
-    - io.vertx-vertx-web-4.5.8.jar
-    - io.vertx-vertx-web-common-4.5.8.jar
+    - io.vertx-vertx-auth-common-4.5.10.jar
+    - io.vertx-vertx-bridge-common-4.5.10.jar
+    - io.vertx-vertx-core-4.5.10.jar
+    - io.vertx-vertx-web-4.5.10.jar
+    - io.vertx-vertx-web-common-4.5.10.jar
   * Apache ZooKeeper
     - org.apache.zookeeper-zookeeper-3.9.2.jar
     - org.apache.zookeeper-zookeeper-jute-3.9.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@ flexible messaging model and an intuitive client API.</description>
     <jersey.version>2.42</jersey.version>
     <athenz.version>1.10.50</athenz.version>
     <prometheus.version>0.16.0</prometheus.version>
-    <vertx.version>4.5.8</vertx.version>
+    <vertx.version>4.5.10</vertx.version>
     <rocksdb.version>7.9.2</rocksdb.version>
     <slf4j.version>2.0.13</slf4j.version>
     <commons.collections4.version>4.4</commons.collections4.version>


### PR DESCRIPTION
### Motivation

Address CVE-2024-8391

### Modifications

Upgrade vertx from 4.5.8 to 4.5.10

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->