### PR TITLE
[fix][broker] Avoid IllegalStateException when marker_type field is not set in publishing

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -363,7 +363,7 @@ public class MessageDeduplication {
             // Message is coming from replication, we need to use the replication's producer name, ledger id and entry
             // id for the purpose of deduplication.
             MessageMetadata md = Commands.peekMessageMetadata(headersAndPayload, "Check-Deduplicate", -1);
-            if (Markers.isReplicationMarker(md.getMarkerType())) {
+            if (md != null && md.hasMarkerType() && Markers.isReplicationMarker(md.getMarkerType())) {
                 publishContext.setProperty(MSG_PROP_IS_REPL_MARKER, "");
             }
             return;


### PR DESCRIPTION
### Motivation

As described in #24085, the changes in #23697 broke compatibility with existing protocol adapters.

### Modifications

Avoid the IllegalStateException mentioned in #24085. This PR doesn't guarantee that there is compatibility, it simply addresses a single issue introduced by #23697 .

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->