### PR TITLE
[fix][sec] Upgrade to Netty 4.1.118

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -47,7 +47,7 @@
     <license-maven-plugin.version>4.1</license-maven-plugin.version>
     <puppycrawl.checkstyle.version>10.14.2</puppycrawl.checkstyle.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-    <netty.version>4.1.117.Final</netty.version>
+    <netty.version>4.1.118.Final</netty.version>
     <guice.version>4.2.3</guice.version>
     <guava.version>32.1.2-jre</guava.version>
     <ant.version>1.10.12</ant.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -293,26 +293,26 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-lang3-3.11.jar
     - org.apache.commons-commons-text-1.10.0.jar
  * Netty
-    - io.netty-netty-buffer-4.1.117.Final.jar
-    - io.netty-netty-codec-4.1.117.Final.jar
-    - io.netty-netty-codec-dns-4.1.117.Final.jar
-    - io.netty-netty-codec-http-4.1.117.Final.jar
-    - io.netty-netty-codec-http2-4.1.117.Final.jar
-    - io.netty-netty-codec-socks-4.1.117.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.117.Final.jar
-    - io.netty-netty-common-4.1.117.Final.jar
-    - io.netty-netty-handler-4.1.117.Final.jar
-    - io.netty-netty-handler-proxy-4.1.117.Final.jar
-    - io.netty-netty-resolver-4.1.117.Final.jar
-    - io.netty-netty-resolver-dns-4.1.117.Final.jar
-    - io.netty-netty-resolver-dns-classes-macos-4.1.117.Final.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.117.Final-osx-aarch_64.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.117.Final-osx-x86_64.jar
-    - io.netty-netty-transport-4.1.117.Final.jar
-    - io.netty-netty-transport-classes-epoll-4.1.117.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.117.Final-linux-aarch_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.117.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-unix-common-4.1.117.Final.jar
+    - io.netty-netty-buffer-4.1.118.Final.jar
+    - io.netty-netty-codec-4.1.118.Final.jar
+    - io.netty-netty-codec-dns-4.1.118.Final.jar
+    - io.netty-netty-codec-http-4.1.118.Final.jar
+    - io.netty-netty-codec-http2-4.1.118.Final.jar
+    - io.netty-netty-codec-socks-4.1.118.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.118.Final.jar
+    - io.netty-netty-common-4.1.118.Final.jar
+    - io.netty-netty-handler-4.1.118.Final.jar
+    - io.netty-netty-handler-proxy-4.1.118.Final.jar
+    - io.netty-netty-resolver-4.1.118.Final.jar
+    - io.netty-netty-resolver-dns-4.1.118.Final.jar
+    - io.netty-netty-resolver-dns-classes-macos-4.1.118.Final.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.118.Final-osx-aarch_64.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.118.Final-osx-x86_64.jar
+    - io.netty-netty-transport-4.1.118.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.118.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.118.Final-linux-aarch_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.118.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-unix-common-4.1.118.Final.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.69.Final.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.69.Final-linux-aarch_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.69.Final-linux-x86_64.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -313,13 +313,13 @@ The Apache Software License, Version 2.0
     - io.netty-netty-transport-native-epoll-4.1.118.Final-linux-aarch_64.jar
     - io.netty-netty-transport-native-epoll-4.1.118.Final-linux-x86_64.jar
     - io.netty-netty-transport-native-unix-common-4.1.118.Final.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.69.Final.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.69.Final-linux-aarch_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.69.Final-linux-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.69.Final-osx-aarch_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.69.Final-osx-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.69.Final-windows-x86_64.jar
-    - io.netty-netty-tcnative-classes-2.0.69.Final.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.70.Final.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.70.Final-linux-aarch_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.70.Final-linux-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.70.Final-osx-aarch_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.70.Final-osx-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.70.Final-windows-x86_64.jar
+    - io.netty-netty-tcnative-classes-2.0.70.Final.jar
     - io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.26.Final.jar
     - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar
     - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -347,22 +347,22 @@ The Apache Software License, Version 2.0
     - commons-text-1.10.0.jar
     - commons-compress-1.26.0.jar
  * Netty
-    - netty-buffer-4.1.117.Final.jar
-    - netty-codec-4.1.117.Final.jar
-    - netty-codec-dns-4.1.117.Final.jar
-    - netty-codec-http-4.1.117.Final.jar
-    - netty-codec-socks-4.1.117.Final.jar
-    - netty-codec-haproxy-4.1.117.Final.jar
-    - netty-common-4.1.117.Final.jar
-    - netty-handler-4.1.117.Final.jar
-    - netty-handler-proxy-4.1.117.Final.jar
-    - netty-resolver-4.1.117.Final.jar
-    - netty-resolver-dns-4.1.117.Final.jar
-    - netty-transport-4.1.117.Final.jar
-    - netty-transport-classes-epoll-4.1.117.Final.jar
-    - netty-transport-native-epoll-4.1.117.Final-linux-aarch_64.jar
-    - netty-transport-native-epoll-4.1.117.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.117.Final.jar
+    - netty-buffer-4.1.118.Final.jar
+    - netty-codec-4.1.118.Final.jar
+    - netty-codec-dns-4.1.118.Final.jar
+    - netty-codec-http-4.1.118.Final.jar
+    - netty-codec-socks-4.1.118.Final.jar
+    - netty-codec-haproxy-4.1.118.Final.jar
+    - netty-common-4.1.118.Final.jar
+    - netty-handler-4.1.118.Final.jar
+    - netty-handler-proxy-4.1.118.Final.jar
+    - netty-resolver-4.1.118.Final.jar
+    - netty-resolver-dns-4.1.118.Final.jar
+    - netty-transport-4.1.118.Final.jar
+    - netty-transport-classes-epoll-4.1.118.Final.jar
+    - netty-transport-native-epoll-4.1.118.Final-linux-aarch_64.jar
+    - netty-transport-native-epoll-4.1.118.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.118.Final.jar
     - netty-tcnative-boringssl-static-2.0.69.Final.jar
     - netty-tcnative-boringssl-static-2.0.69.Final-linux-aarch_64.jar
     - netty-tcnative-boringssl-static-2.0.69.Final-linux-x86_64.jar
@@ -373,9 +373,9 @@ The Apache Software License, Version 2.0
     - netty-incubator-transport-classes-io_uring-0.0.26.Final.jar
     - netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar
     - netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar
-    - netty-resolver-dns-classes-macos-4.1.117.Final.jar
-    - netty-resolver-dns-native-macos-4.1.117.Final-osx-aarch_64.jar
-    - netty-resolver-dns-native-macos-4.1.117.Final-osx-x86_64.jar
+    - netty-resolver-dns-classes-macos-4.1.118.Final.jar
+    - netty-resolver-dns-native-macos-4.1.118.Final-osx-aarch_64.jar
+    - netty-resolver-dns-native-macos-4.1.118.Final-osx-x86_64.jar
  * Prometheus client
     - simpleclient-0.16.0.jar
     - simpleclient_log4j2-0.16.0.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -363,13 +363,13 @@ The Apache Software License, Version 2.0
     - netty-transport-native-epoll-4.1.118.Final-linux-aarch_64.jar
     - netty-transport-native-epoll-4.1.118.Final-linux-x86_64.jar
     - netty-transport-native-unix-common-4.1.118.Final.jar
-    - netty-tcnative-boringssl-static-2.0.69.Final.jar
-    - netty-tcnative-boringssl-static-2.0.69.Final-linux-aarch_64.jar
-    - netty-tcnative-boringssl-static-2.0.69.Final-linux-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.69.Final-osx-aarch_64.jar
-    - netty-tcnative-boringssl-static-2.0.69.Final-osx-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.69.Final-windows-x86_64.jar
-    - netty-tcnative-classes-2.0.69.Final.jar
+    - netty-tcnative-boringssl-static-2.0.70.Final.jar
+    - netty-tcnative-boringssl-static-2.0.70.Final-linux-aarch_64.jar
+    - netty-tcnative-boringssl-static-2.0.70.Final-linux-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.70.Final-osx-aarch_64.jar
+    - netty-tcnative-boringssl-static-2.0.70.Final-osx-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.70.Final-windows-x86_64.jar
+    - netty-tcnative-classes-2.0.70.Final.jar
     - netty-incubator-transport-classes-io_uring-0.0.26.Final.jar
     - netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar
     - netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.10.5</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.7.1</curator.version>
-    <netty.version>4.1.117.Final</netty.version>
+    <netty.version>4.1.118.Final</netty.version>
     <netty-iouring.version>0.0.26.Final</netty-iouring.version>
     <jetty.version>9.4.56.v20240826</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>


### PR DESCRIPTION
### Motivation


```
┌─────────────────────────────────────────────────────┬────────────────┬──────────┬──────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│                       Library                       │ Vulnerability  │ Severity │  Status  │ Installed Version │ Fixed Version │                           Title                           │
├─────────────────────────────────────────────────────┼────────────────┼──────────┼──────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ io.netty:netty-handler                              │ CVE-2025-24970 │ HIGH     │ fixed    │ 4.1.117.Final     │ 4.1.118.Final │ Netty, an asynchronous, event-driven network application  │
│ (io.netty-netty-handler-4.1.117.Final.jar)          │                │          │          │                   │               │ framework, ha ...                                         │
│                                                     │                │          │          │                   │               │ https://avd.aquasec.com/nvd/cve-2025-24970                │
├─────────────────────────────────────────────────────┼────────────────┼──────────┤          ├───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
```

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
