### PR TITLE
[fix] Remove gcompat from the Alpine based image since real glibc is installed

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -89,7 +89,6 @@ RUN apk add --no-cache \
             py3-pip \
             py3-grpcio \
             py3-yaml \
-            gcompat \
             ca-certificates \
             procps \
             curl \


### PR DESCRIPTION
### Motivation

In 3.3.1 and 4.0.0-preview.1 images, Conscrypt cannot be loaded. Jetty uses it for native OpenSSL based TLS.
This caused a problem described in #23364 where the warning log message "2024-09-27T19:25:20,336+0000 [main] WARN  org.apache.pulsar.common.util.SecurityUtility - Conscrypt isn't available for Linux amd64. Using JDK default security provider." broke pulsar-admin output parsing in other scripts. 
The problem was addressed by setting log level to `debug`.

While investigating the issue, it appeared that musl + gcompat and glibc in Alpine shouldn't be mixed at runtime in dynamic linking. It's not recommended to mix musl and glibc either.

However, for the Conscrypt case, the loading of the library works when `gcompat` is removed. There shouldn't be a reason to have `gcompat` exist with the current real `glibc` solution in Alpine.

### Modifications

- remove `gcompat` package from Alpine.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->