### PR TITLE
[fix][broker] Cancel possible pending replay read in cancelPendingRead

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -650,8 +650,9 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
 
     @Override
     protected void cancelPendingRead() {
-        if (havePendingRead && cursor.cancelPendingReadRequest()) {
+        if ((havePendingRead || havePendingReplayRead) && cursor.cancelPendingReadRequest()) {
             havePendingRead = false;
+            havePendingReplayRead = false;
         }
     }
 


### PR DESCRIPTION
### Motivation

There's an inconsistency in the org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers#cancelPendingRead method:
https://github.com/apache/pulsar/blob/e0b754dd3938a2d142623001dbb15c92cc2f5cb4/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java#L651-L656
In addition to `havePendingRead`, there's a separate field `havePendingReplayRead` that tracks a pending read too. It should be taken into account in `cancelPendingRead` method.

### Modifications

- handle `havePendingReplayRead` in `cancelPendingRead` method.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->