### PR TITLE
[fix][broker] Geo Replication lost messages or frequently fails due to Deduplication is not appropriate for Geo-Replication

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
@@ -195,6 +195,7 @@ public abstract class AbstractReplicator implements Replicator {
         prepareCreateProducer().thenCompose(ignore -> {
             ProducerBuilderImpl builderImpl = (ProducerBuilderImpl) producerBuilder;
             builderImpl.getConf().setNonPartitionedTopicExpected(true);
+            builderImpl.getConf().setReplProducer(true);
             return producerBuilder.createAsync().thenAccept(producer -> {
                 setProducerAndTriggerReadEntries(producer);
             });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -567,9 +567,9 @@ public class Producer {
             String replSequenceLIdStr = String.valueOf(getProperty(MSG_PROP_REPL_SEQUENCE_LID));
             String replSequenceEIdStr = String.valueOf(getProperty(MSG_PROP_REPL_SEQUENCE_EID));
             if (!StringUtils.isNumeric(replSequenceLIdStr) || !StringUtils.isNumeric(replSequenceEIdStr)) {
-                log.error("[{}] Message can not determine whether the message is duplicated due to the acquired messages"
-                                + " props were are invalid. producer={}. supportsDedupReplV2: {}, sequence-id {},"
-                                + " prop-{}: {}, prop-{}: {}",
+                log.error("[{}] Message can not determine whether the message is duplicated due to the acquired"
+                                + " messages props were are invalid. producer={}. supportsDedupReplV2: {},"
+                                + " sequence-id {}, prop-{}: {}, prop-{}: {}",
                         producer.topic.getName(), producer.producerName,
                         supportsDedupReplV2(), getSequenceId(),
                         MSG_PROP_REPL_SEQUENCE_LID, replSequenceLIdStr,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -588,7 +588,8 @@ public class Producer {
             }
             // Case-2: is a repl message.
             Object positionPairObj = getProperty(MSG_PROP_REPL_SOURCE_POSITION);
-            if (positionPairObj == null || !(positionPairObj instanceof long[])) {
+            if (positionPairObj == null || !(positionPairObj instanceof long[])
+                    || ((long[]) positionPairObj).length < 2) {
                 log.error("[{}] Message can not determine whether the message is duplicated due to the acquired"
                                 + " messages props were are invalid. producer={}. supportsReplDedupByLidAndEid: {},"
                                 + " sequence-id {}, prop-{}: not in expected format",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -65,6 +65,7 @@ import javax.naming.AuthenticationException;
 import javax.net.ssl.SSLSession;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
+import lombok.Getter;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedLedger;
@@ -237,6 +238,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     private boolean encryptionRequireOnProducer;
 
+    @Getter
     private FeatureFlags features;
 
     private PulsarCommandSender commandSender;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -127,7 +127,7 @@ public interface Topic {
 
         }
 
-        default boolean supportsDedupReplV2() {
+        default boolean supportsReplDedupByLidAndEid() {
             return false;
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -126,6 +126,10 @@ public interface Topic {
         default void setEntryTimestamp(long entryTimestamp) {
 
         }
+
+        default boolean supportsDedupReplV2() {
+            return false;
+        }
     }
 
     CompletableFuture<Void> initialize();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TransportCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TransportCnx.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
+import org.apache.pulsar.common.api.proto.FeatureFlags;
 
 public interface TransportCnx {
 
@@ -103,4 +104,10 @@ public interface TransportCnx {
      * previously called {@link #incrementThrottleCount()}.
      */
     void decrementThrottleCount();
+
+    FeatureFlags getFeatures();
+
+    default boolean isClientSupportsDedupReplV2() {
+        return getFeatures() != null && getFeatures().hasSupportsDedupReplV2() && getFeatures().isSupportsDedupReplV2();
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TransportCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TransportCnx.java
@@ -107,7 +107,8 @@ public interface TransportCnx {
 
     FeatureFlags getFeatures();
 
-    default boolean isClientSupportsDedupReplV2() {
-        return getFeatures() != null && getFeatures().hasSupportsDedupReplV2() && getFeatures().isSupportsDedupReplV2();
+    default boolean isClientSupportsReplDedupByLidAndEid() {
+        return getFeatures() != null && getFeatures().hasSupportsReplDedupByLidAndEid()
+                && getFeatures().isSupportsReplDedupByLidAndEid();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pulsar.broker.service.persistent;
 
-import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SEQUENCE_EID;
-import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SEQUENCE_LID;
+import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SOURCE_EID;
+import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SOURCE_LID;
 import io.netty.buffer.ByteBuf;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -196,13 +196,10 @@ public class GeoPersistentReplicator extends PersistentReplicator {
                     msg.setSchemaInfoForReplicator(schemaFuture.get());
                     msg.getMessageBuilder().clearTxnidMostBits();
                     msg.getMessageBuilder().clearTxnidLeastBits();
-                    // Why not use a generated sequence ID that initialized with "-1" when the replicator is starting?
-                    // Because that we should persist the props to the value of the current value of sequence id for
-                    // each acknowledge after publishing for guarantees the sequence id can be recovered after a cursor
-                    // reset that will happen when getting new schema or publish fails, which cost much more.
-                    msg.getMessageBuilder().addProperty().setKey(MSG_PROP_REPL_SEQUENCE_LID)
+                    // Add props for sequence checking.
+                    msg.getMessageBuilder().addProperty().setKey(MSG_PROP_REPL_SOURCE_LID)
                             .setValue(Long.valueOf(entry.getLedgerId()).toString());
-                    msg.getMessageBuilder().addProperty().setKey(MSG_PROP_REPL_SEQUENCE_EID)
+                    msg.getMessageBuilder().addProperty().setKey(MSG_PROP_REPL_SOURCE_EID)
                             .setValue(Long.valueOf(entry.getEntryId()).toString());
                     msgOut.recordEvent(headersAndPayload.readableBytes());
                     stats.incrementMsgOutCounter();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.broker.service.persistent;
 
+import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SEQUENCE_EID;
+import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SEQUENCE_LID;
 import io.netty.buffer.ByteBuf;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -194,11 +196,22 @@ public class GeoPersistentReplicator extends PersistentReplicator {
                     msg.setSchemaInfoForReplicator(schemaFuture.get());
                     msg.getMessageBuilder().clearTxnidMostBits();
                     msg.getMessageBuilder().clearTxnidLeastBits();
+                    // Why not use a generated sequence ID that initialized with "-1" when the replicator is starting?
+                    // Because that we should persist the props to the value of the current value of sequence id for
+                    // each acknowledge after publishing for guarantees the sequence id can be recovered after a cursor
+                    // reset that will happen when getting new schema or publish fails, which cost much more.
+                    msg.getMessageBuilder().addProperty().setKey(MSG_PROP_REPL_SEQUENCE_LID)
+                            .setValue(Long.valueOf(entry.getLedgerId()).toString());
+                    msg.getMessageBuilder().addProperty().setKey(MSG_PROP_REPL_SEQUENCE_EID)
+                            .setValue(Long.valueOf(entry.getEntryId()).toString());
                     msgOut.recordEvent(headersAndPayload.readableBytes());
                     stats.incrementMsgOutCounter();
                     stats.incrementBytesOutCounter(headersAndPayload.readableBytes());
                     // Increment pending messages for messages produced locally
                     PENDING_MESSAGES_UPDATER.incrementAndGet(this);
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] Publishing {}:{}", replicatorId, entry.getLedgerId(), entry.getEntryId());
+                    }
                     producer.sendAsync(msg, ProducerSendCallback.create(this, entry, msg));
                     atLeastOneMessageSentForReplication = true;
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
@@ -18,8 +18,7 @@
  */
 package org.apache.pulsar.broker.service.persistent;
 
-import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SOURCE_EID;
-import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SOURCE_LID;
+import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SOURCE_POSITION;
 import io.netty.buffer.ByteBuf;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -197,10 +196,8 @@ public class GeoPersistentReplicator extends PersistentReplicator {
                     msg.getMessageBuilder().clearTxnidMostBits();
                     msg.getMessageBuilder().clearTxnidLeastBits();
                     // Add props for sequence checking.
-                    msg.getMessageBuilder().addProperty().setKey(MSG_PROP_REPL_SOURCE_LID)
-                            .setValue(Long.valueOf(entry.getLedgerId()).toString());
-                    msg.getMessageBuilder().addProperty().setKey(MSG_PROP_REPL_SOURCE_EID)
-                            .setValue(Long.valueOf(entry.getEntryId()).toString());
+                    msg.getMessageBuilder().addProperty().setKey(MSG_PROP_REPL_SOURCE_POSITION)
+                            .setValue(String.format("%s:%s", entry.getLedgerId(), entry.getEntryId()));
                     msgOut.recordEvent(headersAndPayload.readableBytes());
                     stats.incrementMsgOutCounter();
                     stats.incrementBytesOutCounter(headersAndPayload.readableBytes());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -358,8 +358,8 @@ public class MessageDeduplication {
 
     private void setContextPropsIfRepl(PublishContext publishContext, ByteBuf headersAndPayload) {
         if (publishContext.getProducerName().startsWith(replicatorPrefix)) {
-            // Message is coming from replication, we need to use the replication's producer name, ledger id and entry id
-            // for the purpose of deduplication.
+            // Message is coming from replication, we need to use the replication's producer name, ledger id and entry
+            // id for the purpose of deduplication.
             int readerIndex = headersAndPayload.readerIndex();
             MessageMetadata md = Commands.parseMessageMetadata(headersAndPayload);
             headersAndPayload.readerIndex(readerIndex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -332,7 +332,7 @@ public class MessageDeduplication {
             return MessageDupStatus.NotDup;
         }
         if (Producer.isRemoteOrShadow(publishContext.getProducerName(), replicatorPrefix)) {
-            if (!publishContext.supportsDedupReplV2()){
+            if (!publishContext.supportsReplDedupByLidAndEid()){
                 return isDuplicateReplV1(publishContext, headersAndPayload);
             } else {
                 return isDuplicateReplV2(publishContext, headersAndPayload);
@@ -410,10 +410,10 @@ public class MessageDeduplication {
         Object positionPairObj = publishContext.getProperty(MSG_PROP_REPL_SOURCE_POSITION);
         if (positionPairObj == null || !(positionPairObj instanceof long[])) {
             log.error("[{}] Message can not determine whether the message is duplicated due to the acquired messages"
-                            + " props were are invalid. producer={}. supportsDedupReplV2: {}, sequence-id {},"
+                            + " props were are invalid. producer={}. supportsReplDedupByLidAndEid: {}, sequence-id {},"
                             + " prop-{}: not in expected format",
                     topic.getName(), publishContext.getProducerName(),
-                    publishContext.supportsDedupReplV2(), publishContext.getSequenceId(),
+                    publishContext.supportsReplDedupByLidAndEid(), publishContext.getSequenceId(),
                     MSG_PROP_REPL_SOURCE_POSITION);
             return MessageDupStatus.Unknown;
         }
@@ -538,7 +538,8 @@ public class MessageDeduplication {
         if (!isEnabled() || publishContext.isMarkerMessage()) {
             return;
         }
-        if (publishContext.getProducerName().startsWith(replicatorPrefix) && publishContext.supportsDedupReplV2()) {
+        if (publishContext.getProducerName().startsWith(replicatorPrefix)
+                && publishContext.supportsReplDedupByLidAndEid()) {
             recordMessagePersistedRepl(publishContext, position);
         } else {
             recordMessagePersistedNormal(publishContext, position);
@@ -549,10 +550,10 @@ public class MessageDeduplication {
         Object positionPairObj = publishContext.getProperty(MSG_PROP_REPL_SOURCE_POSITION);
         if (positionPairObj == null || !(positionPairObj instanceof long[])) {
             log.error("[{}] Can not persist highest sequence-id due to the acquired messages"
-                            + " props are invalid. producer={}. supportsDedupReplV2: {}, sequence-id {},"
+                            + " props are invalid. producer={}. supportsReplDedupByLidAndEid: {}, sequence-id {},"
                             + " prop-{}: not in expected format",
                     topic.getName(), publishContext.getProducerName(),
-                    publishContext.supportsDedupReplV2(), publishContext.getSequenceId(),
+                    publishContext.supportsReplDedupByLidAndEid(), publishContext.getSequenceId(),
                     MSG_PROP_REPL_SOURCE_POSITION);
             recordMessagePersistedNormal(publishContext, position);
             return;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -410,8 +410,8 @@ public class MessageDeduplication {
         synchronized (highestSequencedPushed) {
             Long lastSequenceLIdPushed = highestSequencedPushed.get(lastSequenceLIdKey);
             Long lastSequenceEIdPushed = highestSequencedPushed.get(lastSequenceEIdKey);
-            if (lastSequenceLIdPushed != null && lastSequenceEIdPushed != null &&
-                (replSequenceLId.compareTo(lastSequenceLIdPushed) < 0
+            if (lastSequenceLIdPushed != null && lastSequenceEIdPushed != null
+                && (replSequenceLId.compareTo(lastSequenceLIdPushed) < 0
                         || (replSequenceLId.compareTo(lastSequenceLIdPushed) == 0
                         && replSequenceEId.compareTo(lastSequenceEIdPushed) <= 0))) {
                 if (log.isDebugEnabled()) {
@@ -436,8 +436,8 @@ public class MessageDeduplication {
                             topic.getName(), publishContext.getProducerName(), replSequenceLId,
                             replSequenceEId, lastSequenceLIdPersisted, lastSequenceEIdPersisted);
                 }
-                if (lastSequenceLIdPersisted != null && lastSequenceEIdPersisted != null &&
-                    (replSequenceLId.compareTo(lastSequenceLIdPersisted) < 0
+                if (lastSequenceLIdPersisted != null && lastSequenceEIdPersisted != null
+                    && (replSequenceLId.compareTo(lastSequenceLIdPersisted) < 0
                         || (replSequenceLId.compareTo(lastSequenceLIdPersisted) == 0
                             && replSequenceEId.compareTo(lastSequenceEIdPersisted) <= 0))) {
                     return MessageDupStatus.Dup;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.broker.service.persistent;
 
+import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SEQUENCE_EID;
+import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SEQUENCE_LID;
 import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import java.util.Iterator;
@@ -38,8 +40,10 @@ import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.Topic.PublishContext;
+import org.apache.pulsar.common.api.proto.KeyValue;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.Commands;
 import org.slf4j.Logger;
@@ -321,27 +325,145 @@ public class MessageDeduplication {
      * @return true if the message should be published or false if it was recognized as a duplicate
      */
     public MessageDupStatus isDuplicate(PublishContext publishContext, ByteBuf headersAndPayload) {
+        setContextPropsIfRepl(publishContext, headersAndPayload);
+
         if (!isEnabled() || publishContext.isMarkerMessage()) {
             return MessageDupStatus.NotDup;
         }
+        if (publishContext.getProducerName().startsWith(replicatorPrefix)) {
+            if (!publishContext.supportsDedupReplV2()){
+                return isDuplicateReplV1(publishContext, headersAndPayload);
+            } else {
+                return isDuplicateReplV2(publishContext, headersAndPayload);
+            }
+        }
+        return isDuplicateNormal(publishContext, headersAndPayload, false);
+    }
 
+    public MessageDupStatus isDuplicateReplV1(PublishContext publishContext, ByteBuf headersAndPayload) {
+        // Message is coming from replication, we need to use the original producer name and sequence id
+        // for the purpose of deduplication and not rely on the "replicator" name.
+        int readerIndex = headersAndPayload.readerIndex();
+        MessageMetadata md = Commands.parseMessageMetadata(headersAndPayload);
+        headersAndPayload.readerIndex(readerIndex);
+
+        String producerName = md.getProducerName();
+        long sequenceId = md.getSequenceId();
+        long highestSequenceId = Math.max(md.getHighestSequenceId(), sequenceId);
+        publishContext.setOriginalProducerName(producerName);
+        publishContext.setOriginalSequenceId(sequenceId);
+        publishContext.setOriginalHighestSequenceId(highestSequenceId);
+        return isDuplicateNormal(publishContext, headersAndPayload, true);
+    }
+
+    private void setContextPropsIfRepl(PublishContext publishContext, ByteBuf headersAndPayload) {
+        if (publishContext.getProducerName().startsWith(replicatorPrefix)) {
+            // Message is coming from replication, we need to use the replication's producer name, ledger id and entry id
+            // for the purpose of deduplication.
+            int readerIndex = headersAndPayload.readerIndex();
+            MessageMetadata md = Commands.parseMessageMetadata(headersAndPayload);
+            headersAndPayload.readerIndex(readerIndex);
+
+            Long replSequenceLId = null;
+            Long replSequenceEId = null;
+            List<KeyValue> kvPairList = md.getPropertiesList();
+            for (KeyValue kvPair : kvPairList) {
+                if (kvPair.getKey().equals(MSG_PROP_REPL_SEQUENCE_LID)) {
+                    if (StringUtils.isNumeric(kvPair.getValue())) {
+                        replSequenceLId = Long.valueOf(kvPair.getValue());
+                        publishContext.setProperty(MSG_PROP_REPL_SEQUENCE_LID, replSequenceLId);
+                    } else {
+                        break;
+                    }
+                }
+                if (kvPair.getKey().equals(MSG_PROP_REPL_SEQUENCE_EID)) {
+                    if (StringUtils.isNumeric(kvPair.getValue())) {
+                        replSequenceEId = Long.valueOf(kvPair.getValue());
+                        publishContext.setProperty(MSG_PROP_REPL_SEQUENCE_EID, replSequenceEId);
+                    } else {
+                        break;
+                    }
+                }
+                if (replSequenceLId != null && replSequenceEId != null) {
+                    break;
+                }
+            }
+        }
+    }
+
+    public MessageDupStatus isDuplicateReplV2(PublishContext publishContext, ByteBuf headersAndPayload) {
+        Long replSequenceLId = (Long) publishContext.getProperty(MSG_PROP_REPL_SEQUENCE_LID);
+        Long replSequenceEId = (Long) publishContext.getProperty(MSG_PROP_REPL_SEQUENCE_EID);
+        if (replSequenceLId == null || replSequenceEId == null) {
+            log.error("[{}] Message can not determine whether the message is duplicated due to the acquired messages"
+                            + " props were are invalid. producer={}. supportsDedupReplV2: {}, sequence-id {},"
+                            + " prop-{}: {}, prop-{}: {}",
+                    topic.getName(), publishContext.getProducerName(),
+                    publishContext.supportsDedupReplV2(), publishContext.getSequenceId(),
+                    MSG_PROP_REPL_SEQUENCE_LID, replSequenceLId,
+                    MSG_PROP_REPL_SEQUENCE_EID, replSequenceEId);
+            return MessageDupStatus.Unknown;
+        }
+
+        String lastSequenceLIdKey = publishContext.getProducerName() + "_LID";
+        String lastSequenceEIdKey = publishContext.getProducerName() + "_EID";
+        synchronized (highestSequencedPushed) {
+            Long lastSequenceLIdPushed = highestSequencedPushed.get(lastSequenceLIdKey);
+            Long lastSequenceEIdPushed = highestSequencedPushed.get(lastSequenceEIdKey);
+            if (lastSequenceLIdPushed != null && lastSequenceEIdPushed != null &&
+                (replSequenceLId.compareTo(lastSequenceLIdPushed) < 0
+                        || (replSequenceLId.compareTo(lastSequenceLIdPushed) == 0
+                        && replSequenceEId.compareTo(lastSequenceEIdPushed) <= 0))) {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Message identified as duplicated producer={}. publishing {}:{}, latest publishing"
+                            + " in-progress {}:{}",
+                            topic.getName(), publishContext.getProducerName(), lastSequenceLIdPushed,
+                            lastSequenceEIdPushed, lastSequenceLIdPushed, lastSequenceEIdPushed);
+                }
+
+                // Also need to check sequence ids that has been persisted.
+                // If current message's seq id is smaller or equals to the
+                // "lastSequenceLIdPersisted:lastSequenceEIdPersisted" than its definitely a dup
+                // If current message's seq id is between "lastSequenceLIdPushed:lastSequenceEIdPushed" and
+                // "lastSequenceLIdPersisted:lastSequenceEIdPersisted", then we cannot be sure whether the message
+                // is a dup or not we should return an error to the producer for the latter case so that it can retry
+                // at a future time
+                Long lastSequenceLIdPersisted = highestSequencedPersisted.get(lastSequenceLIdKey);
+                Long lastSequenceEIdPersisted = highestSequencedPersisted.get(lastSequenceEIdKey);
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Message identified as duplicated producer={}. publishing {}:{}, latest"
+                                    + " persisted {}:{}",
+                            topic.getName(), publishContext.getProducerName(), replSequenceLId,
+                            replSequenceEId, lastSequenceLIdPersisted, lastSequenceEIdPersisted);
+                }
+                if (lastSequenceLIdPersisted != null && lastSequenceEIdPersisted != null &&
+                    (replSequenceLId.compareTo(lastSequenceLIdPersisted) < 0
+                        || (replSequenceLId.compareTo(lastSequenceLIdPersisted) == 0
+                            && replSequenceEId.compareTo(lastSequenceEIdPersisted) <= 0))) {
+                    return MessageDupStatus.Dup;
+                } else {
+                    return MessageDupStatus.Unknown;
+                }
+            }
+            highestSequencedPushed.put(lastSequenceLIdKey, replSequenceLId);
+            highestSequencedPushed.put(lastSequenceEIdKey, replSequenceEId);
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("[{}] Message identified as non-duplicated producer={}. publishing {}:{}",
+                    topic.getName(), publishContext.getProducerName(), replSequenceLId, replSequenceEId);
+        }
+        return MessageDupStatus.NotDup;
+    }
+
+    public MessageDupStatus isDuplicateNormal(PublishContext publishContext, ByteBuf headersAndPayload,
+                                              boolean useOriginalProducerName) {
         String producerName = publishContext.getProducerName();
+        if (useOriginalProducerName) {
+            producerName = publishContext.getOriginalProducerName();
+        }
         long sequenceId = publishContext.getSequenceId();
         long highestSequenceId = Math.max(publishContext.getHighestSequenceId(), sequenceId);
         MessageMetadata md = null;
-        if (producerName.startsWith(replicatorPrefix)) {
-            // Message is coming from replication, we need to use the original producer name and sequence id
-            // for the purpose of deduplication and not rely on the "replicator" name.
-            int readerIndex = headersAndPayload.readerIndex();
-            md = Commands.parseMessageMetadata(headersAndPayload);
-            producerName = md.getProducerName();
-            sequenceId = md.getSequenceId();
-            highestSequenceId = Math.max(md.getHighestSequenceId(), sequenceId);
-            publishContext.setOriginalProducerName(producerName);
-            publishContext.setOriginalSequenceId(sequenceId);
-            publishContext.setOriginalHighestSequenceId(highestSequenceId);
-            headersAndPayload.readerIndex(readerIndex);
-        }
         long chunkID = -1;
         long totalChunk = -1;
         if (publishContext.isChunked()) {
@@ -399,7 +521,37 @@ public class MessageDeduplication {
         if (!isEnabled() || publishContext.isMarkerMessage()) {
             return;
         }
+        if (publishContext.getProducerName().startsWith(replicatorPrefix) && publishContext.supportsDedupReplV2()) {
+            recordMessagePersistedRepl(publishContext, position);
+        } else {
+            recordMessagePersistedNormal(publishContext, position);
+        }
+    }
 
+    public void recordMessagePersistedRepl(PublishContext publishContext, Position position) {
+        String replSequenceLIdStr = String.valueOf(publishContext.getProperty(MSG_PROP_REPL_SEQUENCE_LID));
+        String replSequenceEIdStr = String.valueOf(publishContext.getProperty(MSG_PROP_REPL_SEQUENCE_EID));
+        if (!StringUtils.isNumeric(replSequenceLIdStr) || !StringUtils.isNumeric(replSequenceEIdStr)) {
+            log.error("[{}] Can not persist highest sequence-id due to the acquired messages"
+                            + " props are invalid. producer={}. supportsDedupReplV2: {}, sequence-id {},"
+                            + " prop-{}: {}, prop-{}: {}",
+                    topic.getName(), publishContext.getProducerName(),
+                    publishContext.supportsDedupReplV2(), publishContext.getSequenceId(),
+                    MSG_PROP_REPL_SEQUENCE_LID, replSequenceLIdStr,
+                    MSG_PROP_REPL_SEQUENCE_EID, replSequenceEIdStr);
+            recordMessagePersistedNormal(publishContext, position);
+            return;
+        }
+        Long replSequenceLId = Long.valueOf(replSequenceLIdStr);
+        Long replSequenceEId = Long.valueOf(replSequenceEIdStr);
+        String lastSequenceLIdKey = publishContext.getProducerName() + "_LID";
+        String lastSequenceEIdKey = publishContext.getProducerName() + "_EID";
+        highestSequencedPersisted.put(lastSequenceLIdKey, replSequenceLId);
+        highestSequencedPersisted.put(lastSequenceEIdKey, replSequenceEId);
+        increaseSnapshotCounterAndTakeSnapshotIfNeeded(position);
+    }
+
+    public void recordMessagePersistedNormal(PublishContext publishContext, Position position) {
         String producerName = publishContext.getProducerName();
         long sequenceId = publishContext.getSequenceId();
         long highestSequenceId = publishContext.getHighestSequenceId();
@@ -413,9 +565,18 @@ public class MessageDeduplication {
         if (isLastChunk == null || isLastChunk) {
             highestSequencedPersisted.put(producerName, Math.max(highestSequenceId, sequenceId));
         }
+        increaseSnapshotCounterAndTakeSnapshotIfNeeded(position);
+    }
+
+    private void increaseSnapshotCounterAndTakeSnapshotIfNeeded(Position position) {
         if (++snapshotCounter >= snapshotInterval) {
             snapshotCounter = 0;
             takeSnapshot(position);
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Waiting for sequence-id snapshot {}/{}", topic.getName(), snapshotCounter,
+                        snapshotInterval);
+            }
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -362,10 +362,7 @@ public class MessageDeduplication {
         if (publishContext.isMarkerMessage()) {
             // Message is coming from replication, we need to use the replication's producer name, ledger id and entry
             // id for the purpose of deduplication.
-            int readerIndex = headersAndPayload.readerIndex();
-            MessageMetadata md = Commands.parseMessageMetadata(headersAndPayload);
-            headersAndPayload.readerIndex(readerIndex);
-
+            MessageMetadata md = Commands.peekMessageMetadata(headersAndPayload, "Check-Deduplicate", -1);
             if (Markers.isReplicationMarker(md.getMarkerType())) {
                 publishContext.setProperty(MSG_PROP_IS_REPL_MARKER, "");
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ShadowReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ShadowReplicator.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.broker.service.persistent;
 
 
+import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SOURCE_EID;
+import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SOURCE_LID;
 import io.netty.buffer.ByteBuf;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -98,6 +100,11 @@ public class ShadowReplicator extends PersistentReplicator {
                 msg.setReplicatedFrom(localCluster);
 
                 msg.setMessageId(new MessageIdImpl(entry.getLedgerId(), entry.getEntryId(), -1));
+                // Add props for sequence checking.
+                msg.getMessageBuilder().addProperty().setKey(MSG_PROP_REPL_SOURCE_LID)
+                        .setValue(Long.valueOf(entry.getLedgerId()).toString());
+                msg.getMessageBuilder().addProperty().setKey(MSG_PROP_REPL_SOURCE_EID)
+                        .setValue(Long.valueOf(entry.getEntryId()).toString());
 
                 headersAndPayload.retain();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ShadowReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ShadowReplicator.java
@@ -19,8 +19,7 @@
 package org.apache.pulsar.broker.service.persistent;
 
 
-import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SOURCE_EID;
-import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SOURCE_LID;
+import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SOURCE_POSITION;
 import io.netty.buffer.ByteBuf;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -101,10 +100,8 @@ public class ShadowReplicator extends PersistentReplicator {
 
                 msg.setMessageId(new MessageIdImpl(entry.getLedgerId(), entry.getEntryId(), -1));
                 // Add props for sequence checking.
-                msg.getMessageBuilder().addProperty().setKey(MSG_PROP_REPL_SOURCE_LID)
-                        .setValue(Long.valueOf(entry.getLedgerId()).toString());
-                msg.getMessageBuilder().addProperty().setKey(MSG_PROP_REPL_SOURCE_EID)
-                        .setValue(Long.valueOf(entry.getEntryId()).toString());
+                msg.getMessageBuilder().addProperty().setKey(MSG_PROP_REPL_SOURCE_POSITION)
+                        .setValue(String.format("%s:%s", entry.getLedgerId(), entry.getEntryId()));
 
                 headersAndPayload.retain();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerMessageDeduplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerMessageDeduplicationTest.java
@@ -24,10 +24,14 @@ import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.MessageDeduplication;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.common.api.proto.MarkerType;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.testng.annotations.Test;
 
 public class BrokerMessageDeduplicationTest {
@@ -42,7 +46,18 @@ public class BrokerMessageDeduplicationTest {
         doReturn(true).when(deduplication).isEnabled();
         Topic.PublishContext context = mock(Topic.PublishContext.class);
         doReturn(true).when(context).isMarkerMessage();
-        MessageDeduplication.MessageDupStatus status = deduplication.isDuplicate(context, null);
+
+        MessageMetadata msgMetadata = new MessageMetadata();
+        msgMetadata.setMarkerType(MarkerType.TXN_ABORT_VALUE);
+        msgMetadata.setProducerName("p1");
+        msgMetadata.setSequenceId(0);
+        msgMetadata.setPublishTime(System.currentTimeMillis());
+        byte[] metadataData = msgMetadata.toByteArray();
+        ByteBuf byteBuf = UnpooledByteBufAllocator.DEFAULT.heapBuffer(metadataData.length + 4);
+        byteBuf.writeInt(metadataData.length);
+        byteBuf.writeBytes(metadataData);
+
+        MessageDeduplication.MessageDupStatus status = deduplication.isDuplicate(context, byteBuf);
         assertEquals(status, MessageDeduplication.MessageDupStatus.NotDup);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorDeduplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorDeduplicationTest.java
@@ -169,37 +169,37 @@ public class OneWayReplicatorDeduplicationTest extends OneWayReplicatorTestBase 
     public Object[][] deduplicationArgs() {
         return new Object[][] {
             {true/* inject repeated publishing*/, 1/* repeated messages window */,
-                    true /* supportsDedupReplV2 */, false/* multi schemas */},
+                    true /* supportsReplDedupByLidAndEid */, false/* multi schemas */},
             {true/* inject repeated publishing*/, 2/* repeated messages window */,
-                    true /* supportsDedupReplV2 */, false/* multi schemas */},
+                    true /* supportsReplDedupByLidAndEid */, false/* multi schemas */},
             {true/* inject repeated publishing*/, 3/* repeated messages window */,
-                    true /* supportsDedupReplV2 */, false/* multi schemas */},
+                    true /* supportsReplDedupByLidAndEid */, false/* multi schemas */},
             {true/* inject repeated publishing*/, 4/* repeated messages window */,
-                    true /* supportsDedupReplV2 */, false/* multi schemas */},
+                    true /* supportsReplDedupByLidAndEid */, false/* multi schemas */},
             {true/* inject repeated publishing*/, 5/* repeated messages window */,
-                    true /* supportsDedupReplV2 */, false/* multi schemas */},
+                    true /* supportsReplDedupByLidAndEid */, false/* multi schemas */},
             {true/* inject repeated publishing*/, 10/* repeated messages window */,
-                    true /* supportsDedupReplV2 */, false/* multi schemas */},
+                    true /* supportsReplDedupByLidAndEid */, false/* multi schemas */},
             // ===== multi schema
             {true/* inject repeated publishing*/, 1/* repeated messages window */,
-                    true /* supportsDedupReplV2 */, true/* multi schemas */},
+                    true /* supportsReplDedupByLidAndEid */, true/* multi schemas */},
             {true/* inject repeated publishing*/, 2/* repeated messages window */,
-                    true /* supportsDedupReplV2 */, true/* multi schemas */},
+                    true /* supportsReplDedupByLidAndEid */, true/* multi schemas */},
             {true/* inject repeated publishing*/, 3/* repeated messages window */,
-                    true /* supportsDedupReplV2 */, true/* multi schemas */},
+                    true /* supportsReplDedupByLidAndEid */, true/* multi schemas */},
             {true/* inject repeated publishing*/, 4/* repeated messages window */,
-                    true /* supportsDedupReplV2 */, true/* multi schemas */},
+                    true /* supportsReplDedupByLidAndEid */, true/* multi schemas */},
             {true/* inject repeated publishing*/, 5/* repeated messages window */,
-                    true /* supportsDedupReplV2 */, true/* multi schemas */},
+                    true /* supportsReplDedupByLidAndEid */, true/* multi schemas */},
             {true/* inject repeated publishing*/, 10/* repeated messages window */,
-                    true /* supportsDedupReplV2 */, true/* multi schemas */},
+                    true /* supportsReplDedupByLidAndEid */, true/* multi schemas */},
             // ===== Compatability "source-cluster: old, target-cluster: new".
             {false/* inject repeated publishing*/, 0/* repeated messages window */,
-                    false /* supportsDedupReplV2 */, false/* multi schemas */},
+                    false /* supportsReplDedupByLidAndEid */, false/* multi schemas */},
             {false/* inject repeated publishing*/, 0/* repeated messages window */,
-                    false /* supportsDedupReplV2 */, true/* multi schemas */},
+                    false /* supportsReplDedupByLidAndEid */, true/* multi schemas */},
             {true/* inject repeated publishing*/, 3/* repeated messages window */,
-                    false /* supportsDedupReplV2 */, true/* multi schemas */},
+                    false /* supportsReplDedupByLidAndEid */, true/* multi schemas */},
         };
     }
 
@@ -207,7 +207,7 @@ public class OneWayReplicatorDeduplicationTest extends OneWayReplicatorTestBase 
     //  - Review the code to confirm that multi source-brokers can work when the source topic switch.
     @Test(timeOut = 360 * 1000, dataProvider = "deduplicationArgs")
     public void testDeduplication(final boolean injectRepeatedPublish, final int repeatedMessagesWindow,
-                                  final boolean supportsDedupReplV2, boolean multiSchemas) throws Exception {
+                                  final boolean supportsReplDedupByLidAndEid, boolean multiSchemas) throws Exception {
         // 0. Inject a mechanism that duplicate all Send-Command for the replicator.
         final List<ByteBufPair> duplicatedMsgs = new ArrayList<>();
         Runnable taskToClearInjection = injectReplicatorClientCnx(
@@ -215,20 +215,20 @@ public class OneWayReplicatorDeduplicationTest extends OneWayReplicatorTestBase 
 
                 @Override
                 protected ByteBuf newConnectCommand() throws Exception {
-                    if (supportsDedupReplV2) {
+                    if (supportsReplDedupByLidAndEid) {
                         return super.newConnectCommand();
                     }
                     authenticationDataProvider = authentication.getAuthData(remoteHostName);
                     AuthData authData = authenticationDataProvider.authenticate(AuthData.INIT_AUTH_DATA);
                     BaseCommand cmd = Commands.newConnectWithoutSerialize(authentication.getAuthMethodName(), authData,
                             this.protocolVersion, clientVersion, proxyToTargetBrokerAddress, null, null, null, null);
-                    cmd.getConnect().getFeatureFlags().setSupportsDedupReplV2(false);
+                    cmd.getConnect().getFeatureFlags().setSupportsReplDedupByLidAndEid(false);
                     return Commands.serializeWithSize(cmd);
                 }
 
                 @Override
-                public boolean isBrokerSupportsDedupReplV2() {
-                    return supportsDedupReplV2;
+                public boolean isBrokerSupportsReplDedupByLidAndEid() {
+                    return supportsReplDedupByLidAndEid;
                 }
 
                 @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorDeduplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorDeduplicationTest.java
@@ -1,0 +1,493 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.service.persistent.MessageDeduplication;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.InjectedClientCnxClientBuilder;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.MessageIdAdv;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.impl.ClientBuilderImpl;
+import org.apache.pulsar.client.impl.ClientCnx;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
+import org.apache.pulsar.common.api.AuthData;
+import org.apache.pulsar.common.api.proto.BaseCommand;
+import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
+import org.apache.pulsar.common.protocol.ByteBufPair;
+import org.apache.pulsar.common.protocol.Commands;
+import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
+import org.apache.pulsar.zookeeper.ZookeeperServerTest;
+import org.awaitility.Awaitility;
+import org.awaitility.reflect.WhiteboxImpl;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker")
+public class OneWayReplicatorDeduplicationTest extends OneWayReplicatorTestBase {
+
+    static final ObjectMapper JACKSON = new ObjectMapper();
+
+    @Override
+    @BeforeClass(alwaysRun = true, timeOut = 300000)
+    public void setup() throws Exception {
+        super.setup();
+        waitInternalClientCreated();
+    }
+
+    @Override
+    @AfterClass(alwaysRun = true, timeOut = 300000)
+    public void cleanup() throws Exception {
+        super.cleanup();
+    }
+
+    @Override
+    protected void setConfigDefaults(ServiceConfiguration config, String clusterName,
+                                     LocalBookkeeperEnsemble bookkeeperEnsemble, ZookeeperServerTest brokerConfigZk) {
+        super.setConfigDefaults(config, clusterName, bookkeeperEnsemble, brokerConfigZk);
+        // For check whether deduplication snapshot has done.
+        config.setBrokerDeduplicationEntriesInterval(10);
+        config.setReplicationStartAt("earliest");
+        // To cover more cases, write more than one ledger.
+        config.setManagedLedgerMaxEntriesPerLedger(100);
+        config.setManagedLedgerMinLedgerRolloverTimeMinutes(0);
+        config.setManagedLedgerMaxLedgerRolloverTimeMinutes(1);
+    }
+
+    protected void waitReplicatorStopped(String topicName) {
+        Awaitility.await().untilAsserted(() -> {
+            Optional<Topic> topicOptional2 = pulsar2.getBrokerService().getTopic(topicName, false).get();
+            assertTrue(topicOptional2.isPresent());
+            PersistentTopic persistentTopic2 = (PersistentTopic) topicOptional2.get();
+            assertTrue(persistentTopic2.getProducers().isEmpty());
+            Optional<Topic> topicOptional1 = pulsar2.getBrokerService().getTopic(topicName, false).get();
+            assertTrue(topicOptional1.isPresent());
+            PersistentTopic persistentTopic1 = (PersistentTopic) topicOptional2.get();
+            assertTrue(persistentTopic1.getReplicators().isEmpty()
+                    || !persistentTopic1.getReplicators().get(cluster2).isConnected());
+        });
+    }
+
+    protected void waitInternalClientCreated() throws Exception {
+        // Wait for the internal client created.
+        final String topicNameTriggerInternalClientCreate =
+                BrokerTestUtil.newUniqueName("persistent://" + replicatedNamespace + "/tp_");
+        admin1.topics().createNonPartitionedTopic(topicNameTriggerInternalClientCreate);
+        waitReplicatorStarted(topicNameTriggerInternalClientCreate);
+        cleanupTopics(() -> {
+            admin1.topics().delete(topicNameTriggerInternalClientCreate);
+            admin2.topics().delete(topicNameTriggerInternalClientCreate);
+        });
+    }
+
+    protected Runnable injectReplicatorClientCnx(
+            InjectedClientCnxClientBuilder.ClientCnxFactory clientCnxFactory) throws Exception {
+        String cluster2 = pulsar2.getConfig().getClusterName();
+        BrokerService brokerService = pulsar1.getBrokerService();
+        ClientBuilderImpl clientBuilder2 = (ClientBuilderImpl) PulsarClient.builder().serviceUrl(url2.toString());
+
+        // Inject spy client.
+        final var replicationClients = brokerService.getReplicationClients();
+        PulsarClientImpl internalClient = (PulsarClientImpl) replicationClients.get(cluster2);
+        PulsarClientImpl injectedClient = InjectedClientCnxClientBuilder.create(clientBuilder2, clientCnxFactory);
+        assertTrue(replicationClients.remove(cluster2, internalClient));
+        assertNull(replicationClients.putIfAbsent(cluster2, injectedClient));
+
+        // Return a cleanup injection task;
+        return () -> {
+            assertTrue(replicationClients.remove(cluster2, injectedClient));
+            assertNull(replicationClients.putIfAbsent(cluster2, internalClient));
+            injectedClient.closeAsync();
+        };
+    }
+
+    @DataProvider(name = "deduplicationArgs")
+    public Object[][] deduplicationArgs() {
+        return new Object[][] {
+            {true/* inject repeated publishing*/, 1/* repeated messages window */,
+                    true /* supportsDedupReplV2 */, false/* multi schemas */},
+            {true/* inject repeated publishing*/, 2/* repeated messages window */,
+                    true /* supportsDedupReplV2 */, false/* multi schemas */},
+            {true/* inject repeated publishing*/, 3/* repeated messages window */,
+                    true /* supportsDedupReplV2 */, false/* multi schemas */},
+            {true/* inject repeated publishing*/, 4/* repeated messages window */,
+                    true /* supportsDedupReplV2 */, false/* multi schemas */},
+            {true/* inject repeated publishing*/, 5/* repeated messages window */,
+                    true /* supportsDedupReplV2 */, false/* multi schemas */},
+            {true/* inject repeated publishing*/, 10/* repeated messages window */,
+                    true /* supportsDedupReplV2 */, false/* multi schemas */},
+            // ===== multi schema
+            {true/* inject repeated publishing*/, 1/* repeated messages window */,
+                    true /* supportsDedupReplV2 */, true/* multi schemas */},
+            {true/* inject repeated publishing*/, 2/* repeated messages window */,
+                    true /* supportsDedupReplV2 */, true/* multi schemas */},
+            {true/* inject repeated publishing*/, 3/* repeated messages window */,
+                    true /* supportsDedupReplV2 */, true/* multi schemas */},
+            {true/* inject repeated publishing*/, 4/* repeated messages window */,
+                    true /* supportsDedupReplV2 */, true/* multi schemas */},
+            {true/* inject repeated publishing*/, 5/* repeated messages window */,
+                    true /* supportsDedupReplV2 */, true/* multi schemas */},
+            {true/* inject repeated publishing*/, 10/* repeated messages window */,
+                    true /* supportsDedupReplV2 */, true/* multi schemas */},
+            // ===== Compatability "source-cluster: old, target-cluster: new".
+            {false/* inject repeated publishing*/, 0/* repeated messages window */,
+                    false /* supportsDedupReplV2 */, false/* multi schemas */},
+            {false/* inject repeated publishing*/, 0/* repeated messages window */,
+                    false /* supportsDedupReplV2 */, true/* multi schemas */},
+            {true/* inject repeated publishing*/, 3/* repeated messages window */,
+                    false /* supportsDedupReplV2 */, true/* multi schemas */},
+        };
+    }
+
+    // TODO add more tests
+    //  - The old deduplication does not work when multi source producers use a same sequence-id.
+    //    - Add more issue explain in the PR.
+    //  - Review the code to confirm that multi source-brokers can work when the source topic switch.
+    //  - Try to reproduce the issue mentioned in the PR.
+
+    @Test(timeOut = 360 * 1000, dataProvider = "deduplicationArgs")
+    public void testDeduplication(final boolean injectRepeatedPublish, final int repeatedMessagesWindow,
+                                  final boolean supportsDedupReplV2, boolean multiSchemas) throws Exception {
+        // 0. Inject a mechanism that duplicate all Send-Command for the replicator.
+        final List<ByteBufPair> duplicatedMsgs = new ArrayList<>();
+        Runnable taskToClearInjection = injectReplicatorClientCnx(
+            (conf, eventLoopGroup) -> new ClientCnx(InstrumentProvider.NOOP, conf, eventLoopGroup) {
+
+                @Override
+                protected ByteBuf newConnectCommand() throws Exception {
+                    if (supportsDedupReplV2) {
+                        return super.newConnectCommand();
+                    }
+                    authenticationDataProvider = authentication.getAuthData(remoteHostName);
+                    AuthData authData = authenticationDataProvider.authenticate(AuthData.INIT_AUTH_DATA);
+                    BaseCommand cmd = Commands.newConnectWithoutSerialize(authentication.getAuthMethodName(), authData,
+                            this.protocolVersion, clientVersion, proxyToTargetBrokerAddress, null, null, null, null);
+                    cmd.getConnect().getFeatureFlags().setSupportsDedupReplV2(false);
+                    return Commands.serializeWithSize(cmd);
+                }
+
+                @Override
+                public boolean isBrokerSupportsDedupReplV2() {
+                    return supportsDedupReplV2;
+                }
+
+                @Override
+                public ChannelHandlerContext ctx() {
+                    if (!injectRepeatedPublish) {
+                        return super.ctx();
+                    }
+                    final ChannelHandlerContext originalCtx = super.ctx;
+                    ChannelHandlerContext spyContext = spy(originalCtx);
+                    doAnswer(invocation -> {
+                        // Do not repeat the messages re-sending, and clear the previous cached messages when
+                        // calling re-sending, to avoid publishing outs of order.
+                        for (StackTraceElement stackTraceElement : Thread.currentThread().getStackTrace()) {
+                            if (stackTraceElement.toString().contains("recoverProcessOpSendMsgFrom")
+                                    || stackTraceElement.toString().contains("resendMessages")) {
+                                duplicatedMsgs.clear();
+                                return invocation.callRealMethod();
+                            }
+                        }
+
+                        Object data = invocation.getArguments()[0];
+                        if (true && !(data instanceof ByteBufPair)) {
+                            return invocation.callRealMethod();
+                        }
+                        // Repeatedly send every message.
+                        ByteBufPair byteBufPair = (ByteBufPair) data;
+                        ByteBuf buf1 = byteBufPair.getFirst();
+                        ByteBuf buf2 = byteBufPair.getSecond();
+                        int bufferIndex1 = buf1.readerIndex();
+                        int bufferIndex2 = buf2.readerIndex();
+                        // Skip totalSize.
+                        buf1.readInt();
+                        int cmdSize = buf1.readInt();
+                        BaseCommand cmd = new BaseCommand();
+                        cmd.parseFrom(buf1, cmdSize);
+                        buf1.readerIndex(bufferIndex1);
+                        if (cmd.getType().equals(BaseCommand.Type.SEND)) {
+                            synchronized (duplicatedMsgs) {
+                                if (duplicatedMsgs.size() >= repeatedMessagesWindow) {
+                                    for (ByteBufPair bufferPair : duplicatedMsgs) {
+                                        originalCtx.channel().write(bufferPair, originalCtx.voidPromise());
+                                        originalCtx.channel().flush();
+                                    }
+                                    duplicatedMsgs.clear();
+                                }
+                            }
+                            ByteBuf newBuffer1 = UnpooledByteBufAllocator.DEFAULT.heapBuffer(
+                                    buf1.readableBytes());
+                            buf1.readBytes(newBuffer1);
+                            buf1.readerIndex(bufferIndex1);
+                            ByteBuf newBuffer2 = UnpooledByteBufAllocator.DEFAULT.heapBuffer(
+                                    buf2.readableBytes());
+                            buf2.readBytes(newBuffer2);
+                            buf2.readerIndex(bufferIndex2);
+                            synchronized (duplicatedMsgs) {
+                                if (newBuffer2.readableBytes() > 0) {
+                                    duplicatedMsgs.add(ByteBufPair.get(newBuffer1, newBuffer2));
+                                }
+                            }
+                            return invocation.callRealMethod();
+                        } else {
+                            return invocation.callRealMethod();
+                        }
+                    }).when(spyContext).write(any(), any(ChannelPromise.class));
+                    return spyContext;
+                }
+            });
+
+        // 1. Create topics and enable deduplication.
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://" + nonReplicatedNamespace + "/tp_");
+        admin1.topics().createNonPartitionedTopic(topicName);
+        admin1.topics().createSubscription(topicName, "s1", MessageId.earliest);
+        admin2.topics().createNonPartitionedTopic(topicName);
+        admin2.topics().createSubscription(topicName, "s1", MessageId.earliest);
+        Awaitility.await().atMost(Duration.ofSeconds(30)).untilAsserted(() -> {
+            // TODO fix the bug: the policy "admin1.topicPolicies().setDeduplicationSnapshotInterval(topicName, 10)"
+            //      does not work.
+            PersistentTopic persistentTopic1 =
+                    (PersistentTopic) pulsar1.getBrokerService().getTopic(topicName, false).join().get();
+            PersistentTopic persistentTopic2 =
+                    (PersistentTopic) pulsar2.getBrokerService().getTopic(topicName, false).join().get();
+            admin1.topicPolicies().setDeduplicationStatus(topicName, true);
+            admin1.topicPolicies().setSchemaCompatibilityStrategy(topicName,
+                    SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE);
+            admin2.topicPolicies().setDeduplicationStatus(topicName, true);
+            admin2.topicPolicies().setSchemaCompatibilityStrategy(topicName,
+                    SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE);
+            MessageDeduplication messageDeduplication1 = persistentTopic1.getMessageDeduplication();
+            if (messageDeduplication1 != null) {
+                int snapshotInterval1 = WhiteboxImpl.getInternalState(messageDeduplication1, "snapshotInterval");
+                assertEquals(snapshotInterval1, 10);
+            }
+            MessageDeduplication messageDeduplication2 = persistentTopic2.getMessageDeduplication();
+            if (messageDeduplication2 != null) {
+                int snapshotInterval2 = WhiteboxImpl.getInternalState(messageDeduplication2, "snapshotInterval");
+                assertEquals(snapshotInterval2, 10);
+            }
+            assertEquals(persistentTopic1.getHierarchyTopicPolicies().getDeduplicationEnabled().get(), Boolean.TRUE);
+            assertEquals(persistentTopic1.getHierarchyTopicPolicies().getSchemaCompatibilityStrategy().get(),
+                    SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE);
+            assertEquals(persistentTopic2.getHierarchyTopicPolicies().getDeduplicationEnabled().get(), Boolean.TRUE);
+            assertEquals(persistentTopic2.getHierarchyTopicPolicies().getSchemaCompatibilityStrategy().get(),
+                    SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE);
+            // TODO fix the bug: after schema check failed, the replication will get a broken package error.
+        });
+        PersistentTopic tp1 =
+                (PersistentTopic) pulsar1.getBrokerService().getTopic(topicName, false).join().get();
+        PersistentTopic tp2 =
+                (PersistentTopic) pulsar2.getBrokerService().getTopic(topicName, false).join().get();
+
+        // 2, Publish messages.
+        List<String> msgSent = new ArrayList<>();
+        Producer<Integer> p1 = client1.newProducer(Schema.INT32).topic(topicName).create();
+        Producer<Integer> p2 = client1.newProducer(Schema.INT32).topic(topicName).create();
+        Producer<String> p3 = client1.newProducer(Schema.STRING).topic(topicName).create();
+        Producer<Boolean> p4 = client1.newProducer(Schema.BOOL).topic(topicName).create();
+        for (int i = 0; i < 10; i++) {
+            p1.send(i);
+            msgSent.add(String.valueOf(i));
+        }
+        for (int i = 10; i < 200; i++) {
+            int msg1 = i;
+            int msg2 = 1000 + i;
+            String msg3 = (2000 + i) + "";
+            boolean msg4 = i % 2 == 0;
+            p1.send(msg1);
+            p2.send(msg2);
+            msgSent.add(String.valueOf(msg1));
+            msgSent.add(String.valueOf(msg2));
+            if (multiSchemas) {
+                p3.send(msg3);
+                p4.send(msg4);
+                msgSent.add(String.valueOf(msg3));
+                msgSent.add(String.valueOf(msg4));
+            }
+        }
+        p1.close();
+        p2.close();
+        p3.close();
+        p4.close();
+
+        // 3. Enable replication and wait the task to be finished.
+        admin1.topics().setReplicationClusters(topicName, Arrays.asList(cluster1, cluster2));
+        waitReplicatorStarted(topicName);
+        Awaitility.await().atMost(Duration.ofSeconds(60)).untilAsserted(() -> {
+            for (ManagedCursor cursor : tp1.getManagedLedger().getCursors()) {
+                if (cursor.getName().equals("pulsar.repl.r2")) {
+                    long replBacklog = cursor.getNumberOfEntriesInBacklog(true);
+                    log.info("repl backlog: {}", replBacklog);
+                    assertEquals(replBacklog, 0);
+                }
+            }
+        });
+
+        // Verify: all messages were copied correctly.
+        List<String> msgReceived = new ArrayList<>();
+        Consumer<GenericRecord> consumer = client2.newConsumer(Schema.AUTO_CONSUME()).topic(topicName)
+                .subscriptionName("s1").subscribe();
+        while (true) {
+            Message<GenericRecord> msg = consumer.receive(10, TimeUnit.SECONDS);
+            if (msg == null) {
+                break;
+            }
+            MessageIdAdv messageIdAdv = (MessageIdAdv) msg.getMessageId();
+            log.info("received msg. source {}, target {}:{}", StringUtils.join(msg.getProperties().values(), ":"),
+                    messageIdAdv.getLedgerId(), messageIdAdv.getEntryId());
+            msgReceived.add(String.valueOf(msg.getValue()));
+            consumer.acknowledgeAsync(msg);
+        }
+        log.info("c1 topic stats-internal: "
+                + JACKSON.writeValueAsString(admin1.topics().getInternalStats(topicName)));
+        log.info("c2 topic stats-internal: "
+                + JACKSON.writeValueAsString(admin2.topics().getInternalStats(topicName)));
+        log.info("c1 topic stats-internal: "
+                + JACKSON.writeValueAsString(admin1.topics().getStats(topicName)));
+        log.info("c2 topic stats-internal: "
+                + JACKSON.writeValueAsString(admin2.topics().getStats(topicName)));
+        assertEquals(msgReceived, msgSent);
+        consumer.close();
+
+        // Verify: the deduplication cursor has been acked.
+        // "topic-policy.DeduplicationSnapshotInterval" is "10".
+        Awaitility.await().untilAsserted(() -> {
+            for (ManagedCursor cursor : tp1.getManagedLedger().getCursors()) {
+                if (cursor.getName().equals("pulsar.dedup")) {
+                    assertTrue(cursor.getNumberOfEntriesInBacklog(true) < 10);
+                }
+            }
+            for (ManagedCursor cursor : tp2.getManagedLedger().getCursors()) {
+                if (cursor.getName().equals("pulsar.dedup")) {
+                    assertTrue(cursor.getNumberOfEntriesInBacklog(true) < 10);
+                }
+            }
+        });
+        // Remove the injection.
+        taskToClearInjection.run();
+
+        log.info("======  Verify: all messages will be replicated after reopening replication  ======");
+
+        // Verify: all messages will be replicated after reopening replication.
+        // Reopen replication: stop replication.
+        admin1.topics().setReplicationClusters(topicName, Arrays.asList(cluster1));
+        waitReplicatorStopped(topicName);
+        admin2.topics().unload(topicName);
+        admin2.topics().delete(topicName);
+        // Reopen replication: enable replication.
+        admin2.topics().createNonPartitionedTopic(topicName);
+        admin2.topics().createSubscription(topicName, "s1", MessageId.earliest);
+        Awaitility.await().atMost(Duration.ofSeconds(30)).untilAsserted(() -> {
+            PersistentTopic persistentTopic2 =
+                    (PersistentTopic) pulsar2.getBrokerService().getTopic(topicName, false).join().get();
+            admin2.topicPolicies().setDeduplicationStatus(topicName, true);
+            admin2.topicPolicies().setSchemaCompatibilityStrategy(topicName,
+                    SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE);
+            MessageDeduplication messageDeduplication2 = persistentTopic2.getMessageDeduplication();
+            if (messageDeduplication2 != null) {
+                int snapshotInterval2 = WhiteboxImpl.getInternalState(messageDeduplication2, "snapshotInterval");
+                assertEquals(snapshotInterval2, 10);
+            }
+            assertEquals(persistentTopic2.getHierarchyTopicPolicies().getDeduplicationEnabled().get(), Boolean.TRUE);
+            assertEquals(persistentTopic2.getHierarchyTopicPolicies().getSchemaCompatibilityStrategy().get(),
+                    SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE);
+        });
+        admin1.topics().setReplicationClusters(topicName, Arrays.asList(cluster1, cluster2));
+        Awaitility.await().atMost(Duration.ofSeconds(60)).untilAsserted(() -> {
+            for (ManagedCursor cursor : tp2.getManagedLedger().getCursors()) {
+                if (cursor.getName().equals("pulsar.repl.c2")) {
+                    assertEquals(cursor.getNumberOfEntriesInBacklog(true), 0);
+                }
+            }
+        });
+        // Reopen replication: consumption.
+        List<String> msgReceived2 = new ArrayList<>();
+        Consumer<GenericRecord> consumer2 = client2.newConsumer(Schema.AUTO_CONSUME()).topic(topicName)
+                .subscriptionName("s1").subscribe();
+        while (true) {
+            Message<GenericRecord> msg = consumer2.receive(10, TimeUnit.SECONDS);
+            if (msg == null) {
+                break;
+            }
+            MessageIdAdv messageIdAdv = (MessageIdAdv) msg.getMessageId();
+            log.info("received msg. source {}, target {}:{}", StringUtils.join(msg.getProperties().values(), ":"),
+                    messageIdAdv.getLedgerId(), messageIdAdv.getEntryId());
+            msgReceived2.add(String.valueOf(msg.getValue()));
+            consumer2.acknowledgeAsync(msg);
+        }
+        // Verify: all messages were copied correctly.
+        log.info("c1 topic stats-internal: "
+                + JACKSON.writeValueAsString(admin1.topics().getInternalStats(topicName)));
+        log.info("c2 topic stats-internal: "
+                + JACKSON.writeValueAsString(admin2.topics().getInternalStats(topicName)));
+        log.info("c1 topic stats-internal: "
+                + JACKSON.writeValueAsString(admin1.topics().getStats(topicName)));
+        log.info("c2 topic stats-internal: "
+                + JACKSON.writeValueAsString(admin2.topics().getStats(topicName)));
+        assertEquals(msgReceived2, msgSent);
+        consumer2.close();
+
+        // cleanup.
+        admin1.topics().setReplicationClusters(topicName, Arrays.asList(cluster1));
+        waitReplicatorStopped(topicName);
+        Awaitility.await().until(() -> {
+            for (ManagedCursor cursor : tp1.getManagedLedger().getCursors()) {
+                if (cursor.getName().equals("pulsar.repl.r2")) {
+                    return false;
+                }
+            }
+            return true;
+        });
+        admin1.topics().unload(topicName); // TODO fix the bug: topic can not be deleted successfully without an unload.
+        admin1.topics().delete(topicName);
+        admin2.topics().unload(topicName);
+        admin2.topics().delete(topicName);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -405,9 +405,9 @@ public class ReplicatorTest extends ReplicatorTestBase {
 
         int lastId = -1;
         for (int i = 0; i < totalMessages; i++) {
-            Message<GenericRecord> msg1 = consumer1.receive();
-            Message<GenericRecord> msg2 = consumer2.receive();
-            Message<GenericRecord> msg3 = consumer3.receive();
+            Message<GenericRecord> msg1 = consumer1.receive(10, TimeUnit.SECONDS);
+            Message<GenericRecord> msg2 = consumer2.receive(10, TimeUnit.SECONDS);
+            Message<GenericRecord> msg3 = consumer3.receive(10, TimeUnit.SECONDS);
             assertTrue(msg1 != null && msg2 != null && msg3 != null);
             GenericRecord record1 = msg1.getValue();
             GenericRecord record2 = msg2.getValue();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -196,7 +196,7 @@ public class ClientCnx extends PulsarHandler {
     @Getter
     private boolean supportsGetPartitionedMetadataWithoutAutoCreation;
     @Getter
-    private boolean brokerSupportsDedupReplV2;
+    private boolean brokerSupportsReplDedupByLidAndEid;
 
     /** Idle stat. **/
     @Getter
@@ -409,8 +409,8 @@ public class ClientCnx extends PulsarHandler {
         supportsGetPartitionedMetadataWithoutAutoCreation =
             connected.hasFeatureFlags()
                     && connected.getFeatureFlags().isSupportsGetPartitionedMetadataWithoutAutoCreation();
-        brokerSupportsDedupReplV2 =
-            connected.hasFeatureFlags() && connected.getFeatureFlags().isSupportsDedupReplV2();
+        brokerSupportsReplDedupByLidAndEid =
+            connected.hasFeatureFlags() && connected.getFeatureFlags().isSupportsReplDedupByLidAndEid();
 
         // set remote protocol version to the correct version before we complete the connection future
         setRemoteEndpointProtocolVersion(connected.getProtocolVersion());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -122,10 +122,12 @@ public class ClientCnx extends PulsarHandler {
     protected final Authentication authentication;
     protected State state;
 
-    private AtomicLong duplicatedResponseCounter = new AtomicLong(0);
+    @VisibleForTesting
+    protected AtomicLong duplicatedResponseCounter = new AtomicLong(0);
 
+    @VisibleForTesting
     @Getter
-    private final ConcurrentLongHashMap<TimedCompletableFuture<? extends Object>> pendingRequests =
+    protected final ConcurrentLongHashMap<TimedCompletableFuture<? extends Object>> pendingRequests =
             ConcurrentLongHashMap.<TimedCompletableFuture<? extends Object>>newBuilder()
                     .expectedItems(16)
                     .concurrencyLevel(1)

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -483,7 +483,8 @@ public class ClientCnx extends PulsarHandler {
         ProducerImpl<?> producer = producers.get(producerId);
         if (ledgerId == -1 && entryId == -1) {
             log.warn("{} Message with sequence-id {}-{} published by producer [id:{}, name:{}] has been dropped",
-                    ctx.channel(), sequenceId, highestSequenceId, producerId, producer.getProducerName());
+                    ctx.channel(), sequenceId, highestSequenceId, producerId,
+                    producer != null ? producer.getProducerName() : "null");
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("{} Got receipt for producer: [id:{}, name:{}] -- sequence-id: {}-{} -- entry-id: {}:{}",

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
@@ -27,12 +27,20 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.common.api.proto.KeyValue;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.protocol.Markers;
 
 @Slf4j
 public class GeoReplicationProducerImpl extends ProducerImpl{
 
     public static final String MSG_PROP_REPL_SEQUENCE_LID = "__MSG_PROP_REPL_SEQUENCE_LID";
     public static final String MSG_PROP_REPL_SEQUENCE_EID = "__MSG_PROP_REPL_SEQUENCE_EID";
+    public static final String MSG_PROP_IS_REPL_MARKER = "__MSG_PROP_IS_REPL_MARKER";
+
+    private long lastPersistedSourceLedgerId;
+    private long lastPersistedSourceEntryId;
+
+    private final boolean isPersistentTopic;
 
     public GeoReplicationProducerImpl(PulsarClientImpl client, String topic,
                                       ProducerConfigurationData conf,
@@ -40,100 +48,194 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
                                       Schema schema, ProducerInterceptors interceptors,
                                       Optional overrideProducerName) {
         super(client, topic, conf, producerCreatedFuture, partitionIndex, schema, interceptors, overrideProducerName);
+        isPersistentTopic = TopicName.get(topic).isPersistent();
+    }
+
+    private boolean isBrokerSupportsDedupReplV2(ClientCnx cnx) {
+        // Non-Persistent topic does not have ledger id or entry id, so it does not support.
+        return cnx.isBrokerSupportsDedupReplV2() && isPersistentTopic;
     }
 
     @Override
-    protected void ackReceived(ClientCnx cnx, long lIdSent, long eIdSent, long ledgerId, long entryId) {
-        if (!cnx.isBrokerSupportsDedupReplV2()) {
-            super.ackReceived(cnx, lIdSent, eIdSent, ledgerId, entryId);
+    protected void ackReceived(ClientCnx cnx, long seq, long highSeq, long ledgerId, long entryId) {
+        if (!isBrokerSupportsDedupReplV2(cnx)) {
+            // Repl V1 is the same as normal for this handling.
+            super.ackReceived(cnx, seq, highSeq, ledgerId, entryId);
+            return;
+        }
+        synchronized (this) {
+            OpSendMsg op = pendingMessages.peek();
+            if (op == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] [{}] Got ack for timed out msg {}:{}", topic, producerName, seq, highSeq);
+                }
+                return;
+            }
+            // Replicator send markers also, use sequenceId to check the marker send-receipt.
+            if (isReplicationMarker(entryId)) {
+                ackReceivedReplMarker(cnx, op, seq, highSeq, ledgerId, entryId);
+                return;
+            }
+            ackReceivedReplicatedMsg(cnx, op, seq, highSeq, ledgerId, entryId);
+        }
+    }
+    private void ackReceivedReplicatedMsg(ClientCnx cnx, OpSendMsg op, long sourceLId, long sourceEId,
+                                          long targetLId, long targetEid) {
+        // Case-1: repeatedly publish.
+        if (sourceLId < lastPersistedSourceLedgerId
+                || (sourceLId == lastPersistedSourceLedgerId  && sourceEId < lastPersistedSourceEntryId)) {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] [{}] Dropped a repl marker SendReceipt. Got entry {}:{}, last persisted source entry:"
+                        + " {}:{}",
+                        topic, producerName, sourceLId, sourceEId,
+                        lastPersistedSourceLedgerId, lastPersistedSourceEntryId);
+            }
             return;
         }
 
-        OpSendMsg op = null;
-        synchronized (this) {
-            op = pendingMessages.peek();
-            if (op == null) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] [{}] Got ack for timed out msg {}:{}", topic, producerName, lIdSent, eIdSent);
-                }
-                return;
-            }
-            Long lIdPendingRes = null;
-            Long eIdPendingRes = null;
-            List<KeyValue> kvPairList =  op.msg.getMessageBuilder().getPropertiesList();
-            for (KeyValue kvPair : kvPairList) {
-                if (kvPair.getKey().equals(MSG_PROP_REPL_SEQUENCE_LID)) {
-                    if (StringUtils.isNumeric(kvPair.getValue())) {
-                        lIdPendingRes = Long.valueOf(kvPair.getValue());
-                    } else {
-                        break;
-                    }
-                }
-                if (kvPair.getKey().equals(MSG_PROP_REPL_SEQUENCE_EID)) {
-                    if (StringUtils.isNumeric(kvPair.getValue())) {
-                        eIdPendingRes = Long.valueOf(kvPair.getValue());
-                    } else {
-                        break;
-                    }
-                }
-                if (lIdPendingRes != null && eIdPendingRes != null) {
+        // Parse source cluster's entry position.
+        Long pendingLId = null;
+        Long pendingEId = null;
+        List<KeyValue> kvPairList =  op.msg.getMessageBuilder().getPropertiesList();
+        for (KeyValue kvPair : kvPairList) {
+            if (kvPair.getKey().equals(MSG_PROP_REPL_SEQUENCE_LID)) {
+                if (StringUtils.isNumeric(kvPair.getValue())) {
+                    pendingLId = Long.valueOf(kvPair.getValue());
+                } else {
                     break;
                 }
             }
-            if (lIdPendingRes == null || eIdPendingRes == null) {
-                // Rollback to the original implementation.
-                log.error("[{}] [{}] can not found v2 sequence-id {}:{}, ackReceived: {}:{} {}:{} - queue-size: {}",
-                        topic, producerName, lIdPendingRes, eIdPendingRes, lIdSent,
-                        eIdSent, ledgerId, entryId, pendingMessages.messagesCount());
-                cnx.channel().close();
-                return;
+            if (kvPair.getKey().equals(MSG_PROP_REPL_SEQUENCE_EID)) {
+                if (StringUtils.isNumeric(kvPair.getValue())) {
+                    pendingEId = Long.valueOf(kvPair.getValue());
+                } else {
+                    break;
+                }
             }
+            if (pendingLId != null && pendingEId != null) {
+                break;
+            }
+        }
 
-            if (lIdSent == lIdPendingRes && eIdSent == eIdPendingRes) {
-                // Q: After a reconnect, maybe we have lost the response of Send-Receipt, then how can we remove
-                //    pending messages from the queue?
-                // A: if both @param-ledgerId and @param-entry-id are "-1", it means the message has been sent
-                //    successfully.
-                //    PS: broker will respond "-1" only when it confirms the message has been persisted, broker will
-                //        respond a "MessageDeduplication.MessageDupUnknownException" if the message is sending
-                //        in-progress.
-                //    Notice: if send messages outs of oder, may lost messages.
-                // Conclusion: So whether @param-ledgerId and @param-entry-id are "-1" or not, we can remove pending
-                //    message.
-                if (log.isDebugEnabled()) {
-                    log.debug("Got receipt for producer: [{}] -- source-message: {}:{} -- target-msg: {}:{}",
-                            getProducerName(), lIdSent, eIdSent, ledgerId, entryId);
-                }
-                pendingMessages.remove();
-                releaseSemaphoreForSendOp(op);
-                // Since Geo-Replicator will not send batched message, skip to update the field
-                // "LAST_SEQ_ID_PUBLISHED_UPDATER".
-                op.setMessageId(ledgerId, entryId, partitionIndex);
-                try {
-                    // Need to protect ourselves from any exception being thrown in the future handler from the
-                    // application
-                    op.sendComplete(null);
-                } catch (Throwable t) {
-                    log.warn("[{}] [{}] Got exception while completing the callback for -- source-message: {}:{} --"
-                                    + " target-msg: {}:{}",
-                            topic, producerName, lIdSent, eIdSent, ledgerId, entryId, t);
-                }
-                ReferenceCountUtil.safeRelease(op.cmd);
-                op.recycle();
-            } else if (lIdSent < lIdPendingRes || (lIdSent == lIdPendingRes  && eIdSent < eIdPendingRes)) {
-                // Ignoring the ack since it's referring to a message that has already timed out.
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] [{}] Got ack for timed out msg. expecting less or equals {}:{}, but got: {}:{}",
-                            topic, producerName, lIdPendingRes, eIdPendingRes, lIdSent,
-                            eIdSent);
-                }
-            } else {
-                log.warn("[{}] [{}] Got ack for msg. expecting less or equals {}:{}, but got: {}:{} - queue-size: {}",
-                        topic, producerName, lIdPendingRes, eIdPendingRes, lIdSent,
-                        eIdSent, pendingMessages.messagesCount());
-                // Force connection closing so that messages can be re-transmitted in a new connection
-                cnx.channel().close();
+        // Case-2, which is expected.
+        if (pendingLId!= null && pendingEId != null && sourceLId == pendingLId && sourceEId == pendingEId) {
+            // Case-3, which is expected.
+            // Q: After a reconnect, maybe we have lost the response of Send-Receipt, then how can we remove
+            //    pending messages from the queue?
+            // A: if both @param-ledgerId and @param-entry-id are "-1", it means the message has been sent
+            //    successfully.
+            //    PS: broker will respond "-1" only when it confirms the message has been persisted, broker will
+            //        respond a "MessageDeduplication.MessageDupUnknownException" if the message is sending
+            //        in-progress.
+            //    Notice: if send messages outs of oder, may lost messages.
+            // Conclusion: So whether @param-ledgerId and @param-entry-id are "-1" or not, we can remove pending
+            //    message.
+            lastPersistedSourceLedgerId = sourceLId;
+            lastPersistedSourceEntryId = sourceEId;
+            removeAndApplyCallback(op, sourceLId, sourceEId, targetLId, targetEid, false);
+            return;
+        }
+
+        // Case-3: got null source cluster's entry position, which is unexpected.
+        if (pendingLId == null || pendingEId == null) {
+            log.error("[{}] [{}] can not found v2 sequence-id {}:{}, ackReceived: {}:{} {}:{} - queue-size: {}",
+                    topic, producerName, pendingLId, pendingEId, sourceLId,
+                    sourceEId, targetLId, targetEid, pendingMessages.messagesCount());
+            cnx.channel().close();
+            return;
+        }
+
+        // Case-4: unknown error, which is unexpected.
+        log.warn("[{}] [{}] Got ack for msg. expecting {}:{}, but got: {}:{} - queue-size: {}",
+                topic, producerName, pendingLId, pendingEId, sourceLId,
+                sourceEId, pendingMessages.messagesCount());
+        // Force connection closing so that messages can be re-transmitted in a new connection
+        cnx.channel().close();
+    }
+
+    protected void ackReceivedReplMarker(ClientCnx cnx, OpSendMsg op, long req, long highReq,
+                                         long ledgerId, long entryId) {
+        // Case-1: repeatedly publish repl marker.
+        long lastSeqReceivedAck = LAST_SEQ_ID_PUBLISHED_UPDATER.get(this);
+        if (req <= lastSeqReceivedAck) {
+            // Ignoring the ack since it's referring to a message that has already timed out.
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] [{}] Dropped a repl marker SendReceipt. sequenceId: {},"
+                                + " sequenceIdPersisted: {},"
+                                + " highReq: {}, position: {}:{}",
+                        topic, producerName, req, lastSeqReceivedAck, highReq, ledgerId, entryId);
             }
+            return;
+        }
+
+        // Case-2, which is expected:
+        // 1. Broker responds SendReceipt who is a repl marker.
+        // 2. The current pending msg is also a marker.
+        if (isReplicationMarker(op) && req == op.sequenceId) {
+            long calculatedSeq = getHighestSequenceId(op);
+            LAST_SEQ_ID_PUBLISHED_UPDATER.getAndUpdate(this, last -> Math.max(last, calculatedSeq));
+            removeAndApplyCallback(op, req, highReq, ledgerId, entryId, true);
+            return;
+        }
+
+        // Case-3, which is unexpected.
+        // Case-3-1: expected a SendError if "seq <= lastInProgressSend".
+        // Case-3-2: something went wrong.
+        long lastInProgressSend = LAST_SEQ_ID_PUSHED_UPDATER.get(this);
+        String logText = String.format("[%s] [%s] Got ack for a repl marker msg. expecting %s, but got: %s."
+                + " sequenceIdPersisted: %s, lastInProgressSend: %s,"
+                + " HighReq: %s, position: %s:%s, queue-size: %s",
+                topic, producerName, lastSeqReceivedAck - 1, req,
+                lastSeqReceivedAck, lastInProgressSend,
+                highReq, ledgerId, entryId, pendingMessages.messagesCount()
+        );
+        if (req < lastInProgressSend) {
+            log.warn(logText);
+        } else {
+            log.error(logText);
+        }
+        // Force connection closing so that messages can be re-transmitted in a new connection.
+        cnx.channel().close();
+    }
+
+    private void removeAndApplyCallback(OpSendMsg op, long lIdSent, long eIdSent, long ledgerId, long entryId,
+                                        boolean isMarker) {
+        if (log.isDebugEnabled()) {
+            log.debug("Got receipt for producer: [{}] -- source-message: {}:{} -- target-msg: {}:{} -- isMarker: {}",
+                    getProducerName(), lIdSent, eIdSent, ledgerId, entryId, isMarker);
+        }
+        pendingMessages.remove();
+        releaseSemaphoreForSendOp(op);
+        // Since Geo-Replicator will not send batched message, skip to update the field
+        // "LAST_SEQ_ID_PUBLISHED_UPDATER".
+        op.setMessageId(ledgerId, entryId, partitionIndex);
+        try {
+            // Need to protect ourselves from any exception being thrown in the future handler from the
+            // application
+            op.sendComplete(null);
+        } catch (Throwable t) {
+            log.warn("[{}] [{}] Got exception while completing the callback for -- source-message: {}:{} --"
+                            + " target-msg: {}:{} -- isMarker: {}",
+                    topic, producerName, lIdSent, eIdSent, ledgerId, entryId, isMarker, t);
+        }
+        ReferenceCountUtil.safeRelease(op.cmd);
+        op.recycle();
+    }
+
+    private boolean isReplicationMarker(OpSendMsg op) {
+        return op.msg != null && op.msg.getMessageBuilder().hasMarkerType()
+                && Markers.isReplicationMarker(op.msg.getMessageBuilder().getMarkerType());
+    }
+
+    private boolean isReplicationMarker(long highestSeq) {
+        return Long.MIN_VALUE == highestSeq;
+    }
+
+    @Override
+    protected void updateLastSeqPushed(OpSendMsg op) {
+        // Only update the value for repl marker.
+        if (isReplicationMarker(op)) {
+            super.updateLastSeqPushed(op);
         }
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
@@ -78,6 +78,7 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
             ackReceivedReplicatedMsg(cnx, op, seq, highSeq, ledgerId, entryId);
         }
     }
+
     private void ackReceivedReplicatedMsg(ClientCnx cnx, OpSendMsg op, long sourceLId, long sourceEId,
                                           long targetLId, long targetEid) {
         // Parse source cluster's entry position.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import io.netty.util.ReferenceCountUtil;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
+import org.apache.pulsar.common.api.proto.KeyValue;
+
+@Slf4j
+public class GeoReplicationProducerImpl extends ProducerImpl{
+
+    public static String MSG_PROP_REPL_SEQUENCE_LID = "__MSG_PROP_REPL_SEQUENCE_LID";
+    public static String MSG_PROP_REPL_SEQUENCE_EID = "__MSG_PROP_REPL_SEQUENCE_EID";
+
+    public GeoReplicationProducerImpl(PulsarClientImpl client, String topic,
+                                      ProducerConfigurationData conf,
+                                      CompletableFuture producerCreatedFuture, int partitionIndex,
+                                      Schema schema, ProducerInterceptors interceptors,
+                                      Optional overrideProducerName) {
+        super(client, topic, conf, producerCreatedFuture, partitionIndex, schema, interceptors, overrideProducerName);
+    }
+
+    @Override
+    protected void ackReceived(ClientCnx cnx, long lIdSent, long eIdSent, long ledgerId, long entryId) {
+        if (!cnx.isBrokerSupportsDedupReplV2()) {
+            super.ackReceived(cnx, lIdSent, eIdSent, ledgerId, entryId);
+            return;
+        }
+
+        OpSendMsg op = null;
+        synchronized (this) {
+            op = pendingMessages.peek();
+            if (op == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] [{}] Got ack for timed out msg {}:{}", topic, producerName, lIdSent, eIdSent);
+                }
+                return;
+            }
+            Long lIdPendingRes = null;
+            Long eIdPendingRes = null;
+            List<KeyValue> kvPairList =  op.msg.getMessageBuilder().getPropertiesList();
+            for (KeyValue kvPair : kvPairList) {
+                if (kvPair.getKey().equals(MSG_PROP_REPL_SEQUENCE_LID)) {
+                    if (StringUtils.isNumeric(kvPair.getValue())) {
+                        lIdPendingRes = Long.valueOf(kvPair.getValue());
+                    } else {
+                        break;
+                    }
+                }
+                if (kvPair.getKey().equals(MSG_PROP_REPL_SEQUENCE_EID)) {
+                    if (StringUtils.isNumeric(kvPair.getValue())) {
+                        eIdPendingRes = Long.valueOf(kvPair.getValue());
+                    } else {
+                        break;
+                    }
+                }
+                if (lIdPendingRes != null && eIdPendingRes != null) {
+                    break;
+                }
+            }
+            if (lIdPendingRes == null || eIdPendingRes == null) {
+                // Rollback to the original implementation.
+                log.error("[{}] [{}] can not found v2 sequence-id {}:{}, ackReceived: {}:{} {}:{} - queue-size: {}",
+                        topic, producerName, lIdPendingRes, eIdPendingRes, lIdSent,
+                        eIdSent, ledgerId, entryId, pendingMessages.messagesCount());
+                cnx.channel().close();
+                return;
+            }
+
+            if (lIdSent == lIdPendingRes && eIdSent == eIdPendingRes) {
+                // Q: After a reconnect, maybe we have lost the response of Send-Receipt, then how can we remove
+                //    pending messages from the queue?
+                // A: if both @param-ledgerId and @param-entry-id are "-1", it means the message has been sent
+                //    successfully.
+                //    PS: broker will respond "-1" only when it confirms the message has been persisted, broker will
+                //        respond a "MessageDeduplication.MessageDupUnknownException" if the message is sending
+                //        in-progress.
+                //    Notice: if send messages outs of oder, may lost messages.
+                // Conclusion: So whether @param-ledgerId and @param-entry-id are "-1" or not, we can remove pending
+                //    message.
+                if (log.isInfoEnabled()) {
+                    log.info("Got receipt for producer: [{}] -- source-message: {}:{} -- target-msg: {}:{}",
+                            getProducerName(), lIdSent, eIdSent, ledgerId, entryId);
+                }
+                pendingMessages.remove();
+                releaseSemaphoreForSendOp(op);
+                // TODO LAST_SEQ_ID_PUBLISHED_UPDATER.getAndUpdate(this, last -> Math.max(last, getHighestSequenceId(finalOp)));
+                op.setMessageId(ledgerId, entryId, partitionIndex);
+                try {
+                    // Need to protect ourselves from any exception being thrown in the future handler from the
+                    // application
+                    op.sendComplete(null);
+                } catch (Throwable t) {
+                    log.warn("[{}] [{}] Got exception while completing the callback for -- source-message: {}:{} --"
+                                    + " target-msg: {}:{}",
+                            topic, producerName, lIdSent, eIdSent, ledgerId, entryId, t);
+                }
+                ReferenceCountUtil.safeRelease(op.cmd);
+                op.recycle();
+            } else if (lIdSent < lIdPendingRes || (lIdSent == lIdPendingRes  && eIdSent < eIdPendingRes)) {
+                // Ignoring the ack since it's referring to a message that has already timed out.
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] [{}] Got ack for timed out msg. expecting less or equals {}:{}, but got: {}:{}",
+                            topic, producerName, lIdPendingRes, eIdPendingRes, lIdSent,
+                            eIdSent);
+                }
+            } else {
+                log.warn("[{}] [{}] Got ack for msg. expecting less or equals {}:{}, but got: {}:{} - queue-size: {}",
+                        topic, producerName, lIdPendingRes, eIdPendingRes, lIdSent,
+                        eIdSent, pendingMessages.messagesCount());
+                // Force connection closing so that messages can be re-transmitted in a new connection
+                cnx.channel().close();
+            }
+        }
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
@@ -86,14 +86,14 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
         Long pendingEId = null;
         List<KeyValue> kvPairList =  op.msg.getMessageBuilder().getPropertiesList();
         for (KeyValue kvPair : kvPairList) {
-            if (kvPair.getKey().equals(MSG_PROP_REPL_SOURCE_LID)) {
+            if (MSG_PROP_REPL_SOURCE_LID.equals(kvPair.getKey())) {
                 if (StringUtils.isNumeric(kvPair.getValue())) {
                     pendingLId = Long.valueOf(kvPair.getValue());
                 } else {
                     break;
                 }
             }
-            if (kvPair.getKey().equals(MSG_PROP_REPL_SOURCE_EID)) {
+            if (MSG_PROP_REPL_SOURCE_EID.equals(kvPair.getKey())) {
                 if (StringUtils.isNumeric(kvPair.getValue())) {
                     pendingEId = Long.valueOf(kvPair.getValue());
                 } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
@@ -111,8 +111,8 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
         //   - The second time: Replicator --M1--> producer --> ...
         if (pendingLId < lastPersistedSourceLedgerId
                 || (pendingLId == lastPersistedSourceLedgerId  && pendingEId <= lastPersistedSourceEntryId)) {
-            if (log.isInfoEnabled()) {
-                log.info("[{}] [{}] Received an msg send receipt[pending send is repeated due to repl cursor rewind]:"
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] [{}] Received an msg send receipt[pending send is repeated due to repl cursor rewind]:"
                                 + " source entry {}:{}, pending send: {}:{}, latest persisted: {}:{}",
                         topic, producerName, sourceLId, sourceEId, pendingLId, pendingEId,
                         lastPersistedSourceLedgerId, lastPersistedSourceEntryId);
@@ -129,8 +129,8 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
         //  - The second time: producer call Send-Command-1.
         if (sourceLId < lastPersistedSourceLedgerId
                 || (sourceLId == lastPersistedSourceLedgerId  && sourceEId <= lastPersistedSourceEntryId)) {
-            if (log.isInfoEnabled()) {
-                log.info("[{}] [{}] Received an msg send receipt[repeated]: source entry {}:{}, latest persisted:"
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] [{}] Received an msg send receipt[repeated]: source entry {}:{}, latest persisted:"
                                 + " {}:{}",
                         topic, producerName, sourceLId, sourceEId,
                         lastPersistedSourceLedgerId, lastPersistedSourceEntryId);
@@ -140,8 +140,8 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
 
         // Case-3, which is expected.
         if (pendingLId != null && pendingEId != null && sourceLId == pendingLId && sourceEId == pendingEId) {
-            if (log.isInfoEnabled()) {
-                log.info("[{}] [{}] Received an msg send receipt[expected]: source entry {}:{}, target entry:"
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] [{}] Received an msg send receipt[expected]: source entry {}:{}, target entry:"
                                 + " {}:{}",
                         topic, producerName, sourceLId, sourceEId,
                         targetLId, targetEid);
@@ -168,8 +168,8 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
         long lastSeqPersisted = LAST_SEQ_ID_PUBLISHED_UPDATER.get(this);
         if (lastSeqPersisted != 0 && seq <= lastSeqPersisted) {
             // Ignoring the ack since it's referring to a message that has already timed out.
-            if (log.isInfoEnabled()) {
-                log.info("[{}] [{}] Received an repl marker send receipt[repeated]. seq: {}, seqPersisted: {},"
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] [{}] Received an repl marker send receipt[repeated]. seq: {}, seqPersisted: {},"
                                 + " isSourceMarker: {}, target entry: {}:{}",
                         topic, producerName, seq, lastSeqPersisted, isSourceMarker, ledgerId, entryId);
             }
@@ -181,8 +181,8 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
         //   and condition: the current pending msg is also a marker.
         boolean pendingMsgIsReplMarker = isReplicationMarker(op);
         if (pendingMsgIsReplMarker && seq == op.sequenceId) {
-            if (log.isInfoEnabled()) {
-                log.info("[{}] [{}] Received an repl marker send receipt[expected]. seq: {}, seqPersisted: {},"
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] [{}] Received an repl marker send receipt[expected]. seq: {}, seqPersisted: {},"
                                 + " isReplMarker: {}, target entry: {}:{}",
                         topic, producerName, seq, lastSeqPersisted, isSourceMarker, ledgerId, entryId);
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
@@ -109,8 +109,9 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
         //   - The first time: Replicator --M1--> producer --> ...
         //   - Cursor rewind.
         //   - The second time: Replicator --M1--> producer --> ...
-        if (pendingLId < lastPersistedSourceLedgerId
-                || (pendingLId == lastPersistedSourceLedgerId  && pendingEId <= lastPersistedSourceEntryId)) {
+        if (pendingLId != null && pendingEId != null
+                && (pendingLId < lastPersistedSourceLedgerId || (pendingLId.longValue() == lastPersistedSourceLedgerId
+                  && pendingEId.longValue() <= lastPersistedSourceEntryId))) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] Received an msg send receipt[pending send is repeated due to repl cursor rewind]:"
                                 + " source entry {}:{}, pending send: {}:{}, latest persisted: {}:{}",

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
@@ -50,14 +50,14 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
         isPersistentTopic = TopicName.get(topic).isPersistent();
     }
 
-    private boolean isBrokerSupportsDedupReplV2(ClientCnx cnx) {
+    private boolean isBrokerSupportsReplDedupByLidAndEid(ClientCnx cnx) {
         // Non-Persistent topic does not have ledger id or entry id, so it does not support.
-        return cnx.isBrokerSupportsDedupReplV2() && isPersistentTopic;
+        return cnx.isBrokerSupportsReplDedupByLidAndEid() && isPersistentTopic;
     }
 
     @Override
     protected void ackReceived(ClientCnx cnx, long seq, long highSeq, long ledgerId, long entryId) {
-        if (!isBrokerSupportsDedupReplV2(cnx)) {
+        if (!isBrokerSupportsReplDedupByLidAndEid(cnx)) {
             // Repl V1 is the same as normal for this handling.
             super.ackReceived(cnx, seq, highSeq, ledgerId, entryId);
             return;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
@@ -118,7 +118,7 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
         }
 
         // Case-2, which is expected.
-        if (pendingLId!= null && pendingEId != null && sourceLId == pendingLId && sourceEId == pendingEId) {
+        if (pendingLId != null && pendingEId != null && sourceLId == pendingLId && sourceEId == pendingEId) {
             // Case-3, which is expected.
             // Q: After a reconnect, maybe we have lost the response of Send-Receipt, then how can we remove
             //    pending messages from the queue?

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
@@ -106,7 +106,8 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
                 }
                 pendingMessages.remove();
                 releaseSemaphoreForSendOp(op);
-                // TODO LAST_SEQ_ID_PUBLISHED_UPDATER.getAndUpdate(this, last -> Math.max(last, getHighestSequenceId(finalOp)));
+                // Since Geo-Replicator will not send batched message, skip to update the field
+                // "LAST_SEQ_ID_PUBLISHED_UPDATER".
                 op.setMessageId(ledgerId, entryId, partitionIndex);
                 try {
                     // Need to protect ourselves from any exception being thrown in the future handler from the

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
@@ -31,8 +31,8 @@ import org.apache.pulsar.common.api.proto.KeyValue;
 @Slf4j
 public class GeoReplicationProducerImpl extends ProducerImpl{
 
-    public static String MSG_PROP_REPL_SEQUENCE_LID = "__MSG_PROP_REPL_SEQUENCE_LID";
-    public static String MSG_PROP_REPL_SEQUENCE_EID = "__MSG_PROP_REPL_SEQUENCE_EID";
+    public static final String MSG_PROP_REPL_SEQUENCE_LID = "__MSG_PROP_REPL_SEQUENCE_LID";
+    public static final String MSG_PROP_REPL_SEQUENCE_EID = "__MSG_PROP_REPL_SEQUENCE_EID";
 
     public GeoReplicationProducerImpl(PulsarClientImpl client, String topic,
                                       ProducerConfigurationData conf,

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
@@ -139,7 +139,8 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
         }
 
         // Case-3, which is expected.
-        if (pendingLId != null && pendingEId != null && sourceLId == pendingLId && sourceEId == pendingEId) {
+        if (pendingLId != null && pendingEId != null && sourceLId == pendingLId.longValue()
+                && sourceEId == pendingEId.longValue()) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] Received an msg send receipt[expected]: source entry {}:{}, target entry:"
                                 + " {}:{}",

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
@@ -100,8 +100,8 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
                 //    Notice: if send messages outs of oder, may lost messages.
                 // Conclusion: So whether @param-ledgerId and @param-entry-id are "-1" or not, we can remove pending
                 //    message.
-                if (log.isInfoEnabled()) {
-                    log.info("Got receipt for producer: [{}] -- source-message: {}:{} -- target-msg: {}:{}",
+                if (log.isDebugEnabled()) {
+                    log.debug("Got receipt for producer: [{}] -- source-message: {}:{} -- target-msg: {}:{}",
                             getProducerName(), lIdSent, eIdSent, ledgerId, entryId);
                 }
                 pendingMessages.remove();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -115,7 +115,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     // Variable is updated in a synchronized block
     private volatile long msgIdGenerator;
 
-    private final OpSendMsgQueue pendingMessages;
+    protected final OpSendMsgQueue pendingMessages;
     private final Optional<Semaphore> semaphore;
     private volatile Timeout sendTimeout = null;
     private final long lookupDeadline;
@@ -132,12 +132,12 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     private LastSendFutureWrapper lastSendFutureWrapper = LastSendFutureWrapper.create(lastSendFuture);
 
     // Globally unique producer name
-    private String producerName;
+    protected String producerName;
     private final boolean userProvidedProducerName;
 
     private String connectionId;
     private String connectedSince;
-    private final int partitionIndex;
+    protected final int partitionIndex;
 
     private final ProducerStatsRecorder stats;
 
@@ -1254,7 +1254,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         }
     }
 
-    void ackReceived(ClientCnx cnx, long sequenceId, long highestSequenceId, long ledgerId, long entryId) {
+    protected void ackReceived(ClientCnx cnx, long sequenceId, long highestSequenceId, long ledgerId, long entryId) {
         OpSendMsg op = null;
         synchronized (this) {
             op = pendingMessages.peek();
@@ -1333,7 +1333,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         return Math.max(op.highestSequenceId, op.sequenceId);
     }
 
-    private void releaseSemaphoreForSendOp(OpSendMsg op) {
+    protected void releaseSemaphoreForSendOp(OpSendMsg op) {
 
         semaphoreRelease(isBatchMessagingEnabled() ? op.numMessagesInBatch : 1);
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -513,6 +513,10 @@ public class PulsarClientImpl implements PulsarClient {
                                                   ProducerInterceptors interceptors,
                                                   CompletableFuture<Producer<T>> producerCreatedFuture,
                                                   Optional<String> overrideProducerName) {
+        if (conf.isReplProducer()) {
+            return new GeoReplicationProducerImpl(PulsarClientImpl.this, topic, conf, producerCreatedFuture,
+                    partitionIndex, schema, interceptors, overrideProducerName);
+        }
         return new ProducerImpl<>(PulsarClientImpl.this, topic, conf, producerCreatedFuture, partitionIndex, schema,
                 interceptors, overrideProducerName);
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
@@ -206,6 +206,8 @@ public class ProducerConfigurationData implements Serializable, Cloneable {
 
     private boolean isNonPartitionedTopicExpected;
 
+    private boolean isReplProducer;
+
     @ApiModelProperty(
             name = "initialSubscriptionName",
             value = "Use this configuration to automatically create an initial subscription when creating a topic."

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -192,7 +192,7 @@ public class Commands {
         flags.setSupportsBrokerEntryMetadata(true);
         flags.setSupportsPartialProducer(true);
         flags.setSupportsGetPartitionedMetadataWithoutAutoCreation(true);
-        flags.setSupportsDedupReplV2(true);
+        flags.setSupportsReplDedupByLidAndEid(true);
     }
 
     public static ByteBuf newConnect(String authMethodName, String authData, int protocolVersion, String libVersion,
@@ -313,7 +313,7 @@ public class Commands {
 
         connected.setFeatureFlags().setSupportsTopicWatchers(supportsTopicWatchers);
         connected.setFeatureFlags().setSupportsGetPartitionedMetadataWithoutAutoCreation(true);
-        connected.setFeatureFlags().setSupportsDedupReplV2(true);
+        connected.setFeatureFlags().setSupportsReplDedupByLidAndEid(true);
         return cmd;
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -192,6 +192,7 @@ public class Commands {
         flags.setSupportsBrokerEntryMetadata(true);
         flags.setSupportsPartialProducer(true);
         flags.setSupportsGetPartitionedMetadataWithoutAutoCreation(true);
+        flags.setSupportsDedupReplV2(true);
     }
 
     public static ByteBuf newConnect(String authMethodName, String authData, int protocolVersion, String libVersion,
@@ -245,6 +246,15 @@ public class Commands {
     public static ByteBuf newConnect(String authMethodName, AuthData authData, int protocolVersion, String libVersion,
                                      String targetBroker, String originalPrincipal, AuthData originalAuthData,
                                      String originalAuthMethod, String proxyVersion) {
+        BaseCommand cmd = newConnectWithoutSerialize(authMethodName, authData, protocolVersion, libVersion,
+                targetBroker, originalPrincipal, originalAuthData, originalAuthMethod, proxyVersion);
+        return serializeWithSize(cmd);
+    }
+
+    public static BaseCommand newConnectWithoutSerialize(String authMethodName, AuthData authData,
+                                    int protocolVersion, String libVersion,
+                                    String targetBroker, String originalPrincipal, AuthData originalAuthData,
+                                    String originalAuthMethod, String proxyVersion) {
         BaseCommand cmd = localCmd(Type.CONNECT);
         CommandConnect connect = cmd.setConnect()
                 .setClientVersion(libVersion != null ? libVersion : "Pulsar Client")
@@ -277,7 +287,7 @@ public class Commands {
         connect.setProtocolVersion(protocolVersion);
         setFeatureFlags(connect.setFeatureFlags());
 
-        return serializeWithSize(cmd);
+        return cmd;
     }
 
     public static ByteBuf newConnected(int clientProtocoVersion,  boolean supportsTopicWatchers) {
@@ -303,6 +313,7 @@ public class Commands {
 
         connected.setFeatureFlags().setSupportsTopicWatchers(supportsTopicWatchers);
         connected.setFeatureFlags().setSupportsGetPartitionedMetadataWithoutAutoCreation(true);
+        connected.setFeatureFlags().setSupportsDedupReplV2(true);
         return cmd;
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Markers.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Markers.java
@@ -18,6 +18,10 @@
  */
 package org.apache.pulsar.common.protocol;
 
+import static org.apache.pulsar.common.api.proto.MarkerType.REPLICATED_SUBSCRIPTION_SNAPSHOT;
+import static org.apache.pulsar.common.api.proto.MarkerType.REPLICATED_SUBSCRIPTION_SNAPSHOT_REQUEST;
+import static org.apache.pulsar.common.api.proto.MarkerType.REPLICATED_SUBSCRIPTION_SNAPSHOT_RESPONSE;
+import static org.apache.pulsar.common.api.proto.MarkerType.REPLICATED_SUBSCRIPTION_UPDATE;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.io.IOException;
@@ -96,6 +100,13 @@ public class Markers {
         // In future, if we add more marker types that can be also sent to clients
         // we'll have to do finer check here.
         return msgMetadata.hasMarkerType();
+    }
+
+    public static boolean isReplicationMarker(int markerType) {
+        return markerType == REPLICATED_SUBSCRIPTION_SNAPSHOT_REQUEST.getValue()
+                || markerType == REPLICATED_SUBSCRIPTION_SNAPSHOT_RESPONSE.getValue()
+                || markerType == REPLICATED_SUBSCRIPTION_SNAPSHOT.getValue()
+                || markerType == REPLICATED_SUBSCRIPTION_UPDATE.getValue();
     }
 
     public static boolean isReplicatedSubscriptionSnapshotMarker(MessageMetadata msgMetadata) {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -302,7 +302,7 @@ message FeatureFlags {
   optional bool supports_partial_producer = 3 [default = false];
   optional bool supports_topic_watchers = 4 [default = false];
   optional bool supports_get_partitioned_metadata_without_auto_creation = 5 [default = false];
-  optional bool supports_dedup_repl_v2 = 6 [default = false];
+  optional bool supports_repl_dedup_by_lid_and_eid = 6 [default = false];
 }
 
 message CommandConnected {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -302,6 +302,7 @@ message FeatureFlags {
   optional bool supports_partial_producer = 3 [default = false];
   optional bool supports_topic_watchers = 4 [default = false];
   optional bool supports_get_partitioned_metadata_without_auto_creation = 5 [default = false];
+  optional bool supports_dedup_repl_v2 = 6 [default = false];
 }
 
 message CommandConnected {


### PR DESCRIPTION
### Motivation

#### Background

**How does deduplication work?**
- Producer sends messages and records sequence-ids that are pending responses in memory, the variable is `{pendingMessages}`
- Brokers will respond to an invalid position `-1:-1` if the sequence ID published is lower than the previous messages.
- Producer checks whether the next sequence id in `{pendingMessages}` is larger than the one that was rejected.
  - `{next} > {rejected}`: ignore the error, and continue work
  - `{next} < {rejected}`: close channels and reconnect.

Conditions that issue happened

- Replicators send all messages on a topic and do not matter what message was sent by which original producer.
  - **(Highlight)** it mixed messages into `{pendingMessages}` with `message.sequenceId` but ignores `message.original-producer-name`, which may cause the sequence-ids in `{pendingMessages}` is not increasing
- The producer checking the sequence ID after receiving a `-1:-1` send response will fail.

---

**Issue-1: loss messages**

- Publishing in the source cluster
  - Producer-1 send 2 messages: M1(`seq: 0`), M2(`seq: 1`)
  - Producer-2 send 2 messages: M3(`seq: 0`), M4(`seq: 1`)
- Replicate messages to the remote cluster
  - Copies M1 and M2
    - `{pendingMessages}`: `[0,1]`
  - Repeatedly copies M1 and M2. and copies M3 and M4.
    - `{pendingMessages}`: `[0,1,0,1]`
    - After repeatedly copying M1 and M2, the network broke.
    - Receive send receipt:
      - `seq 0, position 0:0`
      - `seq 1, position 0:1`
      - `seq 0, position -1: -1`
      - `seq 1, position -1:-1`
    - `{pendingMessages}`: `[empty]`
- After a topic unloading.
  - The replicator will start after the topic is loaded up(backlog is `0` now).
  - The client will create a new connection.
- Result:
  - Disabled deduplication: copied `[M1, M2, M1, M2]`
  - Enabled deduplication: copied `[M1, M2]`

You can reproduce the issue by the test `testDeduplicationNotLostMessage`

---

**Issue-2: frequently fails**
- Original-producer-2: sent msg `3:0` with sequence-id `10`
- Original-producer-1: sent msg `3:1` with sequence-id `1`
- Original-producer-1: sent msg `3:2` with sequence-id `2`
-0 Replicator copies messages 
  - `{pendingMessages}`: `[10,1, 2]`
- Sent `3:0` successfully
  - `{pendingMessages}`: `[1,2]`
- Resend `3:0`(a duplicated publishing)
  - Receive `-1:-1`(new position relates to the latest publishing) for the latest send-response.
  - `failed-sequenced:10 > pendingMessages[0].sequenceId: 1`
  - Replicator-producer reconnects and resets the cursor, which leads to more duplicated publishing.
  - Loop to the step 1.

No test for reproducing this issue.

### Modifications

**Solution: replicators use a specified sequence ID(`ledegrId:entryId` of the original topic) instead of using the original producers’**
- Original-producer-2: sent msg `3:0` with sequence-id `10`
- Original-producer-1: sent msg `3:1` with sequence-id `1`
- Original-producer-1: sent msg `3:2` with sequence-id `2`
- Replicator copies messages with specified sequence ID(`3:0`)
  - `{pendingMessages}`: `3:0, 3:1, 3:2]`
- Sent `3:0` successfully
  - `{pendingMessages}`: `[3:1, 3:2]`
- Resend `3:0`(a duplicated publishing)
- Receive `-1:-1`(new position relates to the latest publishing) for the latest send-response.	
- Ignored the error since `failed-sequenced(3:0) < pendingMessages[0].sequenceId(3:2)`



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x