### PR TITLE
[improve][ml] Do not switch thread to execute asyncAddEntry's core logic

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -802,11 +802,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         buffer.retain();
 
         // Jump to specific thread to avoid contention from writers writing from different threads
-        executor.execute(() -> {
-            OpAddEntry addOperation = OpAddEntry.createNoRetainBuffer(this, buffer, numberOfMessages, callback, ctx,
-                    currentLedgerTimeoutTriggered);
-            internalAsyncAddEntry(addOperation);
-        });
+        final var addOperation = OpAddEntry.createNoRetainBuffer(this, buffer, numberOfMessages, callback, ctx,
+                currentLedgerTimeoutTriggered);
+        internalAsyncAddEntry(addOperation);
     }
 
     protected synchronized void internalAsyncAddEntry(OpAddEntry addOperation) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ShadowManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ShadowManagedLedgerImpl.java
@@ -240,7 +240,6 @@ public class ShadowManagedLedgerImpl extends ManagedLedgerImpl {
             log.debug("[{}] Add entry into shadow ledger lh={} entries={}, pos=({},{})",
                     name, currentLedger.getId(), currentLedgerEntries, position.getLedgerId(), position.getEntryId());
         }
-        pendingAddEntries.add(addOperation);
         if (position.getLedgerId() <= currentLedger.getId()) {
             // Write into lastLedger
             if (position.getLedgerId() == currentLedger.getId()) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImplTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.intercept;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -29,9 +30,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import lombok.Cleanup;
@@ -499,4 +503,50 @@ public class ManagedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase 
         ledger.close();
     }
 
+    @Test
+    public void testBeforeAddEntry() throws Exception {
+        final var interceptor = new ManagedLedgerInterceptorImpl(getBrokerEntryMetadataInterceptors(), null);
+        final var config = new ManagedLedgerConfig();
+        final var numEntries = 10;
+        config.setMaxEntriesPerLedger(numEntries);
+        config.setManagedLedgerInterceptor(interceptor);
+        @Cleanup final var ml = (ManagedLedgerImpl) factory.open("test_concurrent_add_entry", config);
+
+        final var indexesBeforeAdd = Collections.synchronizedList(new ArrayList<Long>());
+        final var batchSizes = Collections.synchronizedList(new ArrayList<Long>());
+        final var random = new Random();
+        final var latch = new CountDownLatch(numEntries);
+        final var executor = Executors.newFixedThreadPool(2);
+        for (int i = 0; i < numEntries; i++) {
+            final var batchSize = random.nextInt(0, 100);
+            final var msg = "msg-" + i;
+            final var callback = new AsyncCallbacks.AddEntryCallback() {
+
+                @Override
+                public void addComplete(Position position, ByteBuf entryData, Object ctx) {
+                    latch.countDown();
+                }
+
+                @Override
+                public void addFailed(ManagedLedgerException exception, Object ctx) {
+                    log.error("Failed to add {}", msg, exception);
+                    latch.countDown();
+                }
+            };
+            executor.execute(() -> {
+                synchronized (ml) {
+                    batchSizes.add((long) batchSize);
+                    indexesBeforeAdd.add(interceptor.getIndex() + 1); // index is updated in each asyncAddEntry call
+                    ml.asyncAddEntry(Unpooled.wrappedBuffer(msg.getBytes()), batchSize, callback, null);
+                }
+            });
+        }
+        assertTrue(latch.await(3, TimeUnit.SECONDS));
+        for (int i = 1; i < numEntries; i++) {
+            final var sum = batchSizes.get(i) + batchSizes.get(i - 1);
+            batchSizes.set(i, sum);
+        }
+        assertEquals(indexesBeforeAdd.subList(1, numEntries), batchSizes.subList(0, numEntries - 1));
+        executor.shutdown();
+    }
 }


### PR DESCRIPTION
### Motivation

In protocol handler's implementation, sometimes it needs to record the current base offset before the actual `asyncAddEntry` call (or the wrapped `PersistentTopic#publishMessages` call), for example:

```java
    private final PersistentTopic persistentTopic;
    private final Set<Long> pendingBaseOffsets = ConcurrentHashMap.newKeySet();

    private synchronized void add(ByteBuf buffer, int batchSize) {
        final var ml = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
        final var interceptor = (ManagedLedgerInterceptorImpl) ml.getManagedLedgerInterceptor();
        final var baseOffset = interceptor.getIndex(); // the base offset of the next batch to write
        pendingBaseOffsets.add(baseOffset);
        ml.asyncAddEntry(buffer, batchSize, new AsyncCallbacks.AddEntryCallback() {

            @Override
            public void addComplete(Position position, ByteBuf entryData, Object ctx) {
                if (!pendingBaseOffsets.remove(baseOffset)) {
                    log.error("Failed to remove {}", baseOffset);
                }
```

However, the existing implementation won't work as expected that even if the downstream protocol handler guarantees that `asyncAddEntry` is called in a single thread. See https://github.com/apache/pulsar/blob/a19eaa2b972ab8fe1a2a45e65df1566cf28fb336/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L804-L809

First, the code above does not make sense because `internalAsyncAddEntry` itself is already synchronized.

Second, to guarantee thread safety for concurrent add operations, switching to another thread is not more efficient than synchronizing the method call. Mostly, it's less efficient because `execute` involves with at least two method calls (`offer` and `poll`) on a `BlockingQueue`, as well as some other operations (like CAS). Take `ArrayBlockingQueue` as example, both its `offer` and `poll` implementations need to acquire the internal lock.

Third, switching to another thread to execute the core logic is anti-intuitive, especially for modifying some fields that represent the current states. For example, to achieve the same goal at the beginning, I have to write the code like:

```java
        ml.getExecutor().execute(() -> {
            pendingBaseOffsets.add(baseOffset);
            ml.asyncAddEntry(buffer, batchSize, callback, ctx);
        });
```

### Modifications

Split `internalAsyncAddEntry` to two methods `beforeAddEntryToQueue` and `afterAddEntryToQueue` that are called before and after adding the operation to `pendingAddEntries`. Then simplify the code by throwing an exception and pass the exception to the callback. It's also more efficient because `OpAddEntry#failed` won't be called in the synchronized block.

Add `testBeforeAddEntry` to protect the change.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
