### PR TITLE
[fix][broker] Fix the retry mechanism in `MetadataCache#readModifyUpdateOrCreate`

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/BaseResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/BaseResources.java
@@ -34,6 +34,7 @@ import java.util.function.Function;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.metadata.api.MetadataCache;
+import org.apache.pulsar.metadata.api.MetadataCacheConfig;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 
@@ -58,13 +59,19 @@ public class BaseResources<T> {
 
     public BaseResources(MetadataStore store, Class<T> clazz, int operationTimeoutSec) {
         this.store = store;
-        this.cache = store.getMetadataCache(clazz);
+        this.cache = store.getMetadataCache(clazz, MetadataCacheConfig.builder()
+                .retryBackoff(MetadataCacheConfig.DEFAULT_RETRY_BACKOFF_BUILDER.setMandatoryStop(operationTimeoutSec,
+                        TimeUnit.SECONDS))
+                .build());
         this.operationTimeoutSec = operationTimeoutSec;
     }
 
     public BaseResources(MetadataStore store, TypeReference<T> typeRef, int operationTimeoutSec) {
         this.store = store;
-        this.cache = store.getMetadataCache(typeRef);
+        this.cache = store.getMetadataCache(typeRef, MetadataCacheConfig.builder()
+                .retryBackoff(MetadataCacheConfig.DEFAULT_RETRY_BACKOFF_BUILDER.setMandatoryStop(operationTimeoutSec,
+                        TimeUnit.SECONDS))
+                .build());
         this.operationTimeoutSec = operationTimeoutSec;
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/Backoff.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/Backoff.java
@@ -22,7 +22,6 @@ import java.time.Clock;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import lombok.Data;
-import lombok.Getter;
 
 // All variables are in TimeUnit millis by default
 @Data
@@ -35,7 +34,6 @@ public class Backoff {
     private long next;
     private long mandatoryStop;
 
-    @Getter
     private long firstBackoffTimeInMillis;
     private boolean mandatoryStopMade = false;
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/Backoff.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/Backoff.java
@@ -18,11 +18,11 @@
  */
 package org.apache.pulsar.common.util;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.time.Clock;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import lombok.Data;
+import lombok.Getter;
 
 // All variables are in TimeUnit millis by default
 @Data
@@ -35,6 +35,7 @@ public class Backoff {
     private long next;
     private long mandatoryStop;
 
+    @Getter
     private long firstBackoffTimeInMillis;
     private boolean mandatoryStopMade = false;
 
@@ -93,11 +94,6 @@ public class Backoff {
     public void reset() {
         this.next = this.initial;
         this.mandatoryStopMade = false;
-    }
-
-    @VisibleForTesting
-    long getFirstBackoffTimeInMillis() {
-        return firstBackoffTimeInMillis;
     }
 
     public static boolean shouldBackoff(long initialTimestamp, TimeUnit unitInitial, int failedAttempts,

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/BackoffTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/BackoffTest.java
@@ -136,6 +136,7 @@ public class BackoffTest {
 
         // would have been 1600 w/o the mandatory stop
         assertTrue(withinTenPercentAndDecrementTimer(backoff, 400));
+        assertTrue(backoff.isMandatoryStopMade());
         Mockito.when(mockClock.millis()).thenReturn(1900L);
         assertTrue(withinTenPercentAndDecrementTimer(backoff, 3200));
         Mockito.when(mockClock.millis()).thenReturn(3200L);

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCacheConfig.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCacheConfig.java
@@ -24,6 +24,7 @@ import java.util.function.BiConsumer;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import org.apache.pulsar.common.util.BackoffBuilder;
 
 /**
  * The configuration builder for a {@link MetadataCache} config.
@@ -33,6 +34,10 @@ import lombok.ToString;
 @ToString
 public class MetadataCacheConfig<T> {
     private static final long DEFAULT_CACHE_REFRESH_TIME_MILLIS = TimeUnit.MINUTES.toMillis(5);
+    public static final BackoffBuilder DEFAULT_RETRY_BACKOFF_BUILDER =
+            new BackoffBuilder().setInitialTime(5, TimeUnit.MILLISECONDS)
+                    .setMax(3, TimeUnit.SECONDS)
+                    .setMandatoryStop(30, TimeUnit.SECONDS);
 
     /**
      * Specifies that active entries are eligible for automatic refresh once a fixed duration has
@@ -56,5 +61,8 @@ public class MetadataCacheConfig<T> {
      */
     @Builder.Default
     private final BiConsumer<String, Optional<CacheGetResult<T>>> asyncReloadConsumer = null;
+
+    @Builder.Default
+    private final BackoffBuilder retryBackoff = DEFAULT_RETRY_BACKOFF_BUILDER;
 
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
@@ -24,6 +24,7 @@ import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
@@ -61,7 +62,8 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
     private final MetadataStore store;
     private final MetadataStoreExtended storeExtended;
     private final MetadataSerde<T> serde;
-    private final ScheduledExecutorService backoffExecutor = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService backoffExecutor =
+            Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("metadata-cache-backoff"));
 
     private final AsyncLoadingCache<String, Optional<CacheGetResult<T>>> objCache;
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -236,21 +236,21 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
     @Override
     public <T> MetadataCache<T> getMetadataCache(Class<T> clazz, MetadataCacheConfig cacheConfig) {
         MetadataCacheImpl<T> metadataCache = new MetadataCacheImpl<T>(this,
-                TypeFactory.defaultInstance().constructSimpleType(clazz, null), cacheConfig);
+                TypeFactory.defaultInstance().constructSimpleType(clazz, null), cacheConfig, this.executor);
         metadataCaches.add(metadataCache);
         return metadataCache;
     }
 
     @Override
     public <T> MetadataCache<T> getMetadataCache(TypeReference<T> typeRef, MetadataCacheConfig cacheConfig) {
-        MetadataCacheImpl<T> metadataCache = new MetadataCacheImpl<T>(this, typeRef, cacheConfig);
+        MetadataCacheImpl<T> metadataCache = new MetadataCacheImpl<T>(this, typeRef, cacheConfig, this.executor);
         metadataCaches.add(metadataCache);
         return metadataCache;
     }
 
     @Override
     public <T> MetadataCache<T> getMetadataCache(MetadataSerde<T> serde, MetadataCacheConfig cacheConfig) {
-        MetadataCacheImpl<T> metadataCache = new MetadataCacheImpl<>(this, serde, cacheConfig);
+        MetadataCacheImpl<T> metadataCache = new MetadataCacheImpl<>(this, serde, cacheConfig, this.executor);
         metadataCaches.add(metadataCache);
         return metadataCache;
     }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pulsar.metadata;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotSame;
@@ -26,7 +29,9 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -36,6 +41,8 @@ import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
@@ -44,6 +51,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.common.util.BackoffBuilder;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.metadata.api.CacheGetResult;
@@ -52,6 +60,7 @@ import org.apache.pulsar.metadata.api.MetadataCacheConfig;
 import org.apache.pulsar.metadata.api.MetadataSerde;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyExistsException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.ContentDeserializationException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
@@ -61,6 +70,7 @@ import org.apache.pulsar.metadata.api.Stat;
 import org.apache.pulsar.metadata.api.extended.CreateOption;
 import org.apache.pulsar.metadata.cache.impl.MetadataCacheImpl;
 import org.awaitility.Awaitility;
+import org.mockito.stubbing.Answer;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -514,6 +524,51 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         }
     }
 
+    @Test
+    public void readModifyUpdateOrCreateRetryTimeout() throws Exception {
+        String url = zks.getConnectionString();
+        @Cleanup
+        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+
+        MetadataCache<MyClass> cache = store.getMetadataCache(MyClass.class, MetadataCacheConfig.builder()
+                .retryBackoff(new BackoffBuilder()
+                        .setInitialTime(5, TimeUnit.MILLISECONDS)
+                        .setMax(1, TimeUnit.SECONDS)
+                        .setMandatoryStop(3, TimeUnit.SECONDS)).build());
+
+        Field metadataCacheField = cache.getClass().getDeclaredField("objCache");
+        metadataCacheField.setAccessible(true);
+        var objCache = metadataCacheField.get(cache);
+        var spyObjCache = (AsyncLoadingCache<?, ?>) spy(objCache);
+        doAnswer((Answer<CompletableFuture<MyClass>>) invocation -> CompletableFuture.failedFuture(
+                new MetadataStoreException.BadVersionException(""))).when(spyObjCache).get(any());
+        metadataCacheField.set(cache, spyObjCache);
+
+        // Test three times to ensure that the retry works each time.
+        for (int i = 0; i < 3; i++) {
+            var start = System.currentTimeMillis();
+            boolean timeouted = false;
+            try {
+                cache.readModifyUpdateOrCreate(newKey(), Optional::get).join();
+            } catch (CompletionException e) {
+                if (e.getCause() instanceof TimeoutException) {
+                    var elapsed = System.currentTimeMillis() - start;
+                    // Since we reduce the wait time by a random amount for each retry, the total elapsed time should be
+                    // mandatoryStopTime - maxTime * 0.9, which is 2900ms.
+                    assertTrue(elapsed >= 2900L,
+                            "The elapsed time should be greater than the timeout. But now it's " + elapsed);
+                    // The elapsed time should be less than the timeout. The 1.5 factor allows for some extra time.
+                    assertTrue(elapsed < 3000L * 1.5,
+                            "The retry should have been stopped after the timeout. But now it's " + elapsed);
+                    timeouted = true;
+                } else {
+                    fail("Should have failed with TimeoutException, but failed with " + e.getCause());
+                }
+            }
+            assertTrue(timeouted, "Should have failed with TimeoutException, but succeeded");
+        }
+    }
+
     @Test(dataProvider = "impl")
     public void getWithStats(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
@@ -644,5 +699,16 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         Awaitility.await().untilAsserted(() -> {
             refreshed.contains(value2);
         });
+    }
+
+    @Test
+    public void testDefaultMetadataCacheConfig() {
+        final var config = MetadataCacheConfig.builder().build();
+        assertEquals(config.getRefreshAfterWriteMillis(), TimeUnit.MINUTES.toMillis(5));
+        assertEquals(config.getExpireAfterWriteMillis(), TimeUnit.MINUTES.toMillis(10));
+        final var backoff = config.getRetryBackoff().create();
+        assertEquals(backoff.getInitial(), 5);
+        assertEquals(backoff.getMax(), 3000);
+        assertEquals(backoff.getMandatoryStop(), 30_000);
     }
 }


### PR DESCRIPTION
## Motivation

The method `MetadataCache#readModifyUpdateOrCreate` should handle the BadVersionException by retrying the modification process, as already noted in the Java documentation: "The modify function can potentially be called multiple times due to concurrent updates."

Currently, `MetadataCache#readModifyUpdateOrCreate` does not catch the BadVersionException on the second attempt, allowing the exception to be passed to the caller. This issue can be easily reproduced by increasing concurrent futures in the test `MetadataCacheTest#readModifyUpdateBadVersionRetry`.

The current retry implementation is incorrect and lacks a backoff mechanism, which could lead to too many requests to the metadata store.

## Modification

- Correct the retry process in `MetadataCache#readModifyUpdateOrCreate` to ensure BadVersionException is caught during each retry.
- Implement a retry backoff mechanism in `MetadataCache#readModifyUpdateOrCreate` to manage the frequency of retries effectively.
- Add new config `retryBackoff` to the MetadataCacheConfig to control the MetadataCache retry backoff.
- Respective the `metadataStoreOperationTimeoutSeconds` for the MetadataCache retry


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
