### PR TITLE
[improve][broker] Improve Consumer.equals performance

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -1048,6 +1048,9 @@ public class Consumer {
 
     @Override
     public boolean equals(Object obj) {
+        if (this == obj)  {
+            return true;
+        }
         if (obj instanceof Consumer) {
             Consumer other = (Consumer) obj;
             return consumerId == other.consumerId && Objects.equals(cnx.clientAddress(), other.cnx.clientAddress());


### PR DESCRIPTION
### Motivation

- current problem is that unefficient IP address comparison will have to be performed on every match
- equals method should check if the other object is the same instance as the first step
Previously the equals method performance has been improved by @Shawyeok in PR #18662. That addressed the main performance issue and this current PR is a small adjustment to avoid unnecessary work when there's a matching instance.

### Modifications

- add instance check as first step

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->