### PR TITLE
[fix][client] add maxRetryRequestTimes in ClientConfigurationData and remove Duplicate retry logic

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnector.java
@@ -130,7 +130,7 @@ public class AsyncHttpConnector implements Connector, AsyncHttpRequestExecutor {
                         autoCertRefreshTimeSeconds);
         httpClient = createAsyncHttpClient(asyncHttpClientConfig);
         this.requestTimeout = requestTimeoutMs > 0 ? Duration.ofMillis(requestTimeoutMs) : null;
-        this.maxRetries = httpClient.getConfig().getMaxRequestRetry();
+        this.maxRetries = conf.getMaxRetryRequestTimes();
     }
 
     private AsyncHttpClientConfig createAsyncHttpClientConfig(ClientConfigurationData conf, int connectTimeoutMs,
@@ -178,6 +178,7 @@ public class AsyncHttpConnector implements Connector, AsyncHttpRequestExecutor {
             }
         });
         confBuilder.setDisableHttpsEndpointIdentificationAlgorithm(!conf.isTlsHostnameVerificationEnable());
+        confBuilder.setMaxRequestRetry(0);
     }
 
     protected AsyncHttpClient createAsyncHttpClient(AsyncHttpClientConfig asyncHttpClientConfig) {
@@ -293,7 +294,6 @@ public class AsyncHttpConnector implements Connector, AsyncHttpRequestExecutor {
         return resultFuture;
     }
 
-    // TODO: There are problems with this solution since AsyncHttpClient already contains logic to retry requests.
     // This solution doesn't contain backoff handling.
     private <T> void retryOperation(
             final CompletableFuture<T> resultFuture,

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -679,4 +679,12 @@ public interface ClientBuilder extends Serializable, Cloneable {
      * - The `loadManagerClassName` config in broker is a class that implements the `ExtensibleLoadManager` interface
      */
     ClientBuilder lookupProperties(Map<String, String> properties);
+
+    /**
+     * Set the max retry times for a request.
+     *
+     * @param maxRetryTimes
+     * @return the client builder instance
+     */
+    ClientBuilder maxRetryTimes(int maxRetryTimes);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -482,4 +482,10 @@ public class ClientBuilderImpl implements ClientBuilder {
         conf.setLookupProperties(properties);
         return this;
     }
+
+    @Override
+    public ClientBuilder maxRetryTimes(int maxRetryTimes) {
+        conf.setMaxRetryRequestTimes(maxRetryTimes);
+        return this;
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -374,6 +374,12 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private String dnsLookupBindAddress = null;
 
     @ApiModelProperty(
+            name = "maxRetryRequestTimes",
+            value = "The Pulsar admin client max retry request times, default value is 5"
+    )
+    private int maxRetryRequestTimes = 5;
+
+    @ApiModelProperty(
             name = "dnsLookupBindPort",
             value = "The Pulsar client dns lookup bind port, takes effect when dnsLookupBindAddress is configured,"
                     + " default value is 0."

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientBuilderImplTest.java
@@ -170,6 +170,11 @@ public class ClientBuilderImplTest {
         assertThatAuthIsNotSet(auth);
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testClientBuilderWithMaxRetryTime() throws PulsarClientException {
+        PulsarClient.builder().maxRetryTimes(5).build();
+    }
+
     @Test
     public void testLoadConfAuthNotSetWhenEmptyAuthParamsSpecified() {
         Map<String, Object> confProps = new HashMap<>();


### PR DESCRIPTION

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- If the PR belongs to a PIP, please add the PIP link here -->


<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation
The maxRetries property of AsyncHttpConnector is derived from the config of DefaultAsyncHttpClient. 
```
@SneakyThrows
    public AsyncHttpConnector(int connectTimeoutMs, int readTimeoutMs,
                              int requestTimeoutMs,
                              int autoCertRefreshTimeSeconds, ClientConfigurationData conf,
                              boolean acceptGzipCompression) {
        Validate.notEmpty(conf.getServiceUrl(), "Service URL is not provided");
        serviceNameResolver = new PulsarServiceNameResolver();
        String serviceUrl = conf.getServiceUrl();
        serviceNameResolver.updateServiceUrl(serviceUrl);
        this.acceptGzipCompression = acceptGzipCompression;
        AsyncHttpClientConfig asyncHttpClientConfig =
                createAsyncHttpClientConfig(conf, connectTimeoutMs, readTimeoutMs, requestTimeoutMs,
                        autoCertRefreshTimeSeconds);
        httpClient = createAsyncHttpClient(asyncHttpClientConfig);
        this.requestTimeout = requestTimeoutMs > 0 ? Duration.ofMillis(requestTimeoutMs) : null;
        this.maxRetries = httpClient.getConfig().getMaxRequestRetry();
    }
```
This causes both DefaultAsyncHttpClient and AsyncHttpConnector to share the same retry count value. However, since both components implement their own retry logic, this configuration actually results in accumulated retries exceeding the configured limit. Given that DefaultAsyncHttpClient has a default retry count of 5, I propose disabling retries in DefaultAsyncHttpClient (setting its retry count to 0) while maintaining the default configuration, to centralize retry handling exclusively within AsyncHttpConnector.
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

1. **Retry Configuration Support**  
Added `maxRetryRequestTimes` in `ClientConfigurationData` (default: 5) to control admin client request retry behavior. Configuration propagates to `AsyncHttpConnector` implementations.

2. **Client API Enhancements**  
- Extended `ClientBuilder` interface with new `maxRetryTimes()` method
- Implemented configuration injection in `ClientBuilderImpl`

3. **HTTP Connector Refactoring**  
- Modified `AsyncHttpConnector` to use centralized configuration instead of AsyncHttpClient's internal retry setting
- Explicitly disabled underlying library retry via `confBuilder.setMaxRequestRetry(0)`

4. **Validation**  
Added parameter verification test in `ClientBuilderImplTest` to validate retry time configuration constraint

<!-- Describe the modifications you've done. -->

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/walkinggo/pulsar/pull/9

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
