### PR TITLE
[improve][broker] Support values up to 2^32 in ConcurrentBitmapSortedLongPairSet

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/utils/ConcurrentBitmapSortedLongPairSet.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/utils/ConcurrentBitmapSortedLongPairSet.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.utils;
 
-import java.util.Iterator;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
@@ -29,6 +28,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.pulsar.common.util.collections.LongPairSet;
+import org.roaringbitmap.PeekableIntIterator;
 import org.roaringbitmap.RoaringBitmap;
 
 public class ConcurrentBitmapSortedLongPairSet {
@@ -139,10 +139,10 @@ public class ConcurrentBitmapSortedLongPairSet {
         lock.readLock().lock();
         try {
             for (Map.Entry<Long, RoaringBitmap> entry : map.entrySet()) {
-                Iterator<Integer> iterator = entry.getValue().stream().iterator();
+                PeekableIntIterator intIterator = entry.getValue().getIntIterator();
                 boolean continueProcessing = true;
-                while (continueProcessing && iterator.hasNext()) {
-                    T item = longPairConverter.apply(entry.getKey(), iterator.next());
+                while (continueProcessing && intIterator.hasNext()) {
+                    T item = longPairConverter.apply(entry.getKey(), intIterator.next());
                     continueProcessing = itemProcessor.process(item);
                 }
                 if (!continueProcessing) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/utils/ConcurrentBitmapSortedLongPairSetTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/utils/ConcurrentBitmapSortedLongPairSetTest.java
@@ -18,18 +18,19 @@
  */
 package org.apache.pulsar.utils;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
-import lombok.Cleanup;
-import org.apache.pulsar.common.util.collections.ConcurrentLongPairSet;
-import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import lombok.Cleanup;
+import org.apache.pulsar.common.util.collections.ConcurrentLongPairSet;
+import org.testng.annotations.Test;
 
 @Test(groups = "utils")
 public class ConcurrentBitmapSortedLongPairSetTest {
@@ -203,5 +204,28 @@ public class ConcurrentBitmapSortedLongPairSetTest {
         }
 
         assertEquals(set.size(), N * nThreads);
+    }
+
+    @Test
+    public void testValueLargerThanIntegerMAX_VALUE() {
+        ConcurrentBitmapSortedLongPairSet set = new ConcurrentBitmapSortedLongPairSet();
+        long baseValue = Integer.MAX_VALUE;
+        List<Long> addedValues = new ArrayList<>();
+        int items = 10;
+        for (int i = 0; i < items; i++) {
+            long value = baseValue + i;
+            set.add(1, value);
+            addedValues.add(value);
+        }
+        assertEquals(set.size(), items);
+        List<Long> values = new ArrayList<>();
+        set.processItems((item1, item2) -> {
+            assertEquals(item1, 1);
+            return item2;
+        }, (value) -> {
+            values.add(value);
+            return true;
+        });
+        assertThat(values).containsExactlyElementsOf(addedValues);
     }
 }


### PR DESCRIPTION
### Motivation

ConcurrentBitmapSortedLongPairSet doesn't support long right-side values for the added pairs.
This PR mitigates the issue reported as #23877 by properly implementing the iterator so that values up to 2^32 can be supported. 

In addition, this PR optimizes the iterator usable by using RoaringBitmap's PeekableIntIterator which is more performant than using Java's standard Iterator API since PeekableIntIterator uses primitive int values instead of using boxed Integer values.

### Modifications

- Optimize ConcurrentBitmapSortedLongPairSet's processItems method by using PeekableIntIterator instead of Java's standard Iterator API.
- Properly use Integer.toUnsignedLong to support values up to 2^32. RoaringBitmap encodes the bit index as an unsigned int. However since Java doesn't support unsigned ints, it's necessary to use Integer.toUnsignedLong to convert the value to a long value.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->