### PR TITLE
[fix] [broker] Fix incorrect stat sub.msgBacklogNoDelayed if enabled delayedDeliveryFixedDelayDetectionLookahead

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
@@ -151,6 +151,10 @@ public interface Dispatcher {
      */
     default void afterAckMessages(Throwable exOfDeletion, Object ctxOfDeletion){}
 
+    default boolean isAllMessagesAreFixedDelayed() {
+        return false;
+    }
+
     /**
      * Trigger a new "readMoreEntries" if the dispatching has been paused before. This method is only implemented in
      * {@link org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers} right now, other

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Dispatcher.java
@@ -151,7 +151,7 @@ public interface Dispatcher {
      */
     default void afterAckMessages(Throwable exOfDeletion, Object ctxOfDeletion){}
 
-    default boolean isAllMessagesAreFixedDelayed() {
+    default boolean isAllWaitingReadMessagesAreFixedDelayed() {
         return false;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -1335,7 +1335,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
     }
 
     @Override
-    public boolean isAllMessagesAreFixedDelayed() {
+    public boolean isAllWaitingReadMessagesAreFixedDelayed() {
         return shouldPauseDeliveryForDelayTracker();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -1335,6 +1335,11 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
     }
 
     @Override
+    public boolean isAllMessagesAreFixedDelayed() {
+        return shouldPauseDeliveryForDelayTracker();
+    }
+
+    @Override
     public long getNumberOfDelayedMessages() {
         return delayedDeliveryTracker.map(DelayedDeliveryTracker::getNumberOfDelayedMessages).orElse(0L);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1276,7 +1276,7 @@ public class PersistentSubscription extends AbstractSubscription {
                 subStats.unackedMessages = d.getTotalUnackedMessages();
                 subStats.blockedSubscriptionOnUnackedMsgs = d.isBlockedDispatcherOnUnackedMsgs();
                 subStats.msgInReplay = d.getNumberOfMessagesInReplay();
-                if (d.isAllMessagesAreFixedDelayed()) {
+                if (d.isAllWaitingReadMessagesAreFixedDelayed()) {
                     long msgDeliveredOut = 0;
                     for (Consumer c : dispatcher.getConsumers()){
                         msgDeliveredOut += c.getUnackedMessages();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1277,7 +1277,11 @@ public class PersistentSubscription extends AbstractSubscription {
                 subStats.blockedSubscriptionOnUnackedMsgs = d.isBlockedDispatcherOnUnackedMsgs();
                 subStats.msgInReplay = d.getNumberOfMessagesInReplay();
                 if (d.isAllMessagesAreFixedDelayed()) {
-                    subStats.msgDelayed = subStats.msgBacklog;
+                    long msgDeliveredOut = 0;
+                    for (Consumer c : dispatcher.getConsumers()){
+                        msgDeliveredOut += c.getUnackedMessages();
+                    }
+                    subStats.msgDelayed = subStats.msgBacklog - msgDeliveredOut - subStats.msgInReplay;
                     subStats.msgDelayedInMemory = d.getNumberOfDelayedMessages();
                 } else {
                     subStats.msgDelayed = d.getNumberOfDelayedMessages();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1269,16 +1269,23 @@ public class PersistentSubscription extends AbstractSubscription {
                     ((PersistentDispatcherMultipleConsumers) dispatcher).getBucketDelayedIndexStats();
         }
 
+        subStats.msgBacklog = getNumberOfEntriesInBacklog(getStatsOptions.isGetPreciseBacklog());
         if (Subscription.isIndividualAckMode(subType)) {
             if (dispatcher instanceof PersistentDispatcherMultipleConsumers) {
                 PersistentDispatcherMultipleConsumers d = (PersistentDispatcherMultipleConsumers) dispatcher;
                 subStats.unackedMessages = d.getTotalUnackedMessages();
                 subStats.blockedSubscriptionOnUnackedMsgs = d.isBlockedDispatcherOnUnackedMsgs();
-                subStats.msgDelayed = d.getNumberOfDelayedMessages();
                 subStats.msgInReplay = d.getNumberOfMessagesInReplay();
+                if (d.isAllMessagesAreFixedDelayed()) {
+                    subStats.msgDelayed = subStats.msgBacklog;
+                    subStats.msgDelayedInMemory = d.getNumberOfDelayedMessages();
+                } else {
+                    subStats.msgDelayed = d.getNumberOfDelayedMessages();
+                    subStats.msgDelayedInMemory = subStats.msgDelayed;
+                }
             }
         }
-        subStats.msgBacklog = getNumberOfEntriesInBacklog(getStatsOptions.isGetPreciseBacklog());
+
         if (getStatsOptions.isSubscriptionBacklogSize()) {
             subStats.backlogSize = topic.getManagedLedger()
                     .getEstimatedBacklogSize(cursor.getMarkDeletedPosition());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/DelayedDeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/DelayedDeliveryTest.java
@@ -714,7 +714,8 @@ public class DelayedDeliveryTest extends ProducerConsumerBase {
             producer.newMessage().deliverAfter(1, TimeUnit.HOURS).value(i + "").send();
         }
         Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING).topic(topic).subscriptionName(sName)
-                .receiverQueueSize(20).subscriptionType(SubscriptionType.Shared).subscribe();
+                .receiverQueueSize(delayedDeliveryFixedDelayDetectionLookahead * 2)
+                .subscriptionType(SubscriptionType.Shared).subscribe();
 
         PersistentDispatcherMultipleConsumers dispatcher = (PersistentDispatcherMultipleConsumers) persistentTopic
                 .getSubscription(sName).getDispatcher();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/DelayedDeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/DelayedDeliveryTest.java
@@ -25,6 +25,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import io.opentelemetry.api.common.Attributes;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -52,6 +53,7 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.policies.data.DelayedDeliveryPolicies;
 import org.apache.pulsar.common.policies.data.SubscriptionStats;
+import org.apache.pulsar.common.util.collections.GrowableArrayBlockingQueue;
 import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
 import org.awaitility.Awaitility;
 import org.awaitility.reflect.WhiteboxImpl;
@@ -694,7 +696,9 @@ public class DelayedDeliveryTest extends ProducerConsumerBase {
         final long originalDelayedDeliveryFixedDelayDetectionLookahead =
                 pulsar.getConfig().getDelayedDeliveryFixedDelayDetectionLookahead();;
         final int delayedDeliveryFixedDelayDetectionLookahead = 10;
-        final int entries = delayedDeliveryFixedDelayDetectionLookahead * 10;
+        final int msgNoDelayed = 15;
+        final int receiverQueueSize = 10;
+        final int msgDelayed = delayedDeliveryFixedDelayDetectionLookahead * 10;
         final String topic = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
         final String sName = "delayed_s1";
         DelayedDeliveryTrackerFactory delayedDeliveryTrackerFactory =
@@ -709,27 +713,57 @@ public class DelayedDeliveryTest extends ProducerConsumerBase {
         PersistentTopic persistentTopic =
                 (PersistentTopic) pulsar.getBrokerService().getTopic(topic, false).join().get();
 
+        // Send some message no-delayed.
+        // Send many messages delayed.
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
-        for (int i = 0; i < entries; i++) {
+        for (int i = 0; i < msgNoDelayed; i++) {
+            producer.newMessage().send();
+        }
+        for (int i = 0; i < msgDelayed; i++) {
             producer.newMessage().deliverAfter(1, TimeUnit.HOURS).value(i + "").send();
         }
-        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING).topic(topic).subscriptionName(sName)
-                .receiverQueueSize(delayedDeliveryFixedDelayDetectionLookahead * 2)
+        Consumer<String> consumer1 = pulsarClient.newConsumer(Schema.STRING).topic(topic).subscriptionName(sName)
+                .receiverQueueSize(receiverQueueSize)
+                .subscriptionType(SubscriptionType.Shared).subscribe();
+        Consumer<String> consumer2 = pulsarClient.newConsumer(Schema.STRING).topic(topic).subscriptionName(sName)
+                .receiverQueueSize(receiverQueueSize)
                 .subscriptionType(SubscriptionType.Shared).subscribe();
 
+        // Wait for the checker that named "shouldPauseDeliveryForDelayTracker".
         PersistentDispatcherMultipleConsumers dispatcher = (PersistentDispatcherMultipleConsumers) persistentTopic
                 .getSubscription(sName).getDispatcher();
         Awaitility.await().untilAsserted(() -> {
             assertTrue(dispatcher.shouldPauseDeliveryForDelayTracker());
             assertTrue(dispatcher.getNumberOfDelayedMessages() >= delayedDeliveryFixedDelayDetectionLookahead);
         });
-
-        SubscriptionStats subscriptionStats = persistentTopic.getStats(true, false, false)
+        // Verify: backlog stats
+        SubscriptionStats subscriptionStats1 = persistentTopic.getStats(true, false, false)
                 .getSubscriptions().get(sName);
-        assertEquals(subscriptionStats.getMsgBacklog(), entries);
-        assertEquals(subscriptionStats.getMsgDelayed(), entries);
-        assertEquals(subscriptionStats.getMsgBacklogNoDelayed(), 0);
-        assertTrue(subscriptionStats.getMsgDelayedInMemory() < entries);
+        assertEquals(subscriptionStats1.getMsgBacklog(), msgDelayed + msgNoDelayed);
+        assertEquals(subscriptionStats1.getMsgDelayed(), msgDelayed);
+        assertEquals(subscriptionStats1.getMsgBacklogNoDelayed(), msgNoDelayed);
+        assertEquals(subscriptionStats1.getMsgInReplay(), 0);
+        assertTrue(subscriptionStats1.getMsgDelayedInMemory() < msgDelayed);
+
+        // Let some messages being pushed into replay queue.
+        consumer2.close();
+        // Wait for the checker that named "shouldPauseDeliveryForDelayTracker".
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(dispatcher.shouldPauseDeliveryForDelayTracker());
+            assertTrue(dispatcher.getNumberOfDelayedMessages() >= delayedDeliveryFixedDelayDetectionLookahead);
+        });
+        // And verify: backlog stats
+        Awaitility.await().atMost(Duration.ofSeconds(3600)).untilAsserted(() -> {
+            SubscriptionStats subscriptionStats2 = persistentTopic.getStats(true, false, false)
+                    .getSubscriptions().get(sName);
+            assertEquals(subscriptionStats2.getMsgBacklog(), msgDelayed + msgNoDelayed);
+            assertEquals(subscriptionStats2.getMsgDelayed(), msgDelayed);
+            assertEquals(subscriptionStats2.getMsgBacklogNoDelayed(), msgNoDelayed);
+            GrowableArrayBlockingQueue incomingMessages =
+                    WhiteboxImpl.getInternalState(consumer1, "incomingMessages");
+            assertEquals(subscriptionStats2.getMsgInReplay(), msgNoDelayed - incomingMessages.size());
+            assertTrue(subscriptionStats2.getMsgDelayedInMemory() < msgDelayed);
+        });
 
         // cleanup.
         DelayedDeliveryTrackerFactory delayedDeliveryTrackerFactory2 =
@@ -739,7 +773,8 @@ public class DelayedDeliveryTest extends ProducerConsumerBase {
                     originalDelayedDeliveryFixedDelayDetectionLookahead);
             delayedDeliveryTrackerFactory2.initialize(pulsar);
         }
-        consumer.close();
+        consumer1.close();
+        consumer2.close();
         producer.close();
         admin.topics().delete(topic, false);
     }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
@@ -63,8 +63,11 @@ public interface SubscriptionStats {
     /** Flag to verify if subscription is blocked due to reaching threshold of unacked messages. */
     boolean isBlockedSubscriptionOnUnackedMsgs();
 
-    /** Number of delayed messages currently being tracked. */
+    /** Number of delayed messages. */
     long getMsgDelayed();
+
+    /** Number of delayed messages currently being tracked. */
+    long getMsgDelayedInMemory();
 
     /** Number of messages registered for replay. */
     long getMsgInReplay();

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
@@ -73,6 +73,8 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
 
     /** Number of delayed messages currently being tracked. */
     public long msgDelayed;
+    /** Number of delayed messages currently being tracked. */
+    public long msgDelayedInMemory;
 
     /** Number of messages registered for replay. */
     public long msgInReplay;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
@@ -71,8 +71,9 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
     /** Flag to verify if subscription is blocked due to reaching threshold of unacked messages. */
     public boolean blockedSubscriptionOnUnackedMsgs;
 
-    /** Number of delayed messages currently being tracked. */
+    /** Number of delayed messages. */
     public long msgDelayed;
+
     /** Number of delayed messages currently being tracked. */
     public long msgDelayedInMemory;
 


### PR DESCRIPTION
### Motivation

**Background**
- When we notice the `sub.msgBacklogNoDelayed` is a large number, we will increase the consumer count to consume quickly.
- After enabling `delayedDeliveryFixedDelayDetectionLookahead` and the messages encountered the feature, `sub.msgDelayed` is always `50k` and `sub.msgBacklogNoDelayed` keeps increasing, but the consumers will receive nothing.


### Modifications

- Correct the value of `sub.msgBacklogNoDelayed` if enabled `delayedDeliveryFixedDelayDetectionLookahead`
- Write a test.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
