### PR TITLE
[improve] Upgrade lombok to 1.18.36

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@ flexible messaging model and an intuitive client API.</description>
     <hppc.version>0.9.1</hppc.version>
     <spark-streaming_2.10.version>2.1.0</spark-streaming_2.10.version>
     <assertj-core.version>3.24.2</assertj-core.version>
-    <lombok.version>1.18.32</lombok.version>
+    <lombok.version>1.18.36</lombok.version>
     <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
     <jaxb-api>2.3.1</jaxb-api>
     <jakarta.activation.version>1.2.2</jakarta.activation.version>


### PR DESCRIPTION
### Motivation

Keep up-to-date. 

Change log: https://projectlombok.org/changelog

Using the 1.18.36 can avoid the following error when using the idea runs the tests directly:
```
java: Lombok annotation handler class lombok.javac.handlers.HandleToString failed on repo/pulsar/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java: java.lang.StackOverflowError
```

### Modifications

- Upgrade lombok from 1.18.32 to 1.18.36.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->