### PR TITLE
[fix][client] Fix LoadManagerReport not found

### DIFF
--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -367,6 +367,13 @@
                 <relocation>
                   <pattern>org.apache.pulsar.policies</pattern>
                   <shadedPattern>org.apache.pulsar.shade.org.apache.pulsar.policies</shadedPattern>
+                  <!-- exclude references to unshaded classes and interfaces in https://github.com/apache/pulsar/tree/master/pulsar-client-admin-api/src/main/java/org/apache/pulsar/policies/data/loadbalancer -->
+                  <excludes>
+                    <exclude>org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport</exclude>
+                    <exclude>org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats</exclude>
+                    <exclude>org.apache.pulsar.policies.data.loadbalancer.ResourceUsage</exclude>
+                    <exclude>org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData</exclude>
+                  </excludes>
                 </relocation>
                 <relocation>
                   <pattern>org.asynchttpclient</pattern>

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -427,6 +427,13 @@
                 <relocation>
                   <pattern>org.apache.pulsar.policies</pattern>
                   <shadedPattern>org.apache.pulsar.shade.org.apache.pulsar.policies</shadedPattern>
+                  <!-- exclude references to unshaded classes and interfaces in https://github.com/apache/pulsar/tree/master/pulsar-client-admin-api/src/main/java/org/apache/pulsar/policies/data/loadbalancer -->
+                  <excludes>
+                    <exclude>org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport</exclude>
+                    <exclude>org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats</exclude>
+                    <exclude>org.apache.pulsar.policies.data.loadbalancer.ResourceUsage</exclude>
+                    <exclude>org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData</exclude>
+                  </excludes>
                 </relocation>
                 <relocation>
                   <pattern>org.asynchttpclient</pattern>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -339,6 +339,13 @@
                 <relocation>
                   <pattern>org.apache.pulsar.policies</pattern>
                   <shadedPattern>org.apache.pulsar.shade.org.apache.pulsar.policies</shadedPattern>
+                  <!-- exclude references to unshaded classes and interfaces in https://github.com/apache/pulsar/tree/master/pulsar-client-admin-api/src/main/java/org/apache/pulsar/policies/data/loadbalancer -->
+                  <excludes>
+                    <exclude>org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport</exclude>
+                    <exclude>org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats</exclude>
+                    <exclude>org.apache.pulsar.policies.data.loadbalancer.ResourceUsage</exclude>
+                    <exclude>org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData</exclude>
+                  </excludes>
                 </relocation>
                 <relocation>
                   <pattern>org.asynchttpclient</pattern>

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/ObjectMapperFactory.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/ObjectMapperFactory.java
@@ -32,7 +32,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.ClassUtils;
 import org.apache.pulsar.client.admin.internal.data.AuthPoliciesImpl;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.FunctionState;
@@ -263,15 +262,7 @@ public class ObjectMapperFactory {
         mapper.addMixIn(FunctionState.class, JsonIgnorePropertiesMixIn.class);
         mapper.addMixIn(Metrics.class, MetricsMixIn.class);
 
-        try {
-            // We look for LoadManagerReport first, then add deserializer to the module
-            // With shaded client, org.apache.pulsar.policies is relocated to
-            // org.apache.pulsar.shade.org.apache.pulsar.policies
-            ClassUtils.getClass("org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport");
-            module.addDeserializer(LoadManagerReport.class, new LoadReportDeserializer());
-        } catch (ClassNotFoundException e) {
-            log.debug("Add LoadManagerReport deserializer failed because LoadManagerReport.class has been shaded", e);
-        }
+        module.addDeserializer(LoadManagerReport.class, new LoadReportDeserializer());
 
         module.setAbstractTypes(resolver);
 

--- a/tests/pulsar-client-admin-shade-test/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
+++ b/tests/pulsar-client-admin-shade-test/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
@@ -87,6 +87,7 @@ public class SmokeTest extends TestRetrySupport {
         expectedNamespacesList.add("public/default");
         expectedNamespacesList.add("public/functions");
         Assert.assertEquals(admin.namespaces().getNamespaces("public"), expectedNamespacesList);
+        admin.brokerStats().getLoadReport();
     }
 
     @Override

--- a/tests/pulsar-client-all-shade-test/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
+++ b/tests/pulsar-client-all-shade-test/src/test/java/org/apache/pulsar/tests/integration/SmokeTest.java
@@ -87,6 +87,7 @@ public class SmokeTest extends TestRetrySupport {
         expectedNamespacesList.add("public/default");
         expectedNamespacesList.add("public/functions");
         Assert.assertEquals(admin.namespaces().getNamespaces("public"), expectedNamespacesList);
+        admin.brokerStats().getLoadReport();
     }
 
     @Override


### PR DESCRIPTION
### Motivation

When using the `pulsar-client-all` and `pulsar-client-admin` libraries, the `admin.brokerStats().getLoadReport()` doesn't work:

```
DEBUG o.a.p.c.util.ObjectMapperFactory - Add LoadManagerReport deserializer failed because LoadManagerReport.class has been shaded
java.lang.ClassNotFoundException: org.apache.pulsar.shade.org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport
2025-01-23 16:15:16.816 [taskScheduler-9] DEBUG o.a.p.c.util.ObjectMapperFactory - Add LoadManagerReport deserializer failed because LoadManagerReport.class has been shaded
java.lang.ClassNotFoundException: org.apache.pulsar.shade.org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport
2025-01-23 16:15:28.232 [http-nio-10000-exec-1] DEBUG o.s.w.s.m.m.a.ExceptionHandlerExceptionResolver - Resolved [org.springframework.web.util.NestedServletException: Handler dispatch failed; nested exception is java.lang.AbstractMethodError: Receiver class org.apache.pulsar.client.admin.internal.BrokerStatsImpl does not define or inherit an implementation of the resolved method 'abstract org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport getLoadReport()' of interface org.apache.pulsar.client.admin.BrokerStats.]
```

We got this error because the shade plugin relocates the `org.apache.pulsar.policies.data.loadbalancer.*` package, and `org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport` didn't added to the shaded-jar. 

### Modifications

- Relocating the `org.apache.pulsar.policies` is meaningless, so remove that from the shade configuration.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->