### PR TITLE
[fix][broker] Fix failed TokenAuthenticatedProducerConsumerTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenAuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenAuthenticatedProducerConsumerTest.java
@@ -191,14 +191,14 @@ public class TokenAuthenticatedProducerConsumerTest extends ProducerConsumerBase
     }
 
     @Test(dataProvider = "provider")
-    public void testTopicNotFound(boolean useTcpServiceUrl, boolean useCorrectToken) throws Exception {
+    public void testTenantNotExist(boolean useTcpServiceUrl, boolean useCorrectToken) throws Exception {
         final var operationTimeoutMs = 10000;
         final var url = useTcpServiceUrl ? pulsar.getBrokerServiceUrl() : pulsar.getWebServiceAddress();
         final var token = useCorrectToken ? ADMIN_TOKEN : USER_TOKEN;
         @Cleanup final var client = PulsarClient.builder().serviceUrl(url)
                 .operationTimeout(operationTimeoutMs, TimeUnit.MILLISECONDS)
                 .authentication(AuthenticationFactory.token(token)).build();
-        final var topic = "my-property/not-exist/tp"; // the namespace does not exist
+        final var topic = "non-exist/not-exist/tp"; // the namespace does not exist
         var start = System.currentTimeMillis();
         try {
             client.newProducer().topic(topic).create();


### PR DESCRIPTION
### Motivation

`TokenAuthenticatedProducerConsumerTest` cannot pass the test. The root cause is that when a namespace does not exist and the client carries a token without correct permission, the client would fail with `AuthorizationException` but not `TopicDoesNotExistException`.

It's because `PulsarAuthorizationProvider#validateTenantAdminAccess` will fail exceptionally by `NotFoundException` here: https://github.com/apache/pulsar/blob/0b0eef905c3a6ebe8a6fbb284743d98c8e97d5b8/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java#L718

However, when the namespace does not exist, this exception won't be thrown. If `testTopicNotFound` was running after `testTokenProducerAndConsumer`, the "my-property" tenant would be created so it would fail.

However, the CI somehow passed and I see 1 test was skipped.

```
Warning:  Tests run: 6, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 22.034 s - in org.apache.pulsar.client.api.TokenAuthenticatedProducerConsumerTest
```

### Modifications

Change the test from `testTopicNotFound` to `testTenantNotExist` and use a tenant that does not exist.

Regarding the case when the namespace does not exist, we might need another PR for it.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: