### PR TITLE
[fix][ml] The readPosition is greater than the lastPosition

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1904,7 +1904,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             if (ledgerInfo == null || ledgerInfo.getEntries() == 0) {
                 // Cursor is pointing to an empty ledger, there's no need to try opening it. Skip this ledger and
                 // move to the next one
-                opReadEntry.updateReadPosition(PositionFactory.create(opReadEntry.readPosition.getLedgerId() + 1, 0));
+                Position position = PositionFactory.create(opReadEntry.readPosition.getLedgerId() + 1, 0);
+                Position maxPosition = lastConfirmedEntry.getNext();
+                opReadEntry.updateReadPosition(position.compareTo(maxPosition) > 0 ? maxPosition : position);
                 opReadEntry.checkReadCompletion();
                 return;
             }
@@ -2095,7 +2097,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 if (nextLedgerId != null) {
                     opReadEntry.updateReadPosition(PositionFactory.create(nextLedgerId, 0));
                 } else {
-                    opReadEntry.updateReadPosition(PositionFactory.create(ledger.getId() + 1, 0));
+                    Position position = PositionFactory.create(opReadEntry.readPosition.getLedgerId() + 1, 0);
+                    Position maxPosition = lastPosition.getNext();
+                    opReadEntry.updateReadPosition(position.compareTo(maxPosition) > 0 ? maxPosition : position);
                 }
             } else {
                 opReadEntry.updateReadPosition(opReadEntry.readPosition);


### PR DESCRIPTION
### Motivation
Fix issue: https://github.com/apache/pulsar/issues/23673
We found that sometimes `readPosition` is larger than `lastPosition`. If this happens, messages will not be consumed, messages will be backlogged, and recovery will not be possible.
The reason for this problem is probably when executing `updateReadPosition` method.

### Modifications
When executing the `updateReadPosition` method, the updated position is not allowed to exceed lastPosition+1


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->