### PR TITLE
[fix][ml] Fix memory leak due to duplicated RangeCache value retain operations 

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java
@@ -401,12 +401,14 @@ public class RangeCache<Key extends Comparable<Key>, Value extends ValueWithKeyV
                     log.info("Unexpected refCnt {} for key {}, removed entry without releasing the value",
                             value.refCnt(), key);
                 }
+                return RemoveEntryResult.ENTRY_REMOVED;
+            } else {
+                return RemoveEntryResult.CONTINUE_LOOP;
             }
         } finally {
             // remove the extra retain
             value.release();
         }
-        return RemoveEntryResult.ENTRY_REMOVED;
     }
 
     private Pair<Integer, Long> handleRemovalResult(RemovalCounters counters) {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/util/RangeCacheTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/util/RangeCacheTest.java
@@ -27,13 +27,16 @@ import static org.testng.Assert.fail;
 import com.google.common.collect.Lists;
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.ReferenceCounted;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import lombok.Cleanup;
 import lombok.Data;
 import org.apache.commons.lang3.tuple.Pair;
 import org.awaitility.Awaitility;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class RangeCacheTest {
@@ -140,33 +143,47 @@ public class RangeCacheTest {
         assertEquals(cache.getNumberOfEntries(), 2);
     }
 
+    @DataProvider
+    public static Object[][] retainBeforeEviction() {
+        return new Object[][]{ { true }, { false } };
+    }
 
-    @Test
-    public void customTimeExtraction() {
+
+    @Test(dataProvider = "retainBeforeEviction")
+    public void customTimeExtraction(boolean retain) {
         RangeCache<Integer, RefString> cache = new RangeCache<>(value -> value.s.length(), x -> x.s.length());
-        final Runnable assertRefCnt = () -> {
-            final var entries = cache.getRange(1, 4444);
-            for (var entry : entries) {
-                assertEquals(entry.refCnt(), 2);
-                entry.release();
-            }
-        };
 
         cache.put(1, new RefString("1"));
         cache.put(22, new RefString("22"));
         cache.put(333, new RefString("333"));
         cache.put(4444, new RefString("4444"));
 
-        assertRefCnt.run();
         assertEquals(cache.getSize(), 10);
         assertEquals(cache.getNumberOfEntries(), 4);
+        final var retainedEntries = cache.getRange(1, 4444);
+        for (final var entry : retainedEntries) {
+            assertEquals(entry.refCnt(), 2);
+            if (!retain) {
+                entry.release();
+            }
+        }
 
         Pair<Integer, Long> evictedSize = cache.evictLEntriesBeforeTimestamp(3);
         assertEquals(evictedSize.getRight().longValue(), 6);
         assertEquals(evictedSize.getLeft().longValue(), 3);
         assertEquals(cache.getSize(), 4);
         assertEquals(cache.getNumberOfEntries(), 1);
-        assertRefCnt.run();
+
+        if (retain) {
+            final var valueToRefCnt = retainedEntries.stream().collect(Collectors.toMap(RefString::getS,
+                    AbstractReferenceCounted::refCnt));
+            assertEquals(valueToRefCnt, Map.of("1", 1, "22", 1, "333", 1, "4444", 2));
+            retainedEntries.forEach(AbstractReferenceCounted::release);
+        } else {
+            final var valueToRefCnt = retainedEntries.stream().filter(v -> v.refCnt() > 0).collect(Collectors.toMap(
+                    RefString::getS, AbstractReferenceCounted::refCnt));
+            assertEquals(valueToRefCnt, Map.of("4444", 1));
+        }
     }
 
     @Test


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/23903 introduces a memory leak issue in `RangeCache#removeEntry`.

```diff
-        Value value = entryWrapper.getValue(key);
+        Value value = getValueMatchingEntry(entry);
```

Unlike `entryWrapper.getValue`, `getValueMatchingEntry` will increase the reference count of `entry`'s value.

### Modifications

- Remove the duplicated retain operation in `RangeCache#removeEntry`. Add some API notes for the private methods that might increase the reference count of the value
- Apply the reference count validation for eviction on a `RangeCache` (`RangeCacheTest.customTimeExtraction`).

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: