### PR TITLE
[improve][broker] Don't call ManagedLedger#asyncAddEntry in Netty I/O thread

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.function.Predicate;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
@@ -199,6 +200,7 @@ public interface ManagedLedger {
      *            callback object
      * @param ctx
      *            opaque context
+     * @apiNote This method is not guaranteed to be thread safe. The caller should be responsible to call it in order.
      */
     void asyncAddEntry(ByteBuf buffer, int numberOfMessages, AddEntryCallback callback, Object ctx);
 
@@ -733,4 +735,13 @@ public interface ManagedLedger {
     }
 
     Position getFirstPosition();
+
+    /**
+     * In the internal implementation of a managed ledger, it is reasonable to use a single-thread executor to execute
+     * tasks that need to be performed in order. By exposing this internal executor, the caller can synchronize its
+     * custom tasks, as well as the internal tasks.
+     */
+    default Executor getExecutor() {
+        return Runnable::run;
+    }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -798,26 +798,21 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             log.debug("[{}] asyncAddEntry size={} state={}", name, buffer.readableBytes(), state);
         }
 
-        // retain buffer in this thread
+        // The buffer will be queued in `pendingAddEntries` and might be polled later in a different thread. However,
+        // the caller could release it after this method returns. To ensure the buffer is not released when it's polled,
+        // increase the reference count, which should be decreased by `OpAddEntry`'s methods later.
         buffer.retain();
-
-        // Jump to specific thread to avoid contention from writers writing from different threads
         final var addOperation = OpAddEntry.createNoRetainBuffer(this, buffer, numberOfMessages, callback, ctx,
                 currentLedgerTimeoutTriggered);
         var added = false;
         try {
-            // Use synchronized to ensure if `addOperation` is added to queue and fails later, it will be the first
-            // element in `pendingAddEntries`.
-            synchronized (this) {
-                if (managedLedgerInterceptor != null) {
-                    managedLedgerInterceptor.beforeAddEntry(addOperation, addOperation.getNumberOfMessages());
-                }
-                final var state = STATE_UPDATER.get(this);
-                beforeAddEntryToQueue(state);
-                pendingAddEntries.add(addOperation);
-                added = true;
-                afterAddEntryToQueue(state, addOperation);
+            if (managedLedgerInterceptor != null) {
+                managedLedgerInterceptor.beforeAddEntry(addOperation, addOperation.getNumberOfMessages());
             }
+            beforeAddEntryToQueue();
+            pendingAddEntries.add(addOperation);
+            added = true;
+            afterAddEntryToQueue(addOperation);
         } catch (Throwable throwable) {
             if (!added) {
                 addOperation.failed(ManagedLedgerException.getManagedLedgerException(throwable));
@@ -825,7 +820,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
     }
 
-    protected void beforeAddEntryToQueue(State state) throws ManagedLedgerException {
+    protected void beforeAddEntryToQueue() throws ManagedLedgerException {
+        final var state = STATE_UPDATER.get(this);
         if (state.isFenced()) {
             throw new ManagedLedgerFencedException();
         }
@@ -836,7 +832,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
     }
 
-    protected void afterAddEntryToQueue(State state, OpAddEntry addOperation) throws ManagedLedgerException {
+    protected void afterAddEntryToQueue(OpAddEntry addOperation) throws ManagedLedgerException {
+        final var state = STATE_UPDATER.get(this);
         if (state == State.ClosingLedger || state == State.CreatingLedger) {
             // We don't have a ready ledger to write into
             // We are waiting for a new ledger to be created
@@ -893,22 +890,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             return;
         }
         managedLedgerInterceptor.afterFailedAddEntry(numOfMessages);
-    }
-
-    protected boolean beforeAddEntry(OpAddEntry addOperation) {
-        // if no interceptor, just return true to make sure addOperation will be initiate()
-        if (managedLedgerInterceptor == null) {
-            return true;
-        }
-        try {
-            managedLedgerInterceptor.beforeAddEntry(addOperation, addOperation.getNumberOfMessages());
-            return true;
-        } catch (Exception e) {
-            addOperation.failed(
-                    new ManagedLedgerInterceptException("Interceptor managed ledger before add to bookie failed."));
-            log.error("[{}] Failed to intercept adding an entry to bookie.", name, e);
-            return false;
-        }
     }
 
     @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ShadowManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ShadowManagedLedgerImpl.java
@@ -223,14 +223,14 @@ public class ShadowManagedLedgerImpl extends ManagedLedgerImpl {
     }
 
     @Override
-    protected void beforeAddEntryToQueue(State state) throws ManagedLedgerException {
-        if (state != State.LedgerOpened) {
+    protected void beforeAddEntryToQueue() throws ManagedLedgerException {
+        if (STATE_UPDATER.get(this) != State.LedgerOpened) {
             throw new ManagedLedgerException("Managed ledger is not opened");
         }
     }
 
     @Override
-    protected void afterAddEntryToQueue(State state, OpAddEntry addOperation) throws ManagedLedgerException {
+    protected void afterAddEntryToQueue(OpAddEntry addOperation) throws ManagedLedgerException {
         if (addOperation.getCtx() == null || !(addOperation.getCtx() instanceof Position position)) {
             pendingAddEntries.poll();
             throw new ManagedLedgerException("Illegal addOperation context object.");


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/23940 brings a behavior change that the core logic of `ManagedLedger#asyncAddEntry` now won't switch threads, which means it will be executed directly in Netty I/O thread via `PersistentTopic#asyncAddEntry`.

The `beforeAddEntry` method calls the`intercept` and `interceptWithNumberOfMessages` methods for **all broker entry interceptors** and prepends a new broker entry metadata buffer on the original buffer (though it's just a composite buffer).

There is a risk that when many producers send messages to the same managed ledger concurrently, the process of `asyncAddEntry` might block the Netty I/O thread for some time and cause the performance regression.

### Modifications

In `PersistentTopic#publishMessage`, expose the `getExecutor()` method for `ManagedLedger` and execute `ManagedLedger#asyncAddEntry` in that executor. The change of https://github.com/apache/pulsar/pull/12606 is moved to `PersistentTopic` as well that the buffer is retained before switching to another thread. After that, only synchronize `afterAddEntryToQueue` with other synchronized methods of `ManagedLedgerImpl`.

`ManagedLedgerImpl#asyncAddEntry` still doesn't switch the thread, so it would still be possible for the downstream application to synchronize `asyncAddEntry`, either by adding a lock (e.g. `synchronized`) or executing this method is a single thread.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
