### PR TITLE
[fix][broker] Fix reading entries failed due to max in-flight reading

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
@@ -23,6 +23,8 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.ObservableLongCounter;
 import io.prometheus.client.Gauge;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.opentelemetry.Constants;
@@ -56,7 +58,9 @@ public class InflightReadsLimiter implements AutoCloseable {
             .help("Available space for inflight data read from storage or cache")
             .register();
 
-    private final long maxReadsInFlightSize;
+    @Setter
+    @Getter
+    private long maxReadsInFlightSize;
     private long remainingBytes;
 
     public InflightReadsLimiter(long maxReadsInFlightSize, OpenTelemetry openTelemetry) {
@@ -177,6 +181,5 @@ public class InflightReadsLimiter implements AutoCloseable {
     public boolean isDisabled() {
         return maxReadsInFlightSize <= 0;
     }
-
 
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -362,7 +362,12 @@ public class RangeEntryCacheImpl implements EntryCache {
         }
         long estimatedReadSize = (1 + lastEntry - firstEntry)
                 * (estimatedEntrySize + BOOKKEEPER_READ_OVERHEAD_PER_ENTRY);
-        if (estimatedReadSize > pendingReadsLimiter.getMaxReadsInFlightSize()) {
+        final long maxReadsInFlightSize = pendingReadsLimiter.getMaxReadsInFlightSize();
+        if (estimatedReadSize > maxReadsInFlightSize) {
+            String message = "Estimated read size " + estimatedReadSize
+                    + " is larger than managedLedgerMaxReadsInFlightSize " + maxReadsInFlightSize
+                    + " please check managedLedgerMaxReadsInFlightSizeInMB";
+            log.warn(message);
             pendingReadsLimiter.setMaxReadsInFlightSize(estimatedReadSize);
         }
         final AsyncCallbacks.ReadEntriesCallback callback;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -362,6 +362,9 @@ public class RangeEntryCacheImpl implements EntryCache {
         }
         long estimatedReadSize = (1 + lastEntry - firstEntry)
                 * (estimatedEntrySize + BOOKKEEPER_READ_OVERHEAD_PER_ENTRY);
+        if (estimatedReadSize > pendingReadsLimiter.getMaxReadsInFlightSize()) {
+            pendingReadsLimiter.setMaxReadsInFlightSize(estimatedReadSize);
+        }
         final AsyncCallbacks.ReadEntriesCallback callback;
         InflightReadsLimiter.Handle newHandle = pendingReadsLimiter.acquire(estimatedReadSize, handle);
         if (!newHandle.success) {


### PR DESCRIPTION
### Motivation

If the `estimatedReadSize` larger than the `managedLedgerMaxReadsInFlightSizeInMB`, reading entries will fail.

```
2024-10-10T14:31:46,939+0000 [BookKeeperClientWorker-OrderedExecutor-2-0] ERROR org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImpl - Time-out elapsed while acquiring enough permits on the memory limiter to read from ledger 114226, public/default/persistent/test-partition-0, estimated read size 120875300 bytes for 100 entries (check managedLedgerMaxReadsInFlightSizeInMB)
```


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


