### PR TITLE
[fix][broker] Fix some problems in calculate totalAvailableBookies in method getExcludedBookiesWithIsolationGroups when some bookies belongs to multiple isolation groups.

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicy.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicy.java
@@ -206,6 +206,9 @@ public class IsolatedBookieEnsemblePlacementPolicy extends RackawareEnsemblePlac
                     return excludedBookies;
                 }
                 Set<String> allGroups = allGroupsBookieMapping.keySet();
+                if (allGroups.isEmpty()) {
+                    return excludedBookies;
+                }
                 int totalAvailableBookiesInPrimaryGroup = 0;
                 Set<String> primaryIsolationGroup = Collections.emptySet();
                 Set<String> secondaryIsolationGroup = Collections.emptySet();
@@ -222,9 +225,10 @@ public class IsolatedBookieEnsemblePlacementPolicy extends RackawareEnsemblePlac
                         }
                     } else {
                         for (String groupBookie : bookiesInGroup) {
-                            totalAvailableBookiesInPrimaryGroup += knownBookies
-                                .containsKey(BookieId.parse(groupBookie)) ? 1 : 0;
-                            primaryGroupBookies.add(BookieId.parse(groupBookie));
+                            BookieId bookieId = BookieId.parse(groupBookie);
+                            if (primaryGroupBookies.add(bookieId)) {
+                                totalAvailableBookiesInPrimaryGroup += knownBookies.containsKey(bookieId) ? 1 : 0;
+                            }
                         }
                     }
                 }
@@ -256,8 +260,9 @@ public class IsolatedBookieEnsemblePlacementPolicy extends RackawareEnsemblePlac
                         Map<String, BookieInfo> bookieGroup = allGroupsBookieMapping.get(group);
                         if (bookieGroup != null && !bookieGroup.isEmpty()) {
                             for (String bookieAddress : bookieGroup.keySet()) {
-                                excludedBookies.remove(BookieId.parse(bookieAddress));
-                                totalAvailableBookiesFromPrimaryAndSecondary += 1;
+                                if (excludedBookies.remove(BookieId.parse(bookieAddress))) {
+                                    totalAvailableBookiesFromPrimaryAndSecondary += 1;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
### Motivation

Currently, the values ​​of `totalAvailableBookiesInPrimaryGroup` and `totalAvailableBookiesFromPrimaryAndSecondary` may not be accurate because there may be repeated accumulation when some bookies belongs to multiple isolation groups.

For example: There are 3 bookies in total and has 3 group, the distribution is as follows
Group1: bk1
Group2: bk2,bk3
Group3: bk1
When `primaryIsolationGroup` contains Group1 and Group3, `secondaryIsolationGroup` contains Group2, when execute the method `getExcludedBookiesWithIsolationGroups(2, groups[primaryIsolationGroup,secondaryIsolationGroup])`. The correct return value should be empty but current return bk2 and bk3.

The calculation of `totalAvailableBookiesFromPrimaryAndSecondary` has similar problems.

### Modifications
Fix the calculation logic of `totalAvailableBookiesInPrimaryGroup` and `totalAvailableBookiesFromPrimaryAndSecondary`.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->