### PR TITLE
[fix] [broker] Msg delivery is stuck due to items in the collection recentlyJoinedConsumers are out-of-order

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassic.java
@@ -159,7 +159,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassic
         boolean sortNeeded = false;
         Position posPre = null;
         Position posAfter = null;
-        for(Map.Entry<Consumer, Position> entry : recentlyJoinedConsumers.entrySet()) {
+        for (Map.Entry<Consumer, Position> entry : recentlyJoinedConsumers.entrySet()) {
             if (posPre == null) {
                 posPre = entry.getValue();
             } else {
@@ -177,7 +177,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassic
             List<Map.Entry<Consumer, Position>> sortedList = new ArrayList<>(recentlyJoinedConsumers.entrySet());
             Collections.sort(sortedList, Map.Entry.comparingByValue());
             recentlyJoinedConsumers.clear();
-            for(Map.Entry<Consumer, Position> entry : sortedList) {
+            for (Map.Entry<Consumer, Position> entry : sortedList) {
                 recentlyJoinedConsumers.put(entry.getKey(), entry.getValue());
             }
         }
@@ -195,6 +195,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassic
         super.removeConsumer(consumer);
         if (recentlyJoinedConsumers != null) {
             recentlyJoinedConsumers.remove(consumer);
+            sortRecentlyJoinedConsumersIfNeeded();
             if (consumerList.size() == 1) {
                 recentlyJoinedConsumers.clear();
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassic.java
@@ -594,6 +594,9 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassic
     }
 
     public synchronized LinkedHashMap<Consumer, Position> getRecentlyJoinedConsumers() {
+        if (recentlyJoinedConsumers == null) {
+            return null;
+        }
         return new LinkedHashMap<>(recentlyJoinedConsumers);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassic.java
@@ -170,6 +170,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassic
                     sortNeeded = true;
                     break;
                 }
+                posPre = posAfter;
             }
         }
 
@@ -195,7 +196,6 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassic
         super.removeConsumer(consumer);
         if (recentlyJoinedConsumers != null) {
             recentlyJoinedConsumers.remove(consumer);
-            sortRecentlyJoinedConsumersIfNeeded();
             if (consumerList.size() == 1) {
                 recentlyJoinedConsumers.clear();
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassic.java
@@ -436,8 +436,6 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassic
                 if (entry.getValue().compareTo(nextPositionOfTheMarkDeletePosition) <= 0) {
                     itr.remove();
                     hasConsumerRemovedFromTheRecentJoinedConsumers = true;
-                } else {
-                    break;
                 }
             }
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassic.java
@@ -560,8 +560,8 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassic
                 && ksm.isAllowOutOfOrderDelivery() == this.allowOutOfOrderDelivery);
     }
 
-    public LinkedHashMap<Consumer, Position> getRecentlyJoinedConsumers() {
-        return recentlyJoinedConsumers;
+    public synchronized LinkedHashMap<Consumer, Position> getRecentlyJoinedConsumers() {
+        return new LinkedHashMap<>(recentlyJoinedConsumers);
     }
 
     public Map<Consumer, List<Range>> getConsumerKeyHashRanges() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassicTest.java
@@ -192,7 +192,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassicTest {
                 new KeySharedMeta().setKeySharedMode(KeySharedMode.AUTO_SPLIT));
 
         Consumer consumer0 = mock(Consumer.class);
-        when(consumer0.consumerName()).thenReturn("c0");
+        when(consumer0.consumerName()).thenReturn("c0-1");
         Consumer consumer1 = mock(Consumer.class);
         when(consumer1.consumerName()).thenReturn("c1");
         Consumer consumer2 = mock(Consumer.class);
@@ -203,6 +203,8 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassicTest {
         when(consumer4.consumerName()).thenReturn("c4");
         Consumer consumer5 = mock(Consumer.class);
         when(consumer5.consumerName()).thenReturn("c5");
+        Consumer consumer6 = mock(Consumer.class);
+        when(consumer6.consumerName()).thenReturn("c6");
 
         when(cursorMock.getNumberOfEntriesSinceFirstNotAckedMessage()).thenReturn(100L);
         when(cursorMock.getMarkDeletedPosition()).thenReturn(PositionFactory.create(-1, -1));
@@ -210,43 +212,52 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassicTest {
         when(cursorMock.getReadPosition()).thenReturn(PositionFactory.create(0, 0));
         persistentDispatcher.addConsumer(consumer0).join();
 
-        when(cursorMock.getReadPosition()).thenReturn(PositionFactory.create(5, 2));
+        when(cursorMock.getReadPosition()).thenReturn(PositionFactory.create(4, 1));
         persistentDispatcher.addConsumer(consumer1).join();
 
-        when(cursorMock.getReadPosition()).thenReturn(PositionFactory.create(5, 1));
+        when(cursorMock.getReadPosition()).thenReturn(PositionFactory.create(5, 2));
         persistentDispatcher.addConsumer(consumer2).join();
 
-        when(cursorMock.getReadPosition()).thenReturn(PositionFactory.create(5, 3));
+        when(cursorMock.getReadPosition()).thenReturn(PositionFactory.create(5, 1));
         persistentDispatcher.addConsumer(consumer3).join();
 
-        when(cursorMock.getReadPosition()).thenReturn(PositionFactory.create(4, 1));
+        when(cursorMock.getReadPosition()).thenReturn(PositionFactory.create(5, 3));
         persistentDispatcher.addConsumer(consumer4).join();
 
-        when(cursorMock.getReadPosition()).thenReturn(PositionFactory.create(6, 1));
+        when(cursorMock.getReadPosition()).thenReturn(PositionFactory.create(4, 2));
         persistentDispatcher.addConsumer(consumer5).join();
+
+        when(cursorMock.getReadPosition()).thenReturn(PositionFactory.create(6, 1));
+        persistentDispatcher.addConsumer(consumer6).join();
+
+        assertEquals(persistentDispatcher.getRecentlyJoinedConsumers().size(), 6);
 
         Iterator<Map.Entry<Consumer, Position>> itr
                 = persistentDispatcher.getRecentlyJoinedConsumers().entrySet().iterator();
 
         Map.Entry<Consumer, Position> entry1 = itr.next();
-        assertEquals(entry1.getKey(), consumer4);
         assertEquals(entry1.getValue(), PositionFactory.create(4, 1));
+        assertEquals(entry1.getKey(), consumer1);
 
         Map.Entry<Consumer, Position> entry2 = itr.next();
-        assertEquals(entry2.getKey(), consumer2);
-        assertEquals(entry2.getValue(), PositionFactory.create(5, 1));
+        assertEquals(entry2.getValue(), PositionFactory.create(4, 2));
+        assertEquals(entry2.getKey(), consumer5);
 
         Map.Entry<Consumer, Position> entry3 = itr.next();
-        assertEquals(entry3.getKey(), consumer1);
-        assertEquals(entry3.getValue(), PositionFactory.create(5, 2));
+        assertEquals(entry3.getValue(), PositionFactory.create(5, 1));
+        assertEquals(entry3.getKey(), consumer3);
 
         Map.Entry<Consumer, Position> entry4 = itr.next();
-        assertEquals(entry4.getKey(), consumer3);
-        assertEquals(entry4.getValue(), PositionFactory.create(5, 3));
+        assertEquals(entry4.getValue(), PositionFactory.create(5, 2));
+        assertEquals(entry4.getKey(), consumer2);
 
         Map.Entry<Consumer, Position> entry5 = itr.next();
-        assertEquals(entry5.getKey(), consumer5);
-        assertEquals(entry5.getValue(), PositionFactory.create(6, 1));
+        assertEquals(entry5.getValue(), PositionFactory.create(5, 3));
+        assertEquals(entry5.getKey(), consumer4);
+
+        Map.Entry<Consumer, Position> entry6 = itr.next();
+        assertEquals(entry6.getValue(), PositionFactory.create(6, 1));
+        assertEquals(entry6.getKey(), consumer6);
 
         // cleanup.
         persistentDispatcher.close();


### PR DESCRIPTION
### Motivation

Version: `3.0.7`, thanks for @shibd investigating the issue together and mentioning the key clue that items are out of order.

**Issue 1**: concurrentcy access a un-thread-safety collection
- The variable `recentlyJoinedConsumers` of `PersistentStickyKeyDispatcherMultipleConsumers` is used to guarantee the delivery order of Key_Shared subscriptions, which is not a thread-safety collection.
- Almost all operations that access this collection are in a lock block except in one place that the current PR fixes

**Issue 2**: the items in `recentlyJoinedConsumers` are out of order
- First node `104142:122103`
- ...
- middle node 1 `104142:122103`
- middle node 2 `104046:283984`
- ...
- tail node `104046:284275`

But we have more than one place that relies on the order rule, such as follows
- https://github.com/apache/pulsar/blob/branch-3.0/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java#L377

```java
        if (readType == ReadType.Replay) {
            // broker assumes the first node is the eldest one
            PositionImpl minReadPositionForRecentJoinedConsumer = recentlyJoinedConsumers.values().iterator().next();
            if (minReadPositionForRecentJoinedConsumer != null
                    && minReadPositionForRecentJoinedConsumer.compareTo(maxReadPosition) < 0) {
                maxReadPosition = minReadPositionForRecentJoinedConsumer;
            }
        }
```

- https://github.com/apache/pulsar/blob/branch-3.0/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java#L428

```java
            PositionImpl nextPositionOfTheMarkDeletePosition =
                    ((ManagedLedgerImpl) cursor.getManagedLedger()).getNextValidPosition(mdp);
            while (itr.hasNext()) {
                Map.Entry<Consumer, PositionImpl> entry = itr.next();
                if (entry.getValue().compareTo(nextPositionOfTheMarkDeletePosition) <= 0) {
                    itr.remove();
                    hasConsumerRemovedFromTheRecentJoinedConsumers = true;
                } else {
                    // break if one node does not match the check
                    break;
                }
            }
```

- [topic-stats.txt](https://github.com/user-attachments/files/18280668/34-stats.txt)

```json
 "consumersAfterMarkDeletePosition" : {
        "rudder-src-router-19-2" : "104142:122103",
        "rudder-src-router-22-3" : "104142:122103",
        "rudder-src-router-22-2" : "104142:122103",
        "rudder-src-router-12-3" : "104142:122103",
        "rudder-src-router-2-0" : "104142:122103",
        "rudder-src-router-4-1" : "104142:122103",
        "rudder-src-router-18-3" : "104142:122103",
        "rudder-src-router-29-2" : "104046:283984",
        "rudder-src-router-13-1" : "104046:283984",
        "rudder-src-router-13-0" : "104046:283984",
        "rudder-src-router-21-0" : "104046:283984",
        "rudder-src-router-21-1" : "104046:283984",
        "rudder-src-router-17-1" : "104046:283984",
        "rudder-src-router-1-1" : "104046:283984",
        "rudder-src-router-24-1" : "104046:283990",
        "rudder-src-router-3-1" : "104046:283990",
        "rudder-src-router-3-3" : "104046:283990",
        "rudder-src-router-13-2" : "104046:283990",
        "rudder-src-router-7-1" : "104046:283990",
        "rudder-src-router-7-3" : "104046:283990",
        "rudder-src-router-12-2" : "104046:283990",
        "rudder-src-router-2-1" : "104046:284068",
        "rudder-src-router-17-2" : "104046:284068",
        "rudder-src-router-17-0" : "104046:284068",
        "rudder-src-router-6-0" : "104046:284123",
        "rudder-src-router-1-2" : "104046:284123",
        "rudder-src-router-1-0" : "104046:284123",
        "rudder-src-router-18-0" : "104046:284123",
        "rudder-src-router-0-0" : "104046:284123",
        "rudder-src-router-16-0" : "104046:284123",
        "rudder-src-router-27-3" : "104046:284123",
        "rudder-src-router-15-1" : "104046:284124",
        "rudder-src-router-27-2" : "104046:284124",
        "rudder-src-router-15-2" : "104046:284124",
        "rudder-src-router-22-1" : "104046:284138",
        "rudder-src-router-12-0" : "104046:284138",
        "rudder-src-router-24-3" : "104046:284150",
        "rudder-src-router-4-0" : "104046:284150",
        "rudder-src-router-28-0" : "104046:284150",
        "rudder-src-router-28-1" : "104046:284150",
        "rudder-src-router-23-2" : "104046:284150",
        "rudder-src-router-6-1" : "104046:284154",
        "rudder-src-router-5-1" : "104046:284154",
        "rudder-src-router-6-3" : "104046:284154",
        "rudder-src-router-6-2" : "104046:284157",
        "rudder-src-router-5-2" : "104046:284157",
        "rudder-src-router-5-0" : "104046:284157",
        "rudder-src-router-5-3" : "104046:284161",
        "rudder-src-router-0-3" : "104046:284164",
        "rudder-src-router-28-3" : "104046:284164",
        "rudder-src-router-26-3" : "104046:284164",
        "rudder-src-router-11-3" : "104046:284164",
        "rudder-src-router-14-2" : "104046:284169",
        "rudder-src-router-4-2" : "104046:284177",
        "rudder-src-router-29-1" : "104046:284177",
        "rudder-src-router-2-3" : "104046:284177",
        "rudder-src-router-22-0" : "104046:284177",
        "rudder-src-router-23-1" : "104046:284177",
        "rudder-src-router-20-0" : "104046:284182",
        "rudder-src-router-10-2" : "104046:284182",
        "rudder-src-router-20-2" : "104046:284182",
        "rudder-src-router-25-3" : "104046:284182",
        "rudder-src-router-8-3" : "104046:284182",
        "rudder-src-router-8-2" : "104046:284182",
        "rudder-src-router-26-0" : "104046:284182",
        "rudder-src-router-26-2" : "104046:284182",
        "rudder-src-router-4-3" : "104046:284182",
        "rudder-src-router-9-1" : "104046:284182",
        "rudder-src-router-18-1" : "104046:284182",
        "rudder-src-router-0-2" : "104046:284182",
        "rudder-src-router-21-2" : "104046:284182",
        "rudder-src-router-7-2" : "104046:284193",
        "rudder-src-router-27-0" : "104046:284193",
        "rudder-src-router-27-1" : "104046:284193",
        "rudder-src-router-16-3" : "104046:284193",
        "rudder-src-router-21-3" : "104046:284193",
        "rudder-src-router-8-1" : "104046:284193",
        "rudder-src-router-10-1" : "104046:284193",
        "rudder-src-router-10-3" : "104046:284193",
        "rudder-src-router-15-0" : "104046:284193",
        "rudder-src-router-11-1" : "104046:284193",
        "rudder-src-router-11-2" : "104046:284193",
        "rudder-src-router-17-3" : "104046:284193",
        "rudder-src-router-25-0" : "104046:284193",
        "rudder-src-router-19-1" : "104046:284200",
        "rudder-src-router-24-0" : "104046:284200",
        "rudder-src-router-20-1" : "104046:284200",
        "rudder-src-router-14-0" : "104046:284200",
        "rudder-src-router-9-3" : "104046:284200",
        "rudder-src-router-8-0" : "104046:284204",
        "rudder-src-router-14-3" : "104046:284206",
        "rudder-src-router-9-0" : "104046:284206",
        "rudder-src-router-23-0" : "104046:284206",
        "rudder-src-router-23-3" : "104046:284211",
        "rudder-src-router-19-0" : "104046:284211",
        "rudder-src-router-3-0" : "104046:284221",
        "rudder-src-router-3-2" : "104046:284221",
        "rudder-src-router-14-1" : "104046:284223",
        "rudder-src-router-9-2" : "104046:284223",
        "rudder-src-router-29-0" : "104046:284223",
        "rudder-src-router-25-1" : "104046:284223",
        "rudder-src-router-25-2" : "104046:284223",
        "rudder-src-router-13-3" : "104046:284247",
        "rudder-src-router-10-0" : "104046:284251",
        "rudder-src-router-20-3" : "104046:284259",
        "rudder-src-router-18-2" : "104046:284266",
        "rudder-src-router-28-2" : "104046:284266",
        "rudder-src-router-26-1" : "104046:284266",
        "rudder-src-router-0-1" : "104046:284266",
        "rudder-src-router-7-0" : "104046:284266",
        "rudder-src-router-2-2" : "104046:284266",
        "rudder-src-router-15-3" : "104046:284268",
        "rudder-src-router-11-0" : "104046:284268",
        "rudder-src-router-19-3" : "104046:284268",
        "rudder-src-router-1-3" : "104046:284268",
        "rudder-src-router-24-2" : "104046:284275",
        "rudder-src-router-12-1" : "104046:284275",
        "rudder-src-router-16-1" : "104046:284275",
        "rudder-src-router-16-2" : "104046:284275"
}
```

![Screenshot 2024-12-31 at 18 04 16](https://github.com/user-attachments/assets/87227fc7-193d-49ac-a50e-beb1f6fde522)


### Modifications
- fix the concurrency issue
- sort `recentlyJoinedConsumers` when adding/removing consumers, I have not found the root cause of items in `recentlyJoinedConsumers` being out of order, I will continue working on it. Before that let us fix the issue fast

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
