### PR TITLE
[fix][client] PIP-409 retry/dead letter topic producer config don't take effect.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
@@ -1191,15 +1191,17 @@ public class DeadLetterTopicTest extends ProducerConsumerBase {
         // check the retry topic producer enable batch
         List<ConsumerImpl<byte[]>> consumers = ((MultiTopicsConsumerImpl<byte[]>) consumer).getConsumers();
         for (ConsumerImpl<byte[]> consumerImpl : consumers) {
-            if (!consumerImpl.getTopic().endsWith(RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX)) {
-                Producer<byte[]> retryProducer = consumerImpl.getRetryLetterProducer();
-                Producer<byte[]> deadLetterProducer = consumerImpl.getDeadLetterProducer();
-                if (retryProducer != null) {
-                    assertTrue(((ProducerImpl<byte[]>)retryProducer).isBatchMessagingEnabled());
-                }
-                if (deadLetterProducer != null) {
-                    assertTrue(((ProducerImpl<byte[]>) deadLetterProducer).isBatchMessagingEnabled());
-                }
+            Producer<byte[]> retryProducer = consumerImpl.getRetryLetterProducer();
+            Producer<byte[]> deadLetterProducer = consumerImpl.getDeadLetterProducer();
+            // there are two type of consumers in MultiTopicsConsumerImpl when enableRetry is true
+            // 1. consumer subscribe to original topic
+            // 2. consumer subscribe to retry topic
+            if (consumerImpl.getTopic().endsWith(RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX)) {
+                assertTrue(((ProducerImpl<byte[]>) retryProducer).isBatchMessagingEnabled());
+                assertTrue(((ProducerImpl<byte[]>) deadLetterProducer).isBatchMessagingEnabled());
+            } else {
+                assertTrue(((ProducerImpl<byte[]>) retryProducer).isBatchMessagingEnabled());
+                assertNull(deadLetterProducer);
             }
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/RetryTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/RetryTopicTest.java
@@ -146,6 +146,7 @@ public class RetryTopicTest extends ProducerConsumerBase {
         // enable batch
         DeadLetterProducerBuilderCustomizer producerBuilderCustomizer = (context, producerBuilder) -> {
             producerBuilder.enableBatching(true);
+            producerBuilder.enableChunking(false);
         };
         String subscriptionName = "my-subscription";
         String subscriptionNameDLQ = "my-subscription-DLQ";

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -3232,12 +3232,18 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     }
 
     @VisibleForTesting
-    public CompletableFuture<Producer<byte[]>> getRetryLetterProducer() {
-        return retryLetterProducer;
+    public Producer<byte[]> getRetryLetterProducer() {
+        if (retryLetterProducer == null) {
+            return null;
+        }
+        return retryLetterProducer.getNow(null);
     }
 
     @VisibleForTesting
-    public CompletableFuture<Producer<byte[]>> getDeadLetterProducer() {
-        return deadLetterProducer;
+    public Producer<byte[]> getDeadLetterProducer() {
+        if (deadLetterProducer == null) {
+            return null;
+        }
+        return deadLetterProducer.getNow(null);
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -400,7 +400,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                                 topic, subscription))
                         .build();
             }
-
             if (StringUtils.isNotBlank(conf.getDeadLetterPolicy().getRetryLetterTopic())) {
                 this.deadLetterPolicy.setRetryLetterTopic(conf.getDeadLetterPolicy().getRetryLetterTopic());
             } else {
@@ -408,12 +407,14 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                         "%s-%s" + RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX,
                         topic, subscription));
             }
-
             if (StringUtils.isNotBlank(conf.getDeadLetterPolicy().getInitialSubscriptionName())) {
                 this.deadLetterPolicy.setInitialSubscriptionName(
                         conf.getDeadLetterPolicy().getInitialSubscriptionName());
             }
-
+            this.deadLetterPolicy.setRetryLetterProducerBuilderCustomizer(
+                    conf.getDeadLetterPolicy().getRetryLetterProducerBuilderCustomizer());
+            this.deadLetterPolicy.setDeadLetterProducerBuilderCustomizer(
+                    conf.getDeadLetterPolicy().getDeadLetterProducerBuilderCustomizer());
         } else {
             deadLetterPolicy = null;
             possibleSendToDeadLetterTopicMessages = null;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -3233,11 +3233,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
     @VisibleForTesting
     public Producer<byte[]> getRetryLetterProducer() {
-        return (retryLetterProducer == null) ? null : retryLetterProducer.getNow(null);
+        return (retryLetterProducer == null || !retryLetterProducer.isDone()) ? null : retryLetterProducer.join();
     }
 
     @VisibleForTesting
-    public Producer<byte[]> getDeadLetterProducer() {
-        return (deadLetterProducer == null) ? null : deadLetterProducer.getNow(null);
+    public Producer<byte[]> getDeadLetterProducer() throws ExecutionException, InterruptedException {
+        return (deadLetterProducer == null || !deadLetterProducer.isDone()) ? null : deadLetterProducer.get();
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -3230,4 +3230,14 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         IN_PROGRESS,
         COMPLETED
     }
+
+    @VisibleForTesting
+    public CompletableFuture<Producer<byte[]>> getRetryLetterProducer() {
+        return retryLetterProducer;
+    }
+
+    @VisibleForTesting
+    public CompletableFuture<Producer<byte[]>> getDeadLetterProducer() {
+        return deadLetterProducer;
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -3233,17 +3233,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
     @VisibleForTesting
     public Producer<byte[]> getRetryLetterProducer() {
-        if (retryLetterProducer == null) {
-            return null;
-        }
-        return retryLetterProducer.getNow(null);
+        return (retryLetterProducer == null) ? null : retryLetterProducer.getNow(null);
     }
 
     @VisibleForTesting
     public Producer<byte[]> getDeadLetterProducer() {
-        if (deadLetterProducer == null) {
-            return null;
-        }
-        return deadLetterProducer.getNow(null);
+        return (deadLetterProducer == null) ? null : deadLetterProducer.getNow(null);
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -350,7 +350,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         return connectionHandler;
     }
 
-    private boolean isBatchMessagingEnabled() {
+    public boolean isBatchMessagingEnabled() {
         return conf.isBatchingEnabled();
     }
 


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/24020 support configure the producer of retry/dead-letter topic, but it don't take effect.

### Modifications

Make sure the config is used.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository:  https://github.com/thetumbled/pulsar/pull/73
