### PR TITLE
[feat][broker] Prevent auto-creation of topics using legacy cluster-based naming scheme

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -248,7 +248,7 @@ messageExpiryCheckIntervalInMinutes=5
 activeConsumerFailoverDelayTimeMillis=1000
 
 # Enable consistent hashing for selecting the active consumer in partitioned topics with Failover subscription type.
-# For non-partitioned topics, consistent hashing is used by default.
+# For non-partitioned topics, consistent hashing is used by default. 
 activeConsumerFailoverConsistentHashing=false
 
 # How long to delete inactive subscriptions from last consuming

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1966,3 +1966,6 @@ brokerInterceptors=
 
 # Enable or disable the broker interceptor, which is only used for testing for now
 disableBrokerInterceptors=true
+
+# If the topic name contains cluster, not allow to be created automatically.
+enableCreateLegacyTopic=true

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -248,7 +248,7 @@ messageExpiryCheckIntervalInMinutes=5
 activeConsumerFailoverDelayTimeMillis=1000
 
 # Enable consistent hashing for selecting the active consumer in partitioned topics with Failover subscription type.
-# For non-partitioned topics, consistent hashing is used by default. 
+# For non-partitioned topics, consistent hashing is used by default.
 activeConsumerFailoverConsistentHashing=false
 
 # How long to delete inactive subscriptions from last consuming
@@ -1970,4 +1970,3 @@ brokerInterceptors=
 
 # Enable or disable the broker interceptor, which is only used for testing for now
 disableBrokerInterceptors=true
-

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -243,7 +243,7 @@ messageExpiryCheckIntervalInMinutes=5
 # How long to delay rewinding cursor and dispatching messages when active consumer is changed
 activeConsumerFailoverDelayTimeMillis=1000
 
-# Enable consistent hashing for selecting the active consumer in partitioned topics with Failover subscription type. 
+# Enable consistent hashing for selecting the active consumer in partitioned topics with Failover subscription type.
 # For non-partitioned topics, consistent hashing is used by default.
 activeConsumerFailoverConsistentHashing=false
 
@@ -1967,5 +1967,6 @@ brokerInterceptors=
 # Enable or disable the broker interceptor, which is only used for testing for now
 disableBrokerInterceptors=true
 
-# If the topic name contains cluster, not allow to be created automatically.
-enableCreateLegacyTopic=false
+# If automatic topic creation is enabled and the name of the topic contains 'cluster',
+# the topic cannot be automatically created.
+allowAutoTopicCreationWithLegacyNamingScheme=false

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -247,7 +247,7 @@ messageExpiryCheckIntervalInMinutes=5
 # How long to delay rewinding cursor and dispatching messages when active consumer is changed
 activeConsumerFailoverDelayTimeMillis=1000
 
-# Enable consistent hashing for selecting the active consumer in partitioned topics with Failover subscription type.
+# Enable consistent hashing for selecting the active consumer in partitioned topics with Failover subscription type. 
 # For non-partitioned topics, consistent hashing is used by default.
 activeConsumerFailoverConsistentHashing=false
 

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1968,4 +1968,4 @@ brokerInterceptors=
 disableBrokerInterceptors=true
 
 # If the topic name contains cluster, not allow to be created automatically.
-enableCreateLegacyTopic=true
+enableCreateLegacyTopic=false

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -198,6 +198,10 @@ allowAutoTopicCreation=true
 # The type of topic that is allowed to be automatically created.(partitioned/non-partitioned)
 allowAutoTopicCreationType=non-partitioned
 
+# If 'allowAutoTopicCreation' is true and the name of the topic contains 'cluster',
+# the topic cannot be automatically created.
+allowAutoTopicCreationWithLegacyNamingScheme=false
+
 # Enable subscription auto creation if new consumer connected (disable auto creation with value false)
 allowAutoSubscriptionCreation=true
 
@@ -1967,6 +1971,3 @@ brokerInterceptors=
 # Enable or disable the broker interceptor, which is only used for testing for now
 disableBrokerInterceptors=true
 
-# If automatic topic creation is enabled and the name of the topic contains 'cluster',
-# the topic cannot be automatically created.
-allowAutoTopicCreationWithLegacyNamingScheme=false

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -200,7 +200,7 @@ allowAutoTopicCreationType=non-partitioned
 
 # If 'allowAutoTopicCreation' is true and the name of the topic contains 'cluster',
 # the topic cannot be automatically created.
-allowAutoTopicCreationWithLegacyNamingScheme=false
+allowAutoTopicCreationWithLegacyNamingScheme=true
 
 # Enable subscription auto creation if new consumer connected (disable auto creation with value false)
 allowAutoSubscriptionCreation=true

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -1181,6 +1181,10 @@ allowAutoTopicCreation=true
 # The type of topic that is allowed to be automatically created.(partitioned/non-partitioned)
 allowAutoTopicCreationType=non-partitioned
 
+# If 'allowAutoTopicCreation' is true and the name of the topic contains 'cluster',
+# the topic cannot be automatically created.
+allowAutoTopicCreationWithLegacyNamingScheme=false
+
 # Enable subscription auto creation if new consumer connected (disable auto creation with value false)
 allowAutoSubscriptionCreation=true
 
@@ -1357,7 +1361,3 @@ topicCompactionRetainNullKey=false
 # will create topic compaction service based on message eventTime.
 # By default compaction service is based on message publishing order.
 compactionServiceFactoryClassName=org.apache.pulsar.compaction.PulsarCompactionServiceFactory
-
-# If automatic topic creation is enabled and the name of the topic contains 'cluster',
-# the topic cannot be automatically created.
-allowAutoTopicCreationWithLegacyNamingScheme=false

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -152,7 +152,7 @@ maxMessageSizeCheckIntervalInSeconds=60
 # How long to delay rewinding cursor and dispatching messages when active consumer is changed
 activeConsumerFailoverDelayTimeMillis=1000
 
-# Enable consistent hashing for selecting the active consumer in partitioned topics with Failover subscription type. 
+# Enable consistent hashing for selecting the active consumer in partitioned topics with Failover subscription type.
 # For non-partitioned topics, consistent hashing is used by default.
 activeConsumerFailoverConsistentHashing=false
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -1359,4 +1359,4 @@ topicCompactionRetainNullKey=false
 compactionServiceFactoryClassName=org.apache.pulsar.compaction.PulsarCompactionServiceFactory
 
 # If the topic name contains cluster, not allow to be created automatically.
-enableCreateLegacyTopic=true
+enableCreateLegacyTopic=false

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -152,7 +152,7 @@ maxMessageSizeCheckIntervalInSeconds=60
 # How long to delay rewinding cursor and dispatching messages when active consumer is changed
 activeConsumerFailoverDelayTimeMillis=1000
 
-# Enable consistent hashing for selecting the active consumer in partitioned topics with Failover subscription type. 
+# Enable consistent hashing for selecting the active consumer in partitioned topics with Failover subscription type.
 # For non-partitioned topics, consistent hashing is used by default.
 activeConsumerFailoverConsistentHashing=false
 
@@ -1358,5 +1358,6 @@ topicCompactionRetainNullKey=false
 # By default compaction service is based on message publishing order.
 compactionServiceFactoryClassName=org.apache.pulsar.compaction.PulsarCompactionServiceFactory
 
-# If the topic name contains cluster, not allow to be created automatically.
-enableCreateLegacyTopic=false
+# If automatic topic creation is enabled and the name of the topic contains 'cluster',
+# the topic cannot be automatically created.
+allowAutoTopicCreationWithLegacyNamingScheme=false

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -1357,3 +1357,6 @@ topicCompactionRetainNullKey=false
 # will create topic compaction service based on message eventTime.
 # By default compaction service is based on message publishing order.
 compactionServiceFactoryClassName=org.apache.pulsar.compaction.PulsarCompactionServiceFactory
+
+# If the topic name contains cluster, not allow to be created automatically.
+enableCreateLegacyTopic=true

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -152,7 +152,7 @@ maxMessageSizeCheckIntervalInSeconds=60
 # How long to delay rewinding cursor and dispatching messages when active consumer is changed
 activeConsumerFailoverDelayTimeMillis=1000
 
-# Enable consistent hashing for selecting the active consumer in partitioned topics with Failover subscription type.
+# Enable consistent hashing for selecting the active consumer in partitioned topics with Failover subscription type. 
 # For non-partitioned topics, consistent hashing is used by default.
 activeConsumerFailoverConsistentHashing=false
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -1183,7 +1183,7 @@ allowAutoTopicCreationType=non-partitioned
 
 # If 'allowAutoTopicCreation' is true and the name of the topic contains 'cluster',
 # the topic cannot be automatically created.
-allowAutoTopicCreationWithLegacyNamingScheme=false
+allowAutoTopicCreationWithLegacyNamingScheme=true
 
 # Enable subscription auto creation if new consumer connected (disable auto creation with value false)
 allowAutoSubscriptionCreation=true

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2154,6 +2154,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
             doc = "The type of topic that is allowed to be automatically created.(partitioned/non-partitioned)"
     )
     private TopicType allowAutoTopicCreationType = TopicType.NON_PARTITIONED;
+    @FieldContext(category = CATEGORY_SERVER, dynamic = true,
+            doc = "If 'allowAutoTopicCreation' is true and the name of the topic contains 'cluster',"
+                    + "the topic cannot be automatically created."
+    )
+    private boolean allowAutoTopicCreationWithLegacyNamingScheme = false;
     @FieldContext(
         category = CATEGORY_STORAGE_ML,
         dynamic = true,
@@ -3702,11 +3707,6 @@ public class ServiceConfiguration implements PulsarConfiguration {
             doc = "SSL Factory plugin configuration parameters used by internal client.")
     private String brokerClientSslFactoryPluginParams = "";
 
-    @FieldContext(category = CATEGORY_SERVER, dynamic = true,
-            doc = "If automatic topic creation is enabled and the name of the topic contains 'cluster', "
-                    + "the topic cannot be automatically created"
-    )
-    private boolean allowAutoTopicCreationWithLegacyNamingScheme = false;
 
     /* packages management service configurations (begin) */
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -3706,8 +3706,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             category = CATEGORY_TLS,
             doc = "SSL Factory plugin configuration parameters used by internal client.")
     private String brokerClientSslFactoryPluginParams = "";
-
-
+    
     /* packages management service configurations (begin) */
 
     @FieldContext(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -3705,7 +3705,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(category = CATEGORY_SERVER, dynamic = true,
             doc = "Topic name contains cluster, not allow be created automatically."
     )
-    private boolean enableCreateLegacyTopic = true;
+    private boolean enableCreateLegacyTopic = false;
 
     /* packages management service configurations (begin) */
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2158,7 +2158,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             doc = "If 'allowAutoTopicCreation' is true and the name of the topic contains 'cluster',"
                     + "the topic cannot be automatically created."
     )
-    private boolean allowAutoTopicCreationWithLegacyNamingScheme = false;
+    private boolean allowAutoTopicCreationWithLegacyNamingScheme = true;
     @FieldContext(
         category = CATEGORY_STORAGE_ML,
         dynamic = true,

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -3702,6 +3702,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
             doc = "SSL Factory plugin configuration parameters used by internal client.")
     private String brokerClientSslFactoryPluginParams = "";
 
+    @FieldContext(category = CATEGORY_SERVER, dynamic = true,
+            doc = "Topic name contains cluster, not allow be created automatically."
+    )
+    private boolean enableCreateLegacyTopic = true;
+
     /* packages management service configurations (begin) */
 
     @FieldContext(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -3703,9 +3703,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String brokerClientSslFactoryPluginParams = "";
 
     @FieldContext(category = CATEGORY_SERVER, dynamic = true,
-            doc = "Topic name contains cluster, not allow be created automatically."
+            doc = "If automatic topic creation is enabled and the name of the topic contains 'cluster', "
+                    + "the topic cannot be automatically created"
     )
-    private boolean enableCreateLegacyTopic = false;
+    private boolean allowAutoTopicCreationWithLegacyNamingScheme = false;
 
     /* packages management service configurations (begin) */
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -3706,7 +3706,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
             category = CATEGORY_TLS,
             doc = "SSL Factory plugin configuration parameters used by internal client.")
     private String brokerClientSslFactoryPluginParams = "";
-    
+
     /* packages management service configurations (begin) */
 
     @FieldContext(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -3532,8 +3532,10 @@ public class BrokerService implements Closeable {
             return CompletableFuture.completedFuture(true);
         }
 
-        // If the topic name contains cluster, not allow to be created automatically.
-        if (!pulsar.getConfiguration().isEnableCreateLegacyTopic() && StringUtils.isNotBlank(topicName.getCluster())) {
+        //If automatic topic creation is enabled, and the name of the topic contains 'cluster',
+        //the topic cannot be automatically created.
+        if (!pulsar.getConfiguration().isAllowAutoTopicCreationWithLegacyNamingScheme()
+                && StringUtils.isNotBlank(topicName.getCluster())) {
             return CompletableFuture.completedFuture(false);
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -3533,7 +3533,7 @@ public class BrokerService implements Closeable {
         }
 
         // If the topic name contains cluster, not allow to be created automatically.
-        if (pulsar.getConfiguration().isEnableCreateLegacyTopic() && StringUtils.isNotBlank(topicName.getCluster())) {
+        if (!pulsar.getConfiguration().isEnableCreateLegacyTopic() && StringUtils.isNotBlank(topicName.getCluster())) {
             return CompletableFuture.completedFuture(false);
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -3532,6 +3532,11 @@ public class BrokerService implements Closeable {
             return CompletableFuture.completedFuture(true);
         }
 
+        // If the topic name contains cluster, not allow to be created automatically.
+        if (pulsar.getConfiguration().isEnableCreateLegacyTopic() && StringUtils.isNotBlank(topicName.getCluster())) {
+            return CompletableFuture.completedFuture(false);
+        }
+
         final boolean allowed;
         AutoTopicCreationOverride autoTopicCreationOverride = getAutoTopicCreationOverride(topicName, policies);
         if (autoTopicCreationOverride != null) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -3532,7 +3532,7 @@ public class BrokerService implements Closeable {
             return CompletableFuture.completedFuture(true);
         }
 
-        //If automatic topic creation is enabled, and the name of the topic contains 'cluster',
+        //If 'allowAutoTopicCreation' is true, and the name of the topic contains 'cluster',
         //the topic cannot be automatically created.
         if (!pulsar.getConfiguration().isAllowAutoTopicCreationWithLegacyNamingScheme()
                 && StringUtils.isNotBlank(topicName.getCluster())) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
@@ -587,4 +587,17 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
 
     }
 
+    @Test
+    public void testAutoPartitionedTopicNameWithClusterName() throws Exception {
+        pulsar.getConfiguration().setAllowAutoTopicCreation(true);
+        pulsar.getConfiguration().setAllowAutoTopicCreationType(TopicType.PARTITIONED);
+        pulsar.getConfiguration().setDefaultNumPartitions(3);
+
+        final String topicString = "persistent://prop/ns-abc/testTopic/1";
+
+        Assert.assertThrows(PulsarClientException.NotFoundException.class,
+                ()-> pulsarClient.newProducer().topic(topicString).create());
+
+    }
+
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
@@ -595,8 +595,14 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
 
         final String topicString = "persistent://prop/ns-abc/testTopic/1";
 
+        // When allowAutoTopicCreationWithLegacyNamingScheme as the default value is false,
+        // four-paragraph topic cannot be created.
         Assert.assertThrows(PulsarClientException.NotFoundException.class,
                 ()-> pulsarClient.newProducer().topic(topicString).create());
+
+        pulsar.getConfiguration().setAllowAutoTopicCreationWithLegacyNamingScheme(true);
+        Producer producer=pulsarClient.newProducer().topic(topicString).create();
+        Assert.assertEquals(producer.getTopic(), topicString);
 
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
@@ -592,19 +592,18 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         pulsar.getConfiguration().setAllowAutoTopicCreation(true);
         pulsar.getConfiguration().setAllowAutoTopicCreationType(TopicType.PARTITIONED);
         pulsar.getConfiguration().setDefaultNumPartitions(3);
-
+        
         final String topicString = "persistent://prop/ns-abc/testTopic/1";
-
         // When allowAutoTopicCreationWithLegacyNamingScheme as the default value is false,
         // four-paragraph topic cannot be created.
+        pulsar.getConfiguration().setAllowAutoTopicCreationWithLegacyNamingScheme(false);
         Assert.assertThrows(PulsarClientException.NotFoundException.class,
-                ()-> pulsarClient.newProducer().topic(topicString).create());
+                () -> pulsarClient.newProducer().topic(topicString).create());
 
         pulsar.getConfiguration().setAllowAutoTopicCreationWithLegacyNamingScheme(true);
-        Producer producer=pulsarClient.newProducer().topic(topicString).create();
+        Producer producer = pulsarClient.newProducer().topic(topicString).create();
         Assert.assertEquals(producer.getTopic(), topicString);
         producer.close();
-
     }
 
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
@@ -603,6 +603,7 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
         pulsar.getConfiguration().setAllowAutoTopicCreationWithLegacyNamingScheme(true);
         Producer producer=pulsarClient.newProducer().topic(topicString).create();
         Assert.assertEquals(producer.getTopic(), topicString);
+        producer.close();
 
     }
 


### PR DESCRIPTION

### Motivation

Topic name rule

- old version: {tenant}/{cluster}/{namespace}/{topic}

- new version: {tenant}/{namespace}/{topic}

If the name of an automatically created topic contains a "/", the topic will be resolved into a four-segment format (containing a layer of cluster directories). As a result, the automatically created topic does not conform to the latest topic naming rules

### Modifications

No allowto automatically create topic names that contain slashes

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
