### PR TITLE
[fix][build] Remove duplicate dependencies in pom.xml

### DIFF
--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -76,11 +76,6 @@
       <artifactId>pulsar-client-messagecrypto-bc</artifactId>
       <version>${project.version}</version>
     </dependency>
-   <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>pulsar-cli-utils</artifactId>
-      <version>${project.version}</version>
-    </dependency>
     <dependency>
       <groupId>org.asynchttpclient</groupId>
       <artifactId>async-http-client</artifactId>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -248,11 +248,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.re2j</groupId>
-      <artifactId>re2j</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
### Motivation

Pulsar maven build shows some warning at the beginning:
```
[WARNING] Some problems were encountered while building the effective model for org.apache.pulsar:pulsar-common:jar:4.0.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: com.google.re2j:re2j:jar -> duplicate declaration of version (?) @ line 250, column 17
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.apache.pulsar:pulsar-client-tools:jar:4.0.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: ${project.groupId}:pulsar-cli-utils:jar -> duplicate declaration of version ${project.version} @ line 79, column 16
[WARNING]
```

### Modifications

- fix the warnings by removing the duplicate dependencies

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->