### PR TITLE
[improve][broker] Support namespace-level configuration of migratedClusterUrl in blue-green migration feature

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -57,6 +57,7 @@ import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
 import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
 import org.apache.pulsar.common.policies.data.BundlesData;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.NamespaceOperation;
 import org.apache.pulsar.common.policies.data.PersistencePolicies;
 import org.apache.pulsar.common.policies.data.Policies;
@@ -1720,6 +1721,22 @@ public class Namespaces extends NamespacesBase {
                                 boolean migrated) {
         validateNamespaceName(property, cluster, namespace);
         internalEnableMigration(migrated);
+    }
+
+    @POST
+    @Path("/{property}/{cluster}/{namespace}/migrationState")
+    @ApiOperation(hidden = true, value = "Update migration state for a namespace")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Property or cluster or namespace doesn't exist") })
+    public void updateMigrationState(@PathParam("property") String property,
+                                     @PathParam("cluster") String cluster,
+                                     @PathParam("namespace") String namespace,
+                                     @QueryParam("migrated") boolean migrated,
+                                     ClusterUrl clusterUrl) {
+        validateNamespaceName(property, cluster, namespace);
+        internalUpdateMigrationState(migrated, clusterUrl);
     }
 
     @PUT

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -61,6 +61,7 @@ import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
 import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.DelayedDeliveryPolicies;
 import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.EntryFilters;
@@ -3017,6 +3018,21 @@ public class Namespaces extends NamespacesBase {
                                 boolean migrated) {
         validateNamespaceName(tenant, namespace);
         internalEnableMigration(migrated);
+    }
+
+    @POST
+    @Path("/{tenant}/{namespace}/migrationState")
+    @ApiOperation(hidden = true, value = "Update migration state for a namespace")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Operation successful"),
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Property or cluster or namespace doesn't exist") })
+    public void updateMigrationState(@PathParam("tenant") String tenant,
+                                @PathParam("namespace") String namespace,
+                                @QueryParam("migrated") boolean migrated,
+                                ClusterUrl clusterUrl) {
+        validateNamespaceName(tenant, namespace);
+        internalUpdateMigrationState(migrated, clusterUrl);
     }
 
     @POST

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundles.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundles.java
@@ -198,6 +198,7 @@ public class NamespaceBundles {
         return new LocalPolicies(this.getBundlesData(),
                 localPolicies.map(lp -> lp.getLeft().bookieAffinityGroup).orElse(null),
                 localPolicies.map(lp -> lp.getLeft().namespaceAntiAffinityGroup).orElse(null),
-                localPolicies.map(lp -> lp.getLeft().migrated).orElse(false));
+                localPolicies.map(lp -> lp.getLeft().migrated).orElse(false),
+                localPolicies.map(lp -> lp.getLeft().migratedClusterUrl).orElse(null));
     }
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -34,6 +34,7 @@ import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
 import org.apache.pulsar.common.policies.data.BundlesData;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.DelayedDeliveryPolicies;
 import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.EntryFilters;
@@ -4675,6 +4676,28 @@ public interface Namespaces {
      *             Unexpected error
      */
     void updateMigrationState(String namespace, boolean migrated) throws PulsarAdminException;
+
+    /**
+     * Update migration state for a namespace.
+     * @param namespace
+     *            Namespace name
+     * @param migrated
+     *            Flag to determine namespace is migrated or not
+     * @param clusterUrl
+     *            Cluster url data
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Namespace does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void updateMigrationState(String namespace, boolean migrated, ClusterUrl clusterUrl) throws PulsarAdminException;
+
+    /**
+     * Update migration state for a namespace asynchronously.
+     */
+    CompletableFuture<Void> updateMigrationStateAsync(String namespace, boolean migrated, ClusterUrl clusterUrl);
 
     /**
      * Set DispatcherPauseOnAckStatePersistent for a namespace asynchronously.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -43,6 +43,7 @@ import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
 import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
 import org.apache.pulsar.common.policies.data.BundlesData;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.DelayedDeliveryPolicies;
 import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.EntryFilters;
@@ -1931,6 +1932,20 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
         NamespaceName ns = NamespaceName.get(namespace);
         WebTarget path = namespacePath(ns, "migration");
         return asyncPostRequest(path, Entity.entity(migrated, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void updateMigrationState(String namespace, boolean migrated, ClusterUrl clusterUrl)
+            throws PulsarAdminException {
+        sync(() -> updateMigrationStateAsync(namespace, migrated, clusterUrl));
+    }
+
+    @Override
+    public CompletableFuture<Void> updateMigrationStateAsync(String namespace, boolean migrated,
+                                                             ClusterUrl clusterUrl) {
+        NamespaceName ns = NamespaceName.get(namespace);
+        WebTarget path = namespacePath(ns, "migrationState").queryParam("migrated", migrated);
+        return asyncPostRequest(path, Entity.entity(clusterUrl, MediaType.APPLICATION_JSON));
     }
 
     private WebTarget namespacePath(NamespaceName namespace, String... parts) {

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -100,6 +100,7 @@ import org.apache.pulsar.common.policies.data.BookiesClusterInfo;
 import org.apache.pulsar.common.policies.data.BookiesRackConfiguration;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.DelayedDeliveryPolicies;
 import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.FailureDomain;
@@ -913,6 +914,11 @@ public class PulsarAdminToolTest {
         namespaces.run(split("remove-dispatcher-pause-on-ack-state-persistent myprop/clust/ns1"));
         verify(mockNamespaces).removeDispatcherPauseOnAckStatePersistent("myprop/clust/ns1");
 
+        namespaces.run(split(
+                "update-migration-state --migrated --service-url serviceUrl --service-url-secure serviceUrlTls "
+                        + "--broker-url brokerServiceUrl --broker-url-secure brokerServiceUrlTls myprop/clust/ns1"));
+        verify(mockNamespaces).updateMigrationState("myprop/clust/ns1", true,
+                new ClusterUrl("serviceUrl", "serviceUrlTls", "brokerServiceUrl", "brokerServiceUrlTls"));
     }
 
     @Test

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -47,6 +47,7 @@ import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BookieAffinityGroupData;
 import org.apache.pulsar.common.policies.data.BundlesData;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.DelayedDeliveryPolicies;
 import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.EntryFilters;
@@ -2553,10 +2554,24 @@ public class CmdNamespaces extends CmdBase {
         @Option(names = "--migrated", description = "Is namespace migrated")
         private boolean migrated;
 
+        @Option(names = "--service-url", description = "New migrated cluster service url")
+        private String serviceUrl;
+
+        @Option(names = "--service-url-secure",
+                description = "New migrated cluster service url secure")
+        private String serviceUrlTls;
+
+        @Option(names = "--broker-url", description = "New migrated cluster broker service url")
+        private String brokerServiceUrl;
+
+        @Option(names = "--broker-url-secure", description = "New migrated cluster broker service url secure")
+        private String brokerServiceUrlTls;
+
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(namespaceName);
-            getAdmin().namespaces().updateMigrationState(namespace, migrated);
+            ClusterUrl clusterUrl = new ClusterUrl(serviceUrl, serviceUrlTls, brokerServiceUrl, brokerServiceUrlTls);
+            getAdmin().namespaces().updateMigrationState(namespace, migrated, clusterUrl);
         }
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/LocalPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/LocalPolicies.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.common.policies.data;
 
 import static org.apache.pulsar.common.policies.data.PoliciesUtil.defaultBundle;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -35,28 +36,32 @@ public class LocalPolicies {
     // namespace anti-affinity-group
     public final String namespaceAntiAffinityGroup;
     public final boolean migrated;
+    public final ClusterUrl migratedClusterUrl;
 
     public LocalPolicies() {
         bundles = defaultBundle();
         bookieAffinityGroup = null;
         namespaceAntiAffinityGroup = null;
         migrated = false;
+        migratedClusterUrl = null;
     }
 
     public LocalPolicies(BundlesData data,
                          BookieAffinityGroupData bookieAffinityGroup,
                          String namespaceAntiAffinityGroup) {
-        this(data, bookieAffinityGroup, namespaceAntiAffinityGroup, false);
+        this(data, bookieAffinityGroup, namespaceAntiAffinityGroup, false, null);
     }
 
     public LocalPolicies(BundlesData data,
                          BookieAffinityGroupData bookieAffinityGroup,
                          String namespaceAntiAffinityGroup,
-                         boolean migrated) {
+                         boolean migrated,
+                         ClusterUrl migratedClusterUrl) {
         bundles = data;
         this.bookieAffinityGroup = bookieAffinityGroup;
         this.namespaceAntiAffinityGroup = namespaceAntiAffinityGroup;
         this.migrated = migrated;
+        this.migratedClusterUrl = migratedClusterUrl;
     }
 
 }


### PR DESCRIPTION
PIP: 

### Motivation

Currently, Pulsar supports blue-green cluster migration at both the cluster and namespace levels, but the `migratedClusterUrl` can only be set at the cluster level, meaning that migration can only occur to a single cluster. 

However, there are times when we want to migrate different namespaces to different clusters. For example, a certain namespace belongs to a specific business and is currently in a public cluster. We want to migrate this namespace to a dedicated cluster for that business. Therefore, we would like to add the `migratedClusterUrl` configuration at the namespace level to support this functionality

### Modifications

Allow specifying `migratedClusterUrl` at the namespace level.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

Add test in: `org.apache.pulsar.broker.service.ClusterMigrationTest#testNamespaceMigrationWithNamespaceLevelMigratedClusterUrl`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [x] The REST endpoints
- [x] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/hrzzzz/pulsar/pull/15
