### PR TITLE
[fix][broker] Fix typo in `buildMetadataForCompactedLedger`

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LedgerMetadataUtils.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LedgerMetadataUtils.java
@@ -80,7 +80,7 @@ public final class LedgerMetadataUtils {
      * Build additional metadata for a CompactedLedger.
      *
      * @param compactedTopic reference to the compacted topic.
-     * @param compactedToMessageId last mesasgeId.
+     * @param compactedToMessageId last messageId.
      * @return an immutable map which describes the compacted ledger
      */
     public static Map<String, byte[]> buildMetadataForCompactedLedger(String compactedTopic,


### PR DESCRIPTION
### Motivation
Modify the typo in the buildMetadataForCompactedLedger class
### Modifications
Correct the spelling of messageId
<img width="918" alt="Clipboard_Screenshot_1734576611" src="https://github.com/user-attachments/assets/54f7d891-4c45-4ee7-93a9-9f184d7b907e" />

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->