### PR TITLE
[fix][broker] Pattern subscription doesn't work when the pattern excludes the topic domain.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -3160,7 +3160,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         final NamespaceName namespaceName = NamespaceName.get(commandWatchTopicList.getNamespace());
 
         Pattern topicsPattern = Pattern.compile(commandWatchTopicList.hasTopicsPattern()
-                ? commandWatchTopicList.getTopicsPattern() : TopicList.ALL_TOPICS_PATTERN);
+                ? TopicList.removeTopicDomainScheme(commandWatchTopicList.getTopicsPattern())
+                : TopicList.ALL_TOPICS_PATTERN);
         String topicsHash = commandWatchTopicList.hasTopicsHash()
                 ? commandWatchTopicList.getTopicsHash() : null;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicListService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicListService.java
@@ -57,7 +57,7 @@ public class TopicListService {
                                 Pattern topicsPattern, List<String> topics) {
             this.topicListService = topicListService;
             this.id = id;
-            this.topicsPattern = Pattern.compile(TopicList.removeTopicDomainScheme(topicsPattern.toString()));
+            this.topicsPattern = topicsPattern;
             this.matchingTopics = TopicList.filterTopics(topics, topicsPattern);
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicListService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicListService.java
@@ -57,7 +57,7 @@ public class TopicListService {
                                 Pattern topicsPattern, List<String> topics) {
             this.topicListService = topicListService;
             this.id = id;
-            this.topicsPattern = topicsPattern;
+            this.topicsPattern = Pattern.compile(TopicList.removeTopicDomainScheme(topicsPattern.toString()));
             this.matchingTopics = TopicList.filterTopics(topics, topicsPattern);
         }
 
@@ -70,7 +70,8 @@ public class TopicListService {
          */
         @Override
         public void accept(String topicName, NotificationType notificationType) {
-            if (topicsPattern.matcher(TopicName.get(topicName).getPartitionedTopicName()).matches()) {
+            String partitionedTopicName = TopicName.get(topicName).getPartitionedTopicName();
+            if (topicsPattern.matcher(TopicList.removeTopicDomainScheme(partitionedTopicName)).matches()) {
                 List<String> newTopics;
                 List<String> deletedTopics;
                 if (notificationType == NotificationType.Deleted) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicListWatcherTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicListWatcherTest.java
@@ -40,7 +40,7 @@ public class TopicListWatcherTest {
     );
 
     private static final long ID = 7;
-    private static final Pattern PATTERN = Pattern.compile("persistent://tenant/ns/topic\\d+");
+    private static final Pattern PATTERN = Pattern.compile("tenant/ns/topic\\d+");
 
 
     private TopicListService topicListService;

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -128,6 +128,8 @@ public interface ConsumerBuilder<T> extends Cloneable {
     /**
      * Specify a pattern for topics(not contains the partition suffix) that this consumer subscribes to.
      *
+     * <p>Will ignore the topic domain("persistent://" or "non-persistent://") when pattern matching.
+     *
      * <p>The pattern is applied to subscribe to all topics, within a single namespace, that match the
      * pattern.
      *
@@ -143,7 +145,9 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * Specify a pattern for topics(not contains the partition suffix) that this consumer subscribes to.
      *
      * <p>It accepts a regular expression that is compiled into a pattern internally. E.g.,
-     * "persistent://public/default/pattern-topic-.*"
+     * "persistent://public/default/pattern-topic-.*" or "public/default/pattern-topic-.*"
+     *
+     * <p>Will ignore the topic domain("persistent://" or "non-persistent://") when pattern matching.
      *
      * <p>The pattern is applied to subscribe to all topics, within a single namespace, that match the
      * pattern.

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicList.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicList.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.common.topics;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.Hashing;
 import com.google.re2j.Pattern;
 import java.nio.charset.StandardCharsets;
@@ -85,8 +84,7 @@ public class TopicList {
         return s1;
     }
 
-    @VisibleForTesting
-    static String removeTopicDomainScheme(String originalRegexp) {
+    public static String removeTopicDomainScheme(String originalRegexp) {
         if (!originalRegexp.toString().contains(SCHEME_SEPARATOR)) {
             return originalRegexp;
         }


### PR DESCRIPTION
### Motivation

After #16062, we use a notification machine to discover topic changes for pattern subscriptions.

If the user sets a pattern string like `my-property/my-ns/test-pattern.*`(without topic domain) when creating a subscription.

It doesn't receive updates for the latest topics because the topic names include the domain when matching.

For example:
- topicName: `persistent://my-property/my-ns/test-pattern-1`
- topicsPattern: `my-property/my-ns/test-pattern.*`

https://github.com/apache/pulsar/blob/fad925f7c522a30ba9fa005e5788162dd17b21ab/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicListService.java#L73


You can run test to reproduce it: `testSubscribePatterWithOutTopicDomain`


BTW: This issue has always existed, but some clients had a fallback by periodically querying topics for updates.
For the Java client, this has been removed after #20779, which is why the issue occurs.

### Modifications
- Remove the domain from both the `topic name` and the `topic pattern` for matching.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
