### PR TITLE
[improve][broker] Make cluster metadata teardown command support metadata config path

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
@@ -53,15 +53,15 @@ public class PulsarClusterMetadataTeardown {
     @Command(name = "delete-cluster-metadata", showDefaultValues = true, scope = ScopeType.INHERIT)
     private static class Arguments {
         @Option(names = { "-zk",
-                "--zookeeper"}, description = "Local ZooKeeper quorum connection string", required = true)
+                "--zookeeper"}, description = "Local ZooKeeper quorum connection string")
         private String zookeeper;
 
         @Option(names = {"-md",
-                "--metadata-store"}, description = "Metadata Store service url. eg: zk:my-zk:2181", required = false)
+                "--metadata-store"}, description = "Metadata Store service url. eg: zk:my-zk:2181")
         private String metadataStoreUrl;
 
         @Option(names = {"-mscp",
-                "--metadata-store-config-path"}, description = "Metadata Store config path", hidden = false)
+                "--metadata-store-config-path"}, description = "Metadata Store config path")
         private String metadataStoreConfigPath;
 
         @Option(names = {
@@ -116,7 +116,7 @@ public class PulsarClusterMetadataTeardown {
         if (arguments.metadataStoreUrl == null && arguments.zookeeper == null) {
             System.err.println("Metadata store address argument is required (--metadata-store)");
             commander.usage(commander.getOut());
-            System.exit(1);
+            throw new IllegalArgumentException("Metadata store address argument is required (--metadata-store)");
         }
 
         if (arguments.metadataStoreUrl == null) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
@@ -114,7 +114,6 @@ public class PulsarClusterMetadataTeardown {
         }
 
         if (arguments.metadataStoreUrl == null && arguments.zookeeper == null) {
-            System.err.println("Metadata store address argument is required (--metadata-store)");
             commander.usage(commander.getOut());
             throw new IllegalArgumentException("Metadata store address argument is required (--metadata-store)");
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
@@ -66,6 +66,11 @@ public class PulsarClusterMetadataTeardown {
         @Option(names = { "-cs", "--configuration-store" }, description = "Configuration Store connection string")
         private String configurationStore;
 
+        @Option(names = {"-cmscp",
+                "--configuration-metadata-store-config-path"}, description = "Configuration Metadata Store config path",
+                hidden = false)
+        private String configurationStoreConfigPath;
+
         @Option(names = { "--bookkeeper-metadata-service-uri" }, description = "Metadata service uri of BookKeeper")
         private String bkMetadataServiceUri;
 
@@ -127,6 +132,7 @@ public class PulsarClusterMetadataTeardown {
             @Cleanup
             MetadataStore configMetadataStore = MetadataStoreFactory.create(arguments.configurationStore,
                     MetadataStoreConfig.builder().sessionTimeoutMillis(arguments.zkSessionTimeoutMillis)
+                            .configFilePath(arguments.configurationStoreConfigPath)
                             .metadataStoreName(MetadataStoreConfig.CONFIGURATION_METADATA_STORE).build());
             deleteRecursively(configMetadataStore, "/admin/clusters/" + arguments.cluster).join();
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataSetupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataSetupTest.java
@@ -533,7 +533,7 @@ public class ClusterMetadataSetupTest {
             log.info("ZooKeeper started at {}", hostPort);
         }
 
-        private void clear() {
+        void clear() {
             zks.getZKDatabase().clear();
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataTeardownTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ClusterMetadataTeardownTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.zookeeper;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import java.util.SortedMap;
+import org.apache.pulsar.PulsarClusterMetadataSetup;
+import org.apache.pulsar.PulsarClusterMetadataTeardown;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class ClusterMetadataTeardownTest {
+
+    private ClusterMetadataSetupTest.ZookeeperServerTest localZkS;
+
+    @BeforeClass
+    void setup() throws Exception {
+        localZkS = new ClusterMetadataSetupTest.ZookeeperServerTest(0);
+        localZkS.start();
+    }
+
+    @AfterClass
+    void teardown() throws Exception {
+        localZkS.close();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    void cleanup() {
+        localZkS.clear();
+    }
+
+    @Test
+    public void testSetupClusterMetadataAndTeardown() throws Exception {
+        String[] args1 = {
+                "--cluster", "testReSetupClusterMetadata-cluster",
+                "--zookeeper", "127.0.0.1:" + localZkS.getZookeeperPort(),
+                "--configuration-store", "127.0.0.1:" + localZkS.getZookeeperPort(),
+                "--configuration-metadata-store-config-path", "src/test/resources/conf/zk_client_enable_sasl.conf",
+                "--web-service-url", "http://127.0.0.1:8080",
+                "--web-service-url-tls", "https://127.0.0.1:8443",
+                "--broker-service-url", "pulsar://127.0.0.1:6650",
+                "--broker-service-url-tls", "pulsar+ssl://127.0.0.1:6651"
+        };
+        PulsarClusterMetadataSetup.main(args1);
+        SortedMap<String, String> data1 = localZkS.dumpData();
+        String clusterDataJson = data1.get("/admin/clusters/testReSetupClusterMetadata-cluster");
+        assertNotNull(clusterDataJson);
+        ClusterData clusterData = ObjectMapperFactory
+                .getMapper()
+                .reader()
+                .readValue(clusterDataJson, ClusterData.class);
+        assertEquals(clusterData.getServiceUrl(), "http://127.0.0.1:8080");
+        assertEquals(clusterData.getServiceUrlTls(), "https://127.0.0.1:8443");
+        assertEquals(clusterData.getBrokerServiceUrl(), "pulsar://127.0.0.1:6650");
+        assertEquals(clusterData.getBrokerServiceUrlTls(), "pulsar+ssl://127.0.0.1:6651");
+        assertFalse(clusterData.isBrokerClientTlsEnabled());
+
+        String[] args2 = {
+                "--cluster", "testReSetupClusterMetadata-cluster",
+                "--zookeeper", "127.0.0.1:" + localZkS.getZookeeperPort(),
+                "--configuration-store", "127.0.0.1:" + localZkS.getZookeeperPort(),
+                "--configuration-metadata-store-config-path", "src/test/resources/conf/zk_client_enable_sasl.conf",
+        };
+        PulsarClusterMetadataTeardown.main(args2);
+        SortedMap<String, String> data2 = localZkS.dumpData();
+        assertFalse(data2.containsKey("/admin/clusters/testReSetupClusterMetadata-cluster"));
+    }
+}


### PR DESCRIPTION
### Motivation

The pulsar configuration supported `metadataStoreConfigPath` and `configurationStoreConfigPath`, but the cluster metadata teardown command does not have a place to set the config path.

### Modifications

Make cluster metadata init command support metadata config path

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->