### PR TITLE
[fix] [broker] Fix race-condition causing repeated delete topic

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -400,7 +400,7 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
     private static MetaStoreException getException(Throwable t) {
         Throwable actEx = FutureUtil.unwrapCompletionException(t);
         if (actEx instanceof MetadataStoreException.BadVersionException) {
-            return new ManagedLedgerException.BadVersionException(t.getMessage());
+            return new ManagedLedgerException.BadVersionException(actEx.getMessage());
         } else {
             return new MetaStoreException(actEx);
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -399,8 +399,8 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
 
     private static MetaStoreException getException(Throwable t) {
         Throwable actEx = FutureUtil.unwrapCompletionException(t);
-        if (actEx instanceof MetadataStoreException.BadVersionException) {
-            return new ManagedLedgerException.BadVersionException(actEx.getMessage());
+        if (actEx instanceof MetadataStoreException.BadVersionException badVersionException) {
+            return new ManagedLedgerException.BadVersionException(badVersionException);
         } else if (actEx instanceof MetaStoreException metaStoreException){
             return metaStoreException;
         } else {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -398,10 +398,11 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
     }
 
     private static MetaStoreException getException(Throwable t) {
-        if (t.getCause() instanceof MetadataStoreException.BadVersionException) {
+        Throwable actEx = FutureUtil.unwrapCompletionException(t);
+        if (actEx instanceof MetadataStoreException.BadVersionException) {
             return new ManagedLedgerException.BadVersionException(t.getMessage());
         } else {
-            return new MetaStoreException(t);
+            return new MetaStoreException(actEx);
         }
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -401,6 +401,8 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
         Throwable actEx = FutureUtil.unwrapCompletionException(t);
         if (actEx instanceof MetadataStoreException.BadVersionException) {
             return new ManagedLedgerException.BadVersionException(actEx.getMessage());
+        } else if (actEx instanceof MetaStoreException metaStoreException){
+            return metaStoreException;
         } else {
             return new MetaStoreException(actEx);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1565,7 +1565,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 }).whenComplete((value, ex) -> {
                     if (ex != null) {
                         log.error("[{}] Error deleting topic", topic, ex);
-                        unfenceTopicToResume();
                     }
                 });
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/SameAuthParamsLookupAutoClusterFailoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/SameAuthParamsLookupAutoClusterFailoverTest.java
@@ -42,7 +42,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-@Test(groups = "flaky")
 public class SameAuthParamsLookupAutoClusterFailoverTest extends OneWayReplicatorTestBase {
 
     public void setup() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/DisabledCreateTopicToRemoteClusterForReplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/DisabledCreateTopicToRemoteClusterForReplicationTest.java
@@ -44,7 +44,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Slf4j
-@Test(groups = "flaky")
+@Test(groups = "broker")
 public class DisabledCreateTopicToRemoteClusterForReplicationTest extends OneWayReplicatorTestBase {
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -104,7 +104,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Slf4j
-@Test(groups = "flaky")
+@Test(groups = "broker")
 public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
@@ -44,7 +44,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Slf4j
-@Test(groups = "flaky")
+@Test(groups = "broker")
 public class OneWayReplicatorUsingGlobalZKTest extends OneWayReplicatorTest {
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicationTxnTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicationTxnTest.java
@@ -59,7 +59,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Slf4j
-@Test(groups = "flaky")
+@Test(groups = "broker")
 public class ReplicationTxnTest extends OneWayReplicatorTestBase {
 
     private boolean transactionBufferSegmentedSnapshotEnabled = false;


### PR DESCRIPTION
Fixes #23474

### Motivation

#### Background
A lock named `isClosingOrDeleting` prevents concurrently deleting/closing topic

---

#### Issue 1: repeated delete a topic caused by a race condition

The code that deleting the topic is like below

```java
CompletableFuture deleteFuture = () -> {
    CompletableFuture res = new CompletableFuture();
    ....
    if (success) {
        res.complete();
    } else {
        res.failed();
        // Highlight: release the lock `isClosingOrDeleting`.
        //Release the lock the first time.
        unfenceTopicToResume();
    }
};

deleteFuture.whenComplete((__ ,ex) -> {
    if (ex != null) {
        // Highlight: release the lock `isClosingOrDeleting`.
        //Release the lock the second time.
        unfenceTopicToResume();
    }
});
```

The code in `PersistentTopic.delete` acquires the lock once, but releases it twice, which breaks the locker, and leads to multiple deleting runs at the same time.

---

#### Issue 2: `MetaStoreImpl.getException` wrap a `CompletionException` to `MetaStoreException` deactivates the checker of deleting ML in the method `PersistentTopic.delete`

There is a checker that broker will assumed the ML deleting is succeed if it has been deleted before, such as bellow: 

```java
if (exception.getCause()  instanceof MetadataStoreException.NotFoundException) {
    future.complete(ctx);
} 
```

But `MetaStoreImpl.getException` wrap a `CompletionException` to `MetaStoreException`, causing the catch block to get an error like this `MetaStoreException -> CompletionException -> NotFoundException`, it breaks the checker above.


### Modifications

- Fix two issues
- Revert https://github.com/apache/pulsar/pull/23478, which marked multi tests as `flaky`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
