### PR TITLE
[fix][broker] Fix Broker was failing to create producer with broken schema ledger

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/ClientGetSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/ClientGetSchemaTest.java
@@ -20,8 +20,9 @@ package org.apache.pulsar.broker.service.schema;
 
 import static org.apache.pulsar.common.naming.TopicName.PUBLIC_TENANT;
 import static org.apache.pulsar.schema.compatibility.SchemaCompatibilityCheckTest.randomName;
-import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -176,5 +177,37 @@ public class ClientGetSchemaTest extends ProducerConsumerBase {
 
         producer.close();
         consumer.close();
+    }
+
+    @Test
+    public void testAddProducerOnDeletedSchemaLedgerTopic() throws Exception {
+        final String tenant = PUBLIC_TENANT;
+        final String namespace = "test-namespace-" + randomName(16);
+        final String topicOne = "test-deleted-schema-ledger";
+        final String fqtnOne = TopicName.get(TopicDomain.persistent.value(), tenant, namespace, topicOne).toString();
+
+        //pulsar.getConfig().setManagedLedgerForceRecovery(true);
+        admin.namespaces().createNamespace(tenant + "/" + namespace, Sets.newHashSet("test"));
+
+        // (1) create topic with schema
+        Producer<Schemas.PersonTwo> producer = pulsarClient
+                .newProducer(Schema.AVRO(SchemaDefinition.<Schemas.PersonTwo> builder().withAlwaysAllowNull(false)
+                        .withSupportSchemaVersioning(true).withPojo(Schemas.PersonTwo.class).build()))
+                .topic(fqtnOne).create();
+
+        producer.close();
+
+        String key = TopicName.get(fqtnOne).getSchemaName();
+        BookkeeperSchemaStorage schemaStrogate = (BookkeeperSchemaStorage) pulsar.getSchemaStorage();
+        long schemaLedgerId = schemaStrogate.getSchemaLedgerList(key).get(0);
+
+        // (2) break schema locator by deleting schema-ledger
+        schemaStrogate.getBookKeeper().deleteLedger(schemaLedgerId);
+
+        admin.topics().unload(fqtnOne);
+
+        Producer<byte[]> producerWihtoutSchema = pulsarClient.newProducer().topic(fqtnOne).create();
+
+        assertNotNull(producerWihtoutSchema);
     }
 }


### PR DESCRIPTION


<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

When schema ledger is broken and producer tries to connect without schema then broker fails to add that producer with below error.

It fixes below errors
```
03:46:47.861 [pulsar-io-4-63] DEBUG org.apache.pulsar.broker.service.BrokerService - No autoTopicCreateOverride policy found for persistent://ncp/global/content.ncp/url_uuid_alias.prod
03:46:47.861 [pulsar-io-4-63] DEBUG org.apache.pulsar.broker.service.persistent.PersistentTopic - [persistent://ncp/global/content.ncp/url_uuid_alias.prod] Storage size = [0], backlog quota limit
 [53687091200]
03:46:47.861 [pulsar-io-4-63] DEBUG org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage - [ncp/content.ncp/url_uuid_alias.prod] Fetching schema from store
03:46:47.862 [pulsar-io-4-63] DEBUG org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage - [ncp/content.ncp/url_uuid_alias.prod] Got schema locator Optional[org.apache.pulsar.broker.se
rvice.schema.BookkeeperSchemaStorage$LocatorEntry@2a675a45]
03:46:47.862 [pulsar-io-4-63] DEBUG org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage - Reading schema entry from ledgerId: 742584758
entryId: 0

03:46:47.862 [pulsar-io-4-63] DEBUG org.apache.pulsar.metadata.bookkeeper.PulsarLedgerManager - No such ledger: 742584758 at path /ledgers/07/4258/L4758
03:46:47.862 [pulsar-io-4-63] ERROR org.apache.bookkeeper.meta.CleanupLedgerManager - Failed on operating ledger metadata: -25
03:46:47.862 [pulsar-io-4-63] DEBUG org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage - [ncp/content.ncp/url_uuid_alias.prod] Get operation completed. res=null -- ex=java.util.concu
rrent.CompletionException: org.apache.pulsar.broker.service.schema.exceptions.SchemaException: No such ledger exists on Metadata Server -  ledger=742584758 - operation=Failed to open ledger

```

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
