### PR TITLE
[improve][ci] Prevent git force push to more recent maintenance branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -84,6 +84,9 @@ github:
     branch-2.11: {}
     branch-3.0: {}
     branch-3.1: {}
+    branch-3.2: {}
+    branch-3.3: {}
+    branch-4.0: {}
 
 notifications:
   commits:      commits@pulsar.apache.org


### PR DESCRIPTION
### Motivation

Shared branches should always be protected against force pushes, see #14226 for the PR where we enabled this.

### Modifications

- configuration was missing for `branch-3.2` and `branch-3.3`, add
- add for recent `branch-4.0`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->