### PR TITLE
[fix][build] Add develops for buildtools

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -35,6 +35,13 @@
   <packaging>jar</packaging>
   <name>Pulsar Build Tools</name>
 
+  <developers>
+    <developer>
+      <organization>Apache Pulsar developers</organization>
+      <organizationUrl>http://pulsar.apache.org/</organizationUrl>
+    </developer>
+  </developers>
+
   <properties>
     <project.build.outputTimestamp>2024-10-14T13:32:50Z</project.build.outputTimestamp>
     <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
### Motivation

```
1 failed Component Validation

pkg:maven/com.ascentstream.pulsar/buildtools@3.0.x
1
Developers information is missing
```

This report is from the sonatype maven central.

### Modifications

Add `develops` for buildtools.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->