### PR TITLE
[improve][pip] PIP-397: Support topic-level migration from blue cluster to green cluster

### DIFF
--- a/pip/pip-397.md
+++ b/pip/pip-397.md
@@ -92,5 +92,5 @@ Only superuser can access the admin API to enable migration at topic level.
 
 # Links
 
-* Mailing List discussion thread:
+* Mailing List discussion thread: https://lists.apache.org/thread/j8f64frvrbrml2gjzopgss8s83fm1w79
 * Mailing List voting thread:

--- a/pip/pip-397.md
+++ b/pip/pip-397.md
@@ -1,0 +1,96 @@
+# PIP-397: Support topic-level migration from blue cluster to green cluster
+
+# Background knowledge
+Cluster migration or blue-green cluster functionality is used to migrate live traffic from one cluster (blue cluster)
+to another cluster (green cluster).
+
+Currently, Pulsar supports blue-green cluster migration at both the cluster level and the namespace level. 
+
+# Motivation
+
+However, sometimes there are many topics under a single namespace, and we do not want to migrate all topics in that 
+namespace to the green cluster at the same time, as this may introduce risks. Therefore, we would like to introduce 
+topic-level migration functionality to have more granular control over the migration process.
+
+# Goals
+
+## In Scope
+
+Add admin API and command to support topic-level migration from blue cluster to green cluster.
+
+## Out of Scope
+
+# High Level Design
+
+Add admin API and command to support topic-level migration from blue cluster to green cluster.
+
+# Detailed Design
+
+## Design & Implementation Details
+
+Add admin API and command to support topic-level migration from blue cluster to green cluster.
+
+## Public-facing Changes
+
+### Public API
+
+Add a new API to enable migration at topic level:
+```
+    /**
+     * Enable migration for a topic.
+     *
+     * @param topic
+     *             Topic name
+     * @throws PulsarAdminException.NotAuthorizedException
+     *             Don't have admin permission
+     * @throws PulsarAdminException.NotFoundException
+     *             Topic does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void enableMigration(String topic) throws PulsarAdminException;
+
+    /**
+     * Enable migration for a topic asynchronously.
+     */
+    CompletableFuture<Void> enableMigrationAsync(String topic);
+```
+```
+admin.topicPolicies().enableMigration(topic);
+```
+
+### Binary protocol
+
+### Configuration
+
+### CLI
+
+Add a command to enable migration at topic level:
+```
+pulsar-admin topicPolices enable-migration persistent://tenant/namespace/topic
+```
+
+### Metrics
+
+# Monitoring
+
+# Security Considerations
+
+Only superuser can access the admin API to enable migration at topic level.
+
+# Backward & Forward Compatibility
+
+## Upgrade
+
+## Downgrade / Rollback
+
+## Pulsar Geo-Replication Upgrade & Downgrade/Rollback Considerations
+
+# Alternatives
+
+# General Notes
+
+# Links
+
+* Mailing List discussion thread:
+* Mailing List voting thread:


### PR DESCRIPTION
Releted PR: https://github.com/apache/pulsar/pull/23714

### Motivation

Currently, Pulsar supports blue-green cluster migration at both the cluster level and the namespace level. However, sometimes there are many topics under a single namespace, and we do not want to migrate all topics in that namespace to the green cluster at the same time, as this may introduce risks. Therefore, we would like to introduce topic-level migration functionality to have more granular control over the migration process.
### Modifications

Add an admin API and command for enabling migration at the topic level.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

