### PR TITLE
[fix][sql][branch-3.0] Fix decimal compatibility in Trino 368.

### DIFF
--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.sql.presto;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.trino.decoder.FieldValueProviders.bytesValueProvider;
 import static io.trino.decoder.FieldValueProviders.longValueProvider;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -34,8 +35,10 @@ import io.netty.util.ReferenceCountUtil;
 import io.trino.decoder.DecoderColumnHandle;
 import io.trino.decoder.FieldValueProvider;
 import io.trino.spi.block.Block;
+import io.trino.spi.block.Int128ArrayBlock;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.RecordCursor;
+import io.trino.spi.type.Int128;
 import io.trino.spi.type.Type;
 import java.io.IOException;
 import java.util.HashMap;
@@ -711,9 +714,20 @@ public class PulsarRecordCursor implements RecordCursor {
         return currentRowValues[fieldIndex];
     }
 
+    private FieldValueProvider getFieldValueProvider(int fieldIndex) {
+        checkArgument(fieldIndex < columnHandles.size(), "Invalid field index");
+        return currentRowValues[fieldIndex];
+    }
+
     @Override
     public Object getObject(int field) {
-        return getFieldValueProvider(field, Block.class).getBlock();
+        Block block = getFieldValueProvider(field).getBlock();
+        if (block instanceof Int128ArrayBlock) {
+            return Int128.valueOf(
+                    block.getLong(0, 0),
+                    block.getLong(0, SIZE_OF_LONG));
+        }
+        return block;
     }
 
     @Override


### PR DESCRIPTION
### Motivation
After upgrading to trino368 #20016, the long decimal type is represented by a block type. 

However, Trino expects to get an Int128 type, which causes an error.

```
java.lang.IllegalArgumentException: Expected field 6 to be type interface io.trino.spi.block.Block but is class io.trino.spi.type.Int128
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:463)
	at org.apache.pulsar.sql.presto.PulsarRecordCursor.checkFieldType(PulsarRecordCursor.java:761)
	at org.apache.pulsar.sql.presto.PulsarRecordCursor.getFieldValueProvider(PulsarRecordCursor.java:710)
	at org.apache.pulsar.sql.presto.PulsarRecordCursor.getObject(PulsarRecordCursor.java:716)
	at io.trino.spi.connector.RecordPageSource.getNextPage(RecordPageSource.java:116)
	at io.trino.operator.TableScanOperator.getOutput(TableScanOperator.java:311)
	at io.trino.operator.Driver.processInternal(Driver.java:388)
	at io.trino.operator.Driver.lambda$processFor$9(Driver.java:292)
	at io.trino.operator.Driver.tryWithLock(Driver.java:685)
```


### Modifications

1. Remove file type check in `PulsarRecordCursor.getObject()`: We can't simply assume that a Block is an object in trino368;
2. If block is `Int128ArrayBlock`, convert to Int32: This is a simple workaround for the current version. In the new version of Trino, `FieldValueProvider` has provided [getObject](https://github.com/trinodb/trino/blob/master/lib/trino-record-decoder/src/main/java/io/trino/decoder/FieldValueProvider.java#L44-L47) to replace `getBlock`, keeping it consistent with the `RecordCursor` interface. Since it's only contributed back to branch-3.0, a simple fix is provided here.

### Verifying this change
- Verify JSON and AVRO schema with LongDecimalType.
```
trino> SELECT * FROM pulsar."public/default"."my-topic";
 booleanfield | datefield  | decimalfield | doublefield | floatfield | intfield |        longdecimalfield         | longfield | stringfield |  timefield   |     timestampfield      |              uuidfield               | __partition_>
--------------+------------+--------------+-------------+------------+----------+---------------------------------+-----------+-------------+--------------+-------------------------+--------------------------------------+------------->
 true         | 2024-10-08 |        22.33 |        22.2 |        2.2 |       22 | 1234567891234567891234567891.23 |       222 | message_1   | 20:59:50.000 | 2024-10-08 12:59:50.672 | 2bedf524-f17b-410e-b499-05f0d16a3ce7 |            ->
 true         | 2024-10-08 |        22.33 |        22.2 |        2.2 |       22 | 1234567891234567891234567891.23 |       222 | message_1   | 20:59:50.000 | 2024-10-08 12:59:50.685 | 8c6507b8-7211-45e0-a4d6-71bea3a8f58b |            ->
 true         | 2024-10-08 |        22.33 |        22.2 |        2.2 |       22 | 1234567891234567891234567891.23 |       222 | message_1   | 20:59:50.000 | 2024-10-08 12:59:50.706 | ade887cf-32b9-4846-ad7f-7294ce8638b6 |            ->
 true         | 2024-10-08 |        22.33 |        22.2 |        2.2 |       22 | 1234567891234567891234567891.23 |       222 | message_1   | 20:59:50.000 | 2024-10-08 12:59:50.717 | 73c32a72-3bcd-4d2d-adec-668074a85049 |            ->
 true         | 2024-10-08 |        22.33 |        22.2 |        2.2 |       22 | 1234567891234567891234567891.23 |       222 | message_1   | 20:59:50.000 | 2024-10-08 12:59:50.487 | 284237e5-0972-4eb2-92cf-4b56be12e3b6 |            ->
 true         | 2024-10-08 |        22.33 |        22.2 |        2.2 |       22 | 1234567891234567891234567891.23 |       222 | message_1   | 20:59:50.000 | 2024-10-08 12:59:50.612 | d00c5314-0ae7-41d3-8730-a462fe2fa09f |            ->
 true         | 2024-10-08 |        22.33 |        22.2 |        2.2 |       22 | 1234567891234567891234567891.23 |       222 | message_1   | 20:59:50.000 | 2024-10-08 12:59:50.627 | a185064e-d5eb-421d-abcb-f20467c04274 |            ->
 true         | 2024-10-08 |        22.33 |        22.2 |        2.2 |       22 | 1234567891234567891234567891.23 |       222 | message_1   | 20:59:50.000 | 2024-10-08 12:59:50.642 | 839a70d0-48b7-4f87-97e8-67df65381c49 |            ->
 true         | 2024-10-08 |        22.33 |        22.2 |        2.2 |       22 | 1234567891234567891234567891.23 |       222 | message_1   | 20:59:50.000 | 2024-10-08 12:59:50.654 | 7c19b818-482f-4322-a5fe-1a721f4d9c06 |            ->
(9 rows)
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
