### PR TITLE
[fix][broker] Restore the behavior to dispatch batch messages according to consumer permits

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -850,7 +850,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
                 int maxAdditionalUnackedMessages = Math.max(c.getMaxUnackedMessages() - c.getUnackedMessages(), 0);
                 maxMessagesInThisBatch = Math.min(maxMessagesInThisBatch, maxAdditionalUnackedMessages);
             }
-            int maxEntriesInThisBatch = Math.min(availablePermits,
+            int maxEntriesInThisBatch = Math.min(availablePermits / avgBatchSizePerMsg,
                             // use the average batch size per message to calculate the number of entries to
                             // dispatch. round up to the next integer without using floating point arithmetic.
                             (maxMessagesInThisBatch + avgBatchSizePerMsg - 1) / avgBatchSizePerMsg);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -843,14 +843,14 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
                         c, c.getAvailablePermits());
             }
 
-            int maxMessagesInThisBatch =
-                    Math.max(remainingMessages, serviceConfig.getDispatcherMaxRoundRobinBatchSize());
+            int maxMessagesInThisBatch = Math.min(remainingMessages, availablePermits);
             if (c.getMaxUnackedMessages() > 0) {
                 // Calculate the maximum number of additional unacked messages allowed
                 int maxAdditionalUnackedMessages = Math.max(c.getMaxUnackedMessages() - c.getUnackedMessages(), 0);
                 maxMessagesInThisBatch = Math.min(maxMessagesInThisBatch, maxAdditionalUnackedMessages);
             }
-            int maxEntriesInThisBatch = Math.min(availablePermits / avgBatchSizePerMsg,
+            // TODO: add tests to verify dispatcherMaxRoundRobinBatchSize is respected
+            int maxEntriesInThisBatch = Math.min(serviceConfig.getDispatcherMaxRoundRobinBatchSize(),
                             // use the average batch size per message to calculate the number of entries to
                             // dispatch. round up to the next integer without using floating point arithmetic.
                             (maxMessagesInThisBatch + avgBatchSizePerMsg - 1) / avgBatchSizePerMsg);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageTest.java
@@ -1012,6 +1012,10 @@ public class BatchMessageTest extends BrokerTestBase {
         }
         FutureUtil.waitForAll(sendFutureList).get();
 
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertTrue(consumer1.numMessagesInQueue() > 0);
+            assertTrue(consumer2.numMessagesInQueue() > 0);
+        });
         assertEquals(consumer1.numMessagesInQueue(), batchMessages, batchMessages);
         assertEquals(consumer2.numMessagesInQueue(), batchMessages, batchMessages);
 


### PR DESCRIPTION
Fixes #23825

### Motivation

It seems that the PIP-379 breaks https://github.com/apache/pulsar/pull/7266. For example, given the following configs:
- The consumer whose available permits is 10
- There are 10 entries available, each entry's batch size is 10.

When `subscriptionSharedUseClassicPersistentImplementation` is false (by default), 10 entries will be dispatched to the consumer. When it's true (the behavior before 4.0), only 1 entry will be dispatched to the consumer.

### Modifications

Fix the `maxEntriesInThisBatch` calculation in `PersistentDispatcherMultipleConsumers`. In `testBatchMessageDispatchingAccordingToPermits`, wait until the entries are dispatched to consumers. Then this test would fail without this fix.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
