### PR TITLE
[improve][broker][PIP-379] Improve hash collision handling by restoring consumer when other leaves

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/RemovedHashRanges.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/RemovedHashRanges.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service;
 
+import java.util.Arrays;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -70,5 +71,21 @@ public class RemovedHashRanges {
             }
         }
         return false;
+    }
+
+    /**
+     * Checks if all removed ranges are fully contained in the provided list of ranges.
+     */
+    public boolean isFullyContainedInRanges(List<Range> otherRanges) {
+        return Arrays.stream(sortedRanges).allMatch(range ->
+                otherRanges.stream().anyMatch(otherRange -> otherRange.contains(range))
+        );
+    }
+
+    /**
+     * Returns the removed hash ranges as a list of ranges.
+     */
+    public List<Range> asRanges() {
+        return Arrays.asList(sortedRanges);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelectorTest.java
@@ -476,6 +476,40 @@ public class ConsistentHashingStickyKeyConsumerSelectorTest {
     }
 
     @Test
+    public void testShouldContainMinimalMappingChangesWhenConsumerLeavesAndRejoins() {
+        final ConsistentHashingStickyKeyConsumerSelector selector =
+                new ConsistentHashingStickyKeyConsumerSelector(100, true);
+        final String consumerName = "consumer";
+        final int numOfInitialConsumers = 10;
+        List<Consumer> consumers = new ArrayList<>();
+        for (int i = 0; i < numOfInitialConsumers; i++) {
+            final Consumer consumer = createMockConsumer(consumerName, "index " + i, i);
+            consumers.add(consumer);
+            selector.addConsumer(consumer);
+        }
+
+        ConsumerHashAssignmentsSnapshot assignmentsBefore = selector.getConsumerHashAssignmentsSnapshot();
+
+        Map<Consumer, List<Range>> expected = selector.getConsumerKeyHashRanges();
+        assertThat(selector.getConsumerKeyHashRanges()).as("sanity check").containsExactlyInAnyOrderEntriesOf(expected);
+
+        selector.removeConsumer(consumers.get(0));
+        selector.removeConsumer(consumers.get(numOfInitialConsumers / 2));
+        selector.addConsumer(consumers.get(0));
+        selector.addConsumer(consumers.get(numOfInitialConsumers / 2));
+
+        ConsumerHashAssignmentsSnapshot assignmentsAfter = selector.getConsumerHashAssignmentsSnapshot();
+        int removedRangesSize = assignmentsBefore.diffRanges(assignmentsAfter).keySet().stream()
+                .mapToInt(Range::size)
+                .sum();
+        double allowedremovedRangesPercentage = 1; // 1%
+        int hashRangeSize = selector.getKeyHashRange().size();
+        int allowedremovedRanges = (int) (hashRangeSize * (allowedremovedRangesPercentage / 100.0d));
+        assertThat(removedRangesSize).describedAs("Allow up to %d%% of total hash range size to be impacted",
+                allowedremovedRangesPercentage).isLessThan(allowedremovedRanges);
+    }
+
+    @Test
     public void testShouldNotSwapExistingConsumers() {
         final ConsistentHashingStickyKeyConsumerSelector selector =
                 new ConsistentHashingStickyKeyConsumerSelector(200, true);

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Range.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Range.java
@@ -94,10 +94,28 @@ public class Range implements Comparable<Range> {
         return result;
     }
 
+    /**
+     * Check if the value is in the range.
+     * @param value
+     * @return true if the value is in the range.
+     */
     public boolean contains(int value) {
         return value >= start && value <= end;
     }
 
+    /**
+     * Check if the range is fully contained in the other range.
+     * @param otherRange
+     * @return true if the range is fully contained in the other range.
+     */
+    public boolean contains(Range otherRange) {
+        return start <= otherRange.start && end >= otherRange.end;
+    }
+
+    /**
+     * Get the size of the range.
+     * @return the size of the range.
+     */
     public int size() {
         return end - start + 1;
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/api/RangeTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/api/RangeTest.java
@@ -88,6 +88,38 @@ public class RangeTest {
     }
 
     @Test
+    public void testContainsRange() {
+        Range range = Range.of(5, 10);
+
+        // Test ranges that are fully contained
+        Assert.assertTrue(range.contains(Range.of(6, 8)));
+
+        Assert.assertTrue(range.contains(Range.of(5, 10)));
+
+        Assert.assertTrue(range.contains(Range.of(5, 5)));
+
+        Assert.assertTrue(range.contains(Range.of(5, 8)));
+
+        Assert.assertTrue(range.contains(Range.of(10, 10)));
+
+        Assert.assertTrue(range.contains(Range.of(8, 10)));
+
+        // Test ranges that are not fully contained
+        Assert.assertFalse(range.contains(Range.of(1, 5)));
+
+        Assert.assertFalse(range.contains(Range.of(1, 4)));
+
+        Assert.assertFalse(range.contains(Range.of(1, 10)));
+
+        Assert.assertFalse(range.contains(Range.of(1, 11)));
+
+        Assert.assertFalse(range.contains(Range.of(10, 12)));
+
+        Assert.assertFalse(range.contains(Range.of(11, 20)));
+    }
+
+
+    @Test
     public void testSize() {
         Range range = Range.of(0, 0);
         Assert.assertEquals(1, range.size());


### PR DESCRIPTION
Fixes #23443

### Motivation

In the current ConsistentHashingStickyKeyConsumerSelector implementation, when there's a hash ring point collision,
the original entry will be preserved and the attempted addition will be rejected.
This isn't a problem with the consumerNameIndexTracker solution since the collisions won't align for all hash ring points when using the same consumer name. Because of this, collisions won't affect the overall distribution significantly when the number of hash ring points is sufficiently large (>100).

However, when the "selected" consumer is removed, the colliding consumer should be selected and take over it's hash ring point. This PR implements that logic.

### Modifications

- add HashRingPointEntry which holds the selected consumer and the colliding consumers
- add logic for adding and removing to handle the colliding consumers in the designed way.
- add test coverage
  - replace previous test that had too strict expectations.
- add methods to range classes to be used in tests

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->