### PR TITLE
[fix][sec] Upgrade to Netty 4.1.115.Final to address CVE-2024-47535

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -47,7 +47,7 @@
     <license-maven-plugin.version>4.1</license-maven-plugin.version>
     <puppycrawl.checkstyle.version>10.14.2</puppycrawl.checkstyle.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-    <netty.version>4.1.104.Final</netty.version>
+    <netty.version>4.1.115.Final</netty.version>
     <guice.version>4.2.3</guice.version>
     <guava.version>32.1.2-jre</guava.version>
     <ant.version>1.10.12</ant.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -293,33 +293,33 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-lang3-3.11.jar
     - org.apache.commons-commons-text-1.10.0.jar
  * Netty
-    - io.netty-netty-buffer-4.1.113.Final.jar
-    - io.netty-netty-codec-4.1.113.Final.jar
-    - io.netty-netty-codec-dns-4.1.113.Final.jar
-    - io.netty-netty-codec-http-4.1.113.Final.jar
-    - io.netty-netty-codec-http2-4.1.113.Final.jar
-    - io.netty-netty-codec-socks-4.1.113.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.113.Final.jar
-    - io.netty-netty-common-4.1.113.Final.jar
-    - io.netty-netty-handler-4.1.113.Final.jar
-    - io.netty-netty-handler-proxy-4.1.113.Final.jar
-    - io.netty-netty-resolver-4.1.113.Final.jar
-    - io.netty-netty-resolver-dns-4.1.113.Final.jar
-    - io.netty-netty-resolver-dns-classes-macos-4.1.113.Final.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.113.Final-osx-aarch_64.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.113.Final-osx-x86_64.jar
-    - io.netty-netty-transport-4.1.113.Final.jar
-    - io.netty-netty-transport-classes-epoll-4.1.113.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.113.Final-linux-aarch_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.113.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-unix-common-4.1.113.Final.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.66.Final.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.66.Final-linux-aarch_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.66.Final-linux-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.66.Final-osx-aarch_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.66.Final-osx-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.66.Final-windows-x86_64.jar
-    - io.netty-netty-tcnative-classes-2.0.66.Final.jar
+    - io.netty-netty-buffer-4.1.115.Final.jar
+    - io.netty-netty-codec-4.1.115.Final.jar
+    - io.netty-netty-codec-dns-4.1.115.Final.jar
+    - io.netty-netty-codec-http-4.1.115.Final.jar
+    - io.netty-netty-codec-http2-4.1.115.Final.jar
+    - io.netty-netty-codec-socks-4.1.115.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.115.Final.jar
+    - io.netty-netty-common-4.1.115.Final.jar
+    - io.netty-netty-handler-4.1.115.Final.jar
+    - io.netty-netty-handler-proxy-4.1.115.Final.jar
+    - io.netty-netty-resolver-4.1.115.Final.jar
+    - io.netty-netty-resolver-dns-4.1.115.Final.jar
+    - io.netty-netty-resolver-dns-classes-macos-4.1.115.Final.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.115.Final-osx-aarch_64.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.115.Final-osx-x86_64.jar
+    - io.netty-netty-transport-4.1.115.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.115.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.115.Final-linux-aarch_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.115.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-unix-common-4.1.115.Final.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.69.Final.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.69.Final-linux-aarch_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.69.Final-linux-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.69.Final-osx-aarch_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.69.Final-osx-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.69.Final-windows-x86_64.jar
+    - io.netty-netty-tcnative-classes-2.0.69.Final.jar
     - io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.24.Final.jar
     - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
     - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -347,35 +347,35 @@ The Apache Software License, Version 2.0
     - commons-text-1.10.0.jar
     - commons-compress-1.26.0.jar
  * Netty
-    - netty-buffer-4.1.113.Final.jar
-    - netty-codec-4.1.113.Final.jar
-    - netty-codec-dns-4.1.113.Final.jar
-    - netty-codec-http-4.1.113.Final.jar
-    - netty-codec-socks-4.1.113.Final.jar
-    - netty-codec-haproxy-4.1.113.Final.jar
-    - netty-common-4.1.113.Final.jar
-    - netty-handler-4.1.113.Final.jar
-    - netty-handler-proxy-4.1.113.Final.jar
-    - netty-resolver-4.1.113.Final.jar
-    - netty-resolver-dns-4.1.113.Final.jar
-    - netty-transport-4.1.113.Final.jar
-    - netty-transport-classes-epoll-4.1.113.Final.jar
-    - netty-transport-native-epoll-4.1.113.Final-linux-aarch_64.jar
-    - netty-transport-native-epoll-4.1.113.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.113.Final.jar
-    - netty-tcnative-boringssl-static-2.0.66.Final.jar
-    - netty-tcnative-boringssl-static-2.0.66.Final-linux-aarch_64.jar
-    - netty-tcnative-boringssl-static-2.0.66.Final-linux-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.66.Final-osx-aarch_64.jar
-    - netty-tcnative-boringssl-static-2.0.66.Final-osx-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.66.Final-windows-x86_64.jar
-    - netty-tcnative-classes-2.0.66.Final.jar
+    - netty-buffer-4.1.115.Final.jar
+    - netty-codec-4.1.115.Final.jar
+    - netty-codec-dns-4.1.115.Final.jar
+    - netty-codec-http-4.1.115.Final.jar
+    - netty-codec-socks-4.1.115.Final.jar
+    - netty-codec-haproxy-4.1.115.Final.jar
+    - netty-common-4.1.115.Final.jar
+    - netty-handler-4.1.115.Final.jar
+    - netty-handler-proxy-4.1.115.Final.jar
+    - netty-resolver-4.1.115.Final.jar
+    - netty-resolver-dns-4.1.115.Final.jar
+    - netty-transport-4.1.115.Final.jar
+    - netty-transport-classes-epoll-4.1.115.Final.jar
+    - netty-transport-native-epoll-4.1.115.Final-linux-aarch_64.jar
+    - netty-transport-native-epoll-4.1.115.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.115.Final.jar
+    - netty-tcnative-boringssl-static-2.0.69.Final.jar
+    - netty-tcnative-boringssl-static-2.0.69.Final-linux-aarch_64.jar
+    - netty-tcnative-boringssl-static-2.0.69.Final-linux-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.69.Final-osx-aarch_64.jar
+    - netty-tcnative-boringssl-static-2.0.69.Final-osx-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.69.Final-windows-x86_64.jar
+    - netty-tcnative-classes-2.0.69.Final.jar
     - netty-incubator-transport-classes-io_uring-0.0.24.Final.jar
     - netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar
     - netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
-    - netty-resolver-dns-classes-macos-4.1.113.Final.jar
-    - netty-resolver-dns-native-macos-4.1.113.Final-osx-aarch_64.jar
-    - netty-resolver-dns-native-macos-4.1.113.Final-osx-x86_64.jar
+    - netty-resolver-dns-classes-macos-4.1.115.Final.jar
+    - netty-resolver-dns-native-macos-4.1.115.Final-osx-aarch_64.jar
+    - netty-resolver-dns-native-macos-4.1.115.Final-osx-x86_64.jar
  * Prometheus client
     - simpleclient-0.16.0.jar
     - simpleclient_log4j2-0.16.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.10.5</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.7.1</curator.version>
-    <netty.version>4.1.113.Final</netty.version>
+    <netty.version>4.1.115.Final</netty.version>
     <netty-iouring.version>0.0.24.Final</netty-iouring.version>
     <jetty.version>9.4.56.v20240826</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>


### PR DESCRIPTION
### Motivation

Upgrade to Netty 4.1.115.Final to address CVE-2024-47535. This DoS vulnerability doesn't practically apply to Pulsar since the vulnerability requires write access to the filesystem where the application using Netty is running. However, it's always useful to address CVEs by upgrading to a version that doesn't contain known vulnerabilities.

### Modifications

- Upgrade Netty to 4.1.115.Final
  - netty-bom in 4.1.115.Final upgrades Netty tcnative to 2.0.69.Final

- Release notes:
  - [4.1.115.Final](https://netty.io/news/2024/11/12/4-1-115-Final.html)
  - [4.1.114.Final](https://netty.io/news/2024/10/01/4-1-114-Final.html)
  
- Netty tcnative [changes in 2.0.69.Final since 2.0.66.Final](https://github.com/netty/netty-tcnative/compare/netty-tcnative-parent-2.0.66.Final...netty-tcnative-parent-2.0.69.Final) 


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->