### PR TITLE
[improve][ci] Switch to Java 21 as default JVM version for CI

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -25,9 +25,9 @@ on:
       - branch-*
       - pulsar-*
   schedule:
-    # scheduled job with JDK 17
-    - cron: '0 12 * * *'
     # scheduled job with JDK 21
+    - cron: '0 12 * * *'
+    # scheduled job with JDK 17
     # if cron expression is changed, make sure to update the expression in jdk_major_version step in preconditions job
     - cron: '0 6 * * *'
   workflow_dispatch:
@@ -44,7 +44,7 @@ on:
         options:
           - '17'
           - '21'
-        default: '17'
+        default: '21'
       trace_test_resource_cleanup:
         description: 'Collect thread & heap information before exiting a test JVM. When set to "on", thread dump and heap histogram will be collected. When set to "full", a heap dump will also be collected.'
         required: true
@@ -95,13 +95,13 @@ jobs:
       - name: Select JDK major version
         id: jdk_major_version
         run: |
-          # use JDK 21 for the scheduled build with cron expression '0 6 * * *'
+          # use JDK 17 for the scheduled build with cron expression '0 6 * * *'
           if [[ "${{ github.event_name == 'schedule' && github.event.schedule == '0 6 * * *' && 'true' || 'false' }}" == "true" ]]; then
-            echo "jdk_major_version=21" >> $GITHUB_OUTPUT
+            echo "jdk_major_version=17" >> $GITHUB_OUTPUT
             exit 0
           fi
-          # use JDK 17 for build unless overridden with workflow_dispatch input
-          echo "jdk_major_version=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdk_major_version || '17'}}" >> $GITHUB_OUTPUT
+          # use JDK 21 for build unless overridden with workflow_dispatch input
+          echo "jdk_major_version=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdk_major_version || '21'}}" >> $GITHUB_OUTPUT
 
       - name: checkout
         if: ${{ github.event_name == 'pull_request' }}

--- a/bin/function-localrunner
+++ b/bin/function-localrunner
@@ -52,7 +52,14 @@ done
 PULSAR_MEM=${PULSAR_MEM:-"-Xmx128m -XX:MaxDirectMemorySize=128m"}
 
 # Garbage collection options
-PULSAR_GC=${PULSAR_GC:-"-XX:+UseZGC -XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch"}
+if [ -z "$PULSAR_GC" ]; then
+  PULSAR_GC="-XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch"
+  if [[ $JAVA_MAJOR_VERSION -ge 21 ]]; then
+    PULSAR_GC="-XX:+UseZGC -XX:+ZGenerational ${PULSAR_GC}"
+  else
+    PULSAR_GC="-XX:+UseZGC ${PULSAR_GC}"
+  fi
+fi
 
 # Garbage collection log.
 PULSAR_GC_LOG_DIR=${PULSAR_GC_LOG_DIR:-logs}

--- a/conf/bkenv.sh
+++ b/conf/bkenv.sh
@@ -37,9 +37,6 @@ BOOKIE_LOG_DIR=${BOOKIE_LOG_DIR:-"${PULSAR_LOG_DIR}"}
 # Memory size options
 BOOKIE_MEM=${BOOKIE_MEM:-${PULSAR_MEM:-"-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g"}}
 
-# Garbage collection options
-BOOKIE_GC=${BOOKIE_GC:-${PULSAR_GC:-"-XX:+UseZGC -XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch"}}
-
 if [ -z "$JAVA_HOME" ]; then
   JAVA_BIN=java
 else
@@ -59,6 +56,17 @@ for token in $("$JAVA_BIN" -version 2>&1 | grep 'version "'); do
         break
     fi
 done
+
+# Garbage collection options
+BOOKIE_GC="${BOOKIE_GC:-${PULSAR_GC}}"
+if [ -z "$BOOKIE_GC" ]; then
+  BOOKIE_GC="-XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch"
+  if [[ $JAVA_MAJOR_VERSION -ge 21 ]]; then
+    BOOKIE_GC="-XX:+UseZGC -XX:+ZGenerational ${BOOKIE_GC}"
+  else
+    BOOKIE_GC="-XX:+UseZGC ${BOOKIE_GC}"
+  fi
+fi
 
 if [[ -z "$BOOKIE_GC_LOG" ]]; then
   # fallback to PULSAR_GC_LOG if it is set

--- a/conf/pulsar_env.sh
+++ b/conf/pulsar_env.sh
@@ -44,9 +44,6 @@
 # Extra options to be passed to the jvm
 PULSAR_MEM=${PULSAR_MEM:-"-Xms2g -Xmx2g -XX:MaxDirectMemorySize=4g"}
 
-# Garbage collection options
-PULSAR_GC=${PULSAR_GC:-"-XX:+UseZGC -XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch"}
-
 if [ -z "$JAVA_HOME" ]; then
   JAVA_BIN=java
 else
@@ -66,6 +63,16 @@ for token in $("$JAVA_BIN" -version 2>&1 | grep 'version "'); do
         break
     fi
 done
+
+# Garbage collection options
+if [ -z "$PULSAR_GC" ]; then
+  PULSAR_GC="-XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch"
+  if [[ $JAVA_MAJOR_VERSION -ge 21 ]]; then
+    PULSAR_GC="-XX:+UseZGC -XX:+ZGenerational ${PULSAR_GC}"
+  else
+    PULSAR_GC="-XX:+UseZGC ${PULSAR_GC}"
+  fi
+fi
 
 PULSAR_GC_LOG_DIR=${PULSAR_GC_LOG_DIR:-"${PULSAR_LOG_DIR}"}
 

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -18,6 +18,7 @@
 #
 
 ARG ALPINE_VERSION=3.20
+ARG IMAGE_JDK_MAJOR_VERSION=21
 
 # First create a stage with just the Pulsar tarball and scripts
 FROM alpine:$ALPINE_VERSION as pulsar
@@ -54,7 +55,7 @@ RUN chmod -R o+rx /pulsar
 RUN echo 'OPTS="$OPTS -Dorg.xerial.snappy.use.systemlib=true"' >> /pulsar/conf/bkenv.sh
 
 ###  Create one stage to include JVM distribution
-FROM amazoncorretto:21-alpine AS jvm
+FROM amazoncorretto:${IMAGE_JDK_MAJOR_VERSION}-alpine AS jvm
 
 RUN apk add --no-cache binutils
 

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -83,6 +83,7 @@
                           <PULSAR_TARBALL>target/pulsar-server-distribution-${project.version}-bin.tar.gz</PULSAR_TARBALL>
                           <PULSAR_CLIENT_PYTHON_VERSION>${pulsar.client.python.version}</PULSAR_CLIENT_PYTHON_VERSION>
                           <SNAPPY_VERSION>${snappy.version}</SNAPPY_VERSION>
+                          <IMAGE_JDK_MAJOR_VERSION>${IMAGE_JDK_MAJOR_VERSION}</IMAGE_JDK_MAJOR_VERSION>
                         </args>
                         <contextDir>${project.basedir}</contextDir>
                         <tags>

--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,7 @@ flexible messaging model and an intuitive client API.</description>
 
     <pulsar.client.python.version>3.4.0</pulsar.client.python.version>
 
-    <UBUNTU_MIRROR>http://archive.ubuntu.com/ubuntu/</UBUNTU_MIRROR>
-    <UBUNTU_SECURITY_MIRROR>http://security.ubuntu.com/ubuntu/</UBUNTU_SECURITY_MIRROR>
-    <IMAGE_JDK_MAJOR_VERSION>17</IMAGE_JDK_MAJOR_VERSION>
+    <IMAGE_JDK_MAJOR_VERSION>21</IMAGE_JDK_MAJOR_VERSION>
 
     <!--config keys to configure test selection -->
     <include>**/Test*.java,**/*Test.java,**/*Tests.java,**/*TestCase.java</include>
@@ -2748,30 +2746,6 @@ flexible messaging model and an intuitive client API.</description>
       </properties>
     </profile>
 
-    <profile>
-      <id>ubuntu-mirror-set</id>
-      <activation>
-        <property>
-          <name>env.UBUNTU_MIRROR</name>
-        </property>
-      </activation>
-      <properties>
-        <!-- Override the default value with the environment variable -->
-        <UBUNTU_MIRROR>${env.UBUNTU_MIRROR}</UBUNTU_MIRROR>
-      </properties>
-    </profile>
-    <profile>
-      <id>ubuntu-security-mirror-set</id>
-      <activation>
-        <property>
-          <name>env.UBUNTU_SECURITY_MIRROR</name>
-        </property>
-      </activation>
-      <properties>
-        <!-- Override the default value with the environment variable -->
-        <UBUNTU_SECURITY_MIRROR>${env.UBUNTU_SECURITY_MIRROR}</UBUNTU_SECURITY_MIRROR>
-      </properties>
-    </profile>
     <profile>
       <id>jdk-major-version-set</id>
       <activation>


### PR DESCRIPTION
### Motivation

Java 21 has been switched in the Docker image in 3.3.0 with "PIP-324: Alpine image (#22054)":
https://github.com/apache/pulsar/blob/branch-3.3/docker/pulsar/Dockerfile#L61

Pulsar CI should also run on Java 21 by default.

### Modifications

- Use Java 21 by default in CI
- Run a scheduled build on Java 17 with docker image using Java 17
- Add `-XX:+ZGenerational` to `PULSAR_GC` parameters by default when running on Java 21+
- Cleanup remaining Ubuntu related properties from the Maven build.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->