### PR TITLE
[fix][test] Fix flaky test MetadataStoreTest.emptyStoreTest

### DIFF
--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -114,7 +114,7 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
                 MetadataStoreConfig.builder().fsyncEnable(false).build());
 
         String data = "data";
-        String path = "/non-existing-key";
+        String path = "/concurrentPutTest";
         int concurrent = 50;
         List<CompletableFuture<Stat>> futureList = new ArrayList<>();
         for (int i = 0; i < concurrent; i++) {


### PR DESCRIPTION
### Motivation

- If concurrentPutTest runs before emptyStoreTest, it will cause emptyStoreTest to fail

### Modifications

- change the key used in concurrentPutTest

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->