### PR TITLE
[fix][test] Address flaky GetPartitionMetadataMultiBrokerTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
@@ -241,7 +241,7 @@ public class GetPartitionMetadataTest extends TestRetrySupport {
         String pulsarUrl = pulsar1.getBrokerServiceUrl();
         PulsarClientImpl[] clients = getClientsToTest(false);
         for (PulsarClientImpl client : clients) {
-            client.getLookup(pulsarUrl).getBroker(TopicName.get(DEFAULT_NS + "/tp1"));
+            client.getLookup(pulsarUrl).getBroker(TopicName.get(DEFAULT_NS + "/tp1")).join();
         }
         // Inject a not support flag into the connections initialized.
         Field field = ClientCnx.class.getDeclaredField("supportsGetPartitionedMetadataWithoutAutoCreation");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
@@ -47,6 +47,7 @@ import org.apache.pulsar.common.policies.data.ClusterDataImpl;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.tests.TestRetrySupport;
 import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
 import org.awaitility.Awaitility;
 import org.testng.annotations.AfterClass;
@@ -56,7 +57,7 @@ import org.testng.annotations.Test;
 
 @Test(groups = "broker-admin")
 @Slf4j
-public class GetPartitionMetadataTest {
+public class GetPartitionMetadataTest extends TestRetrySupport {
 
     protected static final String DEFAULT_NS = "public/default";
 
@@ -72,8 +73,10 @@ public class GetPartitionMetadataTest {
     protected PulsarClientImpl clientWithHttpLookup1;
     protected PulsarClientImpl clientWitBinaryLookup1;
 
+    @Override
     @BeforeClass(alwaysRun = true)
     protected void setup() throws Exception {
+        incrementSetupNumber();
         bkEnsemble = new LocalBookkeeperEnsemble(3, 0, () -> 0);
         bkEnsemble.start();
         // Start broker.
@@ -85,8 +88,10 @@ public class GetPartitionMetadataTest {
         admin1.namespaces().createNamespace(DEFAULT_NS);
     }
 
+    @Override
     @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
+        markCurrentSetupNumberCleaned();
         cleanupBrokers();
         if (bkEnsemble != null) {
             bkEnsemble.stop();


### PR DESCRIPTION
Fixes #23455

### Motivation

GetPartitionMetadataMultiBrokerTest.testCompatibilityForNewClientAndOldBroker is really flaky and fails often. 
There's an explanation for the flakiness, it's similar as #23259.

### Modifications

- Fix the flakiness in the same way as #23259
- Make the test extend TestRetrySupport and adapt the setup and cleanup methods to use TestRetrySupport.
  - The test doesn't have retries enabled. There are a lot of flaky tests in Pulsar and one of the solutions is to retry the test if it fails. 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->