### PR TITLE
[fix][test]Fix flaky test V1_ProducerConsumerTest.testConcurrentConsumerReceiveWhileReconnect

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v1/V1_ProducerConsumerTest.java
@@ -589,9 +589,11 @@ public class V1_ProducerConsumerTest extends V1_ProducerConsumerBase {
         restartBroker();
 
         // The available permits should be 10 and num messages in the queue should be 90
-        Awaitility.await().untilAsserted(() ->
-                Assert.assertEquals(consumerImpl.getAvailablePermits(), numConsumersThreads));
-        Assert.assertEquals(consumerImpl.numMessagesInQueue(), recvQueueSize - numConsumersThreads);
+        Awaitility.await().untilAsserted(() -> {
+            Assert.assertEquals(consumerImpl.getAvailablePermits(), numConsumersThreads);
+            Assert.assertEquals(consumerImpl.numMessagesInQueue(), recvQueueSize - numConsumersThreads);
+        });
+
         consumer.close();
     }
 


### PR DESCRIPTION
### Motivation

- https://github.com/apache/pulsar/actions/runs/13456263294/job/37600883842?pr=23931

```
  [INFO] Results:
  [INFO] 
  Error:  Failures: 
  Error:    V1_ProducerConsumerTest.testConcurrentConsumerReceiveWhileReconnect:594 expected [90] but found [80]
  [INFO] 
  Error:  Tests run: 366, Failures: 1, Errors: 0, Skipped: 1
```

Root cause: when the verification starts, maybe there is in-flight messages dispatching

### Modifications

Instead of verifying directly, use a `Awaitility.await().untilAsserted(...)`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
