### PR TITLE
[fix][client] Fix reader message filtering issue during blue-green cluster switch

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AcknowledgmentsGroupingTracker.java
@@ -42,4 +42,6 @@ public interface AcknowledgmentsGroupingTracker extends AutoCloseable {
     void close();
 
     void flushAndClean();
+
+    void clean();
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -37,6 +37,7 @@ import io.netty.util.concurrent.FastThreadLocal;
 import io.opentelemetry.api.common.Attributes;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -3099,6 +3100,12 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         ClientCnx cnx = getClientCnx();
         return conf.isAckReceiptEnabled() && cnx != null
                 && Commands.peerSupportsAckReceipt(cnx.getRemoteEndpointProtocolVersion());
+    }
+
+    @Override
+    protected void setRedirectedClusterURI(String serviceUrl, String serviceUrlTls) throws URISyntaxException {
+        super.setRedirectedClusterURI(serviceUrl, serviceUrlTls);
+        acknowledgmentsGroupingTracker.clean();
     }
 
     private static final Logger log = LoggerFactory.getLogger(ConsumerImpl.class);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/NonPersistentAcknowledgmentGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/NonPersistentAcknowledgmentGroupingTracker.java
@@ -71,4 +71,9 @@ public class NonPersistentAcknowledgmentGroupingTracker implements Acknowledgmen
     public void flushAndClean() {
         // no-op
     }
+
+    @Override
+    public void clean() {
+        // no-op
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -518,6 +518,13 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
     }
 
     @Override
+    public void clean() {
+        lastCumulativeAck.reset();
+        pendingIndividualAcks.clear();
+        pendingIndividualBatchIndexAcks.clear();
+    }
+
+    @Override
     public void close() {
         flush();
         if (scheduledTask != null && !scheduledTask.isCancelled()) {


### PR DESCRIPTION
### Motivation
When the delayed acknowledgment feature is enabled, the method `org.apache.pulsar.client.impl.PersistentAcknowledgmentsGroupingTracker#isDuplicate` filters out messages that have already been acknowledged on the client side. 

When using the blue-green cluster feature, after switching from the blue cluster to the green cluster, the message IDs generated by the green cluster may be smaller than those from the blue cluster. In this case, if a reader is used for consumption, the method `org.apache.pulsar.client.impl.PersistentAcknowledgmentsGroupingTracker#isDuplicate` will filter out all messages with IDs less than or equal to `lastCumulativeAck`, which can result in the loss of messages with IDs less than or equal to `lastCumulativeAck` after switching to the green cluster.

### Modifications
Before switching from the blue cluster to the green cluster, first clear the contents of `org.apache.pulsar.client.impl.AcknowledgmentsGroupingTracker`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

Added test in: `org.apache.pulsar.broker.service.ClusterMigrationTest#testMigrationWithReader`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/hrzzzz/pulsar/pull/11

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
