### PR TITLE
[fix] [common] Fix RawMessageImpl.getProperties() failed when the message metadata contains the same key but with different values

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessageImpl.java
@@ -99,7 +99,8 @@ public class RawMessageImpl implements RawMessage {
                               (oldValue, newValue) -> newValue));
         } else if (msgMetadata.getMetadata().getPropertiesCount() > 0) {
             return msgMetadata.getMetadata().getPropertiesList().stream()
-                    .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue));
+                    .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue,
+                            (oldValue, newValue) -> newValue));
         } else {
             return Collections.emptyMap();
         }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/api/raw/RawMessageImplTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/api/raw/RawMessageImplTest.java
@@ -41,7 +41,7 @@ public class RawMessageImplTest {
     private static final String HARD_CODE_KEY_ID_VALUE  = "__pfn_input_msg_id_value__";
 
     @Test
-    public void testGetProperties() {
+    public void testGetMessageSingleMetadataProperties() {
         ReferenceCountedMessageMetadata refCntMsgMetadata =
                 ReferenceCountedMessageMetadata.get(mock(ByteBuf.class));
         SingleMessageMetadata singleMessageMetadata = new SingleMessageMetadata();
@@ -49,6 +49,24 @@ public class RawMessageImplTest {
         singleMessageMetadata.addProperty().setKey(HARD_CODE_KEY).setValue(KEY_VALUE_SECOND);
         singleMessageMetadata.addProperty().setKey(HARD_CODE_KEY_ID).setValue(HARD_CODE_KEY_ID_VALUE);
         RawMessage msg = RawMessageImpl.get(refCntMsgMetadata, singleMessageMetadata, null, 0, 0, 0);
+        Map<String, String> properties = msg.getProperties();
+        assertEquals(properties.get(HARD_CODE_KEY), KEY_VALUE_SECOND);
+        assertEquals(properties.get(HARD_CODE_KEY_ID), HARD_CODE_KEY_ID_VALUE);
+        assertEquals(KEY_VALUE_SECOND, properties.get(HARD_CODE_KEY));
+        assertEquals(HARD_CODE_KEY_ID_VALUE, properties.get(HARD_CODE_KEY_ID));
+    }
+
+    @Test
+    public void testGetMessageMetadataProperties() {
+        ReferenceCountedMessageMetadata refCntMsgMetadata =
+                ReferenceCountedMessageMetadata.get(mock(ByteBuf.class));
+
+        MessageMetadata messageMetadata = refCntMsgMetadata.getMetadata();
+        messageMetadata.addProperty().setKey(HARD_CODE_KEY).setValue(KEY_VALUE_FIRST);
+        messageMetadata.addProperty().setKey(HARD_CODE_KEY).setValue(KEY_VALUE_SECOND);
+        messageMetadata.addProperty().setKey(HARD_CODE_KEY_ID).setValue(HARD_CODE_KEY_ID_VALUE);
+
+        RawMessage msg = RawMessageImpl.get(refCntMsgMetadata, null, null, 0, 0, 0);
         Map<String, String> properties = msg.getProperties();
         assertEquals(properties.get(HARD_CODE_KEY), KEY_VALUE_SECOND);
         assertEquals(properties.get(HARD_CODE_KEY_ID), HARD_CODE_KEY_ID_VALUE);


### PR DESCRIPTION
Main Issue: #23925

My fork PR: https://github.com/horizonzy/pulsar/pull/20

### Motivation
If the message metadata contains the same key but with different values, we should make the later value override the previous value.


### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
