### PR TITLE
[fix] [broker] No longer allow creating subscription that contains slash

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -202,6 +202,10 @@ allowAutoTopicCreationType=non-partitioned
 # the topic cannot be automatically created.
 allowAutoTopicCreationWithLegacyNamingScheme=true
 
+# If 'strictSubscriptionNameVerification' is true, the new subscription name can only contain (a-zA-Z_0-9) and these
+# special chars -=:.
+strictlyVerifySubscriptionName=false
+
 # Enable subscription auto creation if new consumer connected (disable auto creation with value false)
 allowAutoSubscriptionCreation=true
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -1224,6 +1224,10 @@ allowAutoTopicCreationType=non-partitioned
 # the topic cannot be automatically created.
 allowAutoTopicCreationWithLegacyNamingScheme=true
 
+# If 'strictSubscriptionNameVerification' is true, the new subscription name can only contain (a-zA-Z_0-9) and these
+# special chars -=:.
+strictlyVerifySubscriptionName=false
+
 # Enable subscription auto creation if new consumer connected (disable auto creation with value false)
 allowAutoSubscriptionCreation=true
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2163,6 +2163,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
                     + "the topic cannot be automatically created."
     )
     private boolean allowAutoTopicCreationWithLegacyNamingScheme = true;
+    @FieldContext(category = CATEGORY_SERVER, dynamic = true,
+            doc = "If 'strictSubscriptionNameVerification' is true, the new subscription name can only contain"
+                + " (a-zA-Z_0-9) and these special chars -=:."
+    )
+    private boolean strictlyVerifySubscriptionName = false;
     @FieldContext(
         category = CATEGORY_STORAGE_ML,
         dynamic = true,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1717,7 +1717,8 @@ public class PersistentTopics extends PersistentTopicsBase {
             // So denied to create a subscription that contains "/".
             if (pulsar().getConfig().isStrictlyVerifySubscriptionName()
                     && !NamedEntity.isAllowed(decodedSubName)) {
-                throw new RestException(Response.Status.BAD_REQUEST, "Subscription does not allow containing '/'");
+                throw new RestException(Response.Status.BAD_REQUEST, "Please let the subscription only contains"
+                    + " '/w(a-zA-Z_0-9)' or '_', the current value is " + decodedSubName);
             }
             if (!topicName.isPersistent()) {
                 throw new RestException(Response.Status.BAD_REQUEST, "Create subscription on non-persistent topic "

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -1708,6 +1708,15 @@ public class PersistentTopics extends PersistentTopicsBase {
     ) {
         try {
             validateTopicName(tenant, namespace, topic);
+            String decodedSubName = decode(encodedSubName);
+            // If subscription is as "a/b". The url of HTTP API that defined as
+            // "{tenant}/{namespace}/{topic}/{subscription}" will be like below:
+            // "public/default/tp/a/b", then the broker will assume it is a topic that
+            // using the old rule "{tenant}/{cluster}/{namespace}/{topic}/{subscription}".
+            // So denied to create a subscription that contains "/".
+            if (decodedSubName.contains("/")) {
+                throw new RestException(Response.Status.BAD_REQUEST, "Subscription does not allow containing '/'");
+            }
             if (!topicName.isPersistent()) {
                 throw new RestException(Response.Status.BAD_REQUEST, "Create subscription on non-persistent topic "
                         + "can only be done through client");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -59,6 +59,7 @@ import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.ResetCursorData;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
+import org.apache.pulsar.common.naming.NamedEntity;
 import org.apache.pulsar.common.naming.PartitionedManagedLedgerInfo;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.AuthAction;
@@ -1714,7 +1715,8 @@ public class PersistentTopics extends PersistentTopicsBase {
             // "public/default/tp/a/b", then the broker will assume it is a topic that
             // using the old rule "{tenant}/{cluster}/{namespace}/{topic}/{subscription}".
             // So denied to create a subscription that contains "/".
-            if (decodedSubName.contains("/")) {
+            if (pulsar().getConfig().isStrictlyVerifySubscriptionName()
+                    && !NamedEntity.isAllowed(decodedSubName)) {
                 throw new RestException(Response.Status.BAD_REQUEST, "Subscription does not allow containing '/'");
             }
             if (!topicName.isPersistent()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1362,8 +1362,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                                 && !subscriptionExists
                                                 && !NamedEntity.isAllowed(subscriptionName)) {
                                             return FutureUtil.failedFuture(
-                                                            new BrokerServiceException.NamingException(
-                                                                    "Subscription does not allow containing '/'"));
+                                                new BrokerServiceException.NamingException(
+                                                 "Please let the subscription only contains '/w(a-zA-Z_0-9)' or '_',"
+                                                 + " the current value is " + subscriptionName));
                                         }
 
                                         boolean rejectSubscriptionIfDoesNotExist = isDurable

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -156,6 +156,7 @@ import org.apache.pulsar.common.compression.CompressionCodecProvider;
 import org.apache.pulsar.common.intercept.InterceptException;
 import org.apache.pulsar.common.lookup.data.LookupData;
 import org.apache.pulsar.common.naming.Metadata;
+import org.apache.pulsar.common.naming.NamedEntity;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.naming.TopicName;
@@ -1357,7 +1358,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                         // "public/default/tp/a/b", then the broker will assume it is a topic that
                                         // using the old rule "{tenant}/{cluster}/{namespace}/{topic}/{subscription}".
                                         // So denied to create a subscription that contains "/".
-                                        if (!subscriptionExists && subscriptionName.contains("/")) {
+                                        if (getBrokerService().pulsar().getConfig().isStrictlyVerifySubscriptionName()
+                                                && !subscriptionExists
+                                                && !NamedEntity.isAllowed(subscriptionName)) {
                                             return FutureUtil.failedFuture(
                                                             new BrokerServiceException.NamingException(
                                                                     "Subscription does not allow containing '/'"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -283,6 +283,29 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         }
     }
 
+    @Test(timeOut = 30000)
+    public void testSlashSubscriptionName() throws Exception {
+        final String topic = BrokerTestUtil.newUniqueName("my-property/my-ns/tp");
+        admin.topics().createNonPartitionedTopic(topic);
+        try {
+            admin.topics().createSubscription(topic, "a/b", MessageId.earliest);
+            fail("The creation for the subscription that contains '/' should fail");
+        } catch (PulsarAdminException ex) {
+            assertTrue(ex.getMessage().contains("Subscription does not allow containing"));
+            // Expected.
+        }
+        try {
+            pulsarClient.newConsumer().topic(topic).subscriptionName("b/c").subscribe();
+            fail("The creation for the subscription that contains '/' should fail");
+        } catch (PulsarClientException ex) {
+            assertTrue(ex.getMessage().contains("Subscription does not allow containing"));
+            // Expected.
+        }
+        assertEquals(admin.topics().getStats(topic).getSubscriptions().size(), 0);
+        // cleanup.
+        admin.topics().delete(topic);
+    }
+
     @Test(timeOut = 100000)
     public void testPublishTimestampBatchEnabled() throws Exception {
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -286,7 +286,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     @Test(timeOut = 30000)
     public void testSlashSubscriptionName() throws Exception {
         // Enable strictlyVerifySubscriptionName.
-        admin.brokers().updateDynamicConfiguration("strictlyVerifySubscriptionName", "false");
+        admin.brokers().updateDynamicConfiguration("strictlyVerifySubscriptionName", "true");
         Awaitility.await().untilAsserted(() -> {
             assertTrue(pulsar.getConfiguration().isStrictlyVerifySubscriptionName());
         });
@@ -297,14 +297,14 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             admin.topics().createSubscription(topic, "a/b", MessageId.earliest);
             fail("The creation for the subscription that contains '/' should fail");
         } catch (PulsarAdminException ex) {
-            assertTrue(ex.getMessage().contains("Subscription does not allow containing"));
+            assertTrue(ex.getMessage().contains("Please let the subscription only contains"));
             // Expected.
         }
         try {
             pulsarClient.newConsumer().topic(topic).subscriptionName("b/c").subscribe();
             fail("The creation for the subscription that contains '/' should fail");
         } catch (PulsarClientException ex) {
-            assertTrue(ex.getMessage().contains("Subscription does not allow containing"));
+            assertTrue(ex.getMessage().contains("Please let the subscription only contains"));
             // Expected.
         }
         assertEquals(admin.topics().getStats(topic).getSubscriptions().size(), 0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -285,6 +285,12 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
     @Test(timeOut = 30000)
     public void testSlashSubscriptionName() throws Exception {
+        // Enable strictlyVerifySubscriptionName.
+        admin.brokers().updateDynamicConfiguration("strictlyVerifySubscriptionName", "false");
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(pulsar.getConfiguration().isStrictlyVerifySubscriptionName());
+        });
+
         final String topic = BrokerTestUtil.newUniqueName("my-property/my-ns/tp");
         admin.topics().createNonPartitionedTopic(topic);
         try {
@@ -302,8 +308,13 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             // Expected.
         }
         assertEquals(admin.topics().getStats(topic).getSubscriptions().size(), 0);
+
         // cleanup.
         admin.topics().delete(topic);
+        admin.brokers().updateDynamicConfiguration("strictlyVerifySubscriptionName", "false");
+        Awaitility.await().untilAsserted(() -> {
+            assertFalse(pulsar.getConfiguration().isStrictlyVerifySubscriptionName());
+        });
     }
 
     @Test(timeOut = 100000)

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/NamedEntity.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/NamedEntity.java
@@ -33,9 +33,13 @@ public class NamedEntity {
     public static final Pattern NAMED_ENTITY_PATTERN = Pattern.compile("^[-=:.\\w]*$");
 
     public static void checkName(String name) throws IllegalArgumentException {
-        Matcher m = NAMED_ENTITY_PATTERN.matcher(name);
-        if (!m.matches()) {
+        if (!isAllowed(name)) {
             throw new IllegalArgumentException("Invalid named entity: " + name);
         }
+    }
+
+    public static boolean isAllowed(String name) {
+        Matcher m = NAMED_ENTITY_PATTERN.matcher(name);
+        return m.matches();
     }
 }


### PR DESCRIPTION
### Motivation

**Topic name rule**
- old version: `{tenant}/{cluster}/{namespace}/{topic}/{subscription}`
- new version: `{tenant}/{namespace}/{topic}/{subscription}`

There are many HTTP APIs defined as `HTTP Method {topic name}/{subscription name}`

If a subscription contains `/`, the broker will assume it is a topic created with the old rule, then users will get a `cluster does not exist` error or a `topic not found error`

### Modifications

Use the util method https://github.com/apache/pulsar/blob/master/pulsar-common/src/main/java/org/apache/pulsar/common/naming/NamedEntity.java to check new subscription name

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x