### PR TITLE
[improve][broker]Restrict the creation of topics with "-partition--x"

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -3532,6 +3532,12 @@ public class BrokerService implements Closeable {
             return CompletableFuture.completedFuture(true);
         }
 
+        // If this topic name contains "-partition--x" , not allow to be created automatically.
+        if (topicName.getLocalName().contains(TopicName.PARTITIONED_TOPIC_SUFFIX)
+                && topicName.getPartitionIndex() == -1) {
+            return CompletableFuture.completedFuture(false);
+        }
+
         final boolean allowed;
         AutoTopicCreationOverride autoTopicCreationOverride = getAutoTopicCreationOverride(topicName, policies);
         if (autoTopicCreationOverride != null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceAutoTopicCreationTest.java
@@ -587,4 +587,17 @@ public class BrokerServiceAutoTopicCreationTest extends BrokerTestBase{
 
     }
 
+    @Test
+    public void testAutoPartitionedTopicNameWithPartitionCreation() throws Exception {
+        pulsar.getConfiguration().setAllowAutoTopicCreation(true);
+        pulsar.getConfiguration().setAllowAutoTopicCreationType(TopicType.PARTITIONED);
+        pulsar.getConfiguration().setDefaultNumPartitions(3);
+
+        final String topicString = "persistent://prop/ns-abc/testTopic-partition--1";
+
+        Assert.assertThrows(PulsarClientException.NotFoundException.class,
+                ()-> pulsarClient.newProducer().topic(topicString).create());
+
+    }
+
 }


### PR DESCRIPTION

### Motivation
If you actively create a topic with "-partition--x" (x is an integer)(for example, "peisisten://tenant-name/ns-name/topic-name-partition--1"), the topic can be created successfully, and a node with partition 3 will be attached to the zk. But it is not a partition topic

### Modifications

By modifying the isAllowAutoTopicCreationAsync logic () method, when the topic name contains "- partiton - x" (x is an integer), trigger logic returns false

![Clipboard_Screenshot_1732245902](https://github.com/user-attachments/assets/36396111-8ba7-4ee7-a73f-4c57a44b9d7a)


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
