### PR TITLE
[improve][client] Update TypedMessageBuilder deliverAfter and deliverAt api comment

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TypedMessageBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TypedMessageBuilder.java
@@ -189,8 +189,8 @@ public interface TypedMessageBuilder<T> extends Serializable {
      * <p>The timestamp is milliseconds and based on UTC (eg: {@link System#currentTimeMillis()}.
      *
      * <p><b>Note</b>: messages are only delivered with delay when a consumer is consuming
-     * through a {@link SubscriptionType#Shared} subscription. With other subscription
-     * types, the messages will still be delivered immediately.
+     * through a {@link SubscriptionType#Shared} or {@link SubscriptionType#Key_Shared} subscription.
+     * With other subscription types, the messages will still be delivered immediately.
      *
      * @param timestamp
      *            absolute timestamp indicating when the message should be delivered to consumers
@@ -202,8 +202,8 @@ public interface TypedMessageBuilder<T> extends Serializable {
      * Request to deliver the message only after the specified relative delay.
      *
      * <p><b>Note</b>: messages are only delivered with delay when a consumer is consuming
-     * through a {@link SubscriptionType#Shared} subscription. With other subscription
-     * types, the messages will still be delivered immediately.
+     * through a {@link SubscriptionType#Shared} or {@link SubscriptionType#Key_Shared} subscription.
+     * With other subscription types, the messages will still be delivered immediately.
      *
      * @param delay
      *            the amount of delay before the message will be delivered


### PR DESCRIPTION
Fixes #23968

### Motivation
Related Issue: https://github.com/apache/pulsar-site/pull/507

We now support consuming delayed messages with shared and Key-shared type subscriptions, which has been corrected since [pulsar 3.x doc](https://pulsar.apache.org/docs/3.0.x/concepts-messaging/#delayed-message-delivery) in above pr.

But Java code [deliverAt](https://github.com/apache/pulsar/blob/1ab63455c1f36062cbc587244f8c0c5f71be16c5/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TypedMessageBuilder.java#L192) and [deliverAfter](https://github.com/apache/pulsar/blob/1ab63455c1f36062cbc587244f8c0c5f71be16c5/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TypedMessageBuilder.java#L205) comment says we can only support Shared type subscription, so that maybe we need to fix them.

### Modifications
Replace `{@link SubscriptionType#Shared}` comment with `{@link SubscriptionType#Shared} or {@link SubscriptionType#Key_Shared}` in deliverAt and deliverAfter api.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

