### PR TITLE
[fix][sec] Upgrade Avro to 1.11.4 to address CVE-2024-47561

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -460,8 +460,8 @@ The Apache Software License, Version 2.0
   * zt-zip
     - org.zeroturnaround-zt-zip-1.17.jar
   * Apache Avro
-    - org.apache.avro-avro-1.11.3.jar
-    - org.apache.avro-avro-protobuf-1.11.3.jar
+    - org.apache.avro-avro-1.11.4.jar
+    - org.apache.avro-avro-protobuf-1.11.4.jar
   * Apache Curator
     - org.apache.curator-curator-client-5.1.0.jar
     - org.apache.curator-curator-framework-5.1.0.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -414,8 +414,8 @@ The Apache Software License, Version 2.0
  * Google Error Prone Annotations - error_prone_annotations-2.24.0.jar
  * Javassist -- javassist-3.25.0-GA.jar
   * Apache Avro
-    - avro-1.11.3.jar
-    - avro-protobuf-1.11.3.jar
+    - avro-1.11.4.jar
+    - avro-protobuf-1.11.4.jar
  * RE2j -- re2j-1.7.jar
  * Spotify completable-futures -- completable-futures-0.3.6.jar
 

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@ flexible messaging model and an intuitive client API.</description>
     <kafka-client.version>3.4.0</kafka-client.version>
     <rabbitmq-client.version>5.18.0</rabbitmq-client.version>
     <aws-sdk.version>1.12.638</aws-sdk.version>
-    <avro.version>1.11.3</avro.version>
+    <avro.version>1.11.4</avro.version>
     <joda.version>2.10.10</joda.version>
     <jclouds.version>2.6.0</jclouds.version>
     <guice.version>5.1.0</guice.version>


### PR DESCRIPTION
### Motivation

Avro 1.11.3 contains critical 9.3/10 level RCE vulnerability in Avro Java SDK <1.11.4,  CVE-2024-47561

### Modifications

Upgrade Avro to 1.11.4 to address the issue.

### Additional Context

[Dev mailing list discussion](https://lists.apache.org/thread/ptb227lw8lljw5zv7z2qo2mx9xxoyl5c) (contains information about release plan)
[Users mailing list discussion](https://lists.apache.org/thread/wgyjsdpnt4ccrd5xk3sdf6pw81zgvkhx)

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->