### PR TITLE
[improve][broker]Restrict the creation of topics with "-partition--x"

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -3529,6 +3529,12 @@ public class BrokerService implements Closeable {
             return CompletableFuture.completedFuture(true);
         }
 
+        // If this topic name contains "-partition--x" , not allow to be created automatically.
+        if (topicName.getLocalName().contains(TopicName.PARTITIONED_TOPIC_SUFFIX)
+                && topicName.getPartitionIndex() == -1) {
+            return CompletableFuture.completedFuture(false);
+        }
+
         final boolean allowed;
         AutoTopicCreationOverride autoTopicCreationOverride = getAutoTopicCreationOverride(topicName, policies);
         if (autoTopicCreationOverride != null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
@@ -587,4 +587,19 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
 
     }
 
+    @Test
+    public void testAutoPartitionedTopicNameWithPartitionCreation() throws Exception {
+        pulsar.getConfiguration().setAllowAutoTopicCreation(true);
+        pulsar.getConfiguration().setAllowAutoTopicCreationType(TopicType.PARTITIONED);
+        pulsar.getConfiguration().setDefaultNumPartitions(3);
+
+        final String topicString = "persistent://prop/ns-abc/testTopic-partition--1";
+
+        Assert.assertThrows(PulsarClientException.NotFoundException.class,
+                ()-> pulsarClient.newProducer().topic(topicString).create());
+
+    }
+
+
+
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonDurableSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonDurableSubscriptionTest.java
@@ -425,7 +425,7 @@ public class NonDurableSubscriptionTest extends ProducerConsumerBase {
         // Ledger id and entry id both are Long.MAX_VALUE.
         log.info("start test s5");
         String s5 = "s5";
-        MessageIdImpl startMessageId5 = new MessageIdImpl(currentLedger.getId() + 1, Long.MAX_VALUE, -1);
+        MessageIdImpl startMessageId5 = new MessageIdImpl(Long.MAX_VALUE, Long.MAX_VALUE, -1);
         Reader<String> reader5 = pulsarClient.newReader(Schema.STRING).topic(topicName).subscriptionName(s5)
                 .receiverQueueSize(0).startMessageId(startMessageId5).create();
         ManagedLedgerInternalStats.CursorStats cursor5 = admin.topics().getInternalStats(topicName).cursors.get(s5);
@@ -448,7 +448,7 @@ public class NonDurableSubscriptionTest extends ProducerConsumerBase {
         assertEquals(p6.getEntryId(), 0);
         reader6.close();
 
-        // Larger than the latest ledger, and entry id is Long.MAX_VALUE.
+        // Ledger id equals LAC, and entry id is Long.MAX_VALUE.
         log.info("start test s7");
         String s7 = "s7";
         MessageIdImpl startMessageId7 = new MessageIdImpl(ledgers.get(ledgers.size() - 1), Long.MAX_VALUE, -1);
@@ -464,7 +464,7 @@ public class NonDurableSubscriptionTest extends ProducerConsumerBase {
         // A middle ledger id, and entry id is "-1".
         log.info("start test s8");
         String s8 = "s8";
-        MessageIdImpl startMessageId8 = new MessageIdImpl(ledgers.get(2), 0, -1);
+        MessageIdImpl startMessageId8 = new MessageIdImpl(ledgers.get(2), -1, -1);
         Reader<String> reader8 = pulsarClient.newReader(Schema.STRING).topic(topicName).subscriptionName(s8)
                 .receiverQueueSize(0).startMessageId(startMessageId8).create();
         ManagedLedgerInternalStats.CursorStats cursor8 = admin.topics().getInternalStats(topicName).cursors.get(s8);
@@ -474,7 +474,7 @@ public class NonDurableSubscriptionTest extends ProducerConsumerBase {
         assertEquals(p8.getEntryId(), 0);
         reader8.close();
 
-        // Larger than the latest ledger, and entry id is Long.MAX_VALUE.
+        // A middle ledger id, and entry id is Long.MAX_VALUE.
         log.info("start test s9");
         String s9 = "s9";
         MessageIdImpl startMessageId9 = new MessageIdImpl(ledgers.get(2), Long.MAX_VALUE, -1);
@@ -488,7 +488,7 @@ public class NonDurableSubscriptionTest extends ProducerConsumerBase {
         assertEquals(p9.getEntryId(), 0);
         reader9.close();
 
-        // Larger than the latest ledger, and entry id equals with the max entry id of this ledger.
+        // A middle ledger id, and entry id equals with the max entry id of this ledger.
         log.info("start test s10");
         String s10 = "s10";
         MessageIdImpl startMessageId10 = new MessageIdImpl(ledgers.get(2), 0, -1);


### PR DESCRIPTION
### Motivation
If you actively create a topic with "-partition--x" (x is an integer)(for example, "peisisten://tenant-name/ns-name/topic-name-partition--1"), the topic can be created successfully, and a node with partition 3 will be attached to the zk. But it is not a partition topic
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

<!-- Describe the modifications you've done. -->
By modifying the isAllowAutoTopicCreationAsync logic () method, when the topic name contains "- partiton - x" (x is an integer), trigger logic returns false
<img width="897" alt="image" src="https://github.com/user-attachments/assets/63adddbb-57cf-4942-87db-5aa9c5f16337">



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
