### PR TITLE
[fix][broker] Do not record as a topic load failure for the requested broker is not the owner

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -2159,4 +2159,9 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         return (TopicPoliciesService) Reflections.createInstance(className,
                 Thread.currentThread().getContextClassLoader());
     }
+
+    @VisibleForTesting
+    public void setBrokerService(BrokerService brokerService) {
+        this.brokerService = brokerService;
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -2159,9 +2159,4 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         return (TopicPoliciesService) Reflections.createInstance(className,
                 Thread.currentThread().getContextClassLoader());
     }
-
-    @VisibleForTesting
-    public void setBrokerService(BrokerService brokerService) {
-        this.brokerService = brokerService;
-    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1320,7 +1320,9 @@ public class BrokerService implements Closeable {
         topicFuture.exceptionally(t -> {
             // If the broker is not the owner of the topic, the client will redirect to another broker.
             // In this case, we should not record as a topic load failure.
-            if (!(FutureUtil.unwrapCompletionException(t) instanceof ServiceUnitNotReadyException)) {
+            Throwable cause = FutureUtil.unwrapCompletionException(t);
+            if (!(cause instanceof ServiceUnitNotReadyException)
+                    && !(cause.getMessage().contains("not served by this instance"))) {
                 getPulsarStats().recordTopicLoadFailed();
             }
             pulsar.getExecutor().execute(() -> topics.remove(topic, topicFuture));
@@ -1618,7 +1620,9 @@ public class BrokerService implements Closeable {
         topicFuture.exceptionally(t -> {
             // If the broker is not the owner of the topic, the client will redirect to another broker.
             // In this case, we should not record as a topic load failure.
-            if (!(FutureUtil.unwrapCompletionException(t) instanceof ServiceUnitNotReadyException)) {
+            Throwable cause = FutureUtil.unwrapCompletionException(t);
+            if (!(cause instanceof ServiceUnitNotReadyException)
+                    && !(cause.getMessage().contains("not served by this instance"))) {
                 getPulsarStats().recordTopicLoadFailed();
             }
             return Optional.empty();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1320,12 +1320,7 @@ public class BrokerService implements Closeable {
         topicFuture.exceptionally(t -> {
             // If the broker is not the owner of the topic, the client will redirect to another broker.
             // In this case, we should not record as a topic load failure.
-            Throwable cause = FutureUtil.unwrapCompletionException(t);
-            if (!(cause instanceof ServiceUnitNotReadyException)
-                    && !(cause.getMessage().contains("not served by this instance"))) {
-                getPulsarStats().recordTopicLoadFailed();
-            }
-            pulsar.getExecutor().execute(() -> topics.remove(topic, topicFuture));
+            pulsarStats.recordTopicLoadFailed();
             return null;
         });
         final long topicCreateTimeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
@@ -1621,11 +1616,11 @@ public class BrokerService implements Closeable {
             // If the broker is not the owner of the topic, the client will redirect to another broker.
             // In this case, we should not record as a topic load failure.
             Throwable cause = FutureUtil.unwrapCompletionException(t);
-            if (!(cause instanceof ServiceUnitNotReadyException)
-                    && !(cause.getMessage().contains("not served by this instance"))) {
+            if (!(cause instanceof ServiceUnitNotReadyException
+                    && cause.getMessage().contains("not served by this instance"))) {
                 getPulsarStats().recordTopicLoadFailed();
             }
-            return Optional.empty();
+            return null;
         });
 
         checkTopicNsOwnership(topic)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1318,9 +1318,8 @@ public class BrokerService implements Closeable {
     private CompletableFuture<Optional<Topic>> createNonPersistentTopic(String topic) {
         CompletableFuture<Optional<Topic>> topicFuture = new CompletableFuture<>();
         topicFuture.exceptionally(t -> {
-            // If the broker is not the owner of the topic, the client will redirect to another broker.
-            // In this case, we should not record as a topic load failure.
             pulsarStats.recordTopicLoadFailed();
+            pulsar.getExecutor().execute(() -> topics.remove(topic, topicFuture));
             return null;
         });
         final long topicCreateTimeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -714,6 +714,14 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         };
     }
 
+    @DataProvider(name = "TopicDomain")
+    public Object[][] topicDomain() {
+        return new Object[][] {
+                {"persistent"},
+                {"non-persistent"}
+        };
+    }
+
     protected ServiceProducer getServiceProducer(ProducerImpl clientProducer, String topicName) {
         PersistentTopic persistentTopic =
                 (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false).join().get();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -808,14 +808,6 @@ public class NamespaceServiceTest extends BrokerTestBase {
         assertFalse(getResult.isPresent());
     }
 
-    @DataProvider(name = "topicDomain")
-    public Object[] topicDomain() {
-        return new Object[]{
-                TopicDomain.persistent.value(),
-                TopicDomain.non_persistent.value()
-        };
-    }
-
     @Test(dataProvider = "topicDomain")
     public void testCheckTopicExists(String topicDomain) throws Exception {
         String topic = topicDomain + "://prop/ns-abc/" + UUID.randomUUID();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -78,7 +78,6 @@ import org.apache.pulsar.common.naming.NamespaceBundleSplitAlgorithm;
 import org.apache.pulsar.common.naming.NamespaceBundles;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.ServiceUnitId;
-import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.ClusterData;
@@ -103,7 +102,6 @@ import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Test(groups = "flaky")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -1933,7 +1933,6 @@ public class BrokerServiceTest extends BrokerTestBase {
                         + "Please redo the lookup. Request is denied: namespace=pfs/ons")))
             .when(spyService).checkTopicNsOwnership(topicName);
 
-        pulsar.setBrokerService(spyService);
         when(spyService.getPulsarStats()).thenReturn(mock(PulsarStats.class));
 
         // Call the method under test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -53,7 +53,6 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -1928,7 +1928,9 @@ public class BrokerServiceTest extends BrokerTestBase {
         // Mock the checkTopicNsOwnership to throw ServiceUnitNotReadyException
         BrokerService spyService = spy(service);
         doReturn(CompletableFuture.failedFuture(
-                new BrokerServiceException.ServiceUnitNotReadyException("Test exception")))
+                new BrokerServiceException.ServiceUnitNotReadyException("Namespace bundle for topic "
+                        + "(persistent://xxx/xxx/xxx-partition-0) not served by this instance:xyz. "
+                        + "Please redo the lookup. Request is denied: namespace=pfs/ons")))
             .when(spyService).checkTopicNsOwnership(topicName);
 
         pulsar.setBrokerService(spyService);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
@@ -104,11 +104,6 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
         };
     }
 
-    @DataProvider(name = "topicDomain")
-    public static Object[] topicDomain() {
-        return new Object[] { "persistent://", "non-persistent://" };
-    }
-
     private final boolean schemaValidationEnforced;
 
     @Factory(dataProvider = "schemaValidationModes")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
@@ -98,11 +98,6 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
         super.internalCleanup();
     }
 
-    @DataProvider(name = "topicDomain")
-    public static Object[] topicDomain() {
-       return new Object[]{ TopicDomain.persistent.value(), TopicDomain.non_persistent.value()};
-    }
-
     private Set<String> publishMessages(String topic, int count, boolean enableBatch) throws Exception {
         return publishMessages(topic, 0, count, enableBatch, false);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -128,11 +128,6 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         super.internalCleanup();
     }
 
-    @DataProvider(name = "topicDomain")
-    public static Object[] topicDomain() {
-        return new Object[] { "persistent://", "non-persistent://" };
-    }
-
     @Test
     public void testGetSchemaWhenCreateAutoProduceBytesProducer() throws Exception{
         final String tenant = PUBLIC_TENANT;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -98,7 +98,6 @@ import org.apache.pulsar.metadata.api.Stat;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Slf4j


### PR DESCRIPTION
### Motivation

The topic_load_failed metric is introduced by https://github.com/apache/pulsar/pull/19236 which is used to monitor the topic load failures such as timeout, metadata service issue, etc.

But the topic owner check exception is an expected behavior if the requested broker is not the owner of the topic. We should avoid to record as a topic load failure from topic owner check. 

For the non-persistent topic, we don't need this change. 

https://github.com/apache/pulsar/blob/d759a1e616614ab661c3f858292dcada8f733e63/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java#L1351-L1364

### Verifying this change

- New unit tests were added

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
