### PR TITLE
[fix][client] Client interceptors close method not called after producer/consumer/reader close

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerInterceptors.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerInterceptors.java
@@ -211,10 +211,10 @@ public class ConsumerInterceptors<T> implements Closeable {
     }
 
     @Override
-    public void close() throws IOException {
-        for (int i = 0, interceptorsSize = interceptors.size(); i < interceptorsSize; i++) {
+    public void close() {
+        for (ConsumerInterceptor<T> interceptor : interceptors) {
             try {
-                interceptors.get(i).close();
+                interceptor.close();
             } catch (Throwable e) {
                 log.error("Fail to close consumer interceptor ", e);
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerInterceptors.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerInterceptors.java
@@ -115,7 +115,7 @@ public class ProducerInterceptors implements Closeable {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         for (ProducerInterceptor interceptor : interceptors) {
             try {
                 interceptor.close();


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

ClientInterceptors close methods (`ProducerInterceptor#close`, `ConsumerInterceptor#close`, `ReaderInterceptor#close`) give interceptor developer a chance to release resources allocated in the interceptor when producer/consumer/reader is closing.

However, the interceptor's close method not get called in the implementation of [PIP-23][pip-23].

### Modifications

Call interceptors close method in the final stage of closing process, add some unit tests to cover user case.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - *Add integration test for ProducerInterceptor with non-partition and partition topic*
  - *Add integration test for ConsumerInterceptor with non-partition and partition topic*
  - *Add integration test for ReaderInterceptor with non-partition and partition topic*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
