### PR TITLE
[fix][broker] Fix deadlock in Key_Shared PIP-379 implementation

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DrainingHashesTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DrainingHashesTracker.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.PrimitiveIterator;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.common.policies.data.DrainingHash;
@@ -34,7 +36,7 @@ import org.apache.pulsar.common.policies.data.stats.DrainingHashImpl;
 import org.roaringbitmap.RoaringBitmap;
 
 /**
- * A thread-safe map to store draining hashes in the consumer.
+ * A thread-safe map to store draining hashes in the consumer using read-write locks for improved concurrency.
  */
 @Slf4j
 public class DrainingHashesTracker {
@@ -42,6 +44,7 @@ public class DrainingHashesTracker {
     private final UnblockingHandler unblockingHandler;
     // optimize the memory consumption of the map by using primitive int keys
     private final Int2ObjectOpenHashMap<DrainingHashEntry> drainingHashes = new Int2ObjectOpenHashMap<>();
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
     int batchLevel;
     boolean unblockedWhileBatching;
     private final Map<ConsumerIdentityWrapper, ConsumerDrainingHashesStats> consumerDrainingHashesStatsMap =
@@ -52,9 +55,14 @@ public class DrainingHashesTracker {
      */
     @ToString
     public static class DrainingHashEntry {
+        private static final AtomicIntegerFieldUpdater<DrainingHashEntry> REF_COUNT_UPDATER =
+                AtomicIntegerFieldUpdater.newUpdater(DrainingHashEntry.class, "refCount");
+        private static final AtomicIntegerFieldUpdater<DrainingHashEntry> BLOCKED_COUNT_UPDATER =
+                AtomicIntegerFieldUpdater.newUpdater(DrainingHashEntry.class, "blockedCount");
+
         private final Consumer consumer;
-        private int refCount;
-        private int blockedCount;
+        private volatile int refCount;
+        private volatile int blockedCount;
 
         /**
          * Constructs a new DrainingHashEntry with the specified Consumer.
@@ -81,7 +89,7 @@ public class DrainingHashesTracker {
          * Increments the reference count.
          */
         void incrementRefCount() {
-            refCount++;
+            REF_COUNT_UPDATER.incrementAndGet(this);
         }
 
         /**
@@ -90,14 +98,14 @@ public class DrainingHashesTracker {
          * @return true if the reference count is zero, false otherwise
          */
         boolean decrementRefCount() {
-            return --refCount == 0;
+            return REF_COUNT_UPDATER.decrementAndGet(this) == 0;
         }
 
         /**
          * Increments the blocked count.
          */
         void incrementBlockedCount() {
-            blockedCount++;
+            BLOCKED_COUNT_UPDATER.incrementAndGet(this);
         }
 
         /**
@@ -108,51 +116,85 @@ public class DrainingHashesTracker {
         boolean isBlocking() {
             return blockedCount > 0;
         }
+
+        /**
+         * Gets the current reference count.
+         *
+         * @return the current reference count
+         */
+        int getRefCount() {
+            return refCount;
+        }
+
+        /**
+         * Gets the current blocked count.
+         *
+         * @return the current blocked count
+         */
+        int getBlockedCount() {
+            return blockedCount;
+        }
     }
 
     private class ConsumerDrainingHashesStats {
         private final RoaringBitmap drainingHashes = new RoaringBitmap();
-        long drainingHashesClearedTotal;
+        private long drainingHashesClearedTotal;
+        private final ReentrantReadWriteLock statsLock = new ReentrantReadWriteLock();
 
-        public synchronized void addHash(int stickyHash) {
-            drainingHashes.add(stickyHash);
-        }
-
-        public synchronized boolean clearHash(int hash) {
-            drainingHashes.remove(hash);
-            drainingHashesClearedTotal++;
-            boolean empty = drainingHashes.isEmpty();
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Cleared hash {} in stats. empty={} totalCleared={} hashes={}",
-                        dispatcherName, hash, empty, drainingHashesClearedTotal, drainingHashes.getCardinality());
+        public void addHash(int stickyHash) {
+            statsLock.writeLock().lock();
+            try {
+                drainingHashes.add(stickyHash);
+            } finally {
+                statsLock.writeLock().unlock();
             }
-            return empty;
         }
 
-        public synchronized void updateConsumerStats(Consumer consumer, ConsumerStatsImpl consumerStats) {
-            int drainingHashesUnackedMessages = 0;
-            List<DrainingHash> drainingHashesStats = new ArrayList<>();
-            PrimitiveIterator.OfInt hashIterator = drainingHashes.stream().iterator();
-            while (hashIterator.hasNext()) {
-                int hash = hashIterator.nextInt();
-                DrainingHashEntry entry = getEntry(hash);
-                if (entry == null) {
-                    log.warn("[{}] Draining hash {} not found in the tracker for consumer {}", dispatcherName, hash,
-                            consumer);
-                    continue;
+        public boolean clearHash(int hash) {
+            statsLock.writeLock().lock();
+            try {
+                drainingHashes.remove(hash);
+                drainingHashesClearedTotal++;
+                boolean empty = drainingHashes.isEmpty();
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Cleared hash {} in stats. empty={} totalCleared={} hashes={}",
+                            dispatcherName, hash, empty, drainingHashesClearedTotal, drainingHashes.getCardinality());
                 }
-                int unackedMessages = entry.refCount;
-                DrainingHashImpl drainingHash = new DrainingHashImpl();
-                drainingHash.hash = hash;
-                drainingHash.unackMsgs = unackedMessages;
-                drainingHash.blockedAttempts = entry.blockedCount;
-                drainingHashesStats.add(drainingHash);
-                drainingHashesUnackedMessages += unackedMessages;
+                return empty;
+            } finally {
+                statsLock.writeLock().unlock();
             }
-            consumerStats.drainingHashesCount = drainingHashesStats.size();
-            consumerStats.drainingHashesClearedTotal = drainingHashesClearedTotal;
-            consumerStats.drainingHashesUnackedMessages = drainingHashesUnackedMessages;
-            consumerStats.drainingHashes = drainingHashesStats;
+        }
+
+        public void updateConsumerStats(Consumer consumer, ConsumerStatsImpl consumerStats) {
+            statsLock.readLock().lock();
+            try {
+                int drainingHashesUnackedMessages = 0;
+                List<DrainingHash> drainingHashesStats = new ArrayList<>();
+                PrimitiveIterator.OfInt hashIterator = drainingHashes.stream().iterator();
+                while (hashIterator.hasNext()) {
+                    int hash = hashIterator.nextInt();
+                    DrainingHashEntry entry = getEntry(hash);
+                    if (entry == null) {
+                        log.warn("[{}] Draining hash {} not found in the tracker for consumer {}", dispatcherName, hash,
+                                consumer);
+                        continue;
+                    }
+                    int unackedMessages = entry.getRefCount();
+                    DrainingHashImpl drainingHash = new DrainingHashImpl();
+                    drainingHash.hash = hash;
+                    drainingHash.unackMsgs = unackedMessages;
+                    drainingHash.blockedAttempts = entry.getBlockedCount();
+                    drainingHashesStats.add(drainingHash);
+                    drainingHashesUnackedMessages += unackedMessages;
+                }
+                consumerStats.drainingHashesCount = drainingHashesStats.size();
+                consumerStats.drainingHashesClearedTotal = drainingHashesClearedTotal;
+                consumerStats.drainingHashesUnackedMessages = drainingHashesUnackedMessages;
+                consumerStats.drainingHashes = drainingHashesStats;
+            } finally {
+                statsLock.readLock().unlock();
+            }
         }
     }
 
@@ -179,50 +221,66 @@ public class DrainingHashesTracker {
      * @param consumer the consumer
      * @param stickyHash the sticky hash
      */
-    public synchronized void addEntry(Consumer consumer, int stickyHash) {
+    public void addEntry(Consumer consumer, int stickyHash) {
         if (stickyHash == 0) {
             throw new IllegalArgumentException("Sticky hash cannot be 0");
         }
-        DrainingHashEntry entry = drainingHashes.get(stickyHash);
-        if (entry == null) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Adding and incrementing draining hash {} for consumer id:{} name:{}", dispatcherName,
-                        stickyHash, consumer.consumerId(), consumer.consumerName());
+
+        lock.writeLock().lock();
+        try {
+            DrainingHashEntry entry = drainingHashes.get(stickyHash);
+            if (entry == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Adding and incrementing draining hash {} for consumer id:{} name:{}",
+                            dispatcherName, stickyHash, consumer.consumerId(), consumer.consumerName());
+                }
+                entry = new DrainingHashEntry(consumer);
+                drainingHashes.put(stickyHash, entry);
+                // update the consumer specific stats
+                consumerDrainingHashesStatsMap.computeIfAbsent(new ConsumerIdentityWrapper(consumer),
+                        k -> new ConsumerDrainingHashesStats()).addHash(stickyHash);
+            } else if (entry.getConsumer() != consumer) {
+                throw new IllegalStateException(
+                        "Consumer " + entry.getConsumer() + " is already draining hash " + stickyHash
+                                + " in dispatcher " + dispatcherName + ". Same hash being used for consumer " + consumer
+                                + ".");
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Draining hash {} incrementing {} consumer id:{} name:{}", dispatcherName,
+                            stickyHash, entry.getRefCount() + 1, consumer.consumerId(), consumer.consumerName());
+                }
             }
-            entry = new DrainingHashEntry(consumer);
-            drainingHashes.put(stickyHash, entry);
-            // update the consumer specific stats
-            consumerDrainingHashesStatsMap.computeIfAbsent(new ConsumerIdentityWrapper(consumer),
-                    k -> new ConsumerDrainingHashesStats()).addHash(stickyHash);
-        } else if (entry.getConsumer() != consumer) {
-            throw new IllegalStateException(
-                    "Consumer " + entry.getConsumer() + " is already draining hash " + stickyHash
-                            + " in dispatcher " + dispatcherName + ". Same hash being used for consumer " + consumer
-                            + ".");
-        } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Draining hash {} incrementing {} consumer id:{} name:{}", dispatcherName, stickyHash,
-                        entry.refCount + 1, consumer.consumerId(), consumer.consumerName());
-            }
+            entry.incrementRefCount();
+        } finally {
+            lock.writeLock().unlock();
         }
-        entry.incrementRefCount();
     }
 
     /**
      * Start a batch operation. There could be multiple nested batch operations.
      * The unblocking of sticky key hashes will be done only when the last batch operation ends.
      */
-    public synchronized void startBatch() {
-        batchLevel++;
+    public void startBatch() {
+        lock.writeLock().lock();
+        try {
+            batchLevel++;
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     /**
      * End a batch operation.
      */
-    public synchronized void endBatch() {
-        if (--batchLevel == 0 && unblockedWhileBatching) {
-            unblockedWhileBatching = false;
-            unblockingHandler.stickyKeyHashUnblocked(-1);
+    public void endBatch() {
+        lock.writeLock().lock();
+        try {
+            if (--batchLevel == 0 && unblockedWhileBatching) {
+                unblockedWhileBatching = false;
+                unblockingHandler.stickyKeyHashUnblocked(-1);
+            }
+        } finally {
+            lock.writeLock().unlock();
         }
     }
 
@@ -231,46 +289,52 @@ public class DrainingHashesTracker {
      *
      * @param consumer   the consumer
      * @param stickyHash the sticky hash
-     * @param closing
+     * @param closing    whether the consumer is closing
      */
-    public synchronized void reduceRefCount(Consumer consumer, int stickyHash, boolean closing) {
+    public void reduceRefCount(Consumer consumer, int stickyHash, boolean closing) {
         if (stickyHash == 0) {
             return;
         }
-        DrainingHashEntry entry = drainingHashes.get(stickyHash);
-        if (entry == null) {
-            return;
-        }
-        if (entry.getConsumer() != consumer) {
-            throw new IllegalStateException(
-                    "Consumer " + entry.getConsumer() + " is already draining hash " + stickyHash
-                            + " in dispatcher " + dispatcherName + ". Same hash being used for consumer " + consumer
-                            + ".");
-        }
-        if (entry.decrementRefCount()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Draining hash {} removing consumer id:{} name:{}", dispatcherName, stickyHash,
-                        consumer.consumerId(), consumer.consumerName());
+
+        lock.writeLock().lock();
+        try {
+            DrainingHashEntry entry = drainingHashes.get(stickyHash);
+            if (entry == null) {
+                return;
             }
-            DrainingHashEntry removed = drainingHashes.remove(stickyHash);
-            // update the consumer specific stats
-            ConsumerDrainingHashesStats drainingHashesStats =
-                    consumerDrainingHashesStatsMap.get(new ConsumerIdentityWrapper(consumer));
-            if (drainingHashesStats != null) {
-                drainingHashesStats.clearHash(stickyHash);
+            if (entry.getConsumer() != consumer) {
+                throw new IllegalStateException(
+                        "Consumer " + entry.getConsumer() + " is already draining hash " + stickyHash
+                                + " in dispatcher " + dispatcherName + ". Same hash being used for consumer " + consumer
+                                + ".");
             }
-            if (!closing && removed.isBlocking()) {
-                if (batchLevel > 0) {
-                    unblockedWhileBatching = true;
-                } else {
-                    unblockingHandler.stickyKeyHashUnblocked(stickyHash);
+            if (entry.decrementRefCount()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Draining hash {} removing consumer id:{} name:{}", dispatcherName, stickyHash,
+                            consumer.consumerId(), consumer.consumerName());
+                }
+                DrainingHashEntry removed = drainingHashes.remove(stickyHash);
+                // update the consumer specific stats
+                ConsumerDrainingHashesStats drainingHashesStats =
+                        consumerDrainingHashesStatsMap.get(new ConsumerIdentityWrapper(consumer));
+                if (drainingHashesStats != null) {
+                    drainingHashesStats.clearHash(stickyHash);
+                }
+                if (!closing && removed.isBlocking()) {
+                    if (batchLevel > 0) {
+                        unblockedWhileBatching = true;
+                    } else {
+                        unblockingHandler.stickyKeyHashUnblocked(stickyHash);
+                    }
+                }
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Draining hash {} decrementing {} consumer id:{} name:{}", dispatcherName,
+                            stickyHash, entry.getRefCount(), consumer.consumerId(), consumer.consumerName());
                 }
             }
-        } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Draining hash {} decrementing {} consumer id:{} name:{}", dispatcherName, stickyHash,
-                        entry.refCount, consumer.consumerId(), consumer.consumerName());
-            }
+        } finally {
+            lock.writeLock().unlock();
         }
     }
 
@@ -281,12 +345,12 @@ public class DrainingHashesTracker {
      * @param stickyKeyHash the sticky key hash
      * @return true if the sticky key hash should be blocked, false otherwise
      */
-    public synchronized boolean shouldBlockStickyKeyHash(Consumer consumer, int stickyKeyHash) {
+    public boolean shouldBlockStickyKeyHash(Consumer consumer, int stickyKeyHash) {
         if (stickyKeyHash == STICKY_KEY_HASH_NOT_SET) {
             log.warn("[{}] Sticky key hash is not set. Allowing dispatching", dispatcherName);
             return false;
         }
-        DrainingHashEntry entry = drainingHashes.get(stickyKeyHash);
+        DrainingHashEntry entry = getEntry(stickyKeyHash);
         // if the entry is not found, the hash is not draining. Don't block the hash.
         if (entry == null) {
             return false;
@@ -294,10 +358,14 @@ public class DrainingHashesTracker {
         // hash has been reassigned to the original consumer, remove the entry
         // and don't block the hash
         if (entry.getConsumer() == consumer) {
-            log.info("[{}] Hash {} has been reassigned consumer {}. "
-                            + "The draining hash entry with refCount={} will be removed.",
-                    dispatcherName, stickyKeyHash, entry.getConsumer(), entry.refCount);
-            drainingHashes.remove(stickyKeyHash, entry);
+            log.info("[{}] Hash {} has been reassigned consumer {}. The draining hash entry with refCount={} will "
+                    + "be removed.", dispatcherName, stickyKeyHash, entry.getConsumer(), entry.getRefCount());
+            lock.writeLock().lock();
+            try {
+                drainingHashes.remove(stickyKeyHash, entry);
+            } finally {
+                lock.writeLock().unlock();
+            }
             return false;
         }
         // increment the blocked count which is used to determine if the hash is blocking
@@ -313,16 +381,29 @@ public class DrainingHashesTracker {
      * @param stickyKeyHash the sticky key hash
      * @return the draining hash entry, or null if not found
      */
-    public synchronized DrainingHashEntry getEntry(int stickyKeyHash) {
-        return stickyKeyHash != 0 ? drainingHashes.get(stickyKeyHash) : null;
+    public DrainingHashEntry getEntry(int stickyKeyHash) {
+        if (stickyKeyHash == 0) {
+            return null;
+        }
+        lock.readLock().lock();
+        try {
+            return drainingHashes.get(stickyKeyHash);
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     /**
      * Clear all entries in the draining hashes tracker.
      */
-    public synchronized void clear() {
-        drainingHashes.clear();
-        consumerDrainingHashesStatsMap.clear();
+    public void clear() {
+        lock.writeLock().lock();
+        try {
+            drainingHashes.clear();
+            consumerDrainingHashesStatsMap.clear();
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DrainingHashesTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DrainingHashesTracker.java
@@ -165,6 +165,10 @@ public class DrainingHashesTracker {
                     log.debug("[{}] Cleared hash {} in stats. empty={} totalCleared={} hashes={}",
                             dispatcherName, hash, empty, drainingHashesClearedTotal, drainingHashes.getCardinality());
                 }
+                if (empty) {
+                    // reduce memory usage by trimming the bitmap when the RoaringBitmap instance is empty
+                    drainingHashes.trim();
+                }
                 return empty;
             } finally {
                 statsLock.writeLock().unlock();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerTestUtil.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerTestUtil.java
@@ -224,7 +224,22 @@ public class BrokerTestUtil {
     public static <T> void receiveMessages(BiFunction<Consumer<T>, Message<T>, Boolean> messageHandler,
                                        Duration quietTimeout,
                                        Consumer<T>... consumers) {
-        FutureUtil.waitForAll(Arrays.stream(consumers)
+        receiveMessages(messageHandler, quietTimeout, Arrays.stream(consumers));
+    }
+
+    /**
+     * Receive messages concurrently from multiple consumers and handles them using the provided message handler.
+     * The message handler should return true if it wants to continue receiving more messages, false otherwise.
+     *
+     * @param messageHandler the message handler
+     * @param quietTimeout the duration of quiet time after which the method will stop waiting for more messages
+     * @param consumers the consumers to receive messages from
+     * @param <T> the message value type
+     */
+    public static <T> void receiveMessages(BiFunction<Consumer<T>, Message<T>, Boolean> messageHandler,
+                                           Duration quietTimeout,
+                                           Stream<Consumer<T>> consumers) {
+        FutureUtil.waitForAll(consumers
                 .map(consumer -> receiveMessagesAsync(consumer, quietTimeout, messageHandler)).toList()).join();
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -2366,8 +2366,13 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         Thread updateRatesThread = new Thread(() -> {
             while (!Thread.currentThread().isInterrupted()) {
                 pulsar.getBrokerService().updateRates();
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
             }
-        });
+        }, "update-rates-thread");
         updateRatesThread.start();
 
         String topic = newUniqueName("testDeliveryOfRemainingMessages");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -2365,9 +2365,13 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         conf.setUnblockStuckSubscriptionEnabled(false);
         @Cleanup("interrupt")
         Thread updateRatesThread = new Thread(() -> {
-            while (!Thread.currentThread().isInterrupted()) {
+            int count = 0;
+            while (!Thread.currentThread().isInterrupted() && count++ < 1_000_000) {
                 pulsar.getBrokerService().updateRates();
                 Thread.yield();
+                if (count % 10000 == 0) {
+                    log.info("updateRatesThread count: {}", count);
+                }
             }
         }, "update-rates-thread");
         updateRatesThread.start();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -2362,15 +2362,12 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
 
     @Test(dataProvider = "currentImplementationType")
     public void testDeliveryOfRemainingMessagesWithoutDeadlock(KeySharedImplementationType impl) throws Exception {
+        conf.setUnblockStuckSubscriptionEnabled(false);
         @Cleanup("interrupt")
         Thread updateRatesThread = new Thread(() -> {
             while (!Thread.currentThread().isInterrupted()) {
                 pulsar.getBrokerService().updateRates();
-                try {
-                    Thread.sleep(1);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
+                Thread.yield();
             }
         }, "update-rates-thread");
         updateRatesThread.start();


### PR DESCRIPTION
Fixes #23848

### Motivation

The Pulsar 4.0 Key_Shared PIP-379 implementation could deadlock and this problem was first captured in test environment heapdump where the thread stack information included in the heapdump showed multiple threads in blocked state, hinting a deadlock.
With the help of @pdolif, the problem was reproduced in isolation by simply adding this type of test code in a KeySharedSubscriptionTest test case.

```java
// test code that triggered the deadlock issue
new Thread(() -> {
    while(true) { pulsar.getBrokerService().updateRates(); }
}).start();
```
In the test case, this triggered a similar pattern of blocked threads and therefore could be considered a reproduction of the previously faced dead lock issue in a test environment.

threaddump with deadlock:
* in jstack.review https://jstack.review/?https://gist.github.com/lhotari/75eebb84687333bd7b133f2cbf3b6af6#tda_1_dump
* deadlock details: https://gist.github.com/lhotari/75eebb84687333bd7b133f2cbf3b6af6#file-deadlock-txt-L2244

### Modifications

- add test case to reproduce the dead lock case which will prevent future regressions in the same area
- fix the dead lock issue by replacing synchronization with read-write locks
  - locks are for minimum "scope"
  - callbacks are called outside of a lock scope to reduce the chances of potential other deadlocks
- use volatile fields for counters in DrainingHashEntry so that entry methods can be used without separate locks

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->