### PR TITLE
[fix][broker] Continue using the next provider for http authentication if one fails

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
@@ -24,11 +24,10 @@ import io.opentelemetry.api.OpenTelemetry;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import javax.naming.AuthenticationException;
 import javax.servlet.http.HttpServletRequest;
@@ -49,7 +48,7 @@ public class AuthenticationService implements Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(AuthenticationService.class);
     private final String anonymousUserRole;
 
-    private final Map<String, AuthenticationProvider> providers = new HashMap<>();
+    private final Map<String, AuthenticationProvider> providers = new LinkedHashMap<>();
 
     public AuthenticationService(ServiceConfiguration conf) throws PulsarServerException {
         this(conf, OpenTelemetry.noop());
@@ -60,7 +59,7 @@ public class AuthenticationService implements Closeable {
         anonymousUserRole = conf.getAnonymousUserRole();
         if (conf.isAuthenticationEnabled()) {
             try {
-                Map<String, List<AuthenticationProvider>> providerMap = new HashMap<>();
+                Map<String, List<AuthenticationProvider>> providerMap = new LinkedHashMap<>();
                 for (String className : conf.getAuthenticationProviders()) {
                     if (className.isEmpty()) {
                         continue;
@@ -131,7 +130,7 @@ public class AuthenticationService implements Closeable {
             AuthenticationProvider providerToUse = getAuthProvider(authMethodName);
             try {
                 return providerToUse.authenticateHttpRequest(request, response);
-            } catch (AuthenticationException e) {
+            } catch (Exception e) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Authentication failed for provider " + providerToUse.getAuthMethodName() + " : "
                             + e.getMessage(), e);
@@ -142,7 +141,7 @@ public class AuthenticationService implements Closeable {
             for (AuthenticationProvider provider : providers.values()) {
                 try {
                     return provider.authenticateHttpRequest(request, response);
-                } catch (AuthenticationException e) {
+                } catch (Exception e) {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Authentication failed for provider " + provider.getAuthMethodName() + ": "
                                 + e.getMessage(), e);
@@ -183,25 +182,18 @@ public class AuthenticationService implements Closeable {
                 }
                 // Backward compatible, the authData value was null in the previous implementation
                 return providerToUse.authenticateAsync(authData).get();
-            } catch (AuthenticationException e) {
+            } catch (Exception e) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Authentication failed for provider " + providerToUse.getAuthMethodName() + " : "
                             + e.getMessage(), e);
                 }
-                throw e;
-            } catch (ExecutionException | InterruptedException e) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Authentication failed for provider " + providerToUse.getAuthMethodName() + " : "
-                            + e.getMessage(), e);
-                }
-                throw new RuntimeException(e);
             }
         } else {
             for (AuthenticationProvider provider : providers.values()) {
                 try {
                     AuthenticationState authenticationState = provider.newHttpAuthState(request);
                     return provider.authenticateAsync(authenticationState.getAuthDataSource()).get();
-                } catch (ExecutionException | InterruptedException | AuthenticationException e) {
+                } catch (Exception e) {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Authentication failed for provider " + provider.getAuthMethodName() + ": "
                                 + e.getMessage(), e);


### PR DESCRIPTION
### Motivation

When using Pulsar admin version 2.10.x with JWT authentication and a broker running 3.0.x (forked from Apache Pulsar) configured with both Kerberos and JWT authentication providers, we encounter the following issue:

```
ERROR org.apache.pulsar.broker.web.AuthenticationFilter - [172.19.0.17] Error performing authentication for HTTP
2024-12-30 09:52:32 java.lang.IllegalStateException: Header token should exist if no role token.
2024-12-30 09:52:32     at com.google.common.base.Preconditions.checkState(Preconditions.java:512) ~[com.google.guava-guava-32.1.1-jre.jar:?]
2024-12-30 09:52:32     at org.apache.pulsar.broker.authentication.AuthenticationProviderSasl.authenticateHttpRequest(AuthenticationProviderSasl.java:275) ~[com.ascentstream.pulsar-pulsar-broker-auth-sasl-3.0.8.1.jar:3.0.8.1]
2024-12-30 09:52:32     at org.apache.pulsar.broker.authentication.AuthenticationService.authenticateHttpRequest(AuthenticationService.java:133) ~[com.ascentstream.pulsar-pulsar-broker-common-3.0.8.1.jar:3.0.8.1]
2024-12-30 09:52:32     at org.apache.pulsar.broker.web.AuthenticationFilter.doFilter(AuthenticationFilter.java:59) ~[com.ascentstream.pulsar-pulsar-broker-common-3.0.8.1.jar:3.0.8.1]
2024-12-30 09:52:32     at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193) ~[org.eclipse.jetty-jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
2024-12-30 09:52:32     at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626) ~[org.eclipse.jetty-jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
2024-12-30 09:52:32     at org.apache.pulsar.broker.intercept.BrokerInterceptor.onFilter(BrokerInterceptor.java:224) ~[com.ascentstream.pulsar-pulsar-broker-3.0.8.1.jar:3.0.8.1]
2024-12-30 09:52:32     at org.apache.pulsar.broker.web.ProcessHandlerFilter.doFilter(ProcessHandlerFilter.java:46) ~[com.ascentstream.pulsar-pulsar-broker-3.0.8.1.jar:3.0.8.1]
2024-12-30 09:52:32     at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193) ~[org.eclipse.jetty-jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
```

When a request is without the authentication method name in the HTTP header(https://github.com/apache/pulsar/pull/14044 improves that), the broker iterates through each authentication provider to authenticate the request, if authentication data is valid, the broker acts on the request. In this scenario, I ensured that the JWT provider was configured correctly and the token was valid. However, I still encountered an authentication error.

The root cause is that the `org.apache.pulsar.broker.authentication.AuthenticationService#authenticateHttpRequest(javax.servlet.http.HttpServletRequest, org.apache.pulsar.broker.authentication.AuthenticationDataSource)` and `org.apache.pulsar.broker.authentication.AuthenticationService#authenticateHttpRequest(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)` only catches the `AuthenticationExecption`, if one provider throws an exception of a different type, the authentication process will be terminated.

Related to https://github.com/apache/pulsar/pull/23797, which fixes the pulsar chain authentication, not HTTP authentication.

### Modifications

- Use `LinkedHashMap` instead of `HasMap` for provider ordering.
- Catch type `Exception`, which can catch any exceptions.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
