### PR TITLE
[fix] Key_Shared mode consumption latency when low traffic

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -489,12 +489,12 @@ dispatcherReadFailureBackoffMandatoryStopTimeInMs=0
 # On Shared and KeyShared subscriptions, if all available messages in the subscription are filtered
 # out and not dispatched to any consumer, message dispatching will be rescheduled with a backoff
 # delay. This parameter sets the initial backoff delay in milliseconds.
-dispatcherRetryBackoffInitialTimeInMs=100
+dispatcherRetryBackoffInitialTimeInMs=1
 
 # On Shared and KeyShared subscriptions, if all available messages in the subscription are filtered
 # out and not dispatched to any consumer, message dispatching will be rescheduled with a backoff
 # delay. This parameter sets the maximum backoff delay in milliseconds.
-dispatcherRetryBackoffMaxTimeInMs=1000
+dispatcherRetryBackoffMaxTimeInMs=10
 
 # Precise dispatcher flow control according to history message number of each entry
 preciseDispatcherFlowControl=false

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -305,12 +305,12 @@ dispatcherReadFailureBackoffMandatoryStopTimeInMs=0
 # On Shared and KeyShared subscriptions, if all available messages in the subscription are filtered
 # out and not dispatched to any consumer, message dispatching will be rescheduled with a backoff
 # delay. This parameter sets the initial backoff delay in milliseconds.
-dispatcherRetryBackoffInitialTimeInMs=100
+dispatcherRetryBackoffInitialTimeInMs=1
 
 # On Shared and KeyShared subscriptions, if all available messages in the subscription are filtered
 # out and not dispatched to any consumer, message dispatching will be rescheduled with a backoff
 # delay. This parameter sets the maximum backoff delay in milliseconds.
-dispatcherRetryBackoffMaxTimeInMs=1000
+dispatcherRetryBackoffMaxTimeInMs=10
 
 # Precise dispatcher flow control according to history message number of each entry
 preciseDispatcherFlowControl=false

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1231,14 +1231,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
             doc = "On Shared and KeyShared subscriptions, if all available messages in the subscription are filtered "
                     + "out and not dispatched to any consumer, message dispatching will be rescheduled with a backoff "
                     + "delay. This parameter sets the initial backoff delay in milliseconds.")
-    private int dispatcherRetryBackoffInitialTimeInMs = 100;
+    private int dispatcherRetryBackoffInitialTimeInMs = 0;
 
     @FieldContext(
             category = CATEGORY_POLICIES,
             doc = "On Shared and KeyShared subscriptions, if all available messages in the subscription are filtered "
                     + "out and not dispatched to any consumer, message dispatching will be rescheduled with a backoff "
                     + "delay. This parameter sets the maximum backoff delay in milliseconds.")
-    private int dispatcherRetryBackoffMaxTimeInMs = 1000;
+    private int dispatcherRetryBackoffMaxTimeInMs = 0;
 
     @FieldContext(
             dynamic = true,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1231,14 +1231,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
             doc = "On Shared and KeyShared subscriptions, if all available messages in the subscription are filtered "
                     + "out and not dispatched to any consumer, message dispatching will be rescheduled with a backoff "
                     + "delay. This parameter sets the initial backoff delay in milliseconds.")
-    private int dispatcherRetryBackoffInitialTimeInMs = 0;
+    private int dispatcherRetryBackoffInitialTimeInMs = 1;
 
     @FieldContext(
             category = CATEGORY_POLICIES,
             doc = "On Shared and KeyShared subscriptions, if all available messages in the subscription are filtered "
                     + "out and not dispatched to any consumer, message dispatching will be rescheduled with a backoff "
                     + "delay. This parameter sets the maximum backoff delay in milliseconds.")
-    private int dispatcherRetryBackoffMaxTimeInMs = 0;
+    private int dispatcherRetryBackoffMaxTimeInMs = 10;
 
     @FieldContext(
             dynamic = true,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -729,11 +729,13 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
         boolean triggerReadingMore = sendMessagesToConsumers(readType, entries, needAcquireSendInProgress);
         int entriesDispatched = lastNumberOfEntriesDispatched;
         updatePendingBytesToDispatch(-totalBytesSize);
+        if (entriesDispatched > 0) {
+            // Reset the backoff when we successfully dispatched messages
+            retryBackoff.reset();
+        }
         if (triggerReadingMore) {
             if (entriesDispatched > 0 || skipNextBackoff) {
                 skipNextBackoff = false;
-                // Reset the backoff when we successfully dispatched messages
-                retryBackoff.reset();
                 // Call readMoreEntries in the same thread to trigger the next read
                 readMoreEntries();
             } else if (entriesDispatched == 0) {


### PR DESCRIPTION
### Motivation

Without #23226 and #23284, the consumption latency is low, but the consumption latency increases to `1s` when the traffic is low.

Consumption latency after an upgrade(3 topics).

`histogram_quantile(0.98, sum-by (le, topic) (rate (Message_duration_eventstate_ inbound_latencymin_bucket {kubernetes_namespace-"$(env)"} [$__rate_interval])))`

<img width="1858" alt="Screenshot 2024-09-24 at 00 27 11" src="https://github.com/user-attachments/assets/70e3da78-6fd3-4d8e-8f7f-7ef4790c164a">


Root cause

<img width="1328" alt="Screenshot 2024-09-24 at 02 30 27" src="https://github.com/user-attachments/assets/870754c8-fa37-4657-b5a9-5ccde45f769d">



### Modifications

Change the feature's introduced by #23226 default values to 1ms initial / 10ms max.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x