### PR TITLE
[improve][broker] Refactor a private method to eliminate an unnecessary parameter

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -442,7 +442,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
                     if (permits.intValue() > 0) {
                         boolean canDispatchEntry = canDispatchEntry(consumer, entry, readType, stickyKeyHash);
                         if (!canDispatchEntry) {
-                            if(blockedByHash != null){
+                            if (blockedByHash != null) {
                                 blockedByHash.setTrue();
                             }
                             // decrement the permits for the consumer

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -441,14 +441,15 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
                     // a consumer was found for the sticky key hash and the entry can be dispatched
                     if (permits.intValue() > 0) {
                         boolean canDispatchEntry = canDispatchEntry(consumer, entry, readType, stickyKeyHash);
-                        if (!canDispatchEntry) {
-                            if (blockedByHash != null) {
-                                blockedByHash.setTrue();
-                            }
+                        if (canDispatchEntry) {
                             // decrement the permits for the consumer
                             permits.decrement();
                             // allow the entry to be dispatched
                             dispatchEntry = true;
+                        } else {
+                            if (blockedByHash != null) {
+                                blockedByHash.setTrue();
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
### Motivation

- The canDispatchEntry method uses MutableBoolean as an argument, and then changes its value internally, but this variable is not necessary

### Modifications

- Optimize code for readability

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/guan46/pulsar/pull/3
<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
