### PR TITLE
[fix][sec] Upgrade Zookeeper to 3.9.3 to address CVE-2024-51504

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -498,9 +498,9 @@ The Apache Software License, Version 2.0
     - io.vertx-vertx-web-4.5.10.jar
     - io.vertx-vertx-web-common-4.5.10.jar
   * Apache ZooKeeper
-    - org.apache.zookeeper-zookeeper-3.9.2.jar
-    - org.apache.zookeeper-zookeeper-jute-3.9.2.jar
-    - org.apache.zookeeper-zookeeper-prometheus-metrics-3.9.2.jar
+    - org.apache.zookeeper-zookeeper-3.9.3.jar
+    - org.apache.zookeeper-zookeeper-jute-3.9.3.jar
+    - org.apache.zookeeper-zookeeper-prometheus-metrics-3.9.3.jar
   * Snappy Java
     - org.xerial.snappy-snappy-java-1.1.10.5.jar
   * Google HTTP Client

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -464,9 +464,9 @@ The Apache Software License, Version 2.0
     - org.apache.avro-avro-1.11.4.jar
     - org.apache.avro-avro-protobuf-1.11.4.jar
   * Apache Curator
-    - org.apache.curator-curator-client-5.1.0.jar
-    - org.apache.curator-curator-framework-5.1.0.jar
-    - org.apache.curator-curator-recipes-5.1.0.jar
+    - org.apache.curator-curator-client-5.7.1.jar
+    - org.apache.curator-curator-framework-5.7.1.jar
+    - org.apache.curator-curator-recipes-5.7.1.jar
   * Apache Yetus
     - org.apache.yetus-audience-annotations-0.12.0.jar
   * Kubernetes Client

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ flexible messaging model and an intuitive client API.</description>
     <commons-compress.version>1.26.0</commons-compress.version>
 
     <bookkeeper.version>4.17.1</bookkeeper.version>
-    <zookeeper.version>3.9.2</zookeeper.version>
+    <zookeeper.version>3.9.3</zookeeper.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <commons-text.version>1.10.0</commons-text.version>
     <snappy.version>1.1.10.5</snappy.version> <!-- ZooKeeper server -->

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@ flexible messaging model and an intuitive client API.</description>
     <commons-text.version>1.10.0</commons-text.version>
     <snappy.version>1.1.10.5</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
-    <curator.version>5.1.0</curator.version>
+    <curator.version>5.7.1</curator.version>
     <netty.version>4.1.113.Final</netty.version>
     <netty-iouring.version>0.0.24.Final</netty-iouring.version>
     <jetty.version>9.4.56.v20240826</jetty.version>


### PR DESCRIPTION
### Motivation

Zookeeper 3.9.3 addresses CVE-2024-51504

### Modifications

- Upgrade Zookeeper to 3.9.3
- Upgrade Curator to 5.7.1 due to incompatibilities in Curator 5.1.0 with Zookeeper 3.9.3

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->