### PR TITLE
[fix][monitor] Set correct content-type for metrics endpoints in Pulsar for Prometheus 3.x compatibility

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PulsarPrometheusMetricsServlet.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PulsarPrometheusMetricsServlet.java
@@ -145,7 +145,7 @@ public class PulsarPrometheusMetricsServlet extends PrometheusMetricsServlet {
                     response.setStatus(HTTP_STATUS_INTERNAL_SERVER_ERROR_500);
                 } else {
                     response.setStatus(HTTP_STATUS_OK_200);
-                    response.setContentType(PROMETHEUS_CONTENT_TYPE_004);
+                    response.setContentType(PROMETHEUS_TEXT_FORMAT_V1_0_0);
                     if (compressOutput) {
                         response.setHeader("Content-Encoding", "gzip");
                     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -1551,7 +1551,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         final String metricsEndPoint = getPulsar().getWebServiceAddress() + "/metrics";
         HttpResponse response = httpClient.execute(new HttpGet(metricsEndPoint));
         assertEquals(response.getEntity().getContentType().getValue(),
-                PrometheusMetricsServlet.PROMETHEUS_CONTENT_TYPE_004);
+                PrometheusMetricsServlet.PROMETHEUS_TEXT_FORMAT_V1_0_0);
         InputStream inputStream = response.getEntity().getContent();
         InputStreamReader isReader = new InputStreamReader(inputStream);
         BufferedReader reader = new BufferedReader(isReader);

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsMetricsResource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsMetricsResource.java
@@ -64,7 +64,7 @@ public class FunctionsMetricsResource extends FunctionApiResource {
             };
             return Response
                 .ok(streamOut)
-                .type(PrometheusMetricsServlet.PROMETHEUS_CONTENT_TYPE_004)
+                .type(PrometheusMetricsServlet.PROMETHEUS_TEXT_FORMAT_V1_0_0)
                 .build();
         } finally {
             buf.release();


### PR DESCRIPTION
### Motivation

Follow up on #24060 which set an incorrect content type.

Metrics endpoint uses version 1.0.0 of the Prometheus/OpenMetrics text format.

This content-type value ensures compatibility with Prometheus 3.x and later versions.
For details, refer to the Prometheus 3.x migration guide:
https://prometheus.io/docs/prometheus/latest/migration/#scrape-protocols

The difference between version 1.0.0 and 0.0.4 formats is mainly about counters.
The prometheus client_java library >=0.10.0 creates OpenMetrics compatible counters which are not compatible with the 0.0.4 format which is currently in use in BookKeeper.

For implementation details of Prometheus client_java, see:
https://github.com/prometheus/client_java/blob/parent0.16.0/simpleclient/src/main/java/io/prometheus/client/Counter.java#L76-L80
The library will always append "_total" to the counter name unless the counter name already contains "_total" suffix and will have a separate "_created" counter to ensure OpenMetrics compatibility. This change was introduced in https://github.com/prometheus/client_java/pull/615 in version 0.10.0.
Release notes: https://github.com/prometheus/client_java/releases/tag/parent-0.10.0

In Pulsar, the Prometheus client_java library was updated to 0.15.0 with https://github.com/apache/pulsar/pull/13785 in Pulsar 2.11.0.

### Modifications

- set version to 1.0.0 in the content type so that scraping will result in correct metrics

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->