### PR TITLE
[improve][pip] PIP-386: Add resetIncludeHead in CommandSubscribe for startMessageIdInclusive implementation

### DIFF
--- a/pip/pip-386.md
+++ b/pip/pip-386.md
@@ -25,19 +25,6 @@ Add resetIncludeHead in CommandSubscribe to implement startMessageIdInclusive, a
 - PersistTopic#getNonDurableSubscription add the judge condition `(msgId.getBatchIndex() >= 0 || resetIncludeHead)`, entryId - 1 will execute **when msg is batch or the resetIncludeHead is true.**
 
 
-```java
-               if (ledgerId >= 0 && entryId >= 0
-                        && msgId instanceof BatchMessageIdImpl
-                        && (msgId.getBatchIndex() >= 0 || resetIncludeHead)) {
-                    // When the start message is relative to a batch, we need to take one step back on the previous
-                    // message,
-                    // because the "batch" might not have been consumed in its entirety.
-                    // The client will then be able to discard the first messages if needed.
-                    entryId = msgId.getEntryId() - 1;
-                }
-```
-
-
 ### Binary protocol
 
 Add `reset_include_head` field to the `CommandSubscribe`.
@@ -114,5 +101,5 @@ message CommandSubscribe {
 
 # Links
 
-* Mailing List discussion thread:
-* Mailing List voting thread:
+* Mailing List discussion thread: https://lists.apache.org/thread/tvk9nl47gqtbx2nrdzknm4v8sm67ywp9
+* Mailing List voting thread: https://lists.apache.org/thread/x5xknyyr0pyrhwoslbxbbcj0o1xyyyp6


### PR DESCRIPTION
### Motivation

This pip is intended to fix issue https://github.com/apache/pulsar/issues/23239.

In the previous implementation of the method startMessageIdInclusive (https://github.com/apache/pulsar/pull/4331),
we added startMessageIdInclusive() to support include current position of reset on ReaderBuilder.

However, the condition `if (((BatchMessageIdImpl) msgId).getBatchIndex() >= 0)` in PersistentTopic#getNonDurableSubscription was directly removed.
When we use the NonDurableSubscription, this caused the entryId to decrease by 1 for non-batch messages, 
resulting in wrong msgBackLog after topic unload for non-durable subscription.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
