### PR TITLE
[improve][PIP] PIP-383: Support granting/revoking permissions for multiple topics

### DIFF
--- a/pip/pip-383.md
+++ b/pip/pip-383.md
@@ -141,4 +141,4 @@ public class TestAuthorization {
 ## Links
 
 * Mailing List discussion thread:  https://lists.apache.org/thread/6n2jdl9bsf1f6xz2orygz3kvxmy11ykh
-* Mailing List voting thread: 
+* Mailing List voting thread: https://lists.apache.org/thread/qbyvs75r0d64h6jk8w1swr782l85b77h

--- a/pip/pip-383.md
+++ b/pip/pip-383.md
@@ -11,14 +11,14 @@ Therefore, supporting granting permissions for multiple topics is very beneficia
 ## Motivation
 
 Supporting granting/revoking permissions for multiple topics, 
-add `grantPermissionAsync(List<GrantPermissionOptions> options)` and `revokePermissionAsync(List<RevokePermissionOptions> options)` in AuthorizationProvider.
+add `grantPermissionAsync(List<GrantTopicPermissionOptionsf> options)` and `revokePermissionAsync(List<RevokeTopicPermissionOptions> options)` in AuthorizationProvider.
 
 ## Goals
 
 ### In Scope
 
-- Add `grantPermissionAsync(List<GrantPermissionOptions> options)` in AuthorizationProvider.
-- Add `revokePermissionAsync(List<RevokePermissionOptions> options)` in AuthorizationProvider.
+- Add `grantPermissionAsync(List<GrantTopicPermissionOptions> options)` in AuthorizationProvider.
+- Add `revokePermissionAsync(List<GrantTopicPermissionOptions> options)` in AuthorizationProvider.
 
 ## High-Level Design
 
@@ -29,16 +29,22 @@ Add method in AuthorizationProvider
 
 public interface AuthorizationProvider extends Closeable {
 
-    CompletableFuture<Void> grantPermissionAsync(List<GrantPermissionOptions> options);
+    default CompletableFuture<Void> grantPermissionAsync(List<GrantTopicPermissionOptions> options) {
+        return FutureUtil.failedFuture(new IllegalStateException(
+                String.format("grantPermissionAsync is not supported by the Authorization")));
+    }
 
-    CompletableFuture<Void> revokePermissionAsync(List<RevokePermissionOptions> options);
+    default CompletableFuture<Void> revokePermissionAsync(List<RevokeTopicPermissionOptions> options) {
+        return FutureUtil.failedFuture(new IllegalStateException(
+                String.format("revokePermissionAsync is not supported by the Authorization")));
+    }
 }
 ```
 
 ```
 @Data
 @Builder
-public class GrantPermissionOptions {
+public class GrantTopicPermissionOptions {
 
     private final String topic;
     
@@ -49,7 +55,7 @@ public class GrantPermissionOptions {
 
 @Data
 @Builder
-public class RevokePermissionOptions {
+public class RevokeTopicPermissionOptions {
 
     private final String topic;
 
@@ -62,13 +68,13 @@ Add namespace admin API.
 ```java
 public interface Namespaces {
     
-    CompletableFuture<Void> grantPermissionAsync(List<GrantPermissionOptions> options);
+    CompletableFuture<Void> grantPermissionOnTopicsAsync(List<GrantTopicPermissionOptions> options);
 
-    void grantPermission(List<GrantPermissionOptions> options) throws PulsarAdminException;
+    void grantPermissionOnTopics(List<GrantTopicPermissionOptions> options) throws PulsarAdminException;
 
-    CompletableFuture<Void> revokePermissionAsync(List<RevokePermissionOptions> options);
+    CompletableFuture<Void> revokePermissionOnTopicsAsync(List<RevokeTopicPermissionOptions> options);
 
-    void revokePermission(List<RevokePermissionOptions> options) throws PulsarAdminException;
+    void revokePermissionOnTopics(List<RevokeTopicPermissionOptions> options) throws PulsarAdminException;
 }
 ```
 
@@ -76,8 +82,8 @@ Add namespace rest implementation in broker side.
 ```java
 @POST
 @Path("/grantPermissions")
-public void grantPermissions(@Suspended final AsyncResponse asyncResponse,
-                             List<GrantPermissionOptions> options) {
+public void grantPermissionOnTopics(@Suspended final AsyncResponse asyncResponse,
+                             List<GrantTopicPermissionOptions> options) {
     internalGrantPermissionsAsync(options)
             .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -90,8 +96,8 @@ public void grantPermissions(@Suspended final AsyncResponse asyncResponse,
 
 @POST
 @Path("/revokePermissions")
-public void revokePermissions(@Suspended final AsyncResponse asyncResponse,
-                             List<RevokePermissionOptions> options) {
+public void revokePermissionOnTopics(@Suspended final AsyncResponse asyncResponse,
+                             List<RevokeTopicPermissionOptions> options) {
     internalRevokePermissionsAsync(options)
             .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
@@ -113,12 +119,12 @@ public class TestAuthorization {
         List<GrantPermissionOptions> grantPermissions = new ArrayList<>();
         grantPermissions.add(GrantPermissionOptions.builder().topic("topic1").role("role1").actions(Set.of(AuthAction.produce)).build());
         grantPermissions.add(GrantPermissionOptions.builder().topic("topic2").role("role2").actions(Set.of(AuthAction.consume)).build());
-        admin.namespaces().grantPermission(grantPermissions);
+        admin.namespaces().grantPermissionOnTopics(grantPermissions);
         // revoke permission topics
         List<RevokePermissionOptions> revokePermissions = new ArrayList<>();
         revokePermissions.add(RevokePermissionOptions.builder().topic("topic1").role("role1").build());
         revokePermissions.add(RevokePermissionOptions.builder().topic("topic2").role("role2").build());
-        admin.namespaces().revokePermission(revokePermissions);
+        admin.namespaces().revokePermissionOnTopics(revokePermissions);
     }
 }
 

--- a/pip/pip-383.md
+++ b/pip/pip-383.md
@@ -96,5 +96,5 @@ admin.namespaces().revokePermission(revokePermissions);
 
 ## Links
 
-* Mailing List discussion thread: 
+* Mailing List discussion thread:  https://lists.apache.org/thread/6n2jdl9bsf1f6xz2orygz3kvxmy11ykh
 * Mailing List voting thread: 

--- a/pip/pip-383.md
+++ b/pip/pip-383.md
@@ -1,4 +1,4 @@
-# PIP-383: Support granting permissions for multiple topics
+# PIP-383: Support granting/revoking permissions for multiple topics
 
 ## Background
 

--- a/pip/pip-383.md
+++ b/pip/pip-383.md
@@ -24,6 +24,7 @@ add `grantPermissionAsync(List<GrantPermissionOptions> options)` and `revokePerm
 
 ### Design & Implementation Details
 
+Add method in AuthorizationProvider
 ```java
 
 public interface AuthorizationProvider extends Closeable {
@@ -56,7 +57,7 @@ public class RevokePermissionOptions {
 }
 ```
 
-Support this in the namespace admin API.
+Add namespace admin API.
 
 ```java
 public interface Namespaces {
@@ -68,6 +69,37 @@ public interface Namespaces {
     CompletableFuture<Void> revokePermissionAsync(List<RevokePermissionOptions> options);
 
     void revokePermission(List<RevokePermissionOptions> options) throws PulsarAdminException;
+}
+```
+
+Add namespace rest implementation in broker side.
+```java
+@POST
+@Path("/grantPermissions")
+public void grantPermissions(@Suspended final AsyncResponse asyncResponse,
+                             List<GrantPermissionOptions> options) {
+    internalGrantPermissionsAsync(options)
+            .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
+            .exceptionally(ex -> {
+                log.error("[{}] Failed to grant permissions {}",
+                        clientAppId(), options, ex);
+                resumeAsyncResponseExceptionally(asyncResponse, ex);
+                return null;
+            });
+}
+
+@POST
+@Path("/revokePermissions")
+public void revokePermissions(@Suspended final AsyncResponse asyncResponse,
+                             List<RevokePermissionOptions> options) {
+    internalRevokePermissionsAsync(options)
+            .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
+            .exceptionally(ex -> {
+                log.error("[{}] Failed to revoke permissions {}",
+                        clientAppId(), options, ex);
+                resumeAsyncResponseExceptionally(asyncResponse, ex);
+                return null;
+            });
 }
 ```
 

--- a/pip/pip-383.md
+++ b/pip/pip-383.md
@@ -1,0 +1,100 @@
+# PIP-383: Support granting permissions for multiple topics
+
+## Background
+
+In AuthorizationProvider, the authorization interface `grantPermissionAsync(TopicName topicName, Set<AuthAction> actions, String role, String authDataJson)` currently only supports granting permissions to a single topic. 
+If multiple topics need to be authorized under a namespace, the client needs to call the authorization interface concurrently. 
+Since the permissions information are stored in the namespace-level policies, and multiple topics may be on different brokers, concurrent authorization will cause concurrent modification exceptions. 
+Therefore, supporting granting permissions for multiple topics is very friendly.
+
+
+## Motivation
+
+Supporting granting/revoking permissions for multiple topics, 
+add `grantPermissionAsync(List<GrantPermissionOptions> options)` and `revokePermissionAsync(List<RevokePermissionOptions> options)` in AuthorizationProvider.
+
+## Goals
+
+### In Scope
+
+- Add `grantPermissionAsync(List<GrantPermissionOptions> options)` in AuthorizationProvider.
+- Add `revokePermissionAsync(List<RevokePermissionOptions> options)` in AuthorizationProvider.
+
+## High-Level Design
+
+### Design & Implementation Details
+
+```java
+
+public interface AuthorizationProvider extends Closeable {
+
+    CompletableFuture<Void> grantPermissionAsync(List<GrantPermissionOptions> options);
+
+    CompletableFuture<Void> revokePermissionAsync(List<RevokePermissionOptions> options);
+}
+```
+
+```
+@Data
+@Builder
+public class GrantPermissionOptions {
+
+    private final String topic;
+    
+    private final String role;
+
+    private final Set<AuthAction> actions;
+}
+
+@Data
+@Builder
+public class RevokePermissionOptions {
+
+    private final String topic;
+
+    private final String role;
+}
+```
+
+Support this in the namespace admin API.
+
+```java
+public interface Namespaces {
+    
+    CompletableFuture<Void> grantPermissionAsync(List<GrantPermissionOptions> options);
+
+    void grantPermission(List<GrantPermissionOptions> options) throws PulsarAdminException;
+
+    CompletableFuture<Void> revokePermissionAsync(List<RevokePermissionOptions> options);
+
+    void revokePermission(List<RevokePermissionOptions> options) throws PulsarAdminException;
+}
+```
+
+so user can grant/revoke permissions to multi-topics like :
+```java
+// grant permission for multi-topics
+List<GrantPermissionOptions> grantPermissions = new ArrayList<>();
+grantPermissions.add(GrantPermissionOptions.builder().topic("topic1").role("role1").actions(Set.of(AuthAction.produce)).build());
+grantPermissions.add(GrantPermissionOptions.builder().topic("topic2").role("role2").actions(Set.of(AuthAction.consume)).build());
+admin.namespaces().grantPermission(grantPermissions);
+// revoke permission topics
+List<GrantPermissionOptions> revokePermissions = new ArrayList<>();
+revokePermissions.add(RevokePermissionOptions.builder().topic("topic1").role("role1")).build());
+revokePermissions.add(RevokePermissionOptions.builder().topic("topic2").role("role2")).build());
+admin.namespaces().revokePermission(revokePermissions);
+
+```
+
+## Backward & Forward Compatibility
+
+
+
+## Alternatives
+
+## General Notes
+
+## Links
+
+* Mailing List discussion thread: 
+* Mailing List voting thread: 

--- a/pip/pip-383.md
+++ b/pip/pip-383.md
@@ -2,10 +2,10 @@
 
 ## Background
 
-In AuthorizationProvider, the authorization interface `grantPermissionAsync(TopicName topicName, Set<AuthAction> actions, String role, String authDataJson)` currently only supports granting permissions to a single topic. 
-If multiple topics need to be authorized under a namespace, the client needs to call the authorization interface concurrently. 
-Since the permissions information are stored in the namespace-level policies, and multiple topics may be on different brokers, concurrent authorization will cause concurrent modification exceptions. 
-Therefore, supporting granting permissions for multiple topics is very friendly.
+In AuthorizationProvider, the authorization interface `grantPermissionAsync(TopicName topicName, Set<AuthAction> actions, String role, String authDataJson)` currently only supports granting permissions to a single topic at a time.
+When multiple topics need to be authorized under a namespace, the client makes the calls to the authorization interface concurrently. 
+Since the permissions information is stored in the namespace-level policies, and multiple topics may be on different brokers, concurrent authorization modification will cause concurrent modification exceptions. 
+Therefore, supporting granting permissions for multiple topics is very beneficial.
 
 
 ## Motivation
@@ -105,16 +105,22 @@ public void revokePermissions(@Suspended final AsyncResponse asyncResponse,
 
 so user can grant/revoke permissions to multi-topics like :
 ```java
-// grant permission for multi-topics
-List<GrantPermissionOptions> grantPermissions = new ArrayList<>();
-grantPermissions.add(GrantPermissionOptions.builder().topic("topic1").role("role1").actions(Set.of(AuthAction.produce)).build());
-grantPermissions.add(GrantPermissionOptions.builder().topic("topic2").role("role2").actions(Set.of(AuthAction.consume)).build());
-admin.namespaces().grantPermission(grantPermissions);
-// revoke permission topics
-List<GrantPermissionOptions> revokePermissions = new ArrayList<>();
-revokePermissions.add(RevokePermissionOptions.builder().topic("topic1").role("role1")).build());
-revokePermissions.add(RevokePermissionOptions.builder().topic("topic2").role("role2")).build());
-admin.namespaces().revokePermission(revokePermissions);
+public class TestAuthorization {
+    
+    @Test
+    public void testGrantPermission() {
+        // grant permission for multi-topics
+        List<GrantPermissionOptions> grantPermissions = new ArrayList<>();
+        grantPermissions.add(GrantPermissionOptions.builder().topic("topic1").role("role1").actions(Set.of(AuthAction.produce)).build());
+        grantPermissions.add(GrantPermissionOptions.builder().topic("topic2").role("role2").actions(Set.of(AuthAction.consume)).build());
+        admin.namespaces().grantPermission(grantPermissions);
+        // revoke permission topics
+        List<RevokePermissionOptions> revokePermissions = new ArrayList<>();
+        revokePermissions.add(RevokePermissionOptions.builder().topic("topic1").role("role1").build());
+        revokePermissions.add(RevokePermissionOptions.builder().topic("topic2").role("role2").build());
+        admin.namespaces().revokePermission(revokePermissions);
+    }
+}
 
 ```
 

--- a/pip/pip-383.md
+++ b/pip/pip-383.md
@@ -11,7 +11,7 @@ Therefore, supporting granting permissions for multiple topics is very beneficia
 ## Motivation
 
 Supporting granting/revoking permissions for multiple topics, 
-add `grantPermissionAsync(List<GrantTopicPermissionOptionsf> options)` and `revokePermissionAsync(List<RevokeTopicPermissionOptions> options)` in AuthorizationProvider.
+add `grantPermissionAsync(List<GrantTopicPermissionOptions> options)` and `revokePermissionAsync(List<RevokeTopicPermissionOptions> options)` in AuthorizationProvider.
 
 ## Goals
 
@@ -24,7 +24,7 @@ add `grantPermissionAsync(List<GrantTopicPermissionOptionsf> options)` and `revo
 
 ### Design & Implementation Details
 
-Add method in AuthorizationProvider
+Add default method implementation in AuthorizationProvider
 ```java
 
 public interface AuthorizationProvider extends Closeable {


### PR DESCRIPTION
### Motivation

In AuthorizationProvider, the authorization interface `grantPermissionAsync(TopicName topicName, Set<AuthAction> actions, String role, String authDataJson)` currently only supports granting permissions to a single topic. 
If multiple topics need to be authorized under a namespace, the client needs to call the authorization interface concurrently. 
Since the permissions information are stored in the namespace-level policies, and multiple topics may be on different brokers, concurrent authorization will cause concurrent modification exceptions. 
Therefore, supporting granting/revoking permissions for multiple topics is very friendly.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


