### PR TITLE
[improve][client] PIP-393: Support configuring NegativeAckPrecisionBitCnt while building consumer.

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -244,6 +244,19 @@ public interface ConsumerBuilder<T> extends Cloneable {
     ConsumerBuilder<T> negativeAckRedeliveryDelay(long redeliveryDelay, TimeUnit timeUnit);
 
     /**
+     * Sets the redelivery time precision bit count. The lower bits of the redelivery time will be
+     * trimmed to reduce the memory occupation. The default value is 8, which means the redelivery time
+     * will be bucketed by 256ms, the redelivery time could be earlier(no later) than the expected time,
+     * but no more than 256ms. If set to k, the redelivery time will be bucketed by 2^k ms.
+     * If the value is 0, the redelivery time will be accurate to ms.
+     *
+     * @param negativeAckPrecisionBitCnt
+     *            The redelivery time precision bit count.
+     * @return the consumer builder instance
+     */
+    ConsumerBuilder<T> negativeAckPrecisionBitCnt(int negativeAckPrecisionBitCnt);
+
+    /**
      * Select the subscription type to be used when subscribing to a topic.
      *
      * <p>Options are:

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -254,7 +254,7 @@ public interface ConsumerBuilder<T> extends Cloneable {
      *            The redelivery time precision bit count.
      * @return the consumer builder instance
      */
-    ConsumerBuilder<T> negativeAckPrecisionBitCnt(int negativeAckPrecisionBitCnt);
+    ConsumerBuilder<T> negativeAckRedeliveryDelayPrecision(int negativeAckPrecisionBitCount);
 
     /**
      * Select the subscription type to be used when subscribing to a topic.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -282,6 +282,13 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     }
 
     @Override
+    public ConsumerBuilder<T> negativeAckPrecisionBitCnt(int negativeAckPrecisionBitCnt) {
+        checkArgument(negativeAckPrecisionBitCnt>= 0, "negativeAckPrecisionBitCnt needs to be >= 0");
+        conf.setNegativeAckPrecisionBitCnt(negativeAckPrecisionBitCnt);
+        return this;
+    }
+
+    @Override
     public ConsumerBuilder<T> subscriptionType(@NonNull SubscriptionType subscriptionType) {
         conf.setSubscriptionType(subscriptionType);
         return this;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -282,9 +282,9 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     }
 
     @Override
-    public ConsumerBuilder<T> negativeAckPrecisionBitCnt(int negativeAckPrecisionBitCnt) {
-        checkArgument(negativeAckPrecisionBitCnt >= 0, "negativeAckPrecisionBitCnt needs to be >= 0");
-        conf.setNegativeAckPrecisionBitCnt(negativeAckPrecisionBitCnt);
+    public ConsumerBuilder<T> negativeAckRedeliveryDelayPrecision(int negativeAckPrecisionBitCount) {
+        checkArgument(negativeAckPrecisionBitCount >= 0, "negativeAckPrecisionBitCount needs to be >= 0");
+        conf.setNegativeAckPrecisionBitCnt(negativeAckPrecisionBitCount);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -283,7 +283,7 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
 
     @Override
     public ConsumerBuilder<T> negativeAckPrecisionBitCnt(int negativeAckPrecisionBitCnt) {
-        checkArgument(negativeAckPrecisionBitCnt>= 0, "negativeAckPrecisionBitCnt needs to be >= 0");
+        checkArgument(negativeAckPrecisionBitCnt >= 0, "negativeAckPrecisionBitCnt needs to be >= 0");
         conf.setNegativeAckPrecisionBitCnt(negativeAckPrecisionBitCnt);
         return this;
     }


### PR DESCRIPTION
Implementation PR for PIP-393: https://github.com/apache/pulsar/pull/23601.

### Motivation

PR https://github.com/apache/pulsar/pull/23600 has implemented most of the logic, but lack of support for configuring `NegativeAckPrecisionBitCnt` by mistake. 


### Modifications

Add support for configuring `NegativeAckPrecisionBitCnt` while building consumer.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/68