### PR TITLE
[improve][broker] Implementing delayed message cancellation in pulsar

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.broker.service;
 
 import static org.apache.bookkeeper.mledger.util.PositionAckSetUtil.andAckSet;
 import static org.apache.bookkeeper.mledger.util.PositionAckSetUtil.isAckSetEmpty;
+import static org.apache.pulsar.common.naming.Constants.DELAY_CANCELED_MESSAGE_POSITION;
+import static org.apache.pulsar.common.naming.Constants.IS_MARK_DELETE_DELAY_MESSAGE;
 import io.netty.buffer.ByteBuf;
 import io.prometheus.client.Gauge;
 import java.util.ArrayList;
@@ -28,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
@@ -46,10 +49,12 @@ import org.apache.pulsar.broker.service.plugin.EntryFilter;
 import org.apache.pulsar.broker.transaction.pendingack.impl.PendingAckHandleImpl;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.api.proto.CommandAck.AckType;
+import org.apache.pulsar.common.api.proto.KeyValue;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.api.proto.ReplicatedSubscriptionsSnapshot;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.protocol.Markers;
+import org.apache.pulsar.common.util.collections.ConcurrentLongLongPairHashMap;
 import org.apache.pulsar.compaction.Compactor;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -69,10 +74,13 @@ public abstract class AbstractBaseDispatcher extends EntryFilterSupport implemen
     private final LongAdder filterRejectedMsgs = new LongAdder();
     private final LongAdder filterRescheduledMsgs = new LongAdder();
 
+    protected final ConcurrentLongLongPairHashMap delayedMessageMarkDeleteMap;
+
     protected AbstractBaseDispatcher(Subscription subscription, ServiceConfiguration serviceConfig) {
         super(subscription);
         this.serviceConfig = serviceConfig;
         this.dispatchThrottlingOnBatchMessageEnabled = serviceConfig.isDispatchThrottlingOnBatchMessageEnabled();
+        this.delayedMessageMarkDeleteMap = ConcurrentLongLongPairHashMap.newBuilder().autoShrink(true).build();
     }
 
 
@@ -221,6 +229,47 @@ public abstract class AbstractBaseDispatcher extends EntryFilterSupport implemen
                 entries.set(i, null);
                 entry.release();
                 continue;
+            } else if (delayedMessageMarkDeleteMap.containsKey(entry.getLedgerId(), entry.getEntryId())) {
+                // The delayed message is marked for delete.
+                ConcurrentLongLongPairHashMap.LongPair markMessageId = delayedMessageMarkDeleteMap
+                        .get(entry.getLedgerId(), entry.getEntryId());
+                List<Position> deleteDelayedMessageList = new ArrayList<>();
+                deleteDelayedMessageList.add(entry.getPosition());
+                deleteDelayedMessageList.add(PositionFactory.create(markMessageId.first, markMessageId.second));
+
+                delayedMessageMarkDeleteMap.remove(entry.getLedgerId(), entry.getEntryId());
+                individualAcknowledgeMessageIfNeeded(deleteDelayedMessageList, Collections.emptyMap());
+                entries.set(i, null);
+                entry.release();
+                continue;
+            }
+
+            List<KeyValue> propertiesList = msgMetadata.getPropertiesList();
+            if (!propertiesList.isEmpty()) {
+                Map<String, String> propertiesMap = propertiesList.stream()
+                        .filter(p -> p.getKey().equals(DELAY_CANCELED_MESSAGE_POSITION)
+                                || p.getKey().equals(IS_MARK_DELETE_DELAY_MESSAGE))
+                        .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue,
+                                (oldValue, newValue) -> newValue));
+
+                if (propertiesMap.containsKey(IS_MARK_DELETE_DELAY_MESSAGE)) {
+                    if (propertiesMap.containsKey(DELAY_CANCELED_MESSAGE_POSITION)) {
+                        String[] data = propertiesMap.get(DELAY_CANCELED_MESSAGE_POSITION).split(":");
+                        long ledgerId = Long.parseLong(data[0]);
+                        long entryId = Long.parseLong(data[1]);
+                        delayedMessageMarkDeleteMap.put(ledgerId, entryId,
+                                entry.getLedgerId(), entry.getEntryId());
+                        entries.set(i, null);
+                        entry.release();
+                        continue;
+                    } else {
+                        individualAcknowledgeMessageIfNeeded(Collections.singletonList(entry.getPosition()),
+                                Collections.emptyMap());
+                        entries.set(i, null);
+                        entry.release();
+                        continue;
+                    }
+                }
             }
 
             if (hasFilter) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/DelayedDeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/DelayedDeliveryTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.broker.service.persistent;
 
+import static org.apache.pulsar.common.naming.Constants.DELAY_CANCELED_MESSAGE_POSITION;
+import static org.apache.pulsar.common.naming.Constants.IS_MARK_DELETE_DELAY_MESSAGE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -32,6 +34,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import org.apache.bookkeeper.client.BKException;
@@ -43,6 +47,7 @@ import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageIdAdv;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -685,5 +690,66 @@ public class DelayedDeliveryTest extends ProducerConsumerBase {
             assertEquals(ex.getMessage(), "Exceeds max allowed delivery delay of "
                     + maxDeliveryDelayInMillis + " milliseconds");
         }
+    }
+
+    @Test
+    public void testDelayedMessageCancel() throws Exception {
+        String topic = BrokerTestUtil.newUniqueName("testDelayedMessageCancel");
+        CountDownLatch latch = new CountDownLatch(9);
+        Set<String> receivedMessages = ConcurrentHashMap.newKeySet();
+
+        @Cleanup
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName("shared-sub")
+                .subscriptionType(SubscriptionType.Shared)
+                .messageListener((Consumer<String> c, Message<String> msg) -> {
+                    receivedMessages.add(msg.getValue());
+                    c.acknowledgeAsync(msg);
+                    latch.countDown();
+                })
+                .subscribe();
+
+        final long tickTime = 1000L;
+
+        admin.topicPolicies().setDelayedDeliveryPolicy(topic,
+                DelayedDeliveryPolicies.builder()
+                        .active(true)
+                        .tickTime(tickTime)
+                        .maxDeliveryDelayInMillis(10000)
+                        .build());
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topic)
+                .create();
+
+        for (int i = 0; i < 10; i++) {
+            final int n = i;
+            final long currentTime = System.currentTimeMillis();
+            final long deliverAtTime = currentTime + 5000L;
+            producer.newMessage()
+                    .key(String.valueOf(i))
+                    .value("msg-" + i)
+                    .deliverAt(deliverAtTime)
+                    .sendAsync().whenComplete((id, ex) -> {
+                        if (n == 0) {
+                            MessageIdAdv messageIdAdv = (MessageIdAdv) id;
+                            String deleteDelayedMessageId = messageIdAdv.getLedgerId() + ":" + messageIdAdv.getEntryId();
+                            producer.newMessage()
+                                    .key(String.valueOf(n))
+                                    .value("msg-0-mark")
+                                    .deliverAt(deliverAtTime - 2 * tickTime)
+                                    .property(IS_MARK_DELETE_DELAY_MESSAGE, "true")
+                                    .property(DELAY_CANCELED_MESSAGE_POSITION, deleteDelayedMessageId)
+                                    .sendAsync();
+                        }
+                    });
+        }
+        producer.flush();
+
+        assertTrue(latch.await(15, TimeUnit.SECONDS), "Not all messages were received in time");
+        assertFalse(receivedMessages.contains("msg-0") || receivedMessages.contains("msg-0-mark"),
+                "msg-0 and msg-0-mark should have been cancelled but was received");
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/Constants.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/Constants.java
@@ -24,6 +24,8 @@ package org.apache.pulsar.common.naming;
 public class Constants {
 
     public static final String GLOBAL_CLUSTER = "global";
+    public static final String DELAY_CANCELED_MESSAGE_POSITION = "delayCanceledMsgPosition";
+    public static final String IS_MARK_DELETE_DELAY_MESSAGE = "isMarkDeleteDelayMessage";
 
     private Constants() {}
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Main Issue: [#23149](https://github.com/apache/pulsar/issues/23149)

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
In dynamic event-driven architectures, the relevance and timing of messages are crucial. Apache Pulsar currently supports delayed message delivery, which is beneficial for scheduling future processing. However, once scheduled, there is no native support to modify or cancel these messages based on changing circumstances. This limitation poses challenges in situations where messages become obsolete before their scheduled delivery or when system conditions change, necessitating the early processing or cancellation of delayed messages.

如果目前想要实现延迟消息的取消，我们只能在consumer端的内存中存储需要取消的延迟消息，如果延迟时间过长会有很多问题。

### Modifications

<!-- Describe the modifications you've done. -->
The following changes were introduced in Pulsar’s message dispatching components to enable delayed message cancellation:
- Extended AbstractBaseDispatcher with the ability to recognize and handle cancellation properties in message metadata.
- Added constants for identifying cancellation-specific properties in message metadata.

The key implementation detail involves checking each message for a cancellation marker as it becomes eligible for dispatch. If a message is marked for cancellation, it is dropped from the dispatch queue and its associated resources are cleaned up immediately.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
