### PR TITLE
[fix][builds] Fix error "Element encoding is not allowed here" in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2432,7 +2432,8 @@ flexible messaging model and an intuitive client API.</description>
             <configuration>
               <configLocation>${pulsar.basedir}/buildtools/src/main/resources/pulsar/checkstyle.xml</configLocation>
               <suppressionsLocation>${pulsar.basedir}/buildtools/src/main/resources/pulsar/suppressions.xml</suppressionsLocation>
-              <encoding>UTF-8</encoding>
+              <inputEncoding>UTF-8</inputEncoding>
+              <outputEncoding>UTF-8</outputEncoding>
               <excludes>**/proto/*</excludes>
             </configuration>
           </plugin>
@@ -2496,7 +2497,7 @@ flexible messaging model and an intuitive client API.</description>
                          <configuration>
                            <configLocation>${pulsar.basedir}/buildtools/src/main/resources/pulsar/checkstyle.xml</configLocation>
                            <suppressionsLocation>${pulsar.basedir}/buildtools/src/main/resources/pulsar/suppressions.xml</suppressionsLocation>
-                           <encoding>UTF-8</encoding>
+                           <inputEncoding>UTF-8</inputEncoding>
                            <excludes>**/proto/*</excludes>
                          </configuration>
                           <goals>


### PR DESCRIPTION
### Motivation

IntelliJ shows an xml error in pom.xml, "Element encoding is not allowed here"

<img width="835" alt="image" src="https://github.com/user-attachments/assets/51452ccd-ac02-4f0a-ac23-4d06da991603">

### Modifications

- use `inputEncoding` and `outputEncoding` (when applicable) instead of `encoding`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->