### PR TITLE
[fix][broker]Consumer stuck when delete subscription __compaction failed

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -245,6 +245,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     private static final Long COMPACTION_NEVER_RUN = -0xfebecffeL;
     private volatile CompletableFuture<Long> currentCompaction = CompletableFuture.completedFuture(
             COMPACTION_NEVER_RUN);
+    private volatile AtomicBoolean disablingCompaction = new AtomicBoolean(false);
     private TopicCompactionService topicCompactionService;
 
     // TODO: Create compaction strategy from topic policy when exposing strategic compaction to users.
@@ -1340,18 +1341,42 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             return;
         }
 
-        currentCompaction.handle((__, e) -> {
-            if (e != null) {
+        // Avoid concurrently execute compaction and unsubscribing.
+        synchronized (this) {
+            if (!disablingCompaction.compareAndSet(false, true)) {
+                unsubscribeFuture.completeExceptionally(
+                        new SubscriptionBusyException("the subscription is deleting by another task"));
+                return;
+            }
+        }
+        // Unsubscribe compaction cursor and delete compacted ledger.
+        currentCompaction.thenCompose(__ -> {
+            asyncDeleteCursor(subscriptionName, unsubscribeFuture);
+            return unsubscribeFuture;
+        }).thenAccept(__ -> {
+            try {
+                ((PulsarCompactorSubscription) subscription).cleanCompactedLedger();
+            } catch (Exception ex) {
+                Long compactedLedger = null;
+                Optional<CompactedTopicContext> compactedTopicContext = getCompactedTopicContext();
+                if (compactedTopicContext.isPresent() && compactedTopicContext.get().getLedger() != null) {
+                    compactedLedger = compactedTopicContext.get().getLedger().getId();
+                }
+                log.error("[{}][{}][{}] Error cleaning compacted ledger", topic, subscriptionName, compactedLedger, ex);
+            } finally {
+                // Reset the variable: disablingCompaction,
+                disablingCompaction.compareAndSet(true, false);
+            }
+        }).exceptionally(ex -> {
+            if (currentCompaction.isCompletedExceptionally()) {
                 log.warn("[{}][{}] Last compaction task failed", topic, subscriptionName);
-            }
-            return ((PulsarCompactorSubscription) subscription).cleanCompactedLedger();
-        }).whenComplete((__, ex) -> {
-            if (ex != null) {
-                log.error("[{}][{}] Error cleaning compacted ledger", topic, subscriptionName, ex);
-                unsubscribeFuture.completeExceptionally(ex);
             } else {
-                asyncDeleteCursor(subscriptionName, unsubscribeFuture);
+                log.warn("[{}][{}] Failed to delete cursor task failed", topic, subscriptionName);
             }
+            // Reset the variable: disablingCompaction,
+            disablingCompaction.compareAndSet(true, false);
+            unsubscribeFuture.completeExceptionally(ex);
+            return null;
         });
     }
 
@@ -3932,6 +3957,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             try {
                 if (isClosingOrDeleting) {
                     log.info("[{}] Topic is closing or deleting, skip triggering compaction", topic);
+                    return;
+                }
+                if (disablingCompaction.get()) {
+                    log.info("[{}] Compaction is disabling, skip triggering compaction", topic);
                     return;
                 }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
@@ -83,8 +83,15 @@ public class CompactedTopicImpl implements CompactedTopic {
             compactionHorizon = p;
 
             // delete the ledger from the old context once the new one is open
-            return compactedTopicContext.thenCompose(
-                    __ -> previousContext != null ? previousContext : CompletableFuture.completedFuture(null));
+            return compactedTopicContext.thenCompose(ctx -> {
+                if (ctx != null && ctx.getLedger() != null && ctx.getLedger().getId() == compactedLedgerId) {
+                    // Print an error log here, which is not expected.
+                    log.error("[__compaction] Using the same compacted ledger to override the old one, which is not"
+                                    + " expected and it may cause a ledger lost error. {} -> {}", compactedLedgerId,
+                            ctx.getLedger().getId());
+                }
+                return previousContext != null ? previousContext : CompletableFuture.completedFuture(null);
+            });
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/GetLastMessageIdCompactedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/GetLastMessageIdCompactedTest.java
@@ -21,16 +21,23 @@ package org.apache.pulsar.compaction;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.bookkeeper.client.api.BookKeeper;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -38,12 +45,17 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.ReaderImpl;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.MockZooKeeper;
 import org.awaitility.Awaitility;
+import org.awaitility.reflect.WhiteboxImpl;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -304,6 +316,145 @@ public class GetLastMessageIdCompactedTest extends ProducerConsumerBase {
 
         // cleanup.
         consumer.close();
+        producer.close();
+        admin.topics().delete(topicName, false);
+    }
+
+    @DataProvider
+    public Object[][] isInjectedCursorDeleteError() {
+        return new Object[][] {
+                {false},
+                {true}
+        };
+    }
+
+    @Test(dataProvider = "isInjectedCursorDeleteError")
+    public void testReadMsgsAfterUnloading(boolean isInjectedCursorDeleteError) throws Exception {
+        String topicName = "persistent://public/default/" + BrokerTestUtil.newUniqueName("tp");
+        admin.topics().createNonPartitionedTopic(topicName);
+        admin.topicPolicies().setCompactionThreshold(topicName, 1);
+        admin.topics().createSubscription(topicName, "s1", MessageId.earliest);
+        var producer = pulsarClient.newProducer(Schema.STRING).topic(topicName).enableBatching(false).create();
+        producer.newMessage().key("k0").value("v0").send();
+        producer.newMessage().key("k1").value("v1").send();
+        producer.newMessage().key("k2").value("v2").send();
+        triggerCompactionAndWait(topicName);
+        admin.topics().deleteSubscription(topicName, "s1");
+
+        // Disable compaction.
+        // Inject a failure that the first time to delete cursor will fail.
+        if (isInjectedCursorDeleteError) {
+            AtomicInteger times = new AtomicInteger();
+            String cursorPath = String.format("/managed-ledgers/%s/__compaction",
+                    TopicName.get(topicName).getPersistenceNamingEncoding());
+            admin.topicPolicies().removeCompactionThreshold(topicName);
+            mockZooKeeper.failConditional(KeeperException.Code.SESSIONEXPIRED, (op, path) -> {
+                return op == MockZooKeeper.Op.DELETE && cursorPath.equals(path) && times.incrementAndGet() == 1;
+            });
+            mockZooKeeperGlobal.failConditional(KeeperException.Code.SESSIONEXPIRED, (op, path) -> {
+                return op == MockZooKeeper.Op.DELETE && cursorPath.equals(path) && times.incrementAndGet() == 1;
+            });
+            try {
+                admin.topics().deleteSubscription(topicName, "__compaction");
+                fail("Should fail");
+            } catch (Exception ex) {
+                assertTrue(ex instanceof PulsarAdminException.ServerSideErrorException);
+            }
+        }
+
+        // Create a reader with start at earliest.
+        // Verify: the reader will receive 3 messages.
+        admin.topics().unload(topicName);
+        Reader<String> reader = pulsarClient.newReader(Schema.STRING).topic(topicName).readCompacted(true)
+                .startMessageId(MessageId.earliest).create();
+        producer.newMessage().key("k3").value("v3").send();
+        assertTrue(reader.hasMessageAvailable());
+        Message<String> m0 = reader.readNext(10, TimeUnit.SECONDS);
+        assertEquals(m0.getValue(), "v0");
+        assertTrue(reader.hasMessageAvailable());
+        Message<String> m1 = reader.readNext(10, TimeUnit.SECONDS);
+        assertEquals(m1.getValue(), "v1");
+        assertTrue(reader.hasMessageAvailable());
+        Message<String> m2 = reader.readNext(10, TimeUnit.SECONDS);
+        assertEquals(m2.getValue(), "v2");
+        assertTrue(reader.hasMessageAvailable());
+        Message<String> m3 = reader.readNext(10, TimeUnit.SECONDS);
+        assertEquals(m3.getValue(), "v3");
+
+        // cleanup.
+        producer.close();
+        reader.close();
+        admin.topics().delete(topicName, false);
+    }
+
+    @Test
+    public void testDisableCompactionConcurrently() throws Exception {
+        String topicName = "persistent://public/default/" + BrokerTestUtil.newUniqueName("tp");
+        admin.topics().createNonPartitionedTopic(topicName);
+        admin.topicPolicies().setCompactionThreshold(topicName, 1);
+        admin.topics().createSubscription(topicName, "s1", MessageId.earliest);
+        var producer = pulsarClient.newProducer(Schema.STRING).topic(topicName).enableBatching(false).create();
+        producer.newMessage().key("k0").value("v0").send();
+        triggerCompactionAndWait(topicName);
+        admin.topics().deleteSubscription(topicName, "s1");
+        PersistentTopic persistentTopic =
+                (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false).get().get();
+        AtomicBoolean disablingCompaction =
+                WhiteboxImpl.getInternalState(persistentTopic, "disablingCompaction");
+
+        // Disable compaction.
+        // Inject a delay when the first time of deleting cursor.
+        AtomicInteger times = new AtomicInteger();
+        String cursorPath = String.format("/managed-ledgers/%s/__compaction",
+                TopicName.get(topicName).getPersistenceNamingEncoding());
+        admin.topicPolicies().removeCompactionThreshold(topicName);
+        mockZooKeeper.delay(5000, (op, path) -> {
+            return op == MockZooKeeper.Op.DELETE && cursorPath.equals(path) && times.incrementAndGet() == 1;
+        });
+        mockZooKeeperGlobal.delay(5000, (op, path) -> {
+            return op == MockZooKeeper.Op.DELETE && cursorPath.equals(path) && times.incrementAndGet() == 1;
+        });
+        AtomicReference<CompletableFuture<Void>> f1 = new AtomicReference<CompletableFuture<Void>>();
+        AtomicReference<CompletableFuture<Void>> f2 = new AtomicReference<CompletableFuture<Void>>();
+        new Thread(() -> {
+            f1.set(admin.topics().deleteSubscriptionAsync(topicName, "__compaction"));
+        }).start();
+        new Thread(() -> {
+            f2.set(admin.topics().deleteSubscriptionAsync(topicName, "__compaction"));
+        }).start();
+
+        // Verify: the next compaction will be skipped.
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(disablingCompaction.get());
+        });
+        producer.newMessage().key("k1").value("v1").send();
+        producer.newMessage().key("k2").value("v2").send();
+        CompletableFuture<Long> currentCompaction1 =
+                WhiteboxImpl.getInternalState(persistentTopic, "currentCompaction");
+        persistentTopic.triggerCompaction();
+        CompletableFuture<Long> currentCompaction2 =
+                WhiteboxImpl.getInternalState(persistentTopic, "currentCompaction");
+        assertTrue(currentCompaction1 == currentCompaction2);
+
+        // Verify: one of the requests should fail.
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(f1.get() != null);
+            assertTrue(f2.get() != null);
+            assertTrue(f1.get().isDone());
+            assertTrue(f2.get().isDone());
+            assertTrue(f1.get().isCompletedExceptionally() || f2.get().isCompletedExceptionally());
+            assertTrue(!f1.get().isCompletedExceptionally() || !f2.get().isCompletedExceptionally());
+        });
+        try {
+            f1.get().join();
+            f2.get().join();
+            fail("Should fail");
+        } catch (Exception ex) {
+            Throwable actEx = FutureUtil.unwrapCompletionException(ex);
+            assertTrue(actEx instanceof PulsarAdminException.PreconditionFailedException);
+        }
+
+        // cleanup.
         producer.close();
         admin.topics().delete(topicName, false);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/GetLastMessageIdCompactedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/GetLastMessageIdCompactedTest.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.bookkeeper.client.api.BookKeeper;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.BrokerTestUtil;
@@ -329,7 +328,7 @@ public class GetLastMessageIdCompactedTest extends ProducerConsumerBase {
     }
 
     @Test(dataProvider = "isInjectedCursorDeleteError")
-    public void testReadMsgsAfterUnloading(boolean isInjectedCursorDeleteError) throws Exception {
+    public void testReadMsgsAfterDisableCompaction(boolean isInjectedCursorDeleteError) throws Exception {
         String topicName = "persistent://public/default/" + BrokerTestUtil.newUniqueName("tp");
         admin.topics().createNonPartitionedTopic(topicName);
         admin.topicPolicies().setCompactionThreshold(topicName, 1);


### PR DESCRIPTION
### Motivation

**Background**
- The steps of unsubscribing `__compaction`
  - Delete compacted ledger
  - Delete cursor
  - Remove subscription

**Issue 1**: consumer will stuck if deleting cursor(the step 2 above) failed 
- Delete compacted ledger
- Delete cursor failed
- Reload the topic
- Compactor subscription relates to a deleted ledger
- Consumers are stuck because the compacted ledger has been deleted, and the messages were lost. The broker will keep printing the error log below

```
2025-02-13T17:23:51,448 - ERROR - [broker-topic-workers-OrderedExecutor-4-0:PersistentDispatcherSingleActiveConsumer] - [persistent://public/default/tp-74ea581c-d7ca-4558-999b-804b6e33faee / reader-801f712e61-Consumer{subscription=PersistentSubscription{topic=persistent://public/default/tp-74ea581c-d7ca-4558-999b-804b6e33faee, name=reader-801f712e61}, consumerId=1, consumerName=Ti6va, address=[id: 0xce1b338f, L:/127.0.0.1:52193 - R:/127.0.0.1:52199] [SR:127.0.0.1, state:Connected]}] Error reading entries at 11:0 : org.apache.bookkeeper.client.BKException$BKNoSuchLedgerExistsException: No such ledger exists on Bookies - Retrying to read in 15.0 seconds
```

You can reproduce the issue by the test `testReadMsgsAfterDisableCompaction(true)`

---

**issue 2**
The compaction task can concurrently execute by deleting the cursor `__compaction`

### Modifications

- Fix issue 1
- Fix issue 2
- Print an error log if a compactor subscription is initialized twice, which may cause a ledger lost/

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x