### PR TITLE
[fix][ws] Implement missing http header data functions in AuthenticationDataSubscription

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataSubscription.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationDataSubscription.java
@@ -72,6 +72,21 @@ public class AuthenticationDataSubscription implements AuthenticationDataSource 
         return subscription;
     }
 
+    @Override
+    public boolean hasDataFromHttp() {
+        return authData.hasDataFromHttp();
+    }
+
+    @Override
+    public String getHttpAuthType() {
+        return authData.getHttpAuthType();
+    }
+
+    @Override
+    public String getHttpHeader(String name) {
+        return authData.getHttpHeader(name);
+    }
+
     public AuthenticationDataSource getAuthData() {
         return authData;
     }

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationDataSubscriptionTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationDataSubscriptionTest.java
@@ -1,0 +1,30 @@
+package org.apache.pulsar.broker.authentication;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.testng.AssertJUnit.assertEquals;
+import javax.servlet.http.HttpServletRequest;
+import org.testng.annotations.Test;
+
+public class AuthenticationDataSubscriptionTest {
+
+    AuthenticationDataSubscription target;
+
+    @Test
+    public void testTargetFromAuthenticationDataHttp(){
+        var req = mock(HttpServletRequest.class);
+        String headerName = "Authorization";
+        String headerValue = "my-header";
+        String authType = "my-authType";
+        doReturn(headerValue).when(req).getHeader(eq(headerName));
+        doReturn("localhost").when(req).getRemoteAddr();
+        doReturn(4000).when(req).getRemotePort();
+        doReturn(authType).when(req).getAuthType();
+        AuthenticationDataSource authenticationDataSource = new AuthenticationDataHttp(req);
+        target = new AuthenticationDataSubscription(authenticationDataSource, "my-sub");
+        assertEquals(headerValue, target.getHttpHeader(headerName));
+        assertEquals(authType, target.getHttpAuthType());
+        assertEquals(true, target.hasDataFromHttp());
+    }
+}

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationDataSubscriptionTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationDataSubscriptionTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.broker.authentication;
 
 import static org.mockito.ArgumentMatchers.eq;


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->



<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

I realized that http header data interface is missing in AuthenticationDataSubscription.

It appears that websocket consumer authorization fails because authorization providers cannot pull the authorization header from AuthenticationDataSubscription.

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

added http data interface in AuthenticationDataSubscription

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
