### PR TITLE
[fix][broker] Allow broker to handle non-recoverable schema error only if SchemaLedgerForceRecovery flag is enabled

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -671,7 +671,8 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
         return brokerService.pulsar().getSchemaRegistryService().getSchema(getSchemaId()).thenApply(Objects::nonNull)
                 .exceptionally(e -> {
                     Throwable ex = e.getCause();
-                    if (ex instanceof SchemaException || !((SchemaException) ex).isRecoverable()) {
+                    if (brokerService.pulsar().getConfig().isSchemaLedgerForceRecovery()
+                            && !((SchemaException) ex).isRecoverable()) {
                         return false;
                     }
                     throw ex instanceof CompletionException ? (CompletionException) ex : new CompletionException(ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -672,7 +672,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
                 .exceptionally(e -> {
                     Throwable ex = e.getCause();
                     if (brokerService.pulsar().getConfig().isSchemaLedgerForceRecovery()
-                            && !((SchemaException) ex).isRecoverable()) {
+                            && (ex instanceof SchemaException && !((SchemaException) ex).isRecoverable())) {
                         return false;
                     }
                     throw ex instanceof CompletionException ? (CompletionException) ex : new CompletionException(ex);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/ClientGetSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/ClientGetSchemaTest.java
@@ -186,7 +186,7 @@ public class ClientGetSchemaTest extends ProducerConsumerBase {
         final String topicOne = "test-deleted-schema-ledger";
         final String fqtnOne = TopicName.get(TopicDomain.persistent.value(), tenant, namespace, topicOne).toString();
 
-        //pulsar.getConfig().setManagedLedgerForceRecovery(true);
+        pulsar.getConfig().setSchemaLedgerForceRecovery(true);
         admin.namespaces().createNamespace(tenant + "/" + namespace, Sets.newHashSet("test"));
 
         // (1) create topic with schema


### PR DESCRIPTION
### Motivation

We have made broker resilient during non-recoverable schema error with PR: https://github.com/apache/pulsar/pull/23395
However, there is discussion to make it only if  `SchemaLedgerForceRecovery` enabled. so, this PR enables schema lost recovery only if force flag is enabled.



### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
