### PR TITLE
[improve][monitor] Upgrade OTel to 1.41.0

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -338,12 +338,12 @@ The Apache Software License, Version 2.0
     - io.prometheus-simpleclient_tracer_otel-0.16.0.jar
     - io.prometheus-simpleclient_tracer_otel_agent-0.16.0.jar
  * Prometheus exporter
-    - io.prometheus-prometheus-metrics-config-1.2.1.jar
-    - io.prometheus-prometheus-metrics-exporter-common-1.2.1.jar
-    - io.prometheus-prometheus-metrics-exporter-httpserver-1.2.1.jar
-    - io.prometheus-prometheus-metrics-exposition-formats-1.2.1.jar
-    - io.prometheus-prometheus-metrics-model-1.2.1.jar
-    - io.prometheus-prometheus-metrics-shaded-protobuf-1.2.1.jar
+    - io.prometheus-prometheus-metrics-config-1.3.1.jar
+    - io.prometheus-prometheus-metrics-exporter-common-1.3.1.jar
+    - io.prometheus-prometheus-metrics-exporter-httpserver-1.3.1.jar
+    - io.prometheus-prometheus-metrics-exposition-formats-1.3.1.jar
+    - io.prometheus-prometheus-metrics-model-1.3.1.jar
+    - io.prometheus-prometheus-metrics-shaded-protobuf-1.3.1.jar
  * Jakarta Bean Validation API
     - jakarta.validation-jakarta.validation-api-2.0.2.jar
     - javax.validation-validation-api-1.1.0.Final.jar
@@ -516,27 +516,27 @@ The Apache Software License, Version 2.0
   * RoaringBitmap
     - org.roaringbitmap-RoaringBitmap-1.2.0.jar
   * OpenTelemetry
-    - io.opentelemetry-opentelemetry-api-1.38.0.jar
-    - io.opentelemetry-opentelemetry-api-incubator-1.38.0-alpha.jar
-    - io.opentelemetry-opentelemetry-context-1.38.0.jar
-    - io.opentelemetry-opentelemetry-exporter-common-1.38.0.jar
-    - io.opentelemetry-opentelemetry-exporter-otlp-1.38.0.jar
-    - io.opentelemetry-opentelemetry-exporter-otlp-common-1.38.0.jar
-    - io.opentelemetry-opentelemetry-exporter-prometheus-1.38.0-alpha.jar
-    - io.opentelemetry-opentelemetry-exporter-sender-okhttp-1.38.0.jar
-    - io.opentelemetry-opentelemetry-sdk-1.38.0.jar
-    - io.opentelemetry-opentelemetry-sdk-common-1.38.0.jar
-    - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-1.38.0.jar
-    - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-spi-1.38.0.jar
-    - io.opentelemetry-opentelemetry-sdk-logs-1.38.0.jar
-    - io.opentelemetry-opentelemetry-sdk-metrics-1.38.0.jar
-    - io.opentelemetry-opentelemetry-sdk-trace-1.38.0.jar
-    - io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-1.33.3.jar
-    - io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-semconv-1.33.3-alpha.jar
-    - io.opentelemetry.instrumentation-opentelemetry-resources-1.33.3-alpha.jar
-    - io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-java17-1.33.3-alpha.jar
-    - io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-java8-1.33.3-alpha.jar
-    - io.opentelemetry.semconv-opentelemetry-semconv-1.25.0-alpha.jar
+    - io.opentelemetry-opentelemetry-api-1.41.0.jar
+    - io.opentelemetry-opentelemetry-api-incubator-1.41.0-alpha.jar
+    - io.opentelemetry-opentelemetry-context-1.41.0.jar
+    - io.opentelemetry-opentelemetry-exporter-common-1.41.0.jar
+    - io.opentelemetry-opentelemetry-exporter-otlp-1.41.0.jar
+    - io.opentelemetry-opentelemetry-exporter-otlp-common-1.41.0.jar
+    - io.opentelemetry-opentelemetry-exporter-prometheus-1.41.0-alpha.jar
+    - io.opentelemetry-opentelemetry-exporter-sender-okhttp-1.41.0.jar
+    - io.opentelemetry-opentelemetry-sdk-1.41.0.jar
+    - io.opentelemetry-opentelemetry-sdk-common-1.41.0.jar
+    - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-1.41.0.jar
+    - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-spi-1.41.0.jar
+    - io.opentelemetry-opentelemetry-sdk-logs-1.41.0.jar
+    - io.opentelemetry-opentelemetry-sdk-metrics-1.41.0.jar
+    - io.opentelemetry-opentelemetry-sdk-trace-1.41.0.jar
+    - io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-1.33.6.jar
+    - io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-semconv-1.33.6-alpha.jar
+    - io.opentelemetry.instrumentation-opentelemetry-resources-1.33.6-alpha.jar
+    - io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-java17-1.33.6-alpha.jar
+    - io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-java8-1.33.6-alpha.jar
+    - io.opentelemetry.semconv-opentelemetry-semconv-1.28.0-alpha.jar
   * Spotify completable-futures
     - com.spotify-completable-futures-0.3.6.jar
 

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -388,9 +388,9 @@ The Apache Software License, Version 2.0
     - log4j-slf4j2-impl-2.23.1.jar
     - log4j-web-2.23.1.jar
  * OpenTelemetry
-    - opentelemetry-api-1.38.0.jar
-    - opentelemetry-api-incubator-1.38.0-alpha.jar
-    - opentelemetry-context-1.38.0.jar
+    - opentelemetry-api-1.41.0.jar
+    - opentelemetry-api-incubator-1.41.0-alpha.jar
+    - opentelemetry-context-1.41.0.jar
 
  * BookKeeper
     - bookkeeper-common-allocator-4.17.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -258,11 +258,11 @@ flexible messaging model and an intuitive client API.</description>
     <disruptor.version>3.4.3</disruptor.version>
     <zstd-jni.version>1.5.2-3</zstd-jni.version>
     <netty-reactive-streams.version>2.0.6</netty-reactive-streams.version>
-    <opentelemetry.version>1.38.0</opentelemetry.version>
+    <opentelemetry.version>1.41.0</opentelemetry.version>
     <opentelemetry.alpha.version>${opentelemetry.version}-alpha</opentelemetry.alpha.version>
-    <opentelemetry.instrumentation.version>1.33.3</opentelemetry.instrumentation.version>
+    <opentelemetry.instrumentation.version>1.33.6</opentelemetry.instrumentation.version>
     <opentelemetry.instrumentation.alpha.version>${opentelemetry.instrumentation.version}-alpha</opentelemetry.instrumentation.alpha.version>
-    <opentelemetry.semconv.version>1.25.0-alpha</opentelemetry.semconv.version>
+    <opentelemetry.semconv.version>1.28.0-alpha</opentelemetry.semconv.version>
     <picocli.version>4.7.5</picocli.version>
     <re2j.version>1.7</re2j.version>
     <completable-futures.version>0.3.6</completable-futures.version>


### PR DESCRIPTION
### Motivation

Upgrade OpenTelemetry (OTel) libraries so that we stay up-to-date.

### Modifications

- upgrade OTel to 1.41.0 and use other compatible libraries

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->