### PR TITLE
[improve][broker]Optimize message expiration rate repeated update issues

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
@@ -190,7 +190,6 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
             long numMessagesExpired = (long) ctx - cursor.getNumberOfEntriesInBacklog(false);
             msgExpired.recordMultipleEvents(numMessagesExpired, 0 /* no value stats */);
             totalMsgExpired.add(numMessagesExpired);
-            updateRates();
             // If the subscription is a Key_Shared subscription, we should to trigger message dispatch.
             if (subscription != null && subscription.getType() == SubType.Key_Shared) {
                 subscription.getDispatcher().markDeletePositionMoveForward();


### PR DESCRIPTION

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

The message expiration rate is updated in both tasks, as follows:
<img width="1130" alt="Clipboard_Screenshot_1741772793" src="https://github.com/user-attachments/assets/dcbf7a53-0a9e-4987-8f52-0586455298c9" />
<img width="1160" alt="Clipboard_Screenshot_1741772909" src="https://github.com/user-attachments/assets/ab61e64e-05e8-4912-b93f-324b7c6f4605" />

the time period for calculating the rate is the interval between two tasks. If the time interval between two tasks is very small, the calculation speed will be very large.


### Modifications

<!-- Describe the modifications you've done. -->

Delete the update method in the message expiration task, and retain the unified update method in the topic

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


