### PR TITLE
[fix][sec] Replace bcprov-jdk15on dependency with bcprov-jdk18-on

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -964,6 +964,12 @@ flexible messaging model and an intuitive client API.</description>
 
       <dependency>
         <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk18on</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
       </dependency>
@@ -1324,6 +1330,10 @@ flexible messaging model and an intuitive client API.</description>
             <groupId>dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -1334,6 +1344,10 @@ flexible messaging model and an intuitive client API.</description>
           <exclusion>
             <groupId>dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -1346,6 +1360,10 @@ flexible messaging model and an intuitive client API.</description>
             <groupId>dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -1356,6 +1374,10 @@ flexible messaging model and an intuitive client API.</description>
           <exclusion>
             <groupId>dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/pulsar-io/hdfs3/pom.xml
+++ b/pulsar-io/hdfs3/pom.xml
@@ -71,7 +71,15 @@
           <groupId>org.apache.avro</groupId>
           <artifactId>avro</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
     </dependency>
 
     <dependency>

--- a/tiered-storage/file-system/pom.xml
+++ b/tiered-storage/file-system/pom.xml
@@ -53,9 +53,16 @@
                     <groupId>dnsjava</groupId>
                     <artifactId>dnsjava</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs-client</artifactId>
@@ -84,6 +91,10 @@
                 <exclusion>
                     <groupId>dnsjava</groupId>
                     <artifactId>dnsjava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -132,6 +143,10 @@
                 <exclusion>
                     <groupId>dnsjava</groupId>
                     <artifactId>dnsjava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
### Motivation

OWASP dependency check shows an error for bcprov-jdk15-on dependency.

```
One or more dependencies were identified with known vulnerabilities in Apache Pulsar :: Tiered Storage :: Parent:

bcprov-jdk15on-1.70.jar (pkg:maven/org.bouncycastle/bcprov-jdk15on@1.70, cpe:2.3:a:bouncycastle:bouncy-castle-crypto-package:1.70:*:*:*:*:*:*:*, cpe:2.3:a:bouncycastle:bouncy_castle_crypto_package:1.70:*:*:*:*:*:*:*, cpe:2.3:a:bouncycastle:bouncy_castle_for_java:1.70:*:*:*:*:*:*:*, cpe:2.3:a:bouncycastle:legion-of-the-bouncy-castle-java-crytography-api:1.70:*:*:*:*:*:*:*, cpe:2.3:a:bouncycastle:the_bouncy_castle_crypto_package_for_java:1.70:*:*:*:*:*:*:*) : CVE-2024-34447, CVE-2024-29857, CVE-2024-30171, CVE-2023-33202, CVE-2023-33201
```

### Modifications

Replace outdated bcprov-jdk15-on dependency with bcprov-jdk18-on which continues to be updated.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->