### PR TITLE
[fix][test] Fix flaky test ManagedLedgerTest.testDeleteCurrentLedgerWhenItIsClosed

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -4361,9 +4361,10 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
             // Detect the current ledger is full by the timed task. (Imitate: the timed task `checkLedgerRollTask` call
             // `rollCurrentLedgerIfFull` periodically).
             ml.rollCurrentLedgerIfFull();
-            // the ledger closing in the `rollCurrentLedgerIfFull` is async, so the wait is needed.
-            Awaitility.await().untilAsserted(() -> assertEquals(ml.ledgers.size(), 2));
         }
+        // wait the new ledger create
+        Awaitility.await().untilAsserted(() -> assertEquals(ml.ledgers.size(), 2));
+
         // Act: Trigger trimming to delete the previous current ledger.
         ml.internalTrimLedgers(false, Futures.NULL_PROMISE);
         // Verify: A new ledger will be opened after the current ledger is closed and the previous current ledger can be


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/23164

### Motivation
The previous current ledger can only be deleted if the new ledger is created.
When param closeLedgerByAddEntry is true, there may exist the situation: when call internalTrimEdgers to delete previous current ledger, new ledger has not been created, and causing the test failed.
 

                         
### Modifications
Whether closeLedgerByAddEntry is true or false, we both need to add `Awaitility.await().untilAsserted(() -> assertEquals(ml.ledgers.size(), 2));` to wait the new ledger create.
             
 
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
