### PR TITLE
[WIP][improve][ml] Make offloader threshold config dynamic

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloader.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloader.java
@@ -214,6 +214,16 @@ public interface LedgerOffloader {
      */
     OffloadPolicies getOffloadPolicies();
 
+
+    /**
+     * Update the offload policies of this LedgerOffloader.
+     *
+     * @param offloadPolicies the new offload policies
+     */
+    default void updateOffloadPolicies(OffloadPolicies offloadPolicies) {
+        // default no-op
+    }
+
     /**
      * Close the resources if necessary.
      */

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -71,6 +71,7 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenCursorCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.TerminateCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.UpdatePropertiesCallback;
 import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.LedgerOffloader;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedCursor.IndividualDeletedEntries;
 import org.apache.bookkeeper.mledger.ManagedLedger;
@@ -167,6 +168,8 @@ import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.CursorStats;
 import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.LedgerInfo;
+import org.apache.pulsar.common.policies.data.OffloadPolicies;
+import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
@@ -4271,6 +4274,15 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 subscription.getDispatcher().checkAndResumeIfPaused();
             });
         }
+    }
+
+    @Override
+    protected void updateOffloadPolicies(OffloadPolicies offloadPolicies) {
+        LedgerOffloader offloader = ledger.getConfig().getLedgerOffloader();
+        if (null == offloader || null == offloadPolicies) {
+            return;
+        }
+        offloader.updateOffloadPolicies(offloadPolicies);
     }
 
     @Override

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPoliciesImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPoliciesImpl.java
@@ -346,24 +346,28 @@ public class OffloadPoliciesImpl implements Serializable, OffloadPolicies {
         return false;
     }
 
-    public Properties toProperties() {
+    public static Properties toProperties(OffloadPoliciesImpl offloadPolicies) {
         Properties properties = new Properties();
         for (Field f : CONFIGURATION_FIELDS) {
             try {
                 f.setAccessible(true);
                 if ("managedLedgerExtraConfigurations".equals(f.getName())) {
-                    Map<String, String> extraConfig = (Map<String, String>) f.get(this);
+                    Map<String, String> extraConfig = (Map<String, String>) f.get(offloadPolicies);
                     extraConfig.forEach((key, value) -> {
                         setProperty(properties, EXTRA_CONFIG_PREFIX + key, value);
                     });
                 } else {
-                    setProperty(properties, f.getName(), f.get(this));
+                    setProperty(properties, f.getName(), f.get(offloadPolicies));
                 }
             } catch (Exception e) {
                 throw new IllegalArgumentException("An error occurred while processing the field: " + f.getName(), e);
             }
         }
         return properties;
+    }
+
+    public Properties toProperties() {
+        return toProperties(this);
     }
 
     private static void setProperty(Properties properties, String key, Object value) {

--- a/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloader.java
+++ b/tiered-storage/file-system/src/main/java/org/apache/bookkeeper/mledger/offload/filesystem/impl/FileSystemManagedLedgerOffloader.java
@@ -66,7 +66,7 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
     private OrderedScheduler scheduler;
     private static final long ENTRIES_PER_READ = 100;
     private OrderedScheduler assignmentScheduler;
-    private OffloadPolicies offloadPolicies;
+    private volatile OffloadPolicies offloadPolicies;
     private final LedgerOffloaderStats offloaderStats;
 
     public static boolean driverSupported(String driver) {
@@ -392,6 +392,13 @@ public class FileSystemManagedLedgerOffloader implements LedgerOffloader {
     @Override
     public OffloadPolicies getOffloadPolicies() {
         return offloadPolicies;
+    }
+
+    @Override
+    public void updateOffloadPolicies(OffloadPolicies offloadPolicies) {
+        if (null != offloadPolicies) {
+            this.offloadPolicies = offloadPolicies;
+        }
     }
 
     @Override

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloader.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloader.java
@@ -97,7 +97,7 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
     private static final String MANAGED_LEDGER_NAME = "ManagedLedgerName";
 
     private final OrderedScheduler scheduler;
-    private final TieredStorageConfiguration config;
+    private volatile TieredStorageConfiguration config;
     private final Location writeLocation;
 
     // metadata to be stored as part of the offloaded ledger metadata
@@ -661,6 +661,16 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
         Properties properties = new Properties();
         properties.putAll(config.getConfigProperties());
         return OffloadPoliciesImpl.create(properties);
+    }
+
+    @Override
+    public void updateOffloadPolicies(OffloadPolicies offloadPolicies) {
+        Properties properties = OffloadPoliciesImpl.toProperties((OffloadPoliciesImpl) offloadPolicies);
+        try {
+            this.config = TieredStorageConfiguration.create(properties);
+        } catch (IOException e) {
+            log.warn("Failed to update offload policies", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Make offloader threshold configs dynamic

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

