### PR TITLE
[improve][ci] Skip "OWASP dependency check" when data wasn't found in cache

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -1494,15 +1494,21 @@ jobs:
           restore-keys: |
             owasp-dependency-check-data-
 
+      - name: Log warning when skipped
+        if: ${{ !steps.restore-owasp-dependency-check-data.outputs.cache-matched-key }}
+        run: |
+          echo "::warning::OWASP Dependency Check was skipped since the OWASP Dependency check data wasn't found in the cache. Run ci-owasp-dependency-check.yaml workflow to update the cache."
+
       # Projects dependent on flume, hdfs, and hbase currently excluded from the scan.
       - name: trigger dependency check
+        if: ${{ steps.restore-owasp-dependency-check-data.outputs.cache-matched-key }}
         run: |
           mvn -B -ntp verify -PskipDocker,skip-all,owasp-dependency-check -Dcheckstyle.skip=true -DskipTests \
             -pl '!distribution/server,!distribution/io,!distribution/offloaders,!tiered-storage/file-system,!pulsar-io/flume,!pulsar-io/hbase,!pulsar-io/hdfs3,!pulsar-io/docs,!pulsar-io/jdbc/openmldb'
 
       - name: Upload report
         uses: actions/upload-artifact@v4
-        if: ${{ cancelled() || failure() }}
+        if: ${{ steps.restore-owasp-dependency-check-data.outputs.cache-matched-key && (cancelled() || failure()) }}
         continue-on-error: true
         with:
           name: dependency report


### PR DESCRIPTION
### Motivation

Pulsar CI runs an "OWASP dependency check" build as part of the CI workflow when a dependency is updated.
This can take very long for Pull Request builds when the dependency check data isn't found in the cache.

```
Warning:  An NVD API Key was not provided - it is highly recommended to use an NVD API key as the update can take a VERY long time without an API Key
[INFO] NVD API has 280,989 records in this update
[INFO] Downloaded 10,000/280,989 (4%)
[INFO] Downloaded 20,000/280,989 (7%)
[INFO] Downloaded 30,000/280,989 (11%)
[INFO] Downloaded 40,000/280,989 (14%)
[INFO] Downloaded 50,000/280,989 (18%)
[INFO] Downloaded 60,000/280,989 (21%)
[INFO] Downloaded 70,000/280,989 (25%)
[INFO] Downloaded 80,000/280,989 (28%)
[INFO] Downloaded 90,000/280,989 (32%)
[INFO] Downloaded 100,000/280,989 (36%)
[INFO] Downloaded 110,000/280,989 (39%)
[INFO] Downloaded 120,000/280,989 (43%)
[INFO] Downloaded 130,000/280,989 (46%)
[INFO] Downloaded 140,000/281,043 (50%)
[INFO] Downloaded 150,000/281,043 (53%)
[INFO] Downloaded 160,000/281,043 (57%)
[INFO] Downloaded 170,000/281,043 (60%)
...
```

### Modifications

Skip running "OWASP dependency check" when the dependency check data isn't found in the cache.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->