### PR TITLE
[improve][txn] Improve Reader in TransactionBuffer to reduce GC pressure

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/TransactionBufferSnapshotBaseSystemTopicClient.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/TransactionBufferSnapshotBaseSystemTopicClient.java
@@ -205,6 +205,7 @@ public class  TransactionBufferSnapshotBaseSystemTopicClient<T> extends SystemTo
                 .subscriptionRolePrefix(SystemTopicNames.SYSTEM_READER_PREFIX)
                 .startMessageId(MessageId.earliest)
                 .readCompacted(true)
+                .poolMessages(true)
                 .createAsync()
                 .thenApply(reader -> {
                     if (log.isDebugEnabled()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -768,8 +768,16 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                     try {
                         while (wait(reader.hasMoreEventsAsync(), "has more events")) {
                             final var message = wait(reader.readNextAsync(), "read next");
-                            if (topic.getName().equals(message.getValue().getTopicName())) {
-                                snapshotSegmentsWriter.getFuture().get().write(message.getKey(), null);
+                            final String topicName;
+                            final String key;
+                            try {
+                                topicName = message.getValue().getTopicName();
+                                key = message.getKey();
+                            } finally {
+                                message.release();
+                            }
+                            if (topic.getName().equals(topicName)) {
+                                snapshotSegmentsWriter.getFuture().get().write(key, null);
                             }
                         }
                         future.complete(null);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TableView.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TableView.java
@@ -61,12 +61,16 @@ public class TableView<T> {
         final var reader = getReader(topic);
         while (wait(reader.hasMoreEventsAsync(), "has more events")) {
             final var msg = wait(reader.readNextAsync(), "read message");
-            if (msg.getKey() != null) {
-                if (msg.getValue() != null) {
-                    snapshots.put(msg.getKey(), msg.getValue());
-                } else {
-                    snapshots.remove(msg.getKey());
+            try {
+                if (msg.getKey() != null) {
+                    if (msg.getValue() != null) {
+                        snapshots.put(msg.getKey(), msg.getValue());
+                    } else {
+                        snapshots.remove(msg.getKey());
+                    }
                 }
+            } finally {
+                msg.release();
             }
         }
         return snapshots.get(topic);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/SegmentAbortedTxnProcessorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/SegmentAbortedTxnProcessorTest.java
@@ -348,6 +348,7 @@ public class SegmentAbortedTxnProcessorTest extends TransactionTestBase {
                         .createReader(TopicName.get(topic)).get();
         int segmentCount = 0;
         while (reader.hasMoreEvents()) {
+            @Cleanup("release")
             Message<TransactionBufferSnapshotSegment> message = reader.readNextAsync()
                     .get(5, TimeUnit.SECONDS);
             if (topic.equals(message.getValue().getTopicName())) {
@@ -364,6 +365,7 @@ public class SegmentAbortedTxnProcessorTest extends TransactionTestBase {
                         .createReader(TopicName.get(topic)).get();
         int indexCount = 0;
         while (reader.hasMoreEvents()) {
+            @Cleanup("release")
             Message<TransactionBufferSnapshotIndexes> message = reader.readNextAsync()
                     .get(5, TimeUnit.SECONDS);
             if (topic.equals(message.getValue().getTopicName())) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
@@ -715,7 +715,9 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
         indexesWriter.write(SNAPSHOT_INDEX, transactionBufferTransactionBufferSnapshotIndexes);
 
         assertTrue(indexesReader.hasMoreEvents());
-        transactionBufferTransactionBufferSnapshotIndexes = indexesReader.readNext().getValue();
+        @Cleanup("release")
+        Message<TransactionBufferSnapshotIndexes> message = indexesReader.readNext();
+        transactionBufferTransactionBufferSnapshotIndexes = message.getValue();
         assertEquals(transactionBufferTransactionBufferSnapshotIndexes.getTopicName(), SNAPSHOT_INDEX);
         assertEquals(transactionBufferTransactionBufferSnapshotIndexes.getIndexList().size(), 5);
         assertNull(transactionBufferTransactionBufferSnapshotIndexes.getSnapshot());


### PR DESCRIPTION
### Motivation

Make the reader referenced by TransactionBuffer pooling messages to reduce GC pressure.

If `poolMessage=false` of the Reader, pulsar client will copy message payload into heap without pooling. 
Generally, it is not recommended  to users use the feature, because it requires call `message.release()` manually, or it will lead to mem leak.

However, in the broker side, we need this feature to improve JVM GC performance. 
Especially for there is a big number of topics served by a single broker.

### Modifications

1. Make `poolMessage=true` when TopicTransactionBuffer component creating a reader
2. Call `message.release()` manually after process messages.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
