### PR TITLE
[improve][ml]Set default value of managedLedgerPersistIndividualAckAsLongArray to true

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2269,7 +2269,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
             category = CATEGORY_STORAGE_ML,
             doc = "Whether persist cursor ack stats as long arrays, which will compress the data and reduce GC rate")
-    private boolean managedLedgerPersistIndividualAckAsLongArray = false;
+    private boolean managedLedgerPersistIndividualAckAsLongArray = true;
     @FieldContext(
         category = CATEGORY_STORAGE_ML,
         doc = "If enabled, the maximum \"acknowledgment holes\" will not be limited and \"acknowledgment holes\" "


### PR DESCRIPTION
### Motivation

Regard [[DISCUSS] Add an optional config to disable the feature that compresses cursor metadata, which was contributed by #9292](https://lists.apache.org/thread/kfm7n6xf9pf7h76k4gx83zv3c2kj6yy1), we get a conclusion:
- `branch-3.0, branch-3.3, branch-4.0`: set default value of the feature `managedLedgerPersistIndividualAckAsLongArray` to `false`
- `branch-4.1`: set the default value of the feature `managedLedgerPersistIndividualAckAsLongArray` to `true`

### Modifications
- Set the default value of managedLedgerPersistIndividualAckAsLongArray to `true`. This PR should not be cherry-picked into previous versions.



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
