### PR TITLE
[improvement][broker]Add replicate all subscription state switch on the broker side.

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -660,6 +660,11 @@ acknowledgmentAtBatchIndexLevelEnabled=false
 # Enable tracking of replicated subscriptions state across clusters.
 enableReplicatedSubscriptions=true
 
+# Whether to replicate all subscription states. If true, it will overwrite the value of
+# the replicateSubscriptionState configuration item configured by the client consumer;
+# If false, use the value of the client-side replicateSubscriptionState.
+replicateAllSubscriptionState=false
+
 # Frequency of snapshots for replicated subscriptions tracking.
 replicatedSubscriptionsSnapshotFrequencyMillis=1000
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1433,6 +1433,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
             category = CATEGORY_SERVER,
+            doc = "Whether to replicate all subscription states. If true, it will overwrite the value of"
+                    + " the replicateSubscriptionState configuration item configured by the client consumer;"
+                    + " If false, use the value of the client-side replicateSubscriptionState.")
+    private boolean replicateAllSubscriptionState = false;
+
+    @FieldContext(
+            category = CATEGORY_SERVER,
             doc = "Frequency of snapshots for replicated subscriptions tracking.")
     private int replicatedSubscriptionsSnapshotFrequencyMillis = 1_000;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -911,11 +911,18 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         return brokerService.checkTopicNsOwnership(getName()).thenCompose(__ -> {
             boolean replicatedSubscriptionState = replicatedSubscriptionStateArg;
+            boolean enableReplicatedSubscriptions = brokerService.pulsar().getConfiguration()
+                    .isEnableReplicatedSubscriptions();
 
-            if (replicatedSubscriptionState
-                    && !brokerService.pulsar().getConfiguration().isEnableReplicatedSubscriptions()) {
+            if (replicatedSubscriptionState && !enableReplicatedSubscriptions) {
                 log.warn("[{}] Replicated Subscription is disabled by broker.", getName());
                 replicatedSubscriptionState = false;
+            }
+
+            boolean replicateAllSubscriptionState = brokerService.pulsar().getConfiguration()
+                    .isReplicateAllSubscriptionState();
+            if (replicateAllSubscriptionState && enableReplicatedSubscriptions) {
+                replicatedSubscriptionState = true;
             }
 
             if (subType == SubType.Key_Shared


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz
https://github.com/apache/pulsar/issues/23768

<!-- or this PR is one task of an issue -->

Main Issue: #xyz
https://github.com/apache/pulsar/issues/23768

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

In the current version of Pulsar, when performing cluster data synchronization, in order to continue consuming the consumption message location recorded in the source cluster after switching from the source cluster to the target cluster, it is necessary to configure the parameter `repliceSubscriptionState=true` on the client side to replicate the subscribed consumption location information.
There may be some issues with this, such as when my cluster needs to be migrated, if there are dozens of business teams involved in this cluster, then I need to align the migration action with all business teams to ensure that everyone switches and changes at the same pace.
However, this difficulty is very high, as there are complex upstream and downstream dependencies in the data flow between different businesses. At the same time, the business needs to modify the code online in order to replicate the subscription status, which makes our migration efficiency heavily dependent on the business.
For this scenario, we expect to have a global control switch for subscription state replication on the server, which can be enabled to replicate all subscription state information in the cluster without the need for business code modification.

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

Add a switch on the broker side to replicate all subscription states from the source cluster to the target cluster.

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
https://github.com/yyj8/pulsar/pull/11

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
