### PR TITLE
[improve][broker] Add error logs and retry if the broker failed to register itself for metadata node deletion

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryImpl.java
@@ -220,7 +220,11 @@ public class BrokerRegistryImpl implements BrokerRegistry {
             // is expired. In this case, we should register again.
             final var brokerId = t.getPath().substring(LOADBALANCE_BROKERS_ROOT.length() + 1);
             if (t.getType() == NotificationType.Deleted && getBrokerId().equals(brokerId)) {
-                registerAsync();
+                registerAsync().exceptionally(e -> {
+                    log.error("[{}] Failed to register self to {} (state: {})", getBrokerId(), brokerIdKeyPath,
+                            state.get(), e);
+                    return null;
+                });
             }
             if (listeners.isEmpty()) {
                 return;


### PR DESCRIPTION
### Motivation

In my chaos test environment, I found some `registerAsync` call failed. However, there is no error log for it.

### Modifications

Add the error logs for failure of `registerAsync` and retry in `handleMetadataStoreNotification`. For `BrokerRegistryImpl#start`, the error info is wrapped into the `PulsarServerException` propagated to the `PulsarService#start`'s catch block and it will fail fast so we don't need to log errors here.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
