### PR TITLE
[fix][broker] Fix consumer receive individual acknowledged messages from compacted topic after reconnection

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
@@ -893,6 +893,8 @@ public interface ManagedCursor {
 
     boolean isMessageDeleted(Position position);
 
+    boolean isMessageIndividualDeleted(Position position);
+
     ManagedCursor duplicateNonDurableCursor(String nonDurableCursorName) throws ManagedLedgerException;
 
     long[] getBatchPositionAckSet(Position position);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3550,6 +3550,16 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
     }
 
+    @Override
+    public boolean isMessageIndividualDeleted(Position position) {
+        lock.readLock().lock();
+        try {
+            return individualDeletedMessages.contains(position.getLedgerId(), position.getEntryId());
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
     //this method will return a copy of the position's ack set
     @Override
     public long[] getBatchPositionAckSet(Position position) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorImpl.java
@@ -76,4 +76,9 @@ public class ReadOnlyCursorImpl extends ManagedCursorImpl implements ReadOnlyCur
     public boolean isMessageDeleted(Position position) {
         return false;
     }
+
+    @Override
+    public boolean isMessageIndividualDeleted(Position position) {
+        return false;
+    }
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -423,6 +423,11 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
+        public boolean isMessageIndividualDeleted(Position position) {
+            return false;
+        }
+
+        @Override
         public ManagedCursor duplicateNonDurableCursor(String nonDurableCursorName) throws ManagedLedgerException {
             return null;
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/MockManagedCursor.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/MockManagedCursor.java
@@ -427,6 +427,11 @@ public class MockManagedCursor implements ManagedCursor {
     }
 
     @Override
+    public boolean isMessageIndividualDeleted(Position position) {
+        return false;
+    }
+
+    @Override
     public ManagedCursor duplicateNonDurableCursor(String nonDurableCursorName) throws ManagedLedgerException {
         return null;
     }


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/23494

### Motivation
After consumed the compacted topic and individual acknowledged messages, if the topic unload and consumer reconnect, we will receive the individual acknowledged messages again.
Like the none-compacted topic, I think that consumer should not receive  acknowledge message after reconnection.
                                      
### Modifications
 - add `isMessageIndividualDeleted` to check if this message has been individual acknowledged
 - In `CompactedTopicUtils#asyncReadCompactedEntries`, use isMessageIndividualDeleted to filter out and skip unnecessary entry
 
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
