### PR TITLE
[fix][client] Fix Reader.hasMessageAvailable return wrong value after seeking by timestamp with startMessageIdInclusive

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ReaderTest.java
@@ -906,9 +906,8 @@ public class ReaderTest extends MockedPulsarServiceBaseTest {
         }
     }
 
-    @Test(dataProvider = "initializeLastMessageIdInBroker")
-    public void testHasMessageAvailableAfterSeekTimestampWithMessageIdInclusive(boolean initializeLastMessageIdInBroker)
-            throws Exception {
+    @Test
+    public void testHasMessageAvailableAfterSeekTimestampWithMessageIdInclusive() throws Exception {
         final String topic = "persistent://my-property/my-ns/" +
                 "testHasMessageAvailableAfterSeekTimestampWithMessageInclusive";
 
@@ -927,9 +926,8 @@ public class ReaderTest extends MockedPulsarServiceBaseTest {
             Reader<String> reader = pulsarClient.newReader(Schema.STRING).topic(topic).receiverQueueSize(1)
                     .startMessageIdInclusive()
                     .startMessageId(messageId).create();
-            if (initializeLastMessageIdInBroker) {
-                assertTrue(reader.hasMessageAvailable());
-            }
+            assertTrue(reader.hasMessageAvailable());
+
             reader.seek(System.currentTimeMillis());
             assertFalse(reader.hasMessageAvailable());
             Message<String> message = reader.readNext(10, TimeUnit.SECONDS);
@@ -941,9 +939,8 @@ public class ReaderTest extends MockedPulsarServiceBaseTest {
             Reader<String> reader = pulsarClient.newReader(Schema.STRING).topic(topic).receiverQueueSize(1)
                     .startMessageIdInclusive()
                     .startMessageId(messageId).create();
-            if (initializeLastMessageIdInBroker) {
-                assertTrue(reader.hasMessageAvailable());
-            }
+            assertTrue(reader.hasMessageAvailable());
+
             reader.seek(timestampBeforeSend);
             assertTrue(reader.hasMessageAvailable());
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ReaderTest.java
@@ -906,6 +906,49 @@ public class ReaderTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @Test(dataProvider = "initializeLastMessageIdInBroker")
+    public void testHasMessageAvailableAfterSeekTimestampWithMessageIdInclusive(boolean initializeLastMessageIdInBroker)
+            throws Exception {
+        final String topic = "persistent://my-property/my-ns/" +
+                "testHasMessageAvailableAfterSeekTimestampWithMessageInclusive";
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
+        final long timestampBeforeSend = System.currentTimeMillis();
+        final MessageId sentMsgId = producer.send("msg");
+
+        final List<MessageId> messageIds = new ArrayList<>();
+        messageIds.add(MessageId.earliest);
+        messageIds.add(sentMsgId);
+        messageIds.add(MessageId.latest);
+
+        for (MessageId messageId : messageIds) {
+            @Cleanup
+            Reader<String> reader = pulsarClient.newReader(Schema.STRING).topic(topic).receiverQueueSize(1)
+                    .startMessageIdInclusive()
+                    .startMessageId(messageId).create();
+            if (initializeLastMessageIdInBroker) {
+                assertTrue(reader.hasMessageAvailable());
+            }
+            reader.seek(System.currentTimeMillis());
+            assertFalse(reader.hasMessageAvailable());
+            Message<String> message = reader.readNext(10, TimeUnit.SECONDS);
+            assertNull(message);
+        }
+
+        for (MessageId messageId : messageIds) {
+            @Cleanup
+            Reader<String> reader = pulsarClient.newReader(Schema.STRING).topic(topic).receiverQueueSize(1)
+                    .startMessageIdInclusive()
+                    .startMessageId(messageId).create();
+            if (initializeLastMessageIdInBroker) {
+                assertTrue(reader.hasMessageAvailable());
+            }
+            reader.seek(timestampBeforeSend);
+            assertTrue(reader.hasMessageAvailable());
+        }
+    }
+
     @Test
     public void testReaderBuilderStateOnRetryFailure() throws Exception {
         String ns = "my-property/my-ns";

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2515,6 +2515,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                                 .result();
                         if (lastMessageId.getEntryId() < 0) {
                             completehasMessageAvailableWithValue(booleanFuture, false);
+                        } else if (hasSoughtByTimestamp) {
+                            completehasMessageAvailableWithValue(booleanFuture, result < 0);
                         } else {
                             completehasMessageAvailableWithValue(booleanFuture,
                                     resetIncludeHead ? result <= 0 : result < 0);


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/23501

### Motivation
When seek to the current time `reader.seek(System.currentTimeMillis());`,  `reader.hasMessageAvailable()` should return false cause there has no message to read, but right now it returns true.
                                      
### Modifications
- when hasSoughtByTimestamp, we only need to check  result < 0
```java 
else if (hasSoughtByTimestamp) {
      completehasMessageAvailableWithValue(booleanFuture, result < 0);
}
```
 
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
