### PR TITLE
[improve][consumer] Optimizing Exception Handling and Logging in `MultiTopicsConsumerImpl`

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -372,7 +372,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
     @Override
     protected Message<T> internalReceive() throws PulsarClientException {
-        Message<T> message;
+        Message<T> message = null;
         try {
             if (incomingMessages.isEmpty()) {
                 expectMoreIncomingMessages();
@@ -383,6 +383,12 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             unAckedMessageTracker.add(message.getMessageId(), message.getRedeliveryCount());
             resumeReceivingFromPausedConsumersIfNeeded();
             return beforeConsume(message);
+        } catch (IllegalArgumentException e) {
+            log.error("Validation failed: Expected instance of TopicMessageImpl but received {}. Message ID: {}",
+                    message != null ? message.getClass().getName() : "null",
+                    message != null ? message.getMessageId() : "N/A",
+                    e);
+            throw new PulsarClientException("Invalid message type received", e);
         } catch (Exception e) {
             ExceptionHandler.handleInterruptedException(e);
             throw PulsarClientException.unwrap(e);
@@ -391,7 +397,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
     @Override
     protected Message<T> internalReceive(long timeout, TimeUnit unit) throws PulsarClientException {
-        Message<T> message;
+        Message<T> message = null;
         try {
             if (incomingMessages.isEmpty()) {
                 expectMoreIncomingMessages();
@@ -405,6 +411,12 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             }
             resumeReceivingFromPausedConsumersIfNeeded();
             return message;
+        } catch (IllegalArgumentException e) {
+            log.error("Validation failed: Expected instance of TopicMessageImpl but received {}. Message ID: {}",
+                    message != null ? message.getClass().getName() : "null",
+                    message != null ? message.getMessageId() : "N/A",
+                    e);
+            throw new PulsarClientException("Invalid message type received", e);
         } catch (Exception e) {
             ExceptionHandler.handleInterruptedException(e);
             throw PulsarClientException.unwrap(e);


### PR DESCRIPTION
### Motivation

1. **Generic Exception Handling**:
   - The `internalReceive` method currently catches all exceptions, which can obscure the root cause of specific failures, such as invalid message types.

2. **Insufficient Logging for Validation Failures**:
   - When `Preconditions.checkArgument` fails (throwing an `IllegalArgumentException`), the existing implementation does not log detailed information about the failure. This limitation makes it challenging to diagnose issues related to message type mismatches.


### Modifications

- **Enhanced Exception Handling**: Added a specific `catch` block for `IllegalArgumentException` to log detailed information before rethrowing as a `PulsarClientException`.

### Verifying this change


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

