### PR TITLE
[improve][cli] Add compactor type option for compaction tool

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
@@ -55,6 +55,11 @@ import picocli.CommandLine.ScopeType;
 public class CompactorTool {
 
     private static class Arguments {
+        public enum CompactorType {
+            PUBLISHING,
+            EVENT_TIME
+        }
+
         @Option(names = {"-c", "--broker-conf"}, description = "Configuration file for Broker")
         private String brokerConfigFile = "conf/broker.conf";
 
@@ -66,6 +71,9 @@ public class CompactorTool {
 
         @Option(names = {"-g", "--generate-docs"}, description = "Generate docs")
         private boolean generateDocs = false;
+
+        @Option(names = {"-ct", "--compactor-type"}, description = "Choose compactor type, valid types are [PUBLISHING, EVENT_TIME]")
+        private CompactorType compactorType = CompactorType.PUBLISHING;
     }
 
     public static PulsarClient createClient(ServiceConfiguration brokerConfig) throws PulsarClientException {
@@ -172,7 +180,17 @@ public class CompactorTool {
         @Cleanup
         PulsarClient pulsar = createClient(brokerConfig);
 
-        Compactor compactor = new PublishingOrderCompactor(brokerConfig, pulsar, bk, scheduler);
+        Compactor compactor = null;
+
+        switch (arguments.compactorType) {
+            case PUBLISHING:
+                compactor = new PublishingOrderCompactor(brokerConfig, pulsar, bk, scheduler);
+                break;
+            case EVENT_TIME:
+                compactor = new EventTimeOrderCompactor(brokerConfig, pulsar, bk, scheduler);
+                break;
+        }
+
         long ledgerId = compactor.compact(arguments.topic).get();
         log.info("Compaction of topic {} complete. Compacted to ledger {}", arguments.topic, ledgerId);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
@@ -72,8 +72,8 @@ public class CompactorTool {
         @Option(names = {"-g", "--generate-docs"}, description = "Generate docs")
         private boolean generateDocs = false;
 
-        @Option(names = {"-ct", "--compactor-type"}, description = "Choose compactor type, " +
-                "valid types are [PUBLISHING, EVENT_TIME]")
+        @Option(names = {"-ct", "--compactor-type"}, description = "Choose compactor type, "
+                + "valid types are [PUBLISHING, EVENT_TIME]")
         private CompactorType compactorType = CompactorType.PUBLISHING;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
@@ -72,7 +72,8 @@ public class CompactorTool {
         @Option(names = {"-g", "--generate-docs"}, description = "Generate docs")
         private boolean generateDocs = false;
 
-        @Option(names = {"-ct", "--compactor-type"}, description = "Choose compactor type, valid types are [PUBLISHING, EVENT_TIME]")
+        @Option(names = {"-ct", "--compactor-type"}, description = "Choose compactor type, " +
+                "valid types are [PUBLISHING, EVENT_TIME]")
         private CompactorType compactorType = CompactorType.PUBLISHING;
     }
 


### PR DESCRIPTION
Main Issue: https://github.com/apache/pulsar/issues/23445

### Motivation
In the [PIP-352](https://github.com/apache/pulsar/pull/22517)， EventTimeOrderCompactor which compact message based on eventTime was added.

I think that we can add compactor type option in compaction tool, then user can choose to use PublishingOrderCompactor or EventTimeOrderCompactor to compact message
 
### Modifications
- add option `--compactor-type`, default value is `CompactorType.PUBLISHING`  
 
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
