### PR TITLE
[improve][ml] Optimization method getNumberOfEntries

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1149,7 +1149,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     @Override
     public long getNumberOfEntries() {
-        if (readPosition.compareTo(ledger.getLastPosition().getNext()) > 0) {
+        if (readPosition.compareTo(ledger.getLastPosition()) > 0) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] Read position {} is ahead of last position {}. There are no entries to read",
                         ledger.getName(), name, readPosition, ledger.getLastPosition());

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -444,6 +444,10 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
     void testNumberOfEntries() throws Exception {
         ManagedLedger ledger = factory.open("my_test_ledger", new ManagedLedgerConfig().setMaxEntriesPerLedger(2));
 
+        ManagedCursor c0 = ledger.openCursor("c0");
+        assertEquals(c0.getNumberOfEntries(), 0);
+        assertFalse(c0.hasMoreEntries());
+
         ManagedCursor c1 = ledger.openCursor("c1");
         ledger.addEntry("dummy-entry-1".getBytes(Encoding));
         ManagedCursor c2 = ledger.openCursor("c2");


### PR DESCRIPTION
### Motivation
Currently, when `readPosition`== `lastPosition‘next`, getNumberOfEntries will be entered. However, this is meaningless and may affect performance.

For example, readPosition=3:0, lastPosition=3:-1, will enter the getNumberOfEntries method
<img width="1044" alt="image" src="https://github.com/user-attachments/assets/ab973a2b-a137-45f6-bebc-27fff1aa51bb">

### Modifications
When `readPosition` is greater than `lastPosition`, return 0 directly. 


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->