### PR TITLE
[improve][ci] Make semantic pr title required for merging

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -47,6 +47,7 @@ github:
         # See ./github/workflows/README.md for more documentation on this list.
         contexts:
            - Pulsar CI checks completed
+           - Check pull request title
 
       required_pull_request_reviews:
         dismiss_stale_reviews: false


### PR DESCRIPTION
### Motivation

We have been using semantic pr title for a long time, and we can now enable strict checking by marking it as required.

### Modifications

- Update `.asf.yaml` config.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->