### PR TITLE
[fix] Avoid negative estimated entry count

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3814,6 +3814,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         return Math.min(estimateEntryCountBySize(maxSizeBytes, readPosition, ledger), maxEntries);
     }
 
+    // The minimum value is 1
     static int estimateEntryCountBySize(long bytesSize, Position readPosition, ManagedLedgerImpl ml) {
         Position posToRead = readPosition;
         if (!ml.isValidPosition(readPosition)) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3854,8 +3854,8 @@ public class ManagedCursorImpl implements ManagedCursor {
                 posToRead = ml.getNextValidPosition(PositionFactory.create(posToRead.getLedgerId(), Long.MAX_VALUE));
             }
         }
-        int resultInt = Long.valueOf(result).intValue();
-        return Math.max(resultInt < 0 ? Integer.MAX_VALUE : resultInt, 1);
+        int safeInt = result > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) result;
+        return Math.max(safeInt, 1);
     }
 
     @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3811,12 +3811,10 @@ public class ManagedCursorImpl implements ManagedCursor {
         if (maxSizeBytes == NO_MAX_SIZE_LIMIT) {
             return maxEntries;
         }
-        int maxEntriesBasedOnSize =
-                Long.valueOf(estimateEntryCountBySize(maxSizeBytes, readPosition, ledger)).intValue();
-        return Math.min(maxEntriesBasedOnSize, maxEntries);
+        return Math.min(estimateEntryCountBySize(maxSizeBytes, readPosition, ledger), maxEntries);
     }
 
-    static long estimateEntryCountBySize(long bytesSize, Position readPosition, ManagedLedgerImpl ml) {
+    static int estimateEntryCountBySize(long bytesSize, Position readPosition, ManagedLedgerImpl ml) {
         Position posToRead = readPosition;
         if (!ml.isValidPosition(readPosition)) {
             posToRead = ml.getNextValidPosition(readPosition);
@@ -3855,7 +3853,8 @@ public class ManagedCursorImpl implements ManagedCursor {
                 posToRead = ml.getNextValidPosition(PositionFactory.create(posToRead.getLedgerId(), Long.MAX_VALUE));
             }
         }
-        return Math.max(result, 1);
+        int resultInt = Long.valueOf(result).intValue();
+        return Math.max(resultInt < 0 ? Integer.MAX_VALUE : resultInt, 1);
     }
 
     @Override

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -5245,7 +5245,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         // cleanup.
         ml.delete();
 
-        // test estimate long value convert to int value
+        // test estimated long value convert to an int value
         ml = (ManagedLedgerImpl) factory.open(mlName);
         ml.addEntry(new byte[1000]);
         int entryCount11 = ManagedCursorImpl.estimateEntryCountBySize(

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -5173,7 +5173,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
     public void testEstimateEntryCountBySize() throws Exception {
         final String mlName = "ml-" + UUID.randomUUID().toString().replaceAll("-", "");
         ManagedLedgerImpl ml = (ManagedLedgerImpl) factory.open(mlName);
-        long entryCount0 =
+        int entryCount0 =
                 ManagedCursorImpl.estimateEntryCountBySize(16, PositionFactory.create(ml.getCurrentLedger().getId(), 0), ml);
         assertEquals(entryCount0, 1);
         // Avoid trimming ledgers.
@@ -5206,43 +5206,51 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(average3, 4 + BOOKKEEPER_READ_OVERHEAD_PER_ENTRY);
 
         // Test: the individual ledgers.
-        long entryCount1 =
+        int entryCount1 =
                 ManagedCursorImpl.estimateEntryCountBySize(average1 * 16, PositionFactory.create(ledger1, 0), ml);
         assertEquals(entryCount1, 16);
-        long entryCount2 =
+        int entryCount2 =
                 ManagedCursorImpl.estimateEntryCountBySize(average2 * 8, PositionFactory.create(ledger2, 0), ml);
         assertEquals(entryCount2, 8);
-        long entryCount3 =
+        int entryCount3 =
                 ManagedCursorImpl.estimateEntryCountBySize(average3 * 4, PositionFactory.create(ledger3, 0), ml);
         assertEquals(entryCount3, 4);
 
         // Test: across ledgers.
-        long entryCount4 =
+        int entryCount4 =
                 ManagedCursorImpl.estimateEntryCountBySize((average1 * 100) + (average2 * 8), PositionFactory.create(ledger1, 0), ml);
         assertEquals(entryCount4, 108);
-        long entryCount5 =
+        int entryCount5 =
                 ManagedCursorImpl.estimateEntryCountBySize((average2 * 100) + (average3 * 4), PositionFactory.create(ledger2, 0), ml);
         assertEquals(entryCount5, 104);
-        long entryCount6 =
+        int entryCount6 =
                 ManagedCursorImpl.estimateEntryCountBySize((average1 * 100) + (average2 * 100) + (average3 * 4), PositionFactory.create(ledger1, 0), ml);
         assertEquals(entryCount6, 204);
 
-        long entryCount7 =
+        int entryCount7 =
                 ManagedCursorImpl.estimateEntryCountBySize((average1 * 20) + (average2 * 8), PositionFactory.create(ledger1, 80), ml);
         assertEquals(entryCount7, 28);
-        long entryCount8 =
+        int entryCount8 =
                 ManagedCursorImpl.estimateEntryCountBySize((average2 * 20) + (average3 * 4), PositionFactory.create(ledger2, 80), ml);
         assertEquals(entryCount8, 24);
-        long entryCount9 =
+        int entryCount9 =
                 ManagedCursorImpl.estimateEntryCountBySize((average1 * 20) + (average2 * 100)  + (average3 * 4), PositionFactory.create(ledger1, 80), ml);
         assertEquals(entryCount9, 124);
 
         // Test: read more than entries written.
-        long entryCount10 =
+        int entryCount10 =
                 ManagedCursorImpl.estimateEntryCountBySize((average1 * 100) + (average2 * 100) + (average3 * 100) + (average3 * 4) , PositionFactory.create(ledger1, 0), ml);
         assertEquals(entryCount10, 304);
 
         // cleanup.
+        ml.delete();
+
+        // test estimate long value convert to int value
+        ml = (ManagedLedgerImpl) factory.open(mlName);
+        ml.addEntry(new byte[1000]);
+        int entryCount11 = ManagedCursorImpl.estimateEntryCountBySize(
+                Long.MAX_VALUE, PositionFactory.create(ml.getCurrentLedger().getId(), 0), ml);
+        assertTrue(entryCount11 > 1, "entryCount11 is " + entryCount11);
         ml.delete();
     }
 


### PR DESCRIPTION
### Motivation

The estimated entry count may be a negative value in some cases, then the read operation will get an empty result.

### Modifications

Add a negative check after the long value converts to an int value.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
