### PR TITLE
[improve][client] Enhance dynamic topic subscription management in PatternMultiTopicsConsumer

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
@@ -29,8 +29,10 @@ import com.google.common.collect.Lists;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -1169,5 +1171,208 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         } else {
             admin.topics().delete(topicName, false);
         }
+    }
+
+    @Test(timeOut = 20000)
+    public void testBlockAndUnBlockGivenTopics() throws Exception {
+        String baseTopicName = "persistent://my-property/my-ns/testBlockAndUnBlockGivenTopics-" + System.currentTimeMillis();
+        Pattern pattern = Pattern.compile(baseTopicName + ".*");
+
+        // create 3 topics.
+        Producer<String> producer1 = pulsarClient.newProducer(Schema.STRING)
+                .topic(baseTopicName + "-1")
+                .create();
+        Producer<String> producer2 = pulsarClient.newProducer(Schema.STRING)
+                .topic(baseTopicName + "-2")
+                .create();
+        Producer<String> producer3 = pulsarClient.newProducer(Schema.STRING)
+                .topic(baseTopicName + "-3")
+                .create();
+
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topicsPattern(pattern)
+                .patternAutoDiscoveryPeriod(1, TimeUnit.SECONDS)
+                .subscriptionName("sub")
+                .subscriptionType(SubscriptionType.Failover)
+                .subscribe();
+
+        // wait topic list watcher creation.
+        Awaitility.await().untilAsserted(() -> {
+            CompletableFuture completableFuture = WhiteboxImpl.getInternalState(consumer, "watcherFuture");
+            assertTrue(completableFuture.isDone() && !completableFuture.isCompletedExceptionally());
+        });
+
+        assertTrue(consumer instanceof PatternMultiTopicsConsumerImpl);
+        PatternMultiTopicsConsumerImpl<String> consumerImpl = (PatternMultiTopicsConsumerImpl<String>) consumer;
+
+        // verify consumer get methods.
+        assertSame(consumerImpl.getPattern().pattern(), pattern.pattern());
+        assertEquals(consumerImpl.getPartitionedTopics().size(), 0);
+
+        sendMessage(producer1, "msg1-1", consumer);
+        sendMessage(producer2, "msg2-1", consumer);
+        sendMessage(producer3, "msg3-1", consumer);
+
+        // add block topics.
+        Set<String> blockTopics = new HashSet<>();
+        blockTopics.add(baseTopicName + "-2");
+        blockTopics.add(baseTopicName + "-3");
+        ((PatternMultiTopicsConsumerImpl<String>) consumer).blockTopics(blockTopics);
+
+        // waiting for topics to be blocked.
+        Thread.sleep(2000);
+
+        sendMessage(producer1, "msg1-2", consumer);
+        producer2.send("msg2-2");
+        producer3.send("msg3-2");
+
+        // await to check if msg2-2 and msg3-2 is not received in 5 seconds.
+        Awaitility.await().during(5, TimeUnit.SECONDS).until(() -> {
+            Message<String> receivedMessage = consumer.receive(100, TimeUnit.MILLISECONDS);
+            if (receivedMessage != null
+                    && (receivedMessage.getValue().equals("msg2-2") || receivedMessage.getValue().equals("msg3-2"))) {
+                throw new AssertionError("Received message which was supposed to be blocked");
+            }
+            return receivedMessage == null
+                    || (!receivedMessage.getValue().equals("msg2-2") && !receivedMessage.getValue().equals("msg3-2"));
+        });
+
+        ((PatternMultiTopicsConsumerImpl<String>) consumer).unBlockTopics(blockTopics);
+
+        receivedAndAckedMessage(consumer);
+        receivedAndAckedMessage(consumer);
+
+        producer2.send("msg2-3");
+        receivedAndAckedMessage(consumer, "msg2-3");
+        producer3.send("msg3-3");
+        receivedAndAckedMessage(consumer, "msg3-3");
+    }
+
+    @Test(timeOut = 20000)
+    public void testRecheckTopicsAfterTopicBlocked() throws Exception {
+        String baseTopicName = "persistent://my-property/my-ns/testBlockAndUnBlockGivenTopics-"
+                + System.currentTimeMillis();
+        Pattern pattern = Pattern.compile(baseTopicName + ".*");
+
+        // create 2 topics.
+        Producer<String> producer1 = pulsarClient.newProducer(Schema.STRING)
+                .topic(baseTopicName + "-1")
+                .create();
+        Producer<String> producer2 = pulsarClient.newProducer(Schema.STRING)
+                .topic(baseTopicName + "-2")
+                .create();
+
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topicsPattern(pattern)
+                .patternAutoDiscoveryPeriod(1, TimeUnit.SECONDS)
+                .subscriptionName("sub")
+                .subscriptionType(SubscriptionType.Failover)
+                .subscribe();
+
+        // wait topic list watcher creation.
+        Awaitility.await().untilAsserted(() -> {
+            CompletableFuture completableFuture = WhiteboxImpl.getInternalState(consumer, "watcherFuture");
+            assertTrue(completableFuture.isDone() && !completableFuture.isCompletedExceptionally());
+        });
+
+        assertTrue(consumer instanceof PatternMultiTopicsConsumerImpl);
+        PatternMultiTopicsConsumerImpl<String> consumerImpl = (PatternMultiTopicsConsumerImpl<String>) consumer;
+
+        // verify consumer get methods.
+        assertSame(consumerImpl.getPattern().pattern(), pattern.pattern());
+        assertEquals(consumerImpl.getPartitionedTopics().size(), 0);
+
+        sendMessage(producer1, "msg1-1", consumer);
+        sendMessage(producer2, "msg2-1", consumer);
+
+        // add block topics.
+        Set<String> blockTopics = new HashSet<>();
+        blockTopics.add(baseTopicName + "-2");
+        ((PatternMultiTopicsConsumerImpl<String>) consumer).blockTopics(blockTopics);
+
+        // waiting for topic2 to be blocked.
+        Thread.sleep(2000);
+
+        producer2.send("msg2-2");
+
+        ((PatternMultiTopicsConsumerImpl<String>) consumer).recheckTopicsChange();
+
+        // await to check if msg2-2 is not received in 5 seconds.
+        Awaitility.await().during(5, TimeUnit.SECONDS).until(() -> {
+            Message<String> receivedMessage = consumer.receive(100, TimeUnit.MILLISECONDS);
+            if (receivedMessage != null && receivedMessage.getValue().equals("msg2-2")) {
+                throw new AssertionError("Received message which was supposed to be blocked");
+            }
+            return receivedMessage == null || !receivedMessage.getValue().equals("msg2-2");
+        });
+
+        ((PatternMultiTopicsConsumerImpl<String>) consumer).unBlockTopics(blockTopics);
+
+        receivedAndAckedMessage(consumer, "msg2-2");
+    }
+
+    @Test(timeOut = 20000)
+    public void testBlockUnExistsTopic() throws Exception {
+        String baseTopicName = "persistent://my-property/my-ns/testBlockAndUnBlockGivenTopics-"
+                + System.currentTimeMillis();
+        Pattern pattern = Pattern.compile(baseTopicName + ".*");
+
+        Producer<String> producer1 = pulsarClient.newProducer(Schema.STRING)
+                .topic(baseTopicName + "-1")
+                .create();
+
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topicsPattern(pattern)
+                .patternAutoDiscoveryPeriod(1, TimeUnit.SECONDS)
+                .subscriptionName("sub")
+                .subscriptionType(SubscriptionType.Failover)
+                .subscribe();
+
+        // wait topic list watcher creation.
+        Awaitility.await().untilAsserted(() -> {
+            CompletableFuture completableFuture = WhiteboxImpl.getInternalState(consumer, "watcherFuture");
+            assertTrue(completableFuture.isDone() && !completableFuture.isCompletedExceptionally());
+        });
+
+        assertTrue(consumer instanceof PatternMultiTopicsConsumerImpl);
+        PatternMultiTopicsConsumerImpl<String> consumerImpl = (PatternMultiTopicsConsumerImpl<String>) consumer;
+
+        // verify consumer get methods.
+        assertSame(consumerImpl.getPattern().pattern(), pattern.pattern());
+        assertEquals(consumerImpl.getPartitionedTopics().size(), 0);
+
+        sendMessage(producer1, "msg1-1", consumer);
+
+        // add block topics.
+        Set<String> blockTopics = new HashSet<>();
+        blockTopics.add(baseTopicName + "-2");
+        ((PatternMultiTopicsConsumerImpl<String>) consumer).blockTopics(blockTopics);
+
+        // waiting for topic2 to be blocked.
+        Thread.sleep(2000);
+
+        Producer<String> producer2 = pulsarClient.newProducer(Schema.STRING)
+                .topic(baseTopicName + "-2")
+                .create();
+
+        // Blocking a non-existent topic will ignore the block request. At this time, messages can still be consumed.
+        sendMessage(producer2, "msg2-1", consumer);
+    }
+
+    private <T> void sendMessage(Producer<T> producer, T sendMessage,
+                                 Consumer<T> consumer) throws PulsarClientException {
+        producer.send(sendMessage);
+        receivedAndAckedMessage(consumer, sendMessage);
+    }
+
+    private <T> void receivedAndAckedMessage(Consumer<T> consumer, T sendMessage) throws PulsarClientException {
+        Message<T> message = consumer.receive();
+        assertEquals(message.getValue(), sendMessage);
+        consumer.acknowledge(message);
+    }
+
+    private <T> void receivedAndAckedMessage(Consumer<T> consumer) throws PulsarClientException {
+        Message<T> message = consumer.receive();
+        consumer.acknowledge(message);
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.validation.constraints.NotNull;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
@@ -71,6 +72,8 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
     private volatile String topicsHash;
 
     private PatternConsumerUpdateQueue updateTaskQueue;
+
+    private final Set<String> blockedTopics = new HashSet<>();
 
     /***
      * @param topicsPattern The regexp for the topic name(not contains partition suffix).
@@ -171,9 +174,20 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
 
                     final List<String> oldTopics = new ArrayList<>(getPartitions());
                     return updateSubscriptions(topicsPattern, this::setTopicsHash, getTopicsResult,
-                            topicsChangeListener, oldTopics, subscription);
+                            topicsChangeListener, oldTopics, subscription, blockedTopics);
                 }
             });
+    }
+
+    @VisibleForTesting
+    static CompletableFuture<Void> updateSubscriptions(Pattern topicsPattern,
+                                                       java.util.function.Consumer<String> topicsHashSetter,
+                                                       GetTopicsResult getTopicsResult,
+                                                       TopicsChangedListener topicsChangedListener,
+                                                       List<String> oldTopics,
+                                                       String subscriptionForLog) {
+        return updateSubscriptions(topicsPattern, topicsHashSetter, getTopicsResult, topicsChangedListener, oldTopics,
+                subscriptionForLog, Collections.emptySet());
     }
 
     static CompletableFuture<Void> updateSubscriptions(Pattern topicsPattern,
@@ -181,7 +195,7 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                                                        GetTopicsResult getTopicsResult,
                                                        TopicsChangedListener topicsChangedListener,
                                                        List<String> oldTopics,
-                                                       String subscriptionForLog) {
+                                                       String subscriptionForLog, Set<String> blockedTopics) {
         topicsHashSetter.accept(getTopicsResult.getTopicsHash());
         if (!getTopicsResult.isChanged()) {
             return CompletableFuture.completedFuture(null);
@@ -197,6 +211,10 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
         final List<CompletableFuture<?>> listenersCallback = new ArrayList<>(2);
         Set<String> topicsAdded = TopicList.minus(newTopics, oldTopics);
         Set<String> topicsRemoved = TopicList.minus(oldTopics, newTopics);
+        if (!blockedTopics.isEmpty()) {
+            topicsAdded.removeAll(blockedTopics);
+        }
+
         if (log.isDebugEnabled()) {
             log.debug("Pattern consumer [{}] Recheck pattern consumer's topics. topicsAdded: {}, topicsRemoved: {}",
                     subscriptionForLog, topicsAdded, topicsRemoved);
@@ -264,6 +282,9 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                     unsubscribeList.add(unsubscribeFuture);
                     partialRemoved.add(topicName.getPartitionedTopicName());
                     partialRemovedForLog.add(topicName.toString());
+                } else {
+                    // If the topic to be blocked does not exist, it is simply ignored.
+                    blockedTopics.remove(tp);
                 }
             }
             if (log.isDebugEnabled()) {
@@ -423,6 +444,25 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                                                 Throwable error,
                                                 CompletableFuture<Void> subscribeFuture) {
         subscribeFuture.completeExceptionally(error);
+    }
+
+    protected void blockTopics(@NotNull Set<String> topicNames) {
+        if (!topicNames.isEmpty()) {
+            blockedTopics.addAll(topicNames);
+            updateTaskQueue.appendTopicsRemovedOp(topicNames);
+        }
+    }
+
+    protected void unBlockTopics(@NotNull Set<String> topicNames) {
+        topicNames.retainAll(blockedTopics);
+        if (!topicNames.isEmpty()) {
+            updateTaskQueue.appendTopicsAddedOp(topicNames);
+            blockedTopics.removeAll(topicNames);
+        }
+    }
+
+    protected Set<String> getBlockedTopics() {
+        return blockedTopics;
     }
 
     private static final Logger log = LoggerFactory.getLogger(PatternMultiTopicsConsumerImpl.class);


### PR DESCRIPTION
<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
When subscribing to topics using regex patterns, it’s possible to encounter scenarios where some topics process messages slower than others. This can lead to significant performance bottlenecks, as slower topics might block others. There’s a need to manage such situations dynamically to ensure efficient processing and fair resource allocation among topics.

Related discussions can be found in [this Reddit thread](https://www.reddit.com/r/ApachePulsar/comments/1fssbbn/roundrobin_between_wildcard_topics/), which highlights issues similar to what we aim to address.

When using `MultiTopicsConsumerImpl`, we can call this.

https://github.com/apache/pulsar/blob/5a3a1f169a7f90181bd5c213c8e9f479bc74f0f2/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java#L1246-L1258

There is a test case that explains how to unsubscribe from a single topic.

https://github.com/apache/pulsar/blob/5a3a1f169a7f90181bd5c213c8e9f479bc74f0f2/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java#L660-L663

**This proposal seeks to integrate similar functionality into PatternMultiTopicsConsumerImpl, allowing dynamically remove or add specified topics.**

### Modifications

<!-- Describe the modifications you've done. -->

1. UnBlockTopics and BlockTopics Methods: In PatternMultiTopicsConsumerImpl, we introduce two methods: unBlockTopics and blockTopics.

- BlockTopics: Unsubscribe from topics by invoking onTopicsRemoved from TopicsChangedListener.

- UnBlockTopics: Resubscribe to topics by invoking onTopicsAdded from the same listener.

These changes will enable dynamic topic management, greatly improving the consumer’s ability to adapt to changing topic loads and enhancing overall system resilience against individual slow topics.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
