### PR TITLE
[fix] Potential fix for code scanning alert no. 22: HTTP response splitting

### DIFF
--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderSasl.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderSasl.java
@@ -330,6 +330,7 @@ public class AuthenticationProviderSasl implements AuthenticationProvider {
         if (value == null) {
             return null;
         }
-        return value.replaceAll("[\\r\\n]", "");
+        // Remove CRLF and other special characters
+        return value.replaceAll("[\\r\\n]", "").replaceAll("[^\\x20-\\x7E]", "");
     }
 }

--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderSasl.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderSasl.java
@@ -271,7 +271,7 @@ public class AuthenticationProviderSasl implements AuthenticationProvider {
             } else {
                 checkState(request.getHeader(SASL_HEADER_STATE).equalsIgnoreCase(SASL_STATE_SERVER_CHECK_TOKEN));
                 setResponseHeaderState(response, SASL_STATE_COMPLETE);
-                response.setHeader(SASL_STATE_SERVER, request.getHeader(SASL_STATE_SERVER));
+                response.setHeader(SASL_STATE_SERVER, sanitizeHeaderValue(request.getHeader(SASL_STATE_SERVER)));
                 response.setStatus(HttpServletResponse.SC_OK);
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Server side role token verified success: {}", request.getRequestURI(),
@@ -324,5 +324,12 @@ public class AuthenticationProviderSasl implements AuthenticationProvider {
                 return false;
             }
         }
+    }
+
+    private String sanitizeHeaderValue(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.replaceAll("[\\r\\n]", "");
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/apache/pulsar/security/code-scanning/22](https://github.com/apache/pulsar/security/code-scanning/22)

To fix the problem, we need to ensure that any user-provided input used in HTTP headers is properly sanitized to prevent HTTP response splitting. This can be done by removing or escaping special characters such as CRLF from the input before using it in the response header.

The best way to fix this issue is to create a method that sanitizes the input by removing or escaping special characters and then use this method to sanitize the `SASL_STATE_SERVER` header value before setting it in the response.


- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
