### PR TITLE
[fix][test] Fix ManagedCursorTest.testForceCursorRecovery

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4880,6 +4880,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
                 final OpenCallback cb, final Object ctx) {
             if (ledgerErrors.containsKey(lId)) {
                 cb.openComplete(ledgerErrors.get(lId), null, ctx);
+                return;
             }
             super.asyncOpenLedger(lId, digestType, passwd, cb, ctx);
         }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4826,7 +4826,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(cursor.getReadPosition(), markDeletedPosition.getNext());
     }
 
-    @Test(invocationCount = 5000)
+    @Test
     void testForceCursorRecovery() throws Exception {
         TestPulsarMockBookKeeper bk = new TestPulsarMockBookKeeper(executor);
         factory = new ManagedLedgerFactoryImpl(metadataStore, bk);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4873,7 +4873,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
                 final OpenCallback cb, final Object ctx) {
             if (ledgerErrors.containsKey(lId)) {
                 cb.openComplete(ledgerErrors.get(lId), null, ctx);
-            }else{
+            } else {
                 super.asyncOpenLedger(lId, digestType, passwd, cb, ctx);
             }
         }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4840,24 +4840,17 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ManagedCursorInfo info = ManagedCursorInfo.newBuilder().setCursorsLedgerId(invalidLedger).build();
         CountDownLatch latch = new CountDownLatch(1);
         MutableBoolean recovered = new MutableBoolean(false);
-        AtomicBoolean callbackInvoked = new AtomicBoolean(false);
         VoidCallback callback = new VoidCallback() {
             @Override
             public void operationComplete() {
-                if (callbackInvoked.compareAndSet(false, true)) {
-                    log.info("Cursor recovery success");
-                    recovered.setValue(true);
-                    latch.countDown();
-                }
+                recovered.setValue(true);
+                latch.countDown();
             }
 
             @Override
             public void operationFailed(ManagedLedgerException exception) {
-                if (callbackInvoked.compareAndSet(false, true)) {
-                    log.error("Cursor recovery failed", exception);
-                    recovered.setValue(false);
-                    latch.countDown();
-                }
+                recovered.setValue(false);
+                latch.countDown();
             }
         };
         c1.recoverFromLedger(info, callback);
@@ -4880,9 +4873,9 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
                 final OpenCallback cb, final Object ctx) {
             if (ledgerErrors.containsKey(lId)) {
                 cb.openComplete(ledgerErrors.get(lId), null, ctx);
-                return;
+            }else{
+                super.asyncOpenLedger(lId, digestType, passwd, cb, ctx);
             }
-            super.asyncOpenLedger(lId, digestType, passwd, cb, ctx);
         }
     }
 


### PR DESCRIPTION
Fixes #23417 

### Motivation
Ideally, recoverFromLedger should only call operationComplete upon successful recovery and operationFailed upon failure. However, in the actual implementation, both methods may be called due to the following reasons:

Concurrent Execution: If recoverFromLedger is executed in different threads, it may simultaneously meet both success and failure conditions, leading to both callbacks being triggered.

After adding logs, we may see both:
* Cursor recovery success
* Cursor recovery failed

### Modifications

Use an atomic variable. Use an AtomicBoolean in the callback to mark whether the callback method has already been called, preventing duplicate calls.

### Documentation

- [ ] `doc` 
- [ ] `doc-required` 
- [x] `doc-not-needed` 
- [ ] `doc-complete` 
