### PR TITLE
[improve][broker] PIP-392: Add configuration to enable consistent hashing to select active consumer for partitioned topic

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -243,6 +243,10 @@ messageExpiryCheckIntervalInMinutes=5
 # How long to delay rewinding cursor and dispatching messages when active consumer is changed
 activeConsumerFailoverDelayTimeMillis=1000
 
+# Enable consistent hashing for selecting the active consumer in partitioned topics with Failover subscription type. 
+# For non-partitioned topics, consistent hashing is used by default.
+activeConsumerFailoverConsistentHashing=false
+
 # How long to delete inactive subscriptions from last consuming
 # When it is 0, inactive subscriptions are not deleted automatically
 subscriptionExpirationTimeMinutes=0

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -152,6 +152,10 @@ maxMessageSizeCheckIntervalInSeconds=60
 # How long to delay rewinding cursor and dispatching messages when active consumer is changed
 activeConsumerFailoverDelayTimeMillis=1000
 
+# Enable consistent hashing for selecting the active consumer in partitioned topics with Failover subscription type. 
+# For non-partitioned topics, consistent hashing is used by default.
+activeConsumerFailoverConsistentHashing=false
+
 # How long to delete inactive subscriptions from last consuming
 # When it is 0, inactive subscriptions are not deleted automatically
 subscriptionExpirationTimeMinutes=0

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -148,6 +148,10 @@ messageExpiryCheckIntervalInMinutes=5
 # How long to delay rewinding cursor and dispatching messages when active consumer is changed
 activeConsumerFailoverDelayTimeMillis=1000
 
+# Enable consistent hashing for selecting the active consumer in partitioned topics with Failover subscription type. 
+# For non-partitioned topics, consistent hashing is used by default.
+activeConsumerFailoverConsistentHashing=false
+
 # How long to delete inactive subscriptions from last consuming
 # When it is 0, inactive subscriptions are not deleted automatically
 subscriptionExpirationTimeMinutes=0

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -762,6 +762,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int activeConsumerFailoverDelayTimeMillis = 1000;
     @FieldContext(
             category = CATEGORY_POLICIES,
+            doc = "Enable consistent hashing for selecting the active consumer in partitioned "
+                    + "topics with Failover subscription type."
+                    + "For non-partitioned topics, consistent hashing is used by default."
+    )
+    private boolean activeConsumerFailoverConsistentHashing = false;
+    @FieldContext(
+            category = CATEGORY_POLICIES,
             doc = "Maximum time to spend while scanning a subscription to calculate the accurate backlog"
     )
     private long subscriptionBacklogScanMaxTimeMs = 1000 * 60 * 2L;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
@@ -126,7 +126,7 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
                 }
             }
         }
-        int index = partitionIndex >= 0
+        int index = partitionIndex >= 0 && !serviceConfig.isActiveConsumerFailoverConsistentHashing()
                 ? partitionIndex % consumersSize
                 : peekConsumerIndexFromHashRing(makeHashRing(consumersSize));
 


### PR DESCRIPTION
### Motivation
#23583 

### Modifications
- Only use mod when topic is partitionedTopic and activeConsumerFailoverConsistentHashing=false.

### Verifying this change
- Add `testPartitionedTopicDistribution` to cover it


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

