### PR TITLE
[improve][admin] Print error log if handle http response fails

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
@@ -272,7 +272,11 @@ public class AsyncHttpConnector implements Connector, AsyncHttpRequestExecutor {
                 if (response.hasResponseBody()) {
                     jerseyResponse.setEntityStream(response.getResponseBodyAsStream());
                 }
-                callback.response(jerseyResponse);
+                try {
+                    callback.response(jerseyResponse);
+                } catch (Exception ex) {
+                    log.error("failed to handle the http response {}", jerseyResponse, ex);
+                }
             }
         }));
         return responseFuture;


### PR DESCRIPTION
### Motivation

When users are calling `pulsar-admin` API, and there is an internal error( such as a deserialize JSON error), there is no error log.

You can test it this way:
- add a method getMsgRateIn() for `TopicStatsImpl`, and return a `String` value(such as `abc`), which will make the `response.msgRateIn` as a String value `abc`.
- call `pulsar-admin topics stats`
  - You will get nothing, and no error log is printed. 

### Modifications

Print error log if handle HTTP response fails

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x