### PR TITLE
[fix] EXPERIMENT: Switch to use minideb base image to fix glibc compatibility issues

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -17,17 +17,17 @@
 # under the License.
 #
 
-ARG ALPINE_VERSION=3.20
+# syntax=docker/dockerfile:1
 ARG IMAGE_JDK_MAJOR_VERSION=21
 
 # First create a stage with just the Pulsar tarball and scripts
-FROM alpine:$ALPINE_VERSION as pulsar
+FROM bitnami/minideb:bookworm AS pulsar
 
-RUN apk add zip
+RUN apt-get update && apt-get install -y zip
 
 ARG PULSAR_TARBALL
-
 ADD ${PULSAR_TARBALL} /
+
 RUN mv /apache-pulsar-* /pulsar
 RUN rm -rf /pulsar/bin/*.cmd
 
@@ -47,57 +47,49 @@ RUN for SUBDIRECTORY in conf data download logs instances/deps packages-storage;
      chmod -R ug+rwx /pulsar/$SUBDIRECTORY; \
      chown -R 10000:0 /pulsar/$SUBDIRECTORY; \
      done
-
 RUN chmod -R g+rx /pulsar/bin
 RUN chmod -R o+rx /pulsar
 
-# Enable snappy-java to use system lib
-RUN echo 'OPTS="$OPTS -Dorg.xerial.snappy.use.systemlib=true"' >> /pulsar/conf/bkenv.sh
-
 ###  Create one stage to include JVM distribution
-FROM amazoncorretto:${IMAGE_JDK_MAJOR_VERSION}-alpine AS jvm
-
-RUN apk add --no-cache binutils
+FROM bitnami/minideb:bookworm AS jvm
+# Install Amazon Corretto JDK
+RUN <<EOF
+set -e
+apt-get update
+apt-get install -y wget gpg binutils
+wget -O - https://apt.corretto.aws/corretto.key | gpg --dearmor -o /usr/share/keyrings/corretto-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/corretto-keyring.gpg] https://apt.corretto.aws stable main" | tee /etc/apt/sources.list.d/corretto.list
+apt-get update
+apt-get install -y java-${IMAGE_JDK_MAJOR_VERSION}-amazon-corretto-jdk
+EOF
 
 # Use JLink to create a slimmer JDK distribution (see: https://adoptium.net/blog/2021/10/jlink-to-produce-own-runtime/)
 # This still includes all JDK modules, though in the future we could compile a list of required modules
-RUN /usr/lib/jvm/default-jvm/bin/jlink --add-modules ALL-MODULE-PATH --compress zip-9 --no-man-pages --no-header-files --strip-debug --output /opt/jvm
-RUN echo networkaddress.cache.ttl=1 >> /opt/jvm/conf/security/java.security
-RUN echo networkaddress.cache.negative.ttl=1 >> /opt/jvm/conf/security/java.security
+RUN <<EOF
+set -e
+jlink --add-modules ALL-MODULE-PATH --compress zip-9 --no-man-pages --no-header-files --strip-debug --output /opt/jvm
+echo networkaddress.cache.ttl=1 >> /opt/jvm/conf/security/java.security
+echo networkaddress.cache.negative.ttl=1 >> /opt/jvm/conf/security/java.security
+EOF
 
-## Create one stage to include snappy-java native lib
-# Fix the issue when using snappy-java in x86 arch alpine
-# See https://github.com/xerial/snappy-java/issues/181 https://github.com/xerial/snappy-java/issues/579
-# We need to ensure that the version of the native library matches the version of snappy-java imported via Maven
-FROM alpine:$ALPINE_VERSION AS snappy-java
-
-ARG SNAPPY_VERSION
-RUN apk add git alpine-sdk util-linux cmake autoconf automake libtool openjdk17 maven curl bash tar
-ENV JAVA_HOME=/usr
-RUN curl -Ls https://github.com/xerial/snappy-java/archive/refs/tags/v$SNAPPY_VERSION.tar.gz | tar zxf - && cd snappy-java-$SNAPPY_VERSION && make clean-native native
-FROM apachepulsar/glibc-base:2.38 as glibc
-
-## Create final stage from Alpine image
+## Create final stage from minideb image
 ## and add OpenJDK and Python dependencies (for Pulsar functions)
-FROM alpine:$ALPINE_VERSION
-ENV LANG C.UTF-8
+FROM bitnami/minideb:bookworm
+ENV LANG=C.UTF-8
 
-# Install some utilities, some are required by Pulsar scripts
-RUN apk add --no-cache \
-            bash \
-            python3 \
-            py3-pip \
-            py3-grpcio \
-            py3-yaml \
-            gcompat \
-            ca-certificates \
-            procps \
-            curl \
-            bind-tools \
-            openssl
-
-# Upgrade all packages to get latest versions with security fixes
-RUN apk upgrade --no-cache
+# Install packages
+RUN <<EOF
+set -e
+echo 'Acquire::http::Timeout "30";\nAcquire::ftp::Timeout "30";\nAcquire::Retries "3";' > /etc/apt/apt.conf.d/99timeout_and_retries
+apt-get update
+apt-get -y dist-upgrade
+apt-get -y install --no-install-recommends netcat-openbsd dnsutils less procps iputils-ping curl ca-certificates apt-transport-https procps openssl
+apt-get -y install --no-install-recommends python3 python3-kazoo python3-pip python3-yaml
+apt-get -y --purge autoremove
+apt-get autoclean
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+EOF
 
 # Python dependencies
 
@@ -105,44 +97,37 @@ RUN apk upgrade --no-cache
 # If pip cannot find the grpcio wheel that the doesn't match the OS, the grpcio will be compiled locally.
 # Once https://github.com/apache/pulsar-client-python/pull/211 is released, keep only the pulsar-client[all] and kazoo dependencies, and remove comments.
 ARG PULSAR_CLIENT_PYTHON_VERSION
-RUN echo -e "\
+RUN <<EOF
+set -e
+cat > /tmp/requirements.txt <<REQEOF
 #pulsar-client[all]==${PULSAR_CLIENT_PYTHON_VERSION}\n\
-pulsar-client==${PULSAR_CLIENT_PYTHON_VERSION}\n\
-# Zookeeper\n\
-kazoo\n\
-# functions\n\
-protobuf>=3.6.1,<=3.20.3\n\
-grpcio>=1.59.3\n\
-apache-bookkeeper-client>=4.16.1\n\
-prometheus_client\n\
-ratelimit\n\
-# avro\n\
-fastavro>=1.9.2\n\
-" > /requirements.txt
-
-RUN pip3 install --break-system-packages --no-cache-dir --only-binary grpcio -r /requirements.txt
-RUN rm /requirements.txt
-
-# Install GLibc compatibility library
-COPY --from=glibc /root/packages /root/packages
-RUN apk add --allow-untrusted --force-overwrite /root/packages/glibc-*.apk
+pulsar-client==${PULSAR_CLIENT_PYTHON_VERSION}
+# Zookeeper
+kazoo
+# functions
+protobuf>=3.6.1,<=3.20.3
+grpcio>=1.59.3
+apache-bookkeeper-client>=4.16.1
+prometheus_client
+ratelimit
+# avro
+fastavro>=1.9.2
+REQEOF
+pip3 install --break-system-packages --no-cache-dir --only-binary grpcio -r /tmp/requirements.txt
+rm /tmp/requirements.txt
+EOF
 
 COPY --from=jvm /opt/jvm /opt/jvm
 ENV JAVA_HOME=/opt/jvm
 
-COPY --from=snappy-java /tmp/libsnappyjava.so /usr/lib/libsnappyjava.so
-
 # The default is /pulsat/bin and cannot be written.
 ENV PULSAR_PID_DIR=/pulsar/logs
-
 ENV PULSAR_ROOT_LOGGER=INFO,CONSOLE
-
 COPY --from=pulsar /pulsar /pulsar
-
 WORKDIR /pulsar
 ENV PATH=$PATH:$JAVA_HOME/bin:/pulsar/bin
 
 # The UID must be non-zero. Otherwise, it is arbitrary. No logic should rely on its specific value.
 ARG DEFAULT_USERNAME=pulsar
-RUN adduser ${DEFAULT_USERNAME} -u 10000 -G root -D -H -h /pulsar/data
+RUN useradd ${DEFAULT_USERNAME} -u 10000 -g 0 --no-create-home --home-dir /pulsar/data
 USER 10000

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -79,6 +79,7 @@
                     <image>
                       <name>${docker.organization}/${docker.image}</name>
                       <build>
+                        <imagePullPolicy>Always</imagePullPolicy>
                         <args>
                           <PULSAR_TARBALL>target/pulsar-server-distribution-${project.version}-bin.tar.gz</PULSAR_TARBALL>
                           <PULSAR_CLIENT_PYTHON_VERSION>${pulsar.client.python.version}</PULSAR_CLIENT_PYTHON_VERSION>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@ flexible messaging model and an intuitive client API.</description>
     <pulsar.broker.compiler.release>${maven.compiler.target}</pulsar.broker.compiler.release>
     <pulsar.client.compiler.release>8</pulsar.client.compiler.release>
 
-    <pulsar.client.python.version>3.4.0</pulsar.client.python.version>
+    <pulsar.client.python.version>3.5.0</pulsar.client.python.version>
 
     <IMAGE_JDK_MAJOR_VERSION>21</IMAGE_JDK_MAJOR_VERSION>
 
@@ -165,7 +165,7 @@ flexible messaging model and an intuitive client API.</description>
     <reflections.version>0.10.2</reflections.version>
     <swagger.version>1.6.2</swagger.version>
     <puppycrawl.checkstyle.version>10.14.2</puppycrawl.checkstyle.version>
-    <docker-maven.version>0.45.0</docker-maven.version>
+    <docker-maven.version>0.45.1</docker-maven.version>
     <docker.verbose>true</docker.verbose>
     <typetools.version>0.5.0</typetools.version>
     <byte-buddy.version>1.14.12</byte-buddy.version>


### PR DESCRIPTION
### Motivation

Adding real glibc to Alpine based image  is not a supported configuration and in [Ariadne Conill's words](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/24647#note_176723): _"Combining glibc and musl runtimes is basically all but guaranteed to create an unstable environment, unless the system is appropriately configured (glibc side uses glibc binaries only, and vice versa)."_

We have multiple issues which could be caused by the unstable environment:
* #22804
* #23348
* #23306
* https://github.com/apache/pulsar/pull/23364#issuecomment-2380635032

### Modifications

Experiment in switching to use bitnami:minideb  base image.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->