### PR TITLE
[fix][misc] Class conflict during jetcd-core-shaded shading process

### DIFF
--- a/jetcd-core-shaded/pom.xml
+++ b/jetcd-core-shaded/pom.xml
@@ -94,6 +94,10 @@
                   <include>io.etcd:*</include>
                   <include>io.vertx:*</include>
                 </includes>
+                <excludes>
+                  <!-- This is required for execute shade multiple times without clean -->
+                  <exclude>org.apache.pulsar:jetcd-core-shaded</exclude>
+                </excludes>
               </artifactSet>
               <relocations>
                 <!-- relocate vertx packages since they will be transformed to use grpc-netty-shaded packages -->


### PR DESCRIPTION
### Motivation

In the latest release candidates (`3.0.8-candidate-1`, `4.0.1-candidate-1`), the jetcd-core-shaded module [shading issue][1] persists. This occurs because the `maven-shade-plugin` [includes][4] the current project artifact in the shade process. In `jetcd-core-shaded`, we copy `io.etcd.jetcd.*` into the `jetcd-core-shaded` jar without relocation. As a result, when the `install` or `deploy` goals are executed without cleaning the `target` folder, class conflicts arise between `io.etcd.jetcd.*` inside `org.apache.pulsar:jetcd-core-shaded.jar` and `io.etcd:jetcd-core.jar`.

[1]: https://github.com/apache/pulsar/issues/23513#issuecomment-2469496334

#23604 attempted to resolve this issue but failed to account for [build][2] and [deploy][3] in separate steps during the release process. 

[2]: https://pulsar.apache.org/contribute/release-process/#build-release-artifacts  
[3]: https://pulsar.apache.org/contribute/release-process/#stage-maven-modules
[4]: https://github.com/apache/maven-shade-plugin/blob/maven-shade-plugin-3.4.1/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java#L437

### Verifying this Change

To verify this patch, follow these steps:

```shell
# Step 1: Clean and install the `jetcd-core-shaded` module.
mvn clean install -pl jetcd-core-shaded -DskipTests

# Step 2: Install without cleaning, simulating a release process.
mvn install -pl jetcd-core-shaded -DskipTests

# Step 3: Unpack the shaded jar into a directory and verify imports.
# Ensure that the import statement for `io.netty.handler.logging.ByteBufFormat` 
# in `org/apache/pulsar/jetcd/shaded/io/vertx/core/net/NetClientOptions.class` 
# is correct. The expected import is:
# `import io.grpc.netty.shaded.io.netty.handler.logging.ByteBufFormat;`.
unzip $M2_REPO/org/apache/pulsar/jetcd-core-shaded/<VERSION>/jetcd-core-shaded-<VERSION>-shaded.jar \
  -d jetcd-core-shaded/target/shaded-classes
```

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/Shawyeok/pulsar/pull/20

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
