### PR TITLE
[improve][broker] PIP-379: Snapshot hash range assignments only in AUTO_SPLIT ordered mode

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/StickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/StickyKeyConsumerSelector.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.client.api.Range;
 
@@ -50,7 +51,7 @@ public interface StickyKeyConsumerSelector {
      *         The result contains information about the existing consumers whose hash ranges were affected
      *         by the addition of the new consumer.
      */
-    CompletableFuture<ImpactedConsumersResult> addConsumer(Consumer consumer);
+    CompletableFuture<Optional<ImpactedConsumersResult>> addConsumer(Consumer consumer);
 
     /**
      * Remove the consumer.
@@ -59,7 +60,7 @@ public interface StickyKeyConsumerSelector {
      * @return the result of impacted consumers. The result contains information about the existing consumers
      *         whose hash ranges were affected by the removal of the consumer.
      */
-    ImpactedConsumersResult removeConsumer(Consumer consumer);
+    Optional<ImpactedConsumersResult> removeConsumer(Consumer consumer);
 
     /**
      * Select a consumer by sticky key.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
@@ -476,7 +476,8 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
 
     @Test
     public void testShouldContainMinimalMappingChangesWhenConsumerLeavesAndRejoins() {
-        final ConsistentHashingStickyKeyConsumerSelector selector = new ConsistentHashingStickyKeyConsumerSelector(100);
+        final ConsistentHashingStickyKeyConsumerSelector selector =
+                new ConsistentHashingStickyKeyConsumerSelector(100, true);
         final String consumerName = "consumer";
         final int numOfInitialConsumers = 10;
         List<Consumer> consumers = new ArrayList<>();
@@ -563,7 +564,8 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
         // test that adding 1000 consumers with 100 points runs in a reasonable time.
         // This takes about 1 second on Apple M3
         // this unit test can be used for basic profiling
-        final ConsistentHashingStickyKeyConsumerSelector selector = new ConsistentHashingStickyKeyConsumerSelector(100);
+        final ConsistentHashingStickyKeyConsumerSelector selector =
+                new ConsistentHashingStickyKeyConsumerSelector(100, true);
         for (int i = 0; i < 1000; i++) {
             // use real class to avoid Mockito over head
             final Consumer consumer = new Consumer("consumer" + i, 0) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/HashRangeAutoSplitStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/HashRangeAutoSplitStickyKeyConsumerSelectorTest.java
@@ -37,7 +37,8 @@ public class HashRangeAutoSplitStickyKeyConsumerSelectorTest {
 
     @Test
     public void testGetConsumerKeyHashRanges() throws BrokerServiceException.ConsumerAssignException {
-        HashRangeAutoSplitStickyKeyConsumerSelector selector = new HashRangeAutoSplitStickyKeyConsumerSelector(2 << 5);
+        HashRangeAutoSplitStickyKeyConsumerSelector selector =
+                new HashRangeAutoSplitStickyKeyConsumerSelector(2 << 5, false);
         List<String> consumerName = Arrays.asList("consumer1", "consumer2", "consumer3", "consumer4");
         List<Consumer> consumers = new ArrayList<>();
         for (String s : consumerName) {
@@ -61,7 +62,8 @@ public class HashRangeAutoSplitStickyKeyConsumerSelectorTest {
 
     @Test
     public void testGetConsumerKeyHashRangesWithSameConsumerName() throws Exception {
-        HashRangeAutoSplitStickyKeyConsumerSelector selector = new HashRangeAutoSplitStickyKeyConsumerSelector(2 << 5);
+        HashRangeAutoSplitStickyKeyConsumerSelector selector =
+                new HashRangeAutoSplitStickyKeyConsumerSelector(2 << 5, false);
         final String consumerName = "My-consumer";
         List<Consumer> consumers = new ArrayList<>();
         for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
### Motivation

The Key_Shared PIP-379 implementation performs snapshots of hash range assignments after adding or removing a consumer in order to detect the existing consumers and hash ranges that changed as a result. This result is only used in Key_Shared AUTO_SPLIT ordered mode. Therefore, it's an unnecessary overhead for all other use cases. Any unnecessary work that can be avoided is a useful optimization, although the performance of the current snapshotting isn't a concern based on the microbenchmark and optimizations performed in the initial PR. ([comment](https://github.com/apache/pulsar/pull/23352#discussion_r1791091365), [simple microbenchmark](https://github.com/apache/pulsar/blob/7209b21b58d1efcf28a1869555596f5d52c3b348/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java#L562-L587)).

### Modifications

- modify `StickyKeyConsumerSelector` interface:
  - `CompletableFuture<ImpactedConsumersResult> addConsumer(Consumer consumer)` -> `CompletableFuture<Optional<ImpactedConsumersResult>> addConsumer(Consumer consumer)`
  - `ImpactedConsumersResult removeConsumer(Consumer consumer)` -> `Optional<ImpactedConsumersResult> removeConsumer(Consumer consumer)`
- adjust `ConsistentHashingStickyKeyConsumerSelector` and `HashRangeAutoSplitStickyKeyConsumerSelector` to this change
- drop snapshotting in `addConsumer` and `removeConsumer` for `HashRangeExclusiveStickyKeyConsumerSelector` since it's not needed.
- adjust `PersistentStickyKeyDispatcherMultipleConsumers` to configure `ConsistentHashingStickyKeyConsumerSelector` and `HashRangeAutoSplitStickyKeyConsumerSelector` classes to use snapshotting when needed (Key_Shared AUTO_SPLIT ordered mode) and adapt to interface changes.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->