### PR TITLE
[improve] [broker] replace HashMap with inner implementation ConcurrentLongLongPairHashMap in Negative Ack Tracker.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
@@ -311,7 +311,7 @@ public class NegativeAcksTest extends ProducerConsumerBase {
         // negative topic message id
         consumer.negativeAcknowledge(topicMessageId);
         NegativeAcksTracker negativeAcksTracker = consumer.getNegativeAcksTracker();
-        assertEquals(negativeAcksTracker.getNackedMessagesCount().orElse(-1).intValue(), 1);
+        assertEquals(negativeAcksTracker.getNackedMessagesCount().orElse((long) -1).longValue(), 1L);
         assertEquals(unAckedMessageTracker.size(), 0);
         negativeAcksTracker.close();
         // negative batch message id
@@ -319,7 +319,7 @@ public class NegativeAcksTest extends ProducerConsumerBase {
         consumer.negativeAcknowledge(batchMessageId);
         consumer.negativeAcknowledge(batchMessageId2);
         consumer.negativeAcknowledge(batchMessageId3);
-        assertEquals(negativeAcksTracker.getNackedMessagesCount().orElse(-1).intValue(), 1);
+        assertEquals(negativeAcksTracker.getNackedMessagesCount().orElse((long) -1).longValue(), 1L);
         assertEquals(unAckedMessageTracker.size(), 0);
         negativeAcksTracker.close();
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/NegativeAcksTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/NegativeAcksTracker.java
@@ -110,7 +110,7 @@ class NegativeAcksTracker implements Closeable {
         if (nackedMessages == null) {
             nackedMessages = ConcurrentLongLongPairHashMap.newBuilder()
                     .autoShrink(true)
-                    .concurrencyLevel(16)
+                    .concurrencyLevel(1)
                     .build();
         }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/NegativeAcksTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/NegativeAcksTracker.java
@@ -23,7 +23,6 @@ import com.google.common.annotations.VisibleForTesting;
 import io.netty.util.Timeout;
 import io.netty.util.Timer;
 import java.io.Closeable;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -86,7 +85,7 @@ class NegativeAcksTracker implements Closeable {
         });
 
         if (!messagesToRedeliver.isEmpty()) {
-            for(MessageId messageId : messagesToRedeliver) {
+            for (MessageId messageId : messagesToRedeliver) {
                 nackedMessages.remove(((MessageIdImpl) messageId).getLedgerId(),
                         ((MessageIdImpl) messageId).getEntryId());
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/NegativeAcksTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/NegativeAcksTracker.java
@@ -81,7 +81,7 @@ class NegativeAcksTracker implements Closeable {
             if (timestamp < now) {
                 MessageId msgId = new MessageIdImpl(ledgerId, entryId,
                         // need to covert non-partitioned topic partition index to -1
-                        (int)(partitionIndex == NON_PARTITIONED_TOPIC_PARTITION_INDEX ? -1 : partitionIndex));
+                        (int) (partitionIndex == NON_PARTITIONED_TOPIC_PARTITION_INDEX ? -1 : partitionIndex));
                 addChunkedMessageIdsAndRemoveFromSequenceMap(msgId, messagesToRedeliver, this.consumer);
                 messagesToRedeliver.add(msgId);
             }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
@@ -208,7 +208,7 @@ public class ConsumerImplTest {
         Exception checkException = null;
         try {
             if (consumer != null) {
-                consumer.negativeAcknowledge(new MessageIdImpl(-1, -1, -1));
+                consumer.negativeAcknowledge(new MessageIdImpl(0, 0, -1));
                 consumer.close();
             }
         } catch (Exception e) {


### PR DESCRIPTION
### Motivation
**Negative ack feature** need to retain the message id and timestamp info in the memory of the consumer client side, leading to great memory consumption.
This PR aim to replace the `HashMap` with the inner map implementation `ConcurrentLongLongPairHashMap` to reduce the memory consumption. Though `HashMap` is faster than the inner map implementation `ConcurrentLongLongPairHashMap` in some cases, but the most important issue in this case is memory consumption instead of the speed.

Some test data list as follows:

## experiment 1
```

    public static void main(String[] args) throws IOException {
        ConcurrentLongLongPairHashMap map1 = ConcurrentLongLongPairHashMap.newBuilder()
                .autoShrink(true)
                .concurrencyLevel(16)
                .build();
        HashMap<MessageId, Long> map2 = new HashMap<>();
        long numMessages = 5000000;
        long ledgerId, entryId, partitionIndex, timestamp;
        for (long i = 0; i < numMessages; i++) {
            ledgerId = 10000+i;
            entryId = i;
            partitionIndex = 0;
            timestamp = System.currentTimeMillis();
            map1.put(ledgerId, entryId, partitionIndex, timestamp);
            map2.put(new MessageIdImpl(ledgerId, entryId, (int)partitionIndex), timestamp);
        }
        System.out.println("map1 size: " + map1.size());
        System.out.println("map2 size: " + map2.size());
        try {
            Thread.sleep(10000000);
        } catch (InterruptedException e) {
            // TODO Auto-generated catch block
            e.printStackTrace();
        }

    }
```

 - 100w entry
![image](https://github.com/user-attachments/assets/84282976-0d3b-4048-9f8e-6eaa7cd82b4a)

HashMap：178Mb
ConcurrentLongLongPairHashMap：64Mb

- 500w entry
![image](https://github.com/user-attachments/assets/674a1fce-4ad2-49e3-9e89-5f6655d93707)

HashMap：566Mb
ConcurrentLongLongPairHashMap：256Mb

- 1000w entry
![image](https://github.com/user-attachments/assets/8aa6e31b-a1b3-49c3-a882-018be6030e8b)

HashMap：1132MB
**Approximately each entry consume 1132MB/10000000=118byte.**

ConcurrentLongLongPairHashMap：512MB
**Approximately each entry consume 512MB/10000000=53byte.**

With this improvement, we can reduce 50+% of the memory consumption!


## experiment 2
Test three candidate data structures:
- HashMap<LongPair, Long>
org.apache.pulsar.common.util.collections.ConcurrentLongPairSet.LongPair
- HashMap<LongLongPair, Long>
it.unimi.dsi.fastutil.longs.LongLongPair
- ConcurrentLongLongPairHashMap

Test code:
```
    public static void main(String[] args) throws IOException {
        ConcurrentLongLongPairHashMap map1 = ConcurrentLongLongPairHashMap.newBuilder()
                .autoShrink(true)
                .concurrencyLevel(16)
                .build();
        HashMap<LongPair, Long> map4 = new HashMap<>();
        HashMap<LongLongPair, Long> map5 = new HashMap<>();
        long numMessages = 5000000, numLedgers=100;
        long numEntries = numMessages/numLedgers;
        long ledgerId, entryId, partitionIndex, timestamp;
        for(long i=0; i<numLedgers; i++) {
            ledgerId = 10000+i;
            for(long j=0; j<numEntries; j++) {
                entryId = 10000+j;
                partitionIndex = 0;
                timestamp = System.currentTimeMillis();
                map1.put(ledgerId, entryId, partitionIndex, timestamp);
                map4.put(new LongPair(ledgerId, entryId), timestamp);
                map5.put(LongLongPair.of(ledgerId, entryId), timestamp);
            }
        }
        
        System.out.println("map1 size: " + map1.size());
        System.out.println("map4 size: " + map4.size());
        System.out.println("map5 size: " + map5.size());
        try {
            Thread.sleep(10000000);
        } catch (InterruptedException e) {
            // TODO Auto-generated catch block
            e.printStackTrace();
        }

    }
```

The results list as follows:
 - 100w entry
![image](https://github.com/user-attachments/assets/ed27c183-d9eb-4b97-8bde-2bd259cf0fb6)
![image](https://github.com/user-attachments/assets/cbfc230f-49e6-4e73-8418-056aed0d594b)
![image](https://github.com/user-attachments/assets/df838e3c-6205-491d-bef0-a51122030c08)

Conclusion:
HashMap<LongPair, Long>  91MB
HashMap<LongLongPair, Long> 114MB
ConcurrentLongLongPairHashMap 64MB

 - 500w entry
![image](https://github.com/user-attachments/assets/d2dafa78-ddda-4966-aace-a1911c1c5c3b)
![image](https://github.com/user-attachments/assets/2f3d47ba-5700-45e0-8c7a-f8c0b9c569f8)
![image](https://github.com/user-attachments/assets/18d2fba6-860c-4111-8e43-ffcec75b2da5)
HashMap<LongPair, Long>  451MB
HashMap<LongLongPair, Long> 566MB
ConcurrentLongLongPairHashMap 256MB

It shows that the `ConcurrentLongLongPairHashMap` is still the best option to store enormous amount of entries.


### Modifications

Replace `HashMap` with `ConcurrentLongLongPairHashMap` in Negative Ack Tracker.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is already covered by existing tests, such as *(please describe tests)*.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/63