### PR TITLE
[fix][broker] Fix bug causing loss of migrated information when setting other localPolicies in namespace

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundles.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundles.java
@@ -197,6 +197,7 @@ public class NamespaceBundles {
     public LocalPolicies toLocalPolicies() {
         return new LocalPolicies(this.getBundlesData(),
                 localPolicies.map(lp -> lp.getLeft().bookieAffinityGroup).orElse(null),
-                localPolicies.map(lp -> lp.getLeft().namespaceAntiAffinityGroup).orElse(null));
+                localPolicies.map(lp -> lp.getLeft().namespaceAntiAffinityGroup).orElse(null),
+                localPolicies.map(lp -> lp.getLeft().migrated).orElse(false));
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/LocalPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/LocalPolicies.java
@@ -34,20 +34,29 @@ public class LocalPolicies {
     public final BookieAffinityGroupData bookieAffinityGroup;
     // namespace anti-affinity-group
     public final String namespaceAntiAffinityGroup;
-    public boolean migrated;
+    public final boolean migrated;
 
     public LocalPolicies() {
         bundles = defaultBundle();
         bookieAffinityGroup = null;
         namespaceAntiAffinityGroup = null;
+        migrated = false;
     }
 
     public LocalPolicies(BundlesData data,
                          BookieAffinityGroupData bookieAffinityGroup,
                          String namespaceAntiAffinityGroup) {
+        this(data, bookieAffinityGroup, namespaceAntiAffinityGroup, false);
+    }
+
+    public LocalPolicies(BundlesData data,
+                         BookieAffinityGroupData bookieAffinityGroup,
+                         String namespaceAntiAffinityGroup,
+                         boolean migrated) {
         bundles = data;
         this.bookieAffinityGroup = bookieAffinityGroup;
         this.namespaceAntiAffinityGroup = namespaceAntiAffinityGroup;
+        this.migrated = migrated;
     }
 
 }


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/21367 introduced the `migrated` field in `localPolicies` to indicate whether the topics under a namespace have been migrated in the blue-green cluster migration feature.

In https://github.com/apache/pulsar/pull/9598, it is specified that when updating the field content of `localPolicies`, a new object needs to be created instead of updating the original object.

After the addition of the `migrated` field in https://github.com/apache/pulsar/pull/21367, there has been no synchronization of modifications in other places that update `localPolicies`. This could lead to the loss of the `migrated` content during other operations on `localPolicies`, such as setting the `namespaceAntiAffinityGroup`, etc.

### Modifications

1. Synchronize the `migrated` content in the places where `localPolicies` are updated
2. When updating the `migrated` field of `localPolicies`, do not modify the original object

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Added test in: org.apache.pulsar.broker.admin.NamespacesTest#testMigratedInfoIsNotLostDuringOtherLocalPoliciesUpdate

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/hrzzzz/pulsar/pull/13

