### PR TITLE
[fix][ci] Pin aquasecurity/trivy-action@0.26.0 since master is broken

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -894,7 +894,7 @@ jobs:
 
       - name: Run Trivy container scan
         id: trivy_scan
-        uses: aquasecurity/trivy-action@v0.26.0
+        uses: aquasecurity/trivy-action@0.26.0
         if: ${{ github.repository == 'apache/pulsar' && github.event_name != 'pull_request' }}
         continue-on-error: true
         with:

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -894,7 +894,7 @@ jobs:
 
       - name: Run Trivy container scan
         id: trivy_scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.26.0
         if: ${{ github.repository == 'apache/pulsar' && github.event_name != 'pull_request' }}
         continue-on-error: true
         with:


### PR DESCRIPTION
### Motivation

- error message: Bad request - jaxxstorm/action-install-gh-release@v1.10.0 is not allowed to be used in apache/pulsar.

### Modifications

- pin aquasecurity/trivy-action@0.26.0 since master is broken

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->