### PR TITLE
[fix] fix for code scanning alert no. 48: Uncontrolled data used in path expression

### DIFF
--- a/pulsar-package-management/filesystem-storage/src/main/java/org/apache/pulsar/packages/management/storage/filesystem/FileSystemPackagesStorage.java
+++ b/pulsar-package-management/filesystem-storage/src/main/java/org/apache/pulsar/packages/management/storage/filesystem/FileSystemPackagesStorage.java
@@ -59,11 +59,14 @@ public class FileSystemPackagesStorage implements PackagesStorage {
     }
 
     private File getPath(String path) throws IOException {
-        if (path.contains("..")) {
+        // Normalize the path to remove any redundant path elements
+        File f = Paths.get(storagePath.toString(), path).normalize().toFile();
+
+        // Ensure the normalized path is still within the storagePath
+        if (!f.getAbsolutePath().startsWith(storagePath.getAbsolutePath())) {
             throw new IOException("Invalid path: " + path);
         }
 
-        File f = Paths.get(storagePath.toString(), path).toFile();
         if (!f.getParentFile().exists()) {
             if (!f.getParentFile().mkdirs()) {
                 throw new RuntimeException("Failed to create parent dirs for " + path);


### PR DESCRIPTION
Potential fix for [https://github.com/apache/pulsar/security/code-scanning/48](https://github.com/apache/pulsar/security/code-scanning/48)

To fix the problem, we need to enhance the validation of the user-provided path to ensure it does not contain any path traversal sequences or absolute paths. We can achieve this by normalizing the path and ensuring it remains within a predefined base directory.

1. Normalize the path to remove any redundant path elements.
2. Ensure the normalized path is still within the intended base directory.
3. Reject any paths that do not meet these criteria.


- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
