### PR TITLE
[improve][test] Reduce OneWayReplicatorUsingGlobalZKTest.testRemoveCluster execution time

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
@@ -203,13 +203,15 @@ public class OneWayReplicatorUsingGlobalZKTest extends OneWayReplicatorTest {
         // The topics under the namespace of the cluster-1 will be deleted.
         // Verify the result.
         admin1.namespaces().setNamespaceReplicationClusters(ns1, new HashSet<>(Arrays.asList(cluster2)));
-        Awaitility.await().atMost(Duration.ofSeconds(120)).untilAsserted(() -> {
+        Awaitility.await().atMost(Duration.ofSeconds(60)).ignoreExceptions().untilAsserted(() -> {
             Map<String, CompletableFuture<Optional<Topic>>> tps = pulsar1.getBrokerService().getTopics();
             assertFalse(tps.containsKey(topic));
             assertFalse(tps.containsKey(topicChangeEvents));
-            assertFalse(pulsar1.getNamespaceService().checkTopicExists(TopicName.get(topic)).join().isExists());
+            assertFalse(pulsar1.getNamespaceService().checkTopicExists(TopicName.get(topic))
+                    .get(5, TimeUnit.SECONDS).isExists());
             assertFalse(pulsar1.getNamespaceService()
-                    .checkTopicExists(TopicName.get(topicChangeEvents)).join().isExists());
+                    .checkTopicExists(TopicName.get(topicChangeEvents))
+                    .get(5, TimeUnit.SECONDS).isExists());
         });
 
         // cleanup.


### PR DESCRIPTION
### Motivation

OneWayReplicatorUsingGlobalZKTest.testRemoveCluster was timing out in branch-3.3 and I had to improve the test in order to get the test passing in branch-3.3 before 3.3.3 release.

### Modifications

- Add `ignoreExceptions()` to Awaitility
- Add 5 second timeout to existence checks of topics

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->