### PR TITLE
[improve] Upgrade to Netty 4.1.116.Final and io_uring to 0.0.26.Final

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -47,7 +47,7 @@
     <license-maven-plugin.version>4.1</license-maven-plugin.version>
     <puppycrawl.checkstyle.version>10.14.2</puppycrawl.checkstyle.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-    <netty.version>4.1.115.Final</netty.version>
+    <netty.version>4.1.116.Final</netty.version>
     <guice.version>4.2.3</guice.version>
     <guava.version>32.1.2-jre</guava.version>
     <ant.version>1.10.12</ant.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -293,26 +293,26 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-lang3-3.11.jar
     - org.apache.commons-commons-text-1.10.0.jar
  * Netty
-    - io.netty-netty-buffer-4.1.115.Final.jar
-    - io.netty-netty-codec-4.1.115.Final.jar
-    - io.netty-netty-codec-dns-4.1.115.Final.jar
-    - io.netty-netty-codec-http-4.1.115.Final.jar
-    - io.netty-netty-codec-http2-4.1.115.Final.jar
-    - io.netty-netty-codec-socks-4.1.115.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.115.Final.jar
-    - io.netty-netty-common-4.1.115.Final.jar
-    - io.netty-netty-handler-4.1.115.Final.jar
-    - io.netty-netty-handler-proxy-4.1.115.Final.jar
-    - io.netty-netty-resolver-4.1.115.Final.jar
-    - io.netty-netty-resolver-dns-4.1.115.Final.jar
-    - io.netty-netty-resolver-dns-classes-macos-4.1.115.Final.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.115.Final-osx-aarch_64.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.115.Final-osx-x86_64.jar
-    - io.netty-netty-transport-4.1.115.Final.jar
-    - io.netty-netty-transport-classes-epoll-4.1.115.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.115.Final-linux-aarch_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.115.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-unix-common-4.1.115.Final.jar
+    - io.netty-netty-buffer-4.1.116.Final.jar
+    - io.netty-netty-codec-4.1.116.Final.jar
+    - io.netty-netty-codec-dns-4.1.116.Final.jar
+    - io.netty-netty-codec-http-4.1.116.Final.jar
+    - io.netty-netty-codec-http2-4.1.116.Final.jar
+    - io.netty-netty-codec-socks-4.1.116.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.116.Final.jar
+    - io.netty-netty-common-4.1.116.Final.jar
+    - io.netty-netty-handler-4.1.116.Final.jar
+    - io.netty-netty-handler-proxy-4.1.116.Final.jar
+    - io.netty-netty-resolver-4.1.116.Final.jar
+    - io.netty-netty-resolver-dns-4.1.116.Final.jar
+    - io.netty-netty-resolver-dns-classes-macos-4.1.116.Final.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.116.Final-osx-aarch_64.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.116.Final-osx-x86_64.jar
+    - io.netty-netty-transport-4.1.116.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.116.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.116.Final-linux-aarch_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.116.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-unix-common-4.1.116.Final.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.69.Final.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.69.Final-linux-aarch_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.69.Final-linux-x86_64.jar
@@ -320,9 +320,9 @@ The Apache Software License, Version 2.0
     - io.netty-netty-tcnative-boringssl-static-2.0.69.Final-osx-x86_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.69.Final-windows-x86_64.jar
     - io.netty-netty-tcnative-classes-2.0.69.Final.jar
-    - io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.24.Final.jar
-    - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
-    - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar
+    - io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.26.Final.jar
+    - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar
+    - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar
  * Prometheus client
     - io.prometheus.jmx-collector-0.16.1.jar
     - io.prometheus-simpleclient-0.16.0.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -347,22 +347,22 @@ The Apache Software License, Version 2.0
     - commons-text-1.10.0.jar
     - commons-compress-1.26.0.jar
  * Netty
-    - netty-buffer-4.1.115.Final.jar
-    - netty-codec-4.1.115.Final.jar
-    - netty-codec-dns-4.1.115.Final.jar
-    - netty-codec-http-4.1.115.Final.jar
-    - netty-codec-socks-4.1.115.Final.jar
-    - netty-codec-haproxy-4.1.115.Final.jar
-    - netty-common-4.1.115.Final.jar
-    - netty-handler-4.1.115.Final.jar
-    - netty-handler-proxy-4.1.115.Final.jar
-    - netty-resolver-4.1.115.Final.jar
-    - netty-resolver-dns-4.1.115.Final.jar
-    - netty-transport-4.1.115.Final.jar
-    - netty-transport-classes-epoll-4.1.115.Final.jar
-    - netty-transport-native-epoll-4.1.115.Final-linux-aarch_64.jar
-    - netty-transport-native-epoll-4.1.115.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.115.Final.jar
+    - netty-buffer-4.1.116.Final.jar
+    - netty-codec-4.1.116.Final.jar
+    - netty-codec-dns-4.1.116.Final.jar
+    - netty-codec-http-4.1.116.Final.jar
+    - netty-codec-socks-4.1.116.Final.jar
+    - netty-codec-haproxy-4.1.116.Final.jar
+    - netty-common-4.1.116.Final.jar
+    - netty-handler-4.1.116.Final.jar
+    - netty-handler-proxy-4.1.116.Final.jar
+    - netty-resolver-4.1.116.Final.jar
+    - netty-resolver-dns-4.1.116.Final.jar
+    - netty-transport-4.1.116.Final.jar
+    - netty-transport-classes-epoll-4.1.116.Final.jar
+    - netty-transport-native-epoll-4.1.116.Final-linux-aarch_64.jar
+    - netty-transport-native-epoll-4.1.116.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.116.Final.jar
     - netty-tcnative-boringssl-static-2.0.69.Final.jar
     - netty-tcnative-boringssl-static-2.0.69.Final-linux-aarch_64.jar
     - netty-tcnative-boringssl-static-2.0.69.Final-linux-x86_64.jar
@@ -370,12 +370,12 @@ The Apache Software License, Version 2.0
     - netty-tcnative-boringssl-static-2.0.69.Final-osx-x86_64.jar
     - netty-tcnative-boringssl-static-2.0.69.Final-windows-x86_64.jar
     - netty-tcnative-classes-2.0.69.Final.jar
-    - netty-incubator-transport-classes-io_uring-0.0.24.Final.jar
-    - netty-incubator-transport-native-io_uring-0.0.24.Final-linux-aarch_64.jar
-    - netty-incubator-transport-native-io_uring-0.0.24.Final-linux-x86_64.jar
-    - netty-resolver-dns-classes-macos-4.1.115.Final.jar
-    - netty-resolver-dns-native-macos-4.1.115.Final-osx-aarch_64.jar
-    - netty-resolver-dns-native-macos-4.1.115.Final-osx-x86_64.jar
+    - netty-incubator-transport-classes-io_uring-0.0.26.Final.jar
+    - netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar
+    - netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar
+    - netty-resolver-dns-classes-macos-4.1.116.Final.jar
+    - netty-resolver-dns-native-macos-4.1.116.Final-osx-aarch_64.jar
+    - netty-resolver-dns-native-macos-4.1.116.Final-osx-x86_64.jar
  * Prometheus client
     - simpleclient-0.16.0.jar
     - simpleclient_log4j2-0.16.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -146,8 +146,8 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.10.5</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.7.1</curator.version>
-    <netty.version>4.1.115.Final</netty.version>
-    <netty-iouring.version>0.0.24.Final</netty-iouring.version>
+    <netty.version>4.1.116.Final</netty.version>
+    <netty-iouring.version>0.0.26.Final</netty-iouring.version>
     <jetty.version>9.4.56.v20240826</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.42</jersey.version>


### PR DESCRIPTION
### Motivation

Netty 4.1.116.Final contains relevant bug fixes.
  * [Netty 4.1.116.Final release notes](https://netty.io/news/2024/12/17/4-1-116-Final.html)
  * There have been some reports of https://github.com/netty/netty/issues/14479 with Pulsar 4.0.1 / 3.3.3 release.
    * This is fixed with https://github.com/netty/netty/pull/14480
 
Keep the optional Netty io_uring library up-to-date.
  * [io_uring 0.0.26.Final release notes](https://netty.io/news/2024/12/27/io_uring_0-0-26-Final.html)
  * [io_uring 0.0.25.Final release notes](https://netty.io/news/2024/02/19/io_uring_0-0-25-Final.html)

### Modifications

- Upgrade Netty to 4.1.116.Final
- Upgrade Netty io_uring to 0.0.26.Final

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->