### PR TITLE
[fix][test] Fix flaky test OneWayReplicatorUsingGlobalZKTest.testConfigReplicationStartAt

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
@@ -156,6 +156,10 @@ public class OneWayReplicatorUsingGlobalZKTest extends OneWayReplicatorTest {
         p1.close();
 
         admin1.namespaces().setNamespaceReplicationClusters(ns1, new HashSet<>(Arrays.asList(cluster1, cluster2)));
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(admin2.topics().getList(ns1).contains(topic1));
+        });
+        admin2.topics().createSubscription(topic1, subscription1, MessageId.earliest);
         org.apache.pulsar.client.api.Consumer<String> c1 = client2.newConsumer(Schema.STRING).topic(topic1)
                 .subscriptionName(subscription1).subscribe();
         Message<String> msg2 = c1.receive(2, TimeUnit.SECONDS);


### PR DESCRIPTION
### Motivation

**Failed test**: https://github.com/apache/pulsar/actions/runs/13403975927/job/37440612533?pr=23697

```
  [INFO] Results:
  [INFO] 
  Error:  Failures: 
  Error:  org.apache.pulsar.broker.service.OneWayReplicatorUsingGlobalZKTest.testConfigReplicationStartAt
  [INFO]   Run 1: PASS
  Error:    Run 2: OneWayReplicatorUsingGlobalZKTest.testConfigReplicationStartAt:162 expected object to not be null
```

**Root cause**
- background: the default value of creating subscription is `latest`
- issue: if the new subscription created after the msg replicated, the new consumer will receive a `null` value

### Modifications

- Create the subscription with `start = earliest` manually

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
