### PR TITLE
[fix][fn] change async function time get

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaExecutionResult.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaExecutionResult.java
@@ -29,6 +29,7 @@ import lombok.Data;
 public class JavaExecutionResult {
     private Throwable userException;
     private Object result;
+    private final long startTime = System.nanoTime();
 
     public void reset() {
         setUserException(null);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
@@ -188,7 +188,7 @@ public class JavaInstance implements AutoCloseable {
             pendingAsyncRequests.remove(asyncResult);
 
             JavaExecutionResult execResult = asyncResult.getResult();
-
+            execResult.setResult(asyncResult.getProcessResult().get());
             resultConsumer.accept(asyncResult.getRecord(), execResult);
 
             // peek the next result

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
@@ -188,9 +188,13 @@ public class JavaInstance implements AutoCloseable {
             pendingAsyncRequests.remove(asyncResult);
 
             JavaExecutionResult execResult = asyncResult.getResult();
-            execResult.setResult(asyncResult.getProcessResult().get());
+            try {
+                Object result = asyncResult.getProcessResult().get();
+                execResult.setResult(result);
+            } catch (ExecutionException e) {
+                execResult.setUserException(FutureUtil.unwrapCompletionException(e));
+            }
             resultConsumer.accept(asyncResult.getRecord(), execResult);
-
             // peek the next result
             asyncResult = pendingAsyncRequests.peek();
         }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
@@ -47,6 +47,7 @@ public class JavaInstance implements AutoCloseable {
     public static class AsyncFuncRequest {
         private final Record record;
         private final CompletableFuture processResult;
+        private final JavaExecutionResult result;
     }
 
     @Getter(AccessLevel.PACKAGE)
@@ -136,7 +137,7 @@ public class JavaInstance implements AutoCloseable {
                 if (asyncPreserveInputOrderForOutputMessages) {
                     // Function is in format: Function<I, CompletableFuture<O>>
                     AsyncFuncRequest request = new AsyncFuncRequest(
-                            record, (CompletableFuture) output
+                            record, (CompletableFuture) output, executionResult
                     );
                     pendingAsyncRequests.put(request);
                 } else {
@@ -187,13 +188,7 @@ public class JavaInstance implements AutoCloseable {
         while (asyncResult != null && asyncResult.getProcessResult().isDone()) {
             pendingAsyncRequests.remove(asyncResult);
 
-            JavaExecutionResult execResult = new JavaExecutionResult();
-            try {
-                Object result = asyncResult.getProcessResult().get();
-                execResult.setResult(result);
-            } catch (ExecutionException e) {
-                execResult.setUserException(FutureUtil.unwrapCompletionException(e));
-            }
+            JavaExecutionResult execResult = asyncResult.getResult();
 
             resultConsumer.accept(asyncResult.getRecord(), execResult);
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
@@ -149,13 +149,12 @@ public class JavaInstance implements AutoCloseable {
                             processAsyncResultsInInputOrder(asyncResultConsumer);
                         } else {
                             try {
-                                JavaExecutionResult execResult = new JavaExecutionResult();
                                 if (cause != null) {
-                                    execResult.setUserException(FutureUtil.unwrapCompletionException(cause));
+                                    executionResult.setUserException(FutureUtil.unwrapCompletionException(cause));
                                 } else {
-                                    execResult.setResult(res);
+                                    executionResult.setResult(res);
                                 }
-                                asyncResultConsumer.accept(record, execResult);
+                                asyncResultConsumer.accept(record, executionResult);
                             } finally {
                                 asyncRequestsConcurrencyLimiter.release();
                             }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -443,6 +443,8 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
             // increment total successfully processed
             stats.incrTotalProcessedSuccessfully();
         }
+        // handle endTime here
+        stats.processTimeEnd(result.getStartTime());
     }
 
     private void sendOutputMessage(Record srcRecord, Object output) throws Exception {

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -189,8 +189,8 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         this.secretsProvider = secretsProvider;
         this.componentClassLoader = componentClassLoader;
         this.functionClassLoader = transformFunctionClassLoader != null
-            ? transformFunctionClassLoader
-            : componentClassLoader;
+                ? transformFunctionClassLoader
+                : componentClassLoader;
         this.metricsLabels = new String[]{
                 instanceConfig.getFunctionDetails().getTenant(),
                 String.format("%s/%s", instanceConfig.getFunctionDetails().getTenant(),
@@ -235,7 +235,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         ThreadContext.put("instance", instanceConfig.getInstanceName());
 
         log.info("Starting Java Instance {} : \n Details = {}",
-            instanceConfig.getFunctionDetails().getName(), instanceConfig.getFunctionDetails());
+                instanceConfig.getFunctionDetails().getName(), instanceConfig.getFunctionDetails());
 
         Object object;
         if (instanceConfig.getFunctionDetails().getClassName()
@@ -293,8 +293,8 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         try {
             Thread.currentThread().setContextClassLoader(functionClassLoader);
             return new ContextImpl(instanceConfig, instanceLog, client, secretsProvider,
-                collectorRegistry, metricsLabels, this.componentType, this.stats, stateManager,
-                pulsarAdmin, clientBuilder, fatalHandler, producerCache);
+                    collectorRegistry, metricsLabels, this.componentType, this.stats, stateManager,
+                    pulsarAdmin, clientBuilder, fatalHandler, producerCache);
         } finally {
             Thread.currentThread().setContextClassLoader(clsLoader);
         }
@@ -334,8 +334,6 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                 // set last invocation time
                 stats.setLastInvocation(System.currentTimeMillis());
 
-                // start time for process latency stat
-                stats.processTimeStart();
 
                 // process the message
                 Thread.currentThread().setContextClassLoader(functionClassLoader);
@@ -401,9 +399,9 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
             stateStoreProvider.init(stateStoreProviderConfig);
 
             StateStore store = stateStoreProvider.getStateStore(
-                instanceConfig.getFunctionDetails().getTenant(),
-                instanceConfig.getFunctionDetails().getNamespace(),
-                instanceConfig.getFunctionDetails().getName()
+                    instanceConfig.getFunctionDetails().getTenant(),
+                    instanceConfig.getFunctionDetails().getNamespace(),
+                    instanceConfig.getFunctionDetails().getName()
             );
             StateStoreContext context = new StateStoreContextImpl();
             store.init(context);
@@ -513,7 +511,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         if (isKeyValueSeparated && schema instanceof KeyValueSchema) {
             KeyValueSchema<?, ?> kvSchema = (KeyValueSchema<?, ?>) schema;
             finalSchema = KeyValueSchemaImpl.of(kvSchema.getKeySchema(), kvSchema.getValueSchema(),
-                KeyValueEncodingType.SEPARATED);
+                    KeyValueEncodingType.SEPARATED);
         } else {
             finalSchema = schema;
         }
@@ -548,7 +546,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
 
     /**
      * NOTE: this method is be synchronized because it is potentially called by two different places
-     *       one inside the run/finally clause and one inside the ThreadRuntime::stop.
+     * one inside the run/finally clause and one inside the ThreadRuntime::stop.
      */
     @Override
     public synchronized void close() {
@@ -678,8 +676,8 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
     }
 
     private void internalResetMetrics() {
-            stats.reset();
-            javaInstance.resetMetrics();
+        stats.reset();
+        javaInstance.resetMetrics();
     }
 
     private Builder createMetricsDataBuilder() {
@@ -834,7 +832,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
             );
 
             pulsarSourceConfig.setSkipToLatest(
-                sourceSpec.getSkipToLatest()
+                    sourceSpec.getSkipToLatest()
             );
 
             Objects.requireNonNull(contextImpl.getSubscriptionType());
@@ -874,12 +872,12 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
             // check if source is a batch source
             if (sourceSpec.getClassName().equals(BatchSourceExecutor.class.getName())) {
                 object = Reflections.createInstance(
-                  sourceSpec.getClassName(),
-                  this.instanceClassLoader);
+                        sourceSpec.getClassName(),
+                        this.instanceClassLoader);
             } else {
                 object = Reflections.createInstance(
-                  sourceSpec.getClassName(),
-                  this.componentClassLoader);
+                        sourceSpec.getClassName(),
+                        this.componentClassLoader);
             }
         }
 
@@ -911,8 +909,9 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
     /**
      * Recursively interpolate configured secrets into the config map by calling
      * {@link SecretsProvider#interpolateSecretForValue(String)}.
+     *
      * @param secretsProvider - the secrets provider that will convert secret's values into config values.
-     * @param configs - the connector configuration map, which will be mutated.
+     * @param configs         - the connector configuration map, which will be mutated.
      */
     private static void interpolateSecretsIntoConfigs(SecretsProvider secretsProvider,
                                                       Map<String, Object> configs) {
@@ -939,12 +938,13 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                                                                SecretsProvider secretsProvider,
                                                                ClassLoader componentClassLoader,
                                                                org.apache.pulsar.functions.proto.Function
-                                                            .FunctionDetails.ComponentType componentType)
+                                                                       .FunctionDetails.ComponentType componentType)
             throws IOException {
         final Map<String, Object> config = connectorConfigs.isEmpty() ? new HashMap<>() : ObjectMapperFactory
                 .getMapper()
                 .reader()
-                .forType(new TypeReference<Map<String, Object>>() {})
+                .forType(new TypeReference<Map<String, Object>>() {
+                })
                 .readValue(connectorConfigs);
         if (componentType != org.apache.pulsar.functions.proto.Function.FunctionDetails.ComponentType.SINK
                 && componentType != org.apache.pulsar.functions.proto.Function.FunctionDetails.ComponentType.SOURCE) {
@@ -959,7 +959,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                 configClassName = ConnectorUtils
                         .getConnectorDefinition((NarClassLoader) componentClassLoader).getSourceConfigClass();
             } else {
-                configClassName =  ConnectorUtils
+                configClassName = ConnectorUtils
                         .getConnectorDefinition((NarClassLoader) componentClassLoader).getSinkConfigClass();
             }
             if (configClassName != null) {
@@ -1105,7 +1105,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
 
             case AVRO:
                 return AvroSchema.of(SchemaDefinition.<T>builder()
-                    .withPojo(clazz).build());
+                        .withPojo(clazz).build());
 
             case JSON:
                 return JSONSchema.of(SchemaDefinition.<T>builder().withPojo(clazz).build());
@@ -1131,8 +1131,8 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         if (GenericObject.class.isAssignableFrom(clazz)) {
             return SchemaType.AUTO_CONSUME;
         } else if (byte[].class.equals(clazz)
-            || ByteBuf.class.equals(clazz)
-            || ByteBuffer.class.equals(clazz)) {
+                || ByteBuf.class.equals(clazz)
+                || ByteBuffer.class.equals(clazz)) {
             // if sink uses bytes, we should ignore
             return SchemaType.NONE;
         } else {
@@ -1151,8 +1151,8 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
 
     private static SchemaType getDefaultSchemaType(Class<?> clazz) {
         if (byte[].class.equals(clazz)
-            || ByteBuf.class.equals(clazz)
-            || ByteBuffer.class.equals(clazz)) {
+                || ByteBuf.class.equals(clazz)
+                || ByteBuffer.class.equals(clazz)) {
             return SchemaType.NONE;
         } else if (GenericObject.class.isAssignableFrom(clazz)) {
             // the sink is taking generic record/object, so we do auto schema detection

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -344,9 +344,6 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                         asyncErrorHandler);
                 Thread.currentThread().setContextClassLoader(instanceClassLoader);
 
-                // register end time
-                stats.processTimeEnd();
-
                 if (result != null) {
                     // process the synchronous results
                     handleResult(currentRecord, result);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/ComponentStatsManager.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/ComponentStatsManager.java
@@ -101,7 +101,7 @@ public abstract class ComponentStatsManager implements AutoCloseable {
     public abstract void setLastInvocation(long ts);
 
 
-    public abstract void processTimeEnd();
+    public abstract void processTimeEnd(long startTime);
 
     public abstract double getTotalProcessedSuccessfully();
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/ComponentStatsManager.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/ComponentStatsManager.java
@@ -53,9 +53,9 @@ public abstract class ComponentStatsManager implements AutoCloseable {
     }
 
     public static ComponentStatsManager getStatsManager(FunctionCollectorRegistry collectorRegistry,
-                                  String[] metricsLabels,
-                                  ScheduledExecutorService scheduledExecutorService,
-                                  Function.FunctionDetails.ComponentType componentType) {
+                                                        String[] metricsLabels,
+                                                        ScheduledExecutorService scheduledExecutorService,
+                                                        Function.FunctionDetails.ComponentType componentType) {
         switch (componentType) {
             case FUNCTION:
                 return new FunctionStatsManager(collectorRegistry, metricsLabels, scheduledExecutorService);
@@ -100,7 +100,6 @@ public abstract class ComponentStatsManager implements AutoCloseable {
 
     public abstract void setLastInvocation(long ts);
 
-    public abstract void processTimeStart();
 
     public abstract void processTimeEnd();
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/FunctionStatsManager.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/FunctionStatsManager.java
@@ -336,20 +336,15 @@ public class FunctionStatsManager extends ComponentStatsManager {
         statlastInvocationChild.set(ts);
     }
 
-    private Long processTimeStart;
 
-    @Override
-    public void processTimeStart() {
-        processTimeStart = System.nanoTime();
-    }
 
     @Override
     public void processTimeEnd() {
-        if (processTimeStart != null) {
-            double endTimeMs = ((double) System.nanoTime() - processTimeStart) / 1.0E6D;
-            statProcessLatencyChild.observe(endTimeMs);
-            statProcessLatency1minChild.observe(endTimeMs);
-        }
+//        if (processTimeStart != null) {
+//            double endTimeMs = ((double) System.nanoTime() - processTimeStart) / 1.0E6D;
+//            statProcessLatencyChild.observe(endTimeMs);
+//            statProcessLatency1minChild.observe(endTimeMs);
+//        }
     }
 
     @Override

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/FunctionStatsManager.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/FunctionStatsManager.java
@@ -339,12 +339,10 @@ public class FunctionStatsManager extends ComponentStatsManager {
 
 
     @Override
-    public void processTimeEnd() {
-//        if (processTimeStart != null) {
-//            double endTimeMs = ((double) System.nanoTime() - processTimeStart) / 1.0E6D;
-//            statProcessLatencyChild.observe(endTimeMs);
-//            statProcessLatency1minChild.observe(endTimeMs);
-//        }
+    public void processTimeEnd(long startTime) {
+            double endTimeMs = ((double) System.nanoTime() - startTime) / 1.0E6D;
+            statProcessLatencyChild.observe(endTimeMs);
+            statProcessLatency1minChild.observe(endTimeMs);
     }
 
     @Override

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/SinkStatsManager.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/SinkStatsManager.java
@@ -31,7 +31,9 @@ public class SinkStatsManager extends ComponentStatsManager {
 
     public static final String PULSAR_SINK_METRICS_PREFIX = "pulsar_sink_";
 
-    /** Declare metric names. **/
+    /**
+     * Declare metric names.
+     **/
     public static final String SYSTEM_EXCEPTIONS_TOTAL = "system_exceptions_total";
     public static final String SINK_EXCEPTIONS_TOTAL = "sink_exceptions_total";
     public static final String LAST_INVOCATION = "last_invocation";
@@ -43,7 +45,9 @@ public class SinkStatsManager extends ComponentStatsManager {
     public static final String RECEIVED_TOTAL_1min = "received_1min";
     public static final String WRITTEN_TOTAL_1min = "written_1min";
 
-    /** Declare Prometheus stats. **/
+    /**
+     * Declare Prometheus stats.
+     **/
 
     private final Counter statTotalRecordsReceived;
 
@@ -101,99 +105,99 @@ public class SinkStatsManager extends ComponentStatsManager {
         statTotalRecordsReceived = collectorRegistry.registerIfNotExist(
                 PULSAR_SINK_METRICS_PREFIX + RECEIVED_TOTAL,
                 Counter.build()
-                .name(PULSAR_SINK_METRICS_PREFIX + RECEIVED_TOTAL)
-                .help("Total number of records sink has received from Pulsar topic(s).")
-                .labelNames(METRICS_LABEL_NAMES)
-                .create());
+                        .name(PULSAR_SINK_METRICS_PREFIX + RECEIVED_TOTAL)
+                        .help("Total number of records sink has received from Pulsar topic(s).")
+                        .labelNames(METRICS_LABEL_NAMES)
+                        .create());
         statTotalRecordsReceivedChild = statTotalRecordsReceived.labels(metricsLabels);
 
         statTotalSysExceptions = collectorRegistry.registerIfNotExist(
                 PULSAR_SINK_METRICS_PREFIX + SYSTEM_EXCEPTIONS_TOTAL,
                 Counter.build()
-                .name(PULSAR_SINK_METRICS_PREFIX + SYSTEM_EXCEPTIONS_TOTAL)
-                .help("Total number of system exceptions.")
-                .labelNames(METRICS_LABEL_NAMES)
-                .create());
+                        .name(PULSAR_SINK_METRICS_PREFIX + SYSTEM_EXCEPTIONS_TOTAL)
+                        .help("Total number of system exceptions.")
+                        .labelNames(METRICS_LABEL_NAMES)
+                        .create());
         statTotalSysExceptionsChild = statTotalSysExceptions.labels(metricsLabels);
 
         statTotalSinkExceptions = collectorRegistry.registerIfNotExist(
                 PULSAR_SINK_METRICS_PREFIX + SINK_EXCEPTIONS_TOTAL,
                 Counter.build()
-                .name(PULSAR_SINK_METRICS_PREFIX + SINK_EXCEPTIONS_TOTAL)
-                .help("Total number of sink exceptions.")
-                .labelNames(METRICS_LABEL_NAMES)
-                .create());
+                        .name(PULSAR_SINK_METRICS_PREFIX + SINK_EXCEPTIONS_TOTAL)
+                        .help("Total number of sink exceptions.")
+                        .labelNames(METRICS_LABEL_NAMES)
+                        .create());
         statTotalSinkExceptionsChild = statTotalSinkExceptions.labels(metricsLabels);
 
         statTotalWritten = collectorRegistry.registerIfNotExist(
                 PULSAR_SINK_METRICS_PREFIX + WRITTEN_TOTAL,
                 Counter.build()
-                .name(PULSAR_SINK_METRICS_PREFIX + WRITTEN_TOTAL)
-                .help("Total number of records processed by sink.")
-                .labelNames(METRICS_LABEL_NAMES)
-                .create());
+                        .name(PULSAR_SINK_METRICS_PREFIX + WRITTEN_TOTAL)
+                        .help("Total number of records processed by sink.")
+                        .labelNames(METRICS_LABEL_NAMES)
+                        .create());
         statTotalWrittenChild = statTotalWritten.labels(metricsLabels);
 
         statlastInvocation = collectorRegistry.registerIfNotExist(
                 PULSAR_SINK_METRICS_PREFIX + LAST_INVOCATION,
                 Gauge.build()
-                .name(PULSAR_SINK_METRICS_PREFIX + LAST_INVOCATION)
-                .help("The timestamp of the last invocation of the sink.")
-                .labelNames(METRICS_LABEL_NAMES)
-                .create());
+                        .name(PULSAR_SINK_METRICS_PREFIX + LAST_INVOCATION)
+                        .help("The timestamp of the last invocation of the sink.")
+                        .labelNames(METRICS_LABEL_NAMES)
+                        .create());
         statlastInvocationChild = statlastInvocation.labels(metricsLabels);
 
         statTotalRecordsReceived1min = collectorRegistry.registerIfNotExist(
                 PULSAR_SINK_METRICS_PREFIX + RECEIVED_TOTAL_1min,
                 Counter.build()
-                .name(PULSAR_SINK_METRICS_PREFIX + RECEIVED_TOTAL_1min)
-                .help("Total number of messages sink has received from Pulsar topic(s) in the last 1 minute.")
-                .labelNames(METRICS_LABEL_NAMES)
-                .create());
+                        .name(PULSAR_SINK_METRICS_PREFIX + RECEIVED_TOTAL_1min)
+                        .help("Total number of messages sink has received from Pulsar topic(s) in the last 1 minute.")
+                        .labelNames(METRICS_LABEL_NAMES)
+                        .create());
         statTotalRecordsReceivedChild1min = statTotalRecordsReceived1min.labels(metricsLabels);
 
         statTotalSysExceptions1min = collectorRegistry.registerIfNotExist(
                 PULSAR_SINK_METRICS_PREFIX + SYSTEM_EXCEPTIONS_TOTAL_1min,
                 Counter.build()
-                .name(PULSAR_SINK_METRICS_PREFIX + SYSTEM_EXCEPTIONS_TOTAL_1min)
-                .help("Total number of system exceptions in the last 1 minute.")
-                .labelNames(METRICS_LABEL_NAMES)
-                .create());
+                        .name(PULSAR_SINK_METRICS_PREFIX + SYSTEM_EXCEPTIONS_TOTAL_1min)
+                        .help("Total number of system exceptions in the last 1 minute.")
+                        .labelNames(METRICS_LABEL_NAMES)
+                        .create());
         statTotalSysExceptions1minChild = statTotalSysExceptions1min.labels(metricsLabels);
 
         statTotalSinkExceptions1min = collectorRegistry.registerIfNotExist(
                 PULSAR_SINK_METRICS_PREFIX + SINK_EXCEPTIONS_TOTAL_1min,
                 Counter.build()
-                .name(PULSAR_SINK_METRICS_PREFIX + SINK_EXCEPTIONS_TOTAL_1min)
-                .help("Total number of sink exceptions in the last 1 minute.")
-                .labelNames(METRICS_LABEL_NAMES)
-                .create());
+                        .name(PULSAR_SINK_METRICS_PREFIX + SINK_EXCEPTIONS_TOTAL_1min)
+                        .help("Total number of sink exceptions in the last 1 minute.")
+                        .labelNames(METRICS_LABEL_NAMES)
+                        .create());
         statTotalSinkExceptionsChild1min = statTotalSinkExceptions1min.labels(metricsLabels);
 
         statTotalWritten1min = collectorRegistry.registerIfNotExist(
                 PULSAR_SINK_METRICS_PREFIX + WRITTEN_TOTAL_1min,
                 Counter.build()
-                .name(PULSAR_SINK_METRICS_PREFIX + WRITTEN_TOTAL_1min)
-                .help("Total number of records processed by sink the last 1 minute.")
-                .labelNames(METRICS_LABEL_NAMES)
-                .create());
+                        .name(PULSAR_SINK_METRICS_PREFIX + WRITTEN_TOTAL_1min)
+                        .help("Total number of records processed by sink the last 1 minute.")
+                        .labelNames(METRICS_LABEL_NAMES)
+                        .create());
         statTotalWrittenChild1min = statTotalWritten1min.labels(metricsLabels);
 
         sysExceptions = collectorRegistry.registerIfNotExist(
                 PULSAR_SINK_METRICS_PREFIX + "system_exception",
                 Gauge.build()
-                .name(PULSAR_SINK_METRICS_PREFIX + "system_exception")
-                .labelNames(EXCEPTION_METRICS_LABEL_NAMES)
-                .help("Exception from system code.")
-                .create());
+                        .name(PULSAR_SINK_METRICS_PREFIX + "system_exception")
+                        .labelNames(EXCEPTION_METRICS_LABEL_NAMES)
+                        .help("Exception from system code.")
+                        .create());
 
         sinkExceptions = collectorRegistry.registerIfNotExist(
                 PULSAR_SINK_METRICS_PREFIX + "sink_exception",
                 Gauge.build()
-                .name(PULSAR_SINK_METRICS_PREFIX + "sink_exception")
-                .labelNames(EXCEPTION_METRICS_LABEL_NAMES)
-                .help("Exception from sink.")
-                .create());
+                        .name(PULSAR_SINK_METRICS_PREFIX + "sink_exception")
+                        .labelNames(EXCEPTION_METRICS_LABEL_NAMES)
+                        .help("Exception from sink.")
+                        .create());
 
         sysExceptionRateLimiter = RateLimiter.create(5.0d / 60.0d);
         sinkExceptionRateLimiter = RateLimiter.create(5.0d / 60.0d);
@@ -279,10 +283,6 @@ public class SinkStatsManager extends ComponentStatsManager {
         statlastInvocationChild.set(ts);
     }
 
-    @Override
-    public void processTimeStart() {
-        //no-op
-    }
 
     @Override
     public void processTimeEnd() {

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/SinkStatsManager.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/SinkStatsManager.java
@@ -285,7 +285,7 @@ public class SinkStatsManager extends ComponentStatsManager {
 
 
     @Override
-    public void processTimeEnd() {
+    public void processTimeEnd(long startTime) {
         //no-op
     }
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/SourceStatsManager.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/SourceStatsManager.java
@@ -285,7 +285,7 @@ public class SourceStatsManager extends ComponentStatsManager {
 
 
     @Override
-    public void processTimeEnd() {
+    public void processTimeEnd(long startTime) {
         //no-op
     }
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/SourceStatsManager.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/SourceStatsManager.java
@@ -31,7 +31,9 @@ public class SourceStatsManager extends ComponentStatsManager {
 
     public static final String PULSAR_SOURCE_METRICS_PREFIX = "pulsar_source_";
 
-    /** Declare metric names. **/
+    /**
+     * Declare metric names.
+     **/
     public static final String SYSTEM_EXCEPTIONS_TOTAL = "system_exceptions_total";
     public static final String SOURCE_EXCEPTIONS_TOTAL = "source_exceptions_total";
     public static final String LAST_INVOCATION = "last_invocation";
@@ -43,7 +45,9 @@ public class SourceStatsManager extends ComponentStatsManager {
     public static final String RECEIVED_TOTAL_1min = "received_1min";
     public static final String WRITTEN_TOTAL_1min = "written_1min";
 
-    /** Declare Prometheus stats. **/
+    /**
+     * Declare Prometheus stats.
+     **/
 
     private final Counter statTotalRecordsReceived;
 
@@ -101,99 +105,99 @@ public class SourceStatsManager extends ComponentStatsManager {
         statTotalRecordsReceived = collectorRegistry.registerIfNotExist(
                 PULSAR_SOURCE_METRICS_PREFIX + RECEIVED_TOTAL,
                 Counter.build()
-                .name(PULSAR_SOURCE_METRICS_PREFIX + RECEIVED_TOTAL)
-                .help("Total number of records received from source.")
-                .labelNames(METRICS_LABEL_NAMES)
-                .create());
+                        .name(PULSAR_SOURCE_METRICS_PREFIX + RECEIVED_TOTAL)
+                        .help("Total number of records received from source.")
+                        .labelNames(METRICS_LABEL_NAMES)
+                        .create());
         statTotalRecordsReceivedChild = statTotalRecordsReceived.labels(metricsLabels);
 
         statTotalSysExceptions = collectorRegistry.registerIfNotExist(
                 PULSAR_SOURCE_METRICS_PREFIX + SYSTEM_EXCEPTIONS_TOTAL,
                 Counter.build()
-                .name(PULSAR_SOURCE_METRICS_PREFIX + SYSTEM_EXCEPTIONS_TOTAL)
-                .help("Total number of system exceptions.")
-                .labelNames(METRICS_LABEL_NAMES)
-                .create());
+                        .name(PULSAR_SOURCE_METRICS_PREFIX + SYSTEM_EXCEPTIONS_TOTAL)
+                        .help("Total number of system exceptions.")
+                        .labelNames(METRICS_LABEL_NAMES)
+                        .create());
         statTotalSysExceptionsChild = statTotalSysExceptions.labels(metricsLabels);
 
         statTotalSourceExceptions = collectorRegistry.registerIfNotExist(
                 PULSAR_SOURCE_METRICS_PREFIX + SOURCE_EXCEPTIONS_TOTAL,
                 Counter.build()
-                .name(PULSAR_SOURCE_METRICS_PREFIX + SOURCE_EXCEPTIONS_TOTAL)
-                .help("Total number of source exceptions.")
-                .labelNames(METRICS_LABEL_NAMES)
-                .create());
+                        .name(PULSAR_SOURCE_METRICS_PREFIX + SOURCE_EXCEPTIONS_TOTAL)
+                        .help("Total number of source exceptions.")
+                        .labelNames(METRICS_LABEL_NAMES)
+                        .create());
         statTotalSourceExceptionsChild = statTotalSourceExceptions.labels(metricsLabels);
 
         statTotalWritten = collectorRegistry.registerIfNotExist(
                 PULSAR_SOURCE_METRICS_PREFIX + WRITTEN_TOTAL,
                 Counter.build()
-                .name(PULSAR_SOURCE_METRICS_PREFIX + WRITTEN_TOTAL)
-                .help("Total number of records written to a Pulsar topic.")
-                .labelNames(METRICS_LABEL_NAMES)
-                .create());
+                        .name(PULSAR_SOURCE_METRICS_PREFIX + WRITTEN_TOTAL)
+                        .help("Total number of records written to a Pulsar topic.")
+                        .labelNames(METRICS_LABEL_NAMES)
+                        .create());
         statTotalWrittenChild = statTotalWritten.labels(metricsLabels);
 
         statlastInvocation = collectorRegistry.registerIfNotExist(
                 PULSAR_SOURCE_METRICS_PREFIX + LAST_INVOCATION,
                 Gauge.build()
-                .name(PULSAR_SOURCE_METRICS_PREFIX + LAST_INVOCATION)
-                .help("The timestamp of the last invocation of the source.")
-                .labelNames(METRICS_LABEL_NAMES)
-                .create());
+                        .name(PULSAR_SOURCE_METRICS_PREFIX + LAST_INVOCATION)
+                        .help("The timestamp of the last invocation of the source.")
+                        .labelNames(METRICS_LABEL_NAMES)
+                        .create());
         statlastInvocationChild = statlastInvocation.labels(metricsLabels);
 
         statTotalRecordsReceived1min = collectorRegistry.registerIfNotExist(
                 PULSAR_SOURCE_METRICS_PREFIX + RECEIVED_TOTAL_1min,
                 Counter.build()
-                .name(PULSAR_SOURCE_METRICS_PREFIX + RECEIVED_TOTAL_1min)
-                .help("Total number of records received from source in the last 1 minute.")
-                .labelNames(METRICS_LABEL_NAMES)
-                .create());
+                        .name(PULSAR_SOURCE_METRICS_PREFIX + RECEIVED_TOTAL_1min)
+                        .help("Total number of records received from source in the last 1 minute.")
+                        .labelNames(METRICS_LABEL_NAMES)
+                        .create());
         statTotalRecordsReceivedChild1min = statTotalRecordsReceived1min.labels(metricsLabels);
 
         statTotalSysExceptions1min = collectorRegistry.registerIfNotExist(
                 PULSAR_SOURCE_METRICS_PREFIX + SYSTEM_EXCEPTIONS_TOTAL_1min,
                 Counter.build()
-                .name(PULSAR_SOURCE_METRICS_PREFIX + SYSTEM_EXCEPTIONS_TOTAL_1min)
-                .help("Total number of system exceptions in the last 1 minute.")
-                .labelNames(METRICS_LABEL_NAMES)
-                .create());
+                        .name(PULSAR_SOURCE_METRICS_PREFIX + SYSTEM_EXCEPTIONS_TOTAL_1min)
+                        .help("Total number of system exceptions in the last 1 minute.")
+                        .labelNames(METRICS_LABEL_NAMES)
+                        .create());
         statTotalSysExceptions1minChild = statTotalSysExceptions1min.labels(metricsLabels);
 
         statTotalSourceExceptions1min = collectorRegistry.registerIfNotExist(
                 PULSAR_SOURCE_METRICS_PREFIX + SOURCE_EXCEPTIONS_TOTAL_1min,
                 Counter.build()
-                .name(PULSAR_SOURCE_METRICS_PREFIX + SOURCE_EXCEPTIONS_TOTAL_1min)
-                .help("Total number of source exceptions in the last 1 minute.")
-                .labelNames(METRICS_LABEL_NAMES)
-                .create());
+                        .name(PULSAR_SOURCE_METRICS_PREFIX + SOURCE_EXCEPTIONS_TOTAL_1min)
+                        .help("Total number of source exceptions in the last 1 minute.")
+                        .labelNames(METRICS_LABEL_NAMES)
+                        .create());
         statTotalSourceExceptionsChild1min = statTotalSourceExceptions1min.labels(metricsLabels);
 
         statTotalWritten1min = collectorRegistry.registerIfNotExist(
                 PULSAR_SOURCE_METRICS_PREFIX + WRITTEN_TOTAL_1min,
                 Counter.build()
-                .name(PULSAR_SOURCE_METRICS_PREFIX + WRITTEN_TOTAL_1min)
-                .help("Total number of records written to a Pulsar topic in the last 1 minute.")
-                .labelNames(METRICS_LABEL_NAMES)
-                .create());
+                        .name(PULSAR_SOURCE_METRICS_PREFIX + WRITTEN_TOTAL_1min)
+                        .help("Total number of records written to a Pulsar topic in the last 1 minute.")
+                        .labelNames(METRICS_LABEL_NAMES)
+                        .create());
         statTotalWrittenChild1min = statTotalWritten1min.labels(metricsLabels);
 
         sysExceptions = collectorRegistry.registerIfNotExist(
                 PULSAR_SOURCE_METRICS_PREFIX + "system_exception",
                 Gauge.build()
-                .name(PULSAR_SOURCE_METRICS_PREFIX + "system_exception")
-                .labelNames(EXCEPTION_METRICS_LABEL_NAMES)
-                .help("Exception from system code.")
-                .create());
+                        .name(PULSAR_SOURCE_METRICS_PREFIX + "system_exception")
+                        .labelNames(EXCEPTION_METRICS_LABEL_NAMES)
+                        .help("Exception from system code.")
+                        .create());
 
         sourceExceptions = collectorRegistry.registerIfNotExist(
                 PULSAR_SOURCE_METRICS_PREFIX + "source_exception",
                 Gauge.build()
-                .name(PULSAR_SOURCE_METRICS_PREFIX + "source_exception")
-                .labelNames(EXCEPTION_METRICS_LABEL_NAMES)
-                .help("Exception from source.")
-                .create());
+                        .name(PULSAR_SOURCE_METRICS_PREFIX + "source_exception")
+                        .labelNames(EXCEPTION_METRICS_LABEL_NAMES)
+                        .help("Exception from source.")
+                        .create());
 
         sysExceptionRateLimiter = RateLimiter.create(5.0d / 60.0d);
         sourceExceptionRateLimiter = RateLimiter.create(5.0d / 60.0d);
@@ -279,10 +283,6 @@ public class SourceStatsManager extends ComponentStatsManager {
         statlastInvocationChild.set(ts);
     }
 
-    @Override
-    public void processTimeStart() {
-        //no-op
-    }
 
     @Override
     public void processTimeEnd() {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

see #23811  

<!-- or this PR is one task of an issue -->

Main Issue: see #23705

<!-- If the PR belongs to a PIP, please add the PIP link here -->

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation
In the realm of asynchronous processing, precise timing and performance metrics are essential for effective monitoring and optimization. Apache Pulsar Functions, as a distributed compute platform, relies heavily on asynchronous operations to process and transform data streams. However, the current implementation lacks a robust mechanism for accurately capturing and reporting the execution times of these asynchronous functions.

The primary motivation for this Pull Request is to address the limitations of the existing asynchronous function execution time tracking system. By centralizing the start time recording and improving the consistency of execution time data, we aim to provide users with a more reliable and comprehensive view of function performance.
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications
This Pull Request introduces several modifications to the Apache Pulsar Functions project aimed at improving the accuracy and reliability of asynchronous function execution time statistics. The primary goal is to enhance monitoring and analysis capabilities for function performance. Here’s a breakdown of the key changes:

1. Removal of processTimeStart Method: The processTimeStart method in ComponentStatsManager has been removed. This method was previously used to record the start time of asynchronous function execution. The start time is now recorded in the JavaExecutionResult object, providing a more centralized and consistent approach.

2. Modification of JavaInstanceRunnable: The run method in JavaInstanceRunnable has been updated to reflect the removal of processTimeStart. The stats.processTimeStart() call has been deleted, and the stats.processTimeEnd() method now accepts the start time as a parameter to calculate the total execution time.

3. Update to FunctionStatsManager: The processTimeEnd method in FunctionStatsManager has been modified to remove the processTimeStart member variable and accept the start time as a parameter. This allows for accurate calculation of the function’s execution time.

4. Changes to SinkStatsManager and SourceStatsManager: The processTimeEnd methods in SinkStatsManager and SourceStatsManager have been updated to accept the start time as a parameter. However, since these classes do not record processing time, the method bodies remain empty.

5. Addition of startTime in JavaExecutionResult: The JavaExecutionResult class now includes a startTime member variable to store the start time of asynchronous function execution. This allows for accurate calculation of execution time within the handleResult method of JavaInstanceRunnable.

6. Modification of AsyncFuncRequest: The AsyncFuncRequest class in JavaInstance now includes a result member variable of type JavaExecutionResult. This change ensures that the processAsyncResultsInInputOrder method uses the existing JavaExecutionResult object instead of creating a new one, maintaining consistency and avoiding duplication.

7. Use of Same ExecutionResult in Non-asyncPreserveInputOrder Mode: In scenarios where asyncPreserveInputOrderForOutputMessages is disabled, the same executionResult object is now used to avoid unnecessary object creation and potential issues with result assignment.

8. Fix for Result and Exception Handling: Two patches address potential bugs related to result and exception handling in JavaInstance. The processAsyncResultsInInputOrder method now ensures that the result and userException fields of JavaExecutionResult are properly set, improving the reliability of the execution result.

9. Addition of Test Case: A new test case, testAsyncFunctionTime, has been added to verify the accuracy of asynchronous function execution time recording and calculation. This test ensures that the start time recorded in JavaExecutionResult is within an acceptable range of the actual start time.

<!-- Describe the modifications you've done. -->
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
