### PR TITLE
[fix] Avoid NPE when closing an uninitialized SameAuthParamsLookupAutoClusterFailover

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -262,6 +262,9 @@ public class PulsarClientImpl implements PulsarClient {
                     this::reduceConsumerReceiverQueueSize);
             state.set(State.Open);
         } catch (Throwable t) {
+            // Log the exception first, or it could be missed if there are any subsequent exceptions in the
+            // shutdown sequence
+            log.error("Failed to create Pulsar client instance.", t);
             shutdown();
             shutdownEventLoopGroup(eventLoopGroupReference);
             closeCnxPool(connectionPoolReference);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailover.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailover.java
@@ -105,11 +105,21 @@ public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvid
 
     @Override
     public void close() throws Exception {
+        if (closed) {
+            return;
+        }
+
         log.info("Closing service url provider. Current pulsar service: [{}] {}", currentPulsarServiceIndex,
                 pulsarServiceUrlArray[currentPulsarServiceIndex]);
+        if (scheduledCheckTask != null) {
+            scheduledCheckTask.cancel(false);
+        }
+
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+
         closed = true;
-        scheduledCheckTask.cancel(false);
-        executor.shutdownNow();
     }
 
     private int firstHealthyPulsarService() {


### PR DESCRIPTION


### Motivation

An exception in the `PulsarClientImpl` constructor will lead to close the `SameAuthParamsLookupAutoClusterFailover` instance which might not be initialized yet. When it happens it causes an NPE that masks the original exception.

```
Failed to shutdown Pulsar client @timestamp=2025-01-29T20:21:32.607Z logger-name=org.apache.pulsar.client.impl.PulsarClientImpl thread-name=main level=WARN level-value=30000 stack-trace=`java.lang.NullPointerException: Cannot invoke "org.apache.pulsar.shade.io.netty.util.concurrent.ScheduledFuture.cancel(boolean)" because "this.scheduledCheckTask" is null
        at org.apache.pulsar.client.impl.SameAuthParamsLookupAutoClusterFailover.close(SameAuthParamsLookupAutoClusterFailover.java:111)
        at org.apache.pulsar.client.impl.PulsarClientImpl.shutdown(PulsarClientImpl.java:899)
        at org.apache.pulsar.client.impl.PulsarClientImpl.<init>(PulsarClientImpl.java:265)
        at org.apache.pulsar.client.impl.PulsarClientImpl.<init>(PulsarClientImpl.java:168)
        at org.apache.pulsar.client.impl.ClientBuilderImpl.build(ClientBuilderImpl.java:71)
```

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
