### PR TITLE
[fix][build] Remove io.grpc.netty relocation

### DIFF
--- a/jetcd-core-shaded/pom.xml
+++ b/jetcd-core-shaded/pom.xml
@@ -110,6 +110,9 @@
                 <relocation>
                   <pattern>io.grpc.netty</pattern>
                   <shadedPattern>io.grpc.netty.shaded.io.grpc.netty</shadedPattern>
+                  <excludes>
+                    <exclude>io.grpc.netty.shaded.*</exclude>
+                  </excludes>
                 </relocation>
                 <!-- relocate to use grpc-netty-shaded packages -->
                 <relocation>


### PR DESCRIPTION
### Motivation

I'm trying to release the private pulsar 3.0.x, and encountered a compilation issue:
```
$ mvn -T 1C -B -ntp install deploy -Pxxxx-release -DskipTests -Dlicense.skip=true -Dspotbugs.skip=true -Drat.skip=true -Dcheckstyle.skip=true

....
Error:  Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project pulsar-metadata: Compilation failure
Error:  /pulsar/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/EtcdMetadataStore.java:[147,34] cannot access io.grpc.netty.shaded.io.grpc.netty.shaded.io.netty.handler.ssl.SslContext
Error:    class file for io.grpc.netty.shaded.io.grpc.netty.shaded.io.netty.handler.ssl.SslContext not found
Error:  -> [Help 1]
Error:  
```

https://github.com/apache/pulsar/pull/22892 introduces grpc-netty-shaded, the `maven-shade-plugin` rewrites `io.grpc.netty.shaded.io.netty.handler.ssl.SslContext` to `io.grpc.netty.shaded.io.grpc.netty.shaded.io.netty.handler.ssl.SslContext`, which have broken the compilation.

The import of the `io.grpc.netty.shaded.*` should be excluded.

### Modifications

- Exclude `io.grpc.netty.shaded.*` in the `io.grpc.netty` relocation.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->