### PR TITLE
[improve] Upgrade oxia-java to 0.4.10 and fix closing of OxiaMetadataStore

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -481,8 +481,8 @@ The Apache Software License, Version 2.0
   * Prometheus
     - io.prometheus-simpleclient_httpserver-0.16.0.jar
   * Oxia
-    - io.streamnative.oxia-oxia-client-api-0.4.9.jar
-    - io.streamnative.oxia-oxia-client-0.4.9.jar
+    - io.streamnative.oxia-oxia-client-api-0.4.10.jar
+    - io.streamnative.oxia-oxia-client-0.4.10.jar
   * OpenHFT
     - net.openhft-zero-allocation-hashing-0.16.jar
   * Java JSON WebTokens

--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@ flexible messaging model and an intuitive client API.</description>
     <apache-http-client.version>4.5.13</apache-http-client.version>
     <apache-httpcomponents.version>4.4.15</apache-httpcomponents.version>
     <jetcd.version>0.7.7</jetcd.version>
-    <oxia.version>0.4.9</oxia.version>
+    <oxia.version>0.4.10</oxia.version>
     <snakeyaml.version>2.0</snakeyaml.version>
     <ant.version>1.10.12</ant.version>
     <seancfoley.ipaddress.version>5.5.0</seancfoley.ipaddress.version>

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/oxia/OxiaMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/oxia/OxiaMetadataStore.java
@@ -297,10 +297,12 @@ public class OxiaMetadataStore extends AbstractMetadataStore {
 
     @Override
     public void close() throws Exception {
-        if (client != null) {
-            client.close();
+        if (isClosed.compareAndSet(false, true)) {
+            if (client != null) {
+                client.close();
+            }
+            super.close();
         }
-        super.close();
     }
 
     public Optional<MetadataEventSynchronizer> getMetadataEventSynchronizer() {


### PR DESCRIPTION
### Motivation

- oxia-java 0.4.10 switches from javax.annotation to jakarta.annotation
- OxiaMetadataStore close isn't properly changing the state to closed

### Modifications

- upgrade to oxia-java 0.4.10
- fix OxiaMetadataStore.close

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->