### PR TITLE
[fix][broker] Fix rate limiter token bucket and clock consistency issues causing excessive throttling and connection timeouts

### DIFF
--- a/microbench/README.md
+++ b/microbench/README.md
@@ -41,3 +41,29 @@ For fast recompiling of the benchmarks (without compiling Pulsar modules) and cr
 mvn -Pmicrobench -pl microbench clean package
 ```
 
+### Running specific benchmarks
+
+Display help:
+
+```shell
+java -jar microbench/target/microbenchmarks.jar -h
+```
+
+Listing all benchmarks:
+
+```shell
+java -jar microbench/target/microbenchmarks.jar -l
+```
+
+Running specific benchmarks:
+
+```shell
+java -jar microbench/target/microbenchmarks.jar ".*BenchmarkName.*"
+```
+
+Checking what benchmarks match the pattern:
+
+```shell
+java -jar microbench/target/microbenchmarks.jar ".*BenchmarkName.*" -lp
+```
+

--- a/microbench/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucketBenchmark.java
+++ b/microbench/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucketBenchmark.java
@@ -61,8 +61,7 @@ public class AsyncTokenBucketBenchmark {
     @Measurement(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
     @Warmup(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
     public void consumeTokensBenchmark001Threads(Blackhole blackhole) {
-        asyncTokenBucket.consumeTokens(1);
-        blackhole.consume(asyncTokenBucket.getTokens());
+        consumeTokenAndGetTokens(blackhole);
     }
 
     @Threads(10)
@@ -70,8 +69,7 @@ public class AsyncTokenBucketBenchmark {
     @Measurement(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
     @Warmup(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
     public void consumeTokensBenchmark010Threads(Blackhole blackhole) {
-        asyncTokenBucket.consumeTokens(1);
-        blackhole.consume(asyncTokenBucket.getTokens());
+        consumeTokenAndGetTokens(blackhole);
     }
 
     @Threads(100)
@@ -79,7 +77,12 @@ public class AsyncTokenBucketBenchmark {
     @Measurement(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
     @Warmup(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
     public void consumeTokensBenchmark100Threads(Blackhole blackhole) {
+        consumeTokenAndGetTokens(blackhole);
+    }
+
+    private void consumeTokenAndGetTokens(Blackhole blackhole) {
         asyncTokenBucket.consumeTokens(1);
+        // blackhole is used to ensure that the compiler doesn't do dead code elimination
         blackhole.consume(asyncTokenBucket.getTokens());
     }
 }

--- a/microbench/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucketBenchmark.java
+++ b/microbench/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucketBenchmark.java
@@ -33,6 +33,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
 
 @Fork(3)
 @BenchmarkMode(Mode.Throughput)
@@ -59,23 +60,26 @@ public class AsyncTokenBucketBenchmark {
     @Benchmark
     @Measurement(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
     @Warmup(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
-    public void consumeTokensBenchmark001Threads() {
+    public void consumeTokensBenchmark001Threads(Blackhole blackhole) {
         asyncTokenBucket.consumeTokens(1);
+        blackhole.consume(asyncTokenBucket.getTokens());
     }
 
     @Threads(10)
     @Benchmark
     @Measurement(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
     @Warmup(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
-    public void consumeTokensBenchmark010Threads() {
+    public void consumeTokensBenchmark010Threads(Blackhole blackhole) {
         asyncTokenBucket.consumeTokens(1);
+        blackhole.consume(asyncTokenBucket.getTokens());
     }
 
     @Threads(100)
     @Benchmark
     @Measurement(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
     @Warmup(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
-    public void consumeTokensBenchmark100Threads() {
+    public void consumeTokensBenchmark100Threads(Blackhole blackhole) {
         asyncTokenBucket.consumeTokens(1);
+        blackhole.consume(asyncTokenBucket.getTokens());
     }
 }

--- a/microbench/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClockBenchmark.java
+++ b/microbench/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClockBenchmark.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.broker.qos;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@Fork(3)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+public class DefaultMonotonicSnapshotClockBenchmark {
+    private DefaultMonotonicSnapshotClock monotonicSnapshotClock =
+            new DefaultMonotonicSnapshotClock(TimeUnit.MILLISECONDS.toNanos(1), System::nanoTime);
+
+    @TearDown(Level.Iteration)
+    public void teardown() {
+        monotonicSnapshotClock.close();
+    }
+
+    @Threads(1)
+    @Benchmark
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
+    @Warmup(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
+    public void getTickNanos001Threads(Blackhole blackhole) {
+        consumeTokenAndGetTokens(blackhole, false);
+    }
+
+    @Threads(10)
+    @Benchmark
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
+    @Warmup(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
+    public void getTickNanos010Threads(Blackhole blackhole) {
+        consumeTokenAndGetTokens(blackhole, false);
+    }
+
+    @Threads(100)
+    @Benchmark
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
+    @Warmup(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
+    public void getTickNanos100Threads(Blackhole blackhole) {
+        consumeTokenAndGetTokens(blackhole, false);
+    }
+
+    @Threads(1)
+    @Benchmark
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
+    @Warmup(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
+    public void getTickNanosRequestSnapshot001Threads(Blackhole blackhole) {
+        consumeTokenAndGetTokens(blackhole, true);
+    }
+
+    @Threads(10)
+    @Benchmark
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
+    @Warmup(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
+    public void getTickNanosRequestSnapshot010Threads(Blackhole blackhole) {
+        consumeTokenAndGetTokens(blackhole, true);
+    }
+
+    @Threads(100)
+    @Benchmark
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
+    @Warmup(time = 10, timeUnit = TimeUnit.SECONDS, iterations = 1)
+    public void getTickNanosRequestSnapshot100Threads(Blackhole blackhole) {
+        consumeTokenAndGetTokens(blackhole, true);
+    }
+
+    private void consumeTokenAndGetTokens(Blackhole blackhole, boolean requestSnapshot) {
+        // blackhole is used to ensure that the compiler doesn't do dead code elimination
+        blackhole.consume(monotonicSnapshotClock.getTickNanos(requestSnapshot));
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucket.java
@@ -363,7 +363,7 @@ public abstract class AsyncTokenBucket {
      * @param forceUpdateTokens if true, the token balance is updated before the comparison
      * @return true if the bucket contains tokens, false otherwise
      */
-    public boolean containsTokens(boolean forceUpdateTokens) {
+    protected boolean containsTokens(boolean forceUpdateTokens) {
         return tokens(forceUpdateTokens) > 0;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucket.java
@@ -119,14 +119,14 @@ public abstract class AsyncTokenBucket {
      */
     private final LongAdder pendingConsumedTokens = new LongAdder();
 
-    private final boolean getTokensUpdatesTokens;
+    private final boolean consistentTokensView;
 
     protected AsyncTokenBucket(MonotonicSnapshotClock clockSource, long resolutionNanos,
-                               boolean getTokensUpdatesTokens) {
+                               boolean consistentTokensView) {
         this.clockSource = clockSource;
         this.resolutionNanos = resolutionNanos;
         this.lastNanos = Long.MIN_VALUE;
-        this.getTokensUpdatesTokens = getTokensUpdatesTokens;
+        this.consistentTokensView = consistentTokensView;
     }
 
     public static FinalRateAsyncTokenBucketBuilder builder() {
@@ -334,10 +334,10 @@ public abstract class AsyncTokenBucket {
     /**
      * Returns the current number of tokens in the bucket.
      * The token balance is updated if the configured resolutionNanos has passed since the last update unless
-     * getTokensUpdatesTokens is true.
+     * consistentTokensView is true.
      */
     public final long getTokens() {
-        return tokens(getTokensUpdatesTokens);
+        return tokens(consistentTokensView);
     }
 
     public abstract long getRate();
@@ -346,12 +346,12 @@ public abstract class AsyncTokenBucket {
      * Checks if the bucket contains tokens.
      * The token balance is updated before the comparison if the configured resolutionNanos has passed since the last
      * update. It's possible that the returned result is not definite since the token balance is eventually consistent
-     * if getTokensUpdatesTokens is false.
+     * if consistentTokensView is false.
      *
      * @return true if the bucket contains tokens, false otherwise
      */
     public boolean containsTokens() {
-        return containsTokens(getTokensUpdatesTokens);
+        return containsTokens(consistentTokensView);
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucket.java
@@ -42,6 +42,10 @@ import java.util.concurrent.atomic.LongAdder;
  * connection or client from the throttling queue to unthrottle. Before unthrottling, the application should check
  * for available tokens. If tokens are still not available, the application should continue with throttling and
  * repeat the throttling loop.
+ * <p>By default, the AsyncTokenBucket is eventually consistent. This means that the token balance is updated
+ * with added tokens and consumed tokens at most once during each "increment", when time advances more than the
+ * configured resolution. There are settings for configuring consistency, please see {@link AsyncTokenBucketBuilder}
+ * for details.
  * <p>This class does not produce side effects outside its own scope. It functions similarly to a stateful function,
  * akin to a counter function. In essence, it is a sophisticated counter. It can serve as a foundational component for
  * constructing higher-level asynchronous rate limiter implementations, which require side effects for throttling.
@@ -119,14 +123,28 @@ public abstract class AsyncTokenBucket {
      */
     private final LongAdder pendingConsumedTokens = new LongAdder();
 
-    private final boolean consistentTokensView;
+    /**
+     * By default, AsyncTokenBucket is eventually consistent. This means that the consumed tokens are subtracted from
+     * the total amount of tokens at most once during each "increment", when time advances more than the configured
+     * resolution. This setting determines if the consumed tokens are subtracted from tokens balance consistently.
+     * For high performance, it is recommended to keep this setting as false.
+     */
+    private final boolean consistentConsumedTokens;
+    /**
+     * By default, AsyncTokenBucket is eventually consistent. This means that the added tokens are calculated based
+     * on elapsed time at most once during each "increment", when time advances more than the configured
+     * resolution. This setting determines if the added tokens are calculated and added to tokens balance consistently.
+     * For high performance, it is recommended to keep this setting as false.
+     */
+    private final boolean consistentAddedTokens;
 
     protected AsyncTokenBucket(MonotonicSnapshotClock clockSource, long resolutionNanos,
-                               boolean consistentTokensView) {
+                               boolean consistentConsumedTokens, boolean consistentAddedTokens) {
         this.clockSource = clockSource;
         this.resolutionNanos = resolutionNanos;
         this.lastNanos = Long.MIN_VALUE;
-        this.consistentTokensView = consistentTokensView;
+        this.consistentConsumedTokens = consistentConsumedTokens;
+        this.consistentAddedTokens = consistentAddedTokens;
     }
 
     public static FinalRateAsyncTokenBucketBuilder builder() {
@@ -144,40 +162,46 @@ public abstract class AsyncTokenBucket {
     /**
      * Consumes tokens and possibly updates the tokens balance. New tokens are calculated and added to the current
      * tokens balance each time the update takes place. The update takes place once in every interval of the configured
-     * resolutionNanos or when the forceUpdateTokens parameter is true.
+     * resolutionNanos or when the forceConsistentTokens parameter is true.
      * When the tokens balance isn't updated, the consumed tokens are added to the pendingConsumedTokens LongAdder
      * counter which gets flushed the next time the tokens are updated. This makes the tokens balance
      * eventually consistent. The reason for this design choice is to optimize performance by preventing CAS loop
      * contention which could cause excessive CPU consumption.
      *
      * @param consumeTokens     number of tokens to consume, can be 0 to update the tokens balance
-     * @param forceUpdateTokens if true, the tokens are updated even if the configured resolution hasn't passed
+     * @param forceConsistentTokens if true, the token balance is updated consistently
      * @return the current number of tokens in the bucket or Long.MIN_VALUE when the number of tokens is unknown due
      * to eventual consistency
      */
-    private long consumeTokensAndMaybeUpdateTokensBalance(long consumeTokens, boolean forceUpdateTokens) {
+    private long consumeTokensAndMaybeUpdateTokensBalance(long consumeTokens, boolean forceConsistentTokens) {
         if (consumeTokens < 0) {
             throw new IllegalArgumentException("consumeTokens must be >= 0");
         }
-        long currentNanos = clockSource.getTickNanos(forceUpdateTokens);
+        boolean requestConsistentTickNanosSnapshot =
+                consistentAddedTokens || consistentConsumedTokens || forceConsistentTokens || resolutionNanos == 0;
+        long currentNanos = clockSource.getTickNanos(requestConsistentTickNanosSnapshot);
         long newTokens = 0;
         // check if the tokens should be updated immediately
-        if (shouldUpdateTokensImmediately(currentNanos, forceUpdateTokens)) {
+        if (shouldAddTokensImmediately(currentNanos, forceConsistentTokens)) {
             // calculate the number of new tokens since the last update
-            newTokens = calculateNewTokensSinceLastUpdate(currentNanos);
+            newTokens = calculateNewTokensSinceLastUpdate(currentNanos, forceConsistentTokens);
         }
         // update tokens if there are new tokens or if resolutionNanos is set to 0 which is currently used for testing
-        if (newTokens > 0 || resolutionNanos == 0) {
+        if (newTokens > 0 || resolutionNanos == 0 || consistentConsumedTokens || forceConsistentTokens) {
             // flush the pendingConsumedTokens by calling "sumThenReset"
             long currentPendingConsumedTokens = pendingConsumedTokens.sumThenReset();
             // calculate the token delta by subtracting the consumed tokens from the new tokens
             long tokenDelta = newTokens - currentPendingConsumedTokens;
-            // update the tokens and return the current token value
-            return TOKENS_UPDATER.updateAndGet(this,
-                    // limit the tokens to the capacity of the bucket
-                    currentTokens -> Math.min(currentTokens + tokenDelta, getCapacity())
-                            // subtract the consumed tokens from the capped tokens
-                            - consumeTokens);
+            if (tokenDelta != 0 || consumeTokens != 0) {
+                // update the tokens and return the current token value
+                return TOKENS_UPDATER.updateAndGet(this,
+                        // limit the tokens to the capacity of the bucket
+                        currentTokens -> Math.min(currentTokens + tokenDelta, getCapacity())
+                                // subtract the consumed tokens from the capped tokens
+                                - consumeTokens);
+            } else {
+                return tokens;
+            }
         } else {
             // eventual consistent fast path, tokens are not updated immediately
 
@@ -186,13 +210,8 @@ public abstract class AsyncTokenBucket {
                 pendingConsumedTokens.add(consumeTokens);
             }
 
-            if (forceUpdateTokens) {
-                // return the current tokens balance without updating the tokens and resetting the pendingConsumedTokens
-                return tokens - pendingConsumedTokens.sum();
-            } else {
-                // return Long.MIN_VALUE if the current value of tokens is unknown due to the eventual consistency
-                return Long.MIN_VALUE;
-            }
+            // return Long.MIN_VALUE if the current value of tokens is unknown due to the eventual consistency
+            return Long.MIN_VALUE;
         }
     }
 
@@ -201,19 +220,19 @@ public abstract class AsyncTokenBucket {
      *
      * The tokens will be updated once every resolutionNanos nanoseconds.
      * This method checks if the configured resolutionNanos has passed since the last update.
-     * If the forceUpdateTokens is true, the tokens will be updated immediately.
+     * If the forceConsistentTokens is true, the tokens will be updated immediately.
      *
-     * @param currentNanos the current monotonic clock time in nanoseconds
-     * @param forceUpdateTokens if true, the tokens will be updated immediately
+     * @param currentNanos      the current monotonic clock time in nanoseconds
+     * @param forceConsistentTokens if true, the tokens are added even if the configured resolution hasn't fully passed
      * @return true if the tokens should be updated immediately, false otherwise
      */
-    private boolean shouldUpdateTokensImmediately(long currentNanos, boolean forceUpdateTokens) {
+    private boolean shouldAddTokensImmediately(long currentNanos, boolean forceConsistentTokens) {
         long currentIncrement = resolutionNanos != 0 ? currentNanos / resolutionNanos : 0;
         long currentLastIncrement = lastIncrement;
         return currentIncrement == 0
                 || (currentIncrement > currentLastIncrement
                 && LAST_INCREMENT_UPDATER.compareAndSet(this, currentLastIncrement, currentIncrement))
-                || forceUpdateTokens;
+                || consistentAddedTokens || forceConsistentTokens;
     }
 
     /**
@@ -223,11 +242,13 @@ public abstract class AsyncTokenBucket {
      * @param currentNanos the current monotonic clock time in nanoseconds
      * @return the number of new tokens to add since the last update
      */
-    private long calculateNewTokensSinceLastUpdate(long currentNanos) {
+    private long calculateNewTokensSinceLastUpdate(long currentNanos, boolean forceConsistentTokens) {
         long previousLastNanos = lastNanos;
         long newLastNanos;
         // update lastNanos only if at least resolutionNanos/2 nanoseconds has passed since the last update
-        if (currentNanos >= previousLastNanos + resolutionNanos / 2) {
+        // unless consistency is needed
+        long minimumIncrementNanos = forceConsistentTokens || consistentAddedTokens ? 0L : resolutionNanos / 2;
+        if (currentNanos > previousLastNanos + minimumIncrementNanos) {
             newLastNanos = currentNanos;
         } else {
             newLastNanos = previousLastNanos;
@@ -291,15 +312,14 @@ public abstract class AsyncTokenBucket {
     }
 
     /**
-     * Returns the current token balance. When forceUpdateTokens is true, the tokens balance is updated before
-     * returning. If forceUpdateTokens is false, the tokens balance could be updated if the last updated happened
+     * Returns the current token balance. When forceConsistentTokens is true, the tokens balance is updated before
+     * returning. If forceConsistentTokens is false, the tokens balance could be updated if the last updated happened
      * more than resolutionNanos nanoseconds ago.
      *
-     * @param forceUpdateTokens if true, the tokens balance is updated before returning
      * @return the current token balance
      */
-    protected long tokens(boolean forceUpdateTokens) {
-        long currentTokens = consumeTokensAndMaybeUpdateTokensBalance(0, forceUpdateTokens);
+    private long tokens() {
+        long currentTokens = consumeTokensAndMaybeUpdateTokensBalance(0, false);
         if (currentTokens != Long.MIN_VALUE) {
             // when currentTokens isn't Long.MIN_VALUE, the current tokens balance is known
             return currentTokens;
@@ -319,7 +339,7 @@ public abstract class AsyncTokenBucket {
         long currentTokens = consumeTokensAndMaybeUpdateTokensBalance(0, true);
         if (currentTokens == Long.MIN_VALUE) {
             throw new IllegalArgumentException(
-                    "Unexpected result from updateAndConsumeTokens with forceUpdateTokens set to true");
+                    "Unexpected result from updateAndConsumeTokens with forceConsistentTokens set to true");
         }
         if (currentTokens > 0) {
             return 0L;
@@ -334,10 +354,10 @@ public abstract class AsyncTokenBucket {
     /**
      * Returns the current number of tokens in the bucket.
      * The token balance is updated if the configured resolutionNanos has passed since the last update unless
-     * consistentTokensView is true.
+     * consistentConsumedTokens is true.
      */
     public final long getTokens() {
-        return tokens(consistentTokensView);
+        return tokens();
     }
 
     public abstract long getRate();
@@ -346,25 +366,12 @@ public abstract class AsyncTokenBucket {
      * Checks if the bucket contains tokens.
      * The token balance is updated before the comparison if the configured resolutionNanos has passed since the last
      * update. It's possible that the returned result is not definite since the token balance is eventually consistent
-     * if consistentTokensView is false.
+     * if consistentConsumedTokens is false.
      *
      * @return true if the bucket contains tokens, false otherwise
      */
     public boolean containsTokens() {
-        return containsTokens(consistentTokensView);
-    }
-
-    /**
-     * Checks if the bucket contains tokens.
-     * The token balance is updated before the comparison if the configured resolutionNanos has passed since the last
-     * update. The token balance is also updated when forceUpdateTokens is true.
-     * It's possible that the returned result is not definite since the token balance is eventually consistent.
-     *
-     * @param forceUpdateTokens if true, the token balance is updated before the comparison
-     * @return true if the bucket contains tokens, false otherwise
-     */
-    protected boolean containsTokens(boolean forceUpdateTokens) {
-        return tokens(forceUpdateTokens) > 0;
+        return tokens() > 0;
     }
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucket.java
@@ -159,16 +159,15 @@ public abstract class AsyncTokenBucket {
         if (shouldUpdateTokensImmediately(currentNanos, forceUpdateTokens)) {
             // calculate the number of new tokens since the last update
             long newTokens = calculateNewTokensSinceLastUpdate(currentNanos);
-            // calculate the total amount of tokens to consume in this update
             // flush the pendingConsumedTokens by calling "sumThenReset"
-            long totalConsumedTokens = consumeTokens + pendingConsumedTokens.sumThenReset();
+            long currentPendingConsumedTokens = pendingConsumedTokens.sumThenReset();
             // update the tokens and return the current token value
             return TOKENS_UPDATER.updateAndGet(this,
-                    currentTokens ->
-                            // after adding new tokens, limit the tokens to the capacity
-                            Math.min(currentTokens + newTokens, getCapacity())
-                                    // subtract the consumed tokens
-                                    - totalConsumedTokens);
+                    // after adding new tokens subtract the pending consumed tokens and
+                    // limit the tokens to the capacity of the bucket
+                    currentTokens -> Math.min(currentTokens + newTokens - currentPendingConsumedTokens, getCapacity())
+                            // subtract the consumed tokens
+                            - consumeTokens);
         } else {
             // eventual consistent fast path, tokens are not updated immediately
 
@@ -211,8 +210,10 @@ public abstract class AsyncTokenBucket {
      */
     private long calculateNewTokensSinceLastUpdate(long currentNanos) {
         long newTokens;
-        long previousLastNanos = LAST_NANOS_UPDATER.getAndSet(this, currentNanos);
-        if (previousLastNanos == 0) {
+        // update lastNanos if currentNanos is greater than the current lastNanos
+        long previousLastNanos = LAST_NANOS_UPDATER.getAndUpdate(this,
+                currentLastNanos -> Math.max(currentNanos, currentLastNanos));
+        if (previousLastNanos == 0 || previousLastNanos >= currentNanos) {
             newTokens = 0;
         } else {
             long durationNanos = currentNanos - previousLastNanos + REMAINDER_NANOS_UPDATER.getAndSet(this, 0);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucket.java
@@ -229,7 +229,7 @@ public abstract class AsyncTokenBucket {
                         return currentLastNanos;
                     }
                 });
-        if (previousLastNanos == Long.MIN_VALUE || previousLastNanos >= currentNanos) {
+        if (previousLastNanos == Long.MIN_VALUE || currentNanos != lastNanos) {
             newTokens = 0;
         } else {
             long durationNanos = currentNanos - previousLastNanos + REMAINDER_NANOS_UPDATER.getAndSet(this, 0);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucket.java
@@ -363,7 +363,7 @@ public abstract class AsyncTokenBucket {
      * @param forceUpdateTokens if true, the token balance is updated before the comparison
      * @return true if the bucket contains tokens, false otherwise
      */
-    protected boolean containsTokens(boolean forceUpdateTokens) {
+    public boolean containsTokens(boolean forceUpdateTokens) {
         return tokens(forceUpdateTokens) > 0;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucket.java
@@ -166,7 +166,8 @@ public abstract class AsyncTokenBucket {
             // calculate the number of new tokens since the last update
             newTokens = calculateNewTokensSinceLastUpdate(currentNanos);
         }
-        if (newTokens > 0) {
+        // update tokens if there are new tokens or if resolutionNanos is set to 0 which is currently used for testing
+        if (newTokens > 0 || resolutionNanos == 0) {
             // flush the pendingConsumedTokens by calling "sumThenReset"
             long currentPendingConsumedTokens = pendingConsumedTokens.sumThenReset();
             // calculate the token delta by subtracting the consumed tokens from the new tokens

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucketBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucketBuilder.java
@@ -23,7 +23,8 @@ package org.apache.pulsar.broker.qos;
 public abstract class AsyncTokenBucketBuilder<SELF extends AsyncTokenBucketBuilder<SELF>> {
     protected MonotonicSnapshotClock clock = AsyncTokenBucket.DEFAULT_SNAPSHOT_CLOCK;
     protected long resolutionNanos = AsyncTokenBucket.defaultResolutionNanos;
-    protected boolean consistentTokensView;
+    protected boolean consistentConsumedTokens;
+    protected boolean consistentAddedTokens;
 
     protected AsyncTokenBucketBuilder() {
     }
@@ -32,18 +33,45 @@ public abstract class AsyncTokenBucketBuilder<SELF extends AsyncTokenBucketBuild
         return (SELF) this;
     }
 
+    /**
+     * Set the clock source for the token bucket. It's recommended to use the {@link DefaultMonotonicSnapshotClock}
+     * for most use cases.
+     */
     public SELF clock(MonotonicSnapshotClock clock) {
         this.clock = clock;
         return self();
     }
 
+    /**
+     * By default, AsyncTokenBucket is eventually consistent. This means that the token balance is updated, when time
+     * advances more than the configured resolution. This setting determines the duration of the increment.
+     * Setting this value to 0 will make the token balance fully consistent. There's a performance trade-off
+     * when setting this value to 0.
+     */
     public SELF resolutionNanos(long resolutionNanos) {
         this.resolutionNanos = resolutionNanos;
         return self();
     }
 
-    public SELF consistentTokensView(boolean consistentTokensView) {
-        this.consistentTokensView = consistentTokensView;
+    /**
+     * By default, AsyncTokenBucket is eventually consistent. This means that the consumed tokens are subtracted from
+     * the total amount of tokens at most once during each "increment", when time advances more than the configured
+     * resolution. This setting determines if the consumed tokens are subtracted from tokens balance consistently.
+     * For high performance, it is recommended to keep this setting as false.
+     */
+    public SELF consistentConsumedTokens(boolean consistentConsumedTokens) {
+        this.consistentConsumedTokens = consistentConsumedTokens;
+        return self();
+    }
+
+    /**
+     * By default, AsyncTokenBucket is eventually consistent. This means that the added tokens are calculated based
+     * on elapsed time at most once during each "increment", when time advances more than the configured
+     * resolution. This setting determines if the added tokens are calculated and added to tokens balance consistently.
+     * For high performance, it is recommended to keep this setting as false.
+     */
+    public SELF consistentAddedTokens(boolean consistentAddedTokens) {
+        this.consistentAddedTokens = consistentAddedTokens;
         return self();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucketBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucketBuilder.java
@@ -23,7 +23,7 @@ package org.apache.pulsar.broker.qos;
 public abstract class AsyncTokenBucketBuilder<SELF extends AsyncTokenBucketBuilder<SELF>> {
     protected MonotonicSnapshotClock clock = AsyncTokenBucket.DEFAULT_SNAPSHOT_CLOCK;
     protected long resolutionNanos = AsyncTokenBucket.defaultResolutionNanos;
-    protected boolean getTokensUpdatesTokens;
+    protected boolean consistentTokensView;
 
     protected AsyncTokenBucketBuilder() {
     }
@@ -42,8 +42,8 @@ public abstract class AsyncTokenBucketBuilder<SELF extends AsyncTokenBucketBuild
         return self();
     }
 
-    public SELF getTokensUpdatesTokens(boolean getTokensUpdatesTokens) {
-        this.getTokensUpdatesTokens = getTokensUpdatesTokens;
+    public SELF consistentTokensView(boolean consistentTokensView) {
+        this.consistentTokensView = consistentTokensView;
         return self();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucketBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucketBuilder.java
@@ -23,6 +23,7 @@ package org.apache.pulsar.broker.qos;
 public abstract class AsyncTokenBucketBuilder<SELF extends AsyncTokenBucketBuilder<SELF>> {
     protected MonotonicSnapshotClock clock = AsyncTokenBucket.DEFAULT_SNAPSHOT_CLOCK;
     protected long resolutionNanos = AsyncTokenBucket.defaultResolutionNanos;
+    protected boolean getTokensUpdatesTokens;
 
     protected AsyncTokenBucketBuilder() {
     }
@@ -38,6 +39,11 @@ public abstract class AsyncTokenBucketBuilder<SELF extends AsyncTokenBucketBuild
 
     public SELF resolutionNanos(long resolutionNanos) {
         this.resolutionNanos = resolutionNanos;
+        return self();
+    }
+
+    public SELF getTokensUpdatesTokens(boolean getTokensUpdatesTokens) {
+        this.getTokensUpdatesTokens = getTokensUpdatesTokens;
         return self();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
@@ -213,7 +213,7 @@ public class DefaultMonotonicSnapshotClock implements MonotonicSnapshotClock, Au
      * Handles updating the tick value in a monotonic way so that the value is always increasing,
      * regardless of leaps backward in the clock source value.
      */
-    private static class MonotonicLeapDetectingTickUpdater {
+    static class MonotonicLeapDetectingTickUpdater {
         private final LongSupplier clockSource;
         private final long snapshotInternalNanos;
         private final long maxDeltaNanosForLeapDetection;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
@@ -19,7 +19,6 @@
 
 package org.apache.pulsar.broker.qos;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -62,11 +61,6 @@ public class DefaultMonotonicSnapshotClock implements MonotonicSnapshotClock, Au
 
     private void setSnapshotTickNanos(long snapshotTickNanos) {
         this.snapshotTickNanos = snapshotTickNanos;
-    }
-
-    @VisibleForTesting
-    public void requestUpdate() {
-        tickUpdaterThread.requestUpdate();
     }
 
     /**
@@ -165,7 +159,7 @@ public class DefaultMonotonicSnapshotClock implements MonotonicSnapshotClock, Au
             }
         }
 
-        public void requestUpdate() {
+        private void requestUpdate() {
             // increment the request count that ensures that the thread will update the tick value after this request
             // was made also when there's a race condition between the request and the update
             requestCount.incrementAndGet();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
@@ -144,8 +144,10 @@ public class DefaultMonotonicSnapshotClock implements MonotonicSnapshotClock, Au
 
         public void requestUpdateAndWait() {
             if (!running) {
-                // thread has stopped running, fallback to update the value directly without optimizations
-                tickUpdater.update(false);
+                synchronized (tickUpdater) {
+                    // thread has stopped running, fallback to update the value directly without optimizations
+                    tickUpdater.update(false);
+                }
                 return;
             }
             synchronized (tickUpdatedMonitor) {
@@ -214,7 +216,7 @@ public class DefaultMonotonicSnapshotClock implements MonotonicSnapshotClock, Au
          * @param waitedSnapshotInterval if true, the method has waited for the snapshot interval since the previous
          *                               call.
          */
-        public synchronized void update(boolean waitedSnapshotInterval) {
+        public void update(boolean waitedSnapshotInterval) {
             long clockValue = clockSource.getAsLong();
 
             // Initialization

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
@@ -96,7 +96,7 @@ public class DefaultMonotonicSnapshotClock implements MonotonicSnapshotClock, Au
             this.sleepMillis = TimeUnit.NANOSECONDS.toMillis(snapshotIntervalNanos);
             this.sleepNanos = (int) (snapshotIntervalNanos - TimeUnit.MILLISECONDS.toNanos(sleepMillis));
             tickUpdater = new MonotonicLeapDetectingTickUpdater(clockSource, setSnapshotTickNanos,
-                    2 * snapshotIntervalNanos);
+                    snapshotIntervalNanos);
         }
 
         @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
@@ -139,7 +139,7 @@ public class DefaultMonotonicSnapshotClock implements MonotonicSnapshotClock, Au
                             }
                             updatedForRequestCount = requestCount;
                         }
-                        // update the tick value using the tick updater which will tolerate leaps backward or forward
+                        // update the tick value using the tick updater which will tolerate leaps backward
                         tickUpdater.update(waitedSnapshotInterval);
                         notifyAllTickUpdated();
                     } catch (InterruptedException e) {
@@ -207,7 +207,7 @@ public class DefaultMonotonicSnapshotClock implements MonotonicSnapshotClock, Au
 
     /**
      * Handles updating the tick value in a monotonic way so that the value is always increasing,
-     * regardless of leaps backward and forward in the clock source value.
+     * regardless of leaps backward in the clock source value.
      */
     private static class MonotonicLeapDetectingTickUpdater {
         private final LongSupplier clockSource;
@@ -229,7 +229,7 @@ public class DefaultMonotonicSnapshotClock implements MonotonicSnapshotClock, Au
         /**
          * Updates the snapshot tick value. The tickUpdatedCallback is called if the value has changed.
          * The value is updated in a monotonic way so that the value is always increasing, regardless of leaps backward
-         * and forward in the clock source value.
+         * in the clock source value.
          * Leap detection is done by comparing the new value with the previous value and the maximum delta value.
          *
          * @param waitedSnapshotInterval if true, the method has waited for the snapshot interval since the previous
@@ -249,14 +249,13 @@ public class DefaultMonotonicSnapshotClock implements MonotonicSnapshotClock, Au
 
             // calculate the duration since the reference clock source value
             // so that the snapshot value is always increasing and tolerates it when the clock source is not strictly
-            // monotonic across all CPUs and leaps backward or forward
+            // monotonic across all CPUs and leaps backward
             long durationSinceReference = clockValue - referenceClockSourceValue;
             long newSnapshotTickNanos = baseSnapshotTickNanos + durationSinceReference;
 
-            // reset the reference clock source value if the clock source value leaps backward or forward
+            // reset the reference clock source value if the clock source value leaps backward
             // more than the maximum delta value
-            if (newSnapshotTickNanos < previousSnapshotTickNanos - maxDeltaNanosForLeapDetection
-                    || newSnapshotTickNanos > previousSnapshotTickNanos + maxDeltaNanosForLeapDetection) {
+            if (newSnapshotTickNanos < previousSnapshotTickNanos - maxDeltaNanosForLeapDetection) {
                 referenceClockSourceValue = clockValue;
                 long incrementWhenLeapDetected = waitedSnapshotInterval ? snapshotInternalNanos : 0;
                 baseSnapshotTickNanos = previousSnapshotTickNanos + incrementWhenLeapDetected;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
@@ -28,13 +28,31 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Default implementation of {@link MonotonicSnapshotClock}.
+ * Default implementation of {@link MonotonicSnapshotClock} optimized for use with {@link AsyncTokenBucket}.
  *
- * Starts a daemon thread that updates the snapshot value periodically with a configured interval. The close method
- * should be called to stop the thread.
- * A single thread is used to update the monotonic clock value so that the snapshot value is always increasing,
- * even if the clock source is not strictly monotonic across all CPUs. This might be the case in some virtualized
- * environments.
+ * <p>
+ * This class provides a monotonic snapshot value that consistently increases, ensuring reliable behavior
+ * even in environments where the underlying clock source may not be strictly monotonic across all CPUs,
+ * such as certain virtualized platforms.
+ * </p>
+ *
+ * <p>
+ * Upon instantiation, a daemon thread is launched to periodically update the snapshot value at a configured
+ * interval. It is essential to invoke the {@link #close()} method to gracefully terminate this thread when it is
+ * no longer needed.
+ * </p>
+ *
+ * <p>
+ * The {@link AsyncTokenBucket} utilizes this clock to obtain tick values. It does not require a consistent value on
+ * every retrieval. However, when a consistent snapshot is necessary, the {@link #getTickNanos(boolean)} method
+ * is called with the {@code requestSnapshot} parameter set to {@code true}.
+ * </p>
+ *
+ * <p>
+ * By employing a single thread to update the monotonic clock value, this implementation ensures that the snapshot
+ * value remains strictly increasing. This approach mitigates potential inconsistencies that may arise from clock
+ * source discrepancies across different CPUs.
+ * </p>
  */
 public class DefaultMonotonicSnapshotClock implements MonotonicSnapshotClock, AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultMonotonicSnapshotClock.class);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
@@ -19,6 +19,7 @@
 
 package org.apache.pulsar.broker.qos;
 
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongSupplier;
 import org.slf4j.Logger;
@@ -48,7 +49,7 @@ public class DefaultMonotonicSnapshotClock implements MonotonicSnapshotClock, Au
         }
         this.sleepMillis = TimeUnit.NANOSECONDS.toMillis(snapshotIntervalNanos);
         this.sleepNanos = (int) (snapshotIntervalNanos - TimeUnit.MILLISECONDS.toNanos(sleepMillis));
-        this.clockSource = clockSource;
+        this.clockSource = Objects.requireNonNull(clockSource, "clockSource must not be null");
         this.snapshotIntervalNanos = snapshotIntervalNanos;
         tickUpdaterThread = new TickUpdaterThread();
         tickUpdaterThread.start();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
@@ -217,13 +217,15 @@ public class DefaultMonotonicSnapshotClock implements MonotonicSnapshotClock, Au
          *                               call.
          */
         public void update(boolean waitedSnapshotInterval) {
+            // get the current clock source value
             long clockValue = clockSource.getAsLong();
 
-            // Initialization
+            // Initialization on first call
             if (referenceClockSourceValue == Long.MIN_VALUE) {
                 referenceClockSourceValue = clockValue;
                 baseSnapshotTickNanos = clockValue;
                 previousSnapshotTickNanos = clockValue;
+                // update the tick value using the callback
                 tickUpdatedCallback.accept(clockValue);
                 return;
             }
@@ -247,6 +249,7 @@ public class DefaultMonotonicSnapshotClock implements MonotonicSnapshotClock, Au
             if (newSnapshotTickNanos > previousSnapshotTickNanos) {
                 // store the previous value
                 previousSnapshotTickNanos = newSnapshotTickNanos;
+                // update the tick value using the callback
                 tickUpdatedCallback.accept(newSnapshotTickNanos);
             }
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
@@ -29,13 +29,17 @@ import org.slf4j.LoggerFactory;
  *
  * Starts a daemon thread that updates the snapshot value periodically with a configured interval. The close method
  * should be called to stop the thread.
+ * A single thread is used to update the monotonic clock value so that the snapshot value is always increasing,
+ * even if the clock source is not strictly monotonic across all CPUs. This might be the case in some virtualized
+ * environments.
  */
 public class DefaultMonotonicSnapshotClock implements MonotonicSnapshotClock, AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultMonotonicSnapshotClock.class);
     private final long sleepMillis;
     private final int sleepNanos;
     private final LongSupplier clockSource;
-    private final Thread thread;
+    private final TickUpdaterThread tickUpdaterThread;
+    private final long snapshotIntervalNanos;
     private volatile long snapshotTickNanos;
 
     public DefaultMonotonicSnapshotClock(long snapshotIntervalNanos, LongSupplier clockSource) {
@@ -45,45 +49,165 @@ public class DefaultMonotonicSnapshotClock implements MonotonicSnapshotClock, Au
         this.sleepMillis = TimeUnit.NANOSECONDS.toMillis(snapshotIntervalNanos);
         this.sleepNanos = (int) (snapshotIntervalNanos - TimeUnit.MILLISECONDS.toNanos(sleepMillis));
         this.clockSource = clockSource;
-        updateSnapshotTickNanos();
-        thread = new Thread(this::snapshotLoop, getClass().getSimpleName() + "-update-loop");
-        thread.setDaemon(true);
-        thread.start();
+        this.snapshotIntervalNanos = snapshotIntervalNanos;
+        tickUpdaterThread = new TickUpdaterThread();
+        tickUpdaterThread.start();
     }
 
     /** {@inheritDoc} */
     @Override
     public long getTickNanos(boolean requestSnapshot) {
         if (requestSnapshot) {
-            updateSnapshotTickNanos();
+            tickUpdaterThread.requestUpdate();
         }
         return snapshotTickNanos;
     }
 
-    private void updateSnapshotTickNanos() {
-        snapshotTickNanos = clockSource.getAsLong();
-    }
+    /**
+     * A thread that updates snapshotTickNanos value periodically with a configured interval.
+     * The thread is started when the DefaultMonotonicSnapshotClock is created and runs until the close method is
+     * called.
+     * A single thread is used to read the clock source value since on some hardware of virtualized platforms,
+     * System.nanoTime() isn't strictly monotonic across all CPUs. Reading by a single thread will improve the
+     * stability of the read value since a single thread is scheduled on a single CPU. If the thread is migrated
+     * to another CPU, the clock source value might leap backward or forward, but logic in this class will handle it.
+     */
+    private class TickUpdaterThread extends Thread {
+        private final Object tickUpdateDelayMonitor = new Object();
+        private final Object tickUpdatedMonitor = new Object();
+        private final long maxDelta;
+        private long referenceClockSourceValue;
+        private long baseSnapshotTickNanos;
+        private long previousSnapshotTickNanos;
+        private volatile boolean running = false;
+        private boolean tickUpdateDelayMonitorNotified = false;
 
-    private void snapshotLoop() {
-        try {
-            while (!Thread.currentThread().isInterrupted()) {
-                updateSnapshotTickNanos();
+        TickUpdaterThread() {
+            super(DefaultMonotonicSnapshotClock.class.getSimpleName() + "-update-loop");
+            // set as daemon thread so that it doesn't prevent the JVM from exiting
+            setDaemon(true);
+            // set the highest priority
+            setPriority(MAX_PRIORITY);
+            this.maxDelta = 2 * snapshotIntervalNanos;
+        }
+
+        @Override
+        public void run() {
+            try {
+                running = true;
+                // initially update the snapshot value and notify all threads that are waiting for the tick value
+                // the start method waits until the tick value has been updated
+                updateSnapshotTickNanos(false);
+                notifyAllTickUpdated();
+                while (!isInterrupted()) {
+                    try {
+                        boolean snapshotRequested;
+                        // sleep for the configured interval on a monitor that can be notified to stop the sleep
+                        // and update the tick value immediately. This is used in requestUpdate method.
+                        synchronized (tickUpdateDelayMonitor) {
+                            tickUpdateDelayMonitorNotified = false;
+                            tickUpdateDelayMonitor.wait(sleepMillis, sleepNanos);
+                            snapshotRequested = tickUpdateDelayMonitorNotified;
+                        }
+                        updateSnapshotTickNanos(snapshotRequested);
+                        notifyAllTickUpdated();
+                    } catch (InterruptedException e) {
+                        interrupt();
+                        break;
+                    }
+                }
+            } catch (Throwable t) {
+                // report unexpected error since this would be a fatal error when the clock doesn't progress anymore
+                // this is very unlikely to happen, but it's better to log it in any case
+                LOG.error("Unexpected fatal error that stopped the clock.", t);
+            } finally {
+                LOG.info("DefaultMonotonicSnapshotClock's TickUpdaterThread stopped. {},tid={}", this, getId());
+                running = false;
+            }
+        }
+
+        private void updateSnapshotTickNanos(boolean snapshotRequested) {
+            long clockValue = clockSource.getAsLong();
+
+            // Initialization
+            if (referenceClockSourceValue == 0) {
+                referenceClockSourceValue = clockValue;
+                baseSnapshotTickNanos = clockValue;
+                snapshotTickNanos = clockValue;
+                previousSnapshotTickNanos = clockValue;
+                return;
+            }
+
+            // calculate the duration since the reference clock source value
+            // so that the snapshot value is always increasing and tolerates it when the clock source is not strictly
+            // monotonic across all CPUs and leaps backward or forward
+            long durationSinceReference = clockValue - referenceClockSourceValue;
+            long newSnapshotTickNanos = baseSnapshotTickNanos + durationSinceReference;
+
+            // reset the reference clock source value if the clock source value leaps backward or forward
+            if (newSnapshotTickNanos < previousSnapshotTickNanos - maxDelta
+                    || newSnapshotTickNanos > previousSnapshotTickNanos + maxDelta) {
+                referenceClockSourceValue = clockValue;
+                baseSnapshotTickNanos = previousSnapshotTickNanos;
+                if (!snapshotRequested) {
+                    // if the snapshot value is not requested, increment by the snapshot interval
+                    baseSnapshotTickNanos += snapshotIntervalNanos;
+                }
+                newSnapshotTickNanos = baseSnapshotTickNanos;
+            }
+
+            // update snapshotTickNanos value if the new value is greater than the previous value
+            if (newSnapshotTickNanos > previousSnapshotTickNanos) {
+                snapshotTickNanos = newSnapshotTickNanos;
+                // store into a field so that we don't need to do a volatile read to find out the previous value
+                previousSnapshotTickNanos = newSnapshotTickNanos;
+            }
+        }
+
+        private void notifyAllTickUpdated() {
+            synchronized (tickUpdatedMonitor) {
+                // notify all threads that are waiting for the tick value to be updated
+                tickUpdatedMonitor.notifyAll();
+            }
+        }
+
+        public void requestUpdate() {
+            if (!running) {
+                // thread has stopped running, fallback to update the value directly without any optimizations
+                snapshotTickNanos = clockSource.getAsLong();
+                return;
+            }
+            synchronized (tickUpdatedMonitor) {
+                // notify the thread to stop waiting and update the tick value
+                synchronized (tickUpdateDelayMonitor) {
+                    tickUpdateDelayMonitorNotified = true;
+                    tickUpdateDelayMonitor.notify();
+                }
+                // wait until the tick value has been updated
                 try {
-                    Thread.sleep(sleepMillis, sleepNanos);
+                    tickUpdatedMonitor.wait();
                 } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    break;
+                    currentThread().interrupt();
                 }
             }
-        } catch (Throwable t) {
-            // report unexpected error since this would be a fatal error when the clock doesn't progress anymore
-            // this is very unlikely to happen, but it's better to log it in any case
-            LOG.error("Unexpected fatal error that stopped the clock.", t);
+        }
+
+        @Override
+        public synchronized void start() {
+            super.start();
+            // wait until the thread is started and the tick value has been updated
+            synchronized (tickUpdatedMonitor) {
+                try {
+                    tickUpdatedMonitor.wait();
+                } catch (InterruptedException e) {
+                    currentThread().interrupt();
+                }
+            }
         }
     }
 
     @Override
     public void close() {
-        thread.interrupt();
+        tickUpdaterThread.interrupt();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
@@ -175,6 +175,9 @@ public class DefaultMonotonicSnapshotClock implements MonotonicSnapshotClock, Au
             }
             // increment the request count that ensures that the thread will update the tick value after this request
             // was made also when there's a race condition between the request and the update
+            // this solution doesn't prevent all races, and it's not guaranteed that the tick value is always updated
+            // it will prevent the request having to wait for the delayed update cycle. This is sufficient for the
+            // use case.
             requestCount.incrementAndGet();
             synchronized (tickUpdatedMonitor) {
                 // notify the thread to stop waiting and update the tick value

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DynamicRateAsyncTokenBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DynamicRateAsyncTokenBucket.java
@@ -34,9 +34,9 @@ public class DynamicRateAsyncTokenBucket extends AsyncTokenBucket {
 
     protected DynamicRateAsyncTokenBucket(double capacityFactor, LongSupplier rateFunction,
                                           MonotonicSnapshotClock clockSource, LongSupplier ratePeriodNanosFunction,
-                                          long resolutionNanos, double initialTokensFactor,
-                                          double targetFillFactorAfterThrottling) {
-        super(clockSource, resolutionNanos);
+                                          long resolutionNanos, boolean getTokensUpdatesTokens,
+                                          double initialTokensFactor, double targetFillFactorAfterThrottling) {
+        super(clockSource, resolutionNanos, getTokensUpdatesTokens);
         this.capacityFactor = capacityFactor;
         this.rateFunction = rateFunction;
         this.ratePeriodNanosFunction = ratePeriodNanosFunction;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DynamicRateAsyncTokenBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DynamicRateAsyncTokenBucket.java
@@ -34,9 +34,9 @@ public class DynamicRateAsyncTokenBucket extends AsyncTokenBucket {
 
     protected DynamicRateAsyncTokenBucket(double capacityFactor, LongSupplier rateFunction,
                                           MonotonicSnapshotClock clockSource, LongSupplier ratePeriodNanosFunction,
-                                          long resolutionNanos, boolean getTokensUpdatesTokens,
+                                          long resolutionNanos, boolean consistentTokensView,
                                           double initialTokensFactor, double targetFillFactorAfterThrottling) {
-        super(clockSource, resolutionNanos, getTokensUpdatesTokens);
+        super(clockSource, resolutionNanos, consistentTokensView);
         this.capacityFactor = capacityFactor;
         this.rateFunction = rateFunction;
         this.ratePeriodNanosFunction = ratePeriodNanosFunction;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DynamicRateAsyncTokenBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DynamicRateAsyncTokenBucket.java
@@ -34,15 +34,16 @@ public class DynamicRateAsyncTokenBucket extends AsyncTokenBucket {
 
     protected DynamicRateAsyncTokenBucket(double capacityFactor, LongSupplier rateFunction,
                                           MonotonicSnapshotClock clockSource, LongSupplier ratePeriodNanosFunction,
-                                          long resolutionNanos, boolean consistentTokensView,
-                                          double initialTokensFactor, double targetFillFactorAfterThrottling) {
-        super(clockSource, resolutionNanos, consistentTokensView);
+                                          long resolutionNanos, boolean consistentConsumedTokens,
+                                          boolean consistentAddedTokens, double initialTokensFactor,
+                                          double targetFillFactorAfterThrottling) {
+        super(clockSource, resolutionNanos, consistentConsumedTokens, consistentAddedTokens);
         this.capacityFactor = capacityFactor;
         this.rateFunction = rateFunction;
         this.ratePeriodNanosFunction = ratePeriodNanosFunction;
         this.targetFillFactorAfterThrottling = targetFillFactorAfterThrottling;
         this.tokens = (long) (rateFunction.getAsLong() * initialTokensFactor);
-        tokens(false);
+        getTokens();
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DynamicRateAsyncTokenBucketBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DynamicRateAsyncTokenBucketBuilder.java
@@ -64,9 +64,7 @@ public class DynamicRateAsyncTokenBucketBuilder
     @Override
     public AsyncTokenBucket build() {
         return new DynamicRateAsyncTokenBucket(this.capacityFactor, this.rateFunction,
-                this.clock,
-                this.ratePeriodNanosFunction, this.resolutionNanos, this.consistentTokensView,
-                this.initialFillFactor,
-                targetFillFactorAfterThrottling);
+                this.clock, this.ratePeriodNanosFunction, this.resolutionNanos, this.consistentConsumedTokens,
+                this.consistentAddedTokens, this.initialFillFactor, targetFillFactorAfterThrottling);
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DynamicRateAsyncTokenBucketBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DynamicRateAsyncTokenBucketBuilder.java
@@ -65,7 +65,7 @@ public class DynamicRateAsyncTokenBucketBuilder
     public AsyncTokenBucket build() {
         return new DynamicRateAsyncTokenBucket(this.capacityFactor, this.rateFunction,
                 this.clock,
-                this.ratePeriodNanosFunction, this.resolutionNanos,
+                this.ratePeriodNanosFunction, this.resolutionNanos, this.getTokensUpdatesTokens,
                 this.initialFillFactor,
                 targetFillFactorAfterThrottling);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DynamicRateAsyncTokenBucketBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DynamicRateAsyncTokenBucketBuilder.java
@@ -65,7 +65,7 @@ public class DynamicRateAsyncTokenBucketBuilder
     public AsyncTokenBucket build() {
         return new DynamicRateAsyncTokenBucket(this.capacityFactor, this.rateFunction,
                 this.clock,
-                this.ratePeriodNanosFunction, this.resolutionNanos, this.getTokensUpdatesTokens,
+                this.ratePeriodNanosFunction, this.resolutionNanos, this.consistentTokensView,
                 this.initialFillFactor,
                 targetFillFactorAfterThrottling);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/FinalRateAsyncTokenBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/FinalRateAsyncTokenBucket.java
@@ -30,9 +30,9 @@ class FinalRateAsyncTokenBucket extends AsyncTokenBucket {
     private final long targetAmountOfTokensAfterThrottling;
 
     protected FinalRateAsyncTokenBucket(long capacity, long rate, MonotonicSnapshotClock clockSource,
-                                        long ratePeriodNanos, long resolutionNanos, boolean getTokensUpdatesTokens,
+                                        long ratePeriodNanos, long resolutionNanos, boolean consistentTokensView,
                                         long initialTokens) {
-        super(clockSource, resolutionNanos, getTokensUpdatesTokens);
+        super(clockSource, resolutionNanos, consistentTokensView);
         this.capacity = capacity;
         this.rate = rate;
         this.ratePeriodNanos = ratePeriodNanos != -1 ? ratePeriodNanos : ONE_SECOND_NANOS;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/FinalRateAsyncTokenBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/FinalRateAsyncTokenBucket.java
@@ -30,16 +30,16 @@ class FinalRateAsyncTokenBucket extends AsyncTokenBucket {
     private final long targetAmountOfTokensAfterThrottling;
 
     protected FinalRateAsyncTokenBucket(long capacity, long rate, MonotonicSnapshotClock clockSource,
-                                        long ratePeriodNanos, long resolutionNanos, boolean consistentTokensView,
-                                        long initialTokens) {
-        super(clockSource, resolutionNanos, consistentTokensView);
+                                        long ratePeriodNanos, long resolutionNanos, boolean consistentConsumedTokens,
+                                        boolean consistentAddedTokens, long initialTokens) {
+        super(clockSource, resolutionNanos, consistentConsumedTokens, consistentAddedTokens);
         this.capacity = capacity;
         this.rate = rate;
         this.ratePeriodNanos = ratePeriodNanos != -1 ? ratePeriodNanos : ONE_SECOND_NANOS;
         // The target amount of tokens is the amount of tokens made available in the resolution duration
         this.targetAmountOfTokensAfterThrottling = Math.max(this.resolutionNanos * rate / ratePeriodNanos, 1);
         this.tokens = initialTokens;
-        tokens(false);
+        getTokens();
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/FinalRateAsyncTokenBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/FinalRateAsyncTokenBucket.java
@@ -30,8 +30,9 @@ class FinalRateAsyncTokenBucket extends AsyncTokenBucket {
     private final long targetAmountOfTokensAfterThrottling;
 
     protected FinalRateAsyncTokenBucket(long capacity, long rate, MonotonicSnapshotClock clockSource,
-                                        long ratePeriodNanos, long resolutionNanos, long initialTokens) {
-        super(clockSource, resolutionNanos);
+                                        long ratePeriodNanos, long resolutionNanos, boolean getTokensUpdatesTokens,
+                                        long initialTokens) {
+        super(clockSource, resolutionNanos, getTokensUpdatesTokens);
         this.capacity = capacity;
         this.rate = rate;
         this.ratePeriodNanos = ratePeriodNanos != -1 ? ratePeriodNanos : ONE_SECOND_NANOS;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/FinalRateAsyncTokenBucketBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/FinalRateAsyncTokenBucketBuilder.java
@@ -55,7 +55,7 @@ public class FinalRateAsyncTokenBucketBuilder
     public AsyncTokenBucket build() {
         return new FinalRateAsyncTokenBucket(this.capacity != null ? this.capacity : this.rate, this.rate,
                 this.clock,
-                this.ratePeriodNanos, this.resolutionNanos, this.consistentTokensView,
+                this.ratePeriodNanos, this.resolutionNanos, this.consistentConsumedTokens, this.consistentAddedTokens,
                 this.initialTokens != null ? this.initialTokens : this.rate
         );
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/FinalRateAsyncTokenBucketBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/FinalRateAsyncTokenBucketBuilder.java
@@ -55,7 +55,7 @@ public class FinalRateAsyncTokenBucketBuilder
     public AsyncTokenBucket build() {
         return new FinalRateAsyncTokenBucket(this.capacity != null ? this.capacity : this.rate, this.rate,
                 this.clock,
-                this.ratePeriodNanos, this.resolutionNanos, this.getTokensUpdatesTokens,
+                this.ratePeriodNanos, this.resolutionNanos, this.consistentTokensView,
                 this.initialTokens != null ? this.initialTokens : this.rate
         );
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/FinalRateAsyncTokenBucketBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/FinalRateAsyncTokenBucketBuilder.java
@@ -55,7 +55,7 @@ public class FinalRateAsyncTokenBucketBuilder
     public AsyncTokenBucket build() {
         return new FinalRateAsyncTokenBucket(this.capacity != null ? this.capacity : this.rate, this.rate,
                 this.clock,
-                this.ratePeriodNanos, this.resolutionNanos,
+                this.ratePeriodNanos, this.resolutionNanos, this.getTokensUpdatesTokens,
                 this.initialTokens != null ? this.initialTokens : this.rate
         );
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2506,6 +2506,12 @@ public class BrokerService implements Closeable {
 
 
     private void handleMetadataChanges(Notification n) {
+        if (!pulsar.isRunning()) {
+            // Ignore metadata changes when broker is not running
+            log.info("Ignoring metadata change since broker is not running (id={}, state={}) {}", pulsar.getBrokerId(),
+                    pulsar.getState(), n);
+            return;
+        }
         if (n.getType() == NotificationType.Modified && NamespaceResources.pathIsFromNamespace(n.getPath())) {
             NamespaceName ns = NamespaceResources.namespaceFromPath(n.getPath());
             handlePoliciesUpdates(ns);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PublishRateLimiterImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PublishRateLimiterImpl.java
@@ -20,11 +20,11 @@
 package org.apache.pulsar.broker.service;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.netty.channel.EventLoopGroup;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.qos.AsyncTokenBucket;
 import org.apache.pulsar.broker.qos.MonotonicSnapshotClock;
 import org.apache.pulsar.common.policies.data.Policies;
@@ -32,6 +32,7 @@ import org.apache.pulsar.common.policies.data.PublishRate;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.MpscUnboundedArrayQueue;
 
+@Slf4j
 public class PublishRateLimiterImpl implements PublishRateLimiter {
     private volatile AsyncTokenBucket tokenBucketOnMessage;
     private volatile AsyncTokenBucket tokenBucketOnByte;
@@ -80,7 +81,7 @@ public class PublishRateLimiterImpl implements PublishRateLimiter {
         // schedule unthrottling when the throttling count is incremented to 1
         // this is to avoid scheduling unthrottling multiple times for concurrent producers
         if (throttledProducersCount.incrementAndGet() == 1) {
-            EventLoopGroup executor = producer.getCnx().getBrokerService().executor();
+            ScheduledExecutorService executor = producer.getCnx().getBrokerService().executor().next();
             scheduleUnthrottling(executor, calculateThrottlingDurationNanos());
         }
     }
@@ -134,7 +135,11 @@ public class PublishRateLimiterImpl implements PublishRateLimiter {
             // unthrottle as many producers as possible while there are token available
             while ((throttlingDuration = calculateThrottlingDurationNanos()) == 0L
                     && (producer = unthrottlingQueue.poll()) != null) {
-                producer.decrementThrottleCount();
+                try {
+                    producer.decrementThrottleCount();
+                } catch (Exception e) {
+                    log.error("Failed to unthrottle producer {}", producer, e);
+                }
                 throttledProducersCount.decrementAndGet();
             }
             // if there are still producers to be unthrottled, schedule unthrottling again

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
@@ -224,6 +224,7 @@ public class DispatchRateLimiter {
             if (dispatchRate.isRelativeToPublishRate()) {
                 this.dispatchRateLimiterOnMessage =
                         AsyncTokenBucket.builderForDynamicRate()
+                                .getTokensUpdatesTokens(true)
                                 .clock(clock)
                                 .rateFunction(() -> getRelativeDispatchRateInMsg(dispatchRate))
                                 .ratePeriodNanosFunction(() -> ratePeriodNanos)
@@ -231,6 +232,7 @@ public class DispatchRateLimiter {
             } else {
                 this.dispatchRateLimiterOnMessage =
                         AsyncTokenBucket.builder()
+                                .getTokensUpdatesTokens(true)
                                 .clock(clock)
                                 .rate(msgRate).ratePeriodNanos(ratePeriodNanos)
                                 .build();
@@ -244,6 +246,7 @@ public class DispatchRateLimiter {
             if (dispatchRate.isRelativeToPublishRate()) {
                 this.dispatchRateLimiterOnByte =
                         AsyncTokenBucket.builderForDynamicRate()
+                                .getTokensUpdatesTokens(true)
                                 .clock(clock)
                                 .rateFunction(() -> getRelativeDispatchRateInByte(dispatchRate))
                                 .ratePeriodNanosFunction(() -> ratePeriodNanos)
@@ -251,6 +254,7 @@ public class DispatchRateLimiter {
             } else {
                 this.dispatchRateLimiterOnByte =
                         AsyncTokenBucket.builder()
+                                .getTokensUpdatesTokens(true)
                                 .clock(clock)
                                 .rate(byteRate).ratePeriodNanos(ratePeriodNanos)
                                 .build();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
@@ -77,7 +77,9 @@ public class DispatchRateLimiter {
      * @return
      */
     public long getAvailableDispatchRateLimitOnMsg() {
-        return dispatchRateLimiterOnMessage == null ? -1 : Math.max(dispatchRateLimiterOnMessage.getTokens(), 0);
+        AsyncTokenBucket localDispatchRateLimiterOnMessage = dispatchRateLimiterOnMessage;
+        return localDispatchRateLimiterOnMessage == null ? -1 :
+                Math.max(localDispatchRateLimiterOnMessage.getTokens(), 0);
     }
 
     /**
@@ -86,7 +88,8 @@ public class DispatchRateLimiter {
      * @return
      */
     public long getAvailableDispatchRateLimitOnByte() {
-        return dispatchRateLimiterOnByte == null ? -1 : Math.max(dispatchRateLimiterOnByte.getTokens(), 0);
+        AsyncTokenBucket localDispatchRateLimiterOnByte = dispatchRateLimiterOnByte;
+        return localDispatchRateLimiterOnByte == null ? -1 : Math.max(localDispatchRateLimiterOnByte.getTokens(), 0);
     }
 
     /**
@@ -96,11 +99,13 @@ public class DispatchRateLimiter {
      * @param byteSize
      */
     public void consumeDispatchQuota(long numberOfMessages, long byteSize) {
-        if (numberOfMessages > 0 && dispatchRateLimiterOnMessage != null) {
-            dispatchRateLimiterOnMessage.consumeTokens(numberOfMessages);
+        AsyncTokenBucket localDispatchRateLimiterOnMessage = dispatchRateLimiterOnMessage;
+        if (numberOfMessages > 0 && localDispatchRateLimiterOnMessage != null) {
+            localDispatchRateLimiterOnMessage.consumeTokens(numberOfMessages);
         }
-        if (byteSize > 0 && dispatchRateLimiterOnByte != null) {
-            dispatchRateLimiterOnByte.consumeTokens(byteSize);
+        AsyncTokenBucket localDispatchRateLimiterOnByte = dispatchRateLimiterOnByte;
+        if (byteSize > 0 && localDispatchRateLimiterOnByte != null) {
+            localDispatchRateLimiterOnByte.consumeTokens(byteSize);
         }
     }
 
@@ -282,7 +287,8 @@ public class DispatchRateLimiter {
      * @return
      */
     public long getDispatchRateOnMsg() {
-        return dispatchRateLimiterOnMessage != null ? dispatchRateLimiterOnMessage.getRate() : -1;
+        AsyncTokenBucket localDispatchRateLimiterOnMessage = dispatchRateLimiterOnMessage;
+        return localDispatchRateLimiterOnMessage != null ? localDispatchRateLimiterOnMessage.getRate() : -1;
     }
 
     /**
@@ -291,7 +297,8 @@ public class DispatchRateLimiter {
      * @return
      */
     public long getDispatchRateOnByte() {
-        return dispatchRateLimiterOnByte != null ? dispatchRateLimiterOnByte.getRate() : -1;
+        AsyncTokenBucket localDispatchRateLimiterOnByte = dispatchRateLimiterOnByte;
+        return localDispatchRateLimiterOnByte != null ? localDispatchRateLimiterOnByte.getRate() : -1;
     }
 
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
@@ -229,7 +229,6 @@ public class DispatchRateLimiter {
             if (dispatchRate.isRelativeToPublishRate()) {
                 this.dispatchRateLimiterOnMessage =
                         AsyncTokenBucket.builderForDynamicRate()
-                                .getTokensUpdatesTokens(true)
                                 .clock(clock)
                                 .rateFunction(() -> getRelativeDispatchRateInMsg(dispatchRate))
                                 .ratePeriodNanosFunction(() -> ratePeriodNanos)
@@ -237,7 +236,6 @@ public class DispatchRateLimiter {
             } else {
                 this.dispatchRateLimiterOnMessage =
                         AsyncTokenBucket.builder()
-                                .getTokensUpdatesTokens(true)
                                 .clock(clock)
                                 .rate(msgRate).ratePeriodNanos(ratePeriodNanos)
                                 .build();
@@ -251,7 +249,6 @@ public class DispatchRateLimiter {
             if (dispatchRate.isRelativeToPublishRate()) {
                 this.dispatchRateLimiterOnByte =
                         AsyncTokenBucket.builderForDynamicRate()
-                                .getTokensUpdatesTokens(true)
                                 .clock(clock)
                                 .rateFunction(() -> getRelativeDispatchRateInByte(dispatchRate))
                                 .ratePeriodNanosFunction(() -> ratePeriodNanos)
@@ -259,7 +256,6 @@ public class DispatchRateLimiter {
             } else {
                 this.dispatchRateLimiterOnByte =
                         AsyncTokenBucket.builder()
-                                .getTokensUpdatesTokens(true)
                                 .clock(clock)
                                 .rate(byteRate).ratePeriodNanos(ratePeriodNanos)
                                 .build();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SubscribeRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SubscribeRateLimiter.java
@@ -117,7 +117,9 @@ public class SubscribeRateLimiter {
         // update subscribe-rateLimiter
         if (ratePerConsumer > 0) {
             AsyncTokenBucket tokenBucket =
-                    AsyncTokenBucket.builder().rate(ratePerConsumer).ratePeriodNanos(ratePeriodNanos).build();
+                    AsyncTokenBucket.builder()
+                            .clock(brokerService.getPulsar().getMonotonicSnapshotClock())
+                            .rate(ratePerConsumer).ratePeriodNanos(ratePeriodNanos).build();
             this.subscribeRateLimiter.put(consumerIdentifier, tokenBucket);
         } else {
             // subscribe-rate should be disable and close

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SubscribeRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SubscribeRateLimiter.java
@@ -70,7 +70,7 @@ public class SubscribeRateLimiter {
         if (tokenBucket == null) {
             return true;
         }
-        if (!tokenBucket.containsTokens(true)) {
+        if (!tokenBucket.containsTokens()) {
             return false;
         }
         tokenBucket.consumeTokens(1);
@@ -118,6 +118,7 @@ public class SubscribeRateLimiter {
         if (ratePerConsumer > 0) {
             AsyncTokenBucket tokenBucket =
                     AsyncTokenBucket.builder()
+                            .getTokensUpdatesTokens(true)
                             .clock(brokerService.getPulsar().getMonotonicSnapshotClock())
                             .rate(ratePerConsumer).ratePeriodNanos(ratePeriodNanos).build();
             this.subscribeRateLimiter.put(consumerIdentifier, tokenBucket);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SubscribeRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SubscribeRateLimiter.java
@@ -70,7 +70,7 @@ public class SubscribeRateLimiter {
         if (tokenBucket == null) {
             return true;
         }
-        if (!tokenBucket.containsTokens(true)) {
+        if (!tokenBucket.containsTokens()) {
             return false;
         }
         tokenBucket.consumeTokens(1);
@@ -118,6 +118,7 @@ public class SubscribeRateLimiter {
         if (ratePerConsumer > 0) {
             AsyncTokenBucket tokenBucket =
                     AsyncTokenBucket.builder()
+                            .consistentTokensView(true)
                             .clock(brokerService.getPulsar().getMonotonicSnapshotClock())
                             .rate(ratePerConsumer).ratePeriodNanos(ratePeriodNanos).build();
             this.subscribeRateLimiter.put(consumerIdentifier, tokenBucket);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SubscribeRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SubscribeRateLimiter.java
@@ -118,7 +118,8 @@ public class SubscribeRateLimiter {
         if (ratePerConsumer > 0) {
             AsyncTokenBucket tokenBucket =
                     AsyncTokenBucket.builder()
-                            .consistentTokensView(true)
+                            .consistentAddedTokens(true)
+                            .consistentConsumedTokens(true)
                             .clock(brokerService.getPulsar().getMonotonicSnapshotClock())
                             .rate(ratePerConsumer).ratePeriodNanos(ratePeriodNanos).build();
             this.subscribeRateLimiter.put(consumerIdentifier, tokenBucket);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SubscribeRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SubscribeRateLimiter.java
@@ -70,7 +70,7 @@ public class SubscribeRateLimiter {
         if (tokenBucket == null) {
             return true;
         }
-        if (!tokenBucket.containsTokens()) {
+        if (!tokenBucket.containsTokens(true)) {
             return false;
         }
         tokenBucket.consumeTokens(1);
@@ -118,7 +118,6 @@ public class SubscribeRateLimiter {
         if (ratePerConsumer > 0) {
             AsyncTokenBucket tokenBucket =
                     AsyncTokenBucket.builder()
-                            .getTokensUpdatesTokens(true)
                             .clock(brokerService.getPulsar().getMonotonicSnapshotClock())
                             .rate(ratePerConsumer).ratePeriodNanos(ratePeriodNanos).build();
             this.subscribeRateLimiter.put(consumerIdentifier, tokenBucket);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -390,9 +390,11 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         brokerUrlTls = pulsar.getWebServiceAddressTls() != null ? new URL(pulsar.getWebServiceAddressTls()) : null;
 
         URI newLookupUrl = resolveLookupUrl();
-        if (pulsarClient != null && (lookupUrl == null || !newLookupUrl.equals(lookupUrl))) {
-            pulsarClient.shutdown();
+        if (lookupUrl == null || !newLookupUrl.equals(lookupUrl)) {
             lookupUrl = newLookupUrl;
+        }
+        if (pulsarClient != null) {
+            pulsarClient.shutdown();
             pulsarClient = newPulsarClient(lookupUrl.toString(), 0);
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -184,7 +184,9 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         if (isTcpLookup) {
             return URI.create(pulsar.getBrokerServiceUrl());
         } else {
-            return URI.create(brokerUrl.toString());
+            return URI.create(brokerUrl != null
+                    ? brokerUrl.toString()
+                    : brokerUrlTls.toString());
         }
     }
 
@@ -232,11 +234,10 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
 
     protected final void internalSetupForStatsTest() throws Exception {
         init();
-        String lookupUrl = brokerUrl.toString();
-        if (isTcpLookup) {
-            lookupUrl = new URI(pulsar.getBrokerServiceUrl()).toString();
+        if (pulsarClient != null) {
+            pulsarClient.shutdown();
         }
-        pulsarClient = newPulsarClient(lookupUrl, 1);
+        pulsarClient = newPulsarClient(resolveLookupUrl().toString(), 1);
     }
 
     protected void doInitConf() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -392,10 +392,10 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         URI newLookupUrl = resolveLookupUrl();
         if (lookupUrl == null || !newLookupUrl.equals(lookupUrl)) {
             lookupUrl = newLookupUrl;
-        }
-        if (pulsarClient != null) {
-            pulsarClient.shutdown();
-            pulsarClient = newPulsarClient(lookupUrl.toString(), 0);
+            if (pulsarClient != null) {
+                pulsarClient.shutdown();
+                pulsarClient = newPulsarClient(lookupUrl.toString(), 0);
+            }
         }
 
         closeAdmin();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -365,6 +365,9 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
     protected void restartBroker() throws Exception {
         stopBroker();
         startBroker();
+        if (pulsarClient == null) {
+            pulsarClient = newPulsarClient(lookupUrl.toString(), 0);
+        }
     }
 
     protected void stopBroker() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/AsyncTokenBucketTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/AsyncTokenBucketTest.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import org.assertj.core.data.Offset;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -216,7 +215,7 @@ public class AsyncTokenBucketTest {
     @Test
     void shouldHandleEventualConsistency() {
         AtomicLong offset = new AtomicLong(0);
-        long resolutionNanos = TimeUnit.MILLISECONDS.toNanos(100);
+        long resolutionNanos = TimeUnit.MILLISECONDS.toNanos(1);
         DefaultMonotonicSnapshotClock monotonicSnapshotClock =
                 new DefaultMonotonicSnapshotClock(resolutionNanos,
                         () -> offset.get() + manualClockSource.get());
@@ -232,8 +231,7 @@ public class AsyncTokenBucketTest {
         }
         assertThat(asyncTokenBucket.tokens(true))
                 // since the rate is 1/ms and the test increments the clock by 1ms and consumes 1 token in each
-                // iteration, the tokens should be greater than or equal to the initial tokens
-                .isGreaterThanOrEqualTo(initialTokens)
-                .isCloseTo(initialTokens, Offset.offset(1000L));
+                // iteration, the tokens should be equal to the initial tokens
+                .isEqualTo(initialTokens);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/AsyncTokenBucketTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/AsyncTokenBucketTest.java
@@ -205,7 +205,7 @@ public class AsyncTokenBucketTest {
         long resolutionNanos = TimeUnit.MILLISECONDS.toNanos(100);
         DefaultMonotonicSnapshotClock monotonicSnapshotClock =
                 new DefaultMonotonicSnapshotClock(resolutionNanos,
-                        () -> offset.get() + manualClockSource.get(), true);
+                        () -> offset.get() + manualClockSource.get());
         long initialTokens = 500L;
         asyncTokenBucket =
                 AsyncTokenBucket.builder().resolutionNanos(resolutionNanos)
@@ -213,8 +213,6 @@ public class AsyncTokenBucketTest {
         for (int i = 0; i < 100000; i++) {
             // increment the clock by 1ms, since rate is 1000 tokens/s, this should make 1 token available
             incrementMillis(1);
-            // request the clock to be updated
-            monotonicSnapshotClock.requestUpdate();
             // consume 1 token
             asyncTokenBucket.consumeTokens(1);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/AsyncTokenBucketTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/AsyncTokenBucketTest.java
@@ -21,10 +21,8 @@ package org.apache.pulsar.broker.qos;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import org.assertj.core.data.Offset;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -198,41 +196,5 @@ public class AsyncTokenBucketTest {
 
         // there should be 90 tokens available
         assertThat(asyncTokenBucket.tokens(true)).isEqualTo(90);
-    }
-
-    @Test
-    void shouldTolerateInstableClockSourceWhenUpdatingTokens() {
-        AtomicLong offset = new AtomicLong(0);
-        long resolutionNanos = TimeUnit.MILLISECONDS.toNanos(100);
-        DefaultMonotonicSnapshotClock monotonicSnapshotClock =
-                new DefaultMonotonicSnapshotClock(resolutionNanos,
-                        () -> offset.get() + manualClockSource.get());
-        long initialTokens = 500L;
-        asyncTokenBucket =
-                AsyncTokenBucket.builder().resolutionNanos(resolutionNanos)
-                        .capacity(100000).rate(1000).initialTokens(initialTokens).clock(monotonicSnapshotClock).build();
-        Random random = new Random(0);
-        int randomOffsetCount = 0;
-        for (int i = 0; i < 100000; i++) {
-            // increment the clock by 1ms, since rate is 1000 tokens/s, this should make 1 token available
-            incrementMillis(1);
-            if (i % 39 == 0) {
-                // randomly offset the clock source
-                // update the tokens consistently before and after offsetting the clock source
-                asyncTokenBucket.tokens(true);
-                offset.set((random.nextBoolean() ? -1L : 1L) * random.nextLong(0L, 100L) * resolutionNanos);
-                asyncTokenBucket.tokens(true);
-                randomOffsetCount++;
-            }
-            // consume 1 token
-            asyncTokenBucket.consumeTokens(1);
-        }
-        assertThat(asyncTokenBucket.tokens(true))
-                // since the rate is 1/ms and the test increments the clock by 1ms and consumes 1 token in each
-                // iteration, the tokens should be greater than or equal to the initial tokens
-                .isGreaterThanOrEqualTo(initialTokens)
-                // tolerate difference in added tokens since when clock leaps forward or backwards, the clock
-                // is assumed to have moved forward by the resolutionNanos
-                .isCloseTo(initialTokens, Offset.offset(3L * randomOffsetCount));
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/AsyncTokenBucketTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/AsyncTokenBucketTest.java
@@ -218,7 +218,7 @@ public class AsyncTokenBucketTest {
                 // randomly offset the clock source
                 // update the tokens consistently before and after offsetting the clock source
                 asyncTokenBucket.tokens(true);
-                offset.set((random.nextBoolean() ? -1L : 1L) * random.nextLong(3L, 100L) * resolutionNanos);
+                offset.set((random.nextBoolean() ? -1L : 1L) * random.nextLong(0L, 100L) * resolutionNanos);
                 asyncTokenBucket.tokens(true);
                 randomOffsetCount++;
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/AsyncTokenBucketTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/AsyncTokenBucketTest.java
@@ -21,8 +21,10 @@ package org.apache.pulsar.broker.qos;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import org.assertj.core.data.Offset;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -196,5 +198,41 @@ public class AsyncTokenBucketTest {
 
         // there should be 90 tokens available
         assertThat(asyncTokenBucket.tokens(true)).isEqualTo(90);
+    }
+
+    @Test
+    void shouldTolerateInstableClockSourceWhenUpdatingTokens() {
+        AtomicLong offset = new AtomicLong(0);
+        long resolutionNanos = TimeUnit.MILLISECONDS.toNanos(100);
+        DefaultMonotonicSnapshotClock monotonicSnapshotClock =
+                new DefaultMonotonicSnapshotClock(resolutionNanos,
+                        () -> offset.get() + manualClockSource.get());
+        long initialTokens = 500L;
+        asyncTokenBucket =
+                AsyncTokenBucket.builder().resolutionNanos(resolutionNanos)
+                        .capacity(100000).rate(1000).initialTokens(initialTokens).clock(monotonicSnapshotClock).build();
+        Random random = new Random(0);
+        int randomOffsetCount = 0;
+        for (int i = 0; i < 100000; i++) {
+            // increment the clock by 1ms, since rate is 1000 tokens/s, this should make 1 token available
+            incrementMillis(1);
+            if (i % 39 == 0) {
+                // randomly offset the clock source
+                // update the tokens consistently before and after offsetting the clock source
+                asyncTokenBucket.tokens(true);
+                offset.set((random.nextBoolean() ? -1L : 1L) * random.nextLong(0L, 100L) * resolutionNanos);
+                asyncTokenBucket.tokens(true);
+                randomOffsetCount++;
+            }
+            // consume 1 token
+            asyncTokenBucket.consumeTokens(1);
+        }
+        assertThat(asyncTokenBucket.tokens(true))
+                // since the rate is 1/ms and the test increments the clock by 1ms and consumes 1 token in each
+                // iteration, the tokens should be greater than or equal to the initial tokens
+                .isGreaterThanOrEqualTo(initialTokens)
+                // tolerate difference in added tokens since when clock leaps forward or backwards, the clock
+                // is assumed to have moved forward by the resolutionNanos
+                .isCloseTo(initialTokens, Offset.offset(3L * randomOffsetCount));
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/AsyncTokenBucketTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/AsyncTokenBucketTest.java
@@ -93,19 +93,33 @@ public class AsyncTokenBucketTest {
     @Test
     void shouldSupportFractionsAndRetainLeftoverWhenUpdatingTokens() {
         asyncTokenBucket =
-                AsyncTokenBucket.builder().capacity(100).rate(10).initialTokens(0).clock(clockSource).build();
+                AsyncTokenBucket.builder().capacity(100)
+                        .resolutionNanos(TimeUnit.MILLISECONDS.toNanos(1))
+                        .rate(10)
+                        .initialTokens(0)
+                        .clock(clockSource)
+                        .build();
         for (int i = 0; i < 150; i++) {
             incrementMillis(1);
         }
         assertEquals(asyncTokenBucket.getTokens(), 1);
         incrementMillis(150);
         assertEquals(asyncTokenBucket.getTokens(), 3);
+        incrementMillis(1);
+        assertEquals(asyncTokenBucket.getTokens(), 3);
+        incrementMillis(99);
+        assertEquals(asyncTokenBucket.getTokens(), 4);
     }
 
     @Test
     void shouldSupportFractionsAndRetainLeftoverWhenUpdatingTokens2() {
         asyncTokenBucket =
-                AsyncTokenBucket.builder().capacity(100).rate(1).initialTokens(0).clock(clockSource).build();
+                AsyncTokenBucket.builder().capacity(100)
+                        .resolutionNanos(TimeUnit.MILLISECONDS.toNanos(1))
+                        .rate(1)
+                        .initialTokens(0)
+                        .clock(clockSource)
+                        .build();
         for (int i = 0; i < 150; i++) {
             incrementMillis(1);
             assertEquals(asyncTokenBucket.tokens((i + 1) % 31 == 0), 0);
@@ -114,9 +128,9 @@ public class AsyncTokenBucketTest {
         assertEquals(asyncTokenBucket.tokens(true), 0);
         incrementMillis(699);
         assertEquals(asyncTokenBucket.tokens(true), 0);
-        incrementMillis(2);
+        incrementMillis(1);
         assertEquals(asyncTokenBucket.tokens(true), 1);
-        incrementMillis(999);
+        incrementMillis(1000);
         assertEquals(asyncTokenBucket.tokens(true), 2);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClockTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClockTest.java
@@ -38,30 +38,25 @@ public class DefaultMonotonicSnapshotClockTest {
     }
 
     @Test(dataProvider = "booleanValues")
-    void testClockHandlesTimeLeapsBackwardsOrForward(boolean requestSnapshot) throws InterruptedException {
+    void testClockHandlesTimeLeapsBackwards(boolean requestSnapshot) throws InterruptedException {
         long snapshotIntervalMillis = 5;
         AtomicLong clockValue = new AtomicLong(1);
         @Cleanup
         DefaultMonotonicSnapshotClock clock =
                 new DefaultMonotonicSnapshotClock(Duration.ofMillis(snapshotIntervalMillis).toNanos(),
-                        clockValue::get, true);
+                        clockValue::get);
 
 
         long previousTick = -1;
         boolean leapDirection = true;
         for (int i = 0; i < 10000; i++) {
             clockValue.addAndGet(TimeUnit.MILLISECONDS.toNanos(1));
-            if (i % snapshotIntervalMillis == 0) {
-                // let the clock update by a background thread
-                clock.requestUpdate();
-            }
             long tick = clock.getTickNanos(requestSnapshot);
             log.info("i = {}, tick = {}", i, tick);
             if ((i + 1) % 5 == 0) {
                 leapDirection = !leapDirection;
-                log.info("Time leap 5 minutes {}", leapDirection ? "forward" : "backwards");
-                // make the clock leap 5 minute forward or backwards
-                clockValue.addAndGet((leapDirection ? 1L : -1L) * Duration.ofMinutes(5).toNanos());
+                log.info("Time leap 5 minutes backwards");
+                clockValue.addAndGet(-Duration.ofMinutes(5).toNanos());
             }
             if (previousTick != -1) {
                 assertThat(tick)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClockTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClockTest.java
@@ -121,7 +121,7 @@ public class DefaultMonotonicSnapshotClockTest {
     }
 
     @Test
-    void testLeapDetectionIndepently() {
+    void testLeapDetectionIndependently() {
         AtomicLong clockValue = new AtomicLong(0);
         AtomicLong tickValue = new AtomicLong(0);
         long expectedTickValue = 0;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClockTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClockTest.java
@@ -52,10 +52,10 @@ public class DefaultMonotonicSnapshotClockTest {
         for (int i = 0; i < 10000; i++) {
             clockValue.addAndGet(TimeUnit.MILLISECONDS.toNanos(1));
             long tick = clock.getTickNanos(requestSnapshot);
-            log.info("i = {}, tick = {}", i, tick);
+            //log.info("i = {}, tick = {}", i, tick);
             if ((i + 1) % 5 == 0) {
                 leapDirection = !leapDirection;
-                log.info("Time leap 5 minutes backwards");
+                //log.info("Time leap 5 minutes backwards");
                 clockValue.addAndGet(-Duration.ofMinutes(5).toNanos());
             }
             if (previousTick != -1) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClockTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClockTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.broker.qos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.data.Offset;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class DefaultMonotonicSnapshotClockTest {
+    @DataProvider
+    private static Object[] booleanValues() {
+        return new Object[]{ true, false };
+    }
+
+    @Test(dataProvider = "booleanValues")
+    void testClockHandlesTimeLeapsBackwardsOrForward(boolean requestSnapshot) throws InterruptedException {
+        long snapshotIntervalMillis = 5;
+        AtomicLong offsetValue = new AtomicLong(0);
+        @Cleanup
+        DefaultMonotonicSnapshotClock clock =
+                new DefaultMonotonicSnapshotClock(Duration.ofMillis(snapshotIntervalMillis).toNanos(),
+                        () -> System.nanoTime() + offsetValue.get());
+
+        long previousTick = -1;
+        boolean leapDirection = true;
+        for (int i = 0; i < 100; i++) {
+            long tick = clock.getTickNanos(requestSnapshot);
+            log.info("i = {}, tick = {}", i, tick);
+            if ((i + 1) % 3 == 0) {
+                leapDirection = !leapDirection;
+                log.info("Time leap 5 minutes {}", leapDirection ? "forward" : "backwards");
+                // make the clock leap 5 minute forward or backwards
+                offsetValue.set((leapDirection ? 1L : -1L) * Duration.ofMinutes(5).toNanos());
+                Thread.sleep(2 * snapshotIntervalMillis);
+            } else {
+                Thread.sleep(snapshotIntervalMillis);
+            }
+            try {
+                var assertion = assertThat(tick)
+                        .describedAs("i = %d, tick = %d, previousTick = %d", i, tick, previousTick);
+                if (requestSnapshot) {
+                    assertion = assertion.isGreaterThan(previousTick);
+                } else {
+                    assertion = assertion.isGreaterThanOrEqualTo(previousTick);
+                }
+                assertion.isCloseTo(previousTick,
+                                Offset.offset(5 * TimeUnit.MILLISECONDS.toNanos(snapshotIntervalMillis)));
+            } catch (AssertionError e) {
+                if (i < 3) {
+                    // ignore the assertion errors in first 3 rounds since classloading of AssertJ makes the timings
+                    // flaky
+                } else {
+                    throw e;
+                }
+            }
+            previousTick = tick;
+        }
+    }
+
+    @Test
+    void testRequestUpdate() throws InterruptedException {
+        @Cleanup
+        DefaultMonotonicSnapshotClock clock =
+                new DefaultMonotonicSnapshotClock(Duration.ofSeconds(5).toNanos(), System::nanoTime);
+        long tick1 = clock.getTickNanos(false);
+        long tick2 = clock.getTickNanos(true);
+        assertThat(tick2).isGreaterThan(tick1);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/RGUsageMTAggrWaitForAllMsgsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/RGUsageMTAggrWaitForAllMsgsTest.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.qos.AsyncTokenBucket;
 import org.apache.pulsar.broker.resourcegroup.ResourceGroup.BytesAndMessagesCount;
 import org.apache.pulsar.broker.resourcegroup.ResourceGroup.ResourceGroupMonitoringClass;
 import org.apache.pulsar.broker.resourcegroup.ResourceGroupService.ResourceGroupUsageStatsType;
@@ -58,9 +59,10 @@ import org.testng.annotations.Test;
 @Slf4j
 @Test(groups = "flaky")
 public class RGUsageMTAggrWaitForAllMsgsTest extends ProducerConsumerBase {
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
+        AsyncTokenBucket.switchToConsistentTokensView();
         super.internalSetup();
         this.prepareForOps();
 
@@ -91,6 +93,7 @@ public class RGUsageMTAggrWaitForAllMsgsTest extends ProducerConsumerBase {
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
+        AsyncTokenBucket.resetToDefaultEventualConsistentTokensView();
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PublishRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PublishRateLimiterTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
@@ -73,7 +74,9 @@ public class PublishRateLimiterTest {
         when(transportCnx.getBrokerService()).thenReturn(brokerService);
         EventLoopGroup eventLoopGroup = mock(EventLoopGroup.class);
         when(brokerService.executor()).thenReturn(eventLoopGroup);
-        doReturn(null).when(eventLoopGroup).schedule(any(Runnable.class), anyLong(), any());
+        EventLoop eventLoop = mock(EventLoop.class);
+        when(eventLoopGroup.next()).thenReturn(eventLoop);
+        doReturn(null).when(eventLoop).schedule(any(Runnable.class), anyLong(), any());
         incrementSeconds(1);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AbstractMessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AbstractMessageDispatchThrottlingTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
+import org.apache.pulsar.broker.qos.AsyncTokenBucket;
+import org.apache.pulsar.broker.service.BrokerService;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+
+public abstract class AbstractMessageDispatchThrottlingTest extends ProducerConsumerBase {
+    public static <T> T[] merge(T[] first, T[] last) {
+        int totalLength = first.length + last.length;
+        T[] result = Arrays.copyOf(first, totalLength);
+        int offset = first.length;
+        System.arraycopy(last, 0, result, offset, first.length);
+        return result;
+    }
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        AsyncTokenBucket.switchToConsistentTokensView();
+        this.conf.setClusterName("test");
+        internalSetup();
+        producerBaseSetup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        internalCleanup();
+        AsyncTokenBucket.resetToDefaultEventualConsistentTokensView();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    protected void reset() throws Exception {
+        pulsar.getConfiguration().setForceDeleteTenantAllowed(true);
+        pulsar.getConfiguration().setForceDeleteNamespaceAllowed(true);
+
+        for (String tenant : admin.tenants().getTenants()) {
+            for (String namespace : admin.namespaces().getNamespaces(tenant)) {
+                admin.namespaces().deleteNamespace(namespace, true);
+            }
+            admin.tenants().deleteTenant(tenant, true);
+        }
+
+        for (String cluster : admin.clusters().getClusters()) {
+            admin.clusters().deleteCluster(cluster);
+        }
+
+        pulsar.getConfiguration().setForceDeleteTenantAllowed(false);
+        pulsar.getConfiguration().setForceDeleteNamespaceAllowed(false);
+
+        producerBaseSetup();
+    }
+
+    @DataProvider(name = "subscriptions")
+    public Object[][] subscriptionsProvider() {
+        return new Object[][]{new Object[]{SubscriptionType.Shared}, {SubscriptionType.Exclusive}};
+    }
+
+    @DataProvider(name = "dispatchRateType")
+    public Object[][] dispatchRateProvider() {
+        return new Object[][]{{DispatchRateType.messageRate}, {DispatchRateType.byteRate}};
+    }
+
+    @DataProvider(name = "subscriptionAndDispatchRateType")
+    public Object[][] subDisTypeProvider() {
+        List<Object[]> mergeList = new LinkedList<>();
+        for (Object[] sub : subscriptionsProvider()) {
+            for (Object[] dispatch : dispatchRateProvider()) {
+                mergeList.add(AbstractMessageDispatchThrottlingTest.merge(sub, dispatch));
+            }
+        }
+        return mergeList.toArray(new Object[0][0]);
+    }
+
+    protected void deactiveCursors(ManagedLedgerImpl ledger) throws Exception {
+        Field statsUpdaterField = BrokerService.class.getDeclaredField("statsUpdater");
+        statsUpdaterField.setAccessible(true);
+        ScheduledExecutorService statsUpdater = (ScheduledExecutorService) statsUpdaterField
+                .get(pulsar.getBrokerService());
+        statsUpdater.shutdownNow();
+        ledger.getCursors().forEach(cursor -> {
+            ledger.deactivateCursor(cursor);
+        });
+    }
+
+    enum DispatchRateType {
+        messageRate, byteRate;
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AbstractMessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AbstractMessageDispatchThrottlingTest.java
@@ -40,7 +40,7 @@ public abstract class AbstractMessageDispatchThrottlingTest extends ProducerCons
         return result;
     }
 
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         AsyncTokenBucket.switchToConsistentTokensView();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MessageDispatchThrottlingTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.spy;
@@ -43,6 +44,7 @@ import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.cache.PendingReadsManager;
 import org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImpl;
+import org.apache.pulsar.broker.qos.AsyncTokenBucket;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -52,7 +54,7 @@ import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.PublishRate;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.impl.DispatchRateImpl;
-import org.apache.pulsar.broker.qos.AsyncTokenBucket;
+import org.assertj.core.data.Offset;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -585,7 +587,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
         Thread.sleep(1000);
 
         // rate limiter should have limited messages with at least 10% accuracy (or 2 messages if messageRate is low)
-        Assert.assertEquals(totalReceived.get(), messageRate, Math.max(messageRate / 10, 2));
+        assertThat(totalReceived.get()).isCloseTo(messageRate, Offset.offset(Math.max(messageRate / 10, 2)));
 
         consumer1.close();
         consumer2.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MessageDispatchThrottlingTest.java
@@ -44,6 +44,7 @@ import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.cache.PendingReadsManager;
 import org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImpl;
+import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.qos.AsyncTokenBucket;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter;
@@ -152,7 +153,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
 
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingBlock";
 
         admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
@@ -222,7 +223,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     @SuppressWarnings("deprecation")
     @Test
     public void testSystemTopicDeliveryNonBlock() throws Exception {
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
         final String topicName = "persistent://" + namespace + "/" + UUID.randomUUID().toString().replaceAll("-", "");
         admin.topics().createNonPartitionedTopic(topicName);
@@ -266,7 +267,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
             DispatchRateType dispatchRateType) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingBlock";
 
         final int messageRate = 100;
@@ -334,7 +335,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     public void testClusterMsgByteRateLimitingClusterConfig() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingBlock";
         final int messageRate = 5;
         final long byteRate = 1024 * 1024;// 1MB rate enough to let all msg to be delivered
@@ -409,7 +410,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
             throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingAll";
 
         final int messageRate = 10;
@@ -477,7 +478,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
         conf.setDispatchThrottlingOnNonBacklogConsumerEnabled(true);
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingAll";
         final String subscriptionName = "my-subscriber-name";
 
@@ -530,7 +531,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     public void testRateLimitingMultipleConsumers() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingMultipleConsumers";
 
         final int messageRate = 5;
@@ -604,7 +605,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
 
         conf.setDispatchThrottlingOnBatchMessageEnabled(true);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingMultipleConsumers";
 
         final int messageRate = 5;
@@ -672,7 +673,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     public void testClusterRateLimitingConfiguration(SubscriptionType subscription) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingBlock";
         final int messageRate = 5;
 
@@ -735,7 +736,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     public void testMessageByteRateThrottlingCombined(SubscriptionType subscription) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingAll";
 
         final int messageRate = 5; // 5 msgs per second
@@ -805,7 +806,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     public void testGlobalNamespaceThrottling() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingBlock";
 
         final int messageRate = 5;
@@ -871,7 +872,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     public void testNonBacklogConsumerWithThrottlingEnabled(SubscriptionType subscription) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingBlock";
 
         final int messageRate = 10;
@@ -950,7 +951,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     public void testClusterPolicyOverrideConfiguration() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName1 = "persistent://" + namespace + "/throttlingOverride1";
         final String topicName2 = "persistent://" + namespace + "/throttlingOverride2";
         final int clusterMessageRate = 100;
@@ -1020,7 +1021,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     public void testClosingRateLimiter(SubscriptionType subscription) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/closingRateLimiter" + subscription.name();
         final String subName = "mySubscription" + subscription.name();
 
@@ -1068,7 +1069,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     @SuppressWarnings("deprecation")
     @Test
     public void testDispatchRateCompatibility2() throws Exception {
-        final String namespace = "my-property/dispatch-rate-compatibility";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/dispatch-rate-compatibility");
         final String topicName = "persistent://" + namespace + "/t1";
         final String cluster = "test";
         admin.namespaces().createNamespace(namespace, Sets.newHashSet(cluster));
@@ -1135,7 +1136,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     public void testRelativeMessageRateLimitingThrottling(SubscriptionType subscription) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/relative_throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/relative_throttling_ns");
         final String topicName = "persistent://" + namespace + "/relative-throttle" + subscription;
 
         final int messageRate = 1;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MessageDispatchThrottlingTest.java
@@ -63,7 +63,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-@Test(groups = "flaky")
+@Test(groups = "broker-api")
 public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(MessageDispatchThrottlingTest.class);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MessageDispatchThrottlingTest.java
@@ -462,7 +462,7 @@ public class MessageDispatchThrottlingTest extends AbstractMessageDispatchThrott
         admin.namespaces().setDispatchRate(namespace, dispatchRate);
         // create producer and topic
         @Cleanup
-        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
+        Producer<byte[]> producer = pulsarClient.newProducer().enableBatching(false).topic(topicName).create();
         PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
 
         Awaitility.await()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MessageDispatchThrottlingTest.java
@@ -451,6 +451,7 @@ public class MessageDispatchThrottlingTest extends AbstractMessageDispatchThrott
 
         final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingMultipleConsumers";
+        conf.setDispatchThrottlingOnNonBacklogConsumerEnabled(true);
 
         final int messageRate = 5;
         DispatchRate dispatchRate = DispatchRate.builder()
@@ -515,6 +516,7 @@ public class MessageDispatchThrottlingTest extends AbstractMessageDispatchThrott
         assertThat(totalReceived.get()).isCloseTo(messageRate, Offset.offset(Math.max(messageRate / 10, 2)));
 
         log.info("-- Exiting {} test --", methodName);
+        conf.setDispatchThrottlingOnNonBacklogConsumerEnabled(false);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
@@ -316,9 +316,6 @@ public class SubscriptionMessageDispatchThrottlingTest extends MessageDispatchTh
         producer.close();
 
         admin.brokers().updateDynamicConfiguration("dispatchThrottlingRateInByte", Long.toString(initBytes));
-
-        admin.topics().delete(topicName, true);
-        admin.namespaces().deleteNamespace(namespace);
     }
 
     /**
@@ -508,8 +505,6 @@ public class SubscriptionMessageDispatchThrottlingTest extends MessageDispatchTh
         consumer.close();
         producer.close();
         admin.brokers().updateDynamicConfiguration("dispatchThrottlingRateInByte", Long.toString(initBytes));
-        admin.topics().delete(topicName, true);
-        admin.namespaces().deleteNamespace(namespace);
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
@@ -41,7 +41,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker-api")
-public class SubscriptionMessageDispatchThrottlingTest extends MessageDispatchThrottlingTest {
+public class SubscriptionMessageDispatchThrottlingTest extends AbstractMessageDispatchThrottlingTest {
     private static final Logger log = LoggerFactory.getLogger(SubscriptionMessageDispatchThrottlingTest.class);
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SubscriptionMessageDispatchThrottlingTest.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@Test(groups = "flaky")
+@Test(groups = "broker-api")
 public class SubscriptionMessageDispatchThrottlingTest extends MessageDispatchThrottlingTest {
     private static final Logger log = LoggerFactory.getLogger(SubscriptionMessageDispatchThrottlingTest.class);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessagePublishThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessagePublishThrottlingTest.java
@@ -41,7 +41,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-@Test
+@Test(groups = "broker-api")
 public class MessagePublishThrottlingTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(MessagePublishThrottlingTest.class);
 


### PR DESCRIPTION
Fixes #23920

### Motivation

Prior to this PR, connections in Pulsar could experience excessive throttling and timeouts due to issues in rate limiting implementation. This was caused by both calculation errors in token bucket logic and problems with clock source handling in virtualized environments. The PR addresses these issues to prevent unintended long throttling periods and connection timeouts.

Two key issues are addressed in this PR:

1. Calculation Issue in AsyncTokenBucket:
   - The current token calculation logic is flawed when handling consumed tokens in conjunction with newly added tokens
   - When adding new tokens, the eventually consistent token calculation should happen before limiting the tokens to the bucket capacity limit. Since the new tokens were first added and capped to the capacity limit, this led to a situation where the tokens would become negative when the DefaultMonotonicSnapshotClock's thread was not executed with the expected interval for example due to high CPU usage.

2. Clock Source Consistency:
   - The current rate limiting implementation in Pulsar broker can be affected by clock source issues where `System.nanoTime()` isn't strictly monotonic and consistent across multiple CPUs
   - This is a known issue in virtualized environments and certain hardware configurations, particularly:
     - Multi-socket systems where each CPU may have its own TSC (Time Stamp Counter)
     - When CPUs are affected by power management features and running at different frequencies
     - The previous solution was impacted since `System.nanoTime()` was read on different threads.

For details about timekeeping challenges in virtualized environments, see [Linux kernel documentation on timekeeping](https://docs.kernel.org/virt/kvm/x86/timekeeping.html).

Without this fix, when time leaps backwards (for example due to `System.nanoTime` being read by a thread running on a different CPU with unsynchronized TSC), the rate limiter would incorrectly throttle connections for the duration of the time leap. In virtualized environments, the time difference between CPU cores can be significant. Even though such large variances are uncommon, they can cause extended connection timeouts when they occur. This PR significantly improves reliability by preventing such time-variance-induced throttling entirely.

While both forward and backward time leaps can occur in these environments, only backward leaps are explicitly handled. Forward leaps cannot be reliably detected within the eventually consistent logic used in AsyncTokenBucket, and their impact is bounded - at most one rate period (default 1 second) of potential overuse. This design choice favors implementation simplicity and performance while still protecting against the more problematic backward leap case that could cause extended throttling.

Although this PR also covers clock source consistency issues, the most probable root cause for the reported issue #23920 is, however, the calculation logic that was assuming that the DefaultMonotonicSnapshotClock's update thread would always be executing consistently.

### Modifications

1. **AsyncTokenBucket improvements**:
   - Fixed token calculation logic to properly handle consumed tokens:
     - Subtract pendingConsumedTokens from new tokens before capping at bucket capacity
     - This ensures correct token balance even when DefaultMonotonicSnapshotClock's update thread is delayed
   - Added comprehensive test coverage for negative balance and eventual consistency scenarios
   - Added test cases to verify proper token bucket behavior under various conditions

2. **DefaultMonotonicSnapshotClock enhancements**:
   - Implemented a single dedicated thread approach to minimize clock inconsistencies
     - Since System.nanoTime() values can vary slightly between CPUs in multi-core/multi-socket systems, using a single thread ensures time values are read consistently from one CPU
     - This effectively eliminates time variance issues by avoiding cross-CPU clock reads
   - Added handling of backward time leaps in clock source
   - Forward time leaps are intentionally not handled since they cannot be reliably detected in the eventually consistent token bucket logic
   - Forward leaps have minimal impact - at most 1 second of potential overuse with default rate period settings
   - Implemented a low-overhead synchronization mechanism for obtaining consistent clock values when required
   - The implementation is optimized for the common path while providing guarantees when needed

3. **Rate limiter implementations**:
   - Updated PublishRateLimiterImpl to use proper executor for unthrottling
   - Added error handling for producer unthrottling
   - Modified DispatchRateLimiter and SubscribeRateLimiter to use the monotonic clock instance

### Performance

[AsyncTokenBucketBenchmark](https://github.com/lhotari/pulsar/blob/lh-fix-rate-limiting-connection-timeouts/microbench/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucketBenchmark.java) and [DefaultMonotonicSnapshotClockBenchmark](https://github.com/lhotari/pulsar/blob/lh-fix-rate-limiting-connection-timeouts/microbench/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClockBenchmark.java) results with JMH demonstrate high throughput (test results with Apple M3 Max):

```
Benchmark                                                                      Mode  Cnt            Score             Error  Units
AsyncTokenBucketBenchmark.consumeTokensBenchmark001Threads                    thrpt    3    235889973.656 ±    20309920.612  ops/s
AsyncTokenBucketBenchmark.consumeTokensBenchmark010Threads                    thrpt    3   2092331094.972 ±     4154666.893  ops/s
AsyncTokenBucketBenchmark.consumeTokensBenchmark100Threads                    thrpt    3   2423947092.794 ±  1185164011.463  ops/s
DefaultMonotonicSnapshotClockBenchmark.getTickNanos001Threads                 thrpt    3   2031791421.024 ±   281179462.872  ops/s
DefaultMonotonicSnapshotClockBenchmark.getTickNanos010Threads                 thrpt    3  19192224651.486 ±  3492465614.920  ops/s
DefaultMonotonicSnapshotClockBenchmark.getTickNanos100Threads                 thrpt    3  22500950540.764 ± 15333188461.467  ops/s
DefaultMonotonicSnapshotClockBenchmark.getTickNanosRequestSnapshot001Threads  thrpt    3     71259586.362 ±     7340997.362  ops/s
DefaultMonotonicSnapshotClockBenchmark.getTickNanosRequestSnapshot010Threads  thrpt    3     22880953.901 ±     1521620.667  ops/s
DefaultMonotonicSnapshotClockBenchmark.getTickNanosRequestSnapshot100Threads  thrpt    3     16236151.209 ±     5642180.371  ops/s
```

Results with Dell XPS 15 7590 i9-9980HK on Linux:
```
Benchmark                                                                      Mode  Cnt            Score            Error  Units
AsyncTokenBucketBenchmark.consumeTokensBenchmark001Threads                    thrpt    3     54622720.701 ±    4953944.847  ops/s
AsyncTokenBucketBenchmark.consumeTokensBenchmark010Threads                    thrpt    3    361746065.391 ±  155306621.346  ops/s
AsyncTokenBucketBenchmark.consumeTokensBenchmark100Threads                    thrpt    3    410425438.712 ±  524401828.340  ops/s
DefaultMonotonicSnapshotClockBenchmark.getTickNanos001Threads                 thrpt    3   1776174139.570 ±  604272160.441  ops/s
DefaultMonotonicSnapshotClockBenchmark.getTickNanos010Threads                 thrpt    3  10480409935.377 ± 3681168439.649  ops/s
DefaultMonotonicSnapshotClockBenchmark.getTickNanos100Threads                 thrpt    3  10572683864.234 ±  783977752.777  ops/s
DefaultMonotonicSnapshotClockBenchmark.getTickNanosRequestSnapshot001Threads  thrpt    3     30378314.738 ±   11642686.027  ops/s
DefaultMonotonicSnapshotClockBenchmark.getTickNanosRequestSnapshot010Threads  thrpt    3    222770085.250 ±   42935412.356  ops/s
DefaultMonotonicSnapshotClockBenchmark.getTickNanosRequestSnapshot100Threads  thrpt    3    287689452.858 ±  153899991.642  ops/s
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->