### PR TITLE
[improve][broker][PIP-379] Don't replace a consumer when there's a collision

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerHashAssignmentsSnapshot.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerHashAssignmentsSnapshot.java
@@ -71,8 +71,8 @@ public class ConsumerHashAssignmentsSnapshot {
         return new ConsumerHashAssignmentsSnapshot(Collections.emptyList());
     }
 
-    public ImpactedConsumersResult resolveImpactedConsumers(ConsumerHashAssignmentsSnapshot other) {
-        return resolveConsumerRemovedHashRanges(this.hashRangeAssignments, other.hashRangeAssignments);
+    public ImpactedConsumersResult resolveImpactedConsumers(ConsumerHashAssignmentsSnapshot assignmentsAfter) {
+        return resolveConsumerRemovedHashRanges(this.hashRangeAssignments, assignmentsAfter.hashRangeAssignments);
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
@@ -475,11 +475,11 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
     }
 
     @Test
-    public void testShouldContainMinimalMappingChangesWhenConsumerLeavesAndRejoins() {
+    public void testShouldNotContainMappingChangesWhenConsumersLeaveAndRejoinInSameOrder() {
         final ConsistentHashingStickyKeyConsumerSelector selector =
-                new ConsistentHashingStickyKeyConsumerSelector(100, true);
+                new ConsistentHashingStickyKeyConsumerSelector(200, true);
         final String consumerName = "consumer";
-        final int numOfInitialConsumers = 10;
+        final int numOfInitialConsumers = 200;
         List<Consumer> consumers = new ArrayList<>();
         for (int i = 0; i < numOfInitialConsumers; i++) {
             final Consumer consumer = createMockConsumer(consumerName, "index " + i, i);
@@ -498,14 +498,8 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
         selector.addConsumer(consumers.get(numOfInitialConsumers / 2));
 
         ConsumerHashAssignmentsSnapshot assignmentsAfter = selector.getConsumerHashAssignmentsSnapshot();
-        int removedRangesSize = assignmentsBefore.diffRanges(assignmentsAfter).keySet().stream()
-                .mapToInt(Range::size)
-                .sum();
-        double allowedremovedRangesPercentage = 1; // 1%
-        int hashRangeSize = selector.getKeyHashRange().size();
-        int allowedremovedRanges = (int) (hashRangeSize * (allowedremovedRangesPercentage / 100.0d));
-        assertThat(removedRangesSize).describedAs("Allow up to %d%% of total hash range size to be impacted",
-                allowedremovedRangesPercentage).isLessThan(allowedremovedRanges);
+
+        assertThat(assignmentsBefore.resolveImpactedConsumers(assignmentsAfter).getRemovedHashRanges()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Fixes #23439

### Motivation

When a consumer joins or leaves, the hash ranges from existing consumers shouldn't move from one to another.

### Modifications

- Revisit adding the to hash ring so that existing consumers aren't replaced when there are collisions.
- Add a test case which ensures this

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->