### PR TITLE
[improve][fn] Add API endpoint for function-worker for liveness check with configurable flag

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionMetaDataManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionMetaDataManager.java
@@ -81,6 +81,8 @@ public class FunctionMetaDataManager implements AutoCloseable {
     @Getter
     private CompletableFuture<Void> isInitialized = new CompletableFuture<>();
 
+    private boolean isFunctionWorkerAlive = true;
+
     public FunctionMetaDataManager(WorkerConfig workerConfig,
                                    SchedulerManager schedulerManager,
                                    PulsarClient pulsarClient,
@@ -243,6 +245,10 @@ public class FunctionMetaDataManager implements AutoCloseable {
                 needsScheduling = processUpdate(functionMetaData);
             }
         } catch (Exception e) {
+            if (e.getCause() instanceof PulsarClientException.ProducerFencedException) {
+                log.error("Function worker status has been set to false due to ProducerFencedException.");
+                this.isFunctionWorkerAlive = false;
+            }
             log.error("Could not write into Function Metadata topic", e);
             throw new IllegalStateException("Internal Error updating function at the leader", e);
         }
@@ -499,5 +505,9 @@ public class FunctionMetaDataManager implements AutoCloseable {
                 pulsarClient.newReader(), this.workerConfig, lastMessageSeen, this.errorNotifier);
         this.functionMetaDataTopicTailer.start();
         log.info("MetaData Manager Tailer started");
+    }
+
+    public boolean checkLiveliness() {
+        return this.isFunctionWorkerAlive;
     }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/ComponentImpl.java
@@ -1843,4 +1843,10 @@ public abstract class ComponentImpl implements Component<PulsarWorkerService> {
         }
         return null;
     }
+
+    @Override
+    public boolean checkLiveliness() {
+        FunctionMetaDataManager functionMetaDataManager = worker().getFunctionMetaDataManager();
+        return functionMetaDataManager.checkLiveliness();
+    }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionsApiV3Resource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionsApiV3Resource.java
@@ -35,6 +35,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.common.functions.FunctionConfig;
@@ -428,5 +429,25 @@ public class FunctionsApiV3Resource extends FunctionApiResource {
 
         functions().updateFunctionOnWorkerLeader(tenant, namespace, functionName, uploadedInputStream,
                 delete, uri.getRequestUri(), authParams());
+    }
+
+    @GET
+    @Path("/healthz")
+    @ApiOperation(value = "Run a healthCheck against the function worker")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Everything is OK"),
+            @ApiResponse(code = 503, message = "Service not available")
+    })
+    public Response healthCheck() {
+        boolean isAlive = functions().checkLiveliness();
+        if (!isAlive) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity("There is IllegalStateException, Service is not running. Need to restart.")
+                    .build();
+        } else {
+            return Response.status(Response.Status.OK)
+                    .entity("There is no IllegalStateException, Service is running.")
+                    .build();
+        }
     }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/service/api/Component.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/service/api/Component.java
@@ -90,4 +90,6 @@ public interface Component<W extends WorkerService> {
     List<ConnectorDefinition> getListOfConnectors();
 
     void reloadConnectors(AuthenticationParameters authParams);
+
+    boolean checkLiveliness();
 }


### PR DESCRIPTION
### Motivation

This pull request introduces a health check functionality for Kubernetes deployments, specifically adding a liveness probe for the function worker. The liveness probe is crucial for Kubernetes-based applications, enabling automated pod restarts in case of failure. This change ensures that the function worker recovers when a `ProducerFencedException` occurs, which causes the worker to get stuck and not recover.

For instance, when a client makes a request like:

```
curl --location --request PUT 'https://localhost:6651/admin/v3/functions/test/test/test' --header 'Authorization: Bearer <token>' --header '...' --form 'data=@functions-test-1.0.0.jar'
```

For `POST`, `PUT`, and `DELETE` operations, the following error is returned under heavy load:
```json
{"reason":"Internal Error updating function at the leader"}
```

And, when the following error occurs in the function worker currently:

```
ERROR org.apache.pulsar.functions.worker.FunctionMetaDataManager - Could not write into Function Metadata topic │
│ org.apache.pulsar.client.api.PulsarClientException$ProducerFencedException: Producer was fenced
```

The function worker does not recover, leading to an ongoing failure. With this update, the worker will automatically restart with the help of health check with liveliness probe upon encountering this error, ensuring proper recovery and continuity of operations.

### Modifications

This update introduces an API endpoint to perform a liveliness check on the function worker pod. The API returns an HTTP status of `200 (OK)` when the `isLive` flag within `FunctionImpl` is true. If the flag is false, typically after a `ProducerFencedException` occurs, the API will return a status of `503 (Service Unavailable)`.

The Kubernetes deployment configuration has been updated to use this new API endpoint in the liveness probe along with existing `metrics` endpoint, allowing the system to monitor the health and availability of the function worker.

### Verifying this change

- [X] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [ ] `doc-required` 
- [X] `no-need-doc` 
- [ ] `doc` 


