### PR TITLE
[fix][ml] Corrected pulsar_storage_size metric to not multiply offloaded storage by the write quorum

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMBeanImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMBeanImpl.java
@@ -357,7 +357,10 @@ public class ManagedLedgerMBeanImpl implements ManagedLedgerMXBean {
 
     @Override
     public long getStoredMessagesSize() {
-        return managedLedger.getTotalSize() * managedLedger.getConfig().getWriteQuorumSize();
+        long totalSize = managedLedger.getTotalSize();
+        long offloadedSize = managedLedger.getOffloadedSize();
+        long bookieSize = totalSize - offloadedSize;
+        return bookieSize * managedLedger.getConfig().getWriteQuorumSize() + offloadedSize;
     }
 
     @Override


### PR DESCRIPTION
### Motivation

I think pulsar_storage_size is partially double-counted. Currently
[pulsar_storage_size](https://github.com/apache/pulsar/blob/d0025e79e9b866b9d2b5024f16e4d631e744ecd9/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java#L177) = [pulsar_storage_logical_size * number of replicas](https://github.com/apache/pulsar/blob/d0025e79e9b866b9d2b5024f16e4d631e744ecd9/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMBeanImpl.java#L359-L361)

Number of replicas is the same as the bookie write quorum.
pulsar_logical_size doesn't account for the replication, it is sum of customer bytes no matter where they stored at.
and it looks like pulsar_storage_logical_size (calculated [here](https://github.com/apache/pulsar/blob/d0025e79e9b866b9d2b5024f16e4d631e744ecd9/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L528-L532) initially) DOES include pulsar_storage_offloaded_size (calculated [here](https://github.com/apache/pulsar/blob/d0025e79e9b866b9d2b5024f16e4d631e744ecd9/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L4224-L4233)).
But the offloaded ledgers (e.g. S3) do not create multiple replicas.

I think the metric should be calculated as:
`pulsar_storage_size = pulsar_storage_offloaded_size + (pulsar_storage_logical_size - pulsar_storage_offloaded_size) * number of replicas`

### Modifications

adjusted calculations of `pulsar_storage_size`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [X] **The metrics**
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dlg99/pulsar/pull/22
