### PR TITLE
[improve][broker]Add the expired message count metric from this subscription within the last interval.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
@@ -178,6 +178,10 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
         updateRates();
         return msgExpired.getRate();
     }
+    
+    public long getMessageExpiryCount() {
+        return msgExpired.getCount();
+    }
 
     public long getTotalMessageExpired() {
         return totalMsgExpired.sum();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1336,7 +1336,7 @@ public class PersistentSubscription extends AbstractSubscription {
         }
         subStats.msgBacklogNoDelayed = subStats.msgBacklog - subStats.msgDelayed;
         subStats.msgRateExpired = expiryMonitor.getMessageExpiryRate();
-        subStats.msgExpiredCounter = expiryMonitor.getMessageExpiryCount();
+        subStats.msgExpired = expiryMonitor.getMessageExpiryCount();
         subStats.totalMsgExpired = expiryMonitor.getTotalMessageExpired();
         subStats.isReplicated = isReplicated();
         subStats.subscriptionProperties = subscriptionProperties;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1336,6 +1336,7 @@ public class PersistentSubscription extends AbstractSubscription {
         }
         subStats.msgBacklogNoDelayed = subStats.msgBacklog - subStats.msgDelayed;
         subStats.msgRateExpired = expiryMonitor.getMessageExpiryRate();
+        subStats.msgExpiredCounter = expiryMonitor.getMessageExpiryCount();
         subStats.totalMsgExpired = expiryMonitor.getTotalMessageExpired();
         subStats.isReplicated = isReplicated();
         subStats.subscriptionProperties = subscriptionProperties;

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
@@ -84,6 +84,9 @@ public interface SubscriptionStats {
 
     /** Total rate of messages expired on this subscription (msg/s). */
     double getMsgRateExpired();
+    
+    /** The Count of messages expired on this subscription. */
+    long getMsgExpiredCounter();
 
     /** Total messages expired on this subscription. */
     long getTotalMsgExpired();

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
@@ -85,9 +85,6 @@ public interface SubscriptionStats {
     /** Total rate of messages expired on this subscription (msg/s). */
     double getMsgRateExpired();
     
-    /** The Count of messages expired on this subscription. */
-    long getMsgExpiredCounter();
-
     /** Total messages expired on this subscription. */
     long getTotalMsgExpired();
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
@@ -84,7 +84,7 @@ public interface SubscriptionStats {
 
     /** Total rate of messages expired on this subscription (msg/s). */
     double getMsgRateExpired();
-    
+
     /** Total messages expired on this subscription. */
     long getTotalMsgExpired();
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
@@ -93,6 +93,9 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
     /** Total rate of messages expired on this subscription (msg/s). */
     public double msgRateExpired;
 
+    /** The count of expired messages on this subscription. */
+    public long msgExpiredCounter;
+
     /** Total messages expired on this subscription. */
     public long totalMsgExpired;
 
@@ -191,6 +194,7 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
         unackedMessages = 0;
         type = null;
         msgRateExpired = 0;
+        msgExpiredCounter = 0;
         totalMsgExpired = 0;
         lastExpireTimestamp = 0L;
         lastMarkDeleteAdvancedTimestamp = 0L;
@@ -230,6 +234,7 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
         this.unackedMessages += stats.unackedMessages;
         this.type = stats.type;
         this.msgRateExpired += stats.msgRateExpired;
+        this.msgExpiredCounter += stats.msgExpiredCounter;
         this.totalMsgExpired += stats.totalMsgExpired;
         this.isReplicated |= stats.isReplicated;
         this.isDurable |= stats.isDurable;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
@@ -94,7 +94,7 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
     public double msgRateExpired;
 
     /** The count of expired messages on this subscription. */
-    public long msgExpiredCounter;
+    public long msgExpired;
 
     /** Total messages expired on this subscription. */
     public long totalMsgExpired;
@@ -194,7 +194,7 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
         unackedMessages = 0;
         type = null;
         msgRateExpired = 0;
-        msgExpiredCounter = 0;
+        msgExpired = 0;
         totalMsgExpired = 0;
         lastExpireTimestamp = 0L;
         lastMarkDeleteAdvancedTimestamp = 0L;
@@ -234,7 +234,7 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
         this.unackedMessages += stats.unackedMessages;
         this.type = stats.type;
         this.msgRateExpired += stats.msgRateExpired;
-        this.msgExpiredCounter += stats.msgExpiredCounter;
+        this.msgExpired += stats.msgExpired;
         this.totalMsgExpired += stats.totalMsgExpired;
         this.isReplicated |= stats.isReplicated;
         this.isDurable |= stats.isDurable;


### PR DESCRIPTION
### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

The existing `totalMsgExpired` metric tracks cumulative message expiration counts since subscription creation, but lacks granularity for time-bound monitoring. This PR introduces a new metric to track message expiration counts per monitoring interval, enabling better observation of expiration patterns through time-series monitoring systems.

### Modifications

1. Added `msgExpired` counter in subscription statistics tracking message expirations per monitoring interval
2. Modified `PersistentMessageExpiryMonitor` to expose new count metric
3. Updated stats collection in `PersistentSubscription` to include new metric
4. Enhanced subscription stats objects to carry the new metric

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

This improvement enables:
- Monitoring sudden expiration spikes through time-series dashboards
- Calculating expiration rates between sampling periods
- Troubleshooting expiration patterns without needing long-term historical data
- Alignment with other time-bound metrics in Pulsar's monitoring framework



<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
