### PR TITLE
[improve] Use single buffer for metrics when noUnsafe use

### DIFF
--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -77,6 +77,8 @@ alias echo='{ [[ $- =~ .*x.* ]] && trace_enabled=1 || trace_enabled=0; set +x; }
 # Test Groups  -- start --
 function test_group_broker_group_1() {
   mvn_test -pl pulsar-broker -Dgroups='broker' -DtestReuseFork=true
+  # run tests in broker-isolated group individually (instead of with -Dgroups=broker-isolated) to avoid scanning all test classes
+  mvn_test -pl pulsar-broker -Dtest=org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsGeneratorWithNoUnsafeTest -DtestForkCount=1 -DtestReuseFork=false
 }
 
 function test_group_broker_group_2() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.stats.prometheus;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+
 import com.google.common.util.concurrent.MoreExecutors;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -32,21 +33,12 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.zip.GZIPInputStream;
-import lombok.Cleanup;
 import org.apache.commons.io.IOUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.common.util.SimpleTextOutputStream;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class PrometheusMetricsGeneratorTest {
-
-
-    @BeforeClass
-    public static void setProperties() {
-        System.setProperty("io.netty.noUnsafe", "true");
-    }
 
     // reproduce issue #22575
     @Test
@@ -89,24 +81,6 @@ public class PrometheusMetricsGeneratorTest {
             }
         } finally {
             metricsBuffer.release();
-        }
-    }
-
-    @Test
-    public void testWriteStringWithNoUnsafe() {
-        PrometheusMetricsGenerator generator = new PrometheusMetricsGenerator(null, false, false, false, false,
-                Clock.systemUTC());
-        @Cleanup("release")
-        ByteBuf buf = generator.allocateMultipartCompositeDirectBuffer();
-        for (int i = 0; i < 2; i++) {
-            buf.writeBytes(new byte[1024 * 1024]);
-        }
-
-        SimpleTextOutputStream outputStream = new SimpleTextOutputStream(buf);
-        try {
-            outputStream.write("trest");
-        } catch (Exception e) {
-
         }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorTest.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.broker.stats.prometheus;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-
 import com.google.common.util.concurrent.MoreExecutors;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorWithNoUnsafeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorWithNoUnsafeTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.broker.stats.prometheus;
 
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.fail;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.internal.PlatformDependent;
 import java.time.Clock;
@@ -39,6 +38,7 @@ public class PrometheusMetricsGeneratorWithNoUnsafeTest {
     @Test
     public void testWriteStringWithNoUnsafe() {
         assertFalse(PlatformDependent.hasUnsafe());
+        @Cleanup
         PrometheusMetricsGenerator generator = new PrometheusMetricsGenerator(null, false, false, false, false,
             Clock.systemUTC());
         @Cleanup("release")
@@ -47,10 +47,6 @@ public class PrometheusMetricsGeneratorWithNoUnsafeTest {
             buf.writeBytes(new byte[1024 * 1024]);
         }
         SimpleTextOutputStream outputStream = new SimpleTextOutputStream(buf);
-        try {
-            outputStream.write("test");
-        } catch (Exception e) {
-            fail("Should not throw exception");
-        }
+        outputStream.write("test");
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorWithNoUnsafeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorWithNoUnsafeTest.java
@@ -27,6 +27,7 @@ import org.apache.pulsar.common.util.SimpleTextOutputStream;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+@Test(groups = "broker-isolated")
 public class PrometheusMetricsGeneratorWithNoUnsafeTest {
 
     @BeforeClass

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorWithNoUnsafeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorWithNoUnsafeTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats.prometheus;
+
+import static org.testng.Assert.fail;
+
+import io.netty.buffer.ByteBuf;
+import java.time.Clock;
+import lombok.Cleanup;
+import org.apache.pulsar.common.util.SimpleTextOutputStream;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class PrometheusMetricsGeneratorWithNoUnsafeTest {
+
+    @BeforeClass
+    static void setup() {
+        System.setProperty("io.netty.noUnsafe", "true");
+    }
+
+    @Test
+    public void testWriteStringWithNoUnsafe() {
+        PrometheusMetricsGenerator generator = new PrometheusMetricsGenerator(null, false, false, false, false,
+            Clock.systemUTC());
+        @Cleanup("release")
+        ByteBuf buf = generator.allocateMultipartCompositeDirectBuffer();
+        for (int i = 0; i < 2; i++) {
+            buf.writeBytes(new byte[1024 * 1024]);
+        }
+
+        System.out.println(buf.nioBuffers().length);
+        SimpleTextOutputStream outputStream = new SimpleTextOutputStream(buf);
+        try {
+            outputStream.write("test");
+        } catch (Exception e) {
+            fail("Should not throw exception");
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorWithNoUnsafeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGeneratorWithNoUnsafeTest.java
@@ -18,9 +18,10 @@
  */
 package org.apache.pulsar.broker.stats.prometheus;
 
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.fail;
-
 import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.PlatformDependent;
 import java.time.Clock;
 import lombok.Cleanup;
 import org.apache.pulsar.common.util.SimpleTextOutputStream;
@@ -37,6 +38,7 @@ public class PrometheusMetricsGeneratorWithNoUnsafeTest {
 
     @Test
     public void testWriteStringWithNoUnsafe() {
+        assertFalse(PlatformDependent.hasUnsafe());
         PrometheusMetricsGenerator generator = new PrometheusMetricsGenerator(null, false, false, false, false,
             Clock.systemUTC());
         @Cleanup("release")
@@ -44,8 +46,6 @@ public class PrometheusMetricsGeneratorWithNoUnsafeTest {
         for (int i = 0; i < 2; i++) {
             buf.writeBytes(new byte[1024 * 1024]);
         }
-
-        System.out.println(buf.nioBuffers().length);
         SimpleTextOutputStream outputStream = new SimpleTextOutputStream(buf);
         try {
             outputStream.write("test");


### PR DESCRIPTION
---

### Motivation

We have met some core dumps when running pulsar service. Then saw Netty suggested using `io.netty.noUnsafe` to see if it works. https://github.com/netty/netty/issues/2950. After adding that property, the core dump is gone, but the metrics failed to report because of the UnsupportedOpeartion exception.

Netty has a property io.netty.noUnsafe which allows disabling use the unsafe api. When this is enabled, the metrics won't collect because of the Unspport operation exception.
The root cause is it calls the internalNioBuffer which only allow to call when the buffer count is 1. But when using the composite buffer the buffer count may more than 1.
So use the buffer directly when the flag is enabled.

The exception:
                                                                                                                                                                                                                                                             Caused by: java.lang.UnsupportedOperationException
    at io.netty.buffer.CompositeByteBuf.internalNioBuffer(CompositeByteBuf.java:1657) ~[io.netty-netty-buffer-4.1.113.Final.jar:4.1.113.Final]
    at io.netty.buffer.ByteBufUtil.writeUtf8(ByteBufUtil.java:924) ~[io.netty-netty-buffer-4.1.113.Final.jar:4.1.113.Final]
     at io.netty.buffer.ByteBufUtil.writeUtf8(ByteBufUtil.java:900) ~[io.netty-netty-buffer-4.1.113.Final.jar:4.1.113.Final]                                                                                                                                                                                                                 at io.netty.buffer.AbstractByteBuf.setCharSequence0(AbstractByteBuf.java:707) ~[io.netty-netty-buffer-4.1.113.Final.jar:4.1.113.Final]

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
