### PR TITLE
[fix] Use Alpine 3.21 in base image

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-ARG ALPINE_VERSION=3.20
+ARG ALPINE_VERSION=3.21
 ARG IMAGE_JDK_MAJOR_VERSION=21
 
 # First create a stage with just the Pulsar tarball and scripts


### PR DESCRIPTION

### Motivation

There are several CVEs in base image with Alpine 3.20 that are already fixed in 3.21: 

```
apachepulsar/pulsar:4.0.2 (alpine 3.20.5)

Total: 14 (UNKNOWN: 0, LOW: 3, MEDIUM: 7, HIGH: 4, CRITICAL: 0)

┌──────────────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│       Library        │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                            │
├──────────────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ bind-libs            │ CVE-2024-11187 │ HIGH     │ fixed  │ 9.18.32-r0        │ 9.18.33-r0    │ bind: bind9: Many records in the additional section cause   │
│                      │                │          │        │                   │               │ CPU exhaustion                                              │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-11187                  │
│                      ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-12705 │          │        │                   │               │ bind: bind9: DNS-over-HTTPS implementation suffers from     │
│                      │                │          │        │                   │               │ multiple issues under heavy query load...                   │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-12705                  │
├──────────────────────┼────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│ bind-tools           │ CVE-2024-11187 │          │        │                   │               │ bind: bind9: Many records in the additional section cause   │
│                      │                │          │        │                   │               │ CPU exhaustion                                              │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-11187                  │
│                      ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-12705 │          │        │                   │               │ bind: bind9: DNS-over-HTTPS implementation suffers from     │
│                      │                │          │        │                   │               │ multiple issues under heavy query load...                   │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-12705                  │
├──────────────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libcrypto3           │ CVE-2024-13176 │ MEDIUM   │        │ 3.3.2-r1          │ 3.3.2-r2      │ openssl: Timing side-channel in ECDSA signature computation │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-13176                  │
│                      ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-9143  │ LOW      │        │                   │ 3.3.2-r3      │ openssl: Low-level invalid GF(2^m) parameters lead to OOB   │
│                      │                │          │        │                   │               │ memory access                                               │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-9143                   │
├──────────────────────┼────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│ libssl3              │ CVE-2024-13176 │ MEDIUM   │        │                   │ 3.3.2-r2      │ openssl: Timing side-channel in ECDSA signature computation │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-13176                  │
│                      ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-9143  │ LOW      │        │                   │ 3.3.2-r3      │ openssl: Low-level invalid GF(2^m) parameters lead to OOB   │
│                      │                │          │        │                   │               │ memory access                                               │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-9143                   │
├──────────────────────┼────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│ openssl              │ CVE-2024-13176 │ MEDIUM   │        │                   │ 3.3.2-r2      │ openssl: Timing side-channel in ECDSA signature computation │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-13176                  │
│                      ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-9143  │ LOW      │        │                   │ 3.3.2-r3      │ openssl: Low-level invalid GF(2^m) parameters lead to OOB   │
│                      │                │          │        │                   │               │ memory access                                               │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-9143                   │
├──────────────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ pyc                  │ CVE-2025-0938  │ MEDIUM   │        │ 3.12.8-r1         │ 3.12.9-r0     │ python: cpython: URL parser allowed square brackets in      │
│                      │                │          │        │                   │               │ domain names                                                │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-0938                   │
├──────────────────────┤                │          │        │                   │               │                                                             │
│ python3              │                │          │        │                   │               │                                                             │
│                      │                │          │        │                   │               │                                                             │
│                      │                │          │        │                   │               │                                                             │
├──────────────────────┤                │          │        │                   │               │                                                             │
│ python3-pyc          │                │          │        │                   │               │                                                             │
│                      │                │          │        │                   │               │                                                             │
│                      │                │          │        │                   │               │                                                             │
├──────────────────────┤                │          │        │                   │               │                                                             │
│ python3-pycache-pyc0 │                │          │        │                   │               │                                                             │
│                      │                │          │        │                   │               │                                                             │
│                      │                │          │        │                   │               │                                                             │
└──────────────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘
```

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
