### PR TITLE
[improve][pip] PIP-406: Introduce metrics related to dispatch throttled events

### DIFF
--- a/pip/pip-406.md
+++ b/pip/pip-406.md
@@ -1,4 +1,4 @@
-# PIP-406: Introduce pulsar_subscription_dispatch_throttled_msgs and bytes metrics 
+# PIP-406: Introduce metrics related to dispatch_throttled_count
 
 # Background knowledge
 
@@ -10,84 +10,139 @@ this metric may not accurately reflect whether the backlog is due to insufficien
 
 ## Goals
 
-Introduce metrics to indicate the number of `messages/bytes throttled` for a subscription. This allows users to write PromQL queries to identify subscriptions with high backlogs but low or no throttling, pinpointing backlogs caused by insufficient consumer capacity.
+Introduce metrics to indicate the count of `messages/bytes throttled` for **broker/topic/subscription** level rate limit. 
+This allows users to write PromQL queries to identify subscriptions with high backlogs but low or no throttling, pinpointing backlogs caused by insufficient consumer capacity.
 
 ## In Scope
-- Introduce the metric `pulsar_subscription_dispatch_throttled_msgs` to represent the total number of messages throttled for a subscription.
-- Introduce the metric `pulsar_subscription_dispatch_throttled_bytes` to represent the total number of bytes throttled for a subscription.
-- Add `dispatchThrottledMsgs` and `dispatchThrottledBytes` fields to topic subscription stats.
+
+Broker Level:
+- Introduce the metric `pulsar_broker_dispatch_throttled_msg_count` to represent the total count of messages throttled for a broker.
+- Introduce the metric `pulsar_broker_dispatch_throttled_bytes_count` to represent the total count of bytes throttled for a broker.
+
+Topic Level:
+- Introduce the metric `pulsar_dispatch_throttled_msg_count` to represent the total count of messages throttled for a topic.
+- Introduce the metric `pulsar_dispatch_throttled_bytes_count` to represent the total count of bytes throttled for a topic.
+ 
+Subscription Level:
+- Introduce the metric `pulsar_subscription_dispatch_throttled_msg_count` to represent the total count of messages throttled for a subscription.
+- Introduce the metric `pulsar_subscription_dispatch_throttled_bytes_count` to represent the total count of bytes throttled for a subscription.
+ 
 
 ## Out of Scope
-- These states are not persistent and will reset upon subscription reconnection.
+- These states are not persistent and will reset upon broker restart/ topic re-load / subscription reconnected.
 
 # High Level Design
-1. Maintain `dispatchThrottledMsgs` and `dispatchThrottledBytes` in `AbstractBaseDispatcher`. Increase these values whenever the number of messages/bytes is reduced during `calculateToRead`.
-2. Output these fields when retrieving topic stats and metrics.
+1. Maintain `dispatchThrottleMsgCount` and `dispatchThrottleBytesCount` in `DispatchRateLimiter`. Increase these values in the `consumeDispatchQuota` method when the TokenBucket for messages or bytes is insufficient.
+2. Output these fields when retrieving metrics.
 
 
 # Detailed Design
 
 ## Design & Implementation Details
-1. Maintain `dispatchThrottledMsgs` and `dispatchThrottledBytes` in `AbstractBaseDispatcher`:
+1. Maintain `dispatchThrottleMsgCount` and `dispatchThrottleBytesCount` in `DispatchRateLimiter`:
 ```java
-    private final LongAdder dispatchThrottledMsgs = new LongAdder();
-    private final AtomicLong dispatchThrottledBytes = new AtomicLong();
+    private final LongAdder dispatchThrottleMsgCount = new LongAdder();
+    private final LongAdder dispatchThrottleBytesCount = new LongAdder();
 ```
 
-2. During each [calculateToRead](https://github.com/apache/pulsar/blob/411f6973e85b0a6213e992386e1704f93d0aae42/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java#L371-L377),
-if the number of `messages/bytes` is reduced, increase these fields accordingly.
-
-- dispatchThrottledBytes may overflow in extreme cases, so reset this value before overflow:
+2. During each [consumeDispatchQuota](https://github.com/apache/pulsar/blob/c4cff0ab3dac169c0a1418ef2f63f61604f6278e/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java#L97-L104),
+if token bucket is insufficient, increase these fields accordingly.
 ```diff
-     protected Pair<Integer, Long> updateMessagesToRead(DispatchRateLimiter dispatchRateLimiter,
-                                                        int messagesToRead, long bytesToRead) {
-         // update messagesToRead according to available dispatch rate limit.
--        return computeReadLimits(messagesToRead,
-+        Pair<Integer, Long> result = computeReadLimits(messagesToRead,
-                 (int) dispatchRateLimiter.getAvailableDispatchRateLimitOnMsg(),
-                 bytesToRead, dispatchRateLimiter.getAvailableDispatchRateLimitOnByte());
-+        if (result.getLeft() < messagesToRead) {
-+            dispatchThrottledMsgs.add(messagesToRead - result.getLeft());
-+        }
-+        if (result.getRight() < bytesToRead) {
-+            long increment = bytesToRead - result.getRight();
-+            dispatchThrottledBytes.updateAndGet(current -> {
-+                // Check if adding the increment would cause an overflow
-+                if (Long.MAX_VALUE - current < increment) {
-+                    return increment;
-+                }
-+                return current + increment;
-+            });
-+        }
-+        return result;
+     public void consumeDispatchQuota(long numberOfMessages, long byteSize) {
+         AsyncTokenBucket localDispatchRateLimiterOnMessage = dispatchRateLimiterOnMessage;
+         if (numberOfMessages > 0 && localDispatchRateLimiterOnMessage != null) {
+-            localDispatchRateLimiterOnMessage.consumeTokens(numberOfMessages);
++            if (!localDispatchRateLimiterOnMessage.consumeTokensAndCheckIfContainsTokens(numberOfMessages)) {
++                dispatchThrottleMsgCount.increment();
++            }
+         }
+         AsyncTokenBucket localDispatchRateLimiterOnByte = dispatchRateLimiterOnByte;
+         if (byteSize > 0 && localDispatchRateLimiterOnByte != null) {
+-            localDispatchRateLimiterOnByte.consumeTokens(byteSize);
++            if (!localDispatchRateLimiterOnByte.consumeTokensAndCheckIfContainsTokens(byteSize)) {
++                dispatchThrottleBytesCount.increment();
++            }
+         }
      }
 ```
+3. When get stats or metrics for broker/topic/subscription throttle count, output these fields.
 
 ## Public-facing Changes
 
 ### Metrics
 
-- Introduce the metric `pulsar_subscription_dispatch_throttled_msgs` to represent the total number of messages throttled for a subscription.
-- Introduce the metric `pulsar_subscription_dispatch_throttled_bytes` to represent the total number of bytes throttled for a subscription.
-
-1. pulsar_subscription_dispatch_throttled_msgs:
-  - Description: The total number of messages throttled for a subscription.
+1. `pulsar_broker_dispatch_throttled_msg_count`:
+  - Description: The total count of messages throttled for a broker
   - Attributes: 
+    - cluster
+  - Unit: throttled count
+   
+2. `pulsar_broker_dispatch_throttled_bytes_count`:
+  - Description: The total count of bytes throttled for a broker
+  - Attributes:
+    - cluster
+  - Unit: throttled count
+     
+3. `pulsar_dispatch_throttled_msg_count`:
+  - Description: The total count of messages throttled for a topic
+  - Attributes:
+    - tenant
+    - namespace
+    - topic
+  - Unit: messages count
+
+4. `pulsar_dispatch_throttled_bytes_count`:
+  - Description: The total count of messages throttled for a topic
+  - Attributes:
+    - tenant
+    - namespace
+    - topic
+  - Unit: messages count
+
+5. `pulsar_subscription_dispatch_throttled_msg_count`:
+  - Description: The total count of messages throttled for a subscription
+  - Attributes:
     - tenant
     - namespace
     - topic
     - subscription
   - Unit: messages count
-   
-2. pulsar_subscription_dispatch_throttled_bytes:
-    - Description: The total number of bytes throttled for a subscription.
-    - Attributes:
-        - tenant
-        - namespace
-        - topic
-        - subscription
-    - Unit: messages bytes
 
+6. `pulsar_subscription_dispatch_throttled_bytes_count`:
+  - Description: The total count of messages throttled for a subscription
+  - Attributes:
+    - tenant
+    - namespace
+    - topic
+    - subscription
+  - Unit: messages count
+
+### API
+1. Add get throttle count interface on admin api `TopicStats`.
+```java
+    /**
+     * Total count of throttling occurrences due to message rate limiting.
+     */
+    long getDispatchThrottledMsgCount();
+
+    /**
+     * Total count of throttling occurrences due to byte rate limiting.
+     */
+    long getDispatchThrottledBytesCount();
+```
+
+2. Add get throttle count interface on admin api `SubscriptionStats`.
+```java
+    /**
+     * Total count of throttling occurrences due to message rate limiting.
+     */
+    long getDispatchThrottledMsgCount();
+
+    /**
+     * Total count of throttling occurrences due to byte rate limiting.
+     */
+    long getDispatchThrottledBytesCount();
+```
 
 ### Configuration
 - None

--- a/pip/pip-406.md
+++ b/pip/pip-406.md
@@ -45,25 +45,26 @@ Subscription Level:
     private final LongAdder dispatchThrottleBytesCount = new LongAdder();
 ```
 
-2. During each [consumeDispatchQuota](https://github.com/apache/pulsar/blob/c4cff0ab3dac169c0a1418ef2f63f61604f6278e/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java#L97-L104),
-if token bucket is insufficient, increase these fields accordingly.
+2. Each time a read occurs, if the expected number of messages or bytes is reduced, increment the metric by one. 
 ```diff
-     public void consumeDispatchQuota(long numberOfMessages, long byteSize) {
-         AsyncTokenBucket localDispatchRateLimiterOnMessage = dispatchRateLimiterOnMessage;
-         if (numberOfMessages > 0 && localDispatchRateLimiterOnMessage != null) {
--            localDispatchRateLimiterOnMessage.consumeTokens(numberOfMessages);
-+            if (!localDispatchRateLimiterOnMessage.consumeTokensAndCheckIfContainsTokens(numberOfMessages)) {
-+                dispatchThrottleMsgCount.increment();
-+            }
+     private boolean applyDispatchRateLimitsToReadLimits(DispatchRateLimiter rateLimiter,
+                                                         MutablePair<Integer, Long> readLimits,
+                                                         DispatchRateLimiter.Type limiterType) {
++        int originalMessagesToRead = readLimits.getLeft();
++        long originalBytesToRead = readLimits.getRight();
+         // update messagesToRead according to available dispatch rate limit.
+         int availablePermitsOnMsg = (int) rateLimiter.getAvailableDispatchRateLimitOnMsg();
+         if (availablePermitsOnMsg >= 0) {
+@@ -414,6 +416,12 @@ private boolean applyDispatchRateLimitsToReadLimits(DispatchRateLimiter rateLimi
+         if (availablePermitsOnByte >= 0) {
+             readLimits.setRight(Math.min(readLimits.getRight(), availablePermitsOnByte));
          }
-         AsyncTokenBucket localDispatchRateLimiterOnByte = dispatchRateLimiterOnByte;
-         if (byteSize > 0 && localDispatchRateLimiterOnByte != null) {
--            localDispatchRateLimiterOnByte.consumeTokens(byteSize);
-+            if (!localDispatchRateLimiterOnByte.consumeTokensAndCheckIfContainsTokens(byteSize)) {
-+                dispatchThrottleBytesCount.increment();
-+            }
-         }
-     }
++        if (readLimits.getLeft() < originalMessagesToRead) {
++            rateLimiter.increaseDispatchThrottleMsgCount();
++        }
++        if (readLimits.getRight() < originalBytesToRead) {
++            rateLimiter.increaseDispatchThrottleBytesCount();
++        }
 ```
 3. When get stats or metrics for broker/topic/subscription throttle count, output these fields.
 

--- a/pip/pip-406.md
+++ b/pip/pip-406.md
@@ -1,0 +1,75 @@
+# PIP-406: Introduce pulsar_subscription_dispatch_throttled_msgs and bytes metrics 
+
+# Background knowledge
+
+## Motivation
+
+Currently, users can monitor subscription backlogs using the `pulsar_subscription_back_log_no_delayed` metric. 
+However, if [dispatch throttling](https://pulsar.apache.org/docs/next/concepts-throttling/) is configured at the broker/topic/subscription level,
+this metric may not accurately reflect whether the backlog is due to insufficient consumer capacity, as it could be caused by dispatch throttling.
+
+## Goals
+
+Introduce metrics to indicate the number of `messages/bytes throttled` for a subscription. This allows users to write PromQL queries to identify subscriptions with high backlogs but low or no throttling, pinpointing backlogs caused by insufficient consumer capacity.
+
+## In Scope
+- Introduce the metric `pulsar_subscription_dispatch_throttled_msgs` to represent the total number of messages throttled for a subscription.
+- Introduce the metric `pulsar_subscription_dispatch_throttled_bytes` to represent the total number of bytes throttled for a subscription.
+- Add `dispatchThrottledMsgs` and `dispatchThrottledBytes` fields to topic subscription stats.
+
+## Out of Scope
+- These states are not persistent and will reset upon subscription reconnection.
+
+# High Level Design
+1. Maintain `dispatchThrottledMsgs` and `dispatchThrottledBytes` in `AbstractBaseDispatcher`. Increase these values whenever the number of messages/bytes is reduced during `calculateToRead`.
+2. Output these fields when retrieving topic stats and metrics.
+
+
+# Detailed Design
+
+## Design & Implementation Details
+1. Maintain `dispatchThrottledMsgs` and `dispatchThrottledBytes` in `AbstractBaseDispatcher`:
+```java
+    private final LongAdder dispatchThrottledMsgs = new LongAdder();
+    private final AtomicLong dispatchThrottledBytes = new AtomicLong();
+```
+
+2. During each [calculateToRead](https://github.com/apache/pulsar/blob/411f6973e85b0a6213e992386e1704f93d0aae42/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java#L371-L377),
+if the number of `messages/bytes` is reduced, increase these fields accordingly.
+
+- dispatchThrottledBytes may overflow in extreme cases, so reset this value before overflow:
+```diff
+     protected Pair<Integer, Long> updateMessagesToRead(DispatchRateLimiter dispatchRateLimiter,
+                                                        int messagesToRead, long bytesToRead) {
+         // update messagesToRead according to available dispatch rate limit.
+-        return computeReadLimits(messagesToRead,
++        Pair<Integer, Long> result = computeReadLimits(messagesToRead,
+                 (int) dispatchRateLimiter.getAvailableDispatchRateLimitOnMsg(),
+                 bytesToRead, dispatchRateLimiter.getAvailableDispatchRateLimitOnByte());
++        if (result.getLeft() < messagesToRead) {
++            dispatchThrottledMsgs.add(messagesToRead - result.getLeft());
++        }
++        if (result.getRight() < bytesToRead) {
++            long increment = bytesToRead - result.getRight();
++            dispatchThrottledBytes.updateAndGet(current -> {
++                // Check if adding the increment would cause an overflow
++                if (Long.MAX_VALUE - current < increment) {
++                    return increment;
++                }
++                return current + increment;
++            });
++        }
++        return result;
+     }
+```
+
+## Public-facing Changes
+- None
+
+
+### Configuration
+- None
+
+# Backward & Forward Compatibility
+- Full Compatibility
+

--- a/pip/pip-406.md
+++ b/pip/pip-406.md
@@ -1,4 +1,4 @@
-# PIP-406: Introduce metrics related to dispatch throttled number of times
+# PIP-406: Introduce metrics related to dispatch throttled events
 
 # Background knowledge
 
@@ -15,34 +15,31 @@ This allows users to write PromQL queries to identify subscriptions with high ba
 
 ## In Scope
 
-Broker Level:
-- Introduce the metric `pulsar_broker_dispatch_throttled_msg_count` to represent the total number of times message dispatching was throttled on a broker due to broker rate limits.
-- Introduce the metric `pulsar_broker_dispatch_throttled_bytes_count` to represent the total number of times byte dispatching was throttled on a broker due to broker rate limits.
+- Introduce the metric `pulsar_subscription_dispatch_throttled_msg_events` to represent the total number of times message dispatching was throttled on a subscription 
+- Introduce the metric `pulsar_subscription_dispatch_throttled_bytes_events` to represent the total number of times byte dispatching was throttled on a subscription
 
-Topic Level:
-- Introduce the metric `pulsar_dispatch_throttled_msg_count` to represent the total number of times message dispatching was throttled on a topic due to topic rate limits.
-- Introduce the metric `pulsar_dispatch_throttled_bytes_count` to represent the total number of times byte dispatching was throttled on a topic due to topic rate limits.
- 
-Subscription Level:
-- Introduce the metric `pulsar_subscription_dispatch_throttled_msg_count` to represent the total number of times message dispatching was throttled on a subscription due to subscription rate limits.
-- Introduce the metric `pulsar_subscription_dispatch_throttled_bytes_count` to represent the total number of times byte dispatching was throttled on a subscription due to subscription rate limits.
- 
+Since throttling on a subscription can be caused by multiple rate limit(broker/topic/subscription), 
+these metrics will include a label `reason: broker/topic/subscription` to indicate which throttler is responsible.
 
 ## Out of Scope
 - These states are not persistent and will reset upon broker restart/ topic re-load / subscription reconnected.
 
 # High Level Design
-1. Maintain `dispatchThrottleMsgCount` and `dispatchThrottleBytesCount` in `DispatchRateLimiter`. Increase these values in the `consumeDispatchQuota` method when the TokenBucket for messages or bytes is insufficient.
+1. Maintain metrics counters for throttling caused by `broker/topic/subscription` rate limit. Increment the appropriate counter whenever throttling occurs.
 2. Output these fields when retrieving metrics.
 
 
 # Detailed Design
 
 ## Design & Implementation Details
-1. Maintain `dispatchThrottleMsgCount` and `dispatchThrottleBytesCount` in `DispatchRateLimiter`:
+1. Maintain these fields in AbstractBaseDispatcher.
 ```java
-    private final LongAdder dispatchThrottleMsgCount = new LongAdder();
-    private final LongAdder dispatchThrottleBytesCount = new LongAdder();
+    public final LongAdder dispatchThrottledMsgEventsBySubscriptionLimit = new LongAdder();
+    public final LongAdder dispatchThrottledMsgEventsByTopicLimit = new LongAdder();
+    public final LongAdder dispatchThrottledMsgEventsByBrokerLimit = new LongAdder();
+    public final LongAdder dispatchThrottledBytesEventsBySubscriptionLimit = new LongAdder();
+    public final LongAdder dispatchThrottledBytesEventsByTopicLimit = new LongAdder();
+    public final LongAdder dispatchThrottledBytesEventsByBrokerLimit = new LongAdder();
 ```
 
 2. Each time a read occurs, if the expected number of messages or bytes is reduced, increment the metric by one. 
@@ -50,99 +47,125 @@ Subscription Level:
      private boolean applyDispatchRateLimitsToReadLimits(DispatchRateLimiter rateLimiter,
                                                          MutablePair<Integer, Long> readLimits,
                                                          DispatchRateLimiter.Type limiterType) {
-+        int originalMessagesToRead = readLimits.getLeft();
-+        long originalBytesToRead = readLimits.getRight();
-         // update messagesToRead according to available dispatch rate limit.
-         int availablePermitsOnMsg = (int) rateLimiter.getAvailableDispatchRateLimitOnMsg();
-         if (availablePermitsOnMsg >= 0) {
-@@ -414,6 +416,12 @@ private boolean applyDispatchRateLimitsToReadLimits(DispatchRateLimiter rateLimi
-         if (availablePermitsOnByte >= 0) {
-             readLimits.setRight(Math.min(readLimits.getRight(), availablePermitsOnByte));
-         }
-+        if (readLimits.getLeft() < originalMessagesToRead) {
-+            rateLimiter.increaseDispatchThrottleMsgCount();
-+        }
-+        if (readLimits.getRight() < originalBytesToRead) {
-+            rateLimiter.increaseDispatchThrottleBytesCount();
-+        }
++       int originalMessagesToRead = readLimits.getLeft();
++       long originalBytesToRead = readLimits.getRight();
+        int availablePermitsOnMsg = (int) rateLimiter.getAvailableDispatchRateLimitOnMsg();
+        if (availablePermitsOnMsg >= 0) {
+            readLimits.setLeft(Math.min(readLimits.getLeft(), availablePermitsOnMsg));
+        }
+        long availablePermitsOnByte = rateLimiter.getAvailableDispatchRateLimitOnByte();
+        if (availablePermitsOnByte >= 0) {
+            readLimits.setRight(Math.min(readLimits.getRight(), availablePermitsOnByte));
+        }
++       if (readLimits.getLeft() < originalMessagesToRead) {
++           switch (limiterType) {
++               case BROKER -> dispatchThrottledMsgEventsByBrokerLimit.increment();
++               case TOPIC -> dispatchThrottledMsgEventsByTopicLimit.increment();
++               case SUBSCRIPTION -> dispatchThrottledMsgEventsBySubscriptionLimit.increment();
++               default -> {}
++           }
++       }
++       if (readLimits.getRight() < originalBytesToRead) {
++           switch (limiterType) {
++               case BROKER -> dispatchThrottledBytesEventsByBrokerLimit.increment();
++               case TOPIC -> dispatchThrottledBytesEventsByTopicLimit.increment();
++               case SUBSCRIPTION -> dispatchThrottledBytesEventsBySubscriptionLimit.increment();
++               default -> {}
++           }
++       }
 ```
-3. When get stats or metrics for broker/topic/subscription throttle count, output these fields.
+3. Print these metrics when retrieving metrics(TopicStats#printTopicStats). 
+```java
+// write dispatch throttling metrics with `reason` labels to identify specific throttling
+// causes: by subscription limit, by topic limit, or by broker limit.
+writeTopicMetric(stream, "pulsar_subscription_dispatch_throttled_msg_events",
+                 subsStats.dispatchThrottledMsgEventsBySubscriptionLimit, cluster, namespace, topic,
+                 splitTopicAndPartitionIndexLabel, "subscription", sub,
+                    "reason", "subscription");
+writeTopicMetric(stream, "pulsar_subscription_dispatch_throttled_bytes_events",
+                 subsStats.dispatchThrottledBytesEventsBySubscriptionLimit, cluster, namespace, topic,
+                 splitTopicAndPartitionIndexLabel, "subscription", sub,
+                    "reason", "subscription");
+writeTopicMetric(stream, "pulsar_subscription_dispatch_throttled_msg_events",
+                 subsStats.dispatchThrottledMsgEventsByTopicLimit, cluster, namespace, topic,
+                 splitTopicAndPartitionIndexLabel, "subscription", sub,
+                    "reason", "topic");
+writeTopicMetric(stream, "pulsar_subscription_dispatch_throttled_bytes_events",
+                 subsStats.dispatchThrottledBytesEventsByTopicLimit, cluster, namespace, topic,
+                 splitTopicAndPartitionIndexLabel, "subscription", sub,
+                    "reason", "topic");
+writeTopicMetric(stream, "pulsar_subscription_dispatch_throttled_msg_events",
+                 subsStats.dispatchThrottledMsgEventsByBrokerLimit, cluster, namespace, topic,
+                 splitTopicAndPartitionIndexLabel, "subscription", sub,
+                    "reason", "broker");
+writeTopicMetric(stream, "pulsar_subscription_dispatch_throttled_bytes_events",
+                 subsStats.dispatchThrottledBytesEventsByBrokerLimit, cluster, namespace, topic,
+                 splitTopicAndPartitionIndexLabel, "subscription", sub,
+                    "reason", "broker");}
+```
 
 ## Public-facing Changes
 
 ### Metrics
 
-1. `pulsar_broker_dispatch_throttled_msg_count`:
-  - Description: The total number of times message dispatching was throttled on a broker due to broker rate limits
-  - Attributes: 
-    - cluster
-  - Unit: throttled count
-   
-2. `pulsar_broker_dispatch_throttled_bytes_count`:
-  - Description: The total number of times byte dispatching was throttled on a broker due to broker rate limits
-  - Attributes:
-    - cluster
-  - Unit: throttled count
-     
-3. `pulsar_dispatch_throttled_msg_count`:
-  - Description: The total number of times message dispatching was throttled on a topic due to topic rate limits
-  - Attributes:
-    - tenant
-    - namespace
-    - topic
-  - Unit: messages count
-
-4. `pulsar_dispatch_throttled_bytes_count`:
-  - Description: The total number of times byte dispatching was throttled on a topic due to topic rate limits
-  - Attributes:
-    - tenant
-    - namespace
-    - topic
-  - Unit: messages count
-
-5. `pulsar_subscription_dispatch_throttled_msg_count`:
-  - Description: The total number of times message dispatching was throttled on a subscription due to subscription rate limits
+1. `pulsar_subscription_dispatch_throttled_msg_events`:
+  - Description: The total number of times message dispatching was throttled on a subscription 
   - Attributes:
     - tenant
     - namespace
     - topic
     - subscription
+    - `reason`: broker/topic/subscription
   - Unit: messages count
 
-6. `pulsar_subscription_dispatch_throttled_bytes_count`:
-  - Description: The total number of times byte dispatching was throttled on a subscription due to subscription rate limits
+2. `pulsar_subscription_dispatch_throttled_bytes_events`:
+  - Description: The total number of times byte dispatching was throttled on a subscription 
   - Attributes:
     - tenant
     - namespace
     - topic
     - subscription
+    - `reason`: broker/topic/subscription
   - Unit: messages count
 
 ### API
-1. Add get throttle count interface on admin api `TopicStats`.
+Add get throttle count interface on admin api `SubscriptionStats`.
 ```java
     /**
-     * Total count of throttling occurrences due to message rate limiting.
-     */
-    long getDispatchThrottledMsgCount();
+ * Gets the total number of times message dispatching was throttled on a subscription due to broker rate limits.
+ * @return the count of throttled message events by subscription limit, default is 0.
+ */
+long getDispatchThrottledMsgEventsBySubscriptionLimit();
 
-    /**
-     * Total count of throttling occurrences due to byte rate limiting.
-     */
-    long getDispatchThrottledBytesCount();
-```
+/**
+ * Gets the total number of times bytes dispatching was throttled on a subscription due to broker rate limits.
+ * @return the count of throttled bytes by subscription limit, default is 0.
+ */
+long getDispatchThrottledBytesEventsBySubscriptionLimit();
 
-2. Add get throttle count interface on admin api `SubscriptionStats`.
-```java
-    /**
-     * Total count of throttling occurrences due to message rate limiting.
-     */
-    long getDispatchThrottledMsgCount();
+/**
+ * Gets the total number of times message dispatching was throttled on a subscription due to topic rate limits.
+ * @return the count of throttled message events by topic limit, default is 0.
+ */
+long getDispatchThrottledMsgEventsByTopicLimit();
 
-    /**
-     * Total count of throttling occurrences due to byte rate limiting.
-     */
-    long getDispatchThrottledBytesCount();
+/**
+ * Gets the total number of times bytes dispatching was throttled on a subscription due to topic rate limits.
+ * @return the count of throttled bytes events by topic limit, default is 0.
+ */
+long getDispatchThrottledBytesEventsByTopicLimit();
+
+/**
+ * Gets the total number of times message dispatching was throttled on a subscription due to broker rate limits.
+ * @return the count of throttled message events by broker limit, default is 0.
+ */
+long getDispatchThrottledMsgEventsByBrokerLimit();
+
+/**
+ * Gets the total number of times bytes dispatching was throttled on a subscription due to broker rate limits.
+ * @return the count of throttled bytes events by broker limit, default is 0.
+ */
+long getDispatchThrottledBytesEventsByBrokerLimit();
 ```
 
 ### Configuration

--- a/pip/pip-406.md
+++ b/pip/pip-406.md
@@ -1,4 +1,4 @@
-# PIP-406: Introduce metrics related to dispatch_throttled_count
+# PIP-406: Introduce metrics related to dispatch throttled number of times
 
 # Background knowledge
 
@@ -16,16 +16,16 @@ This allows users to write PromQL queries to identify subscriptions with high ba
 ## In Scope
 
 Broker Level:
-- Introduce the metric `pulsar_broker_dispatch_throttled_msg_count` to represent the total count of messages throttled for a broker.
-- Introduce the metric `pulsar_broker_dispatch_throttled_bytes_count` to represent the total count of bytes throttled for a broker.
+- Introduce the metric `pulsar_broker_dispatch_throttled_msg_count` to represent the total number of times message dispatching was throttled on a broker due to broker rate limits.
+- Introduce the metric `pulsar_broker_dispatch_throttled_bytes_count` to represent the total number of times byte dispatching was throttled on a broker due to broker rate limits.
 
 Topic Level:
-- Introduce the metric `pulsar_dispatch_throttled_msg_count` to represent the total count of messages throttled for a topic.
-- Introduce the metric `pulsar_dispatch_throttled_bytes_count` to represent the total count of bytes throttled for a topic.
+- Introduce the metric `pulsar_dispatch_throttled_msg_count` to represent the total number of times message dispatching was throttled on a topic due to topic rate limits.
+- Introduce the metric `pulsar_dispatch_throttled_bytes_count` to represent the total number of times byte dispatching was throttled on a topic due to topic rate limits.
  
 Subscription Level:
-- Introduce the metric `pulsar_subscription_dispatch_throttled_msg_count` to represent the total count of messages throttled for a subscription.
-- Introduce the metric `pulsar_subscription_dispatch_throttled_bytes_count` to represent the total count of bytes throttled for a subscription.
+- Introduce the metric `pulsar_subscription_dispatch_throttled_msg_count` to represent the total number of times message dispatching was throttled on a subscription due to subscription rate limits.
+- Introduce the metric `pulsar_subscription_dispatch_throttled_bytes_count` to represent the total number of times byte dispatching was throttled on a subscription due to subscription rate limits.
  
 
 ## Out of Scope
@@ -73,19 +73,19 @@ Subscription Level:
 ### Metrics
 
 1. `pulsar_broker_dispatch_throttled_msg_count`:
-  - Description: The total count of messages throttled for a broker
+  - Description: The total number of times message dispatching was throttled on a broker due to broker rate limits
   - Attributes: 
     - cluster
   - Unit: throttled count
    
 2. `pulsar_broker_dispatch_throttled_bytes_count`:
-  - Description: The total count of bytes throttled for a broker
+  - Description: The total number of times byte dispatching was throttled on a broker due to broker rate limits
   - Attributes:
     - cluster
   - Unit: throttled count
      
 3. `pulsar_dispatch_throttled_msg_count`:
-  - Description: The total count of messages throttled for a topic
+  - Description: The total number of times message dispatching was throttled on a topic due to topic rate limits
   - Attributes:
     - tenant
     - namespace
@@ -93,7 +93,7 @@ Subscription Level:
   - Unit: messages count
 
 4. `pulsar_dispatch_throttled_bytes_count`:
-  - Description: The total count of messages throttled for a topic
+  - Description: The total number of times byte dispatching was throttled on a topic due to topic rate limits
   - Attributes:
     - tenant
     - namespace
@@ -101,7 +101,7 @@ Subscription Level:
   - Unit: messages count
 
 5. `pulsar_subscription_dispatch_throttled_msg_count`:
-  - Description: The total count of messages throttled for a subscription
+  - Description: The total number of times message dispatching was throttled on a subscription due to subscription rate limits
   - Attributes:
     - tenant
     - namespace
@@ -110,7 +110,7 @@ Subscription Level:
   - Unit: messages count
 
 6. `pulsar_subscription_dispatch_throttled_bytes_count`:
-  - Description: The total count of messages throttled for a subscription
+  - Description: The total number of times byte dispatching was throttled on a subscription due to subscription rate limits
   - Attributes:
     - tenant
     - namespace

--- a/pip/pip-406.md
+++ b/pip/pip-406.md
@@ -64,7 +64,29 @@ if the number of `messages/bytes` is reduced, increase these fields accordingly.
 ```
 
 ## Public-facing Changes
-- None
+
+### Metrics
+
+- Introduce the metric `pulsar_subscription_dispatch_throttled_msgs` to represent the total number of messages throttled for a subscription.
+- Introduce the metric `pulsar_subscription_dispatch_throttled_bytes` to represent the total number of bytes throttled for a subscription.
+
+1. pulsar_subscription_dispatch_throttled_msgs:
+  - Description: The total number of messages throttled for a subscription.
+  - Attributes: 
+    - tenant
+    - namespace
+    - topic
+    - subscription
+  - Unit: messages count
+   
+2. pulsar_subscription_dispatch_throttled_bytes:
+    - Description: The total number of bytes throttled for a subscription.
+    - Attributes:
+        - tenant
+        - namespace
+        - topic
+        - subscription
+    - Unit: messages bytes
 
 
 ### Configuration


### PR DESCRIPTION
### Motivation
- Discuss email: https://lists.apache.org/thread/w9pq1jp3f22prsr97mxzj1yhdoo1cnc4
- Vote thread: https://lists.apache.org/thread/pmgkf67ph98k5l3lr60rtg96octb397q
- Implatement PR: https://github.com/apache/pulsar/pull/23946


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
