### PR TITLE
[improve][monitor] Add version=0.0.4 to /metrics content type for Prometheus 3.x compatibility

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsServlet.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsServlet.java
@@ -40,6 +40,11 @@ import org.slf4j.LoggerFactory;
 
 public class PrometheusMetricsServlet extends HttpServlet {
     public static final String DEFAULT_METRICS_PATH = "/metrics";
+    // Prometheus uses version 0.0.4 of the text format for metrics.
+    // This content-type value ensures compatibility with Prometheus 3.x and later versions.
+    // For details, refer to the Prometheus 3.x migration guide:
+    // https://prometheus.io/docs/prometheus/latest/migration/#scrape-protocols
+    public static final String PROMETHEUS_CONTENT_TYPE_004 = "text/plain; version=0.0.4; charset=utf-8";
     private static final long serialVersionUID = 1L;
     static final int HTTP_STATUS_OK_200 = 200;
     static final int HTTP_STATUS_INTERNAL_SERVER_ERROR_500 = 500;
@@ -164,7 +169,7 @@ public class PrometheusMetricsServlet extends HttpServlet {
 
     private void generateMetricsSynchronously(HttpServletResponse res) throws IOException {
         res.setStatus(HTTP_STATUS_OK_200);
-        res.setContentType("text/plain;charset=utf-8");
+        res.setContentType(PROMETHEUS_CONTENT_TYPE_004);
         PrometheusMetricsGeneratorUtils.generate(cluster, res.getOutputStream(), metricsProviders);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PulsarPrometheusMetricsServlet.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PulsarPrometheusMetricsServlet.java
@@ -145,7 +145,7 @@ public class PulsarPrometheusMetricsServlet extends PrometheusMetricsServlet {
                     response.setStatus(HTTP_STATUS_INTERNAL_SERVER_ERROR_500);
                 } else {
                     response.setStatus(HTTP_STATUS_OK_200);
-                    response.setContentType("text/plain;charset=utf-8");
+                    response.setContentType(PROMETHEUS_CONTENT_TYPE_004);
                     if (compressOutput) {
                         response.setHeader("Content-Encoding", "gzip");
                     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -88,6 +88,7 @@ import org.apache.pulsar.broker.service.BrokerServiceException.PersistenceExcept
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
+import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsServlet;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusRawMetricsProvider;
 import org.apache.pulsar.client.admin.BrokerStats;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -1549,6 +1550,8 @@ public class BrokerServiceTest extends BrokerTestBase {
         CloseableHttpClient httpClient = HttpClientBuilder.create().build();
         final String metricsEndPoint = getPulsar().getWebServiceAddress() + "/metrics";
         HttpResponse response = httpClient.execute(new HttpGet(metricsEndPoint));
+        assertEquals(response.getEntity().getContentType().getValue(),
+                PrometheusMetricsServlet.PROMETHEUS_CONTENT_TYPE_004);
         InputStream inputStream = response.getEntity().getContent();
         InputStreamReader isReader = new InputStreamReader(inputStream);
         BufferedReader reader = new BufferedReader(isReader);

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsMetricsResource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsMetricsResource.java
@@ -32,6 +32,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
+import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsServlet;
 import org.apache.pulsar.common.util.SimpleTextOutputStream;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.rest.FunctionApiResource;
@@ -63,7 +64,7 @@ public class FunctionsMetricsResource extends FunctionApiResource {
             };
             return Response
                 .ok(streamOut)
-                .type(MediaType.TEXT_PLAIN_TYPE)
+                .type(PrometheusMetricsServlet.PROMETHEUS_CONTENT_TYPE_004)
                 .build();
         } finally {
             buf.release();


### PR DESCRIPTION
### Motivation

Prometheus 3.x requires explicit version information in the content type header when scraping metrics. Without this change, Prometheus 3.x might fail scraping metrics from Pulsar endpoints in certain cases where scraping succeeded with Prometheus 2.x. This would cause monitoring issues for users who upgrade to Prometheus 3.x.
See https://prometheus.io/docs/prometheus/latest/migration/#scrape-protocols for more details.

A similar change has been made in BookKeeper with https://github.com/apache/bookkeeper/pull/4208

### Modifications

- Added a constant `PROMETHEUS_CONTENT_TYPE_004` in `PrometheusMetricsServlet` class
- Updated the content type in all metrics endpoints to include `version=0.0.4`:
  - `PrometheusMetricsServlet`
  - `PulsarPrometheusMetricsServlet`
  - `FunctionsMetricsResource`
- Added a test in `BrokerServiceTest` to verify the correct content type is returned

### Additional context

- Until this change is available, it's possible to configure `fallbackScrapeProtocol` in Prometheus at multiple levels. Here's an example for Apache Pulsar Helm chart https://github.com/apache/pulsar-helm-chart/pull/577 .

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->