### PR TITLE
[fix][broker] Make InflightReadsLimiter asynchronous and apply it for replay queue reads

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactoryConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactoryConfig.java
@@ -62,6 +62,18 @@ public class ManagedLedgerFactoryConfig {
     private long managedLedgerMaxReadsInFlightSize = 0;
 
     /**
+     * Maximum time to wait for acquiring permits for max reads in flight when managedLedgerMaxReadsInFlightSizeInMB is
+     * set (>0) and the limit is reached.
+     */
+    private long managedLedgerMaxReadsInFlightPermitsAcquireTimeoutMillis = 60000;
+
+    /**
+     * Maximum number of reads that can be queued for acquiring permits for max reads in flight when
+     * managedLedgerMaxReadsInFlightSizeInMB is set (>0) and the limit is reached.
+     */
+    private int managedLedgerMaxReadsInFlightPermitsAcquireQueueSize = 10000;
+
+    /**
      * Whether trace managed ledger task execution time.
      */
     private boolean traceTaskExecution = true;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -228,7 +228,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                 compressionConfigForManagedCursorInfo);
         this.config = config;
         this.mbean = new ManagedLedgerFactoryMBeanImpl(this);
-        this.entryCacheManager = new RangeEntryCacheManagerImpl(this, openTelemetry);
+        this.entryCacheManager = new RangeEntryCacheManagerImpl(this, scheduledExecutor, openTelemetry);
         this.statsTask = scheduledExecutor.scheduleWithFixedDelay(catchingAndLoggingThrowables(this::refreshStats),
                 0, config.getStatsPeriodSeconds(), TimeUnit.SECONDS);
         this.flushCursorsTask = scheduledExecutor.scheduleAtFixedRate(catchingAndLoggingThrowables(this::flushCursors),

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
@@ -215,7 +215,12 @@ public class InflightReadsLimiter implements AutoCloseable {
             log.debug("timed out queued permits: {}, creationTime: {}, remainingBytes:{}",
                     queuedHandle.handle.permits, queuedHandle.handle.creationTime, remainingBytes);
         }
-        queuedHandle.callback.accept(new Handle(0, queuedHandle.handle.creationTime, false));
+        try {
+            queuedHandle.callback.accept(new Handle(0, queuedHandle.handle.creationTime, false));
+        } catch (Exception e) {
+            log.error("Error in callback of timed out queued permits: {}, creationTime: {}, remainingBytes:{}",
+                    queuedHandle.handle.permits, queuedHandle.handle.creationTime, remainingBytes, e);
+        }
     }
 
     /**
@@ -264,7 +269,12 @@ public class InflightReadsLimiter implements AutoCloseable {
             log.debug("acquired queued permits: {}, creationTime: {}, remainingBytes:{}",
                     queuedHandle.handle.permits, queuedHandle.handle.creationTime, remainingBytes);
         }
-        queuedHandle.callback.accept(queuedHandle.handle);
+        try {
+            queuedHandle.callback.accept(queuedHandle.handle);
+        } catch (Exception e) {
+            log.error("Error in callback of acquired queued permits: {}, creationTime: {}, remainingBytes:{}",
+                    queuedHandle.handle.permits, queuedHandle.handle.creationTime, remainingBytes, e);
+        }
     }
 
     private synchronized void updateMetrics() {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
@@ -27,8 +27,6 @@ import java.util.Queue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import lombok.AllArgsConstructor;
-import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.opentelemetry.Constants;
 import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes.InflightReadLimiterUtilization;
@@ -68,12 +66,7 @@ public class InflightReadsLimiter implements AutoCloseable {
     private final ScheduledExecutorService timeOutExecutor;
     private final boolean enabled;
 
-    @AllArgsConstructor
-    @ToString
-    static class Handle {
-        final long permits;
-        final long creationTime;
-        final boolean success;
+    record Handle(long permits, long creationTime, boolean success) {
     }
 
     record QueuedHandle(Handle handle, Consumer<Handle> callback) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
@@ -22,12 +22,18 @@ import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.ObservableLongCounter;
 import io.prometheus.client.Gauge;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import lombok.AllArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.opentelemetry.Constants;
 import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes.InflightReadLimiterUtilization;
 import org.apache.pulsar.opentelemetry.annotations.PulsarDeprecatedMetric;
+import org.jctools.queues.SpscArrayQueue;
 
 @Slf4j
 public class InflightReadsLimiter implements AutoCloseable {
@@ -58,16 +64,41 @@ public class InflightReadsLimiter implements AutoCloseable {
 
     private final long maxReadsInFlightSize;
     private long remainingBytes;
+    private final long acquireTimeoutMillis;
+    private final ScheduledExecutorService timeOutExecutor;
+    private final boolean enabled;
 
-    public InflightReadsLimiter(long maxReadsInFlightSize, OpenTelemetry openTelemetry) {
-        if (maxReadsInFlightSize <= 0) {
+    @AllArgsConstructor
+    @ToString
+    static class Handle {
+        final long permits;
+        final long creationTime;
+        final boolean success;
+    }
+
+    record QueuedHandle(Handle handle, Consumer<Handle> callback) {
+    }
+
+    private final Queue<QueuedHandle> queuedHandles;
+    private boolean timeoutCheckRunning = false;
+
+    public InflightReadsLimiter(long maxReadsInFlightSize, int maxReadsInFlightAcquireQueueSize,
+                                long acquireTimeoutMillis, ScheduledExecutorService timeOutExecutor,
+                                OpenTelemetry openTelemetry) {
+        this.maxReadsInFlightSize = maxReadsInFlightSize;
+        this.remainingBytes = maxReadsInFlightSize;
+        this.acquireTimeoutMillis = acquireTimeoutMillis;
+        this.timeOutExecutor = timeOutExecutor;
+        if (maxReadsInFlightSize > 0) {
+            enabled = true;
+            this.queuedHandles = new SpscArrayQueue<>(maxReadsInFlightAcquireQueueSize);
+        } else {
+            enabled = false;
+            this.queuedHandles = null;
             // set it to -1 in order to show in the metrics that the metric is not available
             PULSAR_ML_READS_BUFFER_SIZE.set(-1);
             PULSAR_ML_READS_AVAILABLE_BUFFER_SIZE.set(-1);
         }
-        this.maxReadsInFlightSize = maxReadsInFlightSize;
-        this.remainingBytes = maxReadsInFlightSize;
-
         var meter = openTelemetry.getMeter(Constants.BROKER_INSTRUMENTATION_SCOPE_NAME);
         inflightReadsLimitCounter = meter.counterBuilder(INFLIGHT_READS_LIMITER_LIMIT_METRIC_NAME)
                 .setDescription("Maximum number of bytes that can be retained by managed ledger data read from storage "
@@ -102,71 +133,145 @@ public class InflightReadsLimiter implements AutoCloseable {
         inflightReadsUsageCounter.close();
     }
 
-    @AllArgsConstructor
-    @ToString
-    static class Handle {
-        final long acquiredPermits;
-        final boolean success;
-        final int trials;
+    private static final Handle DISABLED = new Handle(0, 0, true);
+    private static final Optional<Handle> DISABLED_OPTIONAL = Optional.of(DISABLED);
 
-        final long creationTime;
+    /**
+     * Acquires permits from the limiter. If the limiter is disabled, it will immediately return a successful handle.
+     * If permits are available, it will return a handle with the acquired permits. If no permits are available,
+     * it will return an empty optional and the callback will be called when permits become available or when the
+     * acquire timeout is reached. The success field in the handle passed to the callback will be false if the acquire
+     * operation times out. The callback should be non-blocking and run on a desired executor handled within the
+     * callback itself.
+     *
+     * A successful handle will have the success field set to true, and the caller must call release with the handle
+     * when the permits are no longer needed.
+     *
+     * If an unsuccessful handle is returned immediately, it means that the queue limit has been reached and the
+     * callback will not be called. The caller should fail the read operation in this case to apply backpressure.
+     *
+     * @param permits  the number of permits to acquire
+     * @param callback the callback to be called when the permits are acquired or timed out
+     * @return an optional handle that contains the permits if acquired, otherwise an empty optional
+     */
+    public Optional<Handle> acquire(long permits, Consumer<Handle> callback) {
+        if (isDisabled()) {
+            return DISABLED_OPTIONAL;
+        }
+        return internalAcquire(permits, callback);
     }
 
-    private static final Handle DISABLED = new Handle(0, true, 0, -1);
-
-    Handle acquire(long permits, Handle current) {
-        if (maxReadsInFlightSize <= 0) {
-            // feature is disabled
-            return DISABLED;
-        }
-        synchronized (this) {
-            try {
-                if (current == null) {
-                    if (remainingBytes == 0) {
-                        return new Handle(0, false, 1, System.currentTimeMillis());
-                    }
-                    if (remainingBytes >= permits) {
-                        remainingBytes -= permits;
-                        return new Handle(permits, true, 1, System.currentTimeMillis());
-                    } else {
-                        long possible = remainingBytes;
-                        remainingBytes = 0;
-                        return new Handle(possible, false, 1, System.currentTimeMillis());
-                    }
-                } else {
-                    if (current.trials >= 4 && current.acquiredPermits > 0) {
-                        remainingBytes += current.acquiredPermits;
-                        return new Handle(0, false, 1, current.creationTime);
-                    }
-                    if (remainingBytes == 0) {
-                        return new Handle(current.acquiredPermits, false, current.trials + 1,
-                                current.creationTime);
-                    }
-                    long needed = permits - current.acquiredPermits;
-                    if (remainingBytes >= needed) {
-                        remainingBytes -= needed;
-                        return new Handle(permits, true, current.trials + 1, current.creationTime);
-                    } else {
-                        long possible = remainingBytes;
-                        remainingBytes = 0;
-                        return new Handle(current.acquiredPermits + possible, false,
-                                current.trials + 1, current.creationTime);
-                    }
-                }
-            } finally {
-                updateMetrics();
+    private synchronized Optional<Handle> internalAcquire(long permits, Consumer<Handle> callback) {
+        Handle handle = new Handle(permits, System.currentTimeMillis(), true);
+        if (remainingBytes >= permits) {
+            remainingBytes -= permits;
+            if (log.isDebugEnabled()) {
+                log.debug("acquired permits: {}, creationTime: {}, remainingBytes:{}", permits, handle.creationTime,
+                        remainingBytes);
+            }
+            updateMetrics();
+            return Optional.of(handle);
+        } else {
+            if (queuedHandles.offer(new QueuedHandle(handle, callback))) {
+                scheduleTimeOutCheck(acquireTimeoutMillis);
+                return Optional.empty();
+            } else {
+                log.warn("Failed to queue handle for acquiring permits: {}, creationTime: {}, remainingBytes:{}",
+                        permits, handle.creationTime, remainingBytes);
+                return Optional.of(new Handle(0, handle.creationTime, false));
             }
         }
     }
 
-    void release(Handle handle) {
+    private synchronized void scheduleTimeOutCheck(long delayMillis) {
+        if (acquireTimeoutMillis <= 0) {
+            return;
+        }
+        if (!timeoutCheckRunning) {
+            timeoutCheckRunning = true;
+            timeOutExecutor.schedule(this::timeoutCheck, delayMillis, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private synchronized void timeoutCheck() {
+        timeoutCheckRunning = false;
+        long delay = 0;
+        while (true) {
+            QueuedHandle queuedHandle = queuedHandles.peek();
+            if (queuedHandle != null) {
+                long age = System.currentTimeMillis() - queuedHandle.handle.creationTime;
+                if (age >= acquireTimeoutMillis) {
+                    // remove the peeked handle from the queue
+                    queuedHandles.poll();
+                    handleTimeout(queuedHandle);
+                } else {
+                    delay = acquireTimeoutMillis - age;
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+        if (delay > 0) {
+            scheduleTimeOutCheck(delay);
+        }
+    }
+
+    private void handleTimeout(QueuedHandle queuedHandle) {
+        if (log.isDebugEnabled()) {
+            log.debug("timed out queued permits: {}, creationTime: {}, remainingBytes:{}",
+                    queuedHandle.handle.permits, queuedHandle.handle.creationTime, remainingBytes);
+        }
+        queuedHandle.callback.accept(new Handle(0, queuedHandle.handle.creationTime, false));
+    }
+
+    /**
+     * Releases permits back to the limiter. If the handle is disabled, this method will be a no-op.
+     *
+     * @param handle the handle containing the permits to release
+     */
+    public void release(Handle handle) {
         if (handle == DISABLED) {
             return;
         }
-        synchronized (this) {
-            remainingBytes += handle.acquiredPermits;
-            updateMetrics();
+        internalRelease(handle);
+    }
+
+    private synchronized void internalRelease(Handle handle) {
+        if (log.isDebugEnabled()) {
+            log.debug("release permits: {}, creationTime: {}, remainingBytes:{}", handle.permits,
+                    handle.creationTime, getRemainingBytes());
         }
+        remainingBytes += handle.permits;
+        while (true) {
+            QueuedHandle queuedHandle = queuedHandles.peek();
+            if (queuedHandle != null) {
+                if (remainingBytes >= queuedHandle.handle.permits) {
+                    // remove the peeked handle from the queue
+                    queuedHandles.poll();
+                    handleQueuedHandle(queuedHandle);
+                } else if (acquireTimeoutMillis > 0
+                        && System.currentTimeMillis() - queuedHandle.handle.creationTime > acquireTimeoutMillis) {
+                    // remove the peeked handle from the queue
+                    queuedHandles.poll();
+                    handleTimeout(queuedHandle);
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+        updateMetrics();
+    }
+
+    private void handleQueuedHandle(QueuedHandle queuedHandle) {
+        remainingBytes -= queuedHandle.handle.permits;
+        if (log.isDebugEnabled()) {
+            log.debug("acquired queued permits: {}, creationTime: {}, remainingBytes:{}",
+                    queuedHandle.handle.permits, queuedHandle.handle.creationTime, remainingBytes);
+        }
+        queuedHandle.callback.accept(queuedHandle.handle);
     }
 
     private synchronized void updateMetrics() {
@@ -175,8 +280,6 @@ public class InflightReadsLimiter implements AutoCloseable {
     }
 
     public boolean isDisabled() {
-        return maxReadsInFlightSize <= 0;
+        return !enabled;
     }
-
-
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/PendingReadsManager.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/PendingReadsManager.java
@@ -27,8 +27,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import lombok.AllArgsConstructor;
-import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
@@ -96,14 +94,10 @@ public class PendingReadsManager {
         this.rangeEntryCache = rangeEntryCache;
     }
 
-    @Value
-    private static class PendingReadKey {
-        private final long startEntry;
-        private final long endEntry;
+    private record PendingReadKey(long startEntry, long endEntry) {
         long size() {
             return endEntry - startEntry + 1;
         }
-
 
         boolean includes(PendingReadKey other) {
             return startEntry <= other.startEntry && other.endEntry <= endEntry;
@@ -136,19 +130,12 @@ public class PendingReadsManager {
 
     }
 
-    @AllArgsConstructor
-    private static final class ReadEntriesCallbackWithContext {
-        final AsyncCallbacks.ReadEntriesCallback callback;
-        final Object ctx;
-        final long startEntry;
-        final long endEntry;
+    private record ReadEntriesCallbackWithContext(AsyncCallbacks.ReadEntriesCallback callback, Object ctx,
+                                                  long startEntry, long endEntry) {
     }
 
-    @AllArgsConstructor
-    private static final class FindPendingReadOutcome {
-        final PendingRead pendingRead;
-        final PendingReadKey missingOnLeft;
-        final PendingReadKey missingOnRight;
+    private record FindPendingReadOutcome(PendingRead pendingRead,
+                                          PendingReadKey missingOnLeft, PendingReadKey missingOnRight) {
         boolean needsAdditionalReads() {
             return missingOnLeft != null || missingOnRight != null;
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -22,18 +22,19 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.createManagedLedgerException;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
 import org.apache.bookkeeper.client.api.BKException;
 import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.client.api.ReadHandle;
-import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntryCallback;
 import org.apache.bookkeeper.mledger.Entry;
@@ -58,6 +59,8 @@ public class RangeEntryCacheImpl implements EntryCache {
      * Overhead per-entry to take into account the envelope.
      */
     public static final long BOOKKEEPER_READ_OVERHEAD_PER_ENTRY = 64;
+    private static final int DEFAULT_ESTIMATED_ENTRY_SIZE = 10 * 1024;
+    private static final boolean DEFAULT_CACHE_INDIVIDUAL_READ_ENTRY = false;
 
     private final RangeEntryCacheManagerImpl manager;
     final ManagedLedgerImpl ml;
@@ -66,18 +69,16 @@ public class RangeEntryCacheImpl implements EntryCache {
     private final boolean copyEntries;
     private final PendingReadsManager pendingReadsManager;
 
-    private volatile long estimatedEntrySize = 10 * 1024;
-
-    private final long readEntryTimeoutMillis;
-
     private static final double MB = 1024 * 1024;
+
+    private final LongAdder totalAddedEntriesSize = new LongAdder();
+    private final LongAdder totalAddedEntriesCount = new LongAdder();
 
     public RangeEntryCacheImpl(RangeEntryCacheManagerImpl manager, ManagedLedgerImpl ml, boolean copyEntries) {
         this.manager = manager;
         this.ml = ml;
         this.pendingReadsManager = new PendingReadsManager(this);
         this.interceptor = ml.getManagedLedgerInterceptor();
-        this.readEntryTimeoutMillis = getManagedLedgerConfig().getReadEntryTimeoutSeconds();
         this.entries = new RangeCache<>(EntryImpl::getLength, EntryImpl::getTimestamp);
         this.copyEntries = copyEntries;
 
@@ -118,17 +119,18 @@ public class RangeEntryCacheImpl implements EntryCache {
 
     @Override
     public boolean insert(EntryImpl entry) {
+        int entryLength = entry.getLength();
         if (!manager.hasSpaceInCache()) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Skipping cache while doing eviction: {} - size: {}", ml.getName(), entry.getPosition(),
-                        entry.getLength());
+                        entryLength);
             }
             return false;
         }
 
         if (log.isDebugEnabled()) {
             log.debug("[{}] Adding entry to cache: {} - size: {}", ml.getName(), entry.getPosition(),
-                    entry.getLength());
+                    entryLength);
         }
 
         Position position = entry.getPosition();
@@ -150,7 +152,9 @@ public class RangeEntryCacheImpl implements EntryCache {
         EntryImpl cacheEntry = EntryImpl.create(position, cachedData);
         cachedData.release();
         if (entries.put(position, cacheEntry)) {
-            manager.entryAdded(entry.getLength());
+            totalAddedEntriesSize.add(entryLength);
+            totalAddedEntriesCount.increment();
+            manager.entryAdded(entryLength);
             return true;
         } else {
             // entry was not inserted into cache, we need to discard it
@@ -226,7 +230,23 @@ public class RangeEntryCacheImpl implements EntryCache {
     public void asyncReadEntry(ReadHandle lh, Position position, final ReadEntryCallback callback,
             final Object ctx) {
         try {
-            asyncReadEntry0(lh, position, callback, ctx);
+            asyncReadEntriesByPosition(lh, position, position, 1,
+                    DEFAULT_CACHE_INDIVIDUAL_READ_ENTRY,
+                    new ReadEntriesCallback() {
+                @Override
+                public void readEntriesComplete(List<Entry> entries, Object ctx) {
+                    if (entries.isEmpty()) {
+                        callback.readEntryFailed(new ManagedLedgerException("Could not read given position"), ctx);
+                    } else {
+                        callback.readEntryComplete(entries.get(0), ctx);
+                    }
+                }
+
+                @Override
+                public void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
+                    callback.readEntryFailed(exception, ctx);
+                }
+            }, ctx, true);
         } catch (Throwable t) {
             log.warn("failed to read entries for {}-{}", lh.getId(), position, t);
             // invalidate all entries related to ledger from the cache (it might happen if entry gets corrupt
@@ -234,47 +254,6 @@ public class RangeEntryCacheImpl implements EntryCache {
             // the bookie)
             invalidateAllEntries(lh.getId());
             callback.readEntryFailed(createManagedLedgerException(t), ctx);
-        }
-    }
-
-    private void asyncReadEntry0(ReadHandle lh, Position position, final ReadEntryCallback callback,
-            final Object ctx) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Reading entry ledger {}: {}", ml.getName(), lh.getId(), position.getEntryId());
-        }
-        EntryImpl entry = entries.get(position);
-        if (entry != null) {
-            EntryImpl cachedEntry = EntryImpl.create(entry);
-            entry.release();
-            manager.mlFactoryMBean.recordCacheHit(cachedEntry.getLength());
-            callback.readEntryComplete(cachedEntry, ctx);
-        } else {
-            ReadEntryUtils.readAsync(ml, lh, position.getEntryId(), position.getEntryId()).thenAcceptAsync(
-                    ledgerEntries -> {
-                        try {
-                            Iterator<LedgerEntry> iterator = ledgerEntries.iterator();
-                            if (iterator.hasNext()) {
-                                LedgerEntry ledgerEntry = iterator.next();
-                                EntryImpl returnEntry = RangeEntryCacheManagerImpl.create(ledgerEntry, interceptor);
-
-                                ml.getMbean().recordReadEntriesOpsCacheMisses(1, returnEntry.getLength());
-                                manager.mlFactoryMBean.recordCacheMiss(1, returnEntry.getLength());
-                                ml.getMbean().addReadEntriesSample(1, returnEntry.getLength());
-                                callback.readEntryComplete(returnEntry, ctx);
-                            } else {
-                                // got an empty sequence
-                                callback.readEntryFailed(new ManagedLedgerException("Could not read given position"),
-                                                         ctx);
-                            }
-                        } finally {
-                            ledgerEntries.close();
-                        }
-                    }, ml.getExecutor()).exceptionally(exception -> {
-                        ml.invalidateLedgerHandle(lh);
-                        pendingReadsManager.invalidateLedger(lh.getId());
-                        callback.readEntryFailed(createManagedLedgerException(exception), ctx);
-                        return null;
-            });
         }
     }
 
@@ -295,38 +274,125 @@ public class RangeEntryCacheImpl implements EntryCache {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     void asyncReadEntry0(ReadHandle lh, long firstEntry, long lastEntry, boolean shouldCacheEntry,
-            final ReadEntriesCallback callback, Object ctx, boolean withLimits) {
-        asyncReadEntry0WithLimits(lh, firstEntry, lastEntry, shouldCacheEntry, callback, ctx, null, withLimits);
+            final ReadEntriesCallback callback, Object ctx, boolean acquirePermits) {
+        final long ledgerId = lh.getId();
+        final int numberOfEntries = (int) (lastEntry - firstEntry) + 1;
+        final Position firstPosition = PositionFactory.create(ledgerId, firstEntry);
+        final Position lastPosition = PositionFactory.create(ledgerId, lastEntry);
+        asyncReadEntriesByPosition(lh, firstPosition, lastPosition, numberOfEntries, shouldCacheEntry, callback, ctx,
+                acquirePermits);
     }
 
-    void asyncReadEntry0WithLimits(ReadHandle lh, long firstEntry, long lastEntry, boolean shouldCacheEntry,
-        final ReadEntriesCallback originalCallback, Object ctx, InflightReadsLimiter.Handle handle,
-                                   boolean withLimits) {
-        AsyncCallbacks.ReadEntriesCallback callback;
-        if (withLimits) {
-            callback = handlePendingReadsLimits(lh, firstEntry, lastEntry, shouldCacheEntry, originalCallback, ctx,
-                    handle);
-        } else {
-            callback = originalCallback;
-        }
-        if (callback == null) {
-            return;
-        }
-
-        final long ledgerId = lh.getId();
-        final int entriesToRead = (int) (lastEntry - firstEntry) + 1;
-        final Position firstPosition = PositionFactory.create(lh.getId(), firstEntry);
-        final Position lastPosition = PositionFactory.create(lh.getId(), lastEntry);
+    void asyncReadEntriesByPosition(ReadHandle lh, Position firstPosition, Position lastPosition, int numberOfEntries,
+                                    boolean shouldCacheEntry, final ReadEntriesCallback originalCallback,
+                                    Object ctx, boolean acquirePermits) {
+        checkArgument(firstPosition.getLedgerId() == lastPosition.getLedgerId(),
+                "Invalid range. Entries %s and %s should be in the same ledger.",
+                firstPosition, lastPosition);
+        checkArgument(firstPosition.getLedgerId() == lh.getId(),
+                "Invalid ReadHandle. The ledger %s of the range positions should match the handle's ledger %s.",
+                firstPosition.getLedgerId(), lh.getId());
 
         if (log.isDebugEnabled()) {
-            log.debug("[{}] Reading entries range ledger {}: {} to {}", ml.getName(), ledgerId, firstEntry, lastEntry);
+            log.debug("[{}] Reading {} entries in range {} to {}", ml.getName(), numberOfEntries, firstPosition,
+                    lastPosition);
         }
 
-        Collection<EntryImpl> cachedEntries = entries.getRange(firstPosition, lastPosition);
+        InflightReadsLimiter pendingReadsLimiter = getPendingReadsLimiter();
+        if (!acquirePermits || pendingReadsLimiter.isDisabled()) {
+            doAsyncReadEntriesByPosition(lh, firstPosition, lastPosition, numberOfEntries, shouldCacheEntry,
+                    originalCallback, ctx);
+        } else {
+            long estimatedEntrySize = getEstimatedEntrySize();
+            long estimatedReadSize = numberOfEntries * estimatedEntrySize;
+            if (log.isDebugEnabled()) {
+                log.debug("Estimated read size: {} bytes for {} entries with {} estimated entry size",
+                        estimatedReadSize,
+                        numberOfEntries, estimatedEntrySize);
+            }
+            Optional<InflightReadsLimiter.Handle> optionalHandle =
+                    pendingReadsLimiter.acquire(estimatedReadSize, handle -> {
+                        // permits were not immediately available, callback will be executed when permits are acquired
+                        // or timeout
+                        ml.getExecutor().execute(() -> {
+                            doAsyncReadEntriesWithAcquiredPermits(lh, firstPosition, lastPosition, numberOfEntries,
+                                    shouldCacheEntry, originalCallback, ctx, handle, estimatedReadSize);
+                        });
+                    });
+            // permits were immediately available and acquired
+            if (optionalHandle.isPresent()) {
+                doAsyncReadEntriesWithAcquiredPermits(lh, firstPosition, lastPosition, numberOfEntries,
+                        shouldCacheEntry, originalCallback, ctx, optionalHandle.get(), estimatedReadSize);
+            }
+        }
+    }
 
-        if (cachedEntries.size() == entriesToRead) {
+    void doAsyncReadEntriesWithAcquiredPermits(ReadHandle lh, Position firstPosition, Position lastPosition,
+                                               int numberOfEntries, boolean shouldCacheEntry,
+                                               final ReadEntriesCallback originalCallback, Object ctx,
+                                               InflightReadsLimiter.Handle handle, long estimatedReadSize) {
+        if (!handle.success) {
+            String message = "Couldn't acquire enough permits "
+                    + "on the max reads in flight limiter to read from ledger "
+                    + lh.getId()
+                    + ", " + getName()
+                    + ", estimated read size " + estimatedReadSize + " bytes"
+                    + " for " + numberOfEntries
+                    + " entries (check managedLedgerMaxReadsInFlightSizeInMB, "
+                    + "managedLedgerMaxReadsInFlightPermitsAcquireTimeoutMillis and "
+                    + "managedLedgerMaxReadsInFlightPermitsAcquireQueueSize)";
+            log.error(message);
+            originalCallback.readEntriesFailed(new ManagedLedgerException.TooManyRequestsException(message), ctx);
+            return;
+        }
+        InflightReadsLimiter pendingReadsLimiter = getPendingReadsLimiter();
+        ReadEntriesCallback wrappedCallback = new ReadEntriesCallback() {
+            @Override
+            public void readEntriesComplete(List<Entry> entries, Object ctx2) {
+                if (!entries.isEmpty()) {
+                    // release permits only when entries have been handled
+                    AtomicInteger remainingCount = new AtomicInteger(entries.size());
+                    for (Entry entry : entries) {
+                        ((EntryImpl) entry).onDeallocate(() -> {
+                            if (remainingCount.decrementAndGet() <= 0) {
+                                pendingReadsLimiter.release(handle);
+                            }
+                        });
+                    }
+                } else {
+                    pendingReadsLimiter.release(handle);
+                }
+                originalCallback.readEntriesComplete(entries, ctx2);
+            }
+
+            @Override
+            public void readEntriesFailed(ManagedLedgerException exception, Object ctx2) {
+                pendingReadsLimiter.release(handle);
+                originalCallback.readEntriesFailed(exception, ctx2);
+            }
+        };
+        doAsyncReadEntriesByPosition(lh, firstPosition, lastPosition, numberOfEntries, shouldCacheEntry,
+                wrappedCallback, ctx);
+    }
+
+    void doAsyncReadEntriesByPosition(ReadHandle lh, Position firstPosition, Position lastPosition, int numberOfEntries,
+                                      boolean shouldCacheEntry, final ReadEntriesCallback callback,
+                                      Object ctx) {
+        Collection<EntryImpl> cachedEntries;
+        if (firstPosition.compareTo(lastPosition) == 0) {
+            EntryImpl cachedEntry = entries.get(firstPosition);
+            if (cachedEntry == null) {
+                cachedEntries = Collections.emptyList();
+            } else {
+                cachedEntries = Collections.singleton(cachedEntry);
+            }
+        } else {
+            cachedEntries = entries.getRange(firstPosition, lastPosition);
+        }
+
+        if (cachedEntries.size() == numberOfEntries) {
             long totalCachedSize = 0;
-            final List<EntryImpl> entriesToReturn = Lists.newArrayListWithExpectedSize(entriesToRead);
+            final List<Entry> entriesToReturn = new ArrayList<>(numberOfEntries);
 
             // All entries found in cache
             for (EntryImpl entry : cachedEntries) {
@@ -337,11 +403,11 @@ public class RangeEntryCacheImpl implements EntryCache {
 
             manager.mlFactoryMBean.recordCacheHits(entriesToReturn.size(), totalCachedSize);
             if (log.isDebugEnabled()) {
-                log.debug("[{}] Ledger {} -- Found in cache entries: {}-{}", ml.getName(), ledgerId, firstEntry,
-                        lastEntry);
+                log.debug("[{}] Cache hit for {} entries in range {} to {}", ml.getName(), numberOfEntries,
+                        firstPosition, lastPosition);
             }
 
-            callback.readEntriesComplete((List) entriesToReturn, ctx);
+            callback.readEntriesComplete(entriesToReturn, ctx);
 
         } else {
             if (!cachedEntries.isEmpty()) {
@@ -349,77 +415,23 @@ public class RangeEntryCacheImpl implements EntryCache {
             }
 
             // Read all the entries from bookkeeper
-            pendingReadsManager.readEntries(lh, firstEntry, lastEntry,
+            pendingReadsManager.readEntries(lh, firstPosition.getEntryId(), lastPosition.getEntryId(),
                     shouldCacheEntry, callback, ctx);
-
         }
     }
 
-    private AsyncCallbacks.ReadEntriesCallback handlePendingReadsLimits(ReadHandle lh,
-                                                                long firstEntry, long lastEntry,
-                                                                boolean shouldCacheEntry,
-                                                                AsyncCallbacks.ReadEntriesCallback originalCallback,
-                                                                Object ctx, InflightReadsLimiter.Handle handle) {
-        InflightReadsLimiter pendingReadsLimiter = getPendingReadsLimiter();
-        if (pendingReadsLimiter.isDisabled()) {
-            return originalCallback;
+    private long getEstimatedEntrySize() {
+        long estimatedEntrySize = getAvgEntrySize();
+        if (estimatedEntrySize == 0) {
+            estimatedEntrySize = DEFAULT_ESTIMATED_ENTRY_SIZE;
         }
-        long estimatedReadSize = (1 + lastEntry - firstEntry)
-                * (estimatedEntrySize + BOOKKEEPER_READ_OVERHEAD_PER_ENTRY);
-        final AsyncCallbacks.ReadEntriesCallback callback;
-        InflightReadsLimiter.Handle newHandle = pendingReadsLimiter.acquire(estimatedReadSize, handle);
-        if (!newHandle.success) {
-            long now = System.currentTimeMillis();
-            if (now - newHandle.creationTime > readEntryTimeoutMillis) {
-                String message = "Time-out elapsed while acquiring enough permits "
-                        + "on the memory limiter to read from ledger "
-                        + lh.getId()
-                        + ", " + getName()
-                        + ", estimated read size " + estimatedReadSize + " bytes"
-                        + " for " + (1 + lastEntry - firstEntry)
-                        + " entries (check managedLedgerMaxReadsInFlightSizeInMB)";
-                log.error(message);
-                pendingReadsLimiter.release(newHandle);
-                originalCallback.readEntriesFailed(
-                        new ManagedLedgerException.TooManyRequestsException(message), ctx);
-                return null;
-            }
-            ml.getExecutor().execute(() -> {
-                asyncReadEntry0WithLimits(lh, firstEntry, lastEntry, shouldCacheEntry,
-                        originalCallback, ctx, newHandle, true);
-            });
-            return null;
-        } else {
-            callback = new AsyncCallbacks.ReadEntriesCallback() {
+        return estimatedEntrySize + BOOKKEEPER_READ_OVERHEAD_PER_ENTRY;
+    }
 
-                @Override
-                public void readEntriesComplete(List<Entry> entries, Object ctx) {
-                    if (!entries.isEmpty()) {
-                        long size = entries.get(0).getLength();
-                        estimatedEntrySize = size;
-
-                        AtomicInteger remainingCount = new AtomicInteger(entries.size());
-                        for (Entry entry : entries) {
-                            ((EntryImpl) entry).onDeallocate(() -> {
-                                if (remainingCount.decrementAndGet() <= 0) {
-                                    pendingReadsLimiter.release(newHandle);
-                                }
-                            });
-                        }
-                    } else {
-                        pendingReadsLimiter.release(newHandle);
-                    }
-                    originalCallback.readEntriesComplete(entries, ctx);
-                }
-
-                @Override
-                public void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
-                    pendingReadsLimiter.release(newHandle);
-                    originalCallback.readEntriesFailed(exception, ctx);
-                }
-            };
-        }
-        return callback;
+    private long getAvgEntrySize() {
+        long totalAddedEntriesCount = this.totalAddedEntriesCount.sum();
+        long totalAddedEntriesSize = this.totalAddedEntriesSize.sum();
+        return totalAddedEntriesCount != 0 ? totalAddedEntriesSize / totalAddedEntriesCount : 0;
     }
 
     /**
@@ -442,8 +454,7 @@ public class RangeEntryCacheImpl implements EntryCache {
                             try {
                                 // We got the entries, we need to transform them to a List<> type
                                 long totalSize = 0;
-                                final List<EntryImpl> entriesToReturn =
-                                        Lists.newArrayListWithExpectedSize(entriesToRead);
+                                final List<EntryImpl> entriesToReturn = new ArrayList<>(entriesToRead);
                                 for (LedgerEntry e : ledgerEntries) {
                                     EntryImpl entry = RangeEntryCacheManagerImpl.create(e, interceptor);
                                     entriesToReturn.add(entry);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -331,7 +331,7 @@ public class RangeEntryCacheImpl implements EntryCache {
                                                int numberOfEntries, boolean shouldCacheEntry,
                                                final ReadEntriesCallback originalCallback, Object ctx,
                                                InflightReadsLimiter.Handle handle, long estimatedReadSize) {
-        if (!handle.success) {
+        if (!handle.success()) {
             String message = String.format(
                     "Couldn't acquire enough permits on the max reads in flight limiter to read from ledger "
                             + "%d, %s, estimated read size %d bytes for %d entries (check "

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -332,15 +332,13 @@ public class RangeEntryCacheImpl implements EntryCache {
                                                final ReadEntriesCallback originalCallback, Object ctx,
                                                InflightReadsLimiter.Handle handle, long estimatedReadSize) {
         if (!handle.success) {
-            String message = "Couldn't acquire enough permits "
-                    + "on the max reads in flight limiter to read from ledger "
-                    + lh.getId()
-                    + ", " + getName()
-                    + ", estimated read size " + estimatedReadSize + " bytes"
-                    + " for " + numberOfEntries
-                    + " entries (check managedLedgerMaxReadsInFlightSizeInMB, "
-                    + "managedLedgerMaxReadsInFlightPermitsAcquireTimeoutMillis and "
-                    + "managedLedgerMaxReadsInFlightPermitsAcquireQueueSize)";
+            String message = String.format(
+                    "Couldn't acquire enough permits on the max reads in flight limiter to read from ledger "
+                            + "%d, %s, estimated read size %d bytes for %d entries (check "
+                            + "managedLedgerMaxReadsInFlightSizeInMB, "
+                            + "managedLedgerMaxReadsInFlightPermitsAcquireTimeoutMillis and "
+                            + "managedLedgerMaxReadsInFlightPermitsAcquireQueueSize)", lh.getId(), getName(),
+                    estimatedReadSize, numberOfEntries);
             log.error(message);
             originalCallback.readEntriesFailed(new ManagedLedgerException.TooManyRequestsException(message), ctx);
             return;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -420,7 +420,8 @@ public class RangeEntryCacheImpl implements EntryCache {
         }
     }
 
-    private long getEstimatedEntrySize() {
+    @VisibleForTesting
+    public long getEstimatedEntrySize() {
         long estimatedEntrySize = getAvgEntrySize();
         if (estimatedEntrySize == 0) {
             estimatedEntrySize = DEFAULT_ESTIMATED_ENTRY_SIZE;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheManagerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheManagerImpl.java
@@ -28,7 +28,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
+import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactoryConfig;
 import org.apache.bookkeeper.mledger.impl.EntryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryMBeanImpl;
@@ -57,12 +59,16 @@ public class RangeEntryCacheManagerImpl implements EntryCacheManager {
     private static final double evictionTriggerThresholdPercent = 0.98;
 
 
-    public RangeEntryCacheManagerImpl(ManagedLedgerFactoryImpl factory, OpenTelemetry openTelemetry) {
-        this.maxSize = factory.getConfig().getMaxCacheSize();
-        this.inflightReadsLimiter = new InflightReadsLimiter(
-                factory.getConfig().getManagedLedgerMaxReadsInFlightSize(), openTelemetry);
+    public RangeEntryCacheManagerImpl(ManagedLedgerFactoryImpl factory, OrderedScheduler scheduledExecutor,
+                                      OpenTelemetry openTelemetry) {
+        ManagedLedgerFactoryConfig config = factory.getConfig();
+        this.maxSize = config.getMaxCacheSize();
+        this.inflightReadsLimiter = new InflightReadsLimiter(config.getManagedLedgerMaxReadsInFlightSize(),
+                config.getManagedLedgerMaxReadsInFlightPermitsAcquireQueueSize(),
+                config.getManagedLedgerMaxReadsInFlightPermitsAcquireTimeoutMillis(),
+                scheduledExecutor, openTelemetry);
         this.evictionTriggerThreshold = (long) (maxSize * evictionTriggerThresholdPercent);
-        this.cacheEvictionWatermark = factory.getConfig().getCacheEvictionWatermark();
+        this.cacheEvictionWatermark = config.getCacheEvictionWatermark();
         this.evictionPolicy = new EntryCacheDefaultEvictionPolicy();
         this.mlFactory = factory;
         this.mlFactoryMBean = factory.getMbean();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3732,6 +3732,10 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         for (int i = 0; i < entries; i++) {
             ledger.addEntry(String.valueOf(i).getBytes(Encoding));
         }
+
+        // clear the cache to avoid flakiness
+        factory.getEntryCacheManager().clear();
+
         List<Entry> entryList = cursor.readEntries(3);
         assertEquals(entryList.size(), 3);
         Awaitility.await().untilAsserted(() -> {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -94,6 +94,7 @@ import org.apache.bookkeeper.client.EnsemblePlacementPolicy;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.PulsarMockBookKeeper;
 import org.apache.bookkeeper.client.PulsarMockLedgerHandle;
+import org.apache.bookkeeper.client.PulsarMockReadHandleInterceptor;
 import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.client.api.ReadHandle;
@@ -3133,17 +3134,26 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         ManagedLedgerConfig config = new ManagedLedgerConfig().setReadEntryTimeoutSeconds(1);
         ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("timeout_ledger_test", config);
 
-        BookKeeper bk = mock(BookKeeper.class);
-        doNothing().when(bk).asyncCreateLedger(anyInt(), anyInt(), anyInt(), any(), any(), any(), any(), any());
+        Position position = ledger.addEntry("entry-1".getBytes());
+
+        // ensure that the read isn't cached
+        factory.getEntryCacheManager().clear();
+
+        bkc.setReadHandleInterceptor(new PulsarMockReadHandleInterceptor() {
+            @Override
+            public CompletableFuture<LedgerEntries> interceptReadAsync(long ledgerId, long firstEntry, long lastEntry,
+                                                                       LedgerEntries entries) {
+                return CompletableFuture.supplyAsync(() -> {
+                    return entries;
+                }, CompletableFuture.delayedExecutor(3, TimeUnit.SECONDS));
+            }
+        });
+
         AtomicReference<ManagedLedgerException> responseException1 = new AtomicReference<>();
         String ctxStr = "timeoutCtx";
-        CompletableFuture<LedgerEntries> entriesFuture = new CompletableFuture<>();
-        ReadHandle ledgerHandle = mock(ReadHandle.class);
-        doReturn(entriesFuture).when(ledgerHandle).readAsync(PositionFactory.EARLIEST.getLedgerId(),
-                PositionFactory.EARLIEST.getEntryId());
 
         // (1) test read-timeout for: ManagedLedger.asyncReadEntry(..)
-        ledger.asyncReadEntry(ledgerHandle, PositionFactory.EARLIEST, new ReadEntryCallback() {
+        ledger.asyncReadEntry(position, new ReadEntryCallback() {
             @Override
             public void readEntryComplete(Entry entry, Object ctx) {
                 responseException1.set(null);
@@ -3155,18 +3165,20 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
                 responseException1.set(exception);
             }
         }, ctxStr);
-        ledger.asyncCreateLedger(bk, config, null, (rc, lh, ctx) -> {}, Collections.emptyMap());
-        retryStrategically((test) -> responseException1.get() != null, 5, 1000);
-        assertNotNull(responseException1.get());
-        assertTrue(responseException1.get().getMessage()
-                .startsWith(BKException.getMessage(BKException.Code.TimeoutException)));
 
-        // (2) test read-timeout for: ManagedLedger.asyncReadEntry(..)
+        Awaitility.await().untilAsserted(() -> {
+            assertNotNull(responseException1.get());
+            assertTrue(responseException1.get().getMessage()
+                    .startsWith(BKException.getMessage(BKException.Code.TimeoutException)));
+        });
+
+        // ensure that the read isn't cached
+        factory.getEntryCacheManager().clear();
+
+        // (2) test read-timeout for: ManagedCursor.asyncReadEntries(..)
         AtomicReference<ManagedLedgerException> responseException2 = new AtomicReference<>();
-        Position readPositionRef = PositionFactory.EARLIEST;
-        ManagedCursorImpl cursor = new ManagedCursorImpl(bk, ledger, "cursor1");
-        OpReadEntry opReadEntry = OpReadEntry.create(cursor, readPositionRef, 1, new ReadEntriesCallback() {
-
+        ManagedCursor cursor = ledger.openCursor("cursor1", InitialPosition.Earliest);
+        cursor.asyncReadEntries(1, new ReadEntriesCallback() {
             @Override
             public void readEntriesComplete(List<Entry> entries, Object ctx) {
             }
@@ -3176,16 +3188,13 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
                 assertEquals(ctxStr, (String) ctx);
                 responseException2.set(exception);
             }
+        }, ctxStr, PositionFactory.LATEST);
 
-        }, null, PositionFactory.LATEST, null);
-        ledger.asyncReadEntry(ledgerHandle, PositionFactory.EARLIEST.getEntryId(), PositionFactory.EARLIEST.getEntryId(),
-                opReadEntry, ctxStr);
-        retryStrategically((test) -> {
-            return responseException2.get() != null;
-        }, 5, 1000);
-        assertNotNull(responseException2.get());
-        assertTrue(responseException2.get().getMessage()
-                .startsWith(BKException.getMessage(BKException.Code.TimeoutException)));
+        Awaitility.await().untilAsserted(() -> {
+            assertNotNull(responseException2.get());
+            assertTrue(responseException2.get().getMessage()
+                    .startsWith(BKException.getMessage(BKException.Code.TimeoutException)));
+        });
 
         ledger.close();
     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
@@ -217,6 +217,9 @@ public class InflightReadsLimiterTest {
         assertFalse(handle2.isPresent());
         assertEquals(limiter.getRemainingBytes(), 0);
 
+        // Introduce a delay to differentiate operations between queued entries
+        Thread.sleep(50);
+
         // Queue the second handle with a successful callback
         MutableObject<InflightReadsLimiter.Handle> handle3Reference = new MutableObject<>();
         Optional<InflightReadsLimiter.Handle> handle3 = limiter.acquire(50, handle3Reference::setValue);
@@ -237,6 +240,7 @@ public class InflightReadsLimiterTest {
         limiter.release(handle1.get());
         assertEquals(limiter.getRemainingBytes(), 100);
     }
+
     private Pair<OpenTelemetrySdk, InMemoryMetricReader> buildOpenTelemetryAndReader() {
         var metricReader = InMemoryMetricReader.create();
         var openTelemetry = AutoConfiguredOpenTelemetrySdk.builder()

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
@@ -84,11 +84,11 @@ public class InflightReadsLimiterTest {
         InflightReadsLimiter limiter =
                 new InflightReadsLimiter(100, ACQUIRE_QUEUE_SIZE, ACQUIRE_TIMEOUT_MILLIS,
                         mock(ScheduledExecutorService.class), openTelemetry);
-        assertEquals(100, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 100);
         assertLimiterMetrics(metricReader, 100, 0, 100);
 
         Optional<InflightReadsLimiter.Handle> optionalHandle = limiter.acquire(100, null);
-        assertEquals(0, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 0);
         assertTrue(optionalHandle.isPresent());
         InflightReadsLimiter.Handle handle = optionalHandle.get();
         assertTrue(handle.success());
@@ -96,19 +96,18 @@ public class InflightReadsLimiterTest {
         assertLimiterMetrics(metricReader, 100, 100, 0);
 
         limiter.release(handle);
-        assertEquals(100, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 100);
         assertLimiterMetrics(metricReader, 100, 0, 100);
     }
-
 
     @Test
     public void testNotEnoughPermits() throws Exception {
         InflightReadsLimiter limiter =
                 new InflightReadsLimiter(100, ACQUIRE_QUEUE_SIZE, ACQUIRE_TIMEOUT_MILLIS,
                         mock(ScheduledExecutorService.class), OpenTelemetry.noop());
-        assertEquals(100, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 100);
         Optional<InflightReadsLimiter.Handle> optionalHandle = limiter.acquire(100, null);
-        assertEquals(0, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 0);
         assertTrue(optionalHandle.isPresent());
         InflightReadsLimiter.Handle handle = optionalHandle.get();
         assertTrue(handle.success());
@@ -116,7 +115,7 @@ public class InflightReadsLimiterTest {
 
         MutableObject<InflightReadsLimiter.Handle> handle2Reference = new MutableObject<>();
         Optional<InflightReadsLimiter.Handle> optionalHandle2 = limiter.acquire(100, handle2Reference::setValue);
-        assertEquals(0, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 0);
         assertFalse(optionalHandle2.isPresent());
 
         limiter.release(handle);
@@ -124,7 +123,7 @@ public class InflightReadsLimiterTest {
         assertTrue(handle2Reference.getValue().success());
 
         limiter.release(handle2Reference.getValue());
-        assertEquals(100, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 100);
     }
 
     @Test
@@ -134,7 +133,7 @@ public class InflightReadsLimiterTest {
         InflightReadsLimiter limiter =
                 new InflightReadsLimiter(100, ACQUIRE_QUEUE_SIZE, ACQUIRE_TIMEOUT_MILLIS,
                         executor, OpenTelemetry.noop());
-        assertEquals(100, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 100);
         limiter.acquire(100, null);
 
         MutableObject<InflightReadsLimiter.Handle> handle2Reference = new MutableObject<>();
@@ -154,12 +153,12 @@ public class InflightReadsLimiterTest {
         InflightReadsLimiter limiter =
                 new InflightReadsLimiter(100, ACQUIRE_QUEUE_SIZE, ACQUIRE_TIMEOUT_MILLIS,
                         executor, OpenTelemetry.noop());
-        assertEquals(100, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 100);
 
         // Acquire the initial permits
         Optional<InflightReadsLimiter.Handle> handle1 = limiter.acquire(100, null);
         assertTrue(handle1.isPresent());
-        assertEquals(0, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 0);
 
         // Queue the first handle with a callback that throws an exception
         MutableObject<InflightReadsLimiter.Handle> handle2Reference = new MutableObject<>();
@@ -168,13 +167,13 @@ public class InflightReadsLimiterTest {
             throw new RuntimeException("Callback exception");
         });
         assertFalse(handle2.isPresent());
-        assertEquals(0, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 0);
 
         // Queue the second handle with a successful callback
         MutableObject<InflightReadsLimiter.Handle> handle3Reference = new MutableObject<>();
         Optional<InflightReadsLimiter.Handle> handle3 = limiter.acquire(50, handle3Reference::setValue);
         assertFalse(handle3.isPresent());
-        assertEquals(0, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 0);
 
         // Release the initial handle to trigger the queued callbacks
         limiter.release(handle1.get());
@@ -184,15 +183,15 @@ public class InflightReadsLimiterTest {
         assertTrue(handle2Reference.getValue().success());
         assertNotNull(handle3Reference.getValue());
         assertTrue(handle3Reference.getValue().success());
-        assertEquals(0, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 0);
 
         // Release the second handle
         limiter.release(handle3Reference.getValue());
-        assertEquals(50, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 50);
 
         // Release the third handle
         limiter.release(handle3Reference.getValue());
-        assertEquals(100, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 100);
     }
 
     @Test
@@ -202,12 +201,12 @@ public class InflightReadsLimiterTest {
         InflightReadsLimiter limiter =
                 new InflightReadsLimiter(100, ACQUIRE_QUEUE_SIZE, ACQUIRE_TIMEOUT_MILLIS,
                         executor, OpenTelemetry.noop());
-        assertEquals(100, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 100);
 
         // Acquire the initial permits
         Optional<InflightReadsLimiter.Handle> handle1 = limiter.acquire(100, null);
         assertTrue(handle1.isPresent());
-        assertEquals(0, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 0);
 
         // Queue the first handle with a callback that times out and throws an exception
         MutableObject<InflightReadsLimiter.Handle> handle2Reference = new MutableObject<>();
@@ -216,13 +215,13 @@ public class InflightReadsLimiterTest {
             throw new RuntimeException("Callback exception on timeout");
         });
         assertFalse(handle2.isPresent());
-        assertEquals(0, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 0);
 
         // Queue the second handle with a successful callback
         MutableObject<InflightReadsLimiter.Handle> handle3Reference = new MutableObject<>();
         Optional<InflightReadsLimiter.Handle> handle3 = limiter.acquire(50, handle3Reference::setValue);
         assertFalse(handle3.isPresent());
-        assertEquals(0, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 0);
 
         // Wait for the timeout to occur
         Thread.sleep(ACQUIRE_TIMEOUT_MILLIS + 100);
@@ -232,13 +231,12 @@ public class InflightReadsLimiterTest {
         assertFalse(handle2Reference.getValue().success());
         assertNotNull(handle3Reference.getValue());
         assertFalse(handle3Reference.getValue().success());
-        assertEquals(0, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 0);
 
         // Release the first handle
         limiter.release(handle1.get());
-        assertEquals(100, limiter.getRemainingBytes());
+        assertEquals(limiter.getRemainingBytes(), 100);
     }
-
     private Pair<OpenTelemetrySdk, InMemoryMetricReader> buildOpenTelemetryAndReader() {
         var metricReader = InMemoryMetricReader.create();
         var openTelemetry = AutoConfiguredOpenTelemetrySdk.builder()

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
@@ -91,8 +91,8 @@ public class InflightReadsLimiterTest {
         assertEquals(0, limiter.getRemainingBytes());
         assertTrue(optionalHandle.isPresent());
         InflightReadsLimiter.Handle handle = optionalHandle.get();
-        assertTrue(handle.success);
-        assertEquals(handle.permits, 100);
+        assertTrue(handle.success());
+        assertEquals(handle.permits(), 100);
         assertLimiterMetrics(metricReader, 100, 100, 0);
 
         limiter.release(handle);
@@ -111,8 +111,8 @@ public class InflightReadsLimiterTest {
         assertEquals(0, limiter.getRemainingBytes());
         assertTrue(optionalHandle.isPresent());
         InflightReadsLimiter.Handle handle = optionalHandle.get();
-        assertTrue(handle.success);
-        assertEquals(handle.permits, 100);
+        assertTrue(handle.success());
+        assertEquals(handle.permits(), 100);
 
         MutableObject<InflightReadsLimiter.Handle> handle2Reference = new MutableObject<>();
         Optional<InflightReadsLimiter.Handle> optionalHandle2 = limiter.acquire(100, handle2Reference::setValue);
@@ -121,7 +121,7 @@ public class InflightReadsLimiterTest {
 
         limiter.release(handle);
         assertNotNull(handle2Reference.getValue());
-        assertTrue(handle2Reference.getValue().success);
+        assertTrue(handle2Reference.getValue().success());
 
         limiter.release(handle2Reference.getValue());
         assertEquals(100, limiter.getRemainingBytes());
@@ -144,7 +144,7 @@ public class InflightReadsLimiterTest {
         Thread.sleep(ACQUIRE_TIMEOUT_MILLIS + 100);
 
         assertNotNull(handle2Reference.getValue());
-        assertFalse(handle2Reference.getValue().success);
+        assertFalse(handle2Reference.getValue().success());
     }
 
     private Pair<OpenTelemetrySdk, InMemoryMetricReader> buildOpenTelemetryAndReader() {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/PendingReadsManagerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/PendingReadsManagerTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -91,7 +92,8 @@ public class PendingReadsManagerTest  {
         config.setReadEntryTimeoutSeconds(10000);
         when(rangeEntryCache.getName()).thenReturn("my-topic");
         when(rangeEntryCache.getManagedLedgerConfig()).thenReturn(config);
-        inflighReadsLimiter = new InflightReadsLimiter(0, OpenTelemetry.noop());
+        inflighReadsLimiter = new InflightReadsLimiter(0, 0, 0,
+                mock(ScheduledExecutorService.class), OpenTelemetry.noop());
         when(rangeEntryCache.getPendingReadsLimiter()).thenReturn(inflighReadsLimiter);
         pendingReadsManager = new PendingReadsManager(rangeEntryCache);
         doAnswer(new Answer() {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2114,6 +2114,15 @@ public class ServiceConfiguration implements PulsarConfiguration {
             + " Consumer Netty channel. Use O to disable")
     private long managedLedgerMaxReadsInFlightSizeInMB = 0;
 
+    @FieldContext(category = CATEGORY_STORAGE_ML, doc = "Maximum time to wait for acquiring permits for max reads in "
+            + "flight when managedLedgerMaxReadsInFlightSizeInMB is set (>0) and the limit is reached.")
+    private long managedLedgerMaxReadsInFlightPermitsAcquireTimeoutMillis = 60000;
+
+    @FieldContext(category = CATEGORY_STORAGE_ML, doc = "Maximum number of reads that can be queued for acquiring "
+            + "permits for max reads in flight when managedLedgerMaxReadsInFlightSizeInMB is set (>0) and the limit "
+            + "is reached.")
+    private int managedLedgerMaxReadsInFlightPermitsAcquireQueueSize = 50000;
+
     @FieldContext(
         category = CATEGORY_STORAGE_ML,
         dynamic = true,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -72,8 +72,21 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
         managedLedgerFactoryConfig.setCacheEvictionTimeThresholdMillis(
                 conf.getManagedLedgerCacheEvictionTimeThresholdMillis());
         managedLedgerFactoryConfig.setCopyEntriesInCache(conf.isManagedLedgerCacheCopyEntries());
-        managedLedgerFactoryConfig.setManagedLedgerMaxReadsInFlightSize(
-                conf.getManagedLedgerMaxReadsInFlightSizeInMB() * 1024L * 1024L);
+        long managedLedgerMaxReadsInFlightSizeBytes = conf.getManagedLedgerMaxReadsInFlightSizeInMB() * 1024L * 1024L;
+        if (managedLedgerMaxReadsInFlightSizeBytes > 0 && conf.getDispatcherMaxReadSizeBytes() > 0
+                && managedLedgerMaxReadsInFlightSizeBytes < conf.getDispatcherMaxReadSizeBytes()) {
+            log.warn("Invalid configuration for managedLedgerMaxReadsInFlightSizeInMB: {}, "
+                            + "dispatcherMaxReadSizeBytes: {}. managedLedgerMaxReadsInFlightSizeInMB in bytes should "
+                            + "be greater than dispatcherMaxReadSizeBytes. You should set "
+                            + "managedLedgerMaxReadsInFlightSizeInMB to at least {}",
+                    conf.getManagedLedgerMaxReadsInFlightSizeInMB(), conf.getDispatcherMaxReadSizeBytes(),
+                    (conf.getDispatcherMaxReadSizeBytes() / (1024L * 1024L)) + 1);
+        }
+        managedLedgerFactoryConfig.setManagedLedgerMaxReadsInFlightSize(managedLedgerMaxReadsInFlightSizeBytes);
+        managedLedgerFactoryConfig.setManagedLedgerMaxReadsInFlightPermitsAcquireTimeoutMillis(
+                conf.getManagedLedgerMaxReadsInFlightPermitsAcquireTimeoutMillis());
+        managedLedgerFactoryConfig.setManagedLedgerMaxReadsInFlightPermitsAcquireQueueSize(
+                conf.getManagedLedgerMaxReadsInFlightPermitsAcquireQueueSize());
         managedLedgerFactoryConfig.setPrometheusStatsLatencyRolloverSeconds(
                 conf.getManagedLedgerPrometheusStatsLatencyRolloverSeconds());
         managedLedgerFactoryConfig.setTraceTaskExecution(conf.isManagedLedgerTraceTaskExecution());


### PR DESCRIPTION
Fixes #23504
Fixes #23506

### Motivation

In the current implementation before this PR there are multiple problems:
* redelivery (replay) queue reads don't get deduplicated or limited by `managedLedgerMaxReadsInFlightSizeInMB`, reported as #23504
* The `managedLedgerMaxReadsInFlightSizeInMB` limit doesn't work properly if `managedLedgerReadEntryTimeoutSeconds` isn't set, reported as #23506.
In addition to this, even if `managedLedgerReadEntryTimeoutSeconds` is set, when the limit is reached, there's no queuing and all threads will be retrying in a tight loop to acquire permits. This tight loop causes unnecessary CPU consumption and contention. 

### Modifications

Enhanced permit acquisition:
 - Added queuing for pending requests when the limit is reached
 - Configurable queue size via `managedLedgerMaxReadsInFlightPermitsAcquireQueueSize`
 - Timeout configuration via `managedLedgerMaxReadsInFlightPermitsAcquireTimeoutMillis`
 - Asynchronous completion of waiting requests to eliminate tight-loop spinning
 - Fast path (no queuing) when permits are immediately available

Improved size estimation:
 - Now uses average entry size for more accurate calculations
 - Previously used only the latest result's size

`managedLedgerMaxReadsInFlightSizeInMB` limit is now applied to replay queue reads

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->