### PR TITLE
[fix][test] Add reconsumeLater call in RetryTopicTest#testRetryTopicWithMultiTopic.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/RetryTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/RetryTopicTest.java
@@ -464,7 +464,7 @@ public class RetryTopicTest extends ProducerConsumerBase {
     }
 
     /**
-     * The test is disabled {@link https://github.com/apache/pulsar/issues/2647}.
+     * Test retry topic with multiple topics
      * @throws Exception
      */
     @Test
@@ -482,7 +482,6 @@ public class RetryTopicTest extends ProducerConsumerBase {
                 .subscriptionName("my-subscription")
                 .subscriptionType(SubscriptionType.Shared)
                 .enableRetry(true)
-                .ackTimeout(1, TimeUnit.SECONDS)
                 .deadLetterPolicy(DeadLetterPolicy.builder().maxRedeliverCount(maxRedeliveryCount).build())
                 .receiverQueueSize(100)
                 .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
@@ -518,6 +517,7 @@ public class RetryTopicTest extends ProducerConsumerBase {
             Message<byte[]> message = consumer.receive();
             log.info("consumer received message : {} {} - total = {}",
                 message.getMessageId(), new String(message.getData()), ++totalReceived);
+            consumer.reconsumeLater(message, 1, TimeUnit.SECONDS);
         } while (totalReceived < sendMessages * (maxRedeliveryCount + 1));
 
         int totalInDeadLetter = 0;


### PR DESCRIPTION
### Motivation

`org.apache.pulsar.client.api.RetryTopicTest#testRetryTopicWithMultiTopic` don't test the behavior of retry topic at all.
Instead of calling `reconsumeLater` to trigger redelivery, current test code trigger redelivery base on ack timeout.


### Modifications

Add reconsumeLater call to test the behavior of retry topic with multiple topics.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 