### PR TITLE
[fix][client] Fix the javadoc for startMessageIdInclusive

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -683,8 +683,7 @@ public interface ConsumerBuilder<T> extends Cloneable {
     ConsumerBuilder<T> keySharedPolicy(KeySharedPolicy keySharedPolicy);
 
     /**
-     * Sets the consumer to include the given position of any reset operation like {@link Consumer#seek(long)} or
-     * {@link Consumer#seek(MessageId)}}.
+     * Sets the consumer to include the given position of reset operation {@link Consumer#seek(MessageId)}}.
      *
      * @return the consumer builder instance
      */

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
@@ -150,7 +150,7 @@ public interface ReaderBuilder<T> extends Cloneable {
     /**
      * Set the reader to include the given position of {@link ReaderBuilder#startMessageId(MessageId)}
      *
-     * <p>This configuration option also applies for any cursor reset operation like {@link Reader#seek(MessageId)}.
+     * <p>This configuration option also applies for cursor reset operation {@link Reader#seek(MessageId)}.
      *
      * @return the reader builder instance
      */


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/23498

### Motivation
 
The `Consumer#seek(long)` and `startMessageIdInclusive` have no relation. Whether startMessageIdInclusive is present or not, Consumer#seek(long) that seek by timestamp will contain the firstMessageId.
In the code, we can see that the `Consumer#seek(long)` seekMessageId use the MessageId.earliest.

```java
@Override
public CompletableFuture<Void> seekAsync(long timestamp) {
    String seekBy = String.format("the timestamp %d", timestamp);
    long requestId = client.newRequestId();
    return seekAsyncInternal(requestId, Commands.newSeek(consumerId, requestId, timestamp),
            MessageId.earliest, timestamp, seekBy);
}
```

                                      
### Modifications
remove the `Consumer#seek(long)` in comment of `ReaderBuilder#startMessageIdInclusive` and `ConsumerBuilder#startMessageIdInclusive`
 
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
