### PR TITLE
[fix][sql] Fix LICENSE

### DIFF
--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -277,22 +277,22 @@ The Apache Software License, Version 2.0
     - joda-time-2.10.10.jar
     - failsafe-3.3.2.jar
   * Jetty
-    - http2-client-9.4.54.v20240208.jar
-    - http2-common-9.4.54.v20240208.jar
-    - http2-hpack-9.4.54.v20240208.jar
-    - http2-http-client-transport-9.4.54.v20240208.jar
-    - jetty-alpn-client-9.4.54.v20240208.jar
-    - http2-server-9.4.54.v20240208.jar
-    - jetty-alpn-java-client-9.4.54.v20240208.jar
-    - jetty-client-9.4.54.v20240208.jar
-    - jetty-http-9.4.54.v20240208.jar
-    - jetty-io-9.4.54.v20240208.jar
-    - jetty-jmx-9.4.54.v20240208.jar
-    - jetty-security-9.4.54.v20240208.jar
-    - jetty-server-9.4.54.v20240208.jar
-    - jetty-servlet-9.4.54.v20240208.jar
-    - jetty-util-9.4.54.v20240208.jar
-    - jetty-util-ajax-9.4.54.v20240208.jar
+    - http2-client-9.4.56.v20240826.jar
+    - http2-common-9.4.56.v20240826.jar
+    - http2-hpack-9.4.56.v20240826.jar
+    - http2-http-client-transport-9.4.56.v20240826.jar
+    - jetty-alpn-client-9.4.56.v20240826.jar
+    - http2-server-9.4.56.v20240826.jar
+    - jetty-alpn-java-client-9.4.56.v20240826.jar
+    - jetty-client-9.4.56.v20240826.jar
+    - jetty-http-9.4.56.v20240826.jar
+    - jetty-io-9.4.56.v20240826.jar
+    - jetty-jmx-9.4.56.v20240826.jar
+    - jetty-security-9.4.56.v20240826.jar
+    - jetty-server-9.4.56.v20240826.jar
+    - jetty-servlet-9.4.56.v20240826.jar
+    - jetty-util-9.4.56.v20240826.jar
+    - jetty-util-ajax-9.4.56.v20240826.jar
   * Byte Buddy
     - byte-buddy-1.14.12.jar
   * Apache BVal


### PR DESCRIPTION
### Motivation

When cherry-picking https://github.com/apache/pulsar/pull/23405 to the branch-3.0, we didn't update the `/pulsar-sql/presto-distribution/LICENSE`, this broke the branch-3.0 CI.

### Modifications

- Update jetty version in the `/pulsar-sql/presto-distribution/LICENSE`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->