### PR TITLE
[fix][test] Fix ReplicatorRateLimiterTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
@@ -611,10 +611,7 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
     }
 
     private static Optional<DispatchRateLimiter> getRateLimiter(PersistentTopic topic) {
-        if (topic.getReplicators().isEmpty()) {
-            return Optional.empty();
-        }
-        return topic.getReplicators().values().iterator().next().getRateLimiter();
+        return topic.getReplicators().values().stream().findFirst().map(Replicator::getRateLimiter).orElseThrow();
     }
 
     private static final Logger log = LoggerFactory.getLogger(ReplicatorRateLimiterTest.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
@@ -611,7 +611,10 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
     }
 
     private static Optional<DispatchRateLimiter> getRateLimiter(PersistentTopic topic) {
-        return getRateLimiter(topic);
+        if (topic.getReplicators().isEmpty()) {
+            return Optional.empty();
+        }
+        return topic.getReplicators().values().iterator().next().getRateLimiter();
     }
 
     private static final Logger log = LoggerFactory.getLogger(ReplicatorRateLimiterTest.class);


### PR DESCRIPTION
### Motivation

The `ReplicatorRateLimiterTest` will always fail with `StackOverflowError `, because in https://github.com/apache/pulsar/pull/23322 the `getRateLimiter` always recursive call to itself.

```
ReplicatorRateLimiterTest.testReplicatorRateLimiterMessageNotReceivedAllMessages
java.lang.StackOverflowError
at org.apache.pulsar.broker.service.ReplicatorRateLimiterTest.getRateLimiter(ReplicatorRateLimiterTest.java:614)
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->