### PR TITLE
[fix][broker] Fix possible mark delete NPE when batch index ack is enabled

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/AckSetState.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/AckSetState.java
@@ -18,6 +18,8 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
+import javax.annotation.Nullable;
+
 /**
  * Interface to manage the ackSet state attached to a position.
  * Helpers in {@link AckSetStateUtil} to create positions with
@@ -28,7 +30,7 @@ public interface AckSetState {
      * Get the ackSet bitset information encoded as a long array.
      * @return the ackSet
      */
-    long[] getAckSet();
+    @Nullable long[] getAckSet();
 
     /**
      * Set the ackSet bitset information as a long array.

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -19,7 +19,6 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Objects.requireNonNull;
 import static org.apache.bookkeeper.mledger.ManagedLedgerException.getManagedLedgerException;
 import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.DEFAULT_LEDGER_DELETE_BACKOFF_TIME_SEC;
@@ -43,6 +42,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -711,7 +711,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     private void recoverBatchDeletedIndexes (
             List<MLDataFormats.BatchedEntryDeletionIndexInfo> batchDeletedIndexInfoList) {
-        checkNotNull(batchDeletedIndexes);
+        Objects.requireNonNull(batchDeletedIndexes);
         lock.writeLock().lock();
         try {
             this.batchDeletedIndexes.clear();
@@ -3844,7 +3844,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             lock.readLock().unlock();
         }
         if (batchDeletedIndexes != null) {
-            checkNotNull(newNonDurableCursor.batchDeletedIndexes);
+            Objects.requireNonNull(newNonDurableCursor.batchDeletedIndexes);
             for (Map.Entry<Position, BitSetRecyclable> entry : this.batchDeletedIndexes.entrySet()) {
                 BitSetRecyclable copiedBitSet = BitSetRecyclable.valueOf(entry.getValue());
                 newNonDurableCursor.batchDeletedIndexes.put(entry.getKey(), copiedBitSet);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckInMemoryDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckInMemoryDeleteTest.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
@@ -45,7 +44,6 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.client.api.transaction.TxnID;
-import org.apache.pulsar.common.util.collections.BitSetRecyclable;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -223,10 +221,7 @@ public class PendingAckInMemoryDeleteTest extends TransactionTestBase {
                                 (LinkedMap<TxnID, HashMap<Position, Position>>) field.get(pendingAckHandle);
                         assertTrue(individualAckOfTransaction.isEmpty());
                         managedCursor = (ManagedCursorImpl) testPersistentSubscription.getCursor();
-                        field = ManagedCursorImpl.class.getDeclaredField("batchDeletedIndexes");
-                        field.setAccessible(true);
-                        final ConcurrentSkipListMap<Position, BitSetRecyclable> batchDeletedIndexes =
-                                (ConcurrentSkipListMap<Position, BitSetRecyclable>) field.get(managedCursor);
+                        final var batchDeletedIndexes = managedCursor.getBatchDeletedIndexes();
                         if (retryCnt == 0) {
                             //one message are not ack
                             Awaitility.await().until(() -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreTest.java
@@ -73,6 +73,7 @@ public class MLPendingAckStoreTest extends TransactionTestBase {
     @BeforeClass
     @Override
     protected void setup() throws Exception {
+        conf.setAcknowledgmentAtBatchIndexLevelEnabled(true);
         setUpBase(1, 1, NAMESPACE1 + "/test", 0);
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/BitSetRecyclable.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/BitSetRecyclable.java
@@ -1211,9 +1211,6 @@ public class BitSetRecyclable implements Cloneable, java.io.Serializable {
         if (recyclerHandle != null) {
             this.clear();
             recyclerHandle.recycle(this);
-            // Reset with null so that recycle() can be called many times but only the 1st time takes effect.
-            // It's used when recycle() is called in ConcurrentSkipListMap's callback
-            recyclerHandle = null;
         }
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/BitSetRecyclable.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/BitSetRecyclable.java
@@ -1211,6 +1211,9 @@ public class BitSetRecyclable implements Cloneable, java.io.Serializable {
         if (recyclerHandle != null) {
             this.clear();
             recyclerHandle.recycle(this);
+            // Reset with null so that recycle() can be called many times but only the 1st time takes effect.
+            // It's used when recycle() is called in ConcurrentSkipListMap's callback
+            recyclerHandle = null;
         }
     }
 }


### PR DESCRIPTION
### Motivation

`MLPendingAckStoreTest#testMainProcess` will fail by NPE if batch index ACK is enabled. The NPE happens when the position argument does not has a non-null `ackSet`.

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

- Add an `ackBatchPosition` method to handle `Optional` objects correctly with elegant and clear code.
- Replace `BitSetRecyclable` with `BitSet` as the value type of `batchDeletedIndexes` to simplify the unnecessarily complicated code of calling `recycle()`. For example, if `recycle()` is called in a callback of `ConcurrentSkipListMap#compute`, it could be called multiple times. Additionally, the optimization for GC is not provided because `BitSetRecyclable` cannot avoid the memory allocation of its underlying long arrays.
- Mark `batchDeletedIndexes` as `@Nullable` and check if it's not null instead of `getConfig().isDeletionAtBatchIndexLevelEnabled()` to eliminate all NPE warnings.

### Verifying this change

Enable batch index ACK in `MLPendingAckStoreTest` and guarantee this test passes.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: