### PR TITLE
[improve][fn]: Added logLevel to change the log level of Function/Source/Sink Pod/Process to desired Level 

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/FunctionConfig.java
@@ -88,6 +88,7 @@ public class FunctionConfig {
 
     private String outputSerdeClassName;
     private String logTopic;
+    private String logLevel;
     private ProcessingGuarantees processingGuarantees;
     // Do we want function instances to process data in the same order as in the input topics
     // This essentially means that every partition of input topic is consumed by only one instance

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/io/SinkConfig.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/io/SinkConfig.java
@@ -95,4 +95,5 @@ public class SinkConfig {
     private String transformFunctionClassName;
     private String transformFunctionConfig;
     private String logTopic;
+    private String logLevel;
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/io/SourceConfig.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/io/SourceConfig.java
@@ -73,4 +73,5 @@ public class SourceConfig {
     // batchBuilder provides two types of batch construction methods, DEFAULT and KEY_BASED
     private String batchBuilder;
     private String logTopic;
+    private String logLevel;
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -228,6 +228,10 @@ public class CmdFunctions extends CmdBase {
                 + " #Java, Python, Go")
         protected String logTopic;
 
+        @Option(names = "--logLevel", description = "Log level at which the logs of a Pulsar Function are produced"
+                + " #Java")
+        protected String logLevel;
+
         @Option(names = {"-st", "--schema-type"}, description = "The builtin schema type or "
                 + "custom schema class name to be used for messages output by the function #Java")
         protected String schemaType = "";
@@ -505,6 +509,9 @@ public class CmdFunctions extends CmdBase {
             }
             if (null != logTopic) {
                 functionConfig.setLogTopic(logTopic);
+            }
+            if (null != logLevel) {
+                functionConfig.setLogLevel(logLevel);
             }
             if (null != className) {
                 functionConfig.setClassName(className);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -410,6 +410,8 @@ public class CmdSinks extends CmdBase {
         protected String transformFunctionConfig;
         @Option(names = "--log-topic", description = "The topic to which the logs of a Pulsar Sink are produced")
         protected String logTopic;
+        @Option(names = "--logLevel", description = "Log level at which the logs of a Pulsar Sink are produced")
+        protected String logLevel;
         @Option(names = "--runtime-flags", description = "Any flags that you want to pass to a runtime"
                 + " (for process & Kubernetes runtime only).")
         protected String runtimeFlags;
@@ -610,6 +612,9 @@ public class CmdSinks extends CmdBase {
             }
             if (null != logTopic) {
                 sinkConfig.setLogTopic(logTopic);
+            }
+            if (null != logLevel) {
+                sinkConfig.setLogLevel(logLevel);
             }
             if (null != runtimeFlags) {
                 sinkConfig.setRuntimeFlags(runtimeFlags);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -364,6 +364,8 @@ public class CmdSources extends CmdBase {
         protected String secretsString;
         @Option(names = "--log-topic", description = "The topic to which the logs of a Pulsar Sink are produced")
         protected String logTopic;
+        @Option(names = "--logLevel", description = "Log level at which the logs of a Pulsar Source are produced")
+        protected String logLevel;
         @Option(names = "--runtime-flags", description = "Any flags that you want to pass to a runtime"
                 + " (for process & Kubernetes runtime only).")
         protected String runtimeFlags;
@@ -504,6 +506,9 @@ public class CmdSources extends CmdBase {
             }
             if (null != logTopic) {
                 sourceConfig.setLogTopic(logTopic);
+            }
+            if (null != logLevel) {
+                sourceConfig.setLogLevel(logLevel);
             }
             if (null != runtimeFlags) {
                 sourceConfig.setRuntimeFlags(runtimeFlags);

--- a/pulsar-functions/proto/src/main/proto/Function.proto
+++ b/pulsar-functions/proto/src/main/proto/Function.proto
@@ -98,6 +98,7 @@ message FunctionDetails {
     bool retainOrdering = 21;
     bool retainKeyOrdering = 22;
     SubscriptionPosition subscriptionPosition = 23;
+    string logLevel = 24;
 }
 
 message ConsumerSpec {

--- a/pulsar-functions/runtime-all/src/main/resources/java_instance_log4j2.xml
+++ b/pulsar-functions/runtime-all/src/main/resources/java_instance_log4j2.xml
@@ -120,7 +120,7 @@
             </AppenderRef>
         </Logger>
         <Root>
-            <level>info</level>
+            <level>${sys:pulsar.log.level}</level>
             <AppenderRef>
                 <ref>${sys:pulsar.log.appender}</ref>
                 <level>${sys:pulsar.log.level}</level>

--- a/pulsar-functions/runtime-all/src/main/resources/kubernetes_instance_log4j2.xml
+++ b/pulsar-functions/runtime-all/src/main/resources/kubernetes_instance_log4j2.xml
@@ -50,7 +50,7 @@
             </AppenderRef>
         </Logger>
         <Root>
-            <level>info</level>
+            <level>${sys:pulsar.log.level}</level>
             <AppenderRef>
                 <ref>Console</ref>
                 <level>${sys:pulsar.log.level}</level>

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeUtils.java
@@ -78,6 +78,7 @@ public class RuntimeUtils {
                                           Integer grpcPort,
                                           Long expectedHealthCheckInterval,
                                           String logConfigFile,
+                                          String logLevel,
                                           String secretsProviderClassName,
                                           String secretsProviderConfig,
                                           Boolean installUserCodeDependencies,
@@ -92,7 +93,7 @@ public class RuntimeUtils {
         cmd.addAll(getCmd(instanceConfig, instanceFile, extraDependenciesDir, logDirectory,
                 originalCodeFileName, originalTransformFunctionFileName, pulsarServiceUrl, stateStorageServiceUrl,
                 authConfig, shardId, grpcPort, expectedHealthCheckInterval,
-                logConfigFile, secretsProviderClassName, secretsProviderConfig,
+                logConfigFile, logLevel, secretsProviderClassName, secretsProviderConfig,
                 installUserCodeDependencies, pythonDependencyRepository,
                 pythonExtraDependencyRepository, narExtractionDirectory,
                 functionInstanceClassPath, false, pulsarWebServiceUrl));
@@ -315,6 +316,7 @@ public class RuntimeUtils {
                                       Integer grpcPort,
                                       Long expectedHealthCheckInterval,
                                       String logConfigFile,
+                                      String logLevel,
                                       String secretsProviderClassName,
                                       String secretsProviderConfig,
                                       Boolean installUserCodeDependencies,
@@ -360,6 +362,7 @@ public class RuntimeUtils {
                 }
                 args.add(String.format("-D%s=%s", FUNCTIONS_INSTANCE_CLASSPATH, systemFunctionInstanceClasspath));
             }
+            args.add("-Dpulsar.log.level=" + logLevel);
             args.add("-Dlog4j.configurationFile=" + logConfigFile);
             args.add("-Dpulsar.function.log.dir=" + genFunctionLogFolder(logDirectory, instanceConfig));
             args.add("-Dpulsar.function.log.file=" + String.format(

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -74,6 +74,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Response;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.functions.auth.KubernetesFunctionAuthProvider;
 import org.apache.pulsar.functions.instance.AuthenticationConfig;
 import org.apache.pulsar.functions.instance.InstanceConfig;
@@ -236,6 +237,10 @@ public class KubernetesRuntime implements Runtime {
             case GO:
                 break;
         }
+        String logLevel = instanceConfig.getFunctionDetails().getLogLevel();
+        if (StringUtils.isBlank(logLevel)) {
+            logLevel = "info";
+        }
 
         this.authConfig = authConfig;
 
@@ -275,6 +280,7 @@ public class KubernetesRuntime implements Runtime {
                         grpcPort,
                         -1L,
                         logConfigFile,
+                        logLevel,
                         secretsProviderClassName,
                         secretsProviderConfig,
                         installUserCodeDependencies,

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/process/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/process/ProcessRuntime.java
@@ -122,6 +122,11 @@ class ProcessRuntime implements Runtime {
             case GO:
                 break;
         }
+        String logLevel = instanceConfig.getFunctionDetails().getLogLevel();
+        if (StringUtils.isBlank(logLevel)) {
+            logLevel = "info";
+        }
+
         this.extraDependenciesDir = extraDependenciesDir;
         this.narExtractionDirectory = narExtractionDirectory;
         this.processArgs = RuntimeUtils.composeCmd(
@@ -142,6 +147,7 @@ class ProcessRuntime implements Runtime {
             instanceConfig.getPort(),
             expectedHealthCheckInterval,
             logConfigFile,
+            logLevel,
             secretsProviderClassName,
             secretsProviderConfig,
             false,

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
@@ -213,6 +213,7 @@ public class RuntimeUtilsTest {
                 23,
                 1234L,
                 "logConfigFile",
+                "info",
                 "secretsProviderClassName",
                 "secretsProviderConfig",
                 false,

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
@@ -475,6 +475,7 @@ public class KubernetesRuntimeTest {
         String expectedArgs = "exec java -cp " + classpath
                 + extraDepsEnv
                 + " -Dpulsar.functions.instance.classpath=/pulsar/lib/*"
+                + " -Dpulsar.log.level=info"
                 + " -Dlog4j.configurationFile=kubernetes_instance_log4j2.xml "
                 + "-Dpulsar.function.log.dir=" + logDirectory + "/" + FunctionCommon.getFullyQualifiedName(config.getFunctionDetails())
                 + " -Dpulsar.function.log.file=" + config.getFunctionDetails().getName() + "-$SHARD_ID"

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/process/ProcessRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/process/ProcessRuntimeTest.java
@@ -324,6 +324,7 @@ public class ProcessRuntimeTest {
         String expectedArgs = "java -cp " + classpath
                 + extraDepsEnv
                 + " -Dpulsar.functions.instance.classpath=/pulsar/lib/*"
+                + " -Dpulsar.log.level=info"
                 + " -Dlog4j.configurationFile=java_instance_log4j2.xml "
                 + "-Dpulsar.function.log.dir=" + logDirectory + "/functions/" + FunctionCommon.getFullyQualifiedName(config.getFunctionDetails())
                 + " -Dpulsar.function.log.file=" + config.getFunctionDetails().getName() + "-" + config.getInstanceId()

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfigUtils.java
@@ -32,6 +32,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.io.File;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -70,6 +71,7 @@ public class FunctionConfigUtils {
 
     static final Integer MAX_PENDING_ASYNC_REQUESTS_DEFAULT = 1000;
     static final Boolean FORWARD_SOURCE_MESSAGE_PROPERTY_DEFAULT = Boolean.TRUE;
+    private static final List<String> VALID_LOG_LEVELS = Arrays.asList("INFO", "DEBUG", "WARN", "ERROR");
 
     private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.create();
 
@@ -272,6 +274,9 @@ public class FunctionConfigUtils {
         if (functionConfig.getLogTopic() != null) {
             functionDetailsBuilder.setLogTopic(functionConfig.getLogTopic());
         }
+        if (functionConfig.getLogLevel() != null) {
+            functionDetailsBuilder.setLogLevel(functionConfig.getLogLevel());
+        }
         if (functionConfig.getRuntime() != null) {
             functionDetailsBuilder.setRuntime(FunctionCommon.convertRuntime(functionConfig.getRuntime()));
         }
@@ -446,6 +451,9 @@ public class FunctionConfigUtils {
         }
         if (!isEmpty(functionDetails.getLogTopic())) {
             functionConfig.setLogTopic(functionDetails.getLogTopic());
+        }
+        if (!isEmpty(functionDetails.getLogLevel())) {
+            functionConfig.setLogLevel(functionDetails.getLogLevel());
         }
         if (functionDetails.getSink().getForwardSourceMessageProperty()) {
             functionConfig.setForwardSourceMessageProperty(functionDetails.getSink().getForwardSourceMessageProperty());
@@ -806,6 +814,13 @@ public class FunctionConfigUtils {
             }
         }
 
+        if (!isEmpty(functionConfig.getLogLevel())) {
+            if (!VALID_LOG_LEVELS.contains(functionConfig.getLogLevel().toUpperCase())) {
+                throw new IllegalArgumentException(
+                        String.format("LogLevel %s is invalid", functionConfig.getLogLevel()));
+            }
+        }
+
         if (functionConfig.getParallelism() != null && functionConfig.getParallelism() <= 0) {
             throw new IllegalArgumentException("Function parallelism must be a positive number");
         }
@@ -1026,6 +1041,9 @@ public class FunctionConfigUtils {
         }
         if (!StringUtils.isEmpty(newConfig.getLogTopic())) {
             mergedConfig.setLogTopic(newConfig.getLogTopic());
+        }
+        if (!StringUtils.isEmpty(newConfig.getLogLevel())) {
+            mergedConfig.setLogLevel(newConfig.getLogLevel());
         }
         if (newConfig.getProcessingGuarantees() != null && !newConfig.getProcessingGuarantees()
                 .equals(existingConfig.getProcessingGuarantees())) {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfigUtils.java
@@ -31,6 +31,7 @@ import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -62,6 +63,8 @@ import org.apache.pulsar.functions.proto.Function.FunctionDetails;
 @Slf4j
 public class SinkConfigUtils {
 
+    private static final List<String> VALID_LOG_LEVELS = Arrays.asList("INFO", "DEBUG", "WARN", "ERROR");
+
     @Getter
     @Setter
     @AllArgsConstructor
@@ -89,6 +92,9 @@ public class SinkConfigUtils {
         }
         if (sinkConfig.getLogTopic() != null) {
             functionDetailsBuilder.setLogTopic(sinkConfig.getLogTopic());
+        }
+        if (sinkConfig.getLogLevel() != null) {
+            functionDetailsBuilder.setLogLevel(sinkConfig.getLogLevel());
         }
         functionDetailsBuilder.setRuntime(FunctionDetails.Runtime.JAVA);
         if (sinkConfig.getParallelism() != null) {
@@ -327,6 +333,9 @@ public class SinkConfigUtils {
         if (!isEmpty(functionDetails.getLogTopic())) {
             sinkConfig.setLogTopic(functionDetails.getLogTopic());
         }
+        if (!isEmpty(functionDetails.getLogLevel())) {
+            sinkConfig.setLogLevel(functionDetails.getLogLevel());
+        }
 
         sinkConfig.setProcessingGuarantees(convertProcessingGuarantee(functionDetails.getProcessingGuarantees()));
 
@@ -436,6 +445,13 @@ public class SinkConfigUtils {
             if (!TopicName.isValid(sinkConfig.getLogTopic())) {
                 throw new IllegalArgumentException(
                         String.format("LogTopic topic %s is invalid", sinkConfig.getLogTopic()));
+            }
+        }
+
+        if (!isEmpty(sinkConfig.getLogLevel())) {
+            if (!VALID_LOG_LEVELS.contains(sinkConfig.getLogLevel().toUpperCase())) {
+                throw new IllegalArgumentException(
+                        String.format("LogLevel %s is invalid", sinkConfig.getLogLevel()));
             }
         }
 
@@ -627,6 +643,9 @@ public class SinkConfigUtils {
         }
         if (!StringUtils.isEmpty(newConfig.getLogTopic())) {
             mergedConfig.setLogTopic(newConfig.getLogTopic());
+        }
+        if (!StringUtils.isEmpty(newConfig.getLogLevel())) {
+            mergedConfig.setLogLevel(newConfig.getLogLevel());
         }
 
         if (newConfig.getInputs() != null) {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfigUtils.java
@@ -28,7 +28,9 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -56,6 +58,8 @@ import org.apache.pulsar.io.core.Source;
 @Slf4j
 public class SourceConfigUtils {
 
+    private static final List<String> VALID_LOG_LEVELS = Arrays.asList("INFO", "DEBUG", "WARN", "ERROR");
+
     @Getter
     @Setter
     @AllArgsConstructor
@@ -82,6 +86,9 @@ public class SourceConfigUtils {
         }
         if (sourceConfig.getLogTopic() != null) {
             functionDetailsBuilder.setLogTopic(sourceConfig.getLogTopic());
+        }
+        if (sourceConfig.getLogLevel() != null) {
+            functionDetailsBuilder.setLogLevel(sourceConfig.getLogLevel());
         }
         functionDetailsBuilder.setRuntime(FunctionDetails.Runtime.JAVA);
         if (sourceConfig.getParallelism() != null) {
@@ -241,6 +248,9 @@ public class SourceConfigUtils {
         if (!isEmpty(functionDetails.getLogTopic())) {
             sourceConfig.setLogTopic(functionDetails.getLogTopic());
         }
+        if (!isEmpty(functionDetails.getLogLevel())) {
+            sourceConfig.setLogLevel(functionDetails.getLogLevel());
+        }
         if (functionDetails.hasResources()) {
             Resources resources = new Resources();
             resources.setCpu(functionDetails.getResources().getCpu());
@@ -279,6 +289,12 @@ public class SourceConfigUtils {
             if (!TopicName.isValid(sourceConfig.getLogTopic())) {
                 throw new IllegalArgumentException(
                         String.format("LogTopic topic %s is invalid", sourceConfig.getLogTopic()));
+            }
+        }
+        if (!isEmpty(sourceConfig.getLogLevel())) {
+            if (!VALID_LOG_LEVELS.contains(sourceConfig.getLogLevel().toUpperCase())) {
+                throw new IllegalArgumentException(
+                        String.format("LogLevel %s is invalid", sourceConfig.getLogLevel()));
             }
         }
         if (sourceConfig.getParallelism() != null && sourceConfig.getParallelism() <= 0) {
@@ -409,6 +425,9 @@ public class SourceConfigUtils {
         }
         if (!StringUtils.isEmpty(newConfig.getLogTopic())) {
             mergedConfig.setLogTopic(newConfig.getLogTopic());
+        }
+        if (!StringUtils.isEmpty(newConfig.getLogLevel())) {
+            mergedConfig.setLogLevel(newConfig.getLogLevel());
         }
         if (newConfig.getProcessingGuarantees() != null && !newConfig.getProcessingGuarantees()
                 .equals(existingConfig.getProcessingGuarantees())) {

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
@@ -596,6 +596,7 @@ public class FunctionConfigUtilsTest {
                 .build();
         boolean autoAck = true;
         String logTopic = "log-topic1";
+        String logLevel = "debug";
         Function.Resources resources = Function.Resources.newBuilder().setCpu(1.5).setDisk(1024 * 20).setRam(1024 * 10).build();
         String packageUrl = "http://package.url";
         Map<String, String> secretsMap = new HashMap<>();
@@ -616,6 +617,7 @@ public class FunctionConfigUtilsTest {
                 .setSource(sourceSpec)
                 .setAutoAck(autoAck)
                 .setLogTopic(logTopic)
+                .setLogLevel(logLevel)
                 .setResources(resources)
                 .setPackageUrl(packageUrl)
                 .setSecretsMap(new Gson().toJson(secretsMap))
@@ -629,6 +631,7 @@ public class FunctionConfigUtilsTest {
         assertEquals(functionConfig.getName(), name);
         assertEquals(functionConfig.getClassName(), classname);
         assertEquals(functionConfig.getLogTopic(), logTopic);
+        assertEquals(functionConfig.getLogLevel(), logLevel);
         assertEquals((Object) functionConfig.getResources().getCpu(), resources.getCpu());
         assertEquals(functionConfig.getResources().getDisk().longValue(), resources.getDisk());
         assertEquals(functionConfig.getResources().getRam().longValue(), resources.getRam());


### PR DESCRIPTION
Master Issue: #23783

### Motivation:

The `pulsar.log.level` property in`kubernetes_instance_log4j2.xml` & `java_instance_log4j2.xml` files in the Pulsar Functions runtime is responsible for configuring the log settings for function pods when using the Java runtime in Kubernetes StatefulSets & for process runtime respectively. Currently, this configuration file is hardcoded to use the `INFO` log level, which restricts flexibility when more granular logging (such as `DEBUG` level) is needed for troubleshooting or deeper monitoring. This limitation is particularly impactful when debugging issues related to sources, sinks, or function executions, where more detailed logs could be beneficial.

Presently, adjusting the log level requires manual changes to the `kubernetes_instance_log4j2.xml` or `java_instance_log4j2.xml` file, which is inefficient and error-prone, especially in dynamic environments. There is no built-in way to modify the log level dynamically without altering the configuration file directly.

This PR introduces a new argument (`logLevel`) to override the JVM property `-Dpulsar.log.level=info` at runtime for functions, sources, and sinks. This change provides a more flexible and dynamic approach to adjust log verbosity based on specific needs, such as enabling `DEBUG` or `ERROR` logs for better diagnostics during troubleshooting.

### Modifications:

- **Introduction of `logLevel` Argument**: Added a new `logLevel` argument for Pulsar Functions, Sources, and Sinks, which allows the user to override the default JVM property `-Dpulsar.log.level=info`. This enables setting custom log levels (e.g., `DEBUG`, `ERROR`) dynamically at runtime without modifying the `kubernetes_instance_log4j2.xml` or `java_instance_log4j2.xml` file.
  
- **JVM Property Override**: The new `logLevel` argument directly overrides the `-Dpulsar.log.level` property, giving users control over the logging level without needing to edit the underlying configuration file.

- **Backward Compatibility**: The default log level remains `INFO` unless the new `logLevel` argument is provided. This ensures that existing deployments continue to function as before.

This update enhances the troubleshooting and monitoring capabilities of Pulsar Functions, offering greater flexibility while preserving the simplicity and stability of existing configurations.


### Verifying this change

- [X] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: yes.  Added a cli arg `logLevel` for creating/updating function/source/sink
  - Anything that affects deployment: no

### Documentation

Check the box below or label this PR directly (if you have committer privilege).

Need to update docs? 

- [X] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)


