### PR TITLE
[fix][ci] Upgrade OWASP Dependency Check to 12.1.0

### DIFF
--- a/.github/workflows/ci-owasp-dependency-check.yaml
+++ b/.github/workflows/ci-owasp-dependency-check.yaml
@@ -89,10 +89,10 @@ jobs:
         timeout-minutes: 5
         with:
           path: ~/.m2/repository/org/owasp/dependency-check-data
-          key: owasp-dependency-check-data-${{ steps.get-weeknum.outputs.weeknum }}
+          key: owasp-dependency-check-data-v11-${{ steps.get-weeknum.outputs.weeknum }}
           enableCrossOsArchive: true
           restore-keys: |
-            owasp-dependency-check-data-
+            owasp-dependency-check-data-v11-
 
       - name: Update OWASP Dependency Check data
         id: update-owasp-dependency-check-data

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -1489,10 +1489,10 @@ jobs:
         timeout-minutes: 5
         with:
           path: ~/.m2/repository/org/owasp/dependency-check-data
-          key: owasp-dependency-check-data-${{ steps.get-weeknum.outputs.weeknum }}
+          key: owasp-dependency-check-data-v11-${{ steps.get-weeknum.outputs.weeknum }}
           enableCrossOsArchive: true
           restore-keys: |
-            owasp-dependency-check-data-
+            owasp-dependency-check-data-v11-
 
       - name: Log warning when skipped
         if: ${{ !steps.restore-owasp-dependency-check-data.outputs.cache-matched-key }}

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@ flexible messaging model and an intuitive client API.</description>
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
-    <dependency-check-maven.version>10.0.2</dependency-check-maven.version>
+    <dependency-check-maven.version>12.1.0</dependency-check-maven.version>
     <roaringbitmap.version>1.2.0</roaringbitmap.version>
     <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
     <oshi.version>6.4.0</oshi.version>


### PR DESCRIPTION
### Motivation

Current version fails to parse NVD API's CVE data:
```
[INFO] Checking for updates
[INFO] NVD API has 285,363 records in this update
[INFO] Downloaded 10,000/285,363 (4%)
[INFO] Downloaded 20,000/285,363 (7%)
[INFO] Downloaded 30,000/285,363 (11%)
[INFO] Downloaded 40,000/285,363 (14%)
[INFO] Downloaded 50,000/285,363 (18%)
[INFO] Downloaded 60,000/285,363 (21%)
[INFO] Downloaded 70,000/285,363 (25%)
[INFO] Downloaded 80,000/285,363 (28%)
[INFO] Downloaded 90,000/285,363 (32%)
[INFO] Downloaded 100,000/285,363 (35%)
[INFO] Downloaded 110,000/285,363 (39%)
[INFO] Downloaded 120,000/285,363 (42%)
[INFO] Downloaded 130,000/285,363 (46%)
[INFO] Downloaded 140,000/285,363 (49%)
[INFO] Downloaded 150,000/285,363 (53%)
[INFO] Downloaded 160,000/285,363 (56%)
[INFO] Downloaded 170,000/285,363 (60%)
[INFO] Downloaded 180,000/285,363 (63%)
[INFO] Downloaded 190,000/285,363 (67%)
[INFO] Downloaded 200,000/285,363 (70%)
[INFO] Downloaded 210,000/285,363 (74%)
[INFO] Downloaded 220,000/285,363 (77%)
[INFO] Downloaded 230,000/285,363 (81%)
[INFO] Downloaded 240,000/285,363 (84%)
Error:  Failed to process CVE-2024-1719
java.lang.NullPointerException
    at java.util.stream.ReferencePipeline$7$1.accept (ReferencePipeline.java:273)
    at java.util.stream.ReferencePipeline$3$1.accept (ReferencePipeline.java:197)
    at java.util.ArrayList$ArrayListSpliterator.tryAdvance (ArrayList.java:1602)
    at java.util.stream.ReferencePipeline$7$1.accept (ReferencePipeline.java:280)
    at java.util.stream.ReferencePipeline$3$1.accept (ReferencePipeline.java:197)
    at java.util.ArrayList$ArrayListSpliterator.tryAdvance (ArrayList.java:1602)
    at java.util.stream.ReferencePipeline.forEachWithCancel (ReferencePipeline.java:129)
    at java.util.stream.AbstractPipeline.copyIntoWithCancel (AbstractPipeline.java:527)
    at java.util.stream.AbstractPipeline.copyInto (AbstractPipeline.java:513)
    at java.util.stream.AbstractPipeline.wrapAndCopyInto (AbstractPipeline.java:499)
    at java.util.stream.MatchOps$MatchOp.evaluateSequential (MatchOps.java:230)
    at java.util.stream.MatchOps$MatchOp.evaluateSequential (MatchOps.java:196)
    at java.util.stream.AbstractPipeline.evaluate (AbstractPipeline.java:234)
    at java.util.stream.ReferencePipeline.anyMatch (ReferencePipeline.java:632)
    at org.owasp.dependencycheck.data.nvdcve.CveItemOperator.testCveCpeStartWithFilter (CveItemOperator.java:228)
    at org.owasp.dependencycheck.data.nvdcve.CveDB.updateVulnerability (CveDB.java:1098)
    at org.owasp.dependencycheck.data.update.nvd.api.NvdApiProcessor.updateCveDb (NvdApiProcessor.java:119)
    at org.owasp.dependencycheck.data.update.nvd.api.NvdApiProcessor.call (NvdApiProcessor.java:96)
    at org.owasp.dependencycheck.data.update.nvd.api.NvdApiProcessor.call (NvdApiProcessor.java:40)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:[113](https://github.com/apache/pulsar/actions/runs/13889055422/job/38857890154#step:9:114)6)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:635)
    at java.lang.Thread.run (Thread.java:840)
```

### Modifications

- upgrade to 12.1.0 version
- internal database format [has changed in v11](https://github.com/dependency-check/DependencyCheck?tab=readme-ov-file#breaking-changes-in-1100)
  - add `v11` to cache key prefix

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->