### PR TITLE
[improve][broker] Reduce memory occupation of the delayed message queue

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
@@ -20,23 +20,21 @@ package org.apache.pulsar.broker.delayed;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.netty.util.Timer;
-import java.time.Clock;
-import java.util.NavigableSet;
-import java.util.TreeSet;
-import java.util.concurrent.CompletableFuture;
-
 import it.unimi.dsi.fastutil.longs.Long2ObjectAVLTreeMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectSortedMap;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
+import java.time.Clock;
+import java.util.NavigableSet;
+import java.util.TreeSet;
+import java.util.concurrent.CompletableFuture;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.pulsar.broker.service.persistent.AbstractPersistentDispatcherMultipleConsumers;
-import org.apache.pulsar.common.util.collections.TripleLongPriorityQueue;
 import org.roaringbitmap.longlong.Roaring64Bitmap;
 
 @Slf4j
@@ -44,8 +42,7 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
 
     // timestamp -> ledgerId -> entryId
     // AVL tree -> OpenHashMap -> RoaringBitmap
-    protected final Long2ObjectSortedMap<Long2ObjectMap<Roaring64Bitmap>> priorityQueue
-            = new Long2ObjectAVLTreeMap<>();
+    protected final Long2ObjectSortedMap<Long2ObjectMap<Roaring64Bitmap>> priorityQueue = new Long2ObjectAVLTreeMap<>();
 
     // If we detect that all messages have fixed delay time, such that the delivery is
     // always going to be in FIFO order, then we can avoid pulling all the messages in
@@ -99,7 +96,7 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
             tickTimeMillis >>= 1;
             bitCnt++;
         }
-        return bitCnt-1;
+        return bitCnt - 1;
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
@@ -43,6 +43,7 @@ import org.roaringbitmap.longlong.Roaring64Bitmap;
 public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker {
 
     // timestamp -> ledgerId -> entryId
+    // AVL tree -> OpenHashMap -> RoaringBitmap
     protected final Long2ObjectSortedMap<Long2ObjectMap<Roaring64Bitmap>> priorityQueue
             = new Long2ObjectAVLTreeMap<>();
 
@@ -62,8 +63,8 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
     // Track whether we have seen all messages with fixed delay so far.
     private boolean messagesHaveFixedDelay = true;
 
-    //
-    private int timestampPrecisionBitCnt = 8;
+    // The bit count to trim to reduce memory occupation.
+    private int timestampPrecisionBitCnt = 0;
 
     InMemoryDelayedDeliveryTracker(AbstractPersistentDispatcherMultipleConsumers dispatcher, Timer timer,
                                    long tickTimeMillis,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
@@ -42,7 +42,8 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
 
     // timestamp -> ledgerId -> entryId
     // AVL tree -> OpenHashMap -> RoaringBitmap
-    protected final Long2ObjectSortedMap<Long2ObjectMap<Roaring64Bitmap>> delayedMessageMap = new Long2ObjectAVLTreeMap<>();
+    protected final Long2ObjectSortedMap<Long2ObjectMap<Roaring64Bitmap>>
+            delayedMessageMap = new Long2ObjectAVLTreeMap<>();
 
     // If we detect that all messages have fixed delay time, such that the delivery is
     // always going to be in FIFO order, then we can avoid pulling all the messages in
@@ -148,7 +149,8 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
      */
     @Override
     public boolean hasMessageAvailable() {
-        boolean hasMessageAvailable = !delayedMessageMap.isEmpty() && delayedMessageMap.firstLongKey() <= getCutoffTime();
+        boolean hasMessageAvailable = !delayedMessageMap.isEmpty()
+                && delayedMessageMap.firstLongKey() <= getCutoffTime();
         if (!hasMessageAvailable) {
             updateTimer();
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/InMemoryDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/InMemoryDeliveryTrackerTest.java
@@ -230,7 +230,7 @@ public class InMemoryDeliveryTrackerTest extends AbstractDeliveryTrackerTest {
                     return;
                 }
                 try {
-                    this.priorityQueue.peekN1();
+                    this.priorityQueue.firstLongKey();
                 } catch (Exception e) {
                     e.printStackTrace();
                     exceptions[0] = e;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/InMemoryDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/InMemoryDeliveryTrackerTest.java
@@ -92,7 +92,7 @@ public class InMemoryDeliveryTrackerTest extends AbstractDeliveryTrackerTest {
                             false, 0)
             }};
             case "testAddMessageWithStrictDelay" -> new Object[][]{{
-                    new InMemoryDelayedDeliveryTracker(dispatcher, timer, 0, clock,
+                    new InMemoryDelayedDeliveryTracker(dispatcher, timer, 1, clock,
                             true, 0)
             }};
             case "testAddMessageWithDeliverAtTimeAfterNowBeforeTickTimeFrequencyWithStrict" -> new Object[][]{{
@@ -108,7 +108,7 @@ public class InMemoryDeliveryTrackerTest extends AbstractDeliveryTrackerTest {
                             true, 0)
             }};
             case "testWithFixedDelays", "testWithMixedDelays","testWithNoDelays" -> new Object[][]{{
-                    new InMemoryDelayedDeliveryTracker(dispatcher, timer, 500, clock,
+                    new InMemoryDelayedDeliveryTracker(dispatcher, timer, 8, clock,
                             true, 100)
             }};
             default -> new Object[][]{{

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/InMemoryDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/InMemoryDeliveryTrackerTest.java
@@ -92,7 +92,7 @@ public class InMemoryDeliveryTrackerTest extends AbstractDeliveryTrackerTest {
                             false, 0)
             }};
             case "testAddMessageWithStrictDelay" -> new Object[][]{{
-                    new InMemoryDelayedDeliveryTracker(dispatcher, timer, 100, clock,
+                    new InMemoryDelayedDeliveryTracker(dispatcher, timer, 0, clock,
                             true, 0)
             }};
             case "testAddMessageWithDeliverAtTimeAfterNowBeforeTickTimeFrequencyWithStrict" -> new Object[][]{{
@@ -100,7 +100,7 @@ public class InMemoryDeliveryTrackerTest extends AbstractDeliveryTrackerTest {
                             true, 0)
             }};
             case "testAddMessageWithDeliverAtTimeAfterNowAfterTickTimeFrequencyWithStrict" -> new Object[][]{{
-                    new InMemoryDelayedDeliveryTracker(dispatcher, timer, 100000, clock,
+                    new InMemoryDelayedDeliveryTracker(dispatcher, timer, 1, clock,
                             true, 0)
             }};
             case "testAddMessageWithDeliverAtTimeAfterFullTickTimeWithStrict" -> new Object[][]{{
@@ -230,7 +230,7 @@ public class InMemoryDeliveryTrackerTest extends AbstractDeliveryTrackerTest {
                     return;
                 }
                 try {
-                    this.priorityQueue.firstLongKey();
+                    this.delayedMessageMap.firstLongKey();
                 } catch (Exception e) {
                     e.printStackTrace();
                     exceptions[0] = e;


### PR DESCRIPTION
### Motivation

Delayed queue consume a lot of memory to store the message id. We can reduce the memory occupation with new data structure simillar to https://github.com/apache/pulsar/pull/23601.

### Modifications

Use new data structure to reduce memory occupation of the delayed message queue, `InMemoryDelayedDeliveryTracker`.

List some experiment data with following test code:
```
    static long trimLowerBit(long timestamp, int bits) {
        return timestamp & (-1L << bits);
    }

    public static void main(String[] args) throws IOException {
        TripleLongPriorityQueue queue = new TripleLongPriorityQueue();
        Long2ObjectSortedMap<Long2ObjectMap<Roaring64Bitmap>> map2 = new Long2ObjectAVLTreeMap<>();

        long numMessages = 10000000, numLedgers=1000;
        long numEntries = numMessages/numLedgers;
        long ledgerId, entryId, partitionIndex, timestamp=System.currentTimeMillis();
        for(long i=0; i<numLedgers; i++) {
            ledgerId = 10000+i;
            for(long j=0; j<numEntries; j++) {
                entryId = 10000+j;
                partitionIndex = 0;
                // 1ms per message
                timestamp++;
                queue.add(timestamp, ledgerId, entryId);
                
                timestamp = trimLowerBit(timestamp, 8);
                if (map2.containsKey(timestamp)) {
                    Long2ObjectMap<Roaring64Bitmap> ledgerMap = map2.get(timestamp);
                    if (ledgerMap.containsKey(ledgerId)) {
                        ledgerMap.get(ledgerId).add(entryId);
                    } else {
                        Roaring64Bitmap entrySet = new Roaring64Bitmap();
                        entrySet.add(entryId);
                        ledgerMap.put(ledgerId, entrySet);
                    }
                } else {
                    Long2ObjectMap<Roaring64Bitmap> ledgerMap = new Long2ObjectOpenHashMap<>();
                    Roaring64Bitmap entrySet = new Roaring64Bitmap();
                    entrySet.add(entryId);
                    ledgerMap.put(ledgerId, entrySet);
                    map2.put(timestamp, ledgerMap);
                }
            }
        }
        
        System.out.println("queue size in MB: " + queue.bytesCapacity() / 1024.0 / 1024.0);
        try {
            Thread.sleep(10000000);
        } catch (InterruptedException e) {
            // TODO Auto-generated catch block
            e.printStackTrace();
        }
    }
```
Produce 1kw entries with 1k ledgers, with the speed of 1 msg/ms.

- Original data structure: TripleLongPriorityQueue
It store the info in the direct memory, we can call `queue.bytesCapacity()` to get the size of memory it take.
![image](https://github.com/user-attachments/assets/c2744d68-be0c-446e-8faa-07376681ccd9)
So, TripleLongPriorityQueue take up 240MB.

- New data structure: `Long2ObjectSortedMap<Long2ObjectMap<Roaring64Bitmap>>`
It store the data in heap, so we can use `jmap` to dump the memory to analyze.
![image](https://github.com/user-attachments/assets/764fa9b4-4354-4b40-a2c9-f161850f69d7)
So, it take up only 8MB, down to only 8/240=3.33% of the original size!



### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*


This change is already covered by existing tests, such as *(please describe tests)*.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/65