### PR TITLE
[fix][build] Add basic support for vscode-java and Eclipse IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ test-reports/
 # Gradle Develocity
 .mvn/.develocity/
 .vscode
+effective-pom.xml

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ test-reports/
 .mvn/.gradle-enterprise/
 # Gradle Develocity
 .mvn/.develocity/
+.vscode

--- a/pom.xml
+++ b/pom.xml
@@ -316,6 +316,7 @@ flexible messaging model and an intuitive client API.</description>
     <errorprone-slf4j.version>0.1.21</errorprone-slf4j.version>
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
+    <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
     <dependency-check-maven.version>10.0.2</dependency-check-maven.version>
     <roaringbitmap.version>1.2.0</roaringbitmap.version>
     <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
@@ -1927,6 +1928,7 @@ flexible messaging model and an intuitive client API.</description>
                 <exclude>generated-site/**</exclude>
                 <exclude>**/*.md</exclude>
                 <exclude>**/.idea/**</exclude>
+                <exclude>**/.vscode/**</exclude>
                 <exclude>**/.mvn/**</exclude>
                 <exclude>**/generated/**</exclude>
                 <exclude>**/zk-3.5-test-data/*</exclude>
@@ -2072,6 +2074,7 @@ flexible messaging model and an intuitive client API.</description>
             <exclude>**/SecurityAuth.audit*</exclude>
             <exclude>**/site2/**</exclude>
             <exclude>**/.idea/**</exclude>
+            <exclude>**/.vscode/**</exclude>
             <exclude>**/.mvn/**</exclude>
             <exclude>**/*.a</exclude>
             <exclude>**/*.so</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -2275,6 +2275,49 @@ flexible messaging model and an intuitive client API.</description>
             <!-- <nvdDatafeedUrl>https://jeremylong.github.io/DependencyCheck/hb_nvd/</nvdDatafeedUrl> -->
           </configuration>
         </plugin>
+        <!-- 
+          vscode-java and Eclipse Maven integration workaround:
+          - Addresses maven-dependency-plugin exception (MDEP-187) issue by ignoring the plugin execution
+          - Uses org.eclipse.m2e:lifecycle-mapping:1.0.0 as configuration placeholder in pluginManagement section
+          For details: https://eclipse.dev/m2e/documentation/m2e-execution-not-covered.html#ignore-plugin-goal
+        -->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <versionRange>[1.0.0,)</versionRange>
+                    <goals>
+                      <goal>copy</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore />
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <versionRange>[1.0.0,)</versionRange>
+                    <goals>
+                      <goal>unpack</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore />
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <extensions>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -676,6 +676,25 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>${build-helper-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>target/generated-sources/lightproto/java</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -294,6 +294,38 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>${build-helper-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>target/generated-sources/protobuf/java</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-test-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>target/generated-test-sources/protobuf/java</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
 
       <plugin>
         <groupId>pl.project13.maven</groupId>

--- a/pulsar-transaction/coordinator/pom.xml
+++ b/pulsar-transaction/coordinator/pom.xml
@@ -67,7 +67,7 @@
         </dependency>
 
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -99,7 +99,37 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${build-helper-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>target/generated-sources/protobuf/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-test-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>target/generated-test-sources/protobuf/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>


### PR DESCRIPTION
### Motivation

Visual Studio Code (vscode) is a popular IDE. It would be great to support developing Pulsar with [vscode-java](https://github.com/redhat-developer/vscode-java).
One of the reasons for adding vscode-java support is due to Cursor AI code editor building upon vscode. When there's vscode-java support in Pulsar, it would be possible to use Cursor for developing Pulsar.

Similar changes are most likely required for supporting Eclipse for Apache Pulsar development since vscode-java uses Eclipse modules under the covers for Java and Maven support. 

The lightproto maven plugin issue most likely impacts IntelliJ too since currently you need to build Pulsar once in order to get lightproto generated classes to resolve. This change will most likely address that issue too.


### Modifications

- workaround issues with [Lightproto plugin that doesn't properly register generated sources in the maven plugin](https://github.com/splunk/lightproto/blob/master/maven-plugin/src/main/java/com/github/splunk/lightproto/maven/plugin/LightProtoMojo.java#L71-L96) (perhaps not an absolute path name?).
  - use [build-helper-maven-plugin's add-source](https://www.mojohaus.org/build-helper-maven-plugin/add-source-mojo.html) and [add-test-source](https://www.mojohaus.org/build-helper-maven-plugin/add-test-source-mojo.html) to workaround the issue.
  - a proper solution would be to fork lightproto and bring it into Apache Pulsar project for maintenance and fix the issue.
- add .vscode to .gitignore and ignore the directory from license checks
- add vscode-java and Eclipse Maven integration workaround by specifying org.eclipse.m2e lifecycle-mapping configuration for ignoring maven-dependency-plugin in IDE builds.

### Example test run

<img width="1896" alt="image" src="https://github.com/user-attachments/assets/48cc5b5a-f890-40a5-86f9-1622c5f4ccd7">



### Additional context

I got test running working with this `settings.json` for "Language Support for Java(TM) by Red Hat" extension
```json
{
    "java.jdt.ls.vmargs": "-Xmx8g -XX:+UseZGC -XX:+ZGenerational -Dsun.zip.disableMemoryMapping=true",
    "java.jdt.ls.java.home": "/Users/lari/.sdkman/candidates/java/21",
    "java.configuration.runtimes": [
        {
            "name": "JavaSE-21",
            "path": "/Users/lari/.sdkman/candidates/java/21",
            "default": true
        },
        {
            "name": "JavaSE-17",
            "path": "/Users/lari/.sdkman/candidates/java/17"
        },
        {
            "name": "JavaSE-11",
            "path": "/Users/lari/.sdkman/candidates/java/11"
        },
        {
            "name": "JavaSE-1.8",
            "path": "/Users/lari/.sdkman/candidates/java/8"
        }
    ],
    "java.autobuild.enabled": false,
    "java.debug.settings.onBuildFailureProceed": true,
    "java.compile.nullAnalysis.mode": "disabled",
    "java.configuration.updateBuildConfiguration": "interactive"
}
```
sdkman setup for JDK versions is explained currently in https://pulsar.apache.org/contribute/release-process/#preparation


in workspace level `settings.json`
```json
{
    "maven.executable.options": "-Pcore-modules,-main"
}
```

configured in 
<img width="592" alt="image" src="https://github.com/user-attachments/assets/5206f7a6-88fc-4e58-bf52-3f2389149840">


Also setting `-Pcore-modules,-main` to speed up compilation

<img width="789" alt="image" src="https://github.com/user-attachments/assets/35120ad6-722e-4a47-a41e-df743a93f0f2">


Also setting profiles in the root project:
<img width="451" alt="image" src="https://github.com/user-attachments/assets/3d5946ee-31cb-445c-a197-005972c6c66b">


Since `"java.autobuild.enabled": false`, you will need to build manually. Having autobuilding disabled is useful for a large project like Pulsar since building will consume resources and it conflicts with manual builds on the command line. 

![image](https://github.com/user-attachments/assets/3af199c1-89e5-4ade-baee-9a782796c7cf)


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->