### PR TITLE
[fix] [ml] incorrect non-durable cursor's backlog due to concurrently trimming ledger and non-durable cursor creation

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1144,16 +1144,14 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             return cachedCursor;
         }
 
-        NonDurableCursorImpl cursor = new NonDurableCursorImpl(bookKeeper, this, cursorName,
-                startCursorPosition, initialPosition, isReadCompacted);
-        cursor.setActive();
-
-        log.info("[{}] Opened new cursor: {}", name, cursor);
         synchronized (this) {
+            NonDurableCursorImpl cursor = new NonDurableCursorImpl(bookKeeper, this, cursorName,
+                    startCursorPosition, initialPosition, isReadCompacted);
+            cursor.setActive();
+            log.info("[{}] Opened new cursor: {}", name, cursor);
             addCursor(cursor);
+            return cursor;
         }
-
-        return cursor;
     }
 
     @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1144,8 +1144,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             return cachedCursor;
         }
 
-        // To avoid cursor initialization and "ML.trimLedgers" execute concurrency, we add this lock block.
-        // See details https://github.com/apache/pulsar/pull/23951.
+        // The backlog of a non-durable cursor could be incorrect if the cursor is created before `internalTrimLedgers`
+        // and added to the managed ledger after `internalTrimLedgers`.
+        // For more details, see https://github.com/apache/pulsar/pull/23951.
         synchronized (this) {
             NonDurableCursorImpl cursor = new NonDurableCursorImpl(bookKeeper, this, cursorName,
                     startCursorPosition, initialPosition, isReadCompacted);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1144,6 +1144,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             return cachedCursor;
         }
 
+        // To avoid cursor initialization and "ML.trimLedgers" execute concurrency, we add this lock block.
+        // See details https://github.com/apache/pulsar/pull/23951.
         synchronized (this) {
             NonDurableCursorImpl cursor = new NonDurableCursorImpl(bookKeeper, this, cursorName,
                     startCursorPosition, initialPosition, isReadCompacted);


### PR DESCRIPTION
### Motivation
**Background**: the logic of calculating `backlog`
- There is a variable named `manegedledger.entriesAddedCounter`, which means how many entries were added after the topic was loaded up at the latest time.
- there is a variable named `cursor.messagesConsumedCounter`, which means how many entries were acked after the cursor was loaded up at the latest time, it can be a negative value.
- Backlog calculating mechanism: `manegedledger.entriesAddedCounter - cursor.messagesConsumedCounter`


**Steps to reproduce the issue**
- `ledgers: [ 1, 2, 3 ]`, `100` entries per ledger.
- `durable-cursor: {mark-deleted-position: 3:0}`
- `manegedledger.entriesAddedCounter`: `0`, no entries were added after the topic was loaded up.
- concurrently trimming ledger and non-durable cursor creation

| time | `trim ledgers` |  non-durable cursor |
| --- | --- | --- |
| 1 | | Init the variable `messagesConsumedCounter` by `managedLegder.ledgers`: `-300` |
| 2 | Calculate ledgers to delete |
| 3 | Move non-durable cursors' mark deleted position |
| 4 | Skip the non-durable cursor because it has not been added to the list `cursors` |
| 5 | Delete ledgers | 
| 6 | | added to the managed ledger via `addCursors` |

After that, if the non-durable cursor receives messages `3:0~3:99` and acknowledges them, the `messagesConsumedCounter` will be -200 (-300 + 100). Then backlog will be 200, but there is no message to consume|

**The issue we encountered**

<img width="1093" alt="Screenshot 2025-02-08 at 17 35 40" src="https://github.com/user-attachments/assets/50996a27-8810-4c3f-aefb-6c8e5c7b6e62" />

<img width="1259" alt="Screenshot 2025-02-08 at 17 35 18" src="https://github.com/user-attachments/assets/d0ad0e6a-c073-4e50-8496-7e41480e1ec8" />



### Modifications

- fix the race condition: since trimming ledger is executed in a lock block `ml.synchronized`, add a lock when creating a non-durable cursor
- Since it is hard to add a test to reproduce the issue, I did not add a test.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x