### PR TITLE
[fix][broker] Fix the broker registering might be blocked for long time

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryIntegrationTest.java
@@ -37,7 +37,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Slf4j
-@Test(groups = "flaky")
+@Test(groups = "broker")
 public class BrokerRegistryIntegrationTest {
 
     private static final String clusterName = "test";
@@ -74,7 +74,7 @@ public class BrokerRegistryIntegrationTest {
         }
     }
 
-    @Test(enabled = false)
+    @Test
     public void testRecoverFromNodeDeletion() throws Exception {
         // Simulate the case that the node was somehow deleted (e.g. by session timeout)
         Awaitility.await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> Assert.assertEquals(
@@ -93,7 +93,7 @@ public class BrokerRegistryIntegrationTest {
         Assert.assertEquals(brokerRegistry.getAvailableBrokersAsync().get(), List.of(pulsar.getBrokerId()));
     }
 
-    @Test(enabled = false)
+    @Test
     public void testRegisterAgain() throws Exception {
         Awaitility.await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> Assert.assertEquals(
                 brokerRegistry.getAvailableBrokersAsync().join(), List.of(pulsar.getBrokerId())));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryIntegrationTest.java
@@ -63,10 +63,15 @@ public class BrokerRegistryIntegrationTest {
 
     @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
+        final var startMs = System.currentTimeMillis();
         if (pulsar != null) {
             pulsar.close();
         }
+        final var elapsedMs = System.currentTimeMillis() - startMs;
         bk.stop();
+        if (elapsedMs > 5000) {
+            throw new RuntimeException("Broker took " + elapsedMs + "ms to close");
+        }
     }
 
     @Test(enabled = false)
@@ -105,7 +110,7 @@ public class BrokerRegistryIntegrationTest {
         });
     }
 
-    private ServiceConfiguration brokerConfig() {
+    protected ServiceConfiguration brokerConfig() {
         final var config = new ServiceConfiguration();
         config.setClusterName(clusterName);
         config.setAdvertisedAddress("localhost");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryMetadataStoreIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryMetadataStoreIntegrationTest.java
@@ -20,7 +20,9 @@ package org.apache.pulsar.broker.loadbalance.extensions;
 
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateMetadataStoreTableViewImpl;
+import org.testng.annotations.Test;
 
+@Test(groups = "broker")
 public class BrokerRegistryMetadataStoreIntegrationTest extends BrokerRegistryIntegrationTest {
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryMetadataStoreIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryMetadataStoreIntegrationTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.extensions;
+
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateMetadataStoreTableViewImpl;
+
+public class BrokerRegistryMetadataStoreIntegrationTest extends BrokerRegistryIntegrationTest {
+
+    @Override
+    protected ServiceConfiguration brokerConfig() {
+        final var config = super.brokerConfig();
+        config.setLoadManagerServiceUnitStateTableViewClassName(
+                ServiceUnitStateMetadataStoreTableViewImpl.class.getName());
+        return config;
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
@@ -173,6 +173,9 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
         TableView<byte[]> tv = pulsarClient.newTableView(Schema.BYTES)
                 .topic(topic)
                 .create();
+        // Verify refresh can handle the case when the topic is empty
+        tv.refreshAsync().get(3, TimeUnit.SECONDS);
+
         // 2. Add a listen action to provide the test environment.
         // The listen action will be triggered when there are incoming messages every time.
         // This is a sync operation, so sleep in the listen action can slow down the reading rate of messages.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -36,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.MessageIdAdv;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.ReaderBuilder;
@@ -260,6 +261,10 @@ public class TableViewImpl<T> implements TableView<T> {
     public CompletableFuture<Void> refreshAsync() {
         CompletableFuture<Void> completableFuture = new CompletableFuture<>();
         reader.thenCompose(reader -> getLastMessageIds(reader).thenAccept(lastMessageIds -> {
+            if (lastMessageIds.isEmpty()) {
+                completableFuture.complete(null);
+                return;
+            }
             // After get the response of lastMessageIds, put the future and result into `refreshMap`
             // and then filter out partitions that has been read to the lastMessageID.
             pendingRefreshRequests.put(completableFuture, lastMessageIds);
@@ -292,6 +297,10 @@ public class TableViewImpl<T> implements TableView<T> {
 
         CompletableFuture<Void> future = new CompletableFuture<>();
         getLastMessageIds(reader).thenAccept(maxMessageIds -> {
+            if (maxMessageIds.isEmpty()) {
+                future.complete(null);
+                return;
+            }
             readAllExistingMessages(reader, future, startTime, messagesRead, maxMessageIds);
         }).exceptionally(ex -> {
             future.completeExceptionally(ex);
@@ -304,7 +313,9 @@ public class TableViewImpl<T> implements TableView<T> {
         return reader.getLastMessageIdsAsync().thenApply(lastMessageIds -> {
             Map<String, TopicMessageId> maxMessageIds = new ConcurrentHashMap<>();
             lastMessageIds.forEach(topicMessageId -> {
-                maxMessageIds.put(topicMessageId.getOwnerTopic(), topicMessageId);
+                if (((MessageIdAdv) topicMessageId).getEntryId() >= 0) {
+                    maxMessageIds.put(topicMessageId.getOwnerTopic(), topicMessageId);
+                }
             });
             return maxMessageIds;
         });


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/23365

### Motivation

https://github.com/apache/pulsar/pull/23359 would register the broker again if the registered metadata node was somehow deleted. However, the listeners in `BrokerRegistryImpl` are triggered in the load manager thread (via `Pulsar#Service#loadManagerExecutor`).

https://github.com/apache/pulsar/blob/5e832a1cc1441eaf8d64fe72c1a2af8829030d3d/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryImpl.java#L229-L233

However, this thread executes many blocking tasks, including `monitor()`, `playLeader()` and `playFollower()` of `ExtensibleLoadManagerImpl`. If there were no available brokers, the blocking tasks might never complete until timeout exceeds. Here is an example:

```
2024-09-29T15:24:15,675 - WARN  - [pulsar-io-24-2:ConnectionHandler] - [non-persistent://pulsar/system/loadbalancer-broker-load-data] [reader-40952cbf05] Could not get connection to broker: org.apache.pulsar.client.api.PulsarClientException$BrokerMetadataException: {"errorMsg":"No available broker found.","reqId":175112655758658573, "remote":"localhost/127.0.0.1:56266", "local":"/127.0.0.1:56281"} -- Will try again in 3.146 s
2024-09-29T15:24:17,686 - WARN  - [pulsar-load-manager-22-1:ExtensibleLoadManagerImpl] - The broker:localhost:56270 failed to set the role. Retrying 1 th ...
org.apache.pulsar.broker.loadbalance.extensions.store.LoadDataStoreException: java.util.concurrent.TimeoutException
	at org.apache.pulsar.broker.loadbalance.extensions.store.TableViewLoadDataStoreImpl.startTableView(TableViewLoadDataStoreImpl.java:179) ~[classes/:?]
	at org.apache.pulsar.broker.loadbalance.extensions.store.TableViewLoadDataStoreImpl.start(TableViewLoadDataStoreImpl.java:157) ~[classes/:?]
	at org.apache.pulsar.broker.loadbalance.extensions.store.TableViewLoadDataStoreImpl.init(TableViewLoadDataStoreImpl.java:141) ~[classes/:?]
	at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.playLeader(ExtensibleLoadManagerImpl.java:849) ~[classes/:?]
```

In this case, `registerAsync` would have to wait until these methods are done, while they could have been recovered by a `registerAsync` call.

While the direct cause of failed `BrokerRegistryIntegrationTest` is that `TableViewImpl#flush` would not complete if there is no message in the topic. See https://github.com/apache/pulsar/issues/23365#issuecomment-2381090760 

### Modifications

Two fixes:
1. Fix the `TableViewImpl#flush` by filtering  the empty topics via checking if the last message id's entry id is non-negative
2. Call `registerAsync` directly in the metadata store callback thread instead of the load manager thread. It's an asynchronous metadata store operation so it won't block the thread.

Tests enhancements:
- Enable `BrokerRegistryIntegrationTest` again to verify fix 1 works
- Check the broker close time to verify fix 2 works
- Add `BrokerRegistryMetadataStoreIntegrationTest` to verify fix 2 works

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 