### PR TITLE
[fix][client] Fix compatibility between kerberos and tls

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsProducerConsumerTest.java
@@ -18,18 +18,24 @@
  */
 package org.apache.pulsar.client.api;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import lombok.Cleanup;
 import org.apache.commons.compress.utils.IOUtils;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.impl.auth.AuthenticationTls;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -294,5 +300,66 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
 
         @Cleanup
         Producer<byte[]> ignored = client.newProducer().topic(topicName).create();
+    }
+
+    @Test
+    public void testTlsWithFakeAuthentication() throws Exception {
+        Authentication authentication = spy(new Authentication() {
+            @Override
+            public String getAuthMethodName() {
+                return "fake";
+            }
+
+            @Override
+            public void configure(Map<String, String> authParams) {
+
+            }
+
+            @Override
+            public void start() {
+
+            }
+
+            @Override
+            public void close() {
+
+            }
+
+            @Override
+            public AuthenticationDataProvider getAuthData(String brokerHostName) {
+                return mock(AuthenticationDataProvider.class);
+            }
+        });
+
+        @Cleanup
+        PulsarAdmin pulsarAdmin = PulsarAdmin.builder()
+                .serviceHttpUrl(getPulsar().getWebServiceAddressTls())
+                .tlsTrustCertsFilePath(CA_CERT_FILE_PATH)
+                .allowTlsInsecureConnection(false)
+                .enableTlsHostnameVerification(false)
+                .tlsKeyFilePath(getTlsFileForClient("admin.key-pk8"))
+                .tlsCertificateFilePath(getTlsFileForClient("admin.cert"))
+                .authentication(authentication)
+                .build();
+        pulsarAdmin.tenants().getTenants();
+        verify(authentication, never()).getAuthData();
+
+        @Cleanup
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(getPulsar().getBrokerServiceUrlTls())
+                .tlsTrustCertsFilePath(CA_CERT_FILE_PATH)
+                .allowTlsInsecureConnection(false)
+                .enableTlsHostnameVerification(false)
+                .tlsKeyFilePath(getTlsFileForClient("admin.key-pk8"))
+                .tlsCertificateFilePath(getTlsFileForClient("admin.cert"))
+                .authentication(authentication).build();
+        verify(authentication, never()).getAuthData();
+
+        final String topicName = "persistent://my-property/my-ns/my-topic-1";
+        internalSetUpForNamespace();
+        @Cleanup
+        Consumer<byte[]> ignoredConsumer =
+                pulsarClient.newConsumer().topic(topicName).subscriptionName("my-subscriber-name").subscribe();
+        @Cleanup
+        Producer<byte[]> ignoredProducer = pulsarClient.newProducer().topic(topicName).create();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsProducerConsumerTest.java
@@ -359,7 +359,9 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
         @Cleanup
         Consumer<byte[]> ignoredConsumer =
                 pulsarClient.newConsumer().topic(topicName).subscriptionName("my-subscriber-name").subscribe();
+        verify(authentication, never()).getAuthData();
         @Cleanup
         Producer<byte[]> ignoredProducer = pulsarClient.newProducer().topic(topicName).create();
+        verify(authentication, never()).getAuthData();
     }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
@@ -191,7 +191,8 @@ public class AsyncHttpConnector implements Connector, AsyncHttpRequestExecutor {
         // Set client key and certificate if available
         sslRefresher = Executors.newScheduledThreadPool(1,
                 new DefaultThreadFactory("pulsar-admin-ssl-refresher"));
-        PulsarSslConfiguration sslConfiguration = buildSslConfiguration(conf);
+        PulsarSslConfiguration sslConfiguration = buildSslConfiguration(conf, serviceNameResolver
+                .resolveHostUri().getHost());
         this.sslFactory = (PulsarSslFactory) Class.forName(conf.getSslFactoryPlugin())
                 .getConstructor().newInstance();
         this.sslFactory.initialize(sslConfiguration);
@@ -519,7 +520,7 @@ public class AsyncHttpConnector implements Connector, AsyncHttpRequestExecutor {
         }
     }
 
-    protected PulsarSslConfiguration buildSslConfiguration(ClientConfigurationData conf)
+    protected PulsarSslConfiguration buildSslConfiguration(ClientConfigurationData conf, String host)
             throws PulsarClientException {
         return PulsarSslConfiguration.builder()
                 .tlsProvider(conf.getSslProvider())
@@ -537,7 +538,7 @@ public class AsyncHttpConnector implements Connector, AsyncHttpRequestExecutor {
                 .allowInsecureConnection(conf.isTlsAllowInsecureConnection())
                 .requireTrustedClientCertOnConnect(false)
                 .tlsEnabledWithKeystore(conf.isUseKeyStoreTls())
-                .authData(conf.getAuthentication().getAuthData())
+                .authData(conf.getAuthentication().getAuthData(host))
                 .tlsCustomParams(conf.getSslFactoryPluginParams())
                 .serverMode(false)
                 .isHttps(true)

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Authentication.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Authentication.java
@@ -48,6 +48,7 @@ public interface Authentication extends Closeable, Serializable {
      * @throws PulsarClientException
      *             any other error
      */
+    @Deprecated
     default AuthenticationDataProvider getAuthData() throws PulsarClientException {
         throw new UnsupportedAuthenticationException("Method not implemented!");
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
@@ -260,7 +260,7 @@ public class CmdConsume extends AbstractCmdConsume {
         try {
             if (authentication != null) {
                 authentication.start();
-                AuthenticationDataProvider authData = authentication.getAuthData();
+                AuthenticationDataProvider authData = authentication.getAuthData(consumerUri.getHost());
                 if (authData.hasDataForHttp()) {
                     for (Map.Entry<String, String> kv : authData.getHttpHeaders()) {
                         consumeRequest.setHeader(kv.getKey(), kv.getValue());

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduce.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduce.java
@@ -469,7 +469,7 @@ public class CmdProduce extends AbstractCmd {
         try {
             if (authentication != null) {
                 authentication.start();
-                AuthenticationDataProvider authData = authentication.getAuthData();
+                AuthenticationDataProvider authData = authentication.getAuthData(produceUri.getHost());
                 if (authData.hasDataForHttp()) {
                     for (Map.Entry<String, String> kv : authData.getHttpHeaders()) {
                         produceRequest.setHeader(kv.getKey(), kv.getValue());

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdRead.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdRead.java
@@ -244,7 +244,7 @@ public class CmdRead extends AbstractCmdConsume {
         try {
             if (authentication != null) {
                 authentication.start();
-                AuthenticationDataProvider authData = authentication.getAuthData();
+                AuthenticationDataProvider authData = authentication.getAuthData(readerUri.getHost());
                 if (authData.hasDataForHttp()) {
                     for (Map.Entry<String, String> kv : authData.getHttpHeaders()) {
                         readRequest.setHeader(kv.getKey(), kv.getValue());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpClient.java
@@ -97,7 +97,8 @@ public class HttpClient implements Closeable {
                 this.executorService = Executors
                         .newSingleThreadScheduledExecutor(new ExecutorProvider
                                 .ExtendedThreadFactory("httpclient-ssl-refresh"));
-                PulsarSslConfiguration sslConfiguration = buildSslConfiguration(conf);
+                PulsarSslConfiguration sslConfiguration =
+                        buildSslConfiguration(conf, serviceNameResolver.resolveHostUri().getHost());
                 this.sslFactory = (PulsarSslFactory) Class.forName(conf.getSslFactoryPlugin())
                         .getConstructor().newInstance();
                 this.sslFactory.initialize(sslConfiguration);
@@ -233,7 +234,7 @@ public class HttpClient implements Closeable {
         return future;
     }
 
-    protected PulsarSslConfiguration buildSslConfiguration(ClientConfigurationData config)
+    protected PulsarSslConfiguration buildSslConfiguration(ClientConfigurationData config, String host)
             throws PulsarClientException {
         return PulsarSslConfiguration.builder()
                 .tlsProvider(config.getSslProvider())
@@ -252,7 +253,7 @@ public class HttpClient implements Closeable {
                 .requireTrustedClientCertOnConnect(false)
                 .tlsEnabledWithKeystore(config.isUseKeyStoreTls())
                 .tlsCustomParams(config.getSslFactoryPluginParams())
-                .authData(config.getAuthentication().getAuthData())
+                .authData(config.getAuthentication().getAuthData(host))
                 .serverMode(false)
                 .isHttps(true)
                 .build();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
@@ -71,7 +71,7 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
         this.socks5ProxyAddress = conf.getSocks5ProxyAddress();
         this.socks5ProxyUsername = conf.getSocks5ProxyUsername();
         this.socks5ProxyPassword = conf.getSocks5ProxyPassword();
-        this.conf = conf;
+        this.conf = conf.clone();
         if (tlsEnabled) {
             this.pulsarSslFactoryMap = new ConcurrentHashMap<>();
             if (scheduledExecutorService != null && conf.getAutoCertRefreshSeconds() > 0) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
@@ -27,8 +27,10 @@ import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.handler.proxy.Socks5ProxyHandler;
 import io.netty.handler.ssl.SslHandler;
 import java.net.InetSocketAddress;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -55,8 +57,8 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
     private final InetSocketAddress socks5ProxyAddress;
     private final String socks5ProxyUsername;
     private final String socks5ProxyPassword;
-
-    private final PulsarSslFactory pulsarSslFactory;
+    private final ClientConfigurationData conf;
+    private final Map<String, PulsarSslFactory> pulsarSslFactoryMap;
 
     private static final long TLS_CERTIFICATE_CACHE_MILLIS = TimeUnit.MINUTES.toMillis(1);
 
@@ -69,26 +71,17 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
         this.socks5ProxyAddress = conf.getSocks5ProxyAddress();
         this.socks5ProxyUsername = conf.getSocks5ProxyUsername();
         this.socks5ProxyPassword = conf.getSocks5ProxyPassword();
-
+        this.conf = conf;
         if (tlsEnabled) {
-            this.pulsarSslFactory = (PulsarSslFactory) Class.forName(conf.getSslFactoryPlugin())
-                    .getConstructor().newInstance();
-            try {
-                PulsarSslConfiguration sslConfiguration = buildSslConfiguration(conf);
-                this.pulsarSslFactory.initialize(sslConfiguration);
-                this.pulsarSslFactory.createInternalSslContext();
-            } catch (Exception e) {
-                log.error("Unable to initialize and create the ssl context", e);
-            }
+            this.pulsarSslFactoryMap = new ConcurrentHashMap<>();
             if (scheduledExecutorService != null && conf.getAutoCertRefreshSeconds() > 0) {
                 scheduledExecutorService.scheduleWithFixedDelay(() -> this.refreshSslContext(conf),
                         conf.getAutoCertRefreshSeconds(),
                         conf.getAutoCertRefreshSeconds(),
                         TimeUnit.SECONDS);
             }
-
         } else {
-            pulsarSslFactory = null;
+            this.pulsarSslFactoryMap = null;
         }
     }
 
@@ -123,6 +116,23 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
         CompletableFuture<Channel> initTlsFuture = new CompletableFuture<>();
         ch.eventLoop().execute(() -> {
             try {
+                PulsarSslFactory pulsarSslFactory = pulsarSslFactoryMap.computeIfAbsent(sniHost.getHostName(), key -> {
+                    try {
+                        PulsarSslFactory factory = (PulsarSslFactory) Class.forName(conf.getSslFactoryPlugin())
+                                .getConstructor().newInstance();
+                        PulsarSslConfiguration sslConfiguration = buildSslConfiguration(conf, key);
+                        factory.initialize(sslConfiguration);
+                        factory.createInternalSslContext();
+                        return factory;
+                    } catch (Exception e) {
+                        log.error("Unable to initialize and create the ssl context", e);
+                        initTlsFuture.completeExceptionally(e);
+                        return null;
+                    }
+                });
+                if (pulsarSslFactory == null) {
+                    return;
+                }
                 SslHandler handler = new SslHandler(pulsarSslFactory
                         .createClientSslEngine(ch.alloc(), sniHost.getHostName(), sniHost.getPort()));
 
@@ -181,7 +191,9 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
             return ch;
         }));
     }
-    protected PulsarSslConfiguration buildSslConfiguration(ClientConfigurationData config)
+
+protected PulsarSslConfiguration buildSslConfiguration(ClientConfigurationData config,
+                                                       String host)
             throws PulsarClientException {
         return PulsarSslConfiguration.builder()
                 .tlsProvider(config.getSslProvider())
@@ -200,28 +212,30 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
                 .requireTrustedClientCertOnConnect(false)
                 .tlsEnabledWithKeystore(config.isUseKeyStoreTls())
                 .tlsCustomParams(config.getSslFactoryPluginParams())
-                .authData(config.getAuthentication().getAuthData())
+                .authData(config.getAuthentication().getAuthData(host))
                 .serverMode(false)
                 .build();
     }
 
     protected void refreshSslContext(ClientConfigurationData conf) {
-        try {
+        pulsarSslFactoryMap.forEach((key, pulsarSslFactory) -> {
             try {
-                if (conf.isUseKeyStoreTls()) {
-                    this.pulsarSslFactory.getInternalSslContext();
-                } else {
-                    this.pulsarSslFactory.getInternalNettySslContext();
+                try {
+                    if (conf.isUseKeyStoreTls()) {
+                        pulsarSslFactory.getInternalSslContext();
+                    } else {
+                        pulsarSslFactory.getInternalNettySslContext();
+                    }
+                } catch (Exception e) {
+                    log.error("SSL Context is not initialized", e);
+                    PulsarSslConfiguration sslConfiguration = buildSslConfiguration(conf, key);
+                    pulsarSslFactory.initialize(sslConfiguration);
                 }
+                pulsarSslFactory.update();
             } catch (Exception e) {
-                log.error("SSL Context is not initialized", e);
-                PulsarSslConfiguration sslConfiguration = buildSslConfiguration(conf);
-                this.pulsarSslFactory.initialize(sslConfiguration);
+                log.error("Failed to refresh SSL context", e);
             }
-            this.pulsarSslFactory.update();
-        } catch (Exception e) {
-            log.error("Failed to refresh SSL context", e);
-        }
+        });
     }
 
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientInitializationTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientInitializationTest.java
@@ -41,6 +41,6 @@ public class ClientInitializationTest {
                 .build();
 
         verify(auth).start();
-        verify(auth, times(1)).getAuthData();
+        verify(auth, times(0)).getAuthData();
     }
 }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
@@ -322,6 +322,10 @@ class AdminProxyHandler extends ProxyServlet {
         } else {
             try {
                 url.append(getWebServiceUrl());
+                if (LOG.isDebugEnabled() && isBlank(brokerWebServiceUrl)) {
+                    LOG.debug("[{}:{}] Selected active broker is {}", request.getRemoteAddr(), request.getRemotePort(),
+                            url);
+                }
             } catch (Exception e) {
                 LOG.warn("[{}:{}] Failed to get next active broker {}", request.getRemoteAddr(),
                         request.getRemotePort(), e.getMessage(), e);

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
@@ -403,7 +403,8 @@ class AdminProxyHandler extends ProxyServlet {
     protected PulsarSslFactory createPulsarSslFactory() {
         try {
             try {
-                AuthenticationDataProvider authData = proxyClientAuthentication.getAuthData(getWebServiceUrl());
+                AuthenticationDataProvider authData =
+                        proxyClientAuthentication.getAuthData(URI.create(getWebServiceUrl()).getHost());
                 PulsarSslConfiguration pulsarSslConfiguration = buildSslConfiguration(authData);
                 PulsarSslFactory sslFactory =
                         (PulsarSslFactory) Class.forName(config.getBrokerClientSslFactoryPlugin())

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyServiceTlsStarterTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyServiceTlsStarterTest.java
@@ -59,6 +59,7 @@ public class ProxyServiceTlsStarterTest extends MockedPulsarServiceBaseTest {
         serviceStarter.getConfig().setBrokerServiceURL(pulsar.getBrokerServiceUrl());
         serviceStarter.getConfig().setBrokerServiceURLTLS(pulsar.getBrokerServiceUrlTls());
         serviceStarter.getConfig().setBrokerWebServiceURL(pulsar.getWebServiceAddress());
+        serviceStarter.getConfig().setBrokerWebServiceURLTLS(pulsar.getWebServiceAddressTls());
         serviceStarter.getConfig().setBrokerClientTrustCertsFilePath(CA_CERT_FILE_PATH);
         serviceStarter.getConfig().setBrokerClientCertificateFilePath(BROKER_CERT_FILE_PATH);
         serviceStarter.getConfig().setBrokerClientKeyFilePath(BROKER_KEY_FILE_PATH);
@@ -79,6 +80,7 @@ public class ProxyServiceTlsStarterTest extends MockedPulsarServiceBaseTest {
     protected void doInitConf() throws Exception {
         super.doInitConf();
         this.conf.setBrokerServicePortTls(Optional.of(0));
+        this.conf.setWebServicePortTls(Optional.of(0));
         this.conf.setTlsCertificateFilePath(PROXY_CERT_FILE_PATH);
         this.conf.setTlsKeyFilePath(PROXY_KEY_FILE_PATH);
     }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/PerformanceClient.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/PerformanceClient.java
@@ -251,7 +251,7 @@ public class PerformanceClient extends CmdBase {
                     Authentication auth = AuthenticationFactory.create(this.authPluginClassName,
                             this.authParams);
                     auth.start();
-                    AuthenticationDataProvider authData = auth.getAuthData();
+                    AuthenticationDataProvider authData = auth.getAuthData(produceUri.getHost());
                     if (authData.hasDataForHttp()) {
                         for (Map.Entry<String, String> kv : authData.getHttpHeaders()) {
                             produceRequest.setHeader(kv.getKey(), kv.getValue());


### PR DESCRIPTION
### Motivation

When the pulsar-admin CLI uses the kerberos authentication with tls transport, we encounter the following issue:

```
$ bin/pulsar-admin tenants list
2024-12-31T15:35:56,308+0800 [main] INFO  org.apache.pulsar.client.impl.auth.AuthenticationSasl - JAAS loginContext is: PulsarClient.
2024-12-31T15:35:56,455+0800 [main] INFO  org.apache.pulsar.common.sasl.JAASCredentialsContainer - successfully logged in.
2024-12-31T15:35:56,459+0800 [pulsar-tgt-refresh-thread] INFO  org.apache.pulsar.common.sasl.TGTRefreshThread - TGT refresh thread started.
2024-12-31T15:35:56,463+0800 [pulsar-tgt-refresh-thread] INFO  org.apache.pulsar.common.sasl.TGTRefreshThread - Client principal is "client/localhost@PULSAR.COM".
2024-12-31T15:35:56,463+0800 [pulsar-tgt-refresh-thread] INFO  org.apache.pulsar.common.sasl.TGTRefreshThread - Server principal is "krbtgt/PULSAR.COM@PULSAR.COM".
2024-12-31T15:35:56,483+0800 [pulsar-tgt-refresh-thread] INFO  org.apache.pulsar.common.sasl.TGTRefreshThread - TGT valid starting at:        Tue Dec 31 15:35:56 CST 2024
2024-12-31T15:35:56,484+0800 [pulsar-tgt-refresh-thread] INFO  org.apache.pulsar.common.sasl.TGTRefreshThread - TGT expires:                  Wed Jan 01 15:35:56 CST 2025
2024-12-31T15:35:56,484+0800 [pulsar-tgt-refresh-thread] INFO  org.apache.pulsar.common.sasl.TGTRefreshThread - TGT refresh sleeping until: Wed Jan 01 11:38:40 CST 2025
class org.apache.pulsar.client.api.PulsarClientException$UnsupportedAuthenticationException: Method not implemented!
```

`Authentication` providers two methods to get the authentication data:

- `org.apache.pulsar.client.api.Authentication#getAuthData(java.lang.String)`
   - For compatibility, which will call `org.apache.pulsar.client.api.Authentication#getAuthData()`
- `org.apache.pulsar.client.api.Authentication#getAuthData()`

However, the client/admin/broker/proxy still calls the `org.apache.pulsar.client.api.Authentication#getAuthData()`, this breaks the kerberos authentication.

### Modifications

- Use `org.apache.pulsar.client.impl.auth.AuthenticationSasl#getAuthData(java.lang.String)` instead of `org.apache.pulsar.client.api.Authentication#getAuthData()`.
- Make `org.apache.pulsar.client.api.Authentication#getAuthData()` as deprecated.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->