### PR TITLE
[fix][test] Fix SimpleProducerConsumerTest.testMultiTopicsConsumerImplPauseForManualSubscription 

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -3557,7 +3557,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         }
 
         // 6. should not consume any messages
-        Awaitility.await().untilAsserted(() -> assertNull(consumer.receive(RECEIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS)));
+        Message<byte[]> msg = consumer.receive(2, TimeUnit.SECONDS);
+        assertNull(msg, "Expected no messages to be consumed while consumer is paused.");
 
         // 7. resume multi-topic consumer
         consumer.resume();


### PR DESCRIPTION
Fixes #23485

### Motivation

`Awaitility.await().untilAsserted(() -> assertNull(consumer.receive(RECEIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS)));
`
The problem lies in this line of code. Through the logs, it can be seen that the exception situation is two calls to consumer. receive. The first call obtains null, and after the successful assertion returns, the second call will receive a message, resulting in one less total call.

![image](https://github.com/user-attachments/assets/36aa3738-6368-4d65-91d0-fbfeb8589c15)

![企业微信截图_17302904118685](https://github.com/user-attachments/assets/6af77600-0503-4c4e-b39b-aae1830ef27e)


### Modifications

Change assertion related code

### Verifying this change

![企业微信截图_17302951303412](https://github.com/user-attachments/assets/b61fb0e1-6631-4b25-b0ab-5e4dd2ba3f1b)

### Documentation

- [ ] `doc` 
- [ ] `doc-required` 
- [x] `doc-not-needed` 
- [ ] `doc-complete` 
