### PR TITLE
[improve][io] Upgrade Spring version to 6.1.13 in IO Connectors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@ flexible messaging model and an intuitive client API.</description>
     <kotlin-stdlib.version>1.8.20</kotlin-stdlib.version>
     <nsq-client.version>1.0</nsq-client.version>
     <cron-utils.version>9.1.6</cron-utils.version>
-    <spring.version>5.3.27</spring.version>
+    <spring.version>6.1.13</spring.version>
     <apache-http-client.version>4.5.13</apache-http-client.version>
     <apache-httpcomponents.version>4.4.15</apache-httpcomponents.version>
     <jetcd.version>0.7.7</jetcd.version>
@@ -2275,7 +2275,7 @@ flexible messaging model and an intuitive client API.</description>
             <!-- <nvdDatafeedUrl>https://jeremylong.github.io/DependencyCheck/hb_nvd/</nvdDatafeedUrl> -->
           </configuration>
         </plugin>
-        <!-- 
+        <!--
           vscode-java and Eclipse Maven integration workaround:
           - Addresses maven-dependency-plugin exception (MDEP-187) issue by ignoring the plugin execution
           - Uses org.eclipse.m2e:lifecycle-mapping:1.0.0 as configuration placeholder in pluginManagement section


### PR DESCRIPTION
### Motivation

- Spring 6.1.x is the only OSS supported version at the moment: https://endoflife.date/spring-framework
- OWASP dependency check reports CVE-2024-38808 (Moderate 5.1/10)

### Modifications

- Upgrade Spring version to 6.1.13

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->