### PR TITLE
[fix][cli] Fix set topic retention policy failed

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -1852,7 +1852,7 @@ public class CmdTopics extends CmdBase {
                 + "-t 120 will set retention to 2 minutes. "
                 + "0 means no retention and -1 means infinite time retention.", required = true,
                 converter = TimeUnitToSecondsConverter.class)
-        private Integer retentionTimeInSec;
+        private Long retentionTimeInSec;
 
         @Option(names = { "--size", "-s" }, description = "Retention size limit with optional size unit suffix. "
                 + "For example, 4096, 10M, 16G, 3T.  The size unit suffix character can be k/K, m/M, g/G, or t/T.  "


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation
When using this command `bin/pulsar-admin topics set-retention -s 20g -t 200d persistent://public/default/test_v1` to set a retention policy for a topic, it failed with following exception
```
PicocliException: Could not set value for field private java.lang.Integer org.apache.pulsar.admin.cli.CmdTopics$SetRetention.retentionTimeInSec to 17280000 while processing argument at or before arg[5] '200d' in [topics, set-retention, -s, 20g, -t, 200d, persistent://public/default/test_v1]: picocli.CommandLine$PicocliException: Could not set value for field private java.lang.Integer org.apache.pulsar.admin.cli.CmdTopics$SetRetention.retentionTimeInSec to 17280000
Usage: pulsar-admin topics set-retention [-hv] -s=<sizeLimit>
       -t=<retentionTimeInSec> <topicName>
Set the retention policy for a topic
      <topicName>          persistent://tenant/namespace/topic
  -h, --help               Show this help message and exit.
  -s, --size=<sizeLimit>   Retention size limit with optional size unit suffix.
                             For example, 4096, 10M, 16G, 3T.  The size unit
                             suffix character can be k/K, m/M, g/G, or t/T.  If
                             the size unit suffix is not specified, the default
                             unit is bytes. 0 or less than 1MB means no
                             retention and -1 means infinite size retention
  -t, --time=<retentionTimeInSec>
                           Retention time with optional time unit suffix. For
                             example, 100m, 3h, 2d, 5w. If the time unit is not
                             specified, the default unit is seconds. For
                             example, -t 120 will set retention to 2 minutes. 0
                             means no retention and -1 means infinite time
                             retention.
  -v, --version            Print version information and exit.
```

It is caused by cast Long to Integer failed
https://github.com/apache/pulsar/blob/28e47fa99dcb080385cfa567b844e74ab0cd85b1/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java#L1854-L1855

https://github.com/apache/pulsar/blob/28e47fa99dcb080385cfa567b844e74ab0cd85b1/pulsar-cli-utils/src/main/java/org/apache/pulsar/cli/converters/picocli/TimeUnitToSecondsConverter.java#L28-L35

### Modifications
Change the type of `retentionTimeInSec` from `Integer` to `Long`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
