### PR TITLE
[improve] Install coreutils in docker image to improve compatibility

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -94,7 +94,8 @@ RUN apk add --no-cache \
             procps \
             curl \
             bind-tools \
-            openssl
+            openssl \
+            coreutils
 
 # Upgrade all packages to get latest versions with security fixes
 RUN apk upgrade --no-cache


### PR DESCRIPTION
Resolves apache/pulsar-helm-chart#554

### Motivation

- the timeout command provided by default busybox implementation in Alpine leaves zombie processes
  - see apache/pulsar-helm-chart#554 for details

### Modifications

- add `coreutils` package to the docker image. The size of `coreutils` is small, only about 1MB.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->