### PR TITLE
[improve][broker] Remove spamming logs for customized managed ledger

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3497,8 +3497,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         TopicName topicName = TopicName.get(getName());
 
         if (!(ledger.getCursors() instanceof ManagedCursorContainer managedCursorContainer)) {
-            return CompletableFuture.failedFuture(new IllegalStateException(
-                    String.format("[%s] No valid cursors found. Skip update old position info.", topicName)));
+            // TODO: support this method with a customized managed ledger implementation
+            return CompletableFuture.completedFuture(null);
         }
 
         if (!hasBacklogs(brokerService.pulsar().getConfiguration().isPreciseTimeBasedBacklogQuotaCheck())) {


### PR DESCRIPTION
### Motivation

For a customized managed ledger implementation, `getCursors()` might not return a `ManagedCursorContainer`. In this case, `updateOldPositionInfo()` will return a failed future so that `monitorBacklogQuota` will keep printing spamming logs.

### Modifications

Return a null completed future in `updateOldPositionInfo` if `getCursors()` does not return a `ManagedCursorContainer`.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
