### PR TITLE
[fix][test] Move ReplicatorRateLimiterTest to broker test group

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
@@ -109,19 +109,23 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
             .ratePeriodInSecond(30)
             .build();
         admin1.topics().setReplicatorDispatchRate(topicName, topicRate);
-        Awaitility.await().untilAsserted(() ->
-            assertEquals(admin1.topics().getReplicatorDispatchRate(topicName), topicRate));
-        assertTrue(getRateLimiter(topic).isPresent());
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnMsg(), 10);
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnByte(), 20L);
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(admin1.topics().getReplicatorDispatchRate(topicName), topicRate);
+            Optional<DispatchRateLimiter> rateLimiter = getRateLimiter(topic);
+            assertTrue(rateLimiter.isPresent());
+            assertEquals(rateLimiter.get().getDispatchRateOnMsg(), 10);
+            assertEquals(rateLimiter.get().getDispatchRateOnByte(), 20L);
+        });
 
         //remove topic-level policy
         admin1.topics().removeReplicatorDispatchRate(topicName);
-        Awaitility.await().untilAsserted(() ->
-            assertNull(admin1.topics().getReplicatorDispatchRate(topicName)));
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnMsg(), -1);
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnByte(),
-            -1L);
+        Awaitility.await().untilAsserted(() -> {
+            assertNull(admin1.topics().getReplicatorDispatchRate(topicName));
+            Optional<DispatchRateLimiter> rateLimiter = getRateLimiter(topic);
+            assertTrue(rateLimiter.isPresent());
+            assertEquals(rateLimiter.get().getDispatchRateOnMsg(), -1);
+            assertEquals(rateLimiter.get().getDispatchRateOnByte(), -1L);
+        });
     }
 
     @Test
@@ -153,19 +157,22 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
             .ratePeriodInSecond(30)
             .build();
         admin1.namespaces().setReplicatorDispatchRate(namespace, topicRate);
-        Awaitility.await().untilAsserted(() ->
-            assertEquals(admin1.namespaces().getReplicatorDispatchRate(namespace), topicRate));
-        assertTrue(getRateLimiter(topic).isPresent());
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnMsg(), 10);
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnByte(), 20L);
+        Awaitility.await().untilAsserted(() -> {
+            Optional<DispatchRateLimiter> rateLimiter = getRateLimiter(topic);
+            assertTrue(rateLimiter.isPresent());
+            assertEquals(rateLimiter.get().getDispatchRateOnMsg(), 10);
+            assertEquals(rateLimiter.get().getDispatchRateOnByte(), 20L);
+        });
 
         //remove topic-level policy
         admin1.namespaces().removeReplicatorDispatchRate(namespace);
-        Awaitility.await().untilAsserted(() ->
-            assertNull(admin1.namespaces().getReplicatorDispatchRate(namespace)));
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnMsg(), -1);
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnByte(),
-            -1L);
+        assertNull(admin1.namespaces().getReplicatorDispatchRate(namespace));
+        Awaitility.await().untilAsserted(() -> {
+            Optional<DispatchRateLimiter> rateLimiter = getRateLimiter(topic);
+            assertTrue(rateLimiter.isPresent());
+            assertEquals(rateLimiter.get().getDispatchRateOnMsg(), -1);
+            assertEquals(rateLimiter.get().getDispatchRateOnByte(), -1L);
+        });
     }
 
     @Test
@@ -202,9 +209,12 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
                 .getAllDynamicConfigurations().get("dispatchThrottlingRatePerReplicatorInByte"), "20");
         });
 
-        assertTrue(getRateLimiter(topic).isPresent());
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnMsg(), 10);
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnByte(), 20L);
+        Awaitility.await().untilAsserted(() -> {
+            Optional<DispatchRateLimiter> rateLimiter = getRateLimiter(topic);
+            assertTrue(rateLimiter.isPresent());
+            assertEquals(getRateLimiter(topic).get().getDispatchRateOnMsg(), 10);
+            assertEquals(getRateLimiter(topic).get().getDispatchRateOnByte(), 20L);
+        });
     }
 
     @Test
@@ -238,10 +248,13 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
                 .ratePeriodInSecond(60)
                 .build();
         admin1.namespaces().setReplicatorDispatchRate(namespace, nsDispatchRate);
-        Awaitility.await()
-                .untilAsserted(() -> assertEquals(admin1.namespaces().getReplicatorDispatchRate(namespace), nsDispatchRate));
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnMsg(), 50);
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnByte(), 60L);
+        assertEquals(admin1.namespaces().getReplicatorDispatchRate(namespace), nsDispatchRate);
+        Awaitility.await().untilAsserted(() -> {
+            Optional<DispatchRateLimiter> rateLimiter = getRateLimiter(topic);
+            assertTrue(rateLimiter.isPresent());
+            assertEquals(rateLimiter.get().getDispatchRateOnMsg(), 50);
+            assertEquals(rateLimiter.get().getDispatchRateOnByte(), 60L);
+        });
 
         //set topic-level policy, which should take effect
         DispatchRate topicRate = DispatchRate.builder()
@@ -250,10 +263,13 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
                 .ratePeriodInSecond(30)
                 .build();
         admin1.topics().setReplicatorDispatchRate(topicName, topicRate);
-        Awaitility.await().untilAsserted(() ->
-                assertEquals(admin1.topics().getReplicatorDispatchRate(topicName), topicRate));
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnMsg(), 10);
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnByte(), 20L);
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(admin1.topics().getReplicatorDispatchRate(topicName), topicRate);
+            Optional<DispatchRateLimiter> rateLimiter = getRateLimiter(topic);
+            assertTrue(rateLimiter.isPresent());
+            assertEquals(rateLimiter.get().getDispatchRateOnMsg(), 10);
+            assertEquals(rateLimiter.get().getDispatchRateOnByte(), 20L);
+        });
 
         //Set the namespace-level policy, which should not take effect
         DispatchRate nsDispatchRate2 = DispatchRate.builder()
@@ -262,24 +278,31 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
                 .ratePeriodInSecond(700)
                 .build();
         admin1.namespaces().setReplicatorDispatchRate(namespace, nsDispatchRate2);
-        Awaitility.await()
-                .untilAsserted(() -> assertEquals(admin1.namespaces().getReplicatorDispatchRate(namespace), nsDispatchRate2));
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnByte(), 20L);
+        assertEquals(admin1.namespaces().getReplicatorDispatchRate(namespace), nsDispatchRate2);
+        Awaitility.await().untilAsserted(() -> {
+            Optional<DispatchRateLimiter> rateLimiter = getRateLimiter(topic);
+            assertTrue(rateLimiter.isPresent());
+            assertEquals(rateLimiter.get().getDispatchRateOnByte(), 20L);
+        });
 
         //remove topic-level policy, namespace-level should take effect
         admin1.topics().removeReplicatorDispatchRate(topicName);
-        Awaitility.await().untilAsserted(() ->
-                assertNull(admin1.topics().getReplicatorDispatchRate(topicName)));
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnMsg(), 500);
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnByte(),
-                600L);
+        Awaitility.await().untilAsserted(() -> {
+            assertNull(admin1.topics().getReplicatorDispatchRate(topicName));
+            Optional<DispatchRateLimiter> rateLimiter = getRateLimiter(topic);
+            assertTrue(rateLimiter.isPresent());
+            assertEquals(rateLimiter.get().getDispatchRateOnMsg(), 500);
+            assertEquals(rateLimiter.get().getDispatchRateOnByte(), 600L);
+        });
 
         //remove namespace-level policy, broker-level should take effect
         admin1.namespaces().setReplicatorDispatchRate(namespace, null);
-        Awaitility.await().untilAsserted(() ->
-                assertEquals(getRateLimiter(topic).get().getDispatchRateOnMsg(), 100));
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnByte(),
-                200L);
+        Awaitility.await().untilAsserted(() -> {
+            Optional<DispatchRateLimiter> rateLimiter = getRateLimiter(topic);
+            assertTrue(rateLimiter.isPresent());
+            assertEquals(rateLimiter.get().getDispatchRateOnMsg(), 100);
+            assertEquals(rateLimiter.get().getDispatchRateOnByte(), 200L);
+        });
     }
 
     /**
@@ -325,20 +348,11 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
                 .build();
         admin1.namespaces().setReplicatorDispatchRate(namespace, dispatchRateMsg);
 
-        boolean replicatorUpdated = false;
-        int retry = 5;
-        for (int i = 0; i < retry; i++) {
-            if (getRateLimiter(topic).isPresent()) {
-                replicatorUpdated = true;
-                break;
-            } else {
-                if (i != retry - 1) {
-                    Thread.sleep(100);
-                }
-            }
-        }
-        Assert.assertTrue(replicatorUpdated);
-        Assert.assertEquals(getRateLimiter(topic).get().getDispatchRateOnMsg(), messageRate);
+        Awaitility.await().untilAsserted(()->{
+            Optional<DispatchRateLimiter> rateLimiter = getRateLimiter(topic);
+            assertTrue(rateLimiter.isPresent());
+            assertEquals(rateLimiter.get().getDispatchRateOnMsg(), 100);
+        });
 
         // 3. change namespace setting of replicator dispatchRateByte, verify topic changed.
         messageRate = 500;
@@ -348,19 +362,12 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
                 .ratePeriodInSecond(360)
                 .build();
         admin1.namespaces().setReplicatorDispatchRate(namespace, dispatchRateByte);
-        replicatorUpdated = false;
-        for (int i = 0; i < retry; i++) {
-            if (getRateLimiter(topic).get().getDispatchRateOnByte() == messageRate) {
-                replicatorUpdated = true;
-                break;
-            } else {
-                if (i != retry - 1) {
-                    Thread.sleep(100);
-                }
-            }
-        }
-        Assert.assertTrue(replicatorUpdated);
-        Assert.assertEquals(admin1.namespaces().getReplicatorDispatchRate(namespace), dispatchRateByte);
+        assertEquals(admin1.namespaces().getReplicatorDispatchRate(namespace), dispatchRateByte);
+        Awaitility.await().untilAsserted(() -> {
+            Optional<DispatchRateLimiter> rateLimiter = getRateLimiter(topic);
+            assertTrue(rateLimiter.isPresent());
+            assertEquals(rateLimiter.get().getDispatchRateOnByte(), 500);
+        });
     }
 
     /**
@@ -410,24 +417,15 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
 
         PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getOrCreateTopic(topicName).get();
 
-        boolean replicatorUpdated = false;
-        int retry = 5;
-        for (int i = 0; i < retry; i++) {
-            if (getRateLimiter(topic).isPresent()) {
-                replicatorUpdated = true;
-                break;
+        Awaitility.await().untilAsserted(() -> {
+            Optional<DispatchRateLimiter> rateLimiter = getRateLimiter(topic);
+            assertTrue(rateLimiter.isPresent());
+            if (DispatchRateType.messageRate.equals(dispatchRateType)) {
+                assertEquals(rateLimiter.get().getDispatchRateOnMsg(), messageRate);
             } else {
-                if (i != retry - 1) {
-                    Thread.sleep(100);
-                }
+                assertEquals(rateLimiter.get().getDispatchRateOnByte(), messageRate);
             }
-        }
-        Assert.assertTrue(replicatorUpdated);
-        if (DispatchRateType.messageRate.equals(dispatchRateType)) {
-            Assert.assertEquals(getRateLimiter(topic).get().getDispatchRateOnMsg(), messageRate);
-        } else {
-            Assert.assertEquals(getRateLimiter(topic).get().getDispatchRateOnByte(), messageRate);
-        }
+        });
 
         @Cleanup
         PulsarClient client2 = PulsarClient.builder().serviceUrl(url2.toString()).statsInterval(0, TimeUnit.SECONDS)
@@ -495,20 +493,11 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
 
         PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getOrCreateTopic(topicName).get();
 
-        boolean replicatorUpdated = false;
-        int retry = 5;
-        for (int i = 0; i < retry; i++) {
-            if (getRateLimiter(topic).isPresent()) {
-                replicatorUpdated = true;
-                break;
-            } else {
-                if (i != retry - 1) {
-                    Thread.sleep(100);
-                }
-            }
-        }
-        Assert.assertTrue(replicatorUpdated);
-        Assert.assertEquals(getRateLimiter(topic).get().getDispatchRateOnMsg(), messageRate);
+        Awaitility.await().untilAsserted(() -> {
+            Optional<DispatchRateLimiter> rateLimiter = getRateLimiter(topic);
+            assertTrue(rateLimiter.isPresent());
+            assertEquals(rateLimiter.get().getDispatchRateOnMsg(), messageRate);
+        });
 
         @Cleanup
         PulsarClient client2 = PulsarClient.builder().serviceUrl(url2.toString()).statsInterval(0, TimeUnit.SECONDS)
@@ -528,21 +517,21 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
             producer.send(new byte[80]);
         }
 
-        Thread.sleep(1000);
-        log.info("Received message number: [{}]", totalReceived.get());
+        Awaitility.await().pollDelay(1, TimeUnit.SECONDS).untilAsserted(()->{
+            log.info("Received message number: [{}]", totalReceived.get());
 
-        Assert.assertEquals(totalReceived.get(), numMessages);
+            Assert.assertEquals(totalReceived.get(), numMessages);
+        });
 
-
-        numMessages = 200;
         // Asynchronously produce messages
-        for (int i = 0; i < numMessages; i++) {
+        for (int i = 0; i < 200; i++) {
             producer.send(new byte[80]);
         }
-        Thread.sleep(1000);
-        log.info("Received message number: [{}]", totalReceived.get());
+        Awaitility.await().pollDelay(1, TimeUnit.SECONDS).untilAsserted(() -> {
+            log.info("Received message number: [{}]", totalReceived.get());
 
-        Assert.assertEquals(totalReceived.get(), messageRate);
+            Assert.assertEquals(totalReceived.get(), messageRate);
+        });
 
         consumer.close();
         producer.close();
@@ -576,9 +565,11 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
 
         PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getOrCreateTopic(topicName).get();
 
-        Awaitility.await()
-                .untilAsserted(() -> assertTrue(getRateLimiter(topic).isPresent()));
-        assertEquals(getRateLimiter(topic).get().getDispatchRateOnByte(), byteRate);
+        Awaitility.await().untilAsserted(() -> {
+            Optional<DispatchRateLimiter> rateLimiter = getRateLimiter(topic);
+            assertTrue(rateLimiter.isPresent());
+            assertEquals(rateLimiter.get().getDispatchRateOnByte(), byteRate);
+        });
 
         @Cleanup
         PulsarClient client2 = PulsarClient.builder().serviceUrl(url2.toString())

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
@@ -49,7 +49,7 @@ import org.testng.annotations.Test;
 /**
  * Starts 3 brokers that are in 3 different clusters
  */
-@Test(groups = "quarantine")
+@Test(groups = "broker")
 public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
 
     protected String methodName;


### PR DESCRIPTION
### Motivation

The `ReplicatorRateLimiterTest` is crucial for verifying the correct behavior of the rate limiter in replication scenarios. If this test is marked as part of the `quarantine` test group, its failure will not block PR merges. This poses a risk: if the replicator limiter is broken, we will not detect regressions promptly.  

To maintain reliability and catch potential issues early, this test should remain a required test and not be moved to `quarantine`.  

### Modifications

- Move `ReplicatorRateLimiterTest` from the `quarantine` test group to the `broker` test group.
- Refactor assert by `Awaitility`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->