### PR TITLE
[improve][broker] Avoid PersistentReplicator.expireMessages logic compute backlog twice

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -670,8 +670,8 @@ public abstract class PersistentReplicator extends AbstractReplicator
 
     @Override
     public boolean expireMessages(int messageTTLInSeconds) {
-        if ((cursor.getNumberOfEntriesInBacklog(false) == 0)
-                || (cursor.getNumberOfEntriesInBacklog(false) < MINIMUM_BACKLOG_FOR_EXPIRY_CHECK
+        long backlog = cursor.getNumberOfEntriesInBacklog(false);
+        if ((backlog == 0) || (backlog < MINIMUM_BACKLOG_FOR_EXPIRY_CHECK
                         && !topic.isOldestMessageExpired(cursor, messageTTLInSeconds))) {
             // don't do anything for almost caught-up connected subscriptions
             return false;


### PR DESCRIPTION
### Motivation
Function `cursor.getNumberOfEntriesInBacklog(false)` maybe called twice in `PersistentReplicator.expireMessages`.

This PR https://github.com/apache/pulsar/pull/20416 optimizes similar problems in `PersistentSubscription.expireMessages`.

### Modifications
Save backlog to variable.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->