### PR TITLE
[improve] Configure Rocksdb to use musl libc flavor of the native library

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -141,6 +141,8 @@ COPY --from=pulsar /pulsar /pulsar
 
 WORKDIR /pulsar
 ENV PATH=$PATH:$JAVA_HOME/bin:/pulsar/bin
+# Use musl libc library for RocksDB
+ENV ROCKSDB_MUSL_LIBC=true
 
 # The UID must be non-zero. Otherwise, it is arbitrary. No logic should rely on its specific value.
 ARG DEFAULT_USERNAME=pulsar


### PR DESCRIPTION
### Motivation

When `ROCKSDB_MUSL_LIBC=true` is set in environment, it simplifies the logic on RocksDB side for initializing the library: https://github.com/facebook/rocksdb/blob/444b3f4845dd01b0d127c4b420fdd3b50ad56682/java/src/main/java/org/rocksdb/util/Environment.java#L73-L91

The problem with the RocksDB logic is that it executes a shell command to detect that it's running in a musl environment.
This could be a problem when shell commands are restricted due to security reasons.

```java
    // check if ldd indicates a muslc lib
    try {
      final Process p =
          new ProcessBuilder("/usr/bin/env", "sh", "-c", "ldd /usr/bin/env | grep -q musl").start();
      if (p.waitFor() == 0) {
        return true;
      }
    } catch (final IOException | InterruptedException e) {
      // do nothing, and move on to the next check
    }
```

### Modifications

- pass `ROCKSDB_MUSL_LIBC=true` in the environment for the docker image

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->