### PR TITLE
[improve][test] Disable OTel autoconfigured exporters in tests

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
@@ -28,6 +28,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.Map;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
@@ -207,6 +208,9 @@ public class InflightReadsLimiterTest {
         var metricReader = InMemoryMetricReader.create();
         var openTelemetry = AutoConfiguredOpenTelemetrySdk.builder()
                 .disableShutdownHook()
+                .addPropertiesSupplier(() -> Map.of("otel.metrics.exporter", "none",
+                        "otel.traces.exporter", "none",
+                        "otel.logs.exporter", "none"))
                 .addMeterProviderCustomizer((builder, __) -> builder.registerMetricReader(metricReader))
                 .build()
                 .getOpenTelemetrySdk();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/BrokerOpenTelemetryTestUtil.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/BrokerOpenTelemetryTestUtil.java
@@ -36,10 +36,18 @@ public class BrokerOpenTelemetryTestUtil {
             sdkBuilder.addMeterProviderCustomizer(
                     (meterProviderBuilder, __) -> meterProviderBuilder.registerMetricReader(reader));
             sdkBuilder.disableShutdownHook();
+            disableExporters(sdkBuilder);
             sdkBuilder.addPropertiesSupplier(
                     () -> Map.of(OpenTelemetryService.OTEL_SDK_DISABLED_KEY, "false",
                             "otel.java.enabled.resource.providers", "none"));
         };
+    }
+
+    public static void disableExporters(AutoConfiguredOpenTelemetrySdkBuilder sdkBuilder) {
+        sdkBuilder.addPropertiesSupplier(() ->
+                Map.of("otel.metrics.exporter", "none",
+                        "otel.traces.exporter", "none",
+                        "otel.logs.exporter", "none"));
     }
 
     public static void assertMetricDoubleSumValue(Collection<MetricData> metrics, String metricName,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
@@ -761,7 +761,8 @@ public class PulsarTestContext implements AutoCloseable {
                 var reader = InMemoryMetricReader.create();
                 openTelemetryMetricReader(reader);
                 registerCloseable(reader);
-                openTelemetrySdkBuilderCustomizer = BrokerOpenTelemetryTestUtil.getOpenTelemetrySdkBuilderConsumer(reader);
+                openTelemetrySdkBuilderCustomizer =
+                        BrokerOpenTelemetryTestUtil.getOpenTelemetrySdkBuilderConsumer(reader);
             } else {
                 openTelemetrySdkBuilderCustomizer = null;
             }

--- a/pulsar-opentelemetry/src/test/java/org/apache/pulsar/opentelemetry/OpenTelemetryServiceTest.java
+++ b/pulsar-opentelemetry/src/test/java/org/apache/pulsar/opentelemetry/OpenTelemetryServiceTest.java
@@ -76,6 +76,11 @@ public class OpenTelemetryServiceTest {
                         (sdkMeterProviderBuilder, __) -> sdkMeterProviderBuilder.registerMetricReader(extraReader));
             }
             autoConfigurationCustomizer.disableShutdownHook();
+            // disable all autoconfigured exporters
+            autoConfigurationCustomizer.addPropertiesSupplier(() ->
+                    Map.of("otel.metrics.exporter", "none",
+                            "otel.traces.exporter", "none",
+                            "otel.logs.exporter", "none"));
             autoConfigurationCustomizer.addPropertiesSupplier(() -> extraProperties);
         };
     }


### PR DESCRIPTION
### Motivation

Running InflightReadsLimiterTest is slow and prints these warnings
```
Nov 01, 2024 4:37:19 PM io.opentelemetry.sdk.internal.ThrottlingLogger doLog
WARNING: Failed to export metrics. Server responded with gRPC status code 2. Error message: Failed to connect to localhost/[0:0:0:0:0:0:0:1]:4317
Nov 01, 2024 4:37:21 PM io.opentelemetry.sdk.internal.ThrottlingLogger doLog
WARNING: Failed to export metrics. Server responded with gRPC status code 2. Error message: Failed to connect to localhost/[0:0:0:0:0:0:0:1]:4317
Nov 01, 2024 4:37:26 PM io.opentelemetry.sdk.internal.ThrottlingLogger doLog
WARNING: Failed to export metrics. Server responded with gRPC status code 2. Error message: Failed to connect to localhost/[0:0:0:0:0:0:0:1]:4317
Nov 01, 2024 4:37:31 PM io.opentelemetry.sdk.internal.ThrottlingLogger doLog
WARNING: Failed to export metrics. Server responded with gRPC status code 2. Error message: Failed to connect to localhost/[0:0:0:0:0:0:0:1]:4317
```

Default OTel exporters should be disabled in tests by default.

### Modifications

Disable default OTel exporters in tests.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->