### PR TITLE
[fix][misc]: ignore deleted ledger when tear down cluster

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
@@ -230,7 +230,8 @@ public class PulsarClusterMetadataTeardown {
                     case BKException.Code.NoSuchLedgerExistsException:
                     case BKException.Code.NoSuchLedgerExistsOnMetadataServerException:
                     case BKException.Code.NoSuchEntryException:
-                        log.warn("Failed to delete ledger.{}", ledgerId, Throwables.getRootCause(ex));
+                        log.warn("Failed to delete deleted ledger. ledgerId={} errorCode={}",
+                                ledgerId, bkException.getCode());
                         return;
                 }
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
@@ -227,7 +227,6 @@ public class PulsarClusterMetadataTeardown {
                 switch (bkException.getCode()) {
                     case BKException.Code.NoSuchLedgerExistsException:
                     case BKException.Code.NoSuchLedgerExistsOnMetadataServerException:
-                    case BKException.Code.NoSuchEntryException:
                         log.warn("Failed to delete deleted ledger. ledgerId={} errorCode={}",
                                 ledgerId, bkException.getCode());
                         return;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar;
 
-import com.google.common.base.Throwables;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.List;
 import java.util.Optional;
@@ -32,7 +31,6 @@ import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.resources.NamespaceResources;
 import org.apache.pulsar.broker.resources.PulsarResources;
 import org.apache.pulsar.broker.resources.TenantResources;


### PR DESCRIPTION
### Motivation

The current tear-down logic is listing ledgers and then deleting them. So, there's a race condition if some internal logic has deleted the schema ledger, which will cause the down process to fail.

### Modifications

- Ignore deleted ledgers while tear-down.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation
- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs, and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
