### PR TITLE
[fix][broker] fix null lookup result when brokers are starting

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -979,6 +979,9 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 this.webSocketService.setLocalCluster(clusterData);
             }
 
+            // Initialize namespace service, after service url assigned. Should init zk and refresh self owner info.
+            this.nsService.initialize();
+
             // Start the leader election service
             startLeaderElectionService();
 
@@ -989,9 +992,6 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             // The load manager service and its service unit state channel need to be initialized first
             // (namespace service depends on load manager)
             this.startLoadManagementService();
-
-            // Initialize namespace service, after service url assigned. Should init zk and refresh self owner info.
-            this.nsService.initialize();
 
             // Start topic level policies service
             this.topicPoliciesService = initTopicPoliciesService();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -318,7 +318,7 @@ public class TopicLookupBase extends PulsarWebResource {
                             }
 
                             LookupData lookupData = lookupResult.get().getLookupData();
-                            printWarnLogIfLookupResUnexpected(topicName, lookupData, pulsarService);
+                            printWarnLogIfLookupResUnexpected(topicName, lookupData, options, pulsarService);
                             if (lookupResult.get().isRedirect()) {
                                 boolean newAuthoritative = lookupResult.get().isAuthoritativeRedirect();
                                 lookupfuture.complete(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -356,7 +356,7 @@ public class TopicLookupBase extends PulsarWebResource {
             log.warn("[{}] Unexpected lookup result: brokerUrl is required when TLS isn't enabled. options: {},"
                 + " result {}", topic, options, lookupData);
         } else if (tlsEnabled && StringUtils.isBlank(lookupData.getBrokerUrlTls())) {
-            log.warn("[{}] Unexpected lookup resul: brokerUrlTls is required when TLS is enabled. options: {},"
+            log.warn("[{}] Unexpected lookup result: brokerUrlTls is required when TLS is enabled. options: {},"
                     + " result {}", topic, options, lookupData);
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -346,16 +346,18 @@ public class TopicLookupBase extends PulsarWebResource {
     /**
      * Check if a internal client will get a null lookup result.
      */
-    private static void printWarnLogIfLookupResUnexpected(TopicName topic, LookupData lookupData,
+    private static void printWarnLogIfLookupResUnexpected(TopicName topic, LookupData lookupData, LookupOptions options,
                                                           PulsarService pulsar) {
         if (!pulsar.getBrokerService().isSystemTopic(topic)) {
             return;
         }
         boolean tlsEnabled = pulsar.getConfig().isBrokerClientTlsEnabled();
         if (!tlsEnabled && StringUtils.isBlank(lookupData.getBrokerUrl())) {
-            log.warn("[{}] Unexpected lookup result {}", topic.toString(), lookupData);
+            log.warn("[{}] Internal lookup without TLS will get a null brokerUrl, which is unexpected. options: {},"
+                + " result {}", topic, options, lookupData);
         } else if (tlsEnabled && StringUtils.isBlank(lookupData.getBrokerUrlTls())) {
-            log.warn("[{}] Unexpected lookup result {}", topic.toString(), lookupData);
+            log.warn("[{}] Internal lookup with TLS will get a null brokerUrl, which is unexpected. options: {},"
+                    + " result {}", topic, options, lookupData);
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -318,6 +318,7 @@ public class TopicLookupBase extends PulsarWebResource {
                             }
 
                             LookupData lookupData = lookupResult.get().getLookupData();
+                            printWarnLogIfLookupResUnexpected(topicName, lookupData, pulsarService);
                             if (lookupResult.get().isRedirect()) {
                                 boolean newAuthoritative = lookupResult.get().isAuthoritativeRedirect();
                                 lookupfuture.complete(
@@ -340,6 +341,22 @@ public class TopicLookupBase extends PulsarWebResource {
         });
 
         return lookupfuture;
+    }
+
+    /**
+     * Check if a internal client will get a null lookup result.
+     */
+    private static void printWarnLogIfLookupResUnexpected(TopicName topic, LookupData lookupData,
+                                                          PulsarService pulsar) {
+        if (!pulsar.getBrokerService().isSystemTopic(topic)) {
+            return;
+        }
+        boolean tlsEnabled = pulsar.getConfig().isBrokerClientTlsEnabled();
+        if (!tlsEnabled && StringUtils.isBlank(lookupData.getBrokerUrl())) {
+            log.warn("[{}] Unexpected lookup result {}", topic.toString(), lookupData);
+        } else if (tlsEnabled && StringUtils.isBlank(lookupData.getBrokerUrlTls())) {
+            log.warn("[{}] Unexpected lookup result {}", topic.toString(), lookupData);
+        }
     }
 
     private static void handleLookupError(CompletableFuture<ByteBuf> lookupFuture, String topicName, String clientAppId,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -353,10 +353,10 @@ public class TopicLookupBase extends PulsarWebResource {
         }
         boolean tlsEnabled = pulsar.getConfig().isBrokerClientTlsEnabled();
         if (!tlsEnabled && StringUtils.isBlank(lookupData.getBrokerUrl())) {
-            log.warn("[{}] Internal lookup without TLS will get a null brokerUrl, which is unexpected. options: {},"
+            log.warn("[{}] Unexpected lookup resul: brokerUrlTls is required when TLS isn't enabled. options: {},"
                 + " result {}", topic, options, lookupData);
         } else if (tlsEnabled && StringUtils.isBlank(lookupData.getBrokerUrlTls())) {
-            log.warn("[{}] Internal lookup with TLS will get a null brokerUrl, which is unexpected. options: {},"
+            log.warn("[{}] Unexpected lookup resul: brokerUrlTls is required when TLS is enabled. options: {},"
                     + " result {}", topic, options, lookupData);
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -353,7 +353,7 @@ public class TopicLookupBase extends PulsarWebResource {
         }
         boolean tlsEnabled = pulsar.getConfig().isBrokerClientTlsEnabled();
         if (!tlsEnabled && StringUtils.isBlank(lookupData.getBrokerUrl())) {
-            log.warn("[{}] Unexpected lookup resul: brokerUrlTls is required when TLS isn't enabled. options: {},"
+            log.warn("[{}] Unexpected lookup result: brokerUrl is required when TLS isn't enabled. options: {},"
                 + " result {}", topic, options, lookupData);
         } else if (tlsEnabled && StringUtils.isBlank(lookupData.getBrokerUrlTls())) {
             log.warn("[{}] Unexpected lookup resul: brokerUrlTls is required when TLS is enabled. options: {},"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
@@ -72,7 +72,7 @@ public class OwnershipCache {
     /**
      * The NamespaceEphemeralData objects that can be associated with the current owner, when the broker is disabled.
      */
-    private final NamespaceEphemeralData selfOwnerInfoDisabled;
+    private NamespaceEphemeralData selfOwnerInfoDisabled;
 
     private final LockManager<NamespaceEphemeralData> lockManager;
 
@@ -119,6 +119,9 @@ public class OwnershipCache {
         this.pulsar = pulsar;
         this.ownerBrokerUrl = pulsar.getBrokerServiceUrl();
         this.ownerBrokerUrlTls = pulsar.getBrokerServiceUrlTls();
+        // At this moment, the variables "webServiceAddress" and "webServiceAddressTls" and so on have not been
+        // initialized, so we will get an empty "selfOwnerInfo" and an empty "selfOwnerInfoDisabled" here.
+        // But do not worry, these two fields will be set by the method "refreshSelfOwnerInfo" soon.
         this.selfOwnerInfo = new NamespaceEphemeralData(ownerBrokerUrl, ownerBrokerUrlTls,
                 pulsar.getWebServiceAddress(), pulsar.getWebServiceAddressTls(),
                 false, pulsar.getAdvertisedListeners());
@@ -351,6 +354,9 @@ public class OwnershipCache {
         this.selfOwnerInfo = new NamespaceEphemeralData(pulsar.getBrokerServiceUrl(),
                 pulsar.getBrokerServiceUrlTls(), pulsar.getWebServiceAddress(),
                 pulsar.getWebServiceAddressTls(), false, pulsar.getAdvertisedListeners());
+        this.selfOwnerInfoDisabled = new NamespaceEphemeralData(pulsar.getBrokerServiceUrl(),
+                pulsar.getBrokerServiceUrlTls(), pulsar.getWebServiceAddress(),
+                pulsar.getWebServiceAddressTls(), true, pulsar.getAdvertisedListeners());
         return selfOwnerInfo.getNativeUrl() != null || selfOwnerInfo.getNativeUrlTls() != null;
     }
 }


### PR DESCRIPTION
### Motivation

**Issue**
- Brokers acquire namespace-bundle locks with the data `OwnershipCache.selfOwnerInfo`
- The initialization of the `OwnershipCache.selfOwnerInfo` is in the method `PulsarService.start()` as bellow
  - call `startNamespaceService()`: this line created the object `OwnershipCache`, but the variable `OwnershipCache.selfOwnerInfo` will be set an empty value due to `PulsarService.brokerServiceUrl` has not been initialized yet.
  - Initialize `PulsarService.brokerServiceUrl`.
  - start leader election service and load manager, at this moment the variable `OwnershipCache.selfOwnerInfo` is still empty, so the client may get a null response
  - call `nsService.initialize()`: reset the variable of `OwnershipCache.selfOwnerInfo`.

**Error logs**

```
2024-11-26T12:47:27,323+0000 [pulsar-io-6-2] WARN  org.apache.pulsar.client.impl.BinaryProtoLookupService - [persistent://{tenant}/{ns}/__change_events-partition-0] invalid url null : Cannot invoke "String.length()" because "this.input" is null
java.lang.NullPointerException: Cannot invoke "String.length()" because "this.input" is null
	at java.base/java.net.URI$Parser.parse(Unknown Source) ~[?:?]
	at java.base/java.net.URI.<init>(Unknown Source) ~[?:?]
	at org.apache.pulsar.client.impl.BinaryProtoLookupService.lambda$findBroker$7(BinaryProtoLookupService.java:198) ~[io.streamnative-pulsar-client-original-3.3.1.8.jar:3.3.1.8]
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.complete(Unknown Source) ~[?:?]
	at org.apache.pulsar.client.impl.ClientCnx.handleLookupResponse(ClientCnx.java:649) ~[io.streamnative-pulsar-client-original-3.3.1.8.jar:3.3.1.8]
	at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:154) ~[io.streamnative-pulsar-common-3.3.1.8.jar:3.3.1.8]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[io.netty-netty-transport-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[io.netty-netty-transport-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[io.netty-netty-transport-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346) ~[io.netty-netty-codec-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318) ~[io.netty-netty-codec-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[io.netty-netty-transport-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[io.netty-netty-transport-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[io.netty-netty-transport-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.handler.flush.FlushConsolidationHandler.channelRead(FlushConsolidationHandler.java:152) ~[io.netty-netty-handler-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442) ~[io.netty-netty-transport-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[io.netty-netty-transport-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[io.netty-netty-transport-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1357) ~[io.netty-netty-transport-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440) ~[io.netty-netty-transport-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[io.netty-netty-transport-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:868) ~[io.netty-netty-transport-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:799) ~[io.netty-netty-transport-classes-epoll-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:501) ~[io.netty-netty-transport-classes-epoll-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:399) ~[io.netty-netty-transport-classes-epoll-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[io.netty-netty-common-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[io.netty-netty-common-4.1.113.Final.jar:4.1.113.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.113.Final.jar:4.1.113.Final]
	at java.base/java.lang.Thread.run(Unknown Source) [?:?]
```

**Heap dump**

`OwnershipCache.selfOwnerInfo` will be reset, but `OwnershipCache.selfOwnerInfoDisabled` never be set again.

![Screenshot 2024-11-26 at 20 58 48](https://github.com/user-attachments/assets/d509d4a0-2722-4cea-b234-1d691dfffe6b)


### Modifications

- reset the variable of `OwnershipCache.selfOwnerInfo` before starting the Load Manager.
- add a warning log if a system topic lookup will get an empty broker URL.
- Since it is hard to write a test, I skip writing a test

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x