### PR TITLE
[fix][broker] Fix namespace unload might be blocked too long with extensible load manager

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -388,7 +388,11 @@ public class BrokersBase extends AdminResource {
                     asyncResponse.resume(Response.ok("ok").build());
                 }).exceptionally(ex -> {
                     if (!isRedirectException(ex)) {
-                        LOG.error("[{}] Fail to run health check.", clientAppId(), ex);
+                        if (isNotFoundException(ex)) {
+                            LOG.warn("[{}] Failed to run health check: {}", clientAppId(), ex.getMessage());
+                        } else {
+                            LOG.error("[{}] Failed to run health check.", clientAppId(), ex);
+                        }
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerCloseTest.java
@@ -38,7 +38,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Slf4j
-@Test(groups = "flaky")
+@Test(groups = "broker")
 public class ExtensibleLoadManagerCloseTest {
 
     private static final String clusterName = "test";
@@ -88,14 +88,18 @@ public class ExtensibleLoadManagerCloseTest {
         config.setLoadManagerClassName(ExtensibleLoadManagerImpl.class.getName());
         config.setLoadBalancerDebugModeEnabled(true);
         config.setBrokerShutdownTimeoutMs(100);
+
+        // Reduce these timeout configs to avoid failed tests being blocked too long
+        config.setMetadataStoreOperationTimeoutSeconds(5);
+        config.setNamespaceBundleUnloadingTimeoutMs(5000);
         return config;
     }
 
 
-    @Test
+    @Test(invocationCount = 10)
     public void testCloseAfterLoadingBundles() throws Exception {
         setupBrokers(3);
-        final var topic = "test";
+        final var topic = "test-" + System.currentTimeMillis();
         final var admin = brokers.get(0).getAdminClient();
         admin.topics().createPartitionedTopic(topic, 20);
         admin.lookups().lookupPartitionedTopic(topic);


### PR DESCRIPTION
Fixes #23412

### Motivation

https://github.com/apache/pulsar/pull/23382 brings a regression to the broker stop phase, which could be blocked by waiting:
- `healthCheckBrokerAsync` in `ServiceUnitStateChannelImpl#doCleanup`, which could be blocked for `metadataStoreOperationTimeoutSeconds` seconds (default: 30s)
- `unloadNamespaceBundle` in `BrokerService#unloadNamespaceBundlesGracefully`, which could be blocked for `namespaceBundleUnloadingTimeoutMs` milliseconds (default: 1 min) for each problematic bundle

~~The 2nd method could be blocked when `healthCheckBrokerAsync` failed with `NotFoundException` but the following steps were not skipped.~~

### Modifications

- Check if the service unit state channel is disabled or closed via `channelDisabled` before `healthCheckBrokerAsync`
- Optimize some logs to avoid printing the whole stacks
- Improve the test to run it for 10 times in case of any flakiness introduced again. The `metadataStoreOperationTimeoutSeconds` and `namespaceBundleUnloadingTimeoutMs` configs are reduced to avoid waiting too long if the test will fail.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: