### PR TITLE
[fix][sec][branch-3.3] Upgrade protobuf-java to 3.25.5 (#23356)

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -565,8 +565,8 @@ MIT License
     - com.auth0-jwks-rsa-0.22.0.jar
 Protocol Buffers License
  * Protocol Buffers
-   - com.google.protobuf-protobuf-java-3.22.3.jar -- ../licenses/LICENSE-protobuf.txt
-   - com.google.protobuf-protobuf-java-util-3.22.3.jar -- ../licenses/LICENSE-protobuf.txt
+   - com.google.protobuf-protobuf-java-3.25.5.jar -- ../licenses/LICENSE-protobuf.txt
+   - com.google.protobuf-protobuf-java-util-3.25.5.jar -- ../licenses/LICENSE-protobuf.txt
 
 CDDL-1.1 -- ../licenses/LICENSE-CDDL-1.1.txt
  * Java Annotations API

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -430,7 +430,7 @@ MIT License
 
 Protocol Buffers License
  * Protocol Buffers
-   - protobuf-java-3.22.3.jar -- ../licenses/LICENSE-protobuf.txt
+   - protobuf-java-3.25.5.jar -- ../licenses/LICENSE-protobuf.txt
 
 CDDL-1.1 -- ../licenses/LICENSE-CDDL-1.1.txt
  * Java Annotations API

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@ flexible messaging model and an intuitive client API.</description>
     <typetools.version>0.5.0</typetools.version>
     <byte-buddy.version>1.14.12</byte-buddy.version>
     <zt-zip.version>1.17</zt-zip.version>
-    <protobuf3.version>3.22.3</protobuf3.version>
+    <protobuf3.version>3.25.5</protobuf3.version>
     <protoc3.version>${protobuf3.version}</protoc3.version>
     <grpc.version>1.56.1</grpc.version>
     <google-http-client.version>1.41.0</google-http-client.version>


### PR DESCRIPTION
Main Issue: #23341

this PR is for branch-3.3, the master branch PR is #23356

### Motivation

- Addressing CVE-2024-7254
  - The CVE is categorized as high (8.7/10). It's a potential denial-of-service issue that
doesn't pose a practical risk for Pulsar users. Since it's in the high category, we must address it regardless of the impact for Pulsar users.
- this might break clients, more about the plan in
  https://lists.apache.org/thread/qy8xp2ht0htvctlx2cwgrq2ppnjcp4m3

### Modifications

- Upgrade protobuf-java to 3.25.5, this PR is currently WIP. The goal is to see if our CI passes.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->