### PR TITLE
[fix][test] Fix memory leak via OTel shutdown hooks in tests

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
@@ -206,6 +206,7 @@ public class InflightReadsLimiterTest {
     private Pair<OpenTelemetrySdk, InMemoryMetricReader> buildOpenTelemetryAndReader() {
         var metricReader = InMemoryMetricReader.create();
         var openTelemetry = AutoConfiguredOpenTelemetrySdk.builder()
+                .disableShutdownHook()
                 .addMeterProviderCustomizer((builder, __) -> builder.registerMetricReader(metricReader))
                 .build()
                 .getOpenTelemetrySdk();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/BrokerOpenTelemetryTestUtil.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/BrokerOpenTelemetryTestUtil.java
@@ -35,6 +35,7 @@ public class BrokerOpenTelemetryTestUtil {
         return sdkBuilder -> {
             sdkBuilder.addMeterProviderCustomizer(
                     (meterProviderBuilder, __) -> meterProviderBuilder.registerMetricReader(reader));
+            sdkBuilder.disableShutdownHook();
             sdkBuilder.addPropertiesSupplier(
                     () -> Map.of(OpenTelemetryService.OTEL_SDK_DISABLED_KEY, "false",
                             "otel.java.enabled.resource.providers", "none"));

--- a/pulsar-opentelemetry/src/test/java/org/apache/pulsar/opentelemetry/OpenTelemetryServiceTest.java
+++ b/pulsar-opentelemetry/src/test/java/org/apache/pulsar/opentelemetry/OpenTelemetryServiceTest.java
@@ -75,6 +75,7 @@ public class OpenTelemetryServiceTest {
                 autoConfigurationCustomizer.addMeterProviderCustomizer(
                         (sdkMeterProviderBuilder, __) -> sdkMeterProviderBuilder.registerMetricReader(extraReader));
             }
+            autoConfigurationCustomizer.disableShutdownHook();
             autoConfigurationCustomizer.addPropertiesSupplier(() -> extraProperties);
         };
     }


### PR DESCRIPTION
### Motivation

OTel AutoConfiguredOpenTelemetrySdkBuilder will register a shutdown hook by default. This will cause a memory leak since there will be a reference to all OpenTelemetrySdk instances until the test JVM completes running tests.

### Modifications

Disable registering shutdown hook in tests. 

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->