### PR TITLE
[fix][client] Fix race-condition causing doReconsumeLater to hang when creating retryLetterProducer has failed

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -750,6 +750,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             } catch (Exception e) {
                 result.completeExceptionally(e);
             }
+        } else {
+            result.completeExceptionally(new PulsarClientException("Retry letter producer is null."));
         }
         MessageId finalMessageId = messageId;
         result.exceptionally(ex -> {


### PR DESCRIPTION
### Motivation

When `retryLetterProducer` creation fails, `retryLetterProducer` will be set to null. So `retryLetterProducer==null `may occur when race-condition is present, at this time, the results cannot be completed.

Only handle the situation when retryLetterProducer is not equal to null:
https://github.com/apache/pulsar/blob/3f12269d8d99e514cf48ef6d57fc3928d37b3646/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java#L678


### Modifications
When `retryLetterProducer==null`, mark the result as an completeExceptionally.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->