### PR TITLE
[improve][fn] Improve implementation for maxPendingAsyncRequests async concurrency limit when return type is CompletableFuture<Void>

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaExecutionResult.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaExecutionResult.java
@@ -27,13 +27,11 @@ import lombok.Data;
  */
 @Data
 public class JavaExecutionResult {
-    private Exception userException;
-    private Exception systemException;
+    private Throwable userException;
     private Object result;
 
     public void reset() {
         setUserException(null);
-        setSystemException(null);
         setResult(null);
     }
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
@@ -25,11 +25,13 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Semaphore;
 import java.util.function.Consumer;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.functions.api.Function;
 import org.apache.pulsar.functions.api.Record;
 
@@ -57,13 +59,26 @@ public class JavaInstance implements AutoCloseable {
     private final ExecutorService executor;
     @Getter
     private final LinkedBlockingQueue<AsyncFuncRequest> pendingAsyncRequests;
+    @Getter
+    private final Semaphore asyncRequestsConcurrencyLimiter;
+    private final boolean asyncPreserveInputOrderForOutputMessages;
 
     public JavaInstance(ContextImpl contextImpl, Object userClassObject, InstanceConfig instanceConfig) {
 
         this.context = contextImpl;
         this.instanceConfig = instanceConfig;
         this.executor = Executors.newSingleThreadExecutor();
-        this.pendingAsyncRequests = new LinkedBlockingQueue<>(this.instanceConfig.getMaxPendingAsyncRequests());
+
+        asyncPreserveInputOrderForOutputMessages =
+                resolveAsyncPreserveInputOrderForOutputMessages(instanceConfig);
+
+        if (asyncPreserveInputOrderForOutputMessages) {
+            this.pendingAsyncRequests = new LinkedBlockingQueue<>(this.instanceConfig.getMaxPendingAsyncRequests());
+            this.asyncRequestsConcurrencyLimiter = null;
+        } else {
+            this.pendingAsyncRequests = null;
+            this.asyncRequestsConcurrencyLimiter = new Semaphore(this.instanceConfig.getMaxPendingAsyncRequests());
+        }
 
         // create the functions
         if (userClassObject instanceof Function) {
@@ -71,6 +86,20 @@ public class JavaInstance implements AutoCloseable {
         } else {
             this.javaUtilFunction = (java.util.function.Function) userClassObject;
         }
+    }
+
+    // resolve whether to preserve input order for output messages for async functions
+    private boolean resolveAsyncPreserveInputOrderForOutputMessages(InstanceConfig instanceConfig) {
+        // no need to preserve input order for output messages if the function returns Void type
+        boolean voidReturnType = instanceConfig.getFunctionDetails() != null
+                && instanceConfig.getFunctionDetails().getSink() != null
+                && Void.class.getName().equals(instanceConfig.getFunctionDetails().getSink().getTypeClassName());
+        if (voidReturnType) {
+            return false;
+        }
+
+        // preserve input order for output messages
+        return true;
     }
 
     @VisibleForTesting
@@ -103,15 +132,33 @@ public class JavaInstance implements AutoCloseable {
         }
 
         if (output instanceof CompletableFuture) {
-            // Function is in format: Function<I, CompletableFuture<O>>
-            AsyncFuncRequest request = new AsyncFuncRequest(
-                record, (CompletableFuture) output
-            );
             try {
-                pendingAsyncRequests.put(request);
-                ((CompletableFuture) output).whenCompleteAsync((res, cause) -> {
+                if (asyncPreserveInputOrderForOutputMessages) {
+                    // Function is in format: Function<I, CompletableFuture<O>>
+                    AsyncFuncRequest request = new AsyncFuncRequest(
+                            record, (CompletableFuture) output
+                    );
+                    pendingAsyncRequests.put(request);
+                } else {
+                    asyncRequestsConcurrencyLimiter.acquire();
+                }
+                ((CompletableFuture<Object>) output).whenCompleteAsync((Object res, Throwable cause) -> {
                     try {
-                        processAsyncResults(asyncResultConsumer);
+                        if (asyncPreserveInputOrderForOutputMessages) {
+                            processAsyncResultsInInputOrder(asyncResultConsumer);
+                        } else {
+                            try {
+                                JavaExecutionResult execResult = new JavaExecutionResult();
+                                if (cause != null) {
+                                    execResult.setUserException(FutureUtil.unwrapCompletionException(cause));
+                                } else {
+                                    execResult.setResult(res);
+                                }
+                                asyncResultConsumer.accept(record, execResult);
+                            } finally {
+                                asyncRequestsConcurrencyLimiter.release();
+                            }
+                        }
                     } catch (Throwable innerException) {
                         // the thread used for processing async results failed
                         asyncFailureHandler.accept(innerException);
@@ -132,21 +179,20 @@ public class JavaInstance implements AutoCloseable {
         }
     }
 
-    private void processAsyncResults(JavaInstanceRunnable.AsyncResultConsumer resultConsumer) throws Exception {
+    // processes the async results in the input order so that the order of the result messages in the output topic
+    // are in the same order as the input
+    private void processAsyncResultsInInputOrder(JavaInstanceRunnable.AsyncResultConsumer resultConsumer)
+            throws Exception {
         AsyncFuncRequest asyncResult = pendingAsyncRequests.peek();
         while (asyncResult != null && asyncResult.getProcessResult().isDone()) {
             pendingAsyncRequests.remove(asyncResult);
-            JavaExecutionResult execResult = new JavaExecutionResult();
 
+            JavaExecutionResult execResult = new JavaExecutionResult();
             try {
                 Object result = asyncResult.getProcessResult().get();
                 execResult.setResult(result);
             } catch (ExecutionException e) {
-                if (e.getCause() instanceof Exception) {
-                    execResult.setUserException((Exception) e.getCause());
-                } else {
-                    execResult.setUserException(new Exception(e.getCause()));
-                }
+                execResult.setUserException(FutureUtil.unwrapCompletionException(e));
             }
 
             resultConsumer.accept(asyncResult.getRecord(), execResult);
@@ -154,7 +200,6 @@ public class JavaInstance implements AutoCloseable {
             // peek the next result
             asyncResult = pendingAsyncRequests.peek();
         }
-
     }
 
     public void initialize() throws Exception {

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -423,7 +423,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
     @VisibleForTesting
     void handleResult(Record srcRecord, JavaExecutionResult result) throws Exception {
         if (result.getUserException() != null) {
-            Exception t = result.getUserException();
+            Throwable t = result.getUserException();
             log.warn("Encountered exception when processing message {}",
                     srcRecord, t);
             stats.incrUserExceptions(t);


### PR DESCRIPTION
## Motivation

When using asynchronous functions in Pulsar Functions, concurrency needs to be limited to prevent unbounded resource consumption. This is currently handled by the `maxPendingAsyncRequests` configuration parameter (default value: 1000). Without such limits, asynchronous processing could lead to unbounded message consumption from input topics, potentially causing resource exhaustion (out-of-memory errors) and function crashes.

However, the current implementation has a performance issue specifically for asynchronous functions that return `CompletableFuture<Void>`. In these cases, the current queue-based implementation introduces unnecessary processing delays when the concurrency limit is reached. In particular:

1. When there's a slow response at the head of the queue, request processing gets delayed unnecessarily when the queue is full. This makes the actual concurrency limit lower than the configured limit and it becomes nondeterministic. Under heavy load, the concurrency limit will be introducing backpressure and this is why any slow request will cause an unnecessary additional latency to the messages in the backlog. This could lead to additional cumulative latency for backlogged messages since all previous delays impact the processing latency of later messages. This type of latency is avoidable with the solution explained in this PR.
2. This introduces avoidable latency for functions using `Context.newOutputMessage(...).sendAsync()` to send messages to multiple topics
3. The current queue-based ordering preservation is unnecessary when no results are being returned (when return type is `CompletableFuture<Void>`)

## Modifications
This PR improves the implementation by:

1. Using a `Semaphore` instead of `LinkedBlockingQueue` for concurrency limiting when the function's return type is `CompletableFuture<Void>`
2. Preserving the existing queue-based implementation for other return types where output message ordering needs to match input ordering
3. Making exception handling more robust by properly unwrapping completion exceptions
4. Simplifying the `JavaExecutionResult` class by removing unused `systemException` field
5. Adding a unit test to verify the new implementation

## Implementation Details

- Added logic to detect `CompletableFuture<Void>` return type through function configuration
- Introduced a `Semaphore`-based concurrency limiter that gets used when order preservation isn't needed
- Maintained backwards compatibility by keeping queue-based implementation for non-void return types
- Updated error handling to better handle asynchronous exceptions and to avoid the extra wrapping of `Throwable` with `new Exception(t)` type of code.
- Added test coverage for the new concurrency limiting approach

## Testing

Added new unit test `testAsyncFunctionMaxPendingVoidResult()` that verifies:
- Proper concurrency limiting with Semaphore
- Correct handling of async void results

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->