### PR TITLE
[fix][meta] Fix ephemeral handling of ZK nodes and fix MockZooKeeper ephemeral and ZK stat handling

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
@@ -285,7 +285,7 @@ public class LoadManagerShared {
     public static String getBundleRangeFromBundleName(String bundleName) {
         // the bundle format is property/cluster/namespace/0x00000000_0xFFFFFFFF
         int pos = bundleName.lastIndexOf("/");
-        checkArgument(pos != -1);
+        checkArgument(pos != -1, "Invalid bundle name format: %s", bundleName);
         return bundleName.substring(pos + 1);
     }
 
@@ -293,7 +293,7 @@ public class LoadManagerShared {
     public static String getNamespaceNameFromBundleName(String bundleName) {
         // the bundle format is property/cluster/namespace/0x00000000_0xFFFFFFFF
         int pos = bundleName.lastIndexOf('/');
-        checkArgument(pos != -1);
+        checkArgument(pos != -1, "Invalid bundle name format: %s", bundleName);
         return bundleName.substring(0, pos);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -583,7 +583,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         for (String bundle : bundleData.keySet()) {
             if (!activeBundles.contains(bundle)){
                 bundleData.remove(bundle);
-                if (pulsar.getLeaderElectionService().isLeader()){
+                if (pulsar.getLeaderElectionService() != null && pulsar.getLeaderElectionService().isLeader()){
                     deleteBundleDataFromMetadataStore(bundle);
                 }
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -1012,7 +1012,7 @@ public abstract class PulsarWebResource {
         if (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(pulsar)) {
             return true;
         }
-        return  pulsar.getLeaderElectionService().isLeader();
+        return pulsar.getLeaderElectionService() != null && pulsar.getLeaderElectionService().isLeader();
     }
 
     public void validateTenantOperation(String tenant, TenantOperation operation) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundles.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundles.java
@@ -108,9 +108,11 @@ public class NamespaceBundles {
 
     public void validateBundle(NamespaceBundle nsBundle) throws Exception {
         int idx = Arrays.binarySearch(partitions, nsBundle.getLowerEndpoint());
-        checkArgument(idx >= 0, "Cannot find bundle in the bundles list");
-        checkArgument(nsBundle.getUpperEndpoint().equals(bundles.get(idx).getUpperEndpoint()),
-                "Invalid upper boundary for bundle");
+        checkArgument(idx >= 0, "Cannot find bundle %s in the bundles list", nsBundle);
+        NamespaceBundle foundBundle = bundles.get(idx);
+        Long upperEndpoint = foundBundle.getUpperEndpoint();
+        checkArgument(nsBundle.getUpperEndpoint().equals(upperEndpoint),
+                "Invalid upper boundary for bundle %s. Expected upper boundary of %s", nsBundle, foundBundle);
     }
 
     public NamespaceBundle getFullBundle() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -487,7 +487,7 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         if (useTestZookeeper) {
             builder.withTestZookeeper();
         } else {
-            builder.withMockZookeeper();
+            builder.withMockZookeeper(true);
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -150,6 +150,9 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
 
     private final List<AutoCloseable> closeables = new ArrayList<>();
 
+    // Set to true in test's constructor to use a real Zookeeper (TestZKServer)
+    protected boolean useTestZookeeper;
+
     public MockedPulsarServiceBaseTest() {
         resetConfig();
     }
@@ -461,7 +464,6 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         PulsarTestContext.Builder builder = PulsarTestContext.builder()
                 .spyByDefault()
                 .config(conf)
-                .withMockZookeeper(true)
                 .pulsarServiceCustomizer(pulsarService -> {
                     try {
                         beforePulsarStart(pulsarService);
@@ -470,7 +472,23 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
                     }
                 })
                 .brokerServiceCustomizer(this::customizeNewBrokerService);
+        configureMetadataStores(builder);
         return builder;
+    }
+
+    /**
+     * Configures the metadata stores for the PulsarTestContext.Builder instance.
+     * Set useTestZookeeper to true in the test's constructor to use TestZKServer which is a real ZooKeeper
+     * implementation.
+     *
+     * @param builder the PulsarTestContext.Builder instance to configure
+     */
+    protected void configureMetadataStores(PulsarTestContext.Builder builder) {
+        if (useTestZookeeper) {
+            builder.withTestZookeeper();
+        } else {
+            builder.withMockZookeeper();
+        }
     }
 
     protected PulsarTestContext createAdditionalPulsarTestContext(ServiceConfiguration conf) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -366,7 +366,14 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
      * @throws Exception if an error occurs
      */
     protected void restartBroker() throws Exception {
+        restartBroker(null);
+    }
+
+    protected void restartBroker(Consumer<ServiceConfiguration> configurationChanger) throws Exception {
         stopBroker();
+        if (configurationChanger != null) {
+            configurationChanger.accept(conf);
+        }
         startBroker();
         if (pulsarClient == null) {
             pulsarClient = newPulsarClient(lookupUrl.toString(), 0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
@@ -19,7 +19,6 @@
 
 package org.apache.pulsar.broker.testcontext;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import io.netty.channel.EventLoopGroup;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
@@ -478,7 +477,7 @@ public class PulsarTestContext implements AutoCloseable {
         }
 
         private MockZooKeeper createMockZooKeeper() throws Exception {
-            MockZooKeeper zk = MockZooKeeper.newInstance(MoreExecutors.newDirectExecutorService());
+            MockZooKeeper zk = MockZooKeeper.newInstance();
             initializeZookeeper(zk);
             registerCloseable(zk::shutdown);
             return zk;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
@@ -27,7 +27,6 @@ import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -65,6 +64,7 @@ import org.apache.pulsar.common.util.PortManager;
 import org.apache.pulsar.compaction.CompactionServiceFactory;
 import org.apache.pulsar.compaction.Compactor;
 import org.apache.pulsar.compaction.PulsarCompactionServiceFactory;
+import org.apache.pulsar.metadata.TestZKServer;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
@@ -72,9 +72,11 @@ import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.impl.MetadataStoreFactoryImpl;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.MockZooKeeper;
 import org.apache.zookeeper.MockZooKeeperSession;
-import org.apache.zookeeper.data.ACL;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
 import org.jetbrains.annotations.NotNull;
 import org.mockito.Mockito;
 import org.mockito.internal.util.MockUtil;
@@ -477,16 +479,77 @@ public class PulsarTestContext implements AutoCloseable {
 
         private MockZooKeeper createMockZooKeeper() throws Exception {
             MockZooKeeper zk = MockZooKeeper.newInstance(MoreExecutors.newDirectExecutorService());
-            List<ACL> dummyAclList = new ArrayList<>(0);
-
-            ZkUtils.createFullPathOptimistic(zk, "/ledgers/available/192.168.1.1:" + 5000,
-                    "".getBytes(StandardCharsets.UTF_8), dummyAclList, CreateMode.PERSISTENT);
-
-            zk.create("/ledgers/LAYOUT", "1\nflat:1".getBytes(StandardCharsets.UTF_8), dummyAclList,
-                    CreateMode.PERSISTENT);
-
+            initializeZookeeper(zk);
             registerCloseable(zk::shutdown);
             return zk;
+        }
+
+        private static void initializeZookeeper(ZooKeeper zk) throws KeeperException, InterruptedException {
+            ZkUtils.createFullPathOptimistic(zk, "/ledgers/available/192.168.1.1:" + 5000,
+                    "".getBytes(StandardCharsets.UTF_8), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+
+            zk.create("/ledgers/LAYOUT", "1\nflat:1".getBytes(StandardCharsets.UTF_8), ZooDefs.Ids.OPEN_ACL_UNSAFE,
+                    CreateMode.PERSISTENT);
+        }
+
+        /**
+         * Configure this PulsarTestContext to use a test ZooKeeper instance which is
+         * shared for both the local and configuration metadata stores.
+         *
+         * @return the builder
+         */
+        public Builder withTestZookeeper() {
+            return withTestZookeeper(false);
+        }
+
+        /**
+         * Configure this PulsarTestContext to use a test ZooKeeper instance.
+         *
+         * @param useSeparateGlobalZk if true, the global (configuration) zookeeper will be a separate instance
+         * @return the builder
+         */
+        public Builder withTestZookeeper(boolean useSeparateGlobalZk) {
+            try {
+                TestZKServer localZk = createTestZookeeper();
+                MetadataStoreExtended localStore =
+                        createTestZookeeperMetadataStore(localZk, MetadataStoreConfig.METADATA_STORE);
+                localMetadataStore(localStore);
+                MetadataStoreExtended configStore;
+                if (useSeparateGlobalZk) {
+                    TestZKServer globalZk = createTestZookeeper();
+                    configStore = createTestZookeeperMetadataStore(globalZk,
+                            MetadataStoreConfig.CONFIGURATION_METADATA_STORE);
+                } else {
+                    configStore =
+                            createTestZookeeperMetadataStore(localZk, MetadataStoreConfig.CONFIGURATION_METADATA_STORE);
+                }
+                configurationMetadataStore(configStore);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return this;
+        }
+
+        private TestZKServer createTestZookeeper() throws Exception {
+            TestZKServer testZKServer = new TestZKServer();
+            try (ZooKeeper zkc = new ZooKeeper(testZKServer.getConnectionString(), 5000, event -> {
+            })) {
+                initializeZookeeper(zkc);
+            }
+            registerCloseable(testZKServer);
+            return testZKServer;
+        }
+
+        private MetadataStoreExtended createTestZookeeperMetadataStore(TestZKServer zkServer,
+                                                                       String metadataStoreName) {
+            try {
+                MetadataStoreExtended store = MetadataStoreExtended.create("zk:" + zkServer.getConnectionString(),
+                        MetadataStoreConfig.builder().metadataStoreName(metadataStoreName).build());
+                registerCloseable(store);
+                return store;
+            } catch (MetadataStoreException e) {
+                throw new RuntimeException(e);
+            }
         }
 
         /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -112,6 +112,7 @@ import org.awaitility.Awaitility;
 import org.awaitility.reflect.WhiteboxImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.ITest;
 import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -120,8 +121,9 @@ import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker-api")
-public class BrokerServiceLookupTest extends ProducerConsumerBase {
+public class BrokerServiceLookupTest extends ProducerConsumerBase implements ITest {
     private static final Logger log = LoggerFactory.getLogger(BrokerServiceLookupTest.class);
+    private String testName;
 
     @DataProvider
     private static Object[] booleanValues() {
@@ -132,6 +134,16 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
     public BrokerServiceLookupTest(boolean useTestZookeeper) {
         // when set to true, TestZKServer is used which is a real ZooKeeper implementation
         this.useTestZookeeper = useTestZookeeper;
+    }
+
+    @Override
+    public String getTestName() {
+        return testName;
+    }
+
+    @BeforeMethod
+    public void applyTestName(Method method) {
+        testName = method.getName() + " with " + (useTestZookeeper ? "TestZKServer" : "MockZooKeeper");
     }
 
     @BeforeMethod
@@ -147,6 +159,7 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
     @Override
     protected void cleanup() throws Exception {
         internalCleanup();
+        testName = null;
     }
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -92,6 +92,7 @@ import org.apache.pulsar.common.naming.ServiceUnitId;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.PoliciesUtil;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.common.util.SecurityUtility;
@@ -322,8 +323,9 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase implements ITe
     @Test
     public void testConcurrentWriteBrokerData() throws Exception {
         Map<String, NamespaceBundleStats> map = new ConcurrentHashMap<>();
+        List<String> boundaries = PoliciesUtil.getBundles(100).getBoundaries();
         for (int i = 0; i < 100; i++) {
-            map.put("key"+ i, new NamespaceBundleStats());
+            map.put("my-property/my-ns/" + boundaries.get(i), new NamespaceBundleStats());
         }
         BrokerService brokerService = mock(BrokerService.class);
         doReturn(brokerService).when(pulsar).getBrokerService();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -112,13 +112,27 @@ import org.awaitility.Awaitility;
 import org.awaitility.reflect.WhiteboxImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker-api")
 public class BrokerServiceLookupTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(BrokerServiceLookupTest.class);
+
+    @DataProvider
+    private static Object[] booleanValues() {
+        return new Object[]{ true, false };
+    }
+
+    @Factory(dataProvider = "booleanValues")
+    public BrokerServiceLookupTest(boolean useTestZookeeper) {
+        // when set to true, TestZKServer is used which is a real ZooKeeper implementation
+        this.useTestZookeeper = useTestZookeeper;
+    }
 
     @BeforeMethod
     @Override
@@ -1197,6 +1211,9 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
 
     @Test
     public void testLookupConnectionNotCloseIfGetUnloadingExOrMetadataEx() throws Exception {
+        if (useTestZookeeper) {
+            throw new SkipException("This test case depends on MockZooKeeper");
+        }
         String tpName = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
         admin.topics().createNonPartitionedTopic(tpName);
         PulsarClientImpl pulsarClientImpl = (PulsarClientImpl) pulsarClient;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -1342,7 +1342,8 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase implements ITe
         }
     }
 
-    @Test(timeOut = 30000)
+    // TODO: This test is disabled since it's invalid. The test fails for both TestZKServer and MockZooKeeper.
+    @Test(timeOut = 30000, enabled = false)
     public void testLookupConnectionNotCloseIfFailedToAcquireOwnershipOfBundle() throws Exception {
         String tpName = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
         admin.topics().createNonPartitionedTopic(tpName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -407,11 +407,11 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase implements ITe
         @Cleanup
         PulsarClient pulsarClient2 = PulsarClient.builder().serviceUrl(brokerServiceUrl.toString()).build();
 
-        // enable authorization: so, broker can validate cluster and redirect if finds different cluster
-        pulsar.getConfiguration().setAuthorizationEnabled(true);
         // restart broker with authorization enabled: it initialize AuthorizationService
-        stopBroker();
-        startBroker();
+        restartBroker(conf -> {
+            // enable authorization: so, broker can validate cluster and redirect if finds different cluster
+            conf.setAuthorizationEnabled(true);
+        });
 
         LoadManager loadManager2 = spy(pulsar2.getLoadManager().get());
         Field loadManagerField = NamespaceService.class.getDeclaredField("loadManager");
@@ -570,18 +570,18 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase implements ITe
         PulsarTestContext pulsarTestContext2 = createAdditionalPulsarTestContext(conf2);
         PulsarService pulsar2 = pulsarTestContext2.getPulsarService();
 
-        // restart broker1 with tls enabled
-        conf.setBrokerServicePortTls(Optional.of(0));
-        conf.setWebServicePortTls(Optional.of(0));
-        conf.setTlsTrustCertsFilePath(CA_CERT_FILE_PATH);
-        conf.setTlsRequireTrustedClientCertOnConnect(true);
-        conf.setTlsCertificateFilePath(BROKER_CERT_FILE_PATH);
-        conf.setTlsKeyFilePath(BROKER_KEY_FILE_PATH);
-        conf.setNumExecutorThreadPoolSize(5);
-        // Not in use, and because TLS is not configured, it will fail to start
-        conf.setSystemTopicEnabled(false);
-        stopBroker();
-        startBroker();
+        restartBroker(conf -> {
+            // restart broker1 with tls enabled
+            conf.setBrokerServicePortTls(Optional.of(0));
+            conf.setWebServicePortTls(Optional.of(0));
+            conf.setTlsTrustCertsFilePath(CA_CERT_FILE_PATH);
+            conf.setTlsRequireTrustedClientCertOnConnect(true);
+            conf.setTlsCertificateFilePath(BROKER_CERT_FILE_PATH);
+            conf.setTlsKeyFilePath(BROKER_KEY_FILE_PATH);
+            conf.setNumExecutorThreadPoolSize(5);
+            // Not in use, and because TLS is not configured, it will fail to start
+            conf.setSystemTopicEnabled(false);
+        });
         pulsar.getLoadManager().get().writeLoadReportOnZookeeper();
         pulsar2.getLoadManager().get().writeLoadReportOnZookeeper();
 
@@ -786,9 +786,9 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase implements ITe
             conf2.setLoadBalancerNamespaceBundleMaxTopics(1);
 
             // configure broker-1 with ModularLoadManager
-            stopBroker();
-            conf.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
-            startBroker();
+            restartBroker(conf -> {
+                conf.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
+            });
 
             @Cleanup
             PulsarTestContext pulsarTestContext2 = createAdditionalPulsarTestContext(conf2);
@@ -908,11 +908,11 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase implements ITe
         final String topicName2 = BrokerTestUtil.newUniqueName("persistent://" + namespace + "/tp_");
         try {
             // configure broker with ModularLoadManager.
-            stopBroker();
-            conf.setDefaultNumberOfNamespaceBundles(1);
-            conf.setLoadBalancerNamespaceBundleMaxTopics(1);
-            conf.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
-            startBroker();
+            restartBroker(conf -> {
+                conf.setDefaultNumberOfNamespaceBundles(1);
+                conf.setLoadBalancerNamespaceBundleMaxTopics(1);
+                conf.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
+            });
             final ModularLoadManagerWrapper modularLoadManagerWrapper =
                     (ModularLoadManagerWrapper) pulsar.getLoadManager().get();
             final ModularLoadManagerImpl modularLoadManager =
@@ -1065,11 +1065,11 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase implements ITe
         admin.namespaces().createNamespace(property + "/" + cluster + "/" + namespace);
         admin.topics().createPartitionedTopic(dest.toString(), totalPartitions);
 
-        stopBroker();
-        conf.setBrokerServicePortTls(Optional.empty());
-        conf.setWebServicePortTls(Optional.empty());
-        conf.setClientLibraryVersionCheckEnabled(true);
-        startBroker();
+        restartBroker(conf -> {
+            conf.setBrokerServicePortTls(Optional.empty());
+            conf.setWebServicePortTls(Optional.empty());
+            conf.setClientLibraryVersionCheckEnabled(true);
+        });
 
         URI brokerServiceUrl = new URI(pulsar.getSafeWebServiceAddress());
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -327,6 +327,7 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase implements ITe
         for (int i = 0; i < 100; i++) {
             map.put("my-property/my-ns/" + boundaries.get(i), new NamespaceBundleStats());
         }
+        BrokerService originalBrokerService = pulsar.getBrokerService();
         BrokerService brokerService = mock(BrokerService.class);
         doReturn(brokerService).when(pulsar).getBrokerService();
         doReturn(map).when(brokerService).getBundleStats();
@@ -357,6 +358,8 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase implements ITe
         for (Future<?> future : list) {
             future.get();
         }
+        // allow proper shutdown so that resources aren't leaked
+        doReturn(originalBrokerService).when(pulsar).getBrokerService();
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerConsumerBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerConsumerBase.java
@@ -40,7 +40,7 @@ public abstract class ProducerConsumerBase extends MockedPulsarServiceBaseTest {
     protected String methodName;
 
     @BeforeMethod(alwaysRun = true)
-    public void beforeMethod(Method m) throws Exception {
+    public void setTestMethodName(Method m) throws Exception {
         methodName = m.getName();
     }
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -130,12 +130,17 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
     @VisibleForTesting
     @SneakyThrows
     public ZKMetadataStore(ZooKeeper zkc, MetadataStoreConfig config) {
-        super(config);
+        this(zkc, config, false);
+    }
 
+    @VisibleForTesting
+    @SneakyThrows
+    public ZKMetadataStore(ZooKeeper zkc, MetadataStoreConfig config, boolean isZkManaged) {
+        super(config);
         this.zkConnectString = null;
         this.rootPath = null;
         this.metadataStoreConfig = null;
-        this.isZkManaged = false;
+        this.isZkManaged = isZkManaged;
         this.zkc = zkc;
         this.sessionWatcher = new ZKSessionWatcher(zkc, this::receivedSessionEvent);
         zkc.addWatch("/", this::handleWatchEvent, AddWatchMode.PERSISTENT_RECURSIVE);

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -71,9 +71,10 @@ import org.apache.zookeeper.client.ConnectStringParser;
 @Slf4j
 public class ZKMetadataStore extends AbstractBatchedMetadataStore
         implements MetadataStoreExtended, MetadataStoreLifecycle {
-
     public static final String ZK_SCHEME = "zk";
     public static final String ZK_SCHEME_IDENTIFIER = "zk:";
+    // ephemeralOwner value for persistent nodes
+    private static final long NOT_EPHEMERAL = 0L;
 
     private final String zkConnectString;
     private final String rootPath;
@@ -478,7 +479,7 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
 
     private Stat getStat(String path, org.apache.zookeeper.data.Stat zkStat) {
         return new Stat(path, zkStat.getVersion(), zkStat.getCtime(), zkStat.getMtime(),
-                zkStat.getEphemeralOwner() != -1,
+                zkStat.getEphemeralOwner() != NOT_EPHEMERAL,
                 zkStat.getEphemeralOwner() == zkc.getSessionId());
     }
 

--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/BookKeeperClusterTestCase.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/BookKeeperClusterTestCase.java
@@ -212,6 +212,7 @@ public abstract class BookKeeperClusterTestCase {
         try {
             // cleanup for metrics.
             metadataStore.close();
+            metadataStore = null;
             stopZKCluster();
         } catch (Exception e) {
             LOG.error("Got Exception while trying to stop ZKCluster", e);
@@ -256,6 +257,9 @@ public abstract class BookKeeperClusterTestCase {
     protected void startZKCluster() throws Exception {
         zkUtil.startCluster();
         zkc = zkUtil.getZooKeeperClient();
+        if (metadataStore != null) {
+            metadataStore.close();
+        }
         metadataStore = new FaultInjectionMetadataStore(
                 MetadataStoreExtended.create(zkUtil.getZooKeeperConnectString(),
                 MetadataStoreConfig.builder().metadataStoreName("metastore-" + getClass().getSimpleName()).build()));

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CompletionException;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.MetadataStoreFactory;
@@ -117,6 +118,14 @@ public abstract class BaseMetadataStoreTest extends TestRetrySupport {
 
     @DataProvider(name = "impl")
     public Object[][] implementations() {
+        // If the environment variable TEST_METADATA_PROVIDERS is set, only run the specified implementations
+        if (StringUtils.isNotBlank(System.getenv("TEST_METADATA_PROVIDERS"))) {
+            return filterImplementations(System.getenv("TEST_METADATA_PROVIDERS").split(","));
+        }
+        return allImplementations();
+    }
+
+    private Object[][] allImplementations() {
         // A Supplier<String> must be used for the Zookeeper connection string parameter. The retried test run will
         // use the same arguments as the failed attempt.
         // The Zookeeper test server gets restarted by TestRetrySupport before the retry.
@@ -144,7 +153,7 @@ public abstract class BaseMetadataStoreTest extends TestRetrySupport {
 
     protected Object[][] filterImplementations(String... providers) {
         Set<String> providersSet = Set.of(providers);
-        return Arrays.stream(implementations())
+        return Arrays.stream(allImplementations())
                 .filter(impl -> providersSet.contains(impl[0]))
                 .toArray(Object[][]::new);
     }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -228,4 +228,15 @@ public abstract class BaseMetadataStoreTest extends TestRetrySupport {
         }
         return false;
     }
+
+    /**
+     * Delete all the empty container nodes
+     * @param provider the metadata store provider
+     * @throws Exception
+     */
+    protected void maybeTriggerDeletingEmptyContainers(String provider) throws Exception {
+        if ("ZooKeeper".equals(provider) && zks != null) {
+            zks.checkContainers();
+        }
+    }
 }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -44,6 +44,10 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 
 public abstract class BaseMetadataStoreTest extends TestRetrySupport {
+    // to debug specific implementations, set the TEST_METADATA_PROVIDERS environment variable
+    // or temporarily hard code this value in the test class before running tests in the IDE
+    // supported values are ZooKeeper,Memory,RocksDB,Etcd,Oxia,MockZooKeeper
+    private static final String TEST_METADATA_PROVIDERS = System.getenv("TEST_METADATA_PROVIDERS");
     private static String originalMetadatastoreProvidersPropertyValue;
     protected TestZKServer zks;
     protected EtcdCluster etcdCluster;
@@ -119,8 +123,8 @@ public abstract class BaseMetadataStoreTest extends TestRetrySupport {
     @DataProvider(name = "impl")
     public Object[][] implementations() {
         // If the environment variable TEST_METADATA_PROVIDERS is set, only run the specified implementations
-        if (StringUtils.isNotBlank(System.getenv("TEST_METADATA_PROVIDERS"))) {
-            return filterImplementations(System.getenv("TEST_METADATA_PROVIDERS").split(","));
+        if (StringUtils.isNotBlank(TEST_METADATA_PROVIDERS)) {
+            return filterImplementations(TEST_METADATA_PROVIDERS.split(","));
         }
         return allImplementations();
     }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -25,6 +25,8 @@ import io.etcd.jetcd.test.EtcdClusterExtension;
 import io.streamnative.oxia.testcontainers.OxiaContainer;
 import java.io.File;
 import java.net.URI;
+import java.util.Arrays;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
 import java.util.function.Predicate;
@@ -132,11 +134,19 @@ public abstract class BaseMetadataStoreTest extends TestRetrySupport {
 
     @DataProvider(name = "distributedImpl")
     public Object[][] distributedImplementations() {
-        return new Object[][]{
-                {"ZooKeeper", stringSupplier(() -> zksConnectionString)},
-                {"Etcd", stringSupplier(() -> "etcd:" + getEtcdClusterConnectString())},
-                {"Oxia", stringSupplier(() -> "oxia://" + getOxiaServerConnectString())},
-        };
+        return filterImplementations("ZooKeeper", "Etcd", "Oxia");
+    }
+
+    @DataProvider(name = "zkImpl")
+    public Object[][] zkImplementation() {
+        return filterImplementations("ZooKeeper");
+    }
+
+    protected Object[][] filterImplementations(String... providers) {
+        Set<String> providersSet = Set.of(providers);
+        return Arrays.stream(implementations())
+                .filter(impl -> providersSet.contains(impl[0]))
+                .toArray(Object[][]::new);
     }
 
     protected synchronized String getOxiaServerConnectString() {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -137,9 +137,9 @@ public abstract class BaseMetadataStoreTest extends TestRetrySupport {
         return filterImplementations("ZooKeeper", "Etcd", "Oxia");
     }
 
-    @DataProvider(name = "zkImpl")
-    public Object[][] zkImplementation() {
-        return filterImplementations("ZooKeeper");
+    @DataProvider(name = "zkImpls")
+    public Object[][] zkImplementations() {
+        return filterImplementations("ZooKeeper", "MockZooKeeper");
     }
 
     protected Object[][] filterImplementations(String... providers) {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -147,7 +147,26 @@ public abstract class BaseMetadataStoreTest extends TestRetrySupport {
     }
 
     public static Supplier<String> stringSupplier(Supplier<String> supplier) {
-        return supplier;
+        return new StringSupplier(supplier);
+    }
+
+    // Implements toString() so that the test name is more descriptive
+    private static class StringSupplier implements Supplier<String> {
+        private final Supplier<String> supplier;
+
+        public StringSupplier(Supplier<String> supplier) {
+            this.supplier = supplier;
+        }
+
+        @Override
+        public String get() {
+            return supplier.get();
+        }
+
+        @Override
+        public String toString() {
+            return get();
+        }
     }
 
     protected String newKey() {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/CounterTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/CounterTest.java
@@ -70,6 +70,7 @@ public class CounterTest extends BaseMetadataStoreTest {
             return;
         }
         String metadataUrl = urlSupplier.get();
+        @Cleanup
         MetadataStoreExtended store1 = MetadataStoreExtended.create(metadataUrl, MetadataStoreConfig.builder().build());
 
         CoordinationService cs1 = new CoordinationServiceImpl(store1);

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/CounterTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/CounterTest.java
@@ -85,7 +85,7 @@ public class CounterTest extends BaseMetadataStoreTest {
         store1.close();
 
         // Delete all the empty container nodes
-        zks.checkContainers();
+        maybeTriggerDeletingEmptyContainers(provider);
 
         @Cleanup
         MetadataStoreExtended store2 = MetadataStoreExtended.create(metadataUrl, MetadataStoreConfig.builder().build());

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
@@ -487,11 +487,10 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
      *
      * @throws Exception
      */
-    @Test
-    public void readModifyUpdateBadVersionRetry() throws Exception {
-        String url = zks.getConnectionString();
+    @Test(dataProvider = "zkImpl")
+    public void readModifyUpdateBadVersionRetry(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
-        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+        MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
 
         MetadataCache<MyClass> cache = store.getMetadataCache(MyClass.class);
 
@@ -505,7 +504,8 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         final var sourceStores = new ArrayList<MetadataStore>();
 
         for (int i = 0; i < 20; i++) {
-            final var sourceStore = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+            final var sourceStore =
+                    MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
             sourceStores.add(sourceStore);
             final var objCache = sourceStore.getMetadataCache(MyClass.class);
             futures.add(objCache.readModifyUpdate(key1, v -> new MyClass(v.a, v.b + 1)));
@@ -516,11 +516,10 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         }
     }
 
-    @Test
-    public void readModifyUpdateOrCreateRetryTimeout() throws Exception {
-        String url = zks.getConnectionString();
+    @Test(dataProvider = "zkImpl")
+    public void readModifyUpdateOrCreateRetryTimeout(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
-        MetadataStore store = MetadataStoreFactory.create(url, MetadataStoreConfig.builder().build());
+        MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
 
         MetadataCache<MyClass> cache = store.getMetadataCache(MyClass.class, MetadataCacheConfig.builder()
                 .retryBackoff(new BackoffBuilder()

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
@@ -71,7 +71,6 @@ import org.apache.pulsar.metadata.api.extended.CreateOption;
 import org.apache.pulsar.metadata.cache.impl.MetadataCacheImpl;
 import org.awaitility.Awaitility;
 import org.mockito.stubbing.Answer;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Slf4j
@@ -113,14 +112,7 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         }
     }
 
-    @DataProvider(name = "zk")
-    public Object[][] zkimplementations() {
-        return new Object[][] {
-            { "ZooKeeper", stringSupplier(() -> zks.getConnectionString()) },
-        };
-    }
-
-    @Test(dataProvider = "zk")
+    @Test(dataProvider = "zkImpl")
     public void crossStoreAddDelete(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
         MetadataStore store1 = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
@@ -185,7 +177,7 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         });
     }
 
-    @Test(dataProvider = "zk")
+    @Test(dataProvider = "zkImpl")
     public void crossStoreUpdates(String provider, Supplier<String> urlSupplier) throws Exception {
         String testName = "cross store updates";
         @Cleanup

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
@@ -112,7 +112,7 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         }
     }
 
-    @Test(dataProvider = "zkImpl")
+    @Test(dataProvider = "zkImpls")
     public void crossStoreAddDelete(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
         MetadataStore store1 = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
@@ -177,7 +177,7 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         });
     }
 
-    @Test(dataProvider = "zkImpl")
+    @Test(dataProvider = "zkImpls")
     public void crossStoreUpdates(String provider, Supplier<String> urlSupplier) throws Exception {
         String testName = "cross store updates";
         @Cleanup
@@ -487,7 +487,7 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
      *
      * @throws Exception
      */
-    @Test(dataProvider = "zkImpl")
+    @Test(dataProvider = "zkImpls")
     public void readModifyUpdateBadVersionRetry(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
         MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
@@ -516,7 +516,7 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         }
     }
 
-    @Test(dataProvider = "zkImpl")
+    @Test(dataProvider = "zkImpls")
     public void readModifyUpdateOrCreateRetryTimeout(String provider, Supplier<String> urlSupplier) throws Exception {
         @Cleanup
         MetadataStore store = MetadataStoreFactory.create(urlSupplier.get(), MetadataStoreConfig.builder().build());

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreExtendedTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreExtendedTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.metadata;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -74,14 +75,14 @@ public class MetadataStoreExtendedTest extends BaseMetadataStoreTest {
         store.put(key1, "value-1".getBytes(), Optional.empty(), EnumSet.noneOf(CreateOption.class)).join();
         var value = store.get(key1).join().get();
         assertEquals(value.getValue(), "value-1".getBytes());
-        // assertFalse(value.getStat().isEphemeral()); // Todo : fix zkStat.getEphemeralOwner() != 0 from test zk
+        assertFalse(value.getStat().isEphemeral());
         assertTrue(value.getStat().isFirstVersion());
         var version = value.getStat().getVersion();
 
         store.put(key1, "value-2".getBytes(), Optional.empty(), EnumSet.noneOf(CreateOption.class)).join();
         value = store.get(key1).join().get();
         assertEquals(value.getValue(), "value-2".getBytes());
-       //assertFalse(value.getStat().isEphemeral());  // Todo : fix zkStat.getEphemeralOwner() != 0 from test zk
+        assertFalse(value.getStat().isEphemeral());
         assertEquals(value.getStat().getVersion(), version + 1);
 
         final String key2 = newKey();

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreExtendedTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreExtendedTest.java
@@ -71,6 +71,7 @@ public class MetadataStoreExtendedTest extends BaseMetadataStoreTest {
     @Test(dataProvider = "impl")
     public void testPersistentOrEphemeralPut(String provider, Supplier<String> urlSupplier) throws Exception {
         final String key1 = newKey();
+        @Cleanup
         MetadataStoreExtended store = MetadataStoreExtended.create(urlSupplier.get(), MetadataStoreConfig.builder().build());
         store.put(key1, "value-1".getBytes(), Optional.empty(), EnumSet.noneOf(CreateOption.class)).join();
         var value = store.get(key1).join().get();

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -432,18 +432,18 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
         store.delete(prefix + "/a1/b1/c1", Optional.empty()).join();
         store.delete(prefix + "/a1/b1/c2", Optional.empty()).join();
 
-        zks.checkContainers();
+        maybeTriggerDeletingEmptyContainers(provider);
         assertFalse(store.exists(prefix + "/a1/b1").join());
 
         store.delete(prefix + "/a1/b2/c1", Optional.empty()).join();
 
-        zks.checkContainers();
+        maybeTriggerDeletingEmptyContainers(provider);
         assertFalse(store.exists(prefix + "/a1/b2").join());
 
-        zks.checkContainers();
+        maybeTriggerDeletingEmptyContainers(provider);
         assertFalse(store.exists(prefix + "/a1").join());
 
-        zks.checkContainers();
+        maybeTriggerDeletingEmptyContainers(provider);
         assertFalse(store.exists(prefix).join());
     }
 

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -551,6 +551,7 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
         builder.configFilePath("src/test/resources/oxia_client.conf");
         MetadataStoreConfig config = builder.build();
 
+        @Cleanup
         OxiaMetadataStore store = (OxiaMetadataStore) MetadataStoreFactory.create(oxia, config);
         var client = (AsyncOxiaClient) WhiteboxImpl.getInternalState(store, "client");
         var sessionManager = (SessionManager) WhiteboxImpl.getInternalState(client, "sessionManager");

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.metadata;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -667,21 +668,25 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
         store.put("/b/c/b/1", "value1".getBytes(StandardCharsets.UTF_8), Optional.empty()).join();
 
         List<String> subPaths = store.getChildren("/").get();
-        Set<String> expectedSet = "ZooKeeper".equals(provider) ? Set.of("a", "b", "zookeeper") : Set.of("a", "b");
+        Set<String> ignoredRootPaths = Set.of("zookeeper");
+        Set<String> expectedSet = Set.of("a", "b");
         for (String subPath : subPaths) {
-            assertTrue(expectedSet.contains(subPath));
+            if (ignoredRootPaths.contains(subPath)) {
+                continue;
+            }
+            assertThat(expectedSet).contains(subPath);
         }
 
         List<String> subPaths2 = store.getChildren("/a").get();
         Set<String> expectedSet2 = Set.of("a-1", "a-2");
         for (String subPath : subPaths2) {
-            assertTrue(expectedSet2.contains(subPath));
+            assertThat(expectedSet2).contains(subPath);
         }
 
         List<String> subPaths3 = store.getChildren("/b").get();
         Set<String> expectedSet3 = Set.of("c");
         for (String subPath : subPaths3) {
-            assertTrue(expectedSet3.contains(subPath));
+            assertThat(expectedSet3).contains(subPath);
         }
     }
 

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -68,6 +68,7 @@ import org.apache.zookeeper.ZooKeeper;
 import org.assertj.core.util.Lists;
 import org.awaitility.Awaitility;
 import org.awaitility.reflect.WhiteboxImpl;
+import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -415,8 +416,8 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
 
     @Test(dataProvider = "impl")
     public void testDeleteUnusedDirectories(String provider, Supplier<String> urlSupplier) throws Exception {
-        if (provider.equals("Oxia")) {
-            return;
+        if (provider.equals("Oxia") || provider.equals("MockZooKeeper")) {
+            throw new SkipException("Oxia and MockZooKeeper do not support deleteUnusedDirectories");
         }
 
         @Cleanup

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MockZooKeeperMetadataStoreProvider.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MockZooKeeperMetadataStoreProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.pulsar.metadata.api.MetadataStore;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.MetadataStoreProvider;
+import org.apache.pulsar.metadata.impl.ZKMetadataStore;
+import org.apache.zookeeper.MockZooKeeper;
+import org.apache.zookeeper.MockZooKeeperSession;
+
+public class MockZooKeeperMetadataStoreProvider implements MetadataStoreProvider {
+    private static final String MOCK_ZK_SCHEME = "mock-zk";
+    private static final ConcurrentMap<String, MockZooKeeper> mockZooKeepers = new ConcurrentHashMap<>();
+
+    @Override
+    public String urlScheme() {
+        return MOCK_ZK_SCHEME;
+    }
+
+    @Override
+    public MetadataStore create(String metadataURL, MetadataStoreConfig metadataStoreConfig,
+                                boolean enableSessionWatcher) throws MetadataStoreException {
+        MockZooKeeper mockZooKeeper = mockZooKeepers.computeIfAbsent(metadataURL,
+                k -> MockZooKeeper.newInstance().registerCloseable(() -> mockZooKeepers.remove(k)));
+        MockZooKeeperSession mockZooKeeperSession = MockZooKeeperSession.newInstance(mockZooKeeper, true);
+        ZKMetadataStore zkMetadataStore = new ZKMetadataStore(mockZooKeeperSession, metadataStoreConfig, true);
+        return zkMetadataStore;
+    }
+}

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerManagerIteratorTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerManagerIteratorTest.java
@@ -407,14 +407,16 @@ public class LedgerManagerIteratorTest extends BaseMetadataStoreTest {
         ExecutorService executor = Executors.newCachedThreadPool();
         final ConcurrentSkipListSet<Long> createdLedgers = new ConcurrentSkipListSet<>();
         for (int i = 0; i < numWriters; ++i) {
+            int writerIndex = i;
             Future<?> f = executor.submit(() -> {
                 @Cleanup
                 LedgerManager writerLM = new PulsarLedgerManager(store, ledgersRoot);
                 Random writerRNG = new Random(rng.nextLong());
-
+                log.info("Writer {} waiting", writerIndex);
                 latch.await();
-
+                log.info("Writer {} started", writerIndex);
                 while (MathUtils.elapsedNanos(start) < runtime) {
+                    log.info("Writer {} writing", writerIndex);
                     long candidate = 0;
                     do {
                         candidate = Math.abs(writerRNG.nextLong());
@@ -426,18 +428,22 @@ public class LedgerManagerIteratorTest extends BaseMetadataStoreTest {
                     createLedger(writerLM, candidate);
                     removeLedger(writerLM, candidate);
                 }
+                log.info("Writer {} finished", writerIndex);
                 return null;
             });
             futures.add(f);
         }
 
         for (int i = 0; i < numCheckers; ++i) {
+            int checkerIndex = i;
             Future<?> f = executor.submit(() -> {
                 @Cleanup
                 LedgerManager checkerLM = new PulsarLedgerManager(store, ledgersRoot);
+                log.info("Checker {} waiting", checkerIndex);
                 latch.await();
-
+                log.info("Checker {} started", checkerIndex);
                 while (MathUtils.elapsedNanos(start) < runtime) {
+                    log.info("Checker {} checking", checkerIndex);
                     LedgerRangeIterator lri = checkerLM.getLedgerRanges(0);
                     Set<Long> returnedIds = ledgerRangeToSet(lri);
                     for (long id : mustExist) {
@@ -449,15 +455,19 @@ public class LedgerManagerIteratorTest extends BaseMetadataStoreTest {
                         assertTrue(ledgersReadAsync.contains(id));
                     }
                 }
+                log.info("Checker {} finished", checkerIndex);
                 return null;
             });
             futures.add(f);
         }
 
         latch.countDown();
+        log.info("Waiting for futures");
         for (Future<?> f : futures) {
+            log.info("Waiting for future");
             f.get();
         }
+        log.info("Completed");
         executor.shutdownNow();
     }
 

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerManagerIteratorTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerManagerIteratorTest.java
@@ -373,7 +373,7 @@ public class LedgerManagerIteratorTest extends BaseMetadataStoreTest {
         assertEquals(ledgersReadAsync, ids, "Comparing LedgersIds read asynchronously");
     }
 
-    @Test(timeOut = 30000, dataProvider = "impl")
+    @Test(timeOut = 60000, dataProvider = "impl")
     public void checkConcurrentModifications(String provider, Supplier<String> urlSupplier) throws Throwable {
         @Cleanup
         MetadataStoreExtended store =

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
@@ -300,7 +300,7 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
         assertEquals(l, lB.get(), "Should be the ledger I marked");
     }
 
-    @Test(dataProvider = "zkImpl", timeOut = 10000)
+    @Test(dataProvider = "zkImpls", timeOut = 10000)
     public void testZkMetasStoreMarkReplicatedDeleteEmptyParentNodes(String provider, Supplier<String> urlSupplier)
             throws Exception {
         methodSetup(urlSupplier);

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
@@ -300,10 +300,10 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
         assertEquals(l, lB.get(), "Should be the ledger I marked");
     }
 
-
-    @Test(timeOut = 10000)
-    public void testZkMetasStoreMarkReplicatedDeleteEmptyParentNodes() throws Exception {
-        methodSetup(stringSupplier(() -> zks.getConnectionString()));
+    @Test(dataProvider = "zkImpl", timeOut = 10000)
+    public void testZkMetasStoreMarkReplicatedDeleteEmptyParentNodes(String provider, Supplier<String> urlSupplier)
+            throws Exception {
+        methodSetup(urlSupplier);
 
         String missingReplica = "localhost:3181";
 

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerIdGeneratorTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerIdGeneratorTest.java
@@ -242,7 +242,7 @@ public class PulsarLedgerIdGeneratorTest extends BaseMetadataStoreTest {
         l1.await();
         log.info("res1 : {}", res1);
 
-        zks.checkContainers();
+        maybeTriggerDeletingEmptyContainers(provider);
 
         CountDownLatch l2 = new CountDownLatch(1);
         AtomicLong res2 = new AtomicLong();

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/MetadataStoreFactoryImplTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/MetadataStoreFactoryImplTest.java
@@ -21,6 +21,10 @@ package org.apache.pulsar.metadata.impl;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import io.opentelemetry.api.OpenTelemetry;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import lombok.Cleanup;
 import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataStore;
@@ -32,26 +36,25 @@ import org.apache.pulsar.metadata.api.extended.CreateOption;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 public class MetadataStoreFactoryImplTest {
-
-    private static Object originalProperty;
+    private static String originalMetadatastoreProvidersPropertyValue;
 
     @BeforeClass
     public void setMetadataStoreProperty() {
-        originalProperty = System.getProperties().get(MetadataStoreFactoryImpl.METADATASTORE_PROVIDERS_PROPERTY);
+        originalMetadatastoreProvidersPropertyValue =
+                System.getProperty(MetadataStoreFactoryImpl.METADATASTORE_PROVIDERS_PROPERTY);
         System.setProperty(MetadataStoreFactoryImpl.METADATASTORE_PROVIDERS_PROPERTY,
                 MyMetadataStoreProvider.class.getName());
     }
 
     @AfterClass
     public void resetMetadataStoreProperty() {
-        if (originalProperty != null) {
-            System.getProperties().put(MetadataStoreFactoryImpl.METADATASTORE_PROVIDERS_PROPERTY, originalProperty);
+        if (originalMetadatastoreProvidersPropertyValue != null) {
+            System.setProperty(MetadataStoreFactoryImpl.METADATASTORE_PROVIDERS_PROPERTY,
+                    originalMetadatastoreProvidersPropertyValue);
+        } else {
+            System.clearProperty(MetadataStoreFactoryImpl.METADATASTORE_PROVIDERS_PROPERTY);
         }
     }
 

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -380,6 +380,7 @@ public class MockZooKeeper extends ZooKeeper {
                 lock();
 
                 if (stopped) {
+                    unlockIfLocked();
                     cb.processResult(KeeperException.Code.CONNECTIONLOSS.intValue(), path, ctx, null);
                     return;
                 }
@@ -437,9 +438,9 @@ public class MockZooKeeper extends ZooKeeper {
                 }
             } catch (Throwable ex) {
                 log.error("create path : {} error", path, ex);
+                unlockIfLocked();
                 cb.processResult(KeeperException.Code.SYSTEMERROR.intValue(), path, ctx, null);
             } finally {
-                unlockIfLocked();
                 removeSessionIdOverride();
             }
         });
@@ -546,9 +547,9 @@ public class MockZooKeeper extends ZooKeeper {
                 }
             } catch (Throwable ex) {
                 log.error("get data : {} error", path, ex);
+                unlockIfLocked();
                 cb.processResult(KeeperException.Code.SYSTEMERROR.intValue(), path, ctx, null, null);
             } finally {
-                unlockIfLocked();
                 removeSessionIdOverride();
             }
         });
@@ -586,6 +587,7 @@ public class MockZooKeeper extends ZooKeeper {
                 cb.processResult(0, path, ctx, children);
             } catch (Throwable ex) {
                 log.error("get children : {} error", path, ex);
+                unlockIfLocked();
                 cb.processResult(KeeperException.Code.SYSTEMERROR.intValue(), path, ctx, null);
             } finally {
                 removeSessionIdOverride();
@@ -648,6 +650,7 @@ public class MockZooKeeper extends ZooKeeper {
                 cb.processResult(0, path, ctx, children, stat);
             } catch (Throwable ex) {
                 log.error("get children : {} error", path, ex);
+                unlockIfLocked();
                 cb.processResult(KeeperException.Code.SYSTEMERROR.intValue(), path, ctx, null, null);
             } finally {
                 removeSessionIdOverride();
@@ -752,9 +755,9 @@ public class MockZooKeeper extends ZooKeeper {
                 }
             } catch (Throwable ex) {
                 log.error("exist : {} error", path, ex);
+                unlockIfLocked();
                 cb.processResult(KeeperException.Code.SYSTEMERROR.intValue(), path, ctx, null);
             } finally {
-                unlockIfLocked();
                 removeSessionIdOverride();
             }
         });
@@ -1005,9 +1008,9 @@ public class MockZooKeeper extends ZooKeeper {
                 }
             } catch (Throwable ex) {
                 log.error("delete path : {} error", path, ex);
+                unlockIfLocked();
                 cb.processResult(KeeperException.Code.SYSTEMERROR.intValue(), path, ctx);
             } finally {
-                unlockIfLocked();
                 removeSessionIdOverride();
             }
         };

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -1021,12 +1021,11 @@ public class MockZooKeeper extends ZooKeeper {
         try {
             handler.handle();
         } catch (Exception e) {
-            log.error("Error handling {} operation for path {} type {} kind {} request {} {}", opName, op.getPath(),
-                    op.getType(), op.getKind(), op.toRequestRecord(),
-                    e instanceof KeeperException ? e.getMessage() : e);
             if (e instanceof KeeperException keeperException) {
                 res.add(new OpResult.ErrorResult(keeperException.code().intValue()));
             } else {
+                log.error("Error handling {} operation for path {} type {} kind {} request {}", opName, op.getPath(),
+                        op.getType(), op.getKind(), op.toRequestRecord(), e);
                 res.add(new OpResult.ErrorResult(KeeperException.Code.RUNTIMEINCONSISTENCY.intValue()));
             }
         }

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -228,16 +228,12 @@ public class MockZooKeeper extends ZooKeeper {
         return runInExecutorReturningValue(() -> internalCreate(path, data, createMode));
     }
 
-    private <T> T runInExecutorReturningValue(Callable<T> task) throws InterruptedException, KeeperException {
-        return runInExecutorReturningValue(task, true);
-    }
-
-    private <T> T runInExecutorReturningValue(Callable<T> task, boolean allowRunningInCurrentThread)
+    private <T> T runInExecutorReturningValue(Callable<T> task)
             throws InterruptedException, KeeperException {
         if (isStopped()) {
             throw new KeeperException.ConnectionLossException();
         }
-        if (allowRunningInCurrentThread && inExecutorThreadLocal.get()) {
+        if (inExecutorThreadLocal.get()) {
             try {
                 return task.call();
             } catch (Exception e) {
@@ -277,11 +273,7 @@ public class MockZooKeeper extends ZooKeeper {
     }
 
     private void runInExecutorAsync(Runnable runnable) {
-        runInExecutorAsync(runnable, true);
-    }
-
-    private void runInExecutorAsync(Runnable runnable, boolean allowRunningInCurrentThread) {
-        if (allowRunningInCurrentThread && inExecutorThreadLocal.get()) {
+        if (inExecutorThreadLocal.get()) {
             try {
                 runnable.run();
             } catch (Throwable t) {

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -1077,13 +1077,13 @@ public class MockZooKeeper extends ZooKeeper {
                 tree.clear();
                 watchers.clear();
                 persistentWatchers.clear();
-                try {
-                    executor.shutdownNow();
-                    executor.awaitTermination(5, TimeUnit.SECONDS);
-                } catch (InterruptedException ex) {
-                    log.error("MockZooKeeper shutdown had error", ex);
-                }
             });
+            try {
+                executor.shutdownNow();
+                executor.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException ex) {
+                log.error("MockZooKeeper shutdown had error", ex);
+            }
         }
     }
 

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -1081,6 +1081,7 @@ public class MockZooKeeper extends ZooKeeper {
                 }
             }
         } catch (Exception e) {
+            log.error("Error in multi", e);
             if (e instanceof KeeperException keeperException) {
                 res.add(new OpResult.ErrorResult(keeperException.code().intValue()));
             }
@@ -1090,7 +1091,7 @@ public class MockZooKeeper extends ZooKeeper {
             if (e instanceof InterruptedException || e instanceof KeeperException) {
                 throw e;
             } else {
-                log.error("Error in multi", e);
+                throw new KeeperException.SystemErrorException();
             }
         }
         return res;

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -329,21 +329,19 @@ public class MockZooKeeper extends ZooKeeper {
             throw new KeeperException.NodeExistsException(path);
         }
 
-        if (!tree.containsKey(parent)) {
+        MockZNode parentNode = tree.get(parent);
+
+        if (parentNode == null) {
             throw new KeeperException.NoNodeException(parent);
         }
 
-        MockZNode parentNode = tree.get(parent);
-
         if (createMode.isSequential()) {
-            int parentVersion = tree.get(parent).getVersion();
+            int parentVersion = parentNode.getVersion();
             path = path + parentVersion;
             parentNode.updateVersion();
         }
 
-        if (parentNode != null) {
-            parentNode.getChildren().add(getNodeName(path));
-        }
+        parentNode.getChildren().add(getNodeName(path));
         tree.put(path, createMockZNode(data, createMode));
 
         toNotifyCreate.addAll(getWatchers(path));

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -1037,7 +1037,8 @@ public class MockZooKeeper extends ZooKeeper {
     }
 
     @Override
-    public List<OpResult> multi(Iterable<org.apache.zookeeper.Op> opsParam) throws InterruptedException, KeeperException {
+    public List<OpResult> multi(Iterable<org.apache.zookeeper.Op> opsParam)
+            throws InterruptedException, KeeperException {
         List<OpResult> res = new ArrayList<>();
         List<org.apache.zookeeper.Op> ops =
                 StreamSupport.stream(opsParam.spliterator(), false).collect(Collectors.toList());

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -324,7 +324,7 @@ public class MockZooKeeper extends ZooKeeper {
         }
 
         if (!parent.isEmpty() && !tree.containsKey(parent)) {
-            throw new KeeperException.NoNodeException();
+            throw new KeeperException.NoNodeException(parent);
         }
 
         if (createMode.isSequential()) {
@@ -583,7 +583,7 @@ public class MockZooKeeper extends ZooKeeper {
         maybeThrowProgrammedFailure(Op.GET_CHILDREN, path);
 
         if (!tree.containsKey(path)) {
-            throw new KeeperException.NoNodeException();
+            throw new KeeperException.NoNodeException(path);
         }
 
         if (watcher != null) {
@@ -749,7 +749,7 @@ public class MockZooKeeper extends ZooKeeper {
         }
 
         if (!tree.containsKey(path)) {
-            throw new KeeperException.NoNodeException();
+            throw new KeeperException.NoNodeException(path);
         }
 
         MockZNode mockZNode = tree.get(path);

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -644,6 +644,10 @@ public class MockZooKeeper extends ZooKeeper {
         return children;
     }
 
+    private boolean hasChildren(String path) {
+        return !findFirstLevelChildren(path).isEmpty();
+    }
+
     @Override
     public Stat exists(String path, boolean watch) throws KeeperException, InterruptedException {
         return runInExecutorReturningValue(() -> internalGetStat(path, null));
@@ -1134,10 +1138,6 @@ public class MockZooKeeper extends ZooKeeper {
 
     public void setSessionId(long id) {
         sessionId = id;
-    }
-
-    private boolean hasChildren(String path) {
-        return !tree.subMap(path + '/', path + '0').isEmpty();
     }
 
     @Override

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -662,7 +662,8 @@ public class MockZooKeeper extends ZooKeeper {
     private List<String> findFirstLevelChildren(String path) {
         List<String> children = new ArrayList<>();
         String requiredPrefix = path.equals("/") ? "/" : path + "/";
-        for (String key : tree.tailMap(path).keySet()) {
+        String lastKey = path.equals("/") ? "0" : path + "0"; // '0' is lexicographically just after '/'
+        for (String key : tree.subMap(requiredPrefix, false, lastKey, false).keySet()) {
             if (key.startsWith(requiredPrefix)) {
                 String relativePath = key.substring(requiredPrefix.length());
                 if (relativePath.indexOf('/') == -1) {

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -38,6 +38,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -273,6 +274,9 @@ public class MockZooKeeper extends ZooKeeper {
     }
 
     private void runInExecutorAsync(Runnable runnable) {
+        if (isStopped()) {
+            throw new RejectedExecutionException("MockZooKeeper is stopped");
+        }
         if (inExecutorThreadLocal.get()) {
             try {
                 runnable.run();

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -20,7 +20,6 @@ package org.apache.zookeeper;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -194,8 +193,7 @@ public class MockZooKeeper extends ZooKeeper {
     private void init() {
         tree = Maps.newTreeMap();
         this.executor = Executors.newSingleThreadExecutor(new DefaultThreadFactory("mock-zookeeper"));
-        SetMultimap<String, NodeWatcher> w = HashMultimap.create();
-        watchers = Multimaps.synchronizedSetMultimap(w);
+        watchers = HashMultimap.create();
         stopped = new AtomicBoolean(false);
         alwaysFail = new AtomicReference<>(KeeperException.Code.OK);
         failures = new CopyOnWriteArrayList<>();
@@ -1199,7 +1197,7 @@ public class MockZooKeeper extends ZooKeeper {
     }
 
 
-    public synchronized void deleteWatchers(long sessionId) {
+    public void deleteWatchers(long sessionId) {
         runInExecutorSync(() -> {
             // remove all persistent watchers for the session
             persistentWatchers.removeIf(w -> w.sessionId == sessionId);

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
@@ -40,7 +40,7 @@ public class MockZooKeeperSession extends ZooKeeper {
 
     private MockZooKeeper mockZooKeeper;
 
-    private long sessionId = 0L;
+    private long sessionId = 1L;
 
     private static final Objenesis objenesis = new ObjenesisStd();
 
@@ -59,6 +59,9 @@ public class MockZooKeeperSession extends ZooKeeper {
         mockZooKeeperSession.mockZooKeeper = mockZooKeeper;
         mockZooKeeperSession.sessionId = sessionIdGenerator.getAndIncrement();
         mockZooKeeperSession.closeMockZooKeeperOnClose = closeMockZooKeeperOnClose;
+        if (closeMockZooKeeperOnClose) {
+            mockZooKeeper.increaseRefCount();
+        }
         return mockZooKeeperSession;
     }
 

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
@@ -115,7 +115,7 @@ public class MockZooKeeperSession extends ZooKeeper {
     }
 
     @Override
-    public byte[] getData(String path, Watcher watcher, Stat stat) throws KeeperException {
+    public byte[] getData(String path, Watcher watcher, Stat stat) throws KeeperException, InterruptedException {
         try {
             mockZooKeeper.overrideSessionId(getSessionId());
             return mockZooKeeper.getData(path, watcher, stat);
@@ -155,7 +155,7 @@ public class MockZooKeeperSession extends ZooKeeper {
     }
 
     @Override
-    public List<String> getChildren(String path, Watcher watcher) throws KeeperException {
+    public List<String> getChildren(String path, Watcher watcher) throws KeeperException, InterruptedException {
         try {
             mockZooKeeper.overrideSessionId(getSessionId());
             return mockZooKeeper.getChildren(path, watcher);

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
@@ -88,10 +88,10 @@ public class MockZooKeeperSession extends ZooKeeper {
     public String create(String path, byte[] data, List<ACL> acl, CreateMode createMode)
             throws KeeperException, InterruptedException {
         try {
-            mockZooKeeper.overrideEpheralOwner(getSessionId());
+            mockZooKeeper.overrideEphemeralOwner(getSessionId());
             return mockZooKeeper.create(path, data, acl, createMode);
         } finally {
-            mockZooKeeper.removeEpheralOwnerOverride();
+            mockZooKeeper.removeEphemeralOwnerOverride();
         }
     }
 
@@ -99,10 +99,10 @@ public class MockZooKeeperSession extends ZooKeeper {
     public void create(final String path, final byte[] data, final List<ACL> acl, CreateMode createMode,
                        final AsyncCallback.StringCallback cb, final Object ctx) {
         try {
-            mockZooKeeper.overrideEpheralOwner(getSessionId());
+            mockZooKeeper.overrideEphemeralOwner(getSessionId());
             mockZooKeeper.create(path, data, acl, createMode, cb, ctx);
         } finally {
-            mockZooKeeper.removeEpheralOwnerOverride();
+            mockZooKeeper.removeEphemeralOwnerOverride();
         }
     }
 
@@ -188,12 +188,22 @@ public class MockZooKeeperSession extends ZooKeeper {
 
     @Override
     public void multi(Iterable<org.apache.zookeeper.Op> ops, AsyncCallback.MultiCallback cb, Object ctx) {
-        mockZooKeeper.multi(ops, cb, ctx);
+        try {
+            mockZooKeeper.overrideEphemeralOwner(getSessionId());
+            mockZooKeeper.multi(ops, cb, ctx);
+        } finally {
+            mockZooKeeper.removeEphemeralOwnerOverride();
+        }
     }
 
     @Override
     public List<OpResult> multi(Iterable<org.apache.zookeeper.Op> ops) throws InterruptedException, KeeperException {
-        return mockZooKeeper.multi(ops);
+        try {
+            mockZooKeeper.overrideEphemeralOwner(getSessionId());
+            return mockZooKeeper.multi(ops);
+        } finally {
+            mockZooKeeper.removeEphemeralOwnerOverride();
+        }
     }
 
     @Override
@@ -221,12 +231,16 @@ public class MockZooKeeperSession extends ZooKeeper {
     public void close() throws InterruptedException {
         if (closeMockZooKeeperOnClose) {
             mockZooKeeper.close();
+        } else {
+            mockZooKeeper.deleteEphemeralNodes(getSessionId());
         }
     }
 
     public void shutdown() throws InterruptedException {
         if (closeMockZooKeeperOnClose) {
             mockZooKeeper.shutdown();
+        } else {
+            mockZooKeeper.deleteEphemeralNodes(getSessionId());
         }
     }
 

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
@@ -84,17 +84,22 @@ public class MockZooKeeperSession extends ZooKeeper {
 
     @Override
     public void register(Watcher watcher) {
-        mockZooKeeper.register(watcher);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            mockZooKeeper.register(watcher);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public String create(String path, byte[] data, List<ACL> acl, CreateMode createMode)
             throws KeeperException, InterruptedException {
         try {
-            mockZooKeeper.overrideEphemeralOwner(getSessionId());
+            mockZooKeeper.overrideSessionId(getSessionId());
             return mockZooKeeper.create(path, data, acl, createMode);
         } finally {
-            mockZooKeeper.removeEphemeralOwnerOverride();
+            mockZooKeeper.removeSessionIdOverride();
         }
     }
 
@@ -102,148 +107,257 @@ public class MockZooKeeperSession extends ZooKeeper {
     public void create(final String path, final byte[] data, final List<ACL> acl, CreateMode createMode,
                        final AsyncCallback.StringCallback cb, final Object ctx) {
         try {
-            mockZooKeeper.overrideEphemeralOwner(getSessionId());
+            mockZooKeeper.overrideSessionId(getSessionId());
             mockZooKeeper.create(path, data, acl, createMode, cb, ctx);
         } finally {
-            mockZooKeeper.removeEphemeralOwnerOverride();
+            mockZooKeeper.removeSessionIdOverride();
         }
     }
 
     @Override
     public byte[] getData(String path, Watcher watcher, Stat stat) throws KeeperException {
-        return mockZooKeeper.getData(path, watcher, stat);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            return mockZooKeeper.getData(path, watcher, stat);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public void getData(final String path, boolean watch, final DataCallback cb, final Object ctx) {
-        mockZooKeeper.getData(path, watch, cb, ctx);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            mockZooKeeper.getData(path, watch, cb, ctx);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public void getData(final String path, final Watcher watcher, final DataCallback cb, final Object ctx) {
-        mockZooKeeper.getData(path, watcher, cb, ctx);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            mockZooKeeper.getData(path, watcher, cb, ctx);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public void getChildren(final String path, final Watcher watcher, final ChildrenCallback cb, final Object ctx) {
-        mockZooKeeper.getChildren(path, watcher, cb, ctx);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            mockZooKeeper.getChildren(path, watcher, cb, ctx);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public List<String> getChildren(String path, Watcher watcher) throws KeeperException {
-        return mockZooKeeper.getChildren(path, watcher);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            return mockZooKeeper.getChildren(path, watcher);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public List<String> getChildren(String path, boolean watch) throws KeeperException, InterruptedException {
-        return mockZooKeeper.getChildren(path, watch);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            return mockZooKeeper.getChildren(path, watch);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public void getChildren(final String path, boolean watcher, final Children2Callback cb, final Object ctx) {
-        mockZooKeeper.getChildren(path, watcher, cb, ctx);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            mockZooKeeper.getChildren(path, watcher, cb, ctx);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public Stat exists(String path, boolean watch) throws KeeperException, InterruptedException {
-        return mockZooKeeper.exists(path, watch);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            return mockZooKeeper.exists(path, watch);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public Stat exists(String path, Watcher watcher) throws KeeperException, InterruptedException {
-        return mockZooKeeper.exists(path, watcher);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            return mockZooKeeper.exists(path, watcher);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public void exists(String path, boolean watch, StatCallback cb, Object ctx) {
-        mockZooKeeper.exists(path, watch, cb, ctx);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            mockZooKeeper.exists(path, watch, cb, ctx);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public void exists(String path, Watcher watcher, StatCallback cb, Object ctx) {
-        mockZooKeeper.exists(path, watcher, cb, ctx);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            mockZooKeeper.exists(path, watcher, cb, ctx);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public void sync(String path, VoidCallback cb, Object ctx) {
-        mockZooKeeper.sync(path, cb, ctx);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            mockZooKeeper.sync(path, cb, ctx);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public Stat setData(final String path, byte[] data, int version) throws KeeperException, InterruptedException {
-        return mockZooKeeper.setData(path, data, version);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            return mockZooKeeper.setData(path, data, version);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public void setData(final String path, final byte[] data, int version, final StatCallback cb, final Object ctx) {
-        mockZooKeeper.setData(path, data, version, cb, ctx);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            mockZooKeeper.setData(path, data, version, cb, ctx);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public void delete(final String path, int version) throws InterruptedException, KeeperException {
-        mockZooKeeper.delete(path, version);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            mockZooKeeper.delete(path, version);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public void delete(final String path, int version, final VoidCallback cb, final Object ctx) {
-        mockZooKeeper.delete(path, version, cb, ctx);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            mockZooKeeper.delete(path, version, cb, ctx);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public void multi(Iterable<org.apache.zookeeper.Op> ops, AsyncCallback.MultiCallback cb, Object ctx) {
         try {
-            mockZooKeeper.overrideEphemeralOwner(getSessionId());
+            mockZooKeeper.overrideSessionId(getSessionId());
             mockZooKeeper.multi(ops, cb, ctx);
         } finally {
-            mockZooKeeper.removeEphemeralOwnerOverride();
+            mockZooKeeper.removeSessionIdOverride();
         }
     }
 
     @Override
     public List<OpResult> multi(Iterable<org.apache.zookeeper.Op> ops) throws InterruptedException, KeeperException {
         try {
-            mockZooKeeper.overrideEphemeralOwner(getSessionId());
+            mockZooKeeper.overrideSessionId(getSessionId());
             return mockZooKeeper.multi(ops);
         } finally {
-            mockZooKeeper.removeEphemeralOwnerOverride();
+            mockZooKeeper.removeSessionIdOverride();
         }
     }
 
     @Override
     public void addWatch(String basePath, Watcher watcher, AddWatchMode mode, VoidCallback cb, Object ctx) {
-        mockZooKeeper.addWatch(basePath, watcher, mode, cb, ctx);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            mockZooKeeper.addWatch(basePath, watcher, mode, cb, ctx);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public void addWatch(String basePath, Watcher watcher, AddWatchMode mode)
             throws KeeperException, InterruptedException {
-        mockZooKeeper.addWatch(basePath, watcher, mode);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            mockZooKeeper.addWatch(basePath, watcher, mode);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public void addWatch(String basePath, AddWatchMode mode) throws KeeperException, InterruptedException {
-        mockZooKeeper.addWatch(basePath, mode);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            mockZooKeeper.addWatch(basePath, mode);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public void addWatch(String basePath, AddWatchMode mode, VoidCallback cb, Object ctx) {
-        mockZooKeeper.addWatch(basePath, mode, cb, ctx);
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
+            mockZooKeeper.addWatch(basePath, mode, cb, ctx);
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
+        }
     }
 
     @Override
     public void close() throws InterruptedException {
-        if (closeMockZooKeeperOnClose) {
-            mockZooKeeper.close();
-        } else {
-            mockZooKeeper.deleteEphemeralNodes(getSessionId());
-        }
+        internalClose(false);
     }
 
     public void shutdown() throws InterruptedException {
-        if (closeMockZooKeeperOnClose) {
-            mockZooKeeper.shutdown();
-        } else {
+        internalClose(true);
+    }
+
+    private void internalClose(boolean shutdown) throws InterruptedException {
+        try {
+            mockZooKeeper.overrideSessionId(getSessionId());
             mockZooKeeper.deleteEphemeralNodes(getSessionId());
+            mockZooKeeper.deleteWatchers(getSessionId());
+            if (closeMockZooKeeperOnClose) {
+                if (shutdown) {
+                    mockZooKeeper.shutdown();
+                } else {
+                    mockZooKeeper.close();
+                }
+            }
+        } finally {
+            mockZooKeeper.removeSessionIdOverride();
         }
     }
 


### PR DESCRIPTION
### Motivation

This PR is a follow-up to #23984 to fix ephemeral status handling in ZKMetadataStore and to improve the ZooKeeper testing infrastructure.

A key addition is enabling pulsar-metadata tests to run against MockZooKeeper through a proper MetadataStoreProvider implementation, ensuring MockZooKeeper correctly implements all features that Pulsar depends on.

### Modifications

1. Fixed Production Code Issues:
  - Fixed ephemeral status handling in ZKMetadataStore to properly detect ephemeral nodes by using the correct comparison value (0L) for non-ephemeral (== persistent) nodes

2. MockZooKeeper improvements and fixes:
  - Fixed ephemeral node handling and cleanup on session termination
  - Improved ZK stat handling with proper timestamps and version numbers
  - Added proper session ID management and consistent thread safety
  - Fixed persistent watcher cleanup on session termination
  - Fixed getChildren implementation and removed code duplication
  - Fixed ordering issues by migrating to use a single threaded executor model
    - This allowed to remove locks and synchronization in most cases

3. Test Framework Improvements::
  - Implemented MockZooKeeperMetadataStoreProvider to allow pulsar-metadata tests to use MockZooKeeper
    - This ensures that MockZooKeeper correctly implements all MetadataStore features that Pulsar depends on
  - Enhanced PulsarTestContext to support toggling between MockZooKeeper and real ZK (TestZKServer) implementations
  - Added ability to run MockedPulsarServiceBaseTest tests with both MockZooKeeper and real ZK (TestZKServer)

There are some unrelated NPE fixes and improvements for better exception messages. I faced those issues while debugging BrokerServiceTest and noticed those exceptions in the execution logs. Some of the exceptions were due to invalid tests, however the improvements will be useful also later.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->