### PR TITLE
[fix][build] Upgrade json-smart to 2.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@ flexible messaging model and an intuitive client API.</description>
     <clickhouse-jdbc.version>0.4.6</clickhouse-jdbc.version>
     <mariadb-jdbc.version>2.7.5</mariadb-jdbc.version>
     <openmldb-jdbc.version>0.4.4-hotfix1</openmldb-jdbc.version>
-    <json-smart.version>2.4.10</json-smart.version>
+    <json-smart.version>2.5.1</json-smart.version>
     <opensearch.version>2.16.0</opensearch.version>
     <elasticsearch-java.version>8.12.1</elasticsearch-java.version>
     <debezium.version>1.9.7.Final</debezium.version>
@@ -326,6 +326,11 @@ flexible messaging model and an intuitive client API.</description>
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>net.minidev</groupId>
+        <artifactId>json-smart</artifactId>
+        <version>${json-smart.version}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.jline</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@ flexible messaging model and an intuitive client API.</description>
     <clickhouse-jdbc.version>0.4.6</clickhouse-jdbc.version>
     <mariadb-jdbc.version>2.7.5</mariadb-jdbc.version>
     <openmldb-jdbc.version>0.4.4-hotfix1</openmldb-jdbc.version>
-    <json-smart.version>2.5.1</json-smart.version>
+    <json-smart.version>2.5.2</json-smart.version>
     <opensearch.version>2.16.0</opensearch.version>
     <elasticsearch-java.version>8.12.1</elasticsearch-java.version>
     <debezium.version>1.9.7.Final</debezium.version>


### PR DESCRIPTION
### Motivation

Build error on the branch-3.0:
```
$ mvn install -Pcore-modules,-main -DskipTests -Dspotbugs.skip=true -T 1C

Caused by: org.eclipse.aether.collection.DependencyCollectionException: Failed to collect dependencies at org.apache.kerby:kerb-simplekdc:jar:1.1.1 -> org.apache.kerby:kerb-client:jar:1.1.1 -> org.apache.kerby:token-provider:jar:1.1.1 -> com.nimbusds:nimbus-jose-jwt:jar:4.41.2 -> net.minidev:json-smart:jar:[1.3.1,2.3]
```

Build [error](https://github.com/apache/pulsar/actions/runs/13282620861/job/37084137661?pr=23966#step:7:4412) on master:
```
Error:  Failed to execute goal on project pulsar-io-azuredataexplorer: Could not collect dependencies for project org.apache.pulsar:pulsar-io-azuredataexplorer:jar:4.1.0-SNAPSHOT
Error:  No versions available for net.minidev:json-smart:jar:[1.3.3,2.4.10] within specified range
Error:  No versions available for net.minidev:json-smart:jar:[1.3.1,2.3] within specified range
Error:  No versions available for net.minidev:json-smart:jar:[1.3.1,2.3] within specified range
Error:  No versions available for net.minidev:json-smart:jar:[1.3.1,2.3] within specified range
Error:  No versions available for net.minidev:json-smart:jar:[1.3.1,2.3] within specified range
Error:  No versions available for net.minidev:json-smart:jar:[1.3.1,2.3] within specified range
```

This is a bug: https://github.com/netplex/json-smart-v2/issues/240

### Modifications

- Upgrade json-smart to 2.5.2 from 2.4.10

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->