### PR TITLE
[fix][broker] Skip to persist cursor info if it failed by cursor closed

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3206,7 +3206,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                 mbean.addWriteCursorLedgerSize(data.length);
                 callback.operationComplete();
             } else {
-                if (isClosed()) {
+                if (state == State.Closed) {
                     // After closed the cursor, the in-progress persistence task will get a
                     // BKException.Code.LedgerClosedException.
                     callback.operationFailed(new CursorAlreadyClosedException(String.format("%s %s skipped this"

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3207,7 +3207,8 @@ public class ManagedCursorImpl implements ManagedCursor {
                 callback.operationComplete();
             } else {
                 if (isClosed()) {
-                    // After closed the cursor, the in-progress will get a BKException.Code.LedgerClosedException.
+                    // After closed the cursor, the in-progress persistence task will get a
+                    // BKException.Code.LedgerClosedException.
                     callback.operationFailed(new CursorAlreadyClosedException(String.format("%s %s skipped this"
                             + " persistence, because the cursor already closed", ledger.getName(), name)));
                     return;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3206,6 +3206,12 @@ public class ManagedCursorImpl implements ManagedCursor {
                 mbean.addWriteCursorLedgerSize(data.length);
                 callback.operationComplete();
             } else {
+                if (isClosed()) {
+                    // After closed the cursor, the in-progress will get a BKException.Code.LedgerClosedException.
+                    callback.operationFailed(new CursorAlreadyClosedException(String.format("%s %s skipped this"
+                            + " persistence, because the cursor already closed", ledger.getName(), name)));
+                    return;
+                }
                 log.warn("[{}] Error updating cursor {} position {} in meta-ledger {}: {}", ledger.getName(), name,
                         position, lh1.getId(), BKException.getMessage(rc));
                 // If we've had a write error, the ledger will be automatically closed, we need to create a new one,


### PR DESCRIPTION
### Motivation

We encountered an issue as follows

| time | `closing topic -> closing curosr` | `in-progress cursor mark deleting` |
| --- | --- | --- |
| 1 | Mark the cursor as closing |
| 2 | Persistent cursor metadata into the cursor ledger `54781383` |
| 3 | Start to close the cursor ledger `54781383` |
| 4 | Mark the ledger `54781383` is closed in memory |
| 5 | | Try to write metadata to the ledger `54781383`, but the ledger was marked closed |
| 6 | | Try to write metadata to ZK after failed writing BK |
| 7 | Start to write the ledger metadata of `54781383` to ZK |
| 8 | | The ZK server closed the connection due to the pulsar trying to write a large value |
| 9 | Write to ZK failed due to the connection being lost | |
| 10 | | retries and keeps triggering a closing of the ZK connection |
| 11 | The retries will fail because the connection is unstable|

I think we need at least `3` fixes
- (What this current PR attempts to do) Do not continue executing the in-progress cursor mark deletion after the cursor is closed.
- (I will push another PR to do it) Add a mechanism that limits the data size that will persist with ZK.
- (I will push another PR to do it) Stop retries if such an issue occurs.

### Modifications

- Skip to persist cursor info if it failed by cursor closed
- [ ] TODO: I will write a test tomorrow.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x