### PR TITLE
[fix][admin] Listen partitioned topic creation event

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/TopicEventsListenerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/TopicEventsListenerTest.java
@@ -265,12 +265,23 @@ public class TopicEventsListenerTest extends BrokerTestBase {
     private void createTopicAndVerifyEvents(String topicDomain, String topicTypePartitioned, String topicName) throws Exception {
         final String[] expectedEvents;
         if (topicDomain.equalsIgnoreCase("persistent") || topicTypePartitioned.equals("partitioned")) {
-            expectedEvents = new String[]{
-                    "LOAD__BEFORE",
-                    "CREATE__BEFORE",
-                    "CREATE__SUCCESS",
-                    "LOAD__SUCCESS"
-            };
+            if (topicTypePartitioned.equals("partitioned")) {
+                expectedEvents = new String[]{
+                        "CREATE__BEFORE",
+                        "CREATE__SUCCESS",
+                        "LOAD__BEFORE",
+                        "CREATE__BEFORE",
+                        "CREATE__SUCCESS",
+                        "LOAD__SUCCESS"
+                };
+            } else {
+                expectedEvents = new String[]{
+                        "LOAD__BEFORE",
+                        "CREATE__BEFORE",
+                        "CREATE__SUCCESS",
+                        "LOAD__SUCCESS"
+                };
+            }
         } else {
             expectedEvents = new String[]{
                     // Before https://github.com/apache/pulsar/pull/21995, Pulsar will skip create topic if the topic


### PR DESCRIPTION
### Motivation

I have a broker interceptor, which will add a topic event listener to listen the topic creation in the `org.apache.pulsar.broker.intercept.BrokerInterceptor#initialize`. However, the partitioned topic creation event can not be recorded(`bin/pulsar-admin topics create-partitioned-topic -p 3 test-topic-event`).

```java
pulsar.getBrokerService().addTopicEventListener((topic, event, stage, t) -> {
            log.info("got event {}__{} for topic {}", event, stage, topic);
});
```

The non-partitioned topic works fine. 

### Modifications

- Call `topicEventsDispatcher` with the `TopicEvent.CREATE` and `EventStage.BEFORE` before creating the persistent/non-persistent partitioned topic.
- Call `topicEventsDispatcher` with the `TopicEvent.CREATE` and `EventStage.SUCCESS/FAILURE`  after the persistent/non-persistent partitioned topic is created.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->