### PR TITLE
[fix][test] Fix DeadLetterTopicTest.testDeadLetterTopicWithInitialSubscriptionAndMultiConsumers

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
@@ -1010,7 +1010,7 @@ public class DeadLetterTopicTest extends ProducerConsumerBase {
                         .maxRedeliverCount(maxRedeliveryCount)
                         .initialSubscriptionName(dlqInitialSub)
                         .build())
-                .receiverQueueSize(100)
+                .receiverQueueSize(20)
                 .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
                 .subscribe();
 
@@ -1023,7 +1023,7 @@ public class DeadLetterTopicTest extends ProducerConsumerBase {
                         .maxRedeliverCount(maxRedeliveryCount)
                         .initialSubscriptionName(dlqInitialSub)
                         .build())
-                .receiverQueueSize(100)
+                .receiverQueueSize(20)
                 .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
                 .subscribe();
 


### PR DESCRIPTION
Fixes #23542

### Motivation

The original `receiverQueueSize `was 100, and the producer generated a total of 100 messages. It is possible that all messages were put into the dead letter queue by one consumer, resulting in assertion failure.

### Modifications

Reduce the size of the `receiverQueueSize `to ensure that every consumer processes the message.

`receiverQueueSize `：100 -> 20
### Verifying this change

![image](https://github.com/user-attachments/assets/d564d59b-8c17-4381-a55d-6540ea729ec6)

The last test was manually cancelled.

### Documentation

- [ ] `doc` 
- [ ] `doc-required` 
- [x] `doc-not-needed` 
- [ ] `doc-complete` 
