### PR TITLE
[improve][test] Upgrade Testcontainers to 1.20.4 and docker-java to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,12 +269,11 @@ flexible messaging model and an intuitive client API.</description>
     <failsafe.version>3.3.2</failsafe.version>
 
     <!-- test dependencies -->
-    <testcontainers.version>1.18.3</testcontainers.version>
+    <testcontainers.version>1.20.4</testcontainers.version>
+    <!-- Set docker-java.version to the version of docker-java used in org.testcontainers:testcontainers pom -->
+    <docker-java.version>3.4.0</docker-java.version>
     <hamcrest.version>2.2</hamcrest.version>
     <restassured.version>5.4.0</restassured.version>
-
-    <!-- Set docker-java.version to the version of docker-java used in Testcontainers -->
-    <docker-java.version>3.3.0</docker-java.version>
     <kerby.version>1.1.1</kerby.version>
     <testng.version>7.7.1</testng.version>
     <mockito.version>5.6.0</mockito.version>


### PR DESCRIPTION
### Motivation

Keep Testcontainers and docker-java up-to-date in Pulsar.

### Modifications

- Upgrade Testcontainers to 1.20.4
- Upgrade docker-java to 3.4.0 since it has to match the version used by Testcontainers
  - https://repo1.maven.org/maven2/org/testcontainers/testcontainers/1.20.4/testcontainers-1.20.4.pom references docker-java 3.4.0

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->