### PR TITLE
[fix][broker] Remove blocking calls from internalGetPartitionedStats

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1522,23 +1522,21 @@ public class PersistentTopicsBase extends AdminResource {
                     }
                 }
                 if (perPartition && stats.partitions.isEmpty()) {
-                    try {
-                        boolean pathExists = namespaceResources().getPartitionedTopicResources()
-                                .partitionedTopicExists(topicName);
-                        if (pathExists) {
-                            stats.partitions.put(topicName.toString(), new TopicStatsImpl());
-                        } else {
-                            asyncResponse.resume(
-                                    new RestException(Status.NOT_FOUND,
-                                            "Internal topics have not been generated yet"));
-                            return null;
-                        }
-                    } catch (Exception e) {
-                        asyncResponse.resume(new RestException(e));
-                        return null;
-                    }
+                    namespaceResources().getPartitionedTopicResources()
+                            .partitionedTopicExistsAsync(topicName)
+                            .thenAccept(exists -> {
+                                if (exists) {
+                                    stats.partitions.put(topicName.toString(), new TopicStatsImpl());
+                                    asyncResponse.resume(stats);
+                                } else {
+                                    asyncResponse.resume(
+                                            new RestException(Status.NOT_FOUND,
+                                                    "Internal topics have not been generated yet"));
+                                }
+                            });
+                } else {
+                    asyncResponse.resume(stats);
                 }
-                asyncResponse.resume(stats);
                 return null;
             });
         }).exceptionally(ex -> {


### PR DESCRIPTION
### Motivation

The `metadata-store` thread is blocked in the Pulsar 3.0.x:
```
"metadata-store-11-1" #18 prio=5 os_prio=0 cpu=191.70ms elapsed=92.64s tid=0x00007fe149887e80 nid=0x3f39b waiting on condition  [0x00007fdedd3fd000]
   java.lang.Thread.State: TIMED_WAITING (parking)
	at jdk.internal.misc.Unsafe.park(java.base@17.0.2/Native Method)
	- parking to wait for  <0x00001000270a2020> (a java.util.concurrent.CompletableFuture$Signaller)
	at java.util.concurrent.locks.LockSupport.parkNanos(java.base@17.0.2/LockSupport.java:252)
	at java.util.concurrent.CompletableFuture$Signaller.block(java.base@17.0.2/CompletableFuture.java:1866)
	at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@17.0.2/ForkJoinPool.java:3463)
	at java.util.concurrent.ForkJoinPool.managedBlock(java.base@17.0.2/ForkJoinPool.java:3434)
	at java.util.concurrent.CompletableFuture.timedGet(java.base@17.0.2/CompletableFuture.java:1939)
	at java.util.concurrent.CompletableFuture.get(java.base@17.0.2/CompletableFuture.java:2095)
	at org.apache.pulsar.broker.resources.BaseResources.exists(BaseResources.java:183)
	at org.apache.pulsar.broker.resources.NamespaceResources$PartitionedTopicResources.partitionedTopicExists(NamespaceResources.java:302)
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.lambda$internalGetPartitionedStats$173(PersistentTopicsBase.java:1579)
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase$$Lambda$687/0x0000000801261160.apply(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniHandle(java.base@17.0.2/CompletableFuture.java:934)
	at java.util.concurrent.CompletableFuture.uniHandleStage(java.base@17.0.2/CompletableFuture.java:950)
	at java.util.concurrent.CompletableFuture.handle(java.base@17.0.2/CompletableFuture.java:2340)
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.lambda$internalGetPartitionedStats$174(PersistentTopicsBase.java:1560)
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase$$Lambda$674/0x00000008012561a0.accept(Unknown Source)
```

### Modifications

Remove blocking calls.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->