### PR TITLE
[feat][client] Support forward proxy for the ZTS server in pulsar-client-auth-athenz

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@ flexible messaging model and an intuitive client API.</description>
     <jetty.version>9.4.56.v20240826</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.42</jersey.version>
-    <athenz.version>1.10.50</athenz.version>
+    <athenz.version>1.10.62</athenz.version>
     <prometheus.version>0.16.0</prometheus.version>
     <vertx.version>4.5.10</vertx.version>
     <rocksdb.version>7.9.2</rocksdb.version>

--- a/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
+++ b/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
@@ -63,6 +63,7 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
     private transient KeyRefresher keyRefresher = null;
     private transient ZTSClient ztsClient = null;
     private String ztsUrl = null;
+    private String ztsProxyUrl = null;
     private String tenantDomain;
     private String tenantService;
     private String providerDomain;
@@ -193,6 +194,9 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
         if (isNotBlank(authParams.get("ztsUrl"))) {
             this.ztsUrl = authParams.get("ztsUrl");
         }
+        if (isNotBlank(authParams.get("ztsProxyUrl"))) {
+            this.ztsProxyUrl = authParams.get("ztsProxyUrl");
+        }
     }
 
     @Override
@@ -219,11 +223,11 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
                 }
                 final SSLContext sslContext = Utils.buildSSLContext(keyRefresher.getKeyManagerProxy(),
                         keyRefresher.getTrustManagerProxy());
-                ztsClient = new ZTSClient(ztsUrl, sslContext);
+                ztsClient = new ZTSClient(ztsUrl, ztsProxyUrl, sslContext);
             } else {
                 ServiceIdentityProvider siaProvider = new SimpleServiceIdentityProvider(tenantDomain, tenantService,
                         privateKey, keyId);
-                ztsClient = new ZTSClient(ztsUrl, tenantDomain, tenantService, siaProvider);
+                ztsClient = new ZTSClient(ztsUrl, ztsProxyUrl, tenantDomain, tenantService, siaProvider);
             }
             ztsClient.setPrefetchAutoEnable(this.autoPrefetchEnabled);
         }


### PR DESCRIPTION
### Motivation
When we can only access the [Athenz ZTS](https://athenz.github.io/athenz/decent_authz_flow/#zts-authz-token-system) server through a forward proxy, we can't use pulsar-client-auth-athenz for an authentication plugin because the current plugin implementation does not support the ztsProxyUrl config of ZTSClient.

### Modifications

Support ztsProxyUrl in the pulsar-client-auth-athenz.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Added an unit test for ztsProxyUrl config

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/equanz/pulsar/pull/12
