### PR TITLE
[improve][ci] Continue Pulsar CI build even when Trivy scanner fails

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -890,8 +890,10 @@ jobs:
         run: src/check-binary-license.sh ./distribution/server/target/apache-pulsar-*-bin.tar.gz && src/check-binary-license.sh ./distribution/shell/target/apache-pulsar-shell-*-bin.tar.gz
 
       - name: Run Trivy container scan
+        id: trivy_scan
         uses: aquasecurity/trivy-action@master
         if: ${{ github.repository == 'apache/pulsar' && github.event_name != 'pull_request' }}
+        continue-on-error: true
         with:
           image-ref: "apachepulsar/pulsar:latest"
           scanners: vuln
@@ -902,7 +904,8 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
-        if: ${{ github.repository == 'apache/pulsar' && github.event_name != 'pull_request' }}
+        if: ${{ steps.trivy_scan.outcome == 'success' && github.repository == 'apache/pulsar' && github.event_name != 'pull_request' }}
+        continue-on-error: true
         with:
           sarif_file: 'trivy-results.sarif'
 


### PR DESCRIPTION
### Motivation

Error message in https://github.com/apache/pulsar/actions/runs/11179184671/job/31078661681#step:13:42 was:
```
2024-10-04T12:05:48Z	FATAL	Fatal error	image scan error: scan error: scan failed: failed analysis: analyze error: pipeline error: failed to analyze layer (sha256:e2f493e066e35423c1459a42bb7c97d05f71f262edd92fbb61e45afd5c1c1ae0): post analysis error: post analysis error: Unable to initialize the Java DB: Java DB update failed: DB download error: OCI repository error: 1 error occurred:
	* GET https://ghcr.io/v2/aquasecurity/trivy-java-db/manifests/1: TOOMANYREQUESTS: retry-after: 297.486µs, allowed: 44000/minute
```

### Modifications

Add `continue-on-error: true` to Trivy steps in Pulsar CI.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->