### PR TITLE
[fix][broker] Correct the 'connected' status in topic stats of multi-partition topic for geo replication

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ReplicatorStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ReplicatorStatsImpl.java
@@ -62,7 +62,7 @@ public class ReplicatorStatsImpl implements ReplicatorStats {
     public long replicationBacklog;
 
     /** is the replication-subscriber up and running to replicate to remote cluster. */
-    public boolean connected;
+    public boolean connected = true;
 
     /** Time in seconds from the time a message was produced to the time when it is about to be replicated. */
     public long replicationDelayInSeconds;


### PR DESCRIPTION
### Motivation

The default value of the `connected` field in `org.apache.pulsar.common.policies.data.stats.ReplicatorStatsImpl` is false, and the logic for accumulating each partition (`org.apache.pulsar.common.policies.data.stats.ReplicatorStatsImpl#add`) is `this.connected &= stats.connected;`. This causes the status of a multi-partition topic to always be false after calculation, and it is impossible to truly feedback the correct status of the geo replication task.

### Modifications

Modify the `connected` field in `org.apache.pulsar.common.policies.data.stats.ReplicatorStatsImpl` from false to true.

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

