### PR TITLE
[improve] Upgrade OpenTelemetry library to 1.44.1 version

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -338,12 +338,11 @@ The Apache Software License, Version 2.0
     - io.prometheus-simpleclient_tracer_otel-0.16.0.jar
     - io.prometheus-simpleclient_tracer_otel_agent-0.16.0.jar
  * Prometheus exporter
-    - io.prometheus-prometheus-metrics-config-1.3.1.jar
-    - io.prometheus-prometheus-metrics-exporter-common-1.3.1.jar
-    - io.prometheus-prometheus-metrics-exporter-httpserver-1.3.1.jar
-    - io.prometheus-prometheus-metrics-exposition-formats-1.3.1.jar
-    - io.prometheus-prometheus-metrics-model-1.3.1.jar
-    - io.prometheus-prometheus-metrics-shaded-protobuf-1.3.1.jar
+    - io.prometheus-prometheus-metrics-config-1.3.3.jar
+    - io.prometheus-prometheus-metrics-exporter-common-1.3.3.jar
+    - io.prometheus-prometheus-metrics-exporter-httpserver-1.3.3.jar
+    - io.prometheus-prometheus-metrics-exposition-formats-1.3.3.jar
+    - io.prometheus-prometheus-metrics-model-1.3.3.jar
  * Jakarta Bean Validation API
     - jakarta.validation-jakarta.validation-api-2.0.2.jar
     - javax.validation-validation-api-1.1.0.Final.jar
@@ -516,21 +515,21 @@ The Apache Software License, Version 2.0
   * RoaringBitmap
     - org.roaringbitmap-RoaringBitmap-1.2.0.jar
   * OpenTelemetry
-    - io.opentelemetry-opentelemetry-api-1.41.0.jar
-    - io.opentelemetry-opentelemetry-api-incubator-1.41.0-alpha.jar
-    - io.opentelemetry-opentelemetry-context-1.41.0.jar
-    - io.opentelemetry-opentelemetry-exporter-common-1.41.0.jar
-    - io.opentelemetry-opentelemetry-exporter-otlp-1.41.0.jar
-    - io.opentelemetry-opentelemetry-exporter-otlp-common-1.41.0.jar
-    - io.opentelemetry-opentelemetry-exporter-prometheus-1.41.0-alpha.jar
-    - io.opentelemetry-opentelemetry-exporter-sender-okhttp-1.41.0.jar
-    - io.opentelemetry-opentelemetry-sdk-1.41.0.jar
-    - io.opentelemetry-opentelemetry-sdk-common-1.41.0.jar
-    - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-1.41.0.jar
-    - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-spi-1.41.0.jar
-    - io.opentelemetry-opentelemetry-sdk-logs-1.41.0.jar
-    - io.opentelemetry-opentelemetry-sdk-metrics-1.41.0.jar
-    - io.opentelemetry-opentelemetry-sdk-trace-1.41.0.jar
+    - io.opentelemetry-opentelemetry-api-1.44.1.jar
+    - io.opentelemetry-opentelemetry-api-incubator-1.44.1-alpha.jar
+    - io.opentelemetry-opentelemetry-context-1.44.1.jar
+    - io.opentelemetry-opentelemetry-exporter-common-1.44.1.jar
+    - io.opentelemetry-opentelemetry-exporter-otlp-1.44.1.jar
+    - io.opentelemetry-opentelemetry-exporter-otlp-common-1.44.1.jar
+    - io.opentelemetry-opentelemetry-exporter-prometheus-1.44.1-alpha.jar
+    - io.opentelemetry-opentelemetry-exporter-sender-okhttp-1.44.1.jar
+    - io.opentelemetry-opentelemetry-sdk-1.44.1.jar
+    - io.opentelemetry-opentelemetry-sdk-common-1.44.1.jar
+    - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-1.44.1.jar
+    - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-spi-1.44.1.jar
+    - io.opentelemetry-opentelemetry-sdk-logs-1.44.1.jar
+    - io.opentelemetry-opentelemetry-sdk-metrics-1.44.1.jar
+    - io.opentelemetry-opentelemetry-sdk-trace-1.44.1.jar
     - io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-1.33.6.jar
     - io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-semconv-1.33.6-alpha.jar
     - io.opentelemetry.instrumentation-opentelemetry-resources-1.33.6-alpha.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -388,9 +388,9 @@ The Apache Software License, Version 2.0
     - log4j-slf4j2-impl-2.23.1.jar
     - log4j-web-2.23.1.jar
  * OpenTelemetry
-    - opentelemetry-api-1.41.0.jar
-    - opentelemetry-api-incubator-1.41.0-alpha.jar
-    - opentelemetry-context-1.41.0.jar
+    - opentelemetry-api-1.44.1.jar
+    - opentelemetry-api-incubator-1.44.1-alpha.jar
+    - opentelemetry-context-1.44.1.jar
 
  * BookKeeper
     - bookkeeper-common-allocator-4.17.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@ flexible messaging model and an intuitive client API.</description>
     <disruptor.version>3.4.3</disruptor.version>
     <zstd-jni.version>1.5.2-3</zstd-jni.version>
     <netty-reactive-streams.version>2.0.6</netty-reactive-streams.version>
-    <opentelemetry.version>1.41.0</opentelemetry.version>
+    <opentelemetry.version>1.44.1</opentelemetry.version>
     <opentelemetry.alpha.version>${opentelemetry.version}-alpha</opentelemetry.alpha.version>
     <opentelemetry.instrumentation.version>1.33.6</opentelemetry.instrumentation.version>
     <opentelemetry.instrumentation.alpha.version>${opentelemetry.instrumentation.version}-alpha</opentelemetry.instrumentation.alpha.version>

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/BrokerOpenTelemetryTestUtil.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/BrokerOpenTelemetryTestUtil.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.stats;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
 import io.opentelemetry.sdk.metrics.data.MetricData;
@@ -52,13 +53,14 @@ public class BrokerOpenTelemetryTestUtil {
 
     public static void assertMetricDoubleSumValue(Collection<MetricData> metrics, String metricName,
                                                   Attributes attributes, Consumer<Double> valueConsumer) {
+        Map<AttributeKey<?>, Object> attributesMap = attributes.asMap();
         assertThat(metrics)
                 .anySatisfy(metric -> assertThat(metric)
                         .hasName(metricName)
                         .hasDoubleSumSatisfying(sum -> sum.satisfies(
                                 sumData -> assertThat(sumData.getPoints()).anySatisfy(
                                         point -> {
-                                            assertThat(point.getAttributes()).isEqualTo(attributes);
+                                            assertThat(point.getAttributes().asMap()).isEqualTo(attributesMap);
                                             valueConsumer.accept(point.getValue());
                                         }))));
     }
@@ -70,13 +72,14 @@ public class BrokerOpenTelemetryTestUtil {
 
     public static void assertMetricLongSumValue(Collection<MetricData> metrics, String metricName,
                                                 Attributes attributes, Consumer<Long> valueConsumer) {
+        Map<AttributeKey<?>, Object> attributesMap = attributes.asMap();
         assertThat(metrics)
                 .anySatisfy(metric -> assertThat(metric)
                         .hasName(metricName)
                         .hasLongSumSatisfying(sum -> sum.satisfies(
                                 sumData -> assertThat(sumData.getPoints()).anySatisfy(
                                         point -> {
-                                            assertThat(point.getAttributes()).isEqualTo(attributes);
+                                            assertThat(point.getAttributes().asMap()).isEqualTo(attributesMap);
                                             valueConsumer.accept(point.getValue());
                                         }))));
     }
@@ -88,13 +91,14 @@ public class BrokerOpenTelemetryTestUtil {
 
     public static void assertMetricLongGaugeValue(Collection<MetricData> metrics, String metricName,
                                                   Attributes attributes, Consumer<Long> valueConsumer) {
+        Map<AttributeKey<?>, Object> attributesMap = attributes.asMap();
         assertThat(metrics)
                 .anySatisfy(metric -> assertThat(metric)
                         .hasName(metricName)
                         .hasLongGaugeSatisfying(gauge -> gauge.satisfies(
                                 pointData -> assertThat(pointData.getPoints()).anySatisfy(
                                         point -> {
-                                            assertThat(point.getAttributes()).isEqualTo(attributes);
+                                            assertThat(point.getAttributes().asMap()).isEqualTo(attributesMap);
                                             valueConsumer.accept(point.getValue());
                                         }))));
     }
@@ -106,13 +110,14 @@ public class BrokerOpenTelemetryTestUtil {
 
     public static void assertMetricDoubleGaugeValue(Collection<MetricData> metrics, String metricName,
                                                   Attributes attributes, Consumer<Double> valueConsumer) {
+        Map<AttributeKey<?>, Object> attributesMap = attributes.asMap();
         assertThat(metrics)
                 .anySatisfy(metric -> assertThat(metric)
                         .hasName(metricName)
                         .hasDoubleGaugeSatisfying(gauge -> gauge.satisfies(
                                 pointData -> assertThat(pointData.getPoints()).anySatisfy(
                                         point -> {
-                                            assertThat(point.getAttributes()).isEqualTo(attributes);
+                                            assertThat(point.getAttributes().asMap()).isEqualTo(attributesMap);
                                             valueConsumer.accept(point.getValue());
                                         }))));
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/metrics/ClientMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/metrics/ClientMetricsTest.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.client.metrics;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
@@ -48,7 +47,7 @@ import org.testng.annotations.Test;
 public class ClientMetricsTest extends ProducerConsumerBase {
 
     InMemoryMetricReader reader;
-    OpenTelemetry otel;
+    OpenTelemetrySdk otel;
 
     @BeforeMethod
     @Override
@@ -67,6 +66,14 @@ public class ClientMetricsTest extends ProducerConsumerBase {
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
+        if (otel != null) {
+            otel.close();
+            otel = null;
+        }
+        if (reader != null) {
+            reader.close();
+            reader = null;
+        }
     }
 
     private Map<String, MetricData> collectMetrics() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/metrics/ClientMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/metrics/ClientMetricsTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.metrics;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
@@ -95,8 +96,9 @@ public class ClientMetricsTest extends ProducerConsumerBase {
         assertNotNull(md, "metric not found: " + name);
         assertEquals(md.getType(), MetricDataType.LONG_SUM);
 
+        Map<AttributeKey<?>, Object> expectedAttributesMap = expectedAttributes.asMap();
         for (var ex : md.getLongSumData().getPoints()) {
-            if (ex.getAttributes().equals(expectedAttributes)) {
+            if (ex.getAttributes().asMap().equals(expectedAttributesMap)) {
                 return ex.getValue();
             }
         }
@@ -116,8 +118,9 @@ public class ClientMetricsTest extends ProducerConsumerBase {
         assertNotNull(md, "metric not found: " + name);
         assertEquals(md.getType(), MetricDataType.HISTOGRAM);
 
+        Map<AttributeKey<?>, Object> expectedAttributesMap = expectedAttributes.asMap();
         for (var ex : md.getHistogramData().getPoints()) {
-            if (ex.getAttributes().equals(expectedAttributes)) {
+            if (ex.getAttributes().asMap().equals(expectedAttributesMap)) {
                 return ex.getCount();
             }
         }


### PR DESCRIPTION
### Motivation

OpenTelemetry library is improving and it's useful to use a recent version to get the improvements in Pulsar too.

### Modifications

Upgrade OpenTelemetry library from 1.41.0 to 1.44.1 version

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->