### PR TITLE
[fix][ml] Avoid NPE when getCurrentLedger() returns null

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3826,7 +3826,8 @@ public class ManagedCursorImpl implements ManagedCursor {
 
         while (remainingBytesSize > 0) {
             // Last ledger.
-            if (posToRead.getLedgerId() == ml.getCurrentLedger().getId()) {
+            LedgerHandle currentLedger = ml.getCurrentLedger();
+            if (currentLedger != null && posToRead.getLedgerId() == currentLedger.getId()) {
                 if (ml.getCurrentLedgerSize() == 0 ||  ml.getCurrentLedgerEntries() == 0) {
                     // Only read 1 entry if no entries to read.
                     return 1;


### PR DESCRIPTION
### Motivation

In branch-3.0, tests are failing with logs about NPEs such as 
```
  java.lang.NullPointerException: Cannot invoke "org.apache.bookkeeper.client.LedgerHandle.getId()" because the return value of "org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.getCurrentLedger()" is null
  	at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.estimateEntryCountBySize(ManagedCursorImpl.java:3705)
  	at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.applyMaxSizeCap(ManagedCursorImpl.java:3691)
  	at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.asyncReadEntriesWithSkip(ManagedCursorImpl.java:853)
  	at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.asyncReadEntries(ManagedCursorImpl.java:840)
```

This is due to #23931 changes.

### Modifications

Handle the case when getCurrentLedger() returns null

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->