### PR TITLE
[improve][io] Allow skipping connector deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,7 @@ flexible messaging model and an intuitive client API.</description>
     <docker.tag>latest</docker.tag>
     <skipSourceReleaseAssembly>false</skipSourceReleaseAssembly>
     <skipBuildDistribution>false</skipBuildDistribution>
+    <skipDeployConnector>false</skipDeployConnector>
     <shadePluginPhase>package</shadePluginPhase>
     <narPluginPhase>package</narPluginPhase>
 

--- a/pulsar-io/common/pom.xml
+++ b/pulsar-io/common/pom.xml
@@ -49,6 +49,13 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>${spotbugs-maven-plugin.version}</version>

--- a/pulsar-io/core/pom.xml
+++ b/pulsar-io/core/pom.xml
@@ -41,6 +41,13 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${spotbugs-maven-plugin.version}</version>

--- a/pulsar-io/pom.xml
+++ b/pulsar-io/pom.xml
@@ -150,6 +150,13 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>${skipDeployConnector}</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <executions>
           <execution>


### PR DESCRIPTION
### Motivation

By default, Pulsar uploads connector JAR and NAR files to Maven Central, but this is unnecessary since connectors are not typically downloaded from Maven Central. Additionally, the large size of the connector files causes timeouts or connection disconnections during the deployment process, as the files exceed Sonatype's size [limitations](https://central.sonatype.org/publish/publish-portal-upload/) for private publishing.

> Central Publisher Portal currently supports common archive extensions, e.g. zip, jar, tar.gz. While you can only upload one zip at a time per publishing request, the archive can contain more than one component. You can upload an archive up to 1GB in size. If your upload fails with an error or does not result in the creation of a deployment first check to see if the file is less than 1GB in size and that it extracts properly with a local archive extract tool. If the archive is valid and fits into the size limit but still won't upload please email [Central Support](mailto:central-support@sonatype.com) and provide as much supporting information as you can (e.g. screenshots, logs, steps to reproduce).

### Modifications

- Add the `skipDeployConnector` property to skip connector deployment.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->