### PR TITLE
[fix][schema] Reject unsupported Avro schema types during schema registration

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
@@ -151,6 +151,11 @@ public class SchemasResourceBase extends AdminResource {
                                 + " org.apache.pulsar.client.api.Schema." + schema.getType()
                                 + " when using a simple type schema"));
                     }
+                    default: {
+                        // ARRAY, MAP, FIXED, NULL.
+                        log.info("[{}] is using a special schema typed [{}]",
+                            String.valueOf(topicName), schema.getType());
+                    }
                 }
             }
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/SchemaDataValidator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/SchemaDataValidator.java
@@ -22,11 +22,15 @@ import org.apache.pulsar.broker.service.schema.KeyValueSchemaCompatibilityCheck;
 import org.apache.pulsar.broker.service.schema.exceptions.InvalidSchemaDataException;
 import org.apache.pulsar.common.protocol.schema.SchemaData;
 import org.apache.pulsar.common.schema.KeyValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A validator to validate the schema data is well formed.
  */
 public interface SchemaDataValidator {
+
+    Logger logger = LoggerFactory.getLogger(SchemaDataValidator.class);
 
     /**
      * Validate if the schema data is well formed.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/SchemaDataValidator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/SchemaDataValidator.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  */
 public interface SchemaDataValidator {
 
-    Logger logger = LoggerFactory.getLogger(SchemaDataValidator.class);
+    Logger LOGGER = LoggerFactory.getLogger(SchemaDataValidator.class);
 
     /**
      * Validate if the schema data is well formed.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/StructSchemaDataValidator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/StructSchemaDataValidator.java
@@ -84,18 +84,8 @@ class StructSchemaDataValidator implements SchemaDataValidator {
                     throw new InvalidSchemaDataException(
                             "Avro schema typed [UNION] is not supported");
                 }
-                case INT:
-                case LONG:
-                case FLOAT:
-                case DOUBLE:
-                case BOOLEAN:
-                case STRING:
-                case BYTES: {
-                    throw new InvalidSchemaDataException("Please call"
-                            + " org.apache.pulsar.client.api.Schema." + schema.getType()
-                            + " when using a simple type schema");
-                }
                 default: {
+                    // INT, LONG, FLOAT, DOUBLE, BOOLEAN, STRING, BYTES.
                     // ARRAY, MAP, FIXED, NULL.
                     LOGGER.info("Registering a special avro schema typed [{}]", schema.getType());
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/StructSchemaDataValidator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/StructSchemaDataValidator.java
@@ -68,6 +68,8 @@ class StructSchemaDataValidator implements SchemaDataValidator {
             } else {
                 throwInvalidSchemaDataException(schemaData, e);
             }
+        } catch (InvalidSchemaDataException invalidSchemaDataException) {
+            throw invalidSchemaDataException;
         } catch (Exception e) {
             throwInvalidSchemaDataException(schemaData, e);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/StructSchemaDataValidator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/StructSchemaDataValidator.java
@@ -95,7 +95,7 @@ class StructSchemaDataValidator implements SchemaDataValidator {
                 }
                 default: {
                     // ARRAY, MAP, FIXED, NULL.
-                    logger.info("Registering a special avro schema typed [{}]", schema.getType());
+                    LOGGER.info("Registering a special avro schema typed [{}]", schema.getType());
                 }
             }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -32,6 +32,7 @@ import static org.testng.Assert.fail;
 import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Sets;
+import io.swagger.models.auth.In;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.Serializable;
@@ -56,6 +57,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema.Parser;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage;
 import org.apache.pulsar.broker.service.schema.SchemaRegistry;
@@ -420,7 +422,35 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         // JSON schema with primitive class can consume
         assertEquals(consumer.receive().getValue().getNativeObject(), producerJsonIntegerValue);
         assertArrayEquals((byte[])  consumer.receive().getValue().getNativeObject(), producerJsonBytesValue);
-}
+    }
+
+    @Test
+    public void testAvroIntSchema() throws Exception {
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://" + PUBLIC_TENANT + "/my-ns/tp");
+
+        Producer<Integer> producer = pulsarClient.newProducer(Schema.AVRO(Integer.class)).topic(topicName).create();
+        Consumer<Integer> consumer = pulsarClient.newConsumer(Schema.AVRO(Integer.class)).topic(topicName)
+                .subscriptionName("sub").subscribe();
+
+        producer.send(1);
+        producer.send(2);
+        producer.send(3);
+
+        Message<Integer> msg1 = consumer.receive(2, TimeUnit.SECONDS);
+        assertNotNull(msg1);
+        assertEquals(msg1.getValue(), 1);
+        Message<Integer> msg2 = consumer.receive(2, TimeUnit.SECONDS);
+        assertNotNull(msg2);
+        assertEquals(msg2.getValue(), 2);
+        Message<Integer> msg3 = consumer.receive(2, TimeUnit.SECONDS);
+        assertNotNull(msg3);
+        assertEquals(msg3.getValue(), 3);
+
+        // cleanup.
+        consumer.close();
+        producer.close();
+        admin.topics().delete(topicName, false);
+    }
 
     @Test
     public void testJSONSchemaDeserialize() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -32,7 +32,6 @@ import static org.testng.Assert.fail;
 import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Sets;
-import io.swagger.models.auth.In;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.Serializable;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
@@ -563,28 +563,6 @@ public class SchemaCompatibilityCheckTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
-    public void testAddSimpleSchema() throws Exception {
-        String namespaceName = PUBLIC_TENANT + "/" + DEFAULT_NAMESPACE;
-        String topicName = BrokerTestUtil.newUniqueName(namespaceName + "/tp");
-        admin.topics().createNonPartitionedTopic(topicName);
-
-        // Create a simple type schema.
-        try {
-            admin.schemas().createSchema(topicName, Schema.AVRO(String.class).getSchemaInfo());
-            fail("avro simple schema is not supported");
-        } catch (PulsarAdminException e) {
-            assertTrue(e.getMessage().contains("org.apache.pulsar.client.api.Schema"));
-        }
-
-        // Create a producer with auto_produce schema.
-        Producer producer = pulsarClient.newProducer(Schema.AUTO_PRODUCE_BYTES()).topic(topicName).create();
-
-        // Cleanup.
-        producer.close();
-        admin.topics().delete(topicName, false);
-    }
-
-    @Test
     public void testAutoProduceSchemaAlwaysCompatible() throws Exception {
         final String tenant = PUBLIC_TENANT;
         final String topic = "topic" + randomName(16);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
@@ -563,6 +563,28 @@ public class SchemaCompatibilityCheckTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
+    public void testAddSimpleSchema() throws Exception {
+        String namespaceName = PUBLIC_TENANT + "/" + DEFAULT_NAMESPACE;
+        String topicName = BrokerTestUtil.newUniqueName(namespaceName + "/tp");
+        admin.topics().createNonPartitionedTopic(topicName);
+
+        // Create a simple type schema.
+        try {
+            admin.schemas().createSchema(topicName, Schema.AVRO(String.class).getSchemaInfo());
+            fail("avro simple schema is not supported");
+        } catch (PulsarAdminException e) {
+            assertTrue(e.getMessage().contains("org.apache.pulsar.client.api.Schema"));
+        }
+
+        // Create a producer with auto_produce schema.
+        Producer producer = pulsarClient.newProducer(Schema.AUTO_PRODUCE_BYTES()).topic(topicName).create();
+
+        // Cleanup.
+        producer.close();
+        admin.topics().delete(topicName, false);
+    }
+
+    @Test
     public void testAutoProduceSchemaAlwaysCompatible() throws Exception {
         final String tenant = PUBLIC_TENANT;
         final String topic = "topic" + randomName(16);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericSchemaImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericSchemaImpl.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.impl.schema.generic;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.avro.AvroRuntimeException;
 import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.GenericSchema;
@@ -40,10 +41,16 @@ public abstract class GenericSchemaImpl extends AvroBaseStructSchema<GenericReco
     protected GenericSchemaImpl(SchemaInfo schemaInfo) {
         super(schemaInfo);
 
-        this.fields = schema.getFields()
-                .stream()
-                .map(f -> new Field(f.name(), f.pos()))
-                .collect(Collectors.toList());
+        try {
+            this.fields = schema.getFields()
+                    .stream()
+                    .map(f -> new Field(f.name(), f.pos()))
+                    .collect(Collectors.toList());
+        } catch (AvroRuntimeException avroRuntimeException) {
+            // Rewrite error log.
+            throw new AvroRuntimeException("Schema typed [" + schema.getClass().getName() +"], simple-type:["
+                    + schema.getType() + "] is not supported. schema-content: " + schema);
+        }
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericSchemaImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericSchemaImpl.java
@@ -48,7 +48,7 @@ public abstract class GenericSchemaImpl extends AvroBaseStructSchema<GenericReco
                     .collect(Collectors.toList());
         } catch (AvroRuntimeException avroRuntimeException) {
             // Rewrite error log.
-            throw new AvroRuntimeException("Schema typed [" + schema.getClass().getName() +"], simple-type:["
+            throw new AvroRuntimeException("Schema typed [" + schema.getClass().getName() + "], simple-type:["
                     + schema.getType() + "] is not supported. schema-content: " + schema);
         }
     }


### PR DESCRIPTION
### Motivation

#### Issue
- User can upload an Avro-Union schema by `pulsar-admin` API
- However, the schema uploaded can not be used, users will get an error "Not a record" when creating a producer with `AUTO_PRODUCE` schema.

### Modifications
- Deny uploading an Avro-Union schema
- Improve the logs when creating a producer failed due to an invalidated schema

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x