### PR TITLE
[improve][client]Add logging for message size exceeding the configured threshold before throwing exception

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -2413,11 +2413,16 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     private boolean isMessageSizeExceeded(OpSendMsg op) {
         if (op.msg != null && !conf.isChunkingEnabled()) {
             int messageSize = op.getMessageHeaderAndPayloadSize();
-            if (messageSize > getMaxMessageSize()) {
+            int maxMessageSize = getMaxMessageSize();
+            if (messageSize > maxMessageSize) {
+                // Log the message size exceeding the limit
+                log.warn("Message size exceeded: Producer {} attempted to send a message of {} bytes, "
+                                + "exceeding the configured maximum size of {} bytes on topic {}.",
+                        producerName, messageSize, maxMessageSize, topic);
                 releaseSemaphoreForSendOp(op);
                 op.sendComplete(new PulsarClientException.InvalidMessageException(
                         format("The producer %s of the topic %s sends a message with %d bytes that exceeds %d bytes",
-                                producerName, topic, messageSize, getMaxMessageSize()),
+                                producerName, topic, messageSize, maxMessageSize),
                         op.sequenceId));
                 return true;
             }


### PR DESCRIPTION
### Motivation

The current behavior does not provide clear visibility when the message size exceeds the configured maximum size, often leading to `InvalidMessageException` error. This change introduces a log statement to notify when the message size exceeds the threshold, helping users identify and troubleshoot message size issues more easily.

### Modifications

Added a `log.warn` statement before releasing the semaphore and throwing the `InvalidMessageException`.
The log includes details about the message size, the configured threshold, and the producer/topic involved, improving visibility for debugging and troubleshooting.

### Verifying this change

- [X] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
