### PR TITLE
[WIP][improve][ci] Enable Netty leak detection in CI and make leaks fail the build

### DIFF
--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -154,6 +154,7 @@ jobs:
       TRACE_TEST_RESOURCE_CLEANUP_DIR: ${{ github.workspace }}/target/trace-test-resource-cleanup
       THREAD_LEAK_DETECTOR_WAIT_MILLIS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.thread_leak_detector_wait_millis || 10000 }}
       THREAD_LEAK_DETECTOR_DIR: ${{ github.workspace }}/target/thread-leak-dumps
+      NETTY_LEAK_DUMP_DIR: ${{ github.workspace }}/target/netty-leak-dumps
     runs-on: ubuntu-22.04
     timeout-minutes: 100
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
@@ -224,6 +225,14 @@ jobs:
             cat threadleak*.txt | awk '/^Summary:/ {print "::warning::" $0 "\n"; next} {print}'  
           fi
 
+      - name: Report detected Netty leaks
+        if: ${{ always() }}
+        run: |
+          if [ -d "$NETTY_LEAK_DUMP_DIR" ]; then
+            cd "$NETTY_LEAK_DUMP_DIR"
+            cat netty_leak_*.txt
+          fi
+
       - name: Create Jacoco reports
         if: ${{ needs.preconditions.outputs.collect_coverage == 'true' }}
         continue-on-error: true
@@ -266,6 +275,7 @@ jobs:
             /tmp/*.hprof
             **/hs_err_*.log
             **/core.*
+            ${{ env.NETTY_LEAK_DUMP_DIR }}/*
             ${{ env.TRACE_TEST_RESOURCE_CLEANUP_DIR }}/*
             ${{ env.THREAD_LEAK_DETECTOR_DIR }}/*
           retention-days: 7

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -704,7 +704,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ !success() }}
         with:
-          name: Integration-${{ matrix.group }}-surefire-reports
+          name: Integration-${{ matrix.name }}-surefire-reports
           path: surefire-reports
           retention-days: 7
 
@@ -712,7 +712,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
-          name: Integration-${{ matrix.group }}-dumps
+          name: Integration-${{ matrix.name }}-dumps
           path: |
             /tmp/*.hprof
             **/hs_err_*.log
@@ -726,7 +726,7 @@ jobs:
         if: ${{ !success() }}
         continue-on-error: true
         with:
-          name: Integration-${{ matrix.group }}-container-logs
+          name: Integration-${{ matrix.name }}-container-logs
           path: tests/integration/target/container-logs
           retention-days: 7
 

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -230,6 +230,7 @@ jobs:
       TRACE_TEST_RESOURCE_CLEANUP_DIR: ${{ github.workspace }}/target/trace-test-resource-cleanup
       THREAD_LEAK_DETECTOR_WAIT_MILLIS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.thread_leak_detector_wait_millis || 10000 }}
       THREAD_LEAK_DETECTOR_DIR: ${{ github.workspace }}/target/thread-leak-dumps
+      NETTY_LEAK_DUMP_DIR: ${{ github.workspace }}/target/netty-leak-dumps
     runs-on: ubuntu-22.04
     timeout-minutes: ${{ matrix.timeout || 60 }}
     needs: ['preconditions', 'build-and-license-check']
@@ -347,6 +348,10 @@ jobs:
             cat threadleak*.txt | awk '/^Summary:/ {print "::warning::" $0 "\n"; next} {print}'
           fi
 
+      - name: Report detected Netty leaks
+        if: ${{ always() }}
+        run: $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh report_netty_leaks
+
       - name: Upload Surefire reports
         uses: actions/upload-artifact@v4
         if: ${{ !success() || env.TRACE_TEST_RESOURCE_CLEANUP != 'off' }}
@@ -364,6 +369,7 @@ jobs:
             /tmp/*.hprof
             **/hs_err_*.log
             **/core.*
+            ${{ env.NETTY_LEAK_DUMP_DIR }}/*
             ${{ env.TRACE_TEST_RESOURCE_CLEANUP_DIR }}/*
             ${{ env.THREAD_LEAK_DETECTOR_DIR }}/*
           retention-days: 7
@@ -552,6 +558,7 @@ jobs:
       PULSAR_TEST_IMAGE_NAME: apachepulsar/java-test-image:latest
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
+      NETTY_LEAK_DUMP_DIR: ${{ github.workspace }}/target/netty-leak-dumps
     strategy:
       fail-fast: false
       matrix:
@@ -689,6 +696,10 @@ jobs:
           report_paths: 'test-reports/TEST-*.xml'
           annotate_only: 'true'
 
+      - name: Report detected Netty leaks
+        if: ${{ always() }}
+        run: $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh report_netty_leaks
+
       - name: Upload Surefire reports
         uses: actions/upload-artifact@v4
         if: ${{ !success() }}
@@ -696,6 +707,19 @@ jobs:
           name: Integration-${{ matrix.group }}-surefire-reports
           path: surefire-reports
           retention-days: 7
+
+      - name: Upload possible heap dump, core dump or crash files
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: Integration-${{ matrix.group }}-dumps
+          path: |
+            /tmp/*.hprof
+            **/hs_err_*.log
+            **/core.*
+            ${{ env.NETTY_LEAK_DUMP_DIR }}/*
+          retention-days: 7
+          if-no-files-found: ignore
 
       - name: Upload container logs
         uses: actions/upload-artifact@v4
@@ -959,6 +983,7 @@ jobs:
       PULSAR_TEST_IMAGE_NAME: apachepulsar/pulsar-test-latest-version:latest
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
+      NETTY_LEAK_DUMP_DIR: ${{ github.workspace }}/target/netty-leak-dumps
     strategy:
       fail-fast: false
       matrix:
@@ -1066,6 +1091,10 @@ jobs:
           report_paths: 'test-reports/TEST-*.xml'
           annotate_only: 'true'
 
+      - name: Report detected Netty leaks
+        if: ${{ always() }}
+        run: $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh report_netty_leaks
+
       - name: Upload container logs
         uses: actions/upload-artifact@v4
         if: ${{ !success() }}
@@ -1082,6 +1111,19 @@ jobs:
           name: System-${{ matrix.name }}-surefire-reports
           path: surefire-reports
           retention-days: 7
+
+      - name: Upload possible heap dump, core dump or crash files
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: System-${{ matrix.group }}-dumps
+          path: |
+            /tmp/*.hprof
+            **/hs_err_*.log
+            **/core.*
+            ${{ env.NETTY_LEAK_DUMP_DIR }}/*
+          retention-days: 7
+          if-no-files-found: ignore
 
       - name: Wait for ssh connection when build fails
         # ssh access is enabled for builds in own forks
@@ -1189,6 +1231,7 @@ jobs:
       PULSAR_TEST_IMAGE_NAME: apachepulsar/pulsar-test-latest-version:latest
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
+      NETTY_LEAK_DUMP_DIR: ${{ github.workspace }}/target/netty-leak-dumps
     strategy:
       fail-fast: false
       matrix:
@@ -1273,12 +1316,16 @@ jobs:
           report_paths: 'test-reports/TEST-*.xml'
           annotate_only: 'true'
 
+      - name: Report detected Netty leaks
+        if: ${{ always() }}
+        run: $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh report_netty_leaks
+
       - name: Upload container logs
         uses: actions/upload-artifact@v4
         if: ${{ !success() }}
         continue-on-error: true
         with:
-          name: System-${{ matrix.group }}-container-logs
+          name: Flaky-System-${{ matrix.group }}-container-logs
           path: tests/integration/target/container-logs
           retention-days: 7
 
@@ -1286,9 +1333,22 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ !success() }}
         with:
-          name: System-${{ matrix.name }}-surefire-reports
+          name: Flaky-System-${{ matrix.name }}-surefire-reports
           path: surefire-reports
           retention-days: 7
+
+      - name: Upload possible heap dump, core dump or crash files
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: Flaky-System-${{ matrix.group }}-dumps
+          path: |
+            /tmp/*.hprof
+            **/hs_err_*.log
+            **/core.*
+            ${{ env.NETTY_LEAK_DUMP_DIR }}/*
+          retention-days: 7
+          if-no-files-found: ignore
 
       - name: Wait for ssh connection when build fails
         # ssh access is enabled for builds in own forks

--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -148,12 +148,17 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- for testing FastThreadLocalStateCleaner -->
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
       <version>${netty.version}</version>
-      <scope>test</scope>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-buffer</artifactId>
+      <version>${netty.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/buildtools/src/main/java/org/apache/pulsar/tests/ExtendedNettyLeakDetector.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/ExtendedNettyLeakDetector.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.ResourceLeakDetector;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A custom Netty leak detector used in Pulsar tests that dumps the detected leaks to a file in a directory that is
+ * configured with the NETTY_LEAK_DUMP_DIR environment variable. This directory defaults to java.io.tmpdir.
+ * The files will be named netty_leak_YYYYMMDD-HHMMSS.SSS.txt.
+ * By default, the JVM will exit when a leak is detected. This behavior can be disabled by setting the
+ * org.apache.pulsar.tests.ExtendedNettyLeakDetector.exitJvmOnLeak system property to false.
+ */
+public class ExtendedNettyLeakDetector<T> extends ResourceLeakDetector<T> {
+    private static final Logger LOG = LoggerFactory.getLogger(ExtendedNettyLeakDetector.class);
+    private static final File DUMP_DIR =
+            new File(System.getenv().getOrDefault("NETTY_LEAK_DUMP_DIR", System.getProperty("java.io.tmpdir")));
+    public static final String EXIT_JVM_ON_LEAK_SYSTEM_PROPERTY_NAME =
+            ExtendedNettyLeakDetector.class.getName() + ".exitJvmOnLeak";
+    public static final String SLEEP_AFTER_GC_AND_FINALIZATION_MILLIS_SYSTEM_PROPERTY_NAME =
+            ExtendedNettyLeakDetector.class.getName() + ".sleepAfterGCAndFinalizationMillis";
+    private static final long SLEEP_AFTER_GC_AND_FINALIZATION_MILLIS = Long.parseLong(System.getProperty(
+            SLEEP_AFTER_GC_AND_FINALIZATION_MILLIS_SYSTEM_PROPERTY_NAME, "10"));
+    private static boolean exitJvmOnLeak = Boolean.valueOf(
+            System.getProperty(EXIT_JVM_ON_LEAK_SYSTEM_PROPERTY_NAME, "true"));
+    private static final boolean DEFAULT_EXIT_JVM_ON_LEAK = exitJvmOnLeak;
+    public static final String EXIT_JVM_DELAY_MILLIS_SYSTEM_PROPERTY_NAME =
+            ExtendedNettyLeakDetector.class.getName() + ".exitJvmDelayMillis";
+    private static final long EXIT_JVM_DELAY_MILLIS =
+            Long.parseLong(System.getProperty(EXIT_JVM_DELAY_MILLIS_SYSTEM_PROPERTY_NAME, "1000"));
+    private boolean exitThreadStarted;
+    private static volatile String initialHint;
+
+    /**
+     * Disable exit on leak.
+     */
+    public static void disableExitJVMOnLeak() {
+        exitJvmOnLeak = false;
+    }
+
+    /**
+     * Restore exit on leak to original value.
+     */
+    public static void restoreExitJVMOnLeak() {
+        triggerLeakDetection();
+        exitJvmOnLeak = DEFAULT_EXIT_JVM_ON_LEAK;
+    }
+
+    /**
+     * Triggers Netty leak detection.
+     * Passing "-XX:+UnlockExperimentalVMOptions -XX:ReferencesPerThread=0" to the JVM will help to detect leaks
+     * with a shorter latency. When ReferencesPerThread is set to 0, the JVM will use maximum parallelism for processing
+     * reference objects. Netty's leak detection relies on WeakReferences and this setting will help to process them
+     * faster.
+     */
+    public static void triggerLeakDetection() {
+        // run System.gc() to trigger finalization of objects and detection of possible Netty leaks
+        System.gc();
+        System.runFinalization();
+        try {
+            // wait for WeakReference collection to complete
+            Thread.sleep(SLEEP_AFTER_GC_AND_FINALIZATION_MILLIS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        triggerLeakReporting();
+    }
+
+    private static void triggerLeakReporting() {
+        // create a ByteBuf and release it to trigger leak detection
+        // this calls ResourceLeakDetector's reportLeak method when paranoid is enabled.
+        ByteBuf buffer = ByteBufAllocator.DEFAULT.directBuffer();
+        // this triggers leak detection which forces tracking even when paranoid isn't enabled
+        // check the source code of ResourceLeakDetector to see how it works or step through it in a debugger
+        // This will call leak detector's trackForcibly method which will then call ResourceLeakDetector's reportLeak
+        // trackForcibly gets called in io.netty.buffer.SimpleLeakAwareByteBuf.unwrappedDerived
+        ByteBuf retainedSlice = buffer.retainedSlice();
+        retainedSlice.release();
+        buffer.release();
+    }
+
+    public ExtendedNettyLeakDetector(Class<?> resourceType, int samplingInterval, long maxActive) {
+        super(resourceType, samplingInterval, maxActive);
+    }
+
+    public ExtendedNettyLeakDetector(Class<?> resourceType, int samplingInterval) {
+        super(resourceType, samplingInterval);
+    }
+
+    public ExtendedNettyLeakDetector(String resourceType, int samplingInterval, long maxActive) {
+        super(resourceType, samplingInterval, maxActive);
+    }
+
+    /**
+     * Set the initial hint to be used when reporting leaks.
+     * This hint will be printed alongside the stack trace of the creation of the resource in the Netty leak report.
+     *
+     * @see ResourceLeakDetector#getInitialHint(String)
+     * @param initialHint the initial hint
+     */
+    public static void setInitialHint(String initialHint) {
+        ExtendedNettyLeakDetector.initialHint = initialHint;
+    }
+
+    @Override
+    protected boolean needReport() {
+        return true;
+    }
+
+    @Override
+    protected Object getInitialHint(String resourceType) {
+        String currentInitialHint = ExtendedNettyLeakDetector.initialHint;
+        if (currentInitialHint != null) {
+            return currentInitialHint;
+        } else {
+            return super.getInitialHint(resourceType);
+        }
+    }
+
+    @Override
+    protected void reportTracedLeak(String resourceType, String records) {
+        super.reportTracedLeak(resourceType, records);
+        dumpToFile(resourceType, records);
+        maybeExitJVM();
+    }
+
+    @Override
+    protected void reportUntracedLeak(String resourceType) {
+        super.reportUntracedLeak(resourceType);
+        dumpToFile(resourceType, null);
+        maybeExitJVM();
+    }
+
+    private synchronized void maybeExitJVM() {
+        if (exitThreadStarted) {
+            return;
+        }
+        if (exitJvmOnLeak) {
+            new Thread(() -> {
+                LOG.error("Exiting JVM due to Netty resource leak. Check logs for more details. Dumped to {}",
+                        DUMP_DIR.getAbsolutePath());
+                System.err.println("Exiting JVM due to Netty resource leak. Check logs for more details. Dumped to "
+                        + DUMP_DIR.getAbsolutePath());
+                triggerLeakDetection();
+                try {
+                    Thread.sleep(EXIT_JVM_DELAY_MILLIS);
+                } catch (InterruptedException e) {
+                    // ignore
+                }
+                triggerLeakDetection();
+                // shutdown log4j2 logging to prevent log truncation
+                LogManager.shutdown();
+                // flush log buffers
+                System.err.flush();
+                System.out.flush();
+                // exit JVM immediately
+                Runtime.getRuntime().halt(1);
+            }).start();
+            exitThreadStarted = true;
+        }
+    }
+
+    private void dumpToFile(String resourceType, String records) {
+        try {
+            if (!DUMP_DIR.exists()) {
+                DUMP_DIR.mkdirs();
+            }
+            String datetimePart =
+                    DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss.SSS").format(ZonedDateTime.now());
+            File nettyLeakDumpFile =
+                    new File(DUMP_DIR, "netty_leak_" + datetimePart + ".txt");
+            // Prefix the line to make it easier to show the errors in GitHub Actions as annotations
+            String linePrefix = exitJvmOnLeak ? "::error::" : "::warning::";
+            try (PrintWriter out = new PrintWriter(new FileWriter(nettyLeakDumpFile, true))) {
+                out.print(linePrefix);
+                if (records != null) {
+                    out.println("Traced leak detected " + resourceType);
+                    out.println(records);
+                } else {
+                    out.println("Untraced leak detected " + resourceType);
+                }
+                out.println();
+                out.flush();
+            }
+        } catch (IOException e) {
+            LOG.error("Cannot write thread leak dump", e);
+        }
+    }
+}

--- a/buildtools/src/main/java/org/apache/pulsar/tests/PulsarTestListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/PulsarTestListener.java
@@ -19,16 +19,21 @@
 package org.apache.pulsar.tests;
 
 import java.util.Arrays;
+import org.testng.IExecutionListener;
+import org.testng.ISuite;
+import org.testng.ISuiteListener;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestResult;
 import org.testng.SkipException;
 import org.testng.internal.thread.ThreadTimeoutException;
 
-public class PulsarTestListener implements ITestListener {
+public class PulsarTestListener implements ITestListener, IExecutionListener, ISuiteListener {
 
     @Override
     public void onTestStart(ITestResult result) {
+        ExtendedNettyLeakDetector.setInitialHint(String.format("Test: %s.%s", result.getTestClass().getName(),
+                result.getMethod().getMethodName()));
         System.out.format("------- Starting test %s.%s(%s)-------\n", result.getTestClass(),
                 result.getMethod().getMethodName(), Arrays.toString(result.getParameters()));
     }
@@ -37,6 +42,7 @@ public class PulsarTestListener implements ITestListener {
     public void onTestSuccess(ITestResult result) {
         System.out.format("------- SUCCESS -- %s.%s(%s)-------\n", result.getTestClass(),
                 result.getMethod().getMethodName(), Arrays.toString(result.getParameters()));
+        ExtendedNettyLeakDetector.triggerLeakDetection();
     }
 
     @Override
@@ -52,6 +58,7 @@ public class PulsarTestListener implements ITestListener {
                 }
             }
         }
+        ExtendedNettyLeakDetector.triggerLeakDetection();
     }
 
     @Override
@@ -71,15 +78,33 @@ public class PulsarTestListener implements ITestListener {
 
     @Override
     public void onTestFailedButWithinSuccessPercentage(ITestResult result) {
-
+        ExtendedNettyLeakDetector.triggerLeakDetection();
     }
 
     @Override
     public void onStart(ITestContext context) {
-
+        ExtendedNettyLeakDetector.setInitialHint("Starting test: " + context.getName());
     }
 
     @Override
     public void onFinish(ITestContext context) {
+        ExtendedNettyLeakDetector.triggerLeakDetection();
+        ExtendedNettyLeakDetector.setInitialHint("Finished test: " + context.getName());
+    }
+
+    @Override
+    public void onFinish(ISuite suite) {
+        ExtendedNettyLeakDetector.setInitialHint("Finished suite: " + suite.getName());
+    }
+
+    @Override
+    public void onExecutionFinish() {
+        ExtendedNettyLeakDetector.triggerLeakDetection();
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        ExtendedNettyLeakDetector.triggerLeakDetection();
     }
 }

--- a/conf/bkenv.sh
+++ b/conf/bkenv.sh
@@ -89,7 +89,7 @@ if [[ -z "$BOOKIE_GC_LOG" ]]; then
 fi
 
 # Extra options to be passed to the jvm
-BOOKIE_EXTRA_OPTS="${BOOKIE_EXTRA_OPTS:-"-Dio.netty.leakDetectionLevel=disabled ${PULSAR_EXTRA_OPTS:-"-Dio.netty.recycler.maxCapacityPerThread=4096"}"}"
+BOOKIE_EXTRA_OPTS="${BOOKIE_EXTRA_OPTS:-"-Dio.netty.leakDetection.level=disabled ${PULSAR_EXTRA_OPTS:-"-Dio.netty.recycler.maxCapacityPerThread=4096"}"}"
 
 # Add extra paths to the bookkeeper classpath
 # BOOKIE_EXTRA_CLASSPATH=

--- a/conf/pulsar_tools_env.sh
+++ b/conf/pulsar_tools_env.sh
@@ -58,7 +58,7 @@ fi
 PULSAR_MEM=${PULSAR_MEM:-"-Xmx128m -XX:MaxDirectMemorySize=128m"}
 
 # Extra options to be passed to the jvm
-PULSAR_EXTRA_OPTS="${PULSAR_MEM} ${PULSAR_GC} ${PULSAR_GC_LOG} -Dio.netty.leakDetectionLevel=disabled ${PULSAR_EXTRA_OPTS}"
+PULSAR_EXTRA_OPTS="${PULSAR_MEM} ${PULSAR_GC} ${PULSAR_GC_LOG} -Dio.netty.leakDetection.level=disabled ${PULSAR_EXTRA_OPTS}"
 
 # Add extra paths to the bookkeeper classpath
 # PULSAR_EXTRA_CLASSPATH=

--- a/deployment/terraform-ansible/templates/pulsar_env.sh
+++ b/deployment/terraform-ansible/templates/pulsar_env.sh
@@ -48,7 +48,7 @@ PULSAR_MEM=" -Xms{{ max_heap_memory }} -Xmx{{ max_heap_memory }} -XX:MaxDirectMe
 PULSAR_GC=" -XX:+UseZGC -XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch"
 
 # Extra options to be passed to the jvm
-PULSAR_EXTRA_OPTS="${PULSAR_EXTRA_OPTS} -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.maxCapacityPerThread=4096"
+PULSAR_EXTRA_OPTS="-Dio.netty.leakDetection.level=disabled -Dio.netty.recycler.maxCapacityPerThread=4096 ${PULSAR_EXTRA_OPTS}"
 
 # Add extra paths to the bookkeeper classpath
 # PULSAR_EXTRA_CLASSPATH=

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,14 @@ flexible messaging model and an intuitive client API.</description>
       --add-opens java.management/sun.management=ALL-UNNAMED <!--JvmDefaultGCMetricsLogger & MBeanStatsGenerator-->
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED <!--MBeanStatsGenerator-->
       --add-opens java.base/jdk.internal.platform=ALL-UNNAMED <!--LinuxInfoUtils-->
+      <!--
+      enable optimized Netty direct memory buffer access
+      https://pulsar.apache.org/docs/4.0.x/client-libraries-java-setup/#enabling-optimized-netty-direct-memory-buffer-access
+      -->
+      --add-opens java.base/java.nio=ALL-UNNAMED
+      --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+      -Dio.netty.tryReflectionSetAccessible=true
+      -Dorg.apache.pulsar.shade.io.netty.tryReflectionSetAccessible=true
     </test.additional.args>
     <testMaxHeapSize>1300M</testMaxHeapSize>
     <testReuseFork>true</testReuseFork>
@@ -122,6 +130,9 @@ flexible messaging model and an intuitive client API.</description>
     <testRetryCount>1</testRetryCount>
     <testFailFast>true</testFailFast>
     <testFailFastFile></testFailFastFile>
+    <testExitJvmOnLeak>false</testExitJvmOnLeak>
+    <testExitJvmOnLeakDelayMillis>1000</testExitJvmOnLeakDelayMillis>
+    <testLeakDetectionLevel>paranoid</testLeakDetectionLevel>
     <testJacocoAgentArgument/>
     <integrationtest.coverage.enabled>false</integrationtest.coverage.enabled>
     <integrationtest.coverage.dir>${project.build.directory}</integrationtest.coverage.dir>
@@ -1818,12 +1829,19 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>${testJacocoAgentArgument} -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${testHeapDumpPath} -XX:+ExitOnOutOfMemoryError -Xmx${testMaxHeapSize} -XX:+UseZGC
+          <argLine>${testJacocoAgentArgument} -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${testHeapDumpPath}
+            -XX:+ExitOnOutOfMemoryError -Xmx${testMaxHeapSize} -XX:+UseZGC
+            -XX:+UnlockExperimentalVMOptions -XX:ReferencesPerThread=0 -XX:+ParallelRefProcEnabled
             -Dpulsar.allocator.pooled=true
-            -Dpulsar.allocator.leak_detection=Advanced
+            -Dio.netty.customResourceLeakDetector=org.apache.pulsar.tests.ExtendedNettyLeakDetector
+            -Dorg.apache.pulsar.tests.ExtendedNettyLeakDetector.exitJvmOnLeak=${testExitJvmOnLeak}
+            -Dorg.apache.pulsar.tests.ExtendedNettyLeakDetector.exitJvmDelayMillis=${testExitJvmOnLeakDelayMillis}
+            -Dio.netty.leakDetection.level=${testLeakDetectionLevel}
+            -Dio.netty.leakDetection.acquireAndReleaseOnly=true
+            -Dio.netty.leakDetection.targetRecords=16
+            -Dio.netty.leakDetection.samplingInterval=32
             -Dpulsar.allocator.exit_on_oom=false
             -Dpulsar.allocator.out_of_memory_policy=FallbackToHeap
-            -Dio.netty.tryReflectionSetAccessible=true
             ${test.additional.args}
           </argLine>
           <reuseForks>${testReuseFork}</reuseForks>

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -661,6 +661,9 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             if (transactionExecutorProvider != null) {
                 transactionExecutorProvider.shutdownNow();
             }
+            if (transactionTimer != null) {
+                transactionTimer.stop();
+            }
             MLPendingAckStoreProvider.closeBufferedWriterMetrics();
             MLTransactionMetadataStoreProvider.closeBufferedWriterMetrics();
             if (this.offloaderStats != null) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -3778,4 +3778,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     public void decrementThrottleCount() {
         throttleTracker.decrementThrottleCount();
     }
+
+    @VisibleForTesting
+    void setAuthState(AuthenticationState authState) {
+        this.authState = authState;
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
@@ -180,12 +180,12 @@ public class GeoPersistentReplicator extends PersistentReplicator {
                 dispatchRateLimiter.ifPresent(rateLimiter -> rateLimiter.consumeDispatchQuota(1, entry.getLength()));
                 msg.setReplicatedFrom(localCluster);
 
-                headersAndPayload.retain();
+                //headersAndPayload.retain();
 
                 CompletableFuture<SchemaInfo> schemaFuture = getSchemaInfo(msg);
                 if (!schemaFuture.isDone() || schemaFuture.isCompletedExceptionally()) {
                     entry.release();
-                    headersAndPayload.release();
+                    //headersAndPayload.release();
                     msg.recycle();
                     // Mark the replicator is fetching the schema for now and rewind the cursor
                     // and trigger the next read after complete the schema fetching.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImplTest.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.broker.intercept;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.nio.charset.StandardCharsets;
@@ -125,10 +124,12 @@ public class ManagedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase 
         assertEquals(19, ((ManagedLedgerInterceptorImpl) ledger.getManagedLedgerInterceptor()).getIndex());
         List<Entry> entryList = cursor.readEntries(numberOfEntries);
         for (int i = 0 ; i < numberOfEntries; i ++) {
+            Entry entry = entryList.get(i);
             BrokerEntryMetadata metadata =
-                    Commands.parseBrokerEntryMetadataIfExist(entryList.get(i).getDataBuffer());
+                    Commands.parseBrokerEntryMetadataIfExist(entry.getDataBuffer());
             assertNotNull(metadata);
             assertEquals(metadata.getIndex(), (i + 1) * MOCK_BATCH_SIZE - 1);
+            entry.release();
         }
 
         cursor.close();
@@ -152,7 +153,9 @@ public class ManagedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase 
         ledger.addEntry("Test Message".getBytes());
         factory.getEntryCacheManager().clear();
         List<Entry> entryList = cursor.readEntries(1);
-        String message = new String(entryList.get(0).getData());
+        Entry entry = entryList.get(0);
+        String message = new String(entry.getData());
+        entry.release();
         Assert.assertTrue(message.equals("Test Message"));
         cursor.close();
         ledger.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractBaseDispatcherTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractBaseDispatcherTest.java
@@ -108,7 +108,9 @@ public class AbstractBaseDispatcherTest {
 
         List<Entry> entries = new ArrayList<>();
 
-        Entry e = EntryImpl.create(1, 2, createMessage("message1", 1));
+        ByteBuf message = createMessage("message1", 1);
+        Entry e = EntryImpl.create(1, 2, message);
+        message.release();
         long expectedBytePermits = e.getLength();
         entries.add(e);
         SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
@@ -124,7 +126,9 @@ public class AbstractBaseDispatcherTest {
     @Test
     public void testFilterEntriesForConsumerOfTxnMsgAbort() {
         List<Entry> entries = new ArrayList<>();
-        entries.add(EntryImpl.create(1, 1, createTnxAbortMessage("message1", 1)));
+        ByteBuf message = createTnxAbortMessage("message1", 1);
+        entries.add(EntryImpl.create(1, 1, message));
+        message.release();
 
         SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
         EntryBatchSizes batchSizes = EntryBatchSizes.get(entries.size());
@@ -140,7 +144,9 @@ public class AbstractBaseDispatcherTest {
         when(mockTopic.isTxnAborted(any(TxnID.class), any())).thenReturn(true);
 
         List<Entry> entries = new ArrayList<>();
-        entries.add(EntryImpl.create(1, 1, createTnxMessage("message1", 1)));
+        ByteBuf message = createTnxMessage("message1", 1);
+        entries.add(EntryImpl.create(1, 1, message));
+        message.release();
 
         SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
         EntryBatchSizes batchSizes = EntryBatchSizes.get(entries.size());
@@ -154,6 +160,7 @@ public class AbstractBaseDispatcherTest {
         ByteBuf markerMessage =
                 Markers.newReplicatedSubscriptionsSnapshotRequest("testSnapshotId", "testSourceCluster");
         entries.add(EntryImpl.create(1, 1, markerMessage));
+        markerMessage.release();
 
         SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
         EntryBatchSizes batchSizes = EntryBatchSizes.get(entries.size());
@@ -164,7 +171,9 @@ public class AbstractBaseDispatcherTest {
     @Test
     public void testFilterEntriesForConsumerOfDelayedMsg() {
         List<Entry> entries = new ArrayList<>();
-        entries.add(EntryImpl.create(1, 1, createDelayedMessage("message1", 1)));
+        ByteBuf message = createDelayedMessage("message1", 1);
+        entries.add(EntryImpl.create(1, 1, message));
+        message.release();
 
         SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
         EntryBatchSizes batchSizes = EntryBatchSizes.get(entries.size());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
@@ -98,7 +98,8 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         headers.writeInt(msgMetadataSize);
         messageMetadata.writeTo(headers);
         ByteBuf headersAndPayload = ByteBufPair.coalesce(ByteBufPair.get(headers, data));
-        byte[] byteMessage = headersAndPayload.nioBuffer().array();
+        byte[] byteMessage = new byte[headersAndPayload.readableBytes()];
+        headersAndPayload.readBytes(byteMessage);
         headersAndPayload.release();
         return byteMessage;
     }
@@ -123,7 +124,8 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
     public static byte[] appendBrokerTimestamp(ByteBuf headerAndPayloads) throws Exception {
         ByteBuf msgWithEntryMeta =
                 Commands.addBrokerEntryMetadata(headerAndPayloads, getBrokerEntryMetadataInterceptors(), 1);
-        byte[] byteMessage = msgWithEntryMeta.nioBuffer().array();
+        byte[] byteMessage = new byte[msgWithEntryMeta.readableBytes()];
+        msgWithEntryMeta.readBytes(byteMessage);
         msgWithEntryMeta.release();
         return byteMessage;
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -53,7 +53,6 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.ReferenceCounted;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.InetAddress;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -72,6 +72,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import javax.naming.AuthenticationException;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
@@ -96,9 +97,11 @@ import org.apache.pulsar.broker.auth.MockAuthenticationProvider;
 import org.apache.pulsar.broker.auth.MockAuthorizationProvider;
 import org.apache.pulsar.broker.auth.MockMultiStageAuthenticationProvider;
 import org.apache.pulsar.broker.auth.MockMutableAuthenticationProvider;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSubscription;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
+import org.apache.pulsar.broker.authentication.AuthenticationState;
 import org.apache.pulsar.broker.authorization.AuthorizationService;
 import org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider;
 import org.apache.pulsar.broker.namespace.NamespaceService;
@@ -117,7 +120,6 @@ import org.apache.pulsar.common.api.proto.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.CommandAddPartitionToTxnResponse;
 import org.apache.pulsar.common.api.proto.CommandAddSubscriptionToTxnResponse;
 import org.apache.pulsar.common.api.proto.CommandAuthChallenge;
-import org.apache.pulsar.common.api.proto.CommandAuthResponse;
 import org.apache.pulsar.common.api.proto.CommandCloseProducer;
 import org.apache.pulsar.common.api.proto.CommandConnected;
 import org.apache.pulsar.common.api.proto.CommandEndTxnOnPartitionResponse;
@@ -332,7 +334,7 @@ public class ServerCnxTest {
 
         assertEquals(serverCnx.getState(), State.Connected);
         assertEquals(serverCnx.getProxyVersion(), "my-pulsar-proxy");
-        channel.finish();
+        channel.finishAndReleaseAll();
     }
 
     @DataProvider(name = "clientVersions")
@@ -3094,7 +3096,7 @@ public class ServerCnxTest {
         Object response = getResponse();
         assertTrue(response instanceof CommandSuccess);
 
-        channel.finish();
+        channel.finishAndReleaseAll();
     }
 
     @Test(timeOut = 30000)
@@ -3399,21 +3401,42 @@ public class ServerCnxTest {
     }
 
     @Test
-    public void testHandleAuthResponseWithoutClientVersion() {
-        ServerCnx cnx = mock(ServerCnx.class, CALLS_REAL_METHODS);
-        CommandAuthResponse authResponse = mock(CommandAuthResponse.class);
-        org.apache.pulsar.common.api.proto.AuthData authData = mock(org.apache.pulsar.common.api.proto.AuthData.class);
-        when(authResponse.getResponse()).thenReturn(authData);
-        when(authResponse.hasResponse()).thenReturn(true);
-        when(authResponse.getResponse().hasAuthMethodName()).thenReturn(true);
-        when(authResponse.getResponse().hasAuthData()).thenReturn(true);
-        when(authResponse.hasClientVersion()).thenReturn(false);
-        try {
-            cnx.handleAuthResponse(authResponse);
-        } catch (Exception ignore) {
-        }
-        verify(authResponse, times(1)).hasClientVersion();
-        verify(authResponse, times(0)).getClientVersion();
+    public void testHandleAuthResponseWithoutClientVersion() throws Exception {
+        resetChannel();
+        // use a dummy authentication provider
+        AuthenticationProvider authenticationProvider = new AuthenticationProvider() {
+            @Override
+            public void initialize(ServiceConfiguration config) throws IOException {
+
+            }
+
+            @Override
+            public String authenticate(AuthenticationDataSource authData) throws AuthenticationException {
+                return "role";
+            }
+
+            @Override
+            public String getAuthMethodName() {
+                return "dummy";
+            }
+
+            @Override
+            public void close() throws IOException {
+
+            }
+        };
+        AuthData clientData = AuthData.of(new byte[0]);
+        AuthenticationState authenticationState =
+                authenticationProvider.newAuthState(clientData, null, null);
+        // inject the AuthenticationState instance so that auth response can be processed
+        serverCnx.setAuthState(authenticationState);
+        // send the auth response with no client version
+        String clientVersion = null;
+        ByteBuf authResponse =
+                Commands.newAuthResponse("token", clientData, Commands.getCurrentProtocolVersion(), clientVersion);
+        channel.writeInbound(authResponse);
+        CommandConnected response = (CommandConnected) getResponse();
+        assertNotNull(response);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageDuplicationTest.java
@@ -35,6 +35,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.EventLoopGroup;
 import java.lang.reflect.Field;
 import java.util.Map;
@@ -99,20 +100,24 @@ public class MessageDuplicationTest extends BrokerTestBase {
 
         MessageDeduplication.MessageDupStatus status = messageDeduplication.isDuplicate(publishContext1, byteBuf1);
         assertEquals(status, MessageDeduplication.MessageDupStatus.NotDup);
+        byteBuf1.release();
 
         Long lastSequenceIdPushed = messageDeduplication.highestSequencedPushed.get(producerName1);
         assertNotNull(lastSequenceIdPushed);
         assertEquals(lastSequenceIdPushed.longValue(), 0);
 
         status = messageDeduplication.isDuplicate(publishContext2, byteBuf2);
+        byteBuf2.release();
         assertEquals(status, MessageDeduplication.MessageDupStatus.NotDup);
         lastSequenceIdPushed = messageDeduplication.highestSequencedPushed.get(producerName2);
         assertNotNull(lastSequenceIdPushed);
         assertEquals(lastSequenceIdPushed.longValue(), 1);
 
+
         byteBuf1 = getMessage(producerName1, 1);
         publishContext1 = getPublishContext(producerName1, 1);
         status = messageDeduplication.isDuplicate(publishContext1, byteBuf1);
+        byteBuf1.release();
         assertEquals(status, MessageDeduplication.MessageDupStatus.NotDup);
         lastSequenceIdPushed = messageDeduplication.highestSequencedPushed.get(producerName1);
         assertNotNull(lastSequenceIdPushed);
@@ -121,6 +126,7 @@ public class MessageDuplicationTest extends BrokerTestBase {
         byteBuf1 = getMessage(producerName1, 5);
         publishContext1 = getPublishContext(producerName1, 5);
         status = messageDeduplication.isDuplicate(publishContext1, byteBuf1);
+        byteBuf1.release();
         assertEquals(status, MessageDeduplication.MessageDupStatus.NotDup);
         lastSequenceIdPushed = messageDeduplication.highestSequencedPushed.get(producerName1);
         assertNotNull(lastSequenceIdPushed);
@@ -129,6 +135,7 @@ public class MessageDuplicationTest extends BrokerTestBase {
         byteBuf1 = getMessage(producerName1, 0);
         publishContext1 = getPublishContext(producerName1, 0);
         status = messageDeduplication.isDuplicate(publishContext1, byteBuf1);
+        byteBuf1.release();
         // should expect unknown because highestSequencePersisted is empty
         assertEquals(status, MessageDeduplication.MessageDupStatus.Unknown);
         lastSequenceIdPushed = messageDeduplication.highestSequencedPushed.get(producerName1);
@@ -141,6 +148,7 @@ public class MessageDuplicationTest extends BrokerTestBase {
         byteBuf1 = getMessage(producerName1, 0);
         publishContext1 = getPublishContext(producerName1, 0);
         status = messageDeduplication.isDuplicate(publishContext1, byteBuf1);
+        byteBuf1.release();
         // now that highestSequencedPersisted, message with seqId of zero can be classified as a dup
         assertEquals(status, MessageDeduplication.MessageDupStatus.Dup);
         lastSequenceIdPushed = messageDeduplication.highestSequencedPushed.get(producerName1);
@@ -160,6 +168,7 @@ public class MessageDuplicationTest extends BrokerTestBase {
 
         publishContext1 = getPublishContext(producerName1, 4, 8);
         status = messageDeduplication.isDuplicate(publishContext1, byteBuf1);
+        byteBuf1.release();
         assertEquals(status, MessageDeduplication.MessageDupStatus.Unknown);
         lastSequenceIdPushed = messageDeduplication.highestSequencedPushed.get(producerName1);
         assertNotNull(lastSequenceIdPushed);
@@ -296,9 +305,12 @@ public class MessageDuplicationTest extends BrokerTestBase {
         lastSequenceIdPushed = messageDeduplication.highestSequencedPushed.get(producerName2);
         assertNotNull(lastSequenceIdPushed);
         assertEquals(lastSequenceIdPushed.longValue(), 1);
+        byteBuf2.release();
+
         lastSequenceIdPushed = messageDeduplication.highestSequencedPersisted.get(producerName2);
         assertNotNull(lastSequenceIdPushed);
         assertEquals(lastSequenceIdPushed.longValue(), 1);
+        byteBuf1.release();
 
         byteBuf1 = getMessage(producerName1, 1);
         publishContext1 = getPublishContext(producerName1, 1);
@@ -311,6 +323,7 @@ public class MessageDuplicationTest extends BrokerTestBase {
         lastSequenceIdPushed = messageDeduplication.highestSequencedPersisted.get(producerName1);
         assertNotNull(lastSequenceIdPushed);
         assertEquals(lastSequenceIdPushed.longValue(), 1);
+        byteBuf1.release();
 
         byteBuf1 = getMessage(producerName1, 5);
         publishContext1 = getPublishContext(producerName1, 5);
@@ -323,6 +336,7 @@ public class MessageDuplicationTest extends BrokerTestBase {
         lastSequenceIdPushed = messageDeduplication.highestSequencedPersisted.get(producerName1);
         assertNotNull(lastSequenceIdPushed);
         assertEquals(lastSequenceIdPushed.longValue(), 5);
+        byteBuf1.release();
 
         // publish dup
         byteBuf1 = getMessage(producerName1, 0);
@@ -333,6 +347,7 @@ public class MessageDuplicationTest extends BrokerTestBase {
         assertNotNull(lastSequenceIdPushed);
         assertEquals(lastSequenceIdPushed.longValue(), 5);
         verify(publishContext1, times(1)).completed(eq(null), eq(-1L), eq(-1L));
+        byteBuf1.release();
 
         // publish message unknown dup status
         byteBuf1 = getMessage(producerName1, 6);
@@ -346,6 +361,7 @@ public class MessageDuplicationTest extends BrokerTestBase {
         lastSequenceIdPushed = messageDeduplication.highestSequencedPersisted.get(producerName1);
         assertNotNull(lastSequenceIdPushed);
         assertEquals(lastSequenceIdPushed.longValue(), 5);
+        byteBuf1.release();
 
         // publish same message again
         byteBuf1 = getMessage(producerName1, 6);
@@ -356,6 +372,7 @@ public class MessageDuplicationTest extends BrokerTestBase {
 
         // complete seq 6 message eventually
         persistentTopic.addComplete(PositionFactory.create(0, 5), null, publishContext1);
+        byteBuf1.release();
 
         // simulate failure
         byteBuf1 = getMessage(producerName1, 7);
@@ -376,6 +393,7 @@ public class MessageDuplicationTest extends BrokerTestBase {
         lastSequenceIdPushed = messageDeduplication.highestSequencedPersisted.get(producerName2);
         assertEquals(lastSequenceIdPushed.longValue(), 1);
         verify(messageDeduplication, times(1)).resetHighestSequenceIdPushed();
+        byteBuf1.release();
 
         // try dup
         byteBuf1 = getMessage(producerName1, 6);
@@ -386,6 +404,7 @@ public class MessageDuplicationTest extends BrokerTestBase {
         lastSequenceIdPushed = messageDeduplication.highestSequencedPushed.get(producerName1);
         assertNotNull(lastSequenceIdPushed);
         assertEquals(lastSequenceIdPushed.longValue(), 6);
+        byteBuf1.release();
 
         // try new message
         byteBuf1 = getMessage(producerName1, 8);
@@ -399,6 +418,7 @@ public class MessageDuplicationTest extends BrokerTestBase {
         lastSequenceIdPushed = messageDeduplication.highestSequencedPersisted.get(producerName1);
         assertNotNull(lastSequenceIdPushed);
         assertEquals(lastSequenceIdPushed.longValue(), 8);
+        byteBuf1.release();
 
     }
 
@@ -408,8 +428,11 @@ public class MessageDuplicationTest extends BrokerTestBase {
                 .setSequenceId(seqId)
                 .setPublishTime(System.currentTimeMillis());
 
-        return serializeMetadataAndPayload(
-                Commands.ChecksumType.Crc32c, messageMetadata, io.netty.buffer.Unpooled.copiedBuffer(new byte[0]));
+        ByteBuf payload = Unpooled.copiedBuffer(new byte[0]);
+        ByteBuf byteBuf = serializeMetadataAndPayload(
+                Commands.ChecksumType.Crc32c, messageMetadata, payload);
+        payload.release();
+        return byteBuf;
     }
 
     public Topic.PublishContext getPublishContext(String producerName, long seqId) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsSnapshotBuilderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsSnapshotBuilderTest.java
@@ -26,6 +26,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import io.netty.buffer.ByteBuf;
+import java.io.IOException;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +38,7 @@ import org.apache.pulsar.common.api.proto.ReplicatedSubscriptionsSnapshotRequest
 import org.apache.pulsar.common.api.proto.ReplicatedSubscriptionsSnapshotResponse;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.protocol.Markers;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -49,6 +51,7 @@ public class ReplicatedSubscriptionsSnapshotBuilderTest {
     private ServiceConfiguration conf;
     private ReplicatedSubscriptionsController controller;
     private List<ByteBuf> markers;
+    private List<ByteBuf> releaseQueue;
 
     @BeforeMethod
     public void setup() {
@@ -59,6 +62,7 @@ public class ReplicatedSubscriptionsSnapshotBuilderTest {
         conf.setReplicatedSubscriptionsSnapshotTimeoutSeconds(3);
 
         markers = new ArrayList<>();
+        releaseQueue = new ArrayList<>();
 
         controller = mock(ReplicatedSubscriptionsController.class);
         when(controller.localCluster()).thenReturn(localCluster);
@@ -70,6 +74,16 @@ public class ReplicatedSubscriptionsSnapshotBuilderTest {
         })
                 .when(controller)
                 .writeMarker(any(ByteBuf.class));
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        if (markers != null) {
+            markers.forEach(ByteBuf::release);
+        }
+        if (releaseQueue != null) {
+            releaseQueue.forEach(ByteBuf::release);
+        }
     }
 
     @Test
@@ -84,8 +98,7 @@ public class ReplicatedSubscriptionsSnapshotBuilderTest {
 
         // Should have sent out a marker to initiate the snapshot
         assertEquals(markers.size(), 1);
-        ReplicatedSubscriptionsSnapshotRequest request = Markers
-                .parseReplicatedSubscriptionsSnapshotRequest(markers.remove(0));
+        ReplicatedSubscriptionsSnapshotRequest request = parseReplicatedSubscriptionsSnapshotRequest();
         assertEquals(request.getSourceCluster(), localCluster);
 
         // Simulate the responses coming back
@@ -110,6 +123,19 @@ public class ReplicatedSubscriptionsSnapshotBuilderTest {
         assertEquals(snapshot.getLocalMessageId().getEntryId(), 1);
     }
 
+    private ReplicatedSubscriptionsSnapshotRequest parseReplicatedSubscriptionsSnapshotRequest()
+            throws IOException {
+        ByteBuf byteBuf = markers.remove(0);
+        releaseQueue.add(byteBuf);
+        return Markers.parseReplicatedSubscriptionsSnapshotRequest(byteBuf);
+    }
+
+    private ReplicatedSubscriptionsSnapshot parseReplicatedSubscriptionsSnapshot() throws IOException {
+        ByteBuf byteBuf = markers.remove(0);
+        releaseQueue.add(byteBuf);
+        return Markers.parseReplicatedSubscriptionsSnapshot(byteBuf);
+    }
+
     @Test
     public void testBuildSnapshotWith3Clusters() throws Exception {
         ReplicatedSubscriptionsSnapshotBuilder builder = new ReplicatedSubscriptionsSnapshotBuilder(controller,
@@ -122,8 +148,7 @@ public class ReplicatedSubscriptionsSnapshotBuilderTest {
 
         // Should have sent out a marker to initiate the snapshot
         assertEquals(markers.size(), 1);
-        ReplicatedSubscriptionsSnapshotRequest request = Markers
-                .parseReplicatedSubscriptionsSnapshotRequest(markers.remove(0));
+        ReplicatedSubscriptionsSnapshotRequest request = parseReplicatedSubscriptionsSnapshotRequest();
         assertEquals(request.getSourceCluster(), localCluster);
 
         // Simulate the responses coming back
@@ -150,7 +175,7 @@ public class ReplicatedSubscriptionsSnapshotBuilderTest {
 
         // Since we have 2 remote clusters, a 2nd round of snapshot will be taken
         assertEquals(markers.size(), 1);
-        request = Markers.parseReplicatedSubscriptionsSnapshotRequest(markers.remove(0));
+        request = parseReplicatedSubscriptionsSnapshotRequest();
         assertEquals(request.getSourceCluster(), localCluster);
 
         // Responses coming back
@@ -177,7 +202,7 @@ public class ReplicatedSubscriptionsSnapshotBuilderTest {
 
         // At this point the snapshot should be created
         assertEquals(markers.size(), 1);
-        ReplicatedSubscriptionsSnapshot snapshot = Markers.parseReplicatedSubscriptionsSnapshot(markers.remove(0));
+        ReplicatedSubscriptionsSnapshot snapshot = parseReplicatedSubscriptionsSnapshot();
         assertEquals(snapshot.getClustersCount(), 2);
         assertEquals(snapshot.getClusterAt(0).getCluster(), "b");
         assertEquals(snapshot.getClusterAt(0).getMessageId().getLedgerId(), 11);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerMemoryLimitTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerMemoryLimitTest.java
@@ -34,17 +34,29 @@ import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SizeUnit;
+import org.apache.pulsar.tests.ExtendedNettyLeakDetector;
 import org.mockito.Mockito;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker-impl")
 public class ProducerMemoryLimitTest extends ProducerConsumerBase {
+    @BeforeClass(alwaysRun = true)
+    public void disableExitJVMOnLeak() {
+        ExtendedNettyLeakDetector.disableExitJVMOnLeak();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void restoreExitJVMOnLeak() {
+        ExtendedNettyLeakDetector.restoreExitJVMOnLeak();
+    }
 
     @Override
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     protected void setup() throws Exception {
         super.internalSetup();
         super.producerBaseSetup();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageImplTest.java
@@ -18,13 +18,20 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.fail;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-
 import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
@@ -39,23 +46,25 @@ import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.tests.ExtendedNettyLeakDetector;
 import org.testng.Assert;
-
-import static org.mockito.Mockito.when;
-import static org.testng.AssertJUnit.fail;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 /**
  * Unit test of {@link MessageImpl}.
  */
 public class MessageImplTest {
+    @BeforeClass(alwaysRun = true)
+    public void disableExitJVMOnLeak() {
+        ExtendedNettyLeakDetector.disableExitJVMOnLeak();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void restoreExitJVMOnLeak() {
+        ExtendedNettyLeakDetector.restoreExitJVMOnLeak();
+    }
 
     @Test
     public void testGetSequenceIdNotAssociated() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
@@ -369,6 +369,7 @@ public final class SchemaUtils {
         ByteBuf byteBuf = PulsarByteBufAllocator.DEFAULT.heapBuffer(dataLength);
         byteBuf.writeInt(keyBytes.length).writeBytes(keyBytes).writeInt(valueBytes.length).writeBytes(valueBytes);
         byteBuf.readBytes(schema);
+        byteBuf.release();
         return schema;
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/ByteBufPair.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/ByteBufPair.java
@@ -82,13 +82,21 @@ public final class ByteBufPair extends AbstractReferenceCounted {
     }
 
     /**
-     * @return a single buffer with the content of both individual buffers
+     * Combines the content of both buffers into a single {@link ByteBuf}.
+     *
+     * <p>This method creates a new {@link ByteBuf} with the combined readable content
+     * of the two buffers in the given {@link ByteBufPair}. The original buffer is
+     * released after the data is written into the new buffer.
+     *
+     * @param pair the {@link ByteBufPair} containing the two buffers to be coalesced
+     * @return a new {@link ByteBuf} containing the combined content of both buffers
      */
     @VisibleForTesting
     public static ByteBuf coalesce(ByteBufPair pair) {
         ByteBuf b = Unpooled.buffer(pair.readableBytes());
         b.writeBytes(pair.b1, pair.b1.readerIndex(), pair.b1.readableBytes());
         b.writeBytes(pair.b2, pair.b2.readerIndex(), pair.b2.readableBytes());
+        pair.release();
         return b;
     }
 

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/allocator/PulsarByteBufAllocatorDefaultTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/allocator/PulsarByteBufAllocatorDefaultTest.java
@@ -25,7 +25,6 @@ import static org.testng.Assert.assertTrue;
 import io.netty.buffer.ByteBufAllocator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.bookkeeper.common.allocator.LeakDetectionPolicy;
 import org.apache.bookkeeper.common.allocator.OutOfMemoryPolicy;
 import org.apache.bookkeeper.common.allocator.PoolingPolicy;
 import org.apache.bookkeeper.common.allocator.impl.ByteBufAllocatorImpl;
@@ -48,7 +47,6 @@ public class PulsarByteBufAllocatorDefaultTest {
             assertTrue(arguments.get(0) instanceof ByteBufAllocator);
             assertEquals(arguments.get(2), PoolingPolicy.PooledDirect);
             assertEquals(arguments.get(4), OutOfMemoryPolicy.FallbackToHeap);
-            assertEquals(arguments.get(6), LeakDetectionPolicy.Advanced);
         })) {
             assertFalse(called.get());
             PulsarByteBufAllocator.createByteBufAllocator();

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/allocator/PulsarByteBufAllocatorOomThrowExceptionTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/allocator/PulsarByteBufAllocatorOomThrowExceptionTest.java
@@ -25,7 +25,6 @@ import static org.testng.Assert.assertTrue;
 import io.netty.buffer.ByteBufAllocator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.bookkeeper.common.allocator.LeakDetectionPolicy;
 import org.apache.bookkeeper.common.allocator.OutOfMemoryPolicy;
 import org.apache.bookkeeper.common.allocator.PoolingPolicy;
 import org.apache.bookkeeper.common.allocator.impl.ByteBufAllocatorImpl;
@@ -49,7 +48,6 @@ public class PulsarByteBufAllocatorOomThrowExceptionTest {
                     assertTrue(arguments.get(0) instanceof ByteBufAllocator);
                     assertEquals(arguments.get(2), PoolingPolicy.PooledDirect);
                     assertEquals(arguments.get(4), OutOfMemoryPolicy.ThrowException);
-                    assertEquals(arguments.get(6), LeakDetectionPolicy.Advanced);
                 })) {
             assertFalse(called.get());
             PulsarByteBufAllocator.createByteBufAllocator();

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/compression/CompressorCodecTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/compression/CompressorCodecTest.java
@@ -139,6 +139,8 @@ public class CompressorCodecTest {
         ByteBuf uncompressed = codec.decode(compressed, 0);
 
         assertEquals(uncompressed, Unpooled.EMPTY_BUFFER);
+        compressed.release();
+        uncompressed.release();
     }
 
     @Test(dataProvider = "codecAndText")

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/MarkersTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/MarkersTest.java
@@ -47,6 +47,7 @@ public class MarkersTest {
 
         assertEquals(request.getSnapshotId(), "sid");
         assertEquals(request.getSourceCluster(), "us-west");
+        buf.release();
     }
 
     @Test
@@ -63,6 +64,7 @@ public class MarkersTest {
         assertEquals(response.getCluster().getCluster(), "us-east");
         assertEquals(response.getCluster().getMessageId().getLedgerId(), 5);
         assertEquals(response.getCluster().getMessageId().getEntryId(), 7);
+        buf.release();
     }
 
     @Test
@@ -91,6 +93,7 @@ public class MarkersTest {
         assertEquals(snapshot.getClusterAt(1).getCluster(), "us-east");
         assertEquals(snapshot.getClusterAt(1).getMessageId().getLedgerId(), 10);
         assertEquals(snapshot.getClusterAt(1).getMessageId().getEntryId(), 11);
+        buf.release();
     }
 
     @Test
@@ -115,6 +118,7 @@ public class MarkersTest {
         assertEquals(snapshot.getClusterAt(1).getCluster(), "us-east");
         assertEquals(snapshot.getClusterAt(1).getMessageId().getLedgerId(), 10);
         assertEquals(snapshot.getClusterAt(1).getMessageId().getEntryId(), 11);
+        buf.release();
     }
 
     @Test
@@ -130,6 +134,7 @@ public class MarkersTest {
         assertEquals(msgMetadata.getSequenceId(), sequenceId);
         assertEquals(msgMetadata.getTxnidMostBits(), mostBits);
         assertEquals(msgMetadata.getTxnidLeastBits(), leastBits);
+        buf.release();
     }
 
     @Test
@@ -146,6 +151,7 @@ public class MarkersTest {
         assertEquals(msgMetadata.getSequenceId(), sequenceId);
         assertEquals(msgMetadata.getTxnidMostBits(), mostBits);
         assertEquals(msgMetadata.getTxnidLeastBits(), leastBits);
+        buf.release();
     }
 
 }

--- a/tests/bc_2_0_0/pom.xml
+++ b/tests/bc_2_0_0/pom.xml
@@ -92,7 +92,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx2G -XX:MaxDirectMemorySize=8G
-                                -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>
                             <skipTests>false</skipTests>

--- a/tests/bc_2_0_1/pom.xml
+++ b/tests/bc_2_0_1/pom.xml
@@ -92,7 +92,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx2G -XX:MaxDirectMemorySize=8G
-                                -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>
                             <skipTests>false</skipTests>

--- a/tests/bc_2_6_0/pom.xml
+++ b/tests/bc_2_6_0/pom.xml
@@ -99,7 +99,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx2G -XX:MaxDirectMemorySize=8G
-                                -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>
                             <skipTests>false</skipTests>

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -39,3 +39,6 @@ RUN mv /etc/supervisord/conf.d/supervisord.conf /etc/supervisord.conf
 COPY target/certificate-authority /pulsar/certificate-authority/
 
 COPY target/java-test-functions.jar /pulsar/examples/
+
+# copy buildtools.jar to /pulsar/lib so that org.apache.pulsar.tests.ExtendedNettyLeakDetector can be used
+COPY target/buildtools.jar /pulsar/lib/

--- a/tests/docker-images/java-test-image/pom.xml
+++ b/tests/docker-images/java-test-image/pom.xml
@@ -91,6 +91,15 @@
                       <outputDirectory>${project.build.directory}</outputDirectory>
                       <destFileName>pulsar-server-distribution-bin.tar.gz</destFileName>
                     </artifactItem>
+                    <artifactItem>
+                      <groupId>org.apache.pulsar</groupId>
+                      <artifactId>buildtools</artifactId>
+                      <version>${project.parent.version}</version>
+                      <type>jar</type>
+                      <overWrite>true</overWrite>
+                      <outputDirectory>${project.build.directory}</outputDirectory>
+                      <destFileName>buildtools.jar</destFileName>
+                    </artifactItem>
                   </artifactItems>
                 </configuration>
               </execution>

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -64,6 +64,9 @@ RUN chmod g+rx /pulsar/examples/python-examples/
 # copy java test examples
 COPY target/java-test-functions.jar /pulsar/examples/
 
+# copy buildtools.jar to /pulsar/lib so that org.apache.pulsar.tests.ExtendedNettyLeakDetector can be used
+COPY target/buildtools.jar /pulsar/lib/
+
 # copy go test examples
 COPY --from=pulsar-function-go /go/bin /pulsar/examples/go-examples
 

--- a/tests/docker-images/latest-version-image/pom.xml
+++ b/tests/docker-images/latest-version-image/pom.xml
@@ -94,6 +94,15 @@
                       <outputDirectory>${project.build.directory}/plugins</outputDirectory>
                       <destFileName>java-test-plugins.nar</destFileName>
                     </artifactItem>
+                    <artifactItem>
+                      <groupId>org.apache.pulsar</groupId>
+                      <artifactId>buildtools</artifactId>
+                      <version>${project.parent.version}</version>
+                      <type>jar</type>
+                      <overWrite>true</overWrite>
+                      <outputDirectory>${project.build.directory}</outputDirectory>
+                      <destFileName>buildtools.jar</destFileName>
+                    </artifactItem>
                   </artifactItems>
                 </configuration>
               </execution>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -302,7 +302,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx1G -XX:MaxDirectMemorySize=1G
-              -Dio.netty.leakDetectionLevel=advanced -Dconfluent.version=${confluent.version} -Djacoco.version=${jacoco-maven-plugin.version}
+              -Dconfluent.version=${confluent.version} -Djacoco.version=${jacoco-maven-plugin.version}
               -Dintegrationtest.coverage.enabled=${integrationtest.coverage.enabled} -Dintegrationtest.coverage.dir=${integrationtest.coverage.dir}
               ${test.additional.args}
               </argLine>

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/BKContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/BKContainer.java
@@ -30,4 +30,9 @@ public class BKContainer extends PulsarContainer<BKContainer> {
             clusterName, hostName, hostName, "bin/run-bookie.sh", BOOKIE_PORT, INVALID_PORT);
         tailContainerLog();
     }
+
+    @Override
+    protected boolean isPassNettyLeakDetectionSystemProperties() {
+        return false;
+    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/CSContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/CSContainer.java
@@ -39,4 +39,9 @@ public class CSContainer extends PulsarContainer<CSContainer> {
     protected boolean isCodeCoverageEnabled() {
         return false;
     }
+
+    @Override
+    protected boolean isPassNettyLeakDetectionSystemProperties() {
+        return false;
+    }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ChaosContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ChaosContainer.java
@@ -19,12 +19,11 @@
 package org.apache.pulsar.tests.integration.containers;
 
 import com.github.dockerjava.api.DockerClient;
-
 import java.util.Base64;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
 import org.apache.pulsar.tests.integration.utils.DockerUtils;
 import org.testcontainers.containers.GenericContainer;
@@ -46,6 +45,26 @@ public class ChaosContainer<SelfT extends ChaosContainer<SelfT>> extends Generic
     protected void configure() {
         super.configure();
         addEnv("MALLOC_ARENA_MAX", "1");
+    }
+
+    protected void appendToEnv(String key, String value) {
+        String existingValue = getEnvMap().get(key);
+        if (existingValue == null) {
+            addEnv(key, value);
+        } else {
+            addEnv(key, existingValue + " " + value);
+        }
+    }
+
+    protected void passSystemPropertyInEnv(String envKey, String systemPropertyName) {
+        String systemPropertyValue = System.getProperty(systemPropertyName);
+        if (systemPropertyValue != null) {
+            String entryValue = "-D" + systemPropertyName + "=" + systemPropertyValue;
+            if (StringUtils.containsWhitespace(systemPropertyValue)) {
+                entryValue = "\"" + entryValue + "\"";
+            }
+            appendToEnv(envKey, entryValue);
+        }
     }
 
     protected void beforeStop() {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PulsarContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PulsarContainer.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.tests.integration.containers;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -29,6 +28,7 @@ import java.util.UUID;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
+import org.apache.pulsar.tests.ExtendedNettyLeakDetector;
 import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
 import org.apache.pulsar.tests.integration.utils.DockerUtils;
 import org.testcontainers.containers.BindMode;
@@ -252,10 +252,35 @@ public abstract class PulsarContainer<SelfT extends PulsarContainer<SelfT>> exte
             configureCodeCoverage();
         }
 
+        if (isPassNettyLeakDetectionSystemProperties()) {
+            passNettyLeakDetectionSystemProperties();
+        }
+
         beforeStart();
         super.start();
         afterStart();
         log.info("[{}] Start pulsar service {} at container {}", getContainerName(), serviceName, getContainerId());
+    }
+
+    protected boolean isPassNettyLeakDetectionSystemProperties() {
+        return true;
+    }
+
+    protected void passNettyLeakDetectionSystemProperties() {
+        if (isPassNettyLeakDetectionSystemProperties()) {
+            String envKey = "PULSAR_EXTRA_OPTS";
+            // pass similar defaults as there is in conf/pulsar_env.sh
+            appendToEnv("PULSAR_EXTRA_OPTS",
+                    "-Dpulsar.allocator.exit_on_oom=true -Dio.netty.recycler.maxCapacityPerThread=4096");
+            passSystemPropertyInEnv(envKey, "io.netty.customResourceLeakDetector");
+            passSystemPropertyInEnv(envKey, ExtendedNettyLeakDetector.EXIT_JVM_ON_LEAK_SYSTEM_PROPERTY_NAME);
+            passSystemPropertyInEnv(envKey, ExtendedNettyLeakDetector.EXIT_JVM_DELAY_MILLIS_SYSTEM_PROPERTY_NAME);
+            passSystemPropertyInEnv(envKey, "io.netty.leakDetection.level");
+            passSystemPropertyInEnv(envKey, "io.netty.leakDetection.targetRecords");
+            passSystemPropertyInEnv(envKey, "io.netty.leakDetection.samplingInterval");
+            passSystemPropertyInEnv(envKey, "io.netty.leakDetection.acquireAndReleaseOnly");
+            addEnv("NETTY_LEAK_DUMP_DIR", "/var/log/pulsar");
+        }
     }
 
     protected boolean isCodeCoverageEnabled() {
@@ -286,7 +311,7 @@ public abstract class PulsarContainer<SelfT extends PulsarContainer<SelfT>> exte
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
-            withEnv("OPTS", "-javaagent:/jacocoDir/" + jacocoAgentJar.getName()
+            appendToEnv("OPTS", "-javaagent:/jacocoDir/" + jacocoAgentJar.getName()
                     + "=destfile=/jacocoDir/jacoco_" + getContainerName() + "_" + System.currentTimeMillis() + ".exec"
                     + ",includes=org.apache.pulsar.*:org.apache.bookkeeper.mledger.*"
                     + ",excludes=*.proto.*:*.shade.*:*.shaded.*");

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ZKContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ZKContainer.java
@@ -39,4 +39,10 @@ public class ZKContainer extends PulsarContainer<ZKContainer> {
     protected boolean isCodeCoverageEnabled() {
         return false;
     }
+
+
+    @Override
+    protected boolean isPassNettyLeakDetectionSystemProperties() {
+        return false;
+    }
 }

--- a/tests/pulsar-client-admin-shade-test/pom.xml
+++ b/tests/pulsar-client-admin-shade-test/pom.xml
@@ -107,7 +107,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx2G -XX:MaxDirectMemorySize=8G
-                                -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>
                             <skipTests>false</skipTests>

--- a/tests/pulsar-client-all-shade-test/pom.xml
+++ b/tests/pulsar-client-all-shade-test/pom.xml
@@ -106,7 +106,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx2G -XX:MaxDirectMemorySize=8G
-                                -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>
                             <skipTests>false</skipTests>

--- a/tests/pulsar-client-shade-test/pom.xml
+++ b/tests/pulsar-client-shade-test/pom.xml
@@ -101,7 +101,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx2G -XX:MaxDirectMemorySize=8G
-                                -Dio.netty.leakDetectionLevel=advanced
                                 ${test.additional.args}
                             </argLine>
                             <skipTests>false</skipTests>


### PR DESCRIPTION
### Motivation

To prevent future memory leak regressions, it's useful to Netty leak detection enabled in CI and make leaks fail the build.

### Modifications

- add custom io.netty.util.ResourceLeakDetector implementation that logs leaks to files
- configure Netty leak detector for unit tests and integration tests
- show detected leaks directly in GitHub Action UI and make log records downloadable

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/201
