### PR TITLE
[fix] [proxy] Fix pattern consumer does not work when using Proxy

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/LookupProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/LookupProxyHandler.java
@@ -341,7 +341,8 @@ public class LookupProxyHandler {
                         Commands.newError(clientRequestId, getServerError(t), t.getMessage()));
                 } else {
                     writeAndFlush(
-                        Commands.newGetTopicsOfNamespaceResponse(r.getTopics(), r.getTopicsHash(), r.isFiltered(),
+                        Commands.newGetTopicsOfNamespaceResponse(r.getNonPartitionedOrPartitionTopics(),
+                                r.getTopicsHash(), r.isFiltered(),
                                 r.isChanged(), clientRequestId));
                 }
             });


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/22854 added a new method `List<Integer> getExistsPartitions(String topic)`, which depends on the new method `GetTopicsResult.nonPartitionedOrPartitionTopics`, but the author of the PR forgot the change the deserializer of Pulsar-Proxy, which may cause the following issue:
- Broker respond: `tp-partition-0`
- Proxy received `tp-partition-0` and recreate a new response that may remove the suffix `-partition-0` to client 
- Client received `tp`, which without `-partition-0`
  - Client assumed the parition `0` does not exists. 

### Modifications

Fix the bug

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
