### PR TITLE
[fix][ci] Configure Docker data-root to /mnt/docker to avoid running out of disk space

### DIFF
--- a/.github/actions/clean-disk/action.yml
+++ b/.github/actions/clean-disk/action.yml
@@ -46,6 +46,15 @@ runs:
             time df -BM / /mnt
             echo "::endgroup::"
           done
+          if [[ "${{ inputs.mode }}" == "full" ]]; then
+            echo "::group::Moving /var/lib/docker to /mnt/docker"
+            sudo systemctl stop docker
+            echo '{"data-root": "/mnt/docker"}' | sudo tee /etc/docker/daemon.json
+            sudo mv /var/lib/docker /mnt/docker
+            sudo systemctl start docker
+            time df -BM / /mnt
+            echo "::endgroup::"
+          fi
           echo "::group::Cleaning apt state"
           time sudo bash -c "apt-get clean; apt-get autoclean; apt-get -y --purge autoremove"
           time df -BM / /mnt


### PR DESCRIPTION
### Motivation

In GitHub Actions CI, disk space has been running out recently.

```
Error:  Failed to execute goal io.fabric8:docker-maven-plugin:0.45.1:build (default) on project pulsar-all-docker-image: Unable to build image [apachepulsar/pulsar-all] : "write /pulsar/connectors/pulsar-io-solr-4.1.0-SNAPSHOT.nar: no space left on device" -> [Help 1]
```
(example from https://github.com/apache/pulsar/actions/runs/13032747233/job/36356115521?pr=23901#step:10:25266)

### Modifications

When running clean-disk action with `mode: full`, configure Docker `data-root` to `/mnt/docker` to avoid running out of disk space. The `/mnt` disk has over 66GB free space in GitHub Actions CI.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->