### PR TITLE
[improve][broker] PIP-380: Support-setting-up-specific-namespaces-to-skipping-the-load-shedding

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2960,6 +2960,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private boolean loadBalancerSheddingBundlesWithPoliciesEnabled = false;
 
     @FieldContext(
+            dynamic = true,
+            category = CATEGORY_LOAD_BALANCER,
+            doc = "The namespaces skip for load shedding"
+    )
+    private Set<String> loadBalancerSheddingExcludedNamespaces = new TreeSet<>();
+
+    @FieldContext(
             category = CATEGORY_LOAD_BALANCER,
             doc = "Time to wait before fixing any stuck in-flight service unit states. "
                     + "The leader monitor fixes any in-flight service unit(bundle) states "

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2962,9 +2962,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
             dynamic = true,
             category = CATEGORY_LOAD_BALANCER,
-            doc = "The namespaces skip for load shedding"
+            doc = "The namespaces to be excluded from load shedding"
     )
-    private Set<String> loadBalancerSheddingExcludedNamespaces = new TreeSet<>();
+    private Set<String> loadBalancerSheddingExcludedNamespaces = new HashSet<>();
 
     @FieldContext(
             category = CATEGORY_LOAD_BALANCER,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -84,6 +84,7 @@ import org.apache.pulsar.broker.loadbalance.extensions.store.LoadDataStoreFactor
 import org.apache.pulsar.broker.loadbalance.extensions.strategy.BrokerSelectionStrategy;
 import org.apache.pulsar.broker.loadbalance.extensions.strategy.BrokerSelectionStrategyFactory;
 import org.apache.pulsar.broker.loadbalance.extensions.strategy.LeastResourceUsageWithWeight;
+import org.apache.pulsar.broker.loadbalance.extensions.strategy.RoundRobinBrokerSelectionStrategy;
 import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared;
 import org.apache.pulsar.broker.loadbalance.impl.SimpleResourceAllocationPolicies;
 import org.apache.pulsar.broker.namespace.LookupOptions;
@@ -160,6 +161,8 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
 
     @Getter
     private final BrokerSelectionStrategy brokerSelectionStrategy;
+
+    private final BrokerSelectionStrategy roundRobinBrokerSelectionStrategy;
 
     @Getter
     private final List<BrokerFilter> brokerFilterPipeline;
@@ -254,6 +257,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
         this.brokerFilterPipeline.add(new BrokerMaxTopicCountFilter());
         this.brokerFilterPipeline.add(new BrokerVersionFilter());
         this.brokerSelectionStrategy = createBrokerSelectionStrategy();
+        this.roundRobinBrokerSelectionStrategy = new RoundRobinBrokerSelectionStrategy();
     }
 
     public static boolean isLoadManagerExtensionEnabled(PulsarService pulsar) {
@@ -636,6 +640,15 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
                             return Optional.empty();
                         }
                         Set<String> candidateBrokers = availableBrokerCandidates.keySet();
+                        Set<String> sheddingExcludedNamespaces = conf.getLoadBalancerSheddingExcludedNamespaces();
+
+                        var namespace = NamespaceBundle.getBundleNamespace(bundle.toString());
+                        if (sheddingExcludedNamespaces.contains(namespace)) {
+                            if (debug(conf, log)) {
+                                log.info("Use round robin broker selector for {}", bundle);
+                            }
+                            return roundRobinBrokerSelectionStrategy.select(candidateBrokers, bundle, context);
+                        }
                         return getBrokerSelectionStrategy().select(candidateBrokers, bundle, context);
                     });
                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/models/TopKBundles.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/models/TopKBundles.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -68,8 +69,10 @@ public class TopKBundles {
     public void update(Map<String, NamespaceBundleStats> bundleStats, int topk) {
         arr.clear();
         try {
+            var conf = pulsar.getConfiguration();
             var isLoadBalancerSheddingBundlesWithPoliciesEnabled =
-                    pulsar.getConfiguration().isLoadBalancerSheddingBundlesWithPoliciesEnabled();
+                    conf.isLoadBalancerSheddingBundlesWithPoliciesEnabled();
+            Set<String> sheddingExcludedNamespaces = conf.getLoadBalancerSheddingExcludedNamespaces();
             for (var etr : bundleStats.entrySet()) {
                 String bundle = etr.getKey();
                 var stat = etr.getValue();
@@ -79,10 +82,14 @@ public class TopKBundles {
                     continue;
                 }
                 // TODO: do not filter system topic while shedding
-                if (NamespaceService.isSystemServiceNamespace(NamespaceBundle.getBundleNamespace(bundle))) {
+                String namespace = NamespaceBundle.getBundleNamespace(bundle);
+                if (NamespaceService.isSystemServiceNamespace(namespace)) {
                     continue;
                 }
                 if (!isLoadBalancerSheddingBundlesWithPoliciesEnabled && hasPolicies(bundle)) {
+                    continue;
+                }
+                if (sheddingExcludedNamespaces.contains(namespace)) {
                     continue;
                 }
                 arr.add(etr);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedder.java
@@ -506,7 +506,8 @@ public class TransferShedder implements NamespaceUnloadStrategy {
                     final String namespaceName = NamespaceBundle.getBundleNamespace(bundle);
                     if (sheddingExcludedNamespaces.contains(namespaceName)) {
                         if (debugMode) {
-                            log.info("Skipping load shedding for namespace {}", namespaceName);
+                            log.info(String.format(CANNOT_UNLOAD_BUNDLE_MSG
+                                    + " Bundle namespace has been found in sheddingExcludedNamespaces", bundle));
                         }
                         continue;
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedder.java
@@ -493,12 +493,20 @@ public class TransferShedder implements NamespaceUnloadStrategy {
                 }
 
                 int remainingTopBundles = maxBrokerTopBundlesLoadData.size();
+                Set<String> sheddingExcludedNamespaces = conf.getLoadBalancerSheddingExcludedNamespaces();
                 for (var e : maxBrokerTopBundlesLoadData) {
                     String bundle = e.bundleName();
                     if (channel != null && !channel.isOwner(bundle, maxBroker)) {
                         if (debugMode) {
                             log.warn(String.format(CANNOT_UNLOAD_BUNDLE_MSG
                                     + " MaxBroker:%s is not the owner.", bundle, maxBroker));
+                        }
+                        continue;
+                    }
+                    final String namespaceName = NamespaceBundle.getBundleNamespace(bundle);
+                    if (sheddingExcludedNamespaces.contains(namespaceName)) {
+                        if (debugMode) {
+                            log.info("Skipping load shedding for namespace {}", namespaceName);
                         }
                         continue;
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/RoundRobinBrokerSelectionStrategy.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/RoundRobinBrokerSelectionStrategy.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.extensions.strategy;
+
+import java.util.Optional;
+import java.util.Set;
+import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
+import org.apache.pulsar.broker.loadbalance.impl.RoundRobinBrokerSelector;
+import org.apache.pulsar.common.naming.ServiceUnitId;
+
+/**
+ * Simple Round Robin Broker Selection Strategy.
+ */
+public class RoundRobinBrokerSelectionStrategy implements BrokerSelectionStrategy {
+    private final RoundRobinBrokerSelector selector = new RoundRobinBrokerSelector();
+
+    @Override
+    public Optional<String> select(Set<String> brokers, ServiceUnitId bundle, LoadManagerContext context) {
+        return selector.selectBroker(brokers, null, null, context.brokerConfiguration());
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -151,6 +151,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
     // Strategy used to determine where new topics should be placed.
     private ModularLoadManagerStrategy placementStrategy;
 
+    private ModularLoadManagerStrategy roundRobinBrokerSelector;
+
     // Policies used to determine which brokers are available for particular namespaces.
     private SimpleResourceAllocationPolicies policies;
 
@@ -251,6 +253,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         defaultStats.msgRateOut = DEFAULT_MESSAGE_RATE;
 
         placementStrategy = ModularLoadManagerStrategy.create(conf);
+        roundRobinBrokerSelector = new RoundRobinBrokerSelector();
         policies = new SimpleResourceAllocationPolicies(pulsar);
         filterPipeline.add(new BrokerLoadManagerClassFilter());
         filterPipeline.add(new BrokerVersionFilter());
@@ -630,6 +633,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         final Map<String, Long> recentlyUnloadedBundles = loadData.getRecentlyUnloadedBundles();
         recentlyUnloadedBundles.keySet().removeIf(e -> recentlyUnloadedBundles.get(e) < timeout);
 
+        Set<String> sheddingExcludedNamespaces = conf.getLoadBalancerSheddingExcludedNamespaces();
         final Multimap<String, String> bundlesToUnload = loadSheddingStrategy.findBundlesForUnloading(loadData, conf);
 
         bundlesToUnload.asMap().forEach((broker, bundles) -> {
@@ -637,6 +641,13 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
             bundles.forEach(bundle -> {
                 final String namespaceName = LoadManagerShared.getNamespaceNameFromBundleName(bundle);
                 final String bundleRange = LoadManagerShared.getBundleRangeFromBundleName(bundle);
+                if (sheddingExcludedNamespaces.contains(namespaceName)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] Skipping load shedding for namespace {}",
+                                loadSheddingStrategy.getClass().getSimpleName(), namespaceName);
+                    }
+                    return;
+                }
                 if (!shouldNamespacePoliciesUnload(namespaceName, bundleRange, broker)) {
                     return;
                 }
@@ -914,8 +925,18 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                         brokerTopicLoadingPredicate);
             }
 
-            // Choose a broker among the potentially smaller filtered list, when possible
-            Optional<String> broker = placementStrategy.selectBroker(brokerCandidateCache, data, loadData, conf);
+            Optional<String> broker;
+            Set<String> sheddingExcludedNamespaces = conf.getLoadBalancerSheddingExcludedNamespaces();
+            String namespaceNameFromBundleName = LoadManagerShared.getNamespaceNameFromBundleName(bundle);
+            if (sheddingExcludedNamespaces.contains(namespaceNameFromBundleName)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Use round robin broker selector for {}", bundle);
+                }
+                broker = roundRobinBrokerSelector.selectBroker(brokerCandidateCache, data, loadData, conf);
+            } else {
+                // Choose a broker among the potentially smaller filtered list, when possible
+                broker = placementStrategy.selectBroker(brokerCandidateCache, data, loadData, conf);
+            }
             if (log.isDebugEnabled()) {
                 log.debug("Selected broker {} from candidate brokers {}", broker, brokerCandidateCache);
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/models/TopKBundlesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/models/TopKBundlesTest.java
@@ -124,8 +124,10 @@ public class TopKBundlesTest {
         stats1.msgRateIn = 500;
         stats1.msgThroughputOut = 10;
         bundleStats.put("pulsar/system/0x00000000_0x0FFFFFFF", stats1);
+
         NamespaceBundleStats stats2 = new NamespaceBundleStats();
         stats2.msgRateIn = 10000;
+        stats2.msgThroughputOut = 10;
         bundleStats.put(bundle1, stats2);
 
         topKBundles.update(bundleStats, 2);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/models/TopKBundlesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/models/TopKBundlesTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared;
@@ -123,6 +124,25 @@ public class TopKBundlesTest {
         stats1.msgRateIn = 500;
         stats1.msgThroughputOut = 10;
         bundleStats.put("pulsar/system/0x00000000_0x0FFFFFFF", stats1);
+        NamespaceBundleStats stats2 = new NamespaceBundleStats();
+        stats2.msgRateIn = 10000;
+        bundleStats.put(bundle1, stats2);
+
+        topKBundles.update(bundleStats, 2);
+
+        assertEquals(topKBundles.getLoadData().getTopBundlesLoadData().size(), 1);
+        var top0 = topKBundles.getLoadData().getTopBundlesLoadData().get(0);
+        assertEquals(top0.bundleName(), bundle1);
+    }
+
+    @Test
+    public void testSheddingExcludedNamespaces() {
+        Map<String, NamespaceBundleStats> bundleStats = new HashMap<>();
+        var topKBundles = new TopKBundles(pulsar);
+        pulsar.getConfiguration().setLoadBalancerSheddingExcludedNamespaces(Set.of("my-tenant/my-namespace2"));
+        NamespaceBundleStats stats1 = new NamespaceBundleStats();
+        stats1.msgRateIn = 500;
+        bundleStats.put("my-tenant/my-namespace2/0x00000000_0x0FFFFFFF", stats1);
 
         NamespaceBundleStats stats2 = new NamespaceBundleStats();
         stats2.msgRateIn = 10000;


### PR DESCRIPTION
PIP: PIP-380 #23304

### Motivation

https://github.com/apache/pulsar/pull/23304

### Modifications

Add a new configuration `loadBalancerSheddingExcludedNamespaces` to allow disabling the load balancer shedding for specific namespaces.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
