### PR TITLE
[improve][broker] Support cleanup `replication cluster` and `allowed cluster` when cluster metadata teardown

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
@@ -162,7 +162,6 @@ public class PulsarClusterMetadataTeardown {
                             .configFilePath(arguments.configurationStoreConfigPath)
                             .metadataStoreName(MetadataStoreConfig.CONFIGURATION_METADATA_STORE).build());
             PulsarResources resources = new PulsarResources(metadataStore, configMetadataStore);
-            resources.getClusterResources().deleteCluster(arguments.cluster);
             // Cleanup replication cluster from all tenants and namespaces
             TenantResources tenantResources = resources.getTenantResources();
             NamespaceResources namespaceResources = resources.getNamespaceResources();
@@ -176,6 +175,12 @@ public class PulsarClusterMetadataTeardown {
                     });
                 }
                 removeCurrentClusterFromAllowedClusters(tenantResources, tenant, arguments.cluster);
+            }
+            try {
+                resources.getClusterResources().deleteCluster(arguments.cluster);
+            } catch (MetadataStoreException.NotFoundException ex) {
+                // Ignore if the cluster does not exist
+                log.info("Cluster metadata for '{}' does not exist.", arguments.cluster);
             }
         }
 


### PR DESCRIPTION
### Motivation

When executing the `delete-cluster-metadata` command, it should remove the current cluster from the `replication cluster` and `allowed cluster`, otherwise the cluster will still replicate the data to a deleted cluster.

### Modifications

Support cleanup `replication cluster` and `allowed cluster` when cluster metadata teardown

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->