### PR TITLE
[fix][perf] fix performanceConsumer log error throughput

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -443,7 +443,7 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
             double elapsed = (now - oldTime) / 1e9;
             long total = totalMessagesReceived.sum();
             double rate = messagesReceived.sumThenReset() / elapsed;
-            double throughput = bytesReceived.sumThenReset() / elapsed * 8 / 1024 / 1024;
+            double throughput = bytesReceived.sumThenReset() / elapsed / 1024 / 1024;
             double rateAck = messageAck.sumThenReset() / elapsed;
             long totalTxnOpSuccessNum = 0;
             long totalTxnOpFailNum = 0;


### PR DESCRIPTION
### Motivation

fix error throughput log in performanceConsumer. bytes -> Mb no need to *8.

### Modifications

fix error.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


