### PR TITLE
[improve][client] Increase default Java client connectionMaxIdleSeconds to 60 seconds

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -894,7 +894,7 @@ jobs:
 
       - name: Run Trivy container scan
         id: trivy_scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.26.0
         if: ${{ github.repository == 'apache/pulsar' && github.event_name != 'pull_request' }}
         continue-on-error: true
         with:

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -139,7 +139,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
             value = "Release the connection if it is not used for more than [connectionMaxIdleSeconds] seconds. "
                     + "If  [connectionMaxIdleSeconds] < 0, disabled the feature that auto release the idle connections"
     )
-    private int connectionMaxIdleSeconds = 25;
+    private int connectionMaxIdleSeconds = 60;
 
     @ApiModelProperty(
             name = "useTcpNoDelay",


### PR DESCRIPTION
### Motivation

The setting was decreased from 180 seconds to 25 seconds in #22541.
The default setting of 25 seconds is causing connection disconnects and connects when they aren't expected.
The reason is that the default for autoUpdatePartitionsInterval is 60 seconds and if idle timeout is shorter, it causes connections to close and open unnecessarily each time the scheduled task runs.

### Modifications

Increase connectionMaxIdleSeconds to 60 seconds

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->