### PR TITLE
[fix] Bring GitHub Discussions back by enabling discussions in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -34,6 +34,8 @@ github:
     issues: true
     # Enable projects for project management boards
     projects: true
+    # Enable discussions
+    discussions: true
   enabled_merge_buttons:
     squash:  true
     merge:   false


### PR DESCRIPTION
### Motivation

GitHub Discussions in ASF projects now require that they are explicitly enabled in `.asf.yaml`. The discussions at https://github.com/apache/pulsar/discussions are currently disabled due to recent changes in ASF infra which now checks this setting.

### Modifications

- enable discussions in `.asf.yaml`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->