### PR TITLE
[fix][build] Use amazoncorretto:21-alpine3.20 JDK build for Alpine 3.20

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -55,7 +55,7 @@ RUN chmod -R o+rx /pulsar
 RUN echo 'OPTS="$OPTS -Dorg.xerial.snappy.use.systemlib=true"' >> /pulsar/conf/bkenv.sh
 
 ###  Create one stage to include JVM distribution
-FROM amazoncorretto:${IMAGE_JDK_MAJOR_VERSION}-alpine AS jvm
+FROM amazoncorretto:${IMAGE_JDK_MAJOR_VERSION}-alpine${ALPINE_VERSION} AS jvm
 
 RUN apk add --no-cache binutils
 


### PR DESCRIPTION
### Motivation

In the Pulsar Dockerfile, amazoncorretto:21-alpine is used as the JDK. 
Since Alpine 3.21 has been released, it now contains a JDK built for Alpine 3.21, which might cause compatibility issues.
It's better to use the build that matches the Alpine version used in Pulsar.

### Modifications

Use the ALPINE_VERSION argument so that amazoncorretto:21-alpine3.20 image is used, matching the ALPINE_VERSION of Pulsar image.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->