### PR TITLE
[fix][client] fix incomingMessageSize and client memory usage is negative

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -1231,6 +1231,11 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         getMemoryLimitController().ifPresent(limiter -> limiter.releaseMemory(message.size()));
     }
 
+    protected void increaseIncomingMessageSize(final Message<?> message) {
+        INCOMING_MESSAGES_SIZE_UPDATER.addAndGet(this, message.size());
+        getMemoryLimitController().ifPresent(limiter -> limiter.forceReserveMemory(message.size()));
+    }
+
     public long getIncomingMessageSize() {
         return INCOMING_MESSAGES_SIZE_UPDATER.get(this);
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1667,6 +1667,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             return;
         }
 
+        // increase incomingMessageSize here because the size would be decreased in messageProcessed() next step
+        increaseIncomingMessageSize(message);
         // increase permits for available message-queue
         messageProcessed(message);
         // call interceptor and complete received callback


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/23622


### Motivation

After testing for autoScaledReceiverQueueSizeEnabled config, found that the client memory usage and incomingMessageSize is negative.

This error result in two problem:
1. autoScaledReceiverQueueSize feature is not correct. The receive queue size is expanded based on wrong memory usage.
2. batchReceivePolicy feature is not correct. The MaxNumBytes config in batchReceivePolicy is judged by wrong incomingMessageSize.

By the way, batchReceivePolicy is default used in multiTopicConsumer since pulsar-2.9.4, while autoScaledReceiverQueueSize is a  optional config in consumer.

The reason is because when enter ConsumerImpl#notifyPendingReceivedCallback, the message would directly pass to pendingReceive request. Then consumerImpl just decrease the incomingMessageSize, but not increase. So the value become negative

### Modifications

fix the error case that only do decrease the size, but not increase.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


