### PR TITLE
[fix] [admin] Fix lookup get a null result if uses proxy

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/LookupImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/LookupImpl.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import javax.ws.rs.client.WebTarget;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.admin.Lookup;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.admin.Topics;
@@ -57,7 +58,8 @@ public class LookupImpl extends BaseResource implements Lookup {
         WebTarget path = v2lookup.path(prefix).path(topicName.getLookupName());
 
         return asyncGetRequest(path, new FutureCallback<LookupData>() {})
-                .thenApply(lookupData -> useTls ? lookupData.getBrokerUrlTls() : lookupData.getBrokerUrl());
+                .thenApply(lookupData -> useTls && StringUtils.isNotBlank(lookupData.getBrokerUrlTls())
+                        ? lookupData.getBrokerUrlTls() : lookupData.getBrokerUrl());
     }
 
     @Override


### PR DESCRIPTION
### Motivation

If the user deploys a cluster with proxy, and network topology like this: Client -> Proxy(with TLS) -> Broker(without TLS)

When the user calls `pulsar-admin topics lookup <topic name>`, the user will get a `null` response.

But the exact value that the broker responded to is below:

```json
{
	"brokerUrl": "pulsar://broker-1.com:6650",
	"httpUrl": "http://broker-1.com:8080",
	"brokerUrlSsl": ""
}
```

It is caused by the pulsar-admin client's issue: https://github.com/apache/pulsar/blob/master/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/LookupImpl.java#L60

```java
if (client.useTls) {
  return response.brokerUrlSsl; // even if it is null 
}
```

### Modifications

- fix the issue
- the test is hard to write, so I skipped to write a test


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
