### PR TITLE
[fix][test] Fix SimpleProducerConsumerTest.testMultiTopicsConsumerImplPauseForManualSubscription

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -3520,7 +3520,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             producer3.send(message.getBytes(UTF_8));
         }
 
-        int receiverQueueSize = 1;
+        int receiverQueueSize = 6;
         Consumer<byte[]> consumer = pulsarClient
             .newConsumer()
             .topics(Lists.newArrayList(topicNameBase + "1", topicNameBase + "2"))


### PR DESCRIPTION
Fixes #23485

### Motivation

After calling `pause()`, there are still messages retained in `incomingMessages` because the internal `consumer `has already pre fetched a message and placed it in `incomingMessages`.

When calling pause(), these pre fetched messages are not immediately cleared, causing instability as messages can still be received during testing.

### Modifications

A larger `receiverQueueSize` allows more messages to be prefetched and cached, ensuring that messages in the buffer are effectively managed after a pause operation, without causing message interference during testing.

In a multi topic consumer environment, the `receiverQueueSize `should be set reasonably. For multi topic consumers, the receiver Queue Size should be large enough to ensure that each internal ConsumerImpl instance can independently perform message prefetching without interfering with each other.

receiverQueueSize  1 -> 6

### Verifying this change

![image](https://github.com/user-attachments/assets/c8af10dc-2561-4660-9b6e-61f1ef8df76d)



### Documentation

- [ ] `doc` 
- [ ] `doc-required` 
- [x] `doc-not-needed` 
- [ ] `doc-complete` 
