### PR TITLE
[fix][test] Fix flaky PrometheusMetricsTest.testBrokerMetrics

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -306,8 +306,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         double systemCursorOutBytes = 0.0;
         for (Metric metric : topicLevelBytesOutTotal) {
-            if (metric.tags.get("subscription").startsWith(SystemTopicNames.SYSTEM_READER_PREFIX)
-                    || metric.tags.get("subscription").equals(Compactor.COMPACTION_SUBSCRIPTION)) {
+            if (metric.tags.get("subscription").startsWith(SystemTopicNames.SYSTEM_READER_PREFIX)) {
                 systemCursorOutBytes = metric.value;
             }
         }


### PR DESCRIPTION
Fixes #24041 

### Motivation

The test contains the following assertion:
```java
assertEquals(systemCursorOutBytes, systemInBytes)
```
`systemInBytes` is set to the value of the `pulsar_broker_in_bytes_total` metric for the system topic.

`systemCursorOutBytes` is currently set to the value of 
- `pulsar_out_bytes_total` of the system reader subscription or 
- `pulsar_out_bytes_total` of the compaction subscription.

The `pulsar_out_bytes_total` metric is always present for both the system reader and compaction subscription, but the order is not deterministic. Therefore, it happens that instead of setting `systemCursorOutBytes` to `pulsar_out_bytes_total` for the system reader subscription, it is set to `pulsar_out_bytes_total` of the compaction subscription (which always seems to be 0).

```java
double systemCursorOutBytes = 0.0;
for (Metric metric : topicLevelBytesOutTotal) {
    if (metric.tags.get("subscription").startsWith(SystemTopicNames.SYSTEM_READER_PREFIX)
            || metric.tags.get("subscription").equals(Compactor.COMPACTION_SUBSCRIPTION)) {
        systemCursorOutBytes = metric.value;
    }
}
```

### Modifications

Remove the `metric.tags.get("subscription").equals(Compactor.COMPACTION_SUBSCRIPTION)` case.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/pdolif/pulsar/pull/8
