### PR TITLE
[improve][broker]Delete unnecessary calls

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -620,6 +620,7 @@ public class Consumer {
                     if (((PersistentSubscription) subscription)
                             .checkIsCanDeleteConsumerPendingAck(position)) {
                         removePendingAcks(ackOwnerConsumer, position);
+                        updateBlockedConsumerOnUnackedMsgs(ackOwnerConsumer);
                     }
                 }
             }));
@@ -693,6 +694,7 @@ public class Consumer {
                             if (((PersistentSubscription) subscription)
                                     .checkIsCanDeleteConsumerPendingAck(positionLongMutablePair.left)) {
                                 removePendingAcks(ackOwnerConsumer, positionLongMutablePair.left);
+                                updateBlockedConsumerOnUnackedMsgs(ackOwnerConsumer);
                             }
                         }
                     }));
@@ -1082,7 +1084,6 @@ public class Consumer {
         if (log.isDebugEnabled()) {
             log.debug("[{}-{}] consumer {} received ack {}", topicName, subscription, consumerId, position);
         }
-        updateBlockedConsumerOnUnackedMsgs(ackOwnedConsumer);
         return true;
     }
 


### PR DESCRIPTION

### Motivation

There are unnecessary calls in the individualAckNormal. Delete the line of code that calls updateBlockedConsumerOnUnackedMsgs to improve performance.

### Modifications

Refer to the Motivation section.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
