### PR TITLE
[improve] Install openssl in the docker image to fix compatibility with Apache Pulsar Helm chart

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -92,7 +92,8 @@ RUN apk add --no-cache \
             ca-certificates \
             procps \
             curl \
-            bind-tools
+            bind-tools \
+            openssl
 
 # Upgrade all packages to get latest versions with security fixes
 RUN apk upgrade --no-cache


### PR DESCRIPTION
### Motivation

Apache Pulsar Helm chart requires openssl in the docker image.

### Modifications

Install the `openssl` package.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->