### PR TITLE
[fix][pip] PIP-399: Fix Metric Name for Delayed Queue

### DIFF
--- a/pip/pip-399.md
+++ b/pip/pip-399.md
@@ -56,5 +56,5 @@ Rename the metric for **one sub** to `pulsar_delayed_message_index_size_bytes`.
 <!--
 Updated afterwards
 -->
-* Mailing List discussion thread:
-* Mailing List voting thread:
+* Mailing List discussion thread: https://lists.apache.org/thread/b8rqld3cww1t34zntgmld50yz34lxx1d
+* Mailing List voting thread: https://lists.apache.org/thread/cyyx29ggjdpbr3kq5vvd6tk83f9vc112

--- a/pip/pip-399.md
+++ b/pip/pip-399.md
@@ -1,0 +1,60 @@
+
+# PIP-399: Fix Metric Name for Delayed Queue
+
+# Background knowledge
+
+Pulsar delayed delivery is a feature that allows messages to be delivered to consumers after a certain delay.
+It will expose a metric to monitor the memory usage of delayed queue.
+
+# Motivation
+
+There is already one metric called `pulsar_delayed_message_index_size_bytes` for the total memory occupation used by delayed queue of **one topic**.
+```
+writeMetric(stream, "pulsar_delayed_message_index_size_bytes", stats.delayedTrackerMemoryUsage,
+                cluster, namespace, topic, splitTopicAndPartitionIndexLabel);
+```
+
+Whereas, the metric for **one sub** also called `pulsar_delayed_message_index_size_bytes`, which do not comform the metric name norm and is confusing.
+```
+writeSubscriptionMetric(stream, "pulsar_delayed_message_index_size_bytes",
+                    subsStats.delayedTrackerMemoryUsage, cluster, namespace, topic, sub, splitTopicAndPartitionIndexLabel);
+```
+
+Currently, it can export metric like:
+```
+# TYPE pulsar_delayed_message_index_size_bytes gauge
+pulsar_delayed_message_index_size_bytes{cluster="MyPulsar",namespace="public/default",topic="persistent://public/default/testNack-partition-0"} 0
+pulsar_delayed_message_index_size_bytes{cluster="MyPulsar",namespace="public/default",topic="persistent://public/default/testNack-partition-0",subscription="sub2"} 0
+```
+
+The metric of topic and subscription mix together. If we want to filter out the metric of sub to pick out the metric of topic, we need to use promsql like:
+`pulsar_delayed_message_index_size_bytes{subscription=""}`
+It is quite weird and not friendly to use.
+
+
+# Goals
+
+Rename the metric for **one sub** to `pulsar_subscription_delayed_message_index_size_bytes`.
+
+
+# Backward & Forward Compatibility
+
+## Upgrade
+
+Rename the metric for **one sub** to `pulsar_subscription_delayed_message_index_size_bytes`.
+
+## Downgrade / Rollback
+
+Rename the metric for **one sub** to `pulsar_delayed_message_index_size_bytes`.
+
+
+
+# General Notes
+
+# Links
+
+<!--
+Updated afterwards
+-->
+* Mailing List discussion thread:
+* Mailing List voting thread:


### PR DESCRIPTION
PIP 399 document.
Implementation: https://github.com/apache/pulsar/pull/23712

### Motivation

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
