### PR TITLE
[fix][cli] Remove deprecated "-client" JVM arg

### DIFF
--- a/conf/pulsar_tools_env.sh
+++ b/conf/pulsar_tools_env.sh
@@ -57,9 +57,6 @@ if [ -n "$PULSAR_MEM" ]; then
 fi
 PULSAR_MEM=${PULSAR_MEM:-"-Xmx128m -XX:MaxDirectMemorySize=128m"}
 
-# Garbage collection options
-PULSAR_GC=${PULSAR_GC:-" -client "}
-
 # Extra options to be passed to the jvm
 PULSAR_EXTRA_OPTS="${PULSAR_MEM} ${PULSAR_GC} ${PULSAR_GC_LOG} -Dio.netty.leakDetectionLevel=disabled ${PULSAR_EXTRA_OPTS}"
 


### PR DESCRIPTION
### Motivation

`-client` and `-server` JVM args have been deprecated in Java for a very long time. Pulsar CLI tools currently add `-client` argument. This causes some OpenJDK distributions to fail:
```
❯ docker run --rm -it bellsoft/liberica-runtime-container:jdk-17-cds-stream-glibc java -client
Unrecognized option: -client
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

### Modifications

- remove the unnecessary `-client` argument.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->