### PR TITLE
[fix][broker] normalize path

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/offload/OffloaderUtils.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/offload/OffloaderUtils.java
@@ -125,7 +125,7 @@ public class OffloaderUtils {
 
     public static Offloaders searchForOffloaders(String offloadersPath, String narExtractionDirectory)
             throws IOException {
-        Path path = Paths.get(offloadersPath).toAbsolutePath();
+        Path path = Paths.get(offloadersPath).toAbsolutePath().normalize();
         log.info("Searching for offloaders in {}", path);
 
         Offloaders offloaders = new Offloaders();

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/plugin/servlet/AdditionalServletUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/plugin/servlet/AdditionalServletUtils.java
@@ -74,7 +74,7 @@ public class AdditionalServletUtils {
      */
     public AdditionalServletDefinitions searchForServlets(String additionalServletDirectory,
                                                           String narExtractionDirectory) throws IOException {
-        Path path = Paths.get(additionalServletDirectory).toAbsolutePath();
+        Path path = Paths.get(additionalServletDirectory).toAbsolutePath().normalize();
         log.info("Searching for additional servlets in {}", path);
 
         AdditionalServletDefinitions servletDefinitions = new AdditionalServletDefinitions();
@@ -119,7 +119,7 @@ public class AdditionalServletUtils {
     public AdditionalServletWithClassLoader load(
             AdditionalServletMetadata metadata, String narExtractionDirectory) throws IOException {
 
-        final File narFile = metadata.getArchivePath().toAbsolutePath().toFile();
+        final File narFile = metadata.getArchivePath().toAbsolutePath().normalize().toFile();
         NarClassLoader ncl = NarClassLoaderBuilder.builder()
                 .narFile(narFile)
                 .parentClassLoader(AdditionalServlet.class.getClassLoader())

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptorUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptorUtils.java
@@ -75,7 +75,7 @@ public class BrokerInterceptorUtils {
      */
     public BrokerInterceptorDefinitions searchForInterceptors(String interceptorsDirectory,
                                                               String narExtractionDirectory) throws IOException {
-        Path path = Paths.get(interceptorsDirectory).toAbsolutePath();
+        Path path = Paths.get(interceptorsDirectory).toAbsolutePath().normalize();
         log.info("Searching for broker interceptors in {}", path);
 
         BrokerInterceptorDefinitions interceptors = new BrokerInterceptorDefinitions();
@@ -119,7 +119,7 @@ public class BrokerInterceptorUtils {
      */
     BrokerInterceptorWithClassLoader load(BrokerInterceptorMetadata metadata, String narExtractionDirectory)
             throws IOException {
-        final File narFile = metadata.getArchivePath().toAbsolutePath().toFile();
+        final File narFile = metadata.getArchivePath().toAbsolutePath().normalize().toFile();
         NarClassLoader ncl = NarClassLoaderBuilder.builder()
                 .narFile(narFile)
                 .parentClassLoader(BrokerInterceptorUtils.class.getClassLoader())

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/protocol/ProtocolHandlerUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/protocol/ProtocolHandlerUtils.java
@@ -75,7 +75,7 @@ class ProtocolHandlerUtils {
      */
     public static ProtocolHandlerDefinitions searchForHandlers(String handlersDirectory,
                                                                String narExtractionDirectory) throws IOException {
-        Path path = Paths.get(handlersDirectory).toAbsolutePath();
+        Path path = Paths.get(handlersDirectory).toAbsolutePath().normalize();
         log.info("Searching for protocol handlers in {}", path);
 
         ProtocolHandlerDefinitions handlers = new ProtocolHandlerDefinitions();
@@ -119,7 +119,7 @@ class ProtocolHandlerUtils {
      */
     static ProtocolHandlerWithClassLoader load(ProtocolHandlerMetadata metadata,
                                                String narExtractionDirectory) throws IOException {
-        final File narFile = metadata.getArchivePath().toAbsolutePath().toFile();
+        final File narFile = metadata.getArchivePath().toAbsolutePath().normalize().toFile();
         NarClassLoader ncl = NarClassLoaderBuilder.builder()
                 .narFile(narFile)
                 .parentClassLoader(ProtocolHandler.class.getClassLoader())

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/plugin/EntryFilterProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/plugin/EntryFilterProvider.java
@@ -122,7 +122,7 @@ public class EntryFilterProvider implements AutoCloseable {
 
     private void initialize() throws IOException {
         final String entryFiltersDirectory = serviceConfiguration.getEntryFiltersDirectory();
-        Path path = Paths.get(entryFiltersDirectory).toAbsolutePath();
+        Path path = Paths.get(entryFiltersDirectory).toAbsolutePath().normalize();
         log.info("Searching for entry filters in {}", path);
 
 
@@ -217,7 +217,7 @@ public class EntryFilterProvider implements AutoCloseable {
         return cachedClassLoaders
                 .computeIfAbsent(absolutePath, narFilePath -> {
                     try {
-                        final File narFile = archivePath.toAbsolutePath().toFile();
+                        final File narFile = archivePath.toAbsolutePath().normalize().toFile();
                         return NarClassLoaderBuilder.builder()
                                 .narFile(narFile)
                                 .parentClassLoader(EntryFilter.class.getClassLoader())

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/utils/CustomCommandFactoryProvider.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/utils/CustomCommandFactoryProvider.java
@@ -77,7 +77,7 @@ public class CustomCommandFactoryProvider {
     private static CustomCommandFactoryDefinitions searchForCustomCommandFactories(String directory,
                                                                        String narExtractionDirectory)
             throws IOException {
-        Path path = Paths.get(directory).toAbsolutePath();
+        Path path = Paths.get(directory).toAbsolutePath().normalize();
         log.debug("Searching for command factories  in {}", path);
 
         CustomCommandFactoryDefinitions customCommandFactoryDefinitions = new CustomCommandFactoryDefinitions();
@@ -142,7 +142,7 @@ public class CustomCommandFactoryProvider {
     private static CustomCommandFactory load(CustomCommandFactoryMetaData metadata,
                                                    String narExtractionDirectory)
             throws IOException {
-        final File narFile = metadata.getArchivePath().toAbsolutePath().toFile();
+        final File narFile = metadata.getArchivePath().toAbsolutePath().normalize().toFile();
         NarClassLoader ncl = NarClassLoaderBuilder.builder()
                 .narFile(narFile)
                 .parentClassLoader(CustomCommandFactory.class.getClassLoader())

--- a/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
+++ b/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
@@ -278,7 +278,7 @@ public class LocalRunner implements AutoCloseable {
         } else {
             directoryPath = Path.of(directory);
         }
-        return directoryPath.toAbsolutePath().toString();
+        return directoryPath.toAbsolutePath().normalize().toString();
     }
 
     private static File createNarExtractionTempDirectory() {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/functions/FunctionUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/functions/FunctionUtils.java
@@ -78,7 +78,7 @@ public class FunctionUtils {
     public static TreeMap<String, FunctionArchive> searchForFunctions(String functionsDirectory,
                                                                       String narExtractionDirectory,
                                                                       boolean enableClassloading) throws IOException {
-        Path path = Paths.get(functionsDirectory).toAbsolutePath();
+        Path path = Paths.get(functionsDirectory).toAbsolutePath().normalize();
         log.info("Searching for functions in {}", path);
 
         TreeMap<String, FunctionArchive> functions = new TreeMap<>();

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
@@ -156,7 +156,7 @@ public class ConnectorUtils {
     public static TreeMap<String, Connector> searchForConnectors(String connectorsDirectory,
                                                                  String narExtractionDirectory,
                                                                  boolean enableClassloading) throws IOException {
-        Path path = Paths.get(connectorsDirectory).toAbsolutePath();
+        Path path = Paths.get(connectorsDirectory).toAbsolutePath().normalize();
         log.info("Searching for connectors in {}", path);
 
         TreeMap<String, Connector> connectors = new TreeMap<>();

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/service/WorkerServiceLoader.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/service/WorkerServiceLoader.java
@@ -73,7 +73,7 @@ public class WorkerServiceLoader {
      */
     static WorkerServiceWithClassLoader load(WorkerServiceMetadata metadata,
                                              String narExtractionDirectory) throws IOException {
-        final File narFile = metadata.getArchivePath().toAbsolutePath().toFile();
+        final File narFile = metadata.getArchivePath().toAbsolutePath().normalize().toFile();
         NarClassLoader ncl = NarClassLoaderBuilder.builder()
                 .narFile(narFile)
                 .parentClassLoader(WorkerService.class.getClassLoader())

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/extensions/ProxyExtensionsUtils.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/extensions/ProxyExtensionsUtils.java
@@ -75,7 +75,7 @@ class ProxyExtensionsUtils {
      */
     public static ExtensionsDefinitions searchForExtensions(String extensionsDirectory,
                                                             String narExtractionDirectory) throws IOException {
-        Path path = Paths.get(extensionsDirectory).toAbsolutePath();
+        Path path = Paths.get(extensionsDirectory).toAbsolutePath().normalize();
         log.info("Searching for extensions in {}", path);
 
         ExtensionsDefinitions extensions = new ExtensionsDefinitions();
@@ -119,7 +119,7 @@ class ProxyExtensionsUtils {
      */
     static ProxyExtensionWithClassLoader load(ProxyExtensionMetadata metadata,
                                               String narExtractionDirectory) throws IOException {
-        final File narFile = metadata.getArchivePath().toAbsolutePath().toFile();
+        final File narFile = metadata.getArchivePath().toAbsolutePath().normalize().toFile();
         NarClassLoader ncl = NarClassLoaderBuilder.builder()
                 .narFile(narFile)
                 .parentClassLoader(ProxyExtension.class.getClassLoader())


### PR DESCRIPTION
### Motivation

In the broker configuration, we're using relative paths for parameters such as `brokerInterceptorsDirectory`, `protocolHandlerDirectory`, `additionalServletDirectory`, and `offloadersDirectory`. These paths include the `./` notation, and since the broker doesn't normalize them, the absolute paths generated are incorrect, for example: `/app/pulsar/20241011165422044/./interceptors/pulsar-xxx.nar`. As a result, the broker is unable to resolve the correct file locations.


Test cases: 
```java
    @Test
    public void testPathNormalize() {
        Path path = Paths.get("./interceptors").toAbsolutePath().normalize();
        assertEquals(path.toString().indexOf("./"), -1);
    }

    @Test
    public void testPathWithoutNormalize() {
        Path path = Paths.get("./interceptors").toAbsolutePath();
        assertNotEquals(path.toString().indexOf("./"), -1);
    }
```

### Modifications

-  Append the `java.nio.file.Path#normalize` call after the `java.nio.file.Path#toAbsolutePath` call to ensure proper path resolution.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->