### PR TITLE
[fix] [bk] Add configuration parameters related to the maximum compaction duration to the bookkeeper.conf

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -552,6 +552,9 @@ minorCompactionThreshold=0.2
 # Note: should be greater than gcWaitTime.
 minorCompactionInterval=3600
 
+# Maximum milliseconds to run minor Compaction. Defaults to -1 run indefinitely.
+minorCompactionMaxTimeMillis=-1
+
 # Set the maximum number of entries which can be compacted without flushing.
 # When compacting, the entries are written to the entrylog and the new offsets
 # are cached in memory. Once the entrylog is flushed the index is updated with
@@ -574,6 +577,9 @@ majorCompactionThreshold=0.5
 # If it is set to less than zero, the major compaction is disabled.
 # Note: should be greater than gcWaitTime.
 majorCompactionInterval=86400
+
+# Maximum milliseconds to run major Compaction. Defaults to -1 run indefinitely.
+majorCompactionMaxTimeMillis=-1
 
 # Throttle compaction by bytes or by entries.
 isThrottleByBytes=false


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->

Fixes #23818


### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
`bookkeeper.conf` is missing parameters related to maximum compaction duration in apache/pulsar. These parameters are useful for managing bookkeeper compaction in heavy workloads.

### Modifications

<!-- Describe the modifications you've done. -->
Added `majorCompactionMaxTimeMillis` and `minorCompactionMaxTimeMillis` to `conf/bookkeeper.conf` so that they can be updated from env variables in pulsar docker containers.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
https://github.com/cognitree/pulsar/pull/18
<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
