### PR TITLE
[fix][client] diable chunk feature for retry/dead letter producer.

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2303,7 +2303,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                                                         this.consumerName, RandomStringUtils.randomAlphanumeric(5)))
                                         .blockIfQueueFull(false)
                                         .enableBatching(false)
-                                        .enableChunking(true)
                                         .createAsync();
                         newProducer.whenComplete((producer, ex) -> {
                             if (ex != null) {
@@ -2368,7 +2367,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                                 .newProducer(Schema.AUTO_PRODUCE_BYTES(schema))
                                 .topic(this.deadLetterPolicy.getRetryLetterTopic())
                                 .enableBatching(false)
-                                .enableChunking(true)
                                 .blockIfQueueFull(false)
                                 .createAsync();
                         newProducer.whenComplete((producer, ex) -> {


### PR DESCRIPTION

### Motivation

- The subscription mode of retry topic must be shared/key-shared type, which has been clarified in https://github.com/apache/pulsar/pull/23859.
- The chunk feature of Pulsar can't work together with shared/key-shared subscription type:
`This feature is currently only supported for non-shared subscriptions and persistent topics.`
The reason accounting for this i guess is that all chunks belonging to same message must be sent to same consumer so that the consumer can ensemble them into one single giant message.

So we can't send chunked message to retry topics.

### Modifications

Diable the chunked message feature for retry topic and dead letter topic.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/thetumbled/pulsar/pull/70
