### PR TITLE
[fix][test] fix flaky testNegativeAcksWithBackoff when batch enabled.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
@@ -255,10 +255,16 @@ public class NegativeAcksTest extends ProducerConsumerBase {
         final int redeliverCount = 5;
         long firstReceivedAt = System.currentTimeMillis();
         long expectedTotalRedeliveryDelay = 0;
+        Message<String> msg = null;
         for (int i = 0; i < redeliverCount; i++) {
             for (int j = 0; j < N; j++) {
-                Message<String> msg = consumer.receive();
+                msg = consumer.receive();
                 log.info("Received message {}", msg.getValue());
+                if (!batching) {
+                    consumer.negativeAcknowledge(msg);
+                }
+            }
+            if (batching) {
                 consumer.negativeAcknowledge(msg);
             }
             expectedTotalRedeliveryDelay += backoff.next(i);
@@ -268,7 +274,7 @@ public class NegativeAcksTest extends ProducerConsumerBase {
 
         // All the messages should be received again
         for (int i = 0; i < N; i++) {
-            Message<String> msg = consumer.receive();
+            msg = consumer.receive();
             receivedMessages.add(msg.getValue());
             consumer.acknowledge(msg);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
@@ -265,6 +265,7 @@ public class NegativeAcksTest extends ProducerConsumerBase {
                 }
             }
             if (batching) {
+                // for batching, we only need to nack one message in the batch to trigger redelivery
                 consumer.negativeAcknowledge(msg);
             }
             expectedTotalRedeliveryDelay += backoff.next(i);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
@@ -255,8 +255,8 @@ public class NegativeAcksTest extends ProducerConsumerBase {
         final int redeliverCount = 5;
         long firstReceivedAt = System.currentTimeMillis();
         long expectedTotalRedeliveryDelay = 0;
-        Message<String> msg = null;
         for (int i = 0; i < redeliverCount; i++) {
+            Message<String> msg = null;
             for (int j = 0; j < N; j++) {
                 msg = consumer.receive();
                 log.info("Received message {}", msg.getValue());
@@ -275,7 +275,7 @@ public class NegativeAcksTest extends ProducerConsumerBase {
 
         // All the messages should be received again
         for (int i = 0; i < N; i++) {
-            msg = consumer.receive();
+            Message<String> msg = consumer.receive();
             receivedMessages.add(msg.getValue());
             consumer.acknowledge(msg);
         }


### PR DESCRIPTION
Main Issue: https://github.com/apache/pulsar/issues/23885

### Motivation

When batch message is negative ack, some undetermined behavior may occur. For example, 
- There are 10 messages batched into one message, all of them are unbatch into consumer's receiver queue.
- consumer negative ack the first 5 messages.
- before the consumer negative ack another 5 messages, the negatve ack tracker trigger the redelivery request.
- broker dispatch this batched message to consumer.
- consumer clear the remaining 5 messages in the queue, and refill 10 messages into the queue.
- Message duplication issue occurs.
IMO, suck kind of problem is reasonable as we only provide At-Least-Once semantices.


### Modifications

This unit test don't handle the batch case at some time. 
Negative ack one message is enough for this test in batch case.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 