### PR TITLE
[fix][client] Pattern subscription regression when broker-side evaluation is disabled

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
@@ -590,12 +590,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
             .messageRoutingMode(org.apache.pulsar.client.api.MessageRoutingMode.RoundRobinPartition)
             .create();
 
-        // 5. call recheckTopics to subscribe each added topics above
-        log.debug("recheck topics change");
-        PatternMultiTopicsConsumerImpl<byte[]> consumer1 = ((PatternMultiTopicsConsumerImpl<byte[]>) consumer);
-        consumer1.run(consumer1.getRecheckPatternTimeout());
-
-        // 6. verify consumer get methods, to get number of partitions and topics, value 6=1+2+3.
+        // 5. verify consumer get methods, to get number of partitions and topics, value 6=1+2+3.
         Awaitility.await().untilAsserted(() -> {
             assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().pattern());
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitions().size(), 6);
@@ -998,7 +993,6 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         // 7. call recheckTopics to subscribe each added topics above, verify topics number: 10=1+2+3+4
         log.debug("recheck topics change");
         PatternMultiTopicsConsumerImpl<byte[]> consumer1 = ((PatternMultiTopicsConsumerImpl<byte[]>) consumer);
-        consumer1.run(consumer1.getRecheckPatternTimeout());
         Awaitility.await().untilAsserted(() -> {
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitions().size(), 10);
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getConsumers().size(), 10);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -1350,9 +1350,6 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         admin.topics().createPartitionedTopic(topicName1, 3);
         assertEquals(admin.topics().getPartitionedTopicMetadata(topicName1).partitions, 3);
 
-        consumer.getRecheckPatternTimeout().task().run(consumer.getRecheckPatternTimeout());
-        Assert.assertTrue(consumer.getRecheckPatternTimeout().isCancelled());
-
         Awaitility.await().untilAsserted(() -> {
             Assert.assertEquals(consumer.getPartitionsOfTheTopicMap(), 8);
             Assert.assertEquals(consumer.allTopicPartitionsNumber.intValue(), 8);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -56,6 +56,8 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
     protected NamespaceName namespaceName;
 
     private final AtomicInteger recheckPatternEpoch = new AtomicInteger();
+    // If recheckPatternTimeout is not null, it means the broker's topic watcher is disabled.
+    // The client need falls back to the polling model.
     private volatile Timeout recheckPatternTimeout = null;
     private volatile String topicsHash;
 
@@ -407,6 +409,11 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
     @VisibleForTesting
     int getRecheckPatternEpoch() {
         return recheckPatternEpoch.get();
+    }
+
+    @VisibleForTesting
+    Timeout getRecheckPatternTimeout() {
+        return recheckPatternTimeout;
     }
 
     protected void handleSubscribeOneTopicError(String topicName,

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -405,11 +405,6 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
     }
 
     @VisibleForTesting
-    Timeout getRecheckPatternTimeout() {
-        return recheckPatternTimeout;
-    }
-
-    @VisibleForTesting
     int getRecheckPatternEpoch() {
         return recheckPatternEpoch.get();
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -44,8 +44,6 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.topics.TopicList;
-import org.apache.pulsar.common.util.Backoff;
-import org.apache.pulsar.common.util.BackoffBuilder;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,15 +55,6 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
     private final CompletableFuture<TopicListWatcher> watcherFuture = new CompletableFuture<>();
     protected NamespaceName namespaceName;
 
-    /**
-     * There is two task to re-check topic changes, the both tasks will not be take affects at the same time.
-     * 1. {@link #recheckTopicsChangeAfterReconnect}: it will be called after the {@link TopicListWatcher} reconnected
-     *     if you enabled {@link TopicListWatcher}. This backoff used to do a retry if
-     *     {@link #recheckTopicsChangeAfterReconnect} is failed.
-     * 2. {@link #run} A scheduled task to trigger re-check topic changes, it will be used if you disabled
-     *     {@link TopicListWatcher}.
-     */
-    private final Backoff recheckPatternTaskBackoff;
     private final AtomicInteger recheckPatternEpoch = new AtomicInteger();
     private volatile Timeout recheckPatternTimeout = null;
     private volatile String topicsHash;
@@ -89,11 +78,6 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
         this.topicsPattern = topicsPattern;
         this.topicsHash = topicsHash;
         this.subscriptionMode = subscriptionMode;
-        this.recheckPatternTaskBackoff = new BackoffBuilder()
-                .setInitialTime(client.getConfiguration().getInitialBackoffIntervalNanos(), TimeUnit.NANOSECONDS)
-                .setMax(client.getConfiguration().getMaxBackoffIntervalNanos(), TimeUnit.NANOSECONDS)
-                .setMandatoryStop(0, TimeUnit.SECONDS)
-                .create();
 
         if (this.namespaceName == null) {
             this.namespaceName = getNameSpaceFromPattern(topicsPattern);
@@ -102,23 +86,24 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
 
         this.topicsChangeListener = new PatternTopicsChangedListener();
         this.updateTaskQueue = new PatternConsumerUpdateQueue(this);
-        this.recheckPatternTimeout = client.timer()
-                .newTimeout(this, Math.max(1, conf.getPatternAutoDiscoveryPeriod()), TimeUnit.SECONDS);
         if (subscriptionMode == Mode.PERSISTENT) {
             long watcherId = client.newTopicListWatcherId();
             new TopicListWatcher(updateTaskQueue, client, topicsPattern, watcherId,
                 namespaceName, topicsHash, watcherFuture, () -> recheckTopicsChangeAfterReconnect());
             watcherFuture
-               .thenAccept(__ -> recheckPatternTimeout.cancel())
                .exceptionally(ex -> {
                    log.warn("Pattern consumer [{}] unable to create topic list watcher. Falling back to only polling"
                            + " for new topics", conf.getSubscriptionName(), ex);
+                   this.recheckPatternTimeout = client.timer().newTimeout(
+                           this, Math.max(1, conf.getPatternAutoDiscoveryPeriod()), TimeUnit.SECONDS);
                    return null;
                });
         } else {
             log.debug("Pattern consumer [{}] not creating topic list watcher for subscription mode {}",
                     conf.getSubscriptionName(), subscriptionMode);
             watcherFuture.complete(null);
+            this.recheckPatternTimeout = client.timer().newTimeout(
+                    this, Math.max(1, conf.getPatternAutoDiscoveryPeriod()), TimeUnit.SECONDS);
         }
     }
 
@@ -155,7 +140,7 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                 // If "recheckTopicsChange" has been called more than one times, only make the last one take affects.
                 // Use "synchronized (recheckPatternTaskBackoff)" instead of
                 // `synchronized(PatternMultiTopicsConsumerImpl.this)` to avoid locking in a wider range.
-                synchronized (recheckPatternTaskBackoff) {
+                synchronized (PatternMultiTopicsConsumerImpl.this) {
                     if (recheckPatternEpoch.get() > epoch) {
                         return CompletableFuture.completedFuture(null);
                     }
@@ -172,6 +157,11 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                     final List<String> oldTopics = new ArrayList<>(getPartitions());
                     return updateSubscriptions(topicsPattern, this::setTopicsHash, getTopicsResult,
                             topicsChangeListener, oldTopics, subscription);
+                }
+            }).thenAccept(__ -> {
+                if (recheckPatternTimeout != null) {
+                    this.recheckPatternTimeout = client.timer().newTimeout(
+                            this, Math.max(1, conf.getPatternAutoDiscoveryPeriod()), TimeUnit.SECONDS);
                 }
             });
     }
@@ -417,6 +407,11 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
     @VisibleForTesting
     Timeout getRecheckPatternTimeout() {
         return recheckPatternTimeout;
+    }
+
+    @VisibleForTesting
+    int getRecheckPatternEpoch() {
+        return recheckPatternEpoch.get();
     }
 
     protected void handleSubscribeOneTopicError(String topicName,


### PR DESCRIPTION
### Motivation

When **EnableBrokerSideSubscriptionPatternEvaluation** is set to false, the pattern subscription can't discover newly created topics. 

This regression was introduced by PR #21853 and #22854, which removed pattern consumer regularity discovery topic logic: 

https://github.com/apache/pulsar/pull/22854/files#diff-779a47f80b0048bab183870ed4c1ecd07ffd538006cf9358e494bee23405d924L154-L159

### Modifications

- Rollback to poll mode for topic discovery when `watcherFuture` returns an exception.
- Remove `recheckPatternTaskBackoff` as it is unused and does not align with the user-side configuration `patternAutoDiscoveryPeriod`.
- Remove test code like `consumer.getRecheckPatternTimeout().task().run(consumer.getRecheckPatternTimeout()); ` from the unit tests, because these tests now operate under the premise of the broker actively pushing topic changes. 

### Verifying this change
- To reproduce and verify this issue, you can run the test testSubscribePatterBrokerDisable.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
