### PR TITLE
[fix][client] Fix inconsistent compression threshold behavior across batching modes

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerConsumerInternalTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerConsumerInternalTest.java
@@ -275,5 +275,20 @@ public class ProducerConsumerInternalTest extends ProducerConsumerBase {
         message = (MessageImpl<byte[]>) consumer.receive();
         compressionType = message.getCompressionType();
         assertEquals(compressionType, CompressionType.LZ4);
+
+        // Verify data integrity
+        String data = "compression test message";
+        producer.conf.setBatchingEnabled(true);
+        producer.getConfiguration().setCompressMinMsgBodySize(1);
+        producer.newMessage().value(data.getBytes()).send();
+        message = (MessageImpl<byte[]>) consumer.receive();
+        assertEquals(new String(message.getData()), data);
+
+        producer.conf.setBatchingEnabled(false);
+        producer.getConfiguration().setCompressMinMsgBodySize(1);
+        producer.newMessage().value(data.getBytes()).send();
+        message = (MessageImpl<byte[]>) consumer.receive();
+        assertEquals(new String(message.getData()), data);
+
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerConsumerInternalTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerConsumerInternalTest.java
@@ -237,7 +237,7 @@ public class ProducerConsumerInternalTest extends ProducerConsumerBase {
 
     @Test
     public void testProducerCompressionMinMsgBodySize() throws PulsarClientException {
-        byte[] msg1022 = new byte[1022];
+        byte[] msg1024 = new byte[1024];
         byte[] msg1025 = new byte[1025];
         final String topicName = BrokerTestUtil.newUniqueName("persistent://my-property/my-ns/tp_");
         @Cleanup
@@ -256,7 +256,7 @@ public class ProducerConsumerInternalTest extends ProducerConsumerBase {
         producer.conf.setCompressionType(CompressionType.LZ4);
         // disable batch
         producer.conf.setBatchingEnabled(false);
-        producer.newMessage().value(msg1022).send();
+        producer.newMessage().value(msg1024).send();
         MessageImpl<byte[]> message = (MessageImpl<byte[]>) consumer.receive();
         CompressionType compressionType = message.getCompressionType();
         assertEquals(compressionType, CompressionType.NONE);
@@ -267,7 +267,7 @@ public class ProducerConsumerInternalTest extends ProducerConsumerBase {
 
         // enable batch
         producer.conf.setBatchingEnabled(true);
-        producer.newMessage().value(msg1022).send();
+        producer.newMessage().value(msg1024).send();
         message = (MessageImpl<byte[]>) consumer.receive();
         compressionType = message.getCompressionType();
         assertEquals(compressionType, CompressionType.NONE);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -542,10 +542,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         boolean compressed = false;
         // Batch will be compressed when closed
         // If a message has a delayed delivery time, we'll always send it individually
-        if (((!isBatchMessagingEnabled() || msgMetadata.hasDeliverAtTime()))) {
-            if (payload.readableBytes() < conf.getCompressMinMsgBodySize()) {
-
-            } else {
+        if ((!isBatchMessagingEnabled() || msgMetadata.hasDeliverAtTime())) {
+            if (payload.readableBytes() > conf.getCompressMinMsgBodySize()) {
                 compressedPayload = applyCompression(payload);
                 compressed = true;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -542,7 +542,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         boolean compressed = false;
         // Batch will be compressed when closed
         // If a message has a delayed delivery time, we'll always send it individually
-        if ((!isBatchMessagingEnabled() || msgMetadata.hasDeliverAtTime())) {
+        if (!isBatchMessagingEnabled() || msgMetadata.hasDeliverAtTime()) {
             if (payload.readableBytes() > conf.getCompressMinMsgBodySize()) {
                 compressedPayload = applyCompression(payload);
                 compressed = true;


### PR DESCRIPTION
https://github.com/apache/pulsar/pull/23526
## Motivation
Fix inconsistent compression threshold behavior across batching modes. For single message sending, compression is enabled when the message size is greater than or equal to the threshold, while for batch sending, compression occurs when the size is greater than the threshold.

## Modifications
1. Standardize the criteria for determining the threshold to enable compression.
2. Optimize formatting.
3. Enhance testing.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
