### PR TITLE
[fix][client] Use dedicated executor for requests in BinaryProtoLookupService (#23378)

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -244,6 +244,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     private final ExecutorProvider brokerClientSharedExternalExecutorProvider;
     private final ScheduledExecutorProvider brokerClientSharedScheduledExecutorProvider;
     private final Timer brokerClientSharedTimer;
+    private final ExecutorProvider brokerClientSharedLookupExecutorProvider;
 
     private MetricsGenerator metricsGenerator;
 
@@ -353,6 +354,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 new ScheduledExecutorProvider(1, "broker-client-shared-scheduled-executor");
         this.brokerClientSharedTimer =
                 new HashedWheelTimer(new DefaultThreadFactory("broker-client-shared-timer"), 1, TimeUnit.MILLISECONDS);
+        this.brokerClientSharedLookupExecutorProvider =
+                new ScheduledExecutorProvider(1, "broker-client-shared-lookup-executor");
 
         // here in the constructor we don't have the offloader scheduler yet
         this.offloaderStats = LedgerOffloaderStats.create(false, false, null, 0);
@@ -593,6 +596,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             brokerClientSharedExternalExecutorProvider.shutdownNow();
             brokerClientSharedInternalExecutorProvider.shutdownNow();
             brokerClientSharedScheduledExecutorProvider.shutdownNow();
+            brokerClientSharedLookupExecutorProvider.shutdownNow();
             brokerClientSharedTimer.stop();
 
             asyncCloseFutures.add(EventLoopUtil.shutdownGracefully(ioEventLoopGroup));
@@ -1587,6 +1591,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 .internalExecutorProvider(brokerClientSharedInternalExecutorProvider)
                 .externalExecutorProvider(brokerClientSharedExternalExecutorProvider)
                 .scheduledExecutorProvider(brokerClientSharedScheduledExecutorProvider)
+                .lookupExecutorProvider(brokerClientSharedLookupExecutorProvider)
                 .build();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
@@ -21,12 +21,14 @@ package org.apache.pulsar.client.impl;
 import static java.lang.String.format;
 import static org.apache.pulsar.client.api.PulsarClientException.FailedFeatureCheck.SupportsGetPartitionedMetadataWithoutAutoCreation;
 import io.netty.buffer.ByteBuf;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -55,9 +57,11 @@ public class BinaryProtoLookupService implements LookupService {
     private final PulsarClientImpl client;
     private final ServiceNameResolver serviceNameResolver;
     private final boolean useTls;
-    private final ExecutorService executor;
+    private final ExecutorService scheduleExecutor;
     private final String listenerName;
     private final int maxLookupRedirects;
+    private final ExecutorService lookupPinnedExecutor;
+    private final boolean createdLookupPinnedExecutor;
 
     private final ConcurrentHashMap<TopicName, CompletableFuture<Pair<InetSocketAddress, InetSocketAddress>>>
             lookupInProgress = new ConcurrentHashMap<>();
@@ -65,27 +69,56 @@ public class BinaryProtoLookupService implements LookupService {
     private final ConcurrentHashMap<TopicName, CompletableFuture<PartitionedTopicMetadata>>
             partitionedMetadataInProgress = new ConcurrentHashMap<>();
 
+    /**
+     * @deprecated use {@link
+     * #BinaryProtoLookupService(PulsarClientImpl, String, String, boolean, ExecutorService, ExecutorService)} instead.
+     */
+    @Deprecated
     public BinaryProtoLookupService(PulsarClientImpl client,
                                     String serviceUrl,
                                     boolean useTls,
-                                    ExecutorService executor)
+                                    ExecutorService scheduleExecutor)
             throws PulsarClientException {
-        this(client, serviceUrl, null, useTls, executor);
+        this(client, serviceUrl, null, useTls, scheduleExecutor);
+    }
+
+    /**
+     * @deprecated use {@link
+     * #BinaryProtoLookupService(PulsarClientImpl, String, String, boolean, ExecutorService, ExecutorService)} instead.
+     */
+    @Deprecated
+    public BinaryProtoLookupService(PulsarClientImpl client,
+                                    String serviceUrl,
+                                    String listenerName,
+                                    boolean useTls,
+                                    ExecutorService scheduleExecutor)
+            throws PulsarClientException {
+        this(client, serviceUrl, listenerName, useTls, scheduleExecutor, null);
     }
 
     public BinaryProtoLookupService(PulsarClientImpl client,
                                     String serviceUrl,
                                     String listenerName,
                                     boolean useTls,
-                                    ExecutorService executor)
+                                    ExecutorService scheduleExecutor,
+                                    ExecutorService lookupPinnedExecutor)
             throws PulsarClientException {
         this.client = client;
         this.useTls = useTls;
-        this.executor = executor;
+        this.scheduleExecutor = scheduleExecutor;
         this.maxLookupRedirects = client.getConfiguration().getMaxLookupRedirects();
         this.serviceNameResolver = new PulsarServiceNameResolver();
         this.listenerName = listenerName;
         updateServiceUrl(serviceUrl);
+
+        if (lookupPinnedExecutor == null) {
+            this.createdLookupPinnedExecutor = true;
+            this.lookupPinnedExecutor =
+                    Executors.newSingleThreadExecutor(new DefaultThreadFactory("pulsar-client-binary-proto-lookup"));
+        } else {
+            this.createdLookupPinnedExecutor = false;
+            this.lookupPinnedExecutor = lookupPinnedExecutor;
+        }
     }
 
     @Override
@@ -153,7 +186,7 @@ public class BinaryProtoLookupService implements LookupService {
             return addressFuture;
         }
 
-        client.getCnxPool().getConnection(socketAddress).thenAccept(clientCnx -> {
+        client.getCnxPool().getConnection(socketAddress).thenAcceptAsync(clientCnx -> {
             long requestId = client.newRequestId();
             ByteBuf request = Commands.newLookup(topicName.toString(), listenerName, authoritative, requestId);
             clientCnx.newLookup(request, requestId).whenComplete((r, t) -> {
@@ -218,7 +251,7 @@ public class BinaryProtoLookupService implements LookupService {
                 }
                 client.getCnxPool().releaseConnection(clientCnx);
             });
-        }).exceptionally(connectionException -> {
+        }, lookupPinnedExecutor).exceptionally(connectionException -> {
             addressFuture.completeExceptionally(FutureUtil.unwrapCompletionException(connectionException));
             return null;
         });
@@ -230,7 +263,7 @@ public class BinaryProtoLookupService implements LookupService {
 
         CompletableFuture<PartitionedTopicMetadata> partitionFuture = new CompletableFuture<>();
 
-        client.getCnxPool().getConnection(socketAddress).thenAccept(clientCnx -> {
+        client.getCnxPool().getConnection(socketAddress).thenAcceptAsync(clientCnx -> {
             boolean finalAutoCreationEnabled = metadataAutoCreationEnabled;
             if (!metadataAutoCreationEnabled && !clientCnx.isSupportsGetPartitionedMetadataWithoutAutoCreation()) {
                 if (useFallbackForNonPIP344Brokers) {
@@ -269,7 +302,7 @@ public class BinaryProtoLookupService implements LookupService {
                 }
                 client.getCnxPool().releaseConnection(clientCnx);
             });
-        }).exceptionally(connectionException -> {
+        }, lookupPinnedExecutor).exceptionally(connectionException -> {
             partitionFuture.completeExceptionally(FutureUtil.unwrapCompletionException(connectionException));
             return null;
         });
@@ -291,7 +324,7 @@ public class BinaryProtoLookupService implements LookupService {
             return schemaFuture;
         }
         InetSocketAddress socketAddress = serviceNameResolver.resolveHost();
-        client.getCnxPool().getConnection(socketAddress).thenAccept(clientCnx -> {
+        client.getCnxPool().getConnection(socketAddress).thenAcceptAsync(clientCnx -> {
             long requestId = client.newRequestId();
             ByteBuf request = Commands.newGetSchema(requestId, topicName.toString(),
                 Optional.ofNullable(BytesSchemaVersion.of(version)));
@@ -305,7 +338,7 @@ public class BinaryProtoLookupService implements LookupService {
                 }
                 client.getCnxPool().releaseConnection(clientCnx);
             });
-        }).exceptionally(ex -> {
+        }, lookupPinnedExecutor).exceptionally(ex -> {
             schemaFuture.completeExceptionally(FutureUtil.unwrapCompletionException(ex));
             return null;
         });
@@ -348,7 +381,7 @@ public class BinaryProtoLookupService implements LookupService {
                                          Mode mode,
                                          String topicsPattern,
                                          String topicsHash) {
-        client.getCnxPool().getConnection(socketAddress).thenAccept(clientCnx -> {
+        client.getCnxPool().getConnection(socketAddress).thenAcceptAsync(clientCnx -> {
             long requestId = client.newRequestId();
             ByteBuf request = Commands.newGetTopicsOfNamespaceRequest(
                 namespace.toString(), requestId, mode, topicsPattern, topicsHash);
@@ -365,7 +398,7 @@ public class BinaryProtoLookupService implements LookupService {
                 }
                 client.getCnxPool().releaseConnection(clientCnx);
             });
-        }).exceptionally((e) -> {
+        }, lookupPinnedExecutor).exceptionally((e) -> {
             long nextDelay = Math.min(backoff.next(), remainingTime.get());
             if (nextDelay <= 0) {
                 getTopicsResultFuture.completeExceptionally(
@@ -375,7 +408,7 @@ public class BinaryProtoLookupService implements LookupService {
                 return null;
             }
 
-            ((ScheduledExecutorService) executor).schedule(() -> {
+            ((ScheduledExecutorService) scheduleExecutor).schedule(() -> {
                 log.warn("[namespace: {}] Could not get connection while getTopicsUnderNamespace -- Will try again in"
                                 + " {} ms", namespace, nextDelay);
                 remainingTime.addAndGet(-nextDelay);
@@ -389,7 +422,9 @@ public class BinaryProtoLookupService implements LookupService {
 
     @Override
     public void close() throws Exception {
-        // no-op
+        if (createdLookupPinnedExecutor && lookupPinnedExecutor != null && !lookupPinnedExecutor.isShutdown()) {
+            lookupPinnedExecutor.shutdown();
+        }
     }
 
     public static class LookupDataResult {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BinaryProtoLookupServiceTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BinaryProtoLookupServiceTest.java
@@ -25,28 +25,44 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.concurrent.DefaultThreadFactory;
 
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.PulsarClientException.LookupException;
 import org.apache.pulsar.client.impl.BinaryProtoLookupService.LookupDataResult;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.common.api.proto.BaseCommand;
+import org.apache.pulsar.common.api.proto.BaseCommand.Type;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.protocol.Commands;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class BinaryProtoLookupServiceTest {
     private BinaryProtoLookupService lookup;
     private TopicName topicName;
+    private ExecutorService internalExecutor;
+
+    @AfterMethod
+    public void cleanup() throws Exception {
+        internalExecutor.shutdown();
+        lookup.close();
+    }
 
     @BeforeMethod
     public void setup() throws Exception {
@@ -72,9 +88,15 @@ public class BinaryProtoLookupServiceTest {
         doReturn(cnxPool).when(client).getCnxPool();
         doReturn(clientConfig).when(client).getConfiguration();
         doReturn(1L).when(client).newRequestId();
+        ClientConfigurationData data = new ClientConfigurationData();
+        doReturn(data).when(client).getConfiguration();
+        internalExecutor =
+                Executors.newSingleThreadExecutor(new DefaultThreadFactory("pulsar-client-test-internal-executor"));
+        doReturn(internalExecutor).when(client).getInternalExecutorService();
 
-        lookup = spy(
-                new BinaryProtoLookupService(client, "pulsar://localhost:6650", false, mock(ExecutorService.class)));
+        lookup = spy(new BinaryProtoLookupService(client, "pulsar://localhost:6650", null, false,
+                mock(ExecutorService.class), internalExecutor));
+
         topicName = TopicName.get("persistent://tenant1/ns1/t1");
     }
 
@@ -114,6 +136,37 @@ public class BinaryProtoLookupServiceTest {
             assertTrue(cause instanceof LookupException);
             assertEquals(cause.getMessage(), "Too many redirects: 1");
         }
+    }
+
+    @Test
+    public void testCommandUnChangedInDifferentThread() throws Exception {
+        BaseCommand successCommand = Commands.newSuccessCommand(10000);
+        lookup.getBroker(topicName).get();
+        assertEquals(successCommand.getType(), Type.SUCCESS);
+        lookup.getPartitionedTopicMetadata(topicName, true, true).get();
+        assertEquals(successCommand.getType(), Type.SUCCESS);
+    }
+
+    @Test
+    public void testCommandChangedInSameThread() throws Exception {
+        AtomicReference<BaseCommand> successCommand = new AtomicReference<>();
+        internalExecutor.execute(() -> successCommand.set(Commands.newSuccessCommand(10000)));
+        Awaitility.await().untilAsserted(() -> {
+            BaseCommand baseCommand = successCommand.get();
+            assertNotNull(baseCommand);
+            assertEquals(baseCommand.getType(), Type.SUCCESS);
+        });
+        lookup.getBroker(topicName).get();
+        assertEquals(successCommand.get().getType(), Type.LOOKUP);
+
+        internalExecutor.execute(() -> successCommand.set(Commands.newSuccessCommand(10000)));
+        Awaitility.await().untilAsserted(() -> {
+            BaseCommand baseCommand = successCommand.get();
+            assertNotNull(baseCommand);
+            assertEquals(baseCommand.getType(), Type.SUCCESS);
+        });
+        lookup.getPartitionedTopicMetadata(topicName, true, true).get();
+        assertEquals(successCommand.get().getType(), Type.PARTITIONED_METADATA);
     }
 
     private static LookupDataResult createLookupDataResult(String brokerUrl, boolean redirect) throws Exception {


### PR DESCRIPTION
### Motivation

Cherry-pick #23378 to the branch-3.0.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->