### PR TITLE
[fix][broker] topic policy deadlock block metadata thread.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -273,6 +273,12 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
             @Data
             class PoliciesFutureHolder {
                 CompletableFuture<Optional<TopicPolicies>> future;
+
+                public CompletableFuture<Optional<TopicPolicies>> getFuture() {
+                    return Objects.requireNonNullElseGet(future,
+                            () -> CompletableFuture.failedFuture(
+                                    new IllegalStateException("BUG! unexpected topic policy init.")));
+                }
             }
             final var policiesFutureHolder = new PoliciesFutureHolder();
             // NOTICE: avoid using any callback with lock scope to avoid deadlock

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -34,10 +34,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nonnull;
-
-import it.unimi.dsi.fastutil.Pair;
 import lombok.Data;
 import org.apache.commons.lang3.concurrent.ConcurrentInitializer;
 import org.apache.commons.lang3.concurrent.LazyInitializer;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -286,13 +286,13 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                     });
                     policiesFutureHolder.setValue(Pair.of(true, policies));
                 } else {
-                    log.info("The future of {} has been removed from cache, retry getTopicPolicies again", namespace);
                     policiesFutureHolder.setValue(Pair.of(false, null));
                 }
                 return existingFuture;
             });
             final var p = policiesFutureHolder.getValue();
             if (!p.getLeft()) {
+                log.info("The future of {} has been removed from cache, retry getTopicPolicies again", namespace);
                 return getTopicPoliciesAsync(topicName, type);
             }
             return CompletableFuture.completedFuture(p.getRight());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -57,7 +57,6 @@ import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.TopicPolicies;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.slf4j.Logger;


### PR DESCRIPTION
### Motivation

```
Found one Java-level deadlock:
=============================
"metadata-store-10-1":
  waiting to lock monitor 0x00007fb363ef6a60 (object 0x00000000bf8b3b88, a java.util.concurrent.ConcurrentHashMap$Node),
  which is held by "broker-client-shared-internal-executor-5-1"

"broker-client-shared-internal-executor-5-1":
  waiting to lock monitor 0x00007fb36617a5b0 (object 0x00000000bdf00940, a java.util.concurrent.ConcurrentHashMap$ReservationNode),
  which is held by "pulsar-io-3-6"

"pulsar-io-3-6":
  waiting to lock monitor 0x00007fb363ef6a60 (object 0x00000000bf8b3b88, a java.util.concurrent.ConcurrentHashMap$Node),
  which is held by "broker-client-shared-internal-executor-5-1"

Java stack information for the threads listed above:
===================================================
"metadata-store-10-1":
	at java.util.concurrent.ConcurrentHashMap.compute(java.base@21.0.5/Unknown Source)
	- waiting to lock <0x00000000bf8b3b88> (a java.util.concurrent.ConcurrentHashMap$Node)
	at org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService.lambda$getTopicPoliciesAsync$10(SystemTopicBasedTopicPoliciesService.java:271)
	at org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService$$Lambda/0x0000000100bbdac0.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniAcceptNow(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.uniAcceptStage(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.thenAccept(java.base@21.0.5/Unknown Source)
	at org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService.getTopicPoliciesAsync(SystemTopicBasedTopicPoliciesService.java:271)
	at org.apache.pulsar.broker.service.BrokerService.getTopicPoliciesBypassSystemTopic(BrokerService.java:1186)
	at org.apache.pulsar.broker.service.BrokerService.lambda$getTopic$37(BrokerService.java:1080)
	at org.apache.pulsar.broker.service.BrokerService$$Lambda/0x00000001007af710.apply(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniComposeStage(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.thenCompose(java.base@21.0.5/Unknown Source)
	at org.apache.pulsar.broker.service.BrokerService.getTopic(BrokerService.java:1076)
	at org.apache.pulsar.broker.service.BrokerService.getTopic(BrokerService.java:1040)
	at org.apache.pulsar.broker.service.BrokerService.getTopic(BrokerService.java:1035)
	at org.apache.pulsar.broker.service.ServerCnx.lambda$handleSubscribe$18(ServerCnx.java:1331)
	at org.apache.pulsar.broker.service.ServerCnx$$Lambda/0x0000000100ba4230.apply(Unknown Source)
	at java.util.concurrent.CompletableFuture$UniCompose.tryFire(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.complete(java.base@21.0.5/Unknown Source)
	at org.apache.pulsar.metadata.impl.ZKMetadataStore.handleGetResult(ZKMetadataStore.java:289)
	at org.apache.pulsar.metadata.impl.ZKMetadataStore.lambda$batchOperation$7(ZKMetadataStore.java:233)
	at org.apache.pulsar.metadata.impl.ZKMetadataStore$$Lambda/0x00000001004c1740.run(Unknown Source)
	at java.util.concurrent.Executors$RunnableAdapter.call(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.FutureTask.run(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@21.0.5/Unknown Source)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.runWith(java.base@21.0.5/Unknown Source)
	at java.lang.Thread.run(java.base@21.0.5/Unknown Source)
"broker-client-shared-internal-executor-5-1":
	at java.util.concurrent.ConcurrentHashMap.transfer(java.base@21.0.5/Unknown Source)
	- waiting to lock <0x00000000bdf00940> (a java.util.concurrent.ConcurrentHashMap$ReservationNode)
	at java.util.concurrent.ConcurrentHashMap.addCount(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(java.base@21.0.5/Unknown Source)
	at org.apache.pulsar.broker.service.BrokerService.lambda$getTopic$36(BrokerService.java:1110)
	at org.apache.pulsar.broker.service.BrokerService$$Lambda/0x00000001007ada38.apply(Unknown Source)
	at java.util.concurrent.CompletableFuture$UniCompose.tryFire(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.complete(java.base@21.0.5/Unknown Source)
	at org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService.lambda$getTopicPoliciesAsync$9(SystemTopicBasedTopicPoliciesService.java:280)
	at org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService$$Lambda/0x0000000100c36818.apply(Unknown Source)
	at java.util.concurrent.ConcurrentHashMap.compute(java.base@21.0.5/Unknown Source)
	- locked <0x00000000bf8b3b88> (a java.util.concurrent.ConcurrentHashMap$Node)
	at org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService.lambda$getTopicPoliciesAsync$10(SystemTopicBasedTopicPoliciesService.java:271)
	at org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService$$Lambda/0x0000000100bbdac0.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture$UniAccept.tryFire(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.complete(java.base@21.0.5/Unknown Source)
	at org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService.lambda$initPolicesCache$21(SystemTopicBasedTopicPoliciesService.java:463)
	at org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService$$Lambda/0x0000000100c2be30.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniWhenComplete(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.complete(java.base@21.0.5/Unknown Source)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl.lambda$hasMessageAvailableAsync$37(MultiTopicsConsumerImpl.java:879)
	at org.apache.pulsar.client.impl.MultiTopicsConsumerImpl$$Lambda/0x0000000100c2b980.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniWhenComplete(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.complete(java.base@21.0.5/Unknown Source)
	at org.apache.pulsar.client.impl.ConsumerImpl.lambda$completehasMessageAvailableWithValue$65(ConsumerImpl.java:2574)
	at org.apache.pulsar.client.impl.ConsumerImpl$$Lambda/0x0000000100c35920.run(Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@21.0.5/Unknown Source)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.runWith(java.base@21.0.5/Unknown Source)
	at java.lang.Thread.run(java.base@21.0.5/Unknown Source)
"pulsar-io-3-6":
	at java.util.concurrent.ConcurrentHashMap.compute(java.base@21.0.5/Unknown Source)
	- waiting to lock <0x00000000bf8b3b88> (a java.util.concurrent.ConcurrentHashMap$Node)
	at org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService.lambda$getTopicPoliciesAsync$10(SystemTopicBasedTopicPoliciesService.java:271)
	at org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService$$Lambda/0x0000000100bbdac0.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniAcceptNow(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.uniAcceptStage(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.thenAccept(java.base@21.0.5/Unknown Source)
	at org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService.getTopicPoliciesAsync(SystemTopicBasedTopicPoliciesService.java:271)
	at org.apache.pulsar.broker.service.BrokerService.getTopicPoliciesBypassSystemTopic(BrokerService.java:1186)
	at org.apache.pulsar.broker.service.BrokerService.getManagedLedgerConfig(BrokerService.java:1906)
	at org.apache.pulsar.broker.service.BrokerService.getManagedLedgerFactoryForTopic(BrokerService.java:1273)
	at org.apache.pulsar.broker.service.BrokerService.fetchTopicPropertiesAsync(BrokerService.java:1658)
	at org.apache.pulsar.broker.service.BrokerService.lambda$checkOwnershipAndCreatePersistentTopic$76(BrokerService.java:1694)
	at org.apache.pulsar.broker.service.BrokerService$$Lambda/0x00000001007b3220.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniAcceptNow(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.uniAcceptStage(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.thenAccept(java.base@21.0.5/Unknown Source)
	at org.apache.pulsar.broker.service.BrokerService.checkOwnershipAndCreatePersistentTopic(BrokerService.java:1689)
	at org.apache.pulsar.broker.service.BrokerService.lambda$loadOrCreatePersistentTopic$66(BrokerService.java:1624)
	at org.apache.pulsar.broker.service.BrokerService$$Lambda/0x00000001007b2ba0.run(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniRunNow(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.uniRunStage(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.thenRun(java.base@21.0.5/Unknown Source)
	at org.apache.pulsar.broker.service.BrokerService.loadOrCreatePersistentTopic(BrokerService.java:1620)
	at org.apache.pulsar.broker.service.BrokerService.lambda$getTopic$35(BrokerService.java:1111)
	at org.apache.pulsar.broker.service.BrokerService$$Lambda/0x0000000100c36e50.apply(Unknown Source)
	at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(java.base@21.0.5/Unknown Source)
	- locked <0x00000000bdf00940> (a java.util.concurrent.ConcurrentHashMap$ReservationNode)
	at org.apache.pulsar.broker.service.BrokerService.lambda$getTopic$36(BrokerService.java:1110)
	at org.apache.pulsar.broker.service.BrokerService$$Lambda/0x00000001007ada38.apply(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniComposeStage(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.thenCompose(java.base@21.0.5/Unknown Source)
	at org.apache.pulsar.broker.service.BrokerService.lambda$getTopic$37(BrokerService.java:1087)
	at org.apache.pulsar.broker.service.BrokerService$$Lambda/0x00000001007af710.apply(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniComposeStage(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.thenCompose(java.base@21.0.5/Unknown Source)
	at org.apache.pulsar.broker.service.BrokerService.getTopic(BrokerService.java:1076)
	at org.apache.pulsar.broker.service.BrokerService.getTopic(BrokerService.java:1040)
	at org.apache.pulsar.broker.service.BrokerService.getTopic(BrokerService.java:1035)
	at org.apache.pulsar.broker.service.ServerCnx.lambda$handleSubscribe$18(ServerCnx.java:1331)
	at org.apache.pulsar.broker.service.ServerCnx$$Lambda/0x0000000100ba4230.apply(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniComposeStage(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.thenCompose(java.base@21.0.5/Unknown Source)
	at org.apache.pulsar.broker.service.ServerCnx.lambda$handleSubscribe$24(ServerCnx.java:1330)
	at org.apache.pulsar.broker.service.ServerCnx$$Lambda/0x0000000100b9ec00.apply(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniApplyNow(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.uniApplyStage(java.base@21.0.5/Unknown Source)
	at java.util.concurrent.CompletableFuture.thenApply(java.base@21.0.5/Unknown Source)
	at org.apache.pulsar.broker.service.ServerCnx.handleSubscribe(ServerCnx.java:1271)
	at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:243)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler.flow.FlowControlHandler.dequeue(FlowControlHandler.java:202)
	at io.netty.handler.flow.FlowControlHandler.channelRead(FlowControlHandler.java:164)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:333)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:455)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler.flush.FlushConsolidationHandler.channelRead(FlushConsolidationHandler.java:152)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1357)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:868)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.runWith(java.base@21.0.5/Unknown Source)
	at java.lang.Thread.run(java.base@21.0.5/Unknown Source)
```

### Modifications

- Move the callback logic out of lock scope.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
