### PR TITLE
[test] Add validation tests for dispatcherMaxRoundRobinBatchSize (https://github.com/apache/pulsar/issues/24094)

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
@@ -407,4 +407,32 @@ public class ServiceConfigurationTest {
                 ServiceConfiguration.class);
         assertEquals(conf.lookupProperties(), Map.of("lookup.key2", "value2"));
     }
+
+    @Test
+    public void testDispatcherMaxRoundRobinBatchSizeProperty() throws Exception {
+        // 1. set empty value
+        String emptyConf = "dispatcherMaxRoundRobinBatchSize=\n";
+        ServiceConfiguration defaultConfig = PulsarConfigurationLoader.create(
+                new ByteArrayInputStream(emptyConf.getBytes()),
+                ServiceConfiguration.class
+        );
+        assertEquals(defaultConfig.getDispatcherMaxRoundRobinBatchSize(),20);
+
+        // 2. set valid value: 30
+        String validConf = "dispatcherMaxRoundRobinBatchSize=30\n";
+        try (InputStream stream = new ByteArrayInputStream(validConf.getBytes())) {
+            ServiceConfiguration config = PulsarConfigurationLoader.create(stream, ServiceConfiguration.class);
+            assertEquals(config.getDispatcherMaxRoundRobinBatchSize(),30);
+        }
+
+        // 3. set invalid type: "invalidValueType"
+        String invalidConf = "dispatcherMaxRoundRobinBatchSize=invalidValueType\n";
+        try (InputStream stream = new ByteArrayInputStream(invalidConf.getBytes())) {
+            ServiceConfiguration config = PulsarConfigurationLoader.create(stream, ServiceConfiguration.class);
+            fail("Expected IllegalArgumentException for negative value");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("failed to initialize dispatcherMaxRoundRobinBatchSize field while setting value invalidValueType"));
+        }
+
+    }
 }


### PR DESCRIPTION
[test] Add validation tests for dispatcherMaxRoundRobinBatchSize (https://github.com/apache/pulsar/issues/24094)

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes (https://github.com/apache/pulsar/issues/24094)

<!-- or this PR is one task of an issue -->

Main Issue:  (https://github.com/apache/pulsar/issues/24094)

<!-- If the PR belongs to a PIP, please add the PIP link here -->

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

Motivation: The `dispatcherMaxRoundRobinBatchSize` config currently lacks validation tests, which poses a risk of regressions during code changes. Adding these tests ensures that invalid configurations (e.g., negative values, non-integer types) are caught early.

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Modifications:  
- Added unit tests in  `pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java` to validate:  
  - Empty configuration uses default value (`dispatcherMaxRoundRobinBatchSize=20`).  
  - Valid numeric value (`30`) is accepted.  
  - Non-numeric input (`"invalidValueType"`) triggers `IllegalArgumentException` with error message matching `"failed to initialize dispatcherMaxRoundRobinBatchSize field while setting value invalidValueType"`. 

<!-- Describe the modifications you've done. -->

### Verifying this change
- [x] This change added tests and can be verified as follows:
  - Run `mvn test` to ensure all tests pass.

### Does this pull request potentially affect one of the following parts:


<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [x] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: (https://github.com/jojowyh/pulsar/commit/5bbc9ae3b27106f051b912f39205e6d210ffde34)

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
