### PR TITLE
[fix][sec] Upgrade async-http-client to 2.12.4 to address CVE-2024-53990

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -570,7 +570,7 @@ Protocol Buffers License
 
 CDDL-1.1 -- ../licenses/LICENSE-CDDL-1.1.txt
  * Java Annotations API
-    - com.sun.activation-javax.activation-1.2.0.jar
+    - com.sun.activation-jakarta.activation-1.2.2.jar
  * Java Servlet API -- javax.servlet-javax.servlet-api-3.1.0.jar
  * WebSocket Server API -- javax.websocket-javax.websocket-client-api-1.0.jar
  * HK2 - Dependency Injection Kernel

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -389,8 +389,8 @@ The Apache Software License, Version 2.0
  * AirCompressor
     - io.airlift-aircompressor-0.27.jar
  * AsyncHttpClient
-    - org.asynchttpclient-async-http-client-2.12.1.jar
-    - org.asynchttpclient-async-http-client-netty-utils-2.12.1.jar
+    - org.asynchttpclient-async-http-client-2.12.4.jar
+    - org.asynchttpclient-async-http-client-netty-utils-2.12.4.jar
  * Jetty
     - org.eclipse.jetty-jetty-client-9.4.56.v20240826.jar
     - org.eclipse.jetty-jetty-continuation-9.4.56.v20240826.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -399,8 +399,8 @@ The Apache Software License, Version 2.0
   * AirCompressor
      - aircompressor-0.27.jar
  * AsyncHttpClient
-    - async-http-client-2.12.1.jar
-    - async-http-client-netty-utils-2.12.1.jar
+    - async-http-client-2.12.4.jar
+    - async-http-client-netty-utils-2.12.4.jar
  * Jetty
     - jetty-client-9.4.56.v20240826.jar
     - jetty-http-9.4.56.v20240826.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -431,7 +431,7 @@ MIT License
 
 CDDL-1.1 -- ../licenses/LICENSE-CDDL-1.1.txt
  * Java Annotations API
-    - javax.activation-1.2.0.jar
+    - jakarta.activation-1.2.2.jar
  * WebSocket Server API -- javax.websocket-client-api-1.0.jar
  * HK2 - Dependency Injection Kernel
     - hk2-api-2.6.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@ flexible messaging model and an intuitive client API.</description>
     <lombok.version>1.18.32</lombok.version>
     <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
     <jaxb-api>2.3.1</jaxb-api>
-    <javax.activation.version>1.2.0</javax.activation.version>
     <jakarta.activation.version>1.2.2</jakarta.activation.version>
     <jakarta.xml.bind.version>2.3.3</jakarta.xml.bind.version>
     <jakarta.validation.version>2.0.2</jakarta.validation.version>
@@ -1439,12 +1438,6 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>jakarta.xml.bind</groupId>
         <artifactId>jakarta.xml.bind-api</artifactId>
         <version>${jakarta.xml.bind.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.sun.activation</groupId>
-        <artifactId>javax.activation</artifactId>
-        <version>${javax.activation.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@ flexible messaging model and an intuitive client API.</description>
     <prometheus-jmx.version>0.16.1</prometheus-jmx.version>
     <confluent.version>6.2.8</confluent.version>
     <aircompressor.version>0.27</aircompressor.version>
-    <asynchttpclient.version>2.12.1</asynchttpclient.version>
+    <asynchttpclient.version>2.12.4</asynchttpclient.version>
     <commons-lang3.version>3.11</commons-lang3.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-io.version>2.18.0</commons-io.version>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -458,7 +458,7 @@
 
     <dependency>
       <groupId>com.sun.activation</groupId>
-      <artifactId>javax.activation</artifactId>
+      <artifactId>jakarta.activation</artifactId>
     </dependency>
 
     <dependency>

--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -112,6 +112,7 @@
                   <include>com.spotify:completable-futures</include>
                   <include>com.squareup.*:*</include>
                   <include>com.sun.activation:javax.activation</include>
+                  <include>com.sun.activation:jakarta.activation</include>
                   <include>com.typesafe.netty:netty-reactive-streams</include>
                   <include>com.yahoo.datasketches:*</include>
                   <include>com.yahoo.datasketches:sketches-core</include>

--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -111,7 +111,6 @@
                   <include>com.google.re2j:re2j</include>
                   <include>com.spotify:completable-futures</include>
                   <include>com.squareup.*:*</include>
-                  <include>com.sun.activation:javax.activation</include>
                   <include>com.sun.activation:jakarta.activation</include>
                   <include>com.typesafe.netty:netty-reactive-streams</include>
                   <include>com.yahoo.datasketches:*</include>

--- a/pulsar-client-admin/pom.xml
+++ b/pulsar-client-admin/pom.xml
@@ -87,7 +87,7 @@
     </dependency>
     <dependency>
       <groupId>com.sun.activation</groupId>
-      <artifactId>javax.activation</artifactId>
+      <artifactId>jakarta.activation</artifactId>
       <scope>runtime</scope>
     </dependency>
 

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -153,6 +153,7 @@
                   <include>com.spotify:completable-futures</include>
                   <include>com.squareup.*:*</include>
                   <include>com.sun.activation:javax.activation</include>
+                  <include>com.sun.activation:jakarta.activation</include>
                   <!-- Avro transitive dependencies -->
                   <include>com.thoughtworks.paranamer:paranamer</include>
                   <include>com.typesafe.netty:netty-reactive-streams</include>

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -152,7 +152,6 @@
                   <include>com.google.re2j:re2j</include>
                   <include>com.spotify:completable-futures</include>
                   <include>com.squareup.*:*</include>
-                  <include>com.sun.activation:javax.activation</include>
                   <include>com.sun.activation:jakarta.activation</include>
                   <!-- Avro transitive dependencies -->
                   <include>com.thoughtworks.paranamer:paranamer</include>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -126,7 +126,6 @@
                   <include>com.google.j2objc:*</include>
                   <include>com.google.re2j:re2j</include>
                   <include>com.spotify:completable-futures</include>
-                  <include>com.sun.activation:javax.activation</include>
                   <include>com.sun.activation:jakarta.activation</include>
                   <!-- Avro transitive dependencies -->
                   <include>com.thoughtworks.paranamer:paranamer</include>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -127,6 +127,7 @@
                   <include>com.google.re2j:re2j</include>
                   <include>com.spotify:completable-futures</include>
                   <include>com.sun.activation:javax.activation</include>
+                  <include>com.sun.activation:jakarta.activation</include>
                   <!-- Avro transitive dependencies -->
                   <include>com.thoughtworks.paranamer:paranamer</include>
                   <include>com.typesafe.netty:netty-reactive-streams</include>

--- a/pulsar-proxy/pom.xml
+++ b/pulsar-proxy/pom.xml
@@ -140,7 +140,7 @@
 
     <dependency>
       <groupId>com.sun.activation</groupId>
-      <artifactId>javax.activation</artifactId>
+      <artifactId>jakarta.activation</artifactId>
     </dependency>
 
     <dependency>

--- a/tiered-storage/jcloud/pom.xml
+++ b/tiered-storage/jcloud/pom.xml
@@ -117,7 +117,7 @@
 
     <dependency>
       <groupId>com.sun.activation</groupId>
-      <artifactId>javax.activation</artifactId>
+      <artifactId>jakarta.activation</artifactId>
       <scope>runtime</scope>
     </dependency>
 


### PR DESCRIPTION
### Motivation

Upgrade to async-http-client 2.12.4 which contains a fix for CVE-2024-53990. See https://lists.apache.org/thread/fpg465pxytqkxbs57h7p3mckn9dwh3zq for more details.

### Modifications

- Upgrade async-http-client from 2.12.1 to 2.12.4
  - [Changes since 2.12.1](https://github.com/AsyncHttpClient/async-http-client/compare/async-http-client-project-2.12.1...6afba08)
- Adapt to https://github.com/AsyncHttpClient/async-http-client/commit/ac2d4bdf46abf96aeb5a61d56bc5718ac005184a change
  - Replace `com.sun.activation:javax.activation` with `com.sun.activation:jakarta.activation`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->