### PR TITLE
[fix][broker] Fix NPE while publishing Metadata-Event with not init producer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarMetadataEventSynchronizer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarMetadataEventSynchronizer.java
@@ -120,6 +120,7 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
         if (!isProducerStarted()) {
             log.info("Producer is not started on {}, failed to publish {}", topicName, event);
             future.completeExceptionally(new IllegalStateException("producer is not started yet"));
+            return;
         }
         producer.newMessage().value(event).sendAsync().thenAccept(__ -> {
             log.info("successfully published metadata change event {}", event);
@@ -135,6 +136,7 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
     private void startProducer() {
         if (isClosingOrClosed()) {
             log.info("[{}] Skip to start new producer because the synchronizer is closed", topicName);
+            return;
         }
         if (producer != null) {
             log.error("[{}] Failed to start the producer because the producer has been set, state: {}",


### PR DESCRIPTION
### Motivation

Currently, if broker tries to publish metadata-event before Metadata Event synchronizer is successfully created producer then it throws below NullPointerException and it should be fixed
```
java.util.concurrent.CompletionException: java.lang.NullPointerException: Cannot invoke "org.apache.pulsar.client.api.Producer.newMessage()" because "this.producer" is null
        at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:332) ~[?:?]
        at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:674) ~[?:?]
        at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:662) ~[?:?]
        at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2168) ~[?:?]
        at org.apache.pulsar.broker.resources.BaseResources.setAsync(BaseResources.java:151) ~[org.apache.pulsar-pulsar-broker-common-4.jar:4]
        at org.apache.pulsar.broker.resources.NamespaceResources.setPoliciesAsync(NamespaceResources.java:145) ~[org.apache.pulsar-pulsar-broker-common-4.jar:4]
        at org.apache.pulsar.broker.admin.impl.NamespacesBase.setBacklogQuotaAsync(NamespacesBase.java:1343) ~[org.apache.pulsar-pulsar-broker-4.jar:4]
        at org.apache.pulsar.broker.admin.impl.NamespacesBase.lambda$internalSetBacklogQuota$276(NamespacesBase.java:2653) ~[org.apache.pulsar-pulsar-broker-4.jar:4]
        at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187) ~[?:?]
        at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309) ~[?:?]
        at org.apache.pulsar.broker.admin.impl.NamespacesBase.internalSetBacklogQuota(NamespacesBase.java:2653) ~[org.apache.pulsar-pulsar-broker-4.jar:4]
        at org.apache.pulsar.broker.admin.v1.Namespaces.setBacklogQuota(Namespaces.java:1171) ~[org.apache.pulsar-pulsar-broker-4.jar:4]


```

### Modifications

This PR fixes NPE while publishing metadata event.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
