### PR TITLE
[improve][broker] extract getMaxEntriesInThisBatch into a method and add unit test for it

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -437,7 +437,7 @@ public class NonPersistentSubscription extends AbstractSubscription {
      *
      * @param consumer consumer object that is initiating the unsubscribe operation
      * @param force unsubscribe forcefully by disconnecting consumers and closing subscription
-     * @return CompletableFuture indicating the completion of ubsubscribe operation
+     * @return CompletableFuture indicating the completion of unsubscribe operation
      */
     @Override
     public CompletableFuture<Void> doUnsubscribe(Consumer consumer, boolean force) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -834,29 +834,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
                 lastNumberOfEntriesProcessed = (int) totalEntriesProcessed;
                 return false;
             }
-
-            // round-robin dispatch batch size for this consumer
-            int availablePermits = c.isWritable() ? c.getAvailablePermits() : 1;
-            if (log.isDebugEnabled() && !c.isWritable()) {
-                log.debug("[{}-{}] consumer is not writable. dispatching only 1 message to {}; "
-                                + "availablePermits are {}", topic.getName(), name,
-                        c, c.getAvailablePermits());
-            }
-
-            int maxMessagesInThisBatch = Math.min(remainingMessages, availablePermits);
-            if (c.getMaxUnackedMessages() > 0) {
-                // Calculate the maximum number of additional unacked messages allowed
-                int maxAdditionalUnackedMessages = Math.max(c.getMaxUnackedMessages() - c.getUnackedMessages(), 0);
-                maxMessagesInThisBatch = Math.min(maxMessagesInThisBatch, maxAdditionalUnackedMessages);
-            }
-            // TODO: add tests to verify dispatcherMaxRoundRobinBatchSize is respected
-            int maxEntriesInThisBatch = Math.min(serviceConfig.getDispatcherMaxRoundRobinBatchSize(),
-                            // use the average batch size per message to calculate the number of entries to
-                            // dispatch. round up to the next integer without using floating point arithmetic.
-                            (maxMessagesInThisBatch + avgBatchSizePerMsg - 1) / avgBatchSizePerMsg);
-            // pick at least one entry to dispatch
-            maxEntriesInThisBatch = Math.max(maxEntriesInThisBatch, 1);
-
+            int maxEntriesInThisBatch = getMaxEntriesInThisBatch(remainingMessages, c, avgBatchSizePerMsg);
             int end = Math.min(start + maxEntriesInThisBatch, entries.size());
             List<Entry> entriesForThisConsumer = entries.subList(start, end);
 
@@ -907,6 +885,32 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
         }
 
         return true;
+    }
+
+
+    @VisibleForTesting
+    int getMaxEntriesInThisBatch(int remainingMessages, Consumer c, int avgBatchSizePerMsg) {
+        // round-robin dispatch batch size for this consumer
+        int availablePermits = c.isWritable() ? c.getAvailablePermits() : 1;
+        if (log.isDebugEnabled() && !c.isWritable()) {
+            log.debug("[{}-{}] consumer is not writable. dispatching only 1 message to {}; "
+                            + "availablePermits are {}", topic.getName(), name,
+                    c, c.getAvailablePermits());
+        }
+
+        int maxMessagesInThisBatch = Math.min(remainingMessages, availablePermits);
+        if (c.getMaxUnackedMessages() > 0) {
+            // Calculate the maximum number of additional unacked messages allowed
+            int maxAdditionalUnackedMessages = Math.max(c.getMaxUnackedMessages() - c.getUnackedMessages(), 0);
+            maxMessagesInThisBatch = Math.min(maxMessagesInThisBatch, maxAdditionalUnackedMessages);
+        }
+        int maxEntriesInThisBatch = Math.min(serviceConfig.getDispatcherMaxRoundRobinBatchSize(),
+                // use the average batch size per message to calculate the number of entries to
+                // dispatch. round up to the next integer without using floating point arithmetic.
+                (maxMessagesInThisBatch + avgBatchSizePerMsg - 1) / avgBatchSizePerMsg);
+        // pick at least one entry to dispatch
+        maxEntriesInThisBatch = Math.max(maxEntriesInThisBatch, 1);
+        return maxEntriesInThisBatch;
     }
 
     protected boolean addEntryToReplay(Entry entry) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumerMaxEntriesInBatchTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumerMaxEntriesInBatchTest.java
@@ -1,125 +1,95 @@
 package org.apache.pulsar.broker.service.persistent;
 
-import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.broker.BrokerTestUtil;
-import org.apache.pulsar.broker.service.Dispatcher;
-import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.ProducerConsumerBase;
-import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.SubscriptionType;
-import org.awaitility.Awaitility;
 import static org.testng.Assert.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-@Slf4j
 @Test(groups = "broker-api")
-public class PersistentDispatcherMultipleConsumerMaxEntriesInBatchTest extends ProducerConsumerBase {
-    @BeforeClass(alwaysRun = true)
-    @Override
-    protected void setup() throws Exception {
-        super.internalSetup();
-        super.producerBaseSetup();
-    }
-
-    @AfterClass(alwaysRun = true)
-    @Override
-    protected void cleanup() throws Exception {
-        super.internalCleanup();
-    }
-
+public class PersistentDispatcherMultipleConsumerMaxEntriesInBatchTest {
 
     /**
-     * in this test, entry size > consumer's permis > {@link org.apache.pulsar.broker.ServiceConfiguration#getDispatcherMaxRoundRobinBatchSize()}
+     * in this test, remainingMessages > consumer's permits >
+     * {@link org.apache.pulsar.broker.ServiceConfiguration#getDispatcherMaxRoundRobinBatchSize()}
      * so, dispatcherMaxRoundRobinBatchSize's limitation will reach first.
-     *
-     * @throws Exception
      */
     @Test
-    public void testMaxEntriesInBatchWithDispatcherMaxRoundRobinBatchSizeSmallest() throws Exception {
-        final String topicName = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
-        final String subscription = "s1";
-        admin.topics().createNonPartitionedTopic(topicName);
+    public void testMaxEntriesInBatchWithDispatcherMaxRoundRobinBatchSizeSmallest() {
         final int dispatcherMaxRoundRobinBatchSize = 20;
-        conf.setDispatcherMaxRoundRobinBatchSize(dispatcherMaxRoundRobinBatchSize);
-        final int messageSize = 200;
-        final int consumerQueueSize = 200;
-        final int batchSize = 5;
+        final int remainingMessages = 200;
+        final int availablePermits = 200;
+        final int avgBatchSizePerMsg = 5;
+        final int maxUnackedMessages = 50000;
+        final int unackedMessages = 0;
 
-        admin.topics().createSubscription(topicName, subscription, MessageId.earliest);
-
-        Consumer<String> consumer =
-                pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subscription)
-                        .receiverQueueSize(consumerQueueSize)
-                        .subscriptionType(SubscriptionType.Shared).subscribe();
-
-        Dispatcher dispatcher = pulsar.getBrokerService()
-                .getTopic(topicName, false).join().get()
-                .getSubscription(subscription).getDispatcher();
-
-        Awaitility.await().atMost(30000, TimeUnit.SECONDS).untilAsserted(() -> {
-            assertTrue(((PersistentDispatcherMultipleConsumers) dispatcher).getNextConsumer() != null);
-        });
-        for (int i = 1; i < messageSize; i++) {
-            int maxEntriesInThisBatch = ((PersistentDispatcherMultipleConsumers) dispatcher).getMaxEntriesInThisBatch(i,
-                    ((PersistentDispatcherMultipleConsumers) dispatcher).getNextConsumer(), batchSize);
-            if (i / batchSize < conf.getDispatcherMaxRoundRobinBatchSize()) {
-                assertEquals(maxEntriesInThisBatch, i % batchSize == 0 ? i / batchSize : i / batchSize + 1);
+        for (int i = 1; i < remainingMessages; i++) {
+            int maxEntriesInThisBatch =
+                    PersistentDispatcherMultipleConsumers.getMaxEntriesInThisBatch(i, maxUnackedMessages,
+                            unackedMessages,
+                            avgBatchSizePerMsg, availablePermits, dispatcherMaxRoundRobinBatchSize);
+            if (i / avgBatchSizePerMsg < dispatcherMaxRoundRobinBatchSize) {
+                assertEquals(maxEntriesInThisBatch,
+                        i % avgBatchSizePerMsg == 0 ? i / avgBatchSizePerMsg : i / avgBatchSizePerMsg + 1);
             } else {
-                assertEquals(maxEntriesInThisBatch, conf.getDispatcherMaxRoundRobinBatchSize());
+                assertEquals(maxEntriesInThisBatch, dispatcherMaxRoundRobinBatchSize);
             }
         }
-
-        consumer.close();
-        admin.topics().delete(topicName, false);
     }
 
     /**
-     * in this test, entry size > {@link org.apache.pulsar.broker.ServiceConfiguration#getDispatcherMaxRoundRobinBatchSize()} > consumer' permits.
+     * in this test, remainingMessages >
+     * {@link org.apache.pulsar.broker.ServiceConfiguration#getDispatcherMaxRoundRobinBatchSize()} > consumer' permits.
      * so, consumer's permits limitation will reach first.
-     *
-     * @throws Exception
      */
     @Test
-    public void testMaxEntriesInBatchWithMessageRangeAndSmallestQueueSize() throws Exception {
-        final String topicName = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
-        final String subscription = "s1";
-        admin.topics().createNonPartitionedTopic(topicName);
+    public void testMaxEntriesInBatchWithMessageRangeAndSmallestQueueSize() {
         final int dispatcherMaxRoundRobinBatchSize = 20;
-        conf.setDispatcherMaxRoundRobinBatchSize(dispatcherMaxRoundRobinBatchSize);
-        final int messageSize = 200;
-        final int consumerQueueSize = 75;
-        final int batchSize = 5;
+        final int remainingMessages = 200;
+        final int availablePermits = 75;
+        final int avgBatchSizePerMsg = 5;
+        final int maxUnackedMessages = 50000;
+        final int unackedMessages = 0;
 
-        admin.topics().createSubscription(topicName, subscription, MessageId.earliest);
-
-        Consumer<String> consumer =
-                pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subscription)
-                        .receiverQueueSize(consumerQueueSize)
-                        .subscriptionType(SubscriptionType.Shared).subscribe();
-
-        Dispatcher dispatcher = pulsar.getBrokerService()
-                .getTopic(topicName, false).join().get()
-                .getSubscription(subscription).getDispatcher();
-
-        Awaitility.await().atMost(30000, TimeUnit.SECONDS).untilAsserted(() -> {
-            assertTrue(((PersistentDispatcherMultipleConsumers) dispatcher).getNextConsumer() != null);
-        });
-        for (int i = 1; i < messageSize; i++) {
-            int maxEntriesInThisBatch = ((PersistentDispatcherMultipleConsumers) dispatcher).getMaxEntriesInThisBatch(i,
-                    ((PersistentDispatcherMultipleConsumers) dispatcher).getNextConsumer(), batchSize);
-            if (i / batchSize < consumerQueueSize / batchSize) {
-                assertEquals(maxEntriesInThisBatch, i % batchSize == 0 ? i / batchSize : i / batchSize + 1);
+        for (int i = 1; i < remainingMessages; i++) {
+            int maxEntriesInThisBatch =
+                    PersistentDispatcherMultipleConsumers.getMaxEntriesInThisBatch(i, maxUnackedMessages,
+                            unackedMessages,
+                            avgBatchSizePerMsg, availablePermits, dispatcherMaxRoundRobinBatchSize);
+            if (i < availablePermits) {
+                assertEquals(maxEntriesInThisBatch,
+                        i % avgBatchSizePerMsg == 0 ? i / avgBatchSizePerMsg : i / avgBatchSizePerMsg + 1);
             } else {
-                assertEquals(maxEntriesInThisBatch, consumerQueueSize % batchSize == 0 ? consumerQueueSize / batchSize : consumerQueueSize / batchSize + 1);
+                assertEquals(maxEntriesInThisBatch,
+                        availablePermits % avgBatchSizePerMsg == 0 ? availablePermits / avgBatchSizePerMsg :
+                                availablePermits / avgBatchSizePerMsg + 1);
             }
         }
+    }
 
-        consumer.close();
-        admin.topics().delete(topicName, false);
+    /**
+     * in this test, entry size >
+     * {@link org.apache.pulsar.broker.ServiceConfiguration#getDispatcherMaxRoundRobinBatchSize()} > consumer' permits >
+     * unAckedMessages
+     * so, unAckedMessages limitation will reach first.
+     */
+    @Test
+    public void testMaxEntriesInBatchWithUnackedMessagesLimitation() {
+        final int dispatcherMaxRoundRobinBatchSize = 20;
+        final int remainingMessages = 200;
+        final int availablePermits = 75;
+        final int avgBatchSizePerMsg = 5;
+        final int maxUnackedMessages = 500;
+        final int unackedMessages = 480;
+
+        for (int i = 1; i < remainingMessages; i++) {
+            int maxEntriesInThisBatch =
+                    PersistentDispatcherMultipleConsumers.getMaxEntriesInThisBatch(i, maxUnackedMessages,
+                            unackedMessages,
+                            avgBatchSizePerMsg, availablePermits, dispatcherMaxRoundRobinBatchSize);
+            if (i < (maxUnackedMessages - unackedMessages)) {
+                assertEquals(maxEntriesInThisBatch,
+                        i % avgBatchSizePerMsg == 0 ? i / avgBatchSizePerMsg : i / avgBatchSizePerMsg + 1);
+            } else {
+                assertEquals(maxEntriesInThisBatch, (maxUnackedMessages - unackedMessages) / avgBatchSizePerMsg);
+            }
+        }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumerMaxEntriesInBatchTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumerMaxEntriesInBatchTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pulsar.broker.service.persistent;
 
 import static org.testng.Assert.assertEquals;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumerMaxEntriesInBatchTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumerMaxEntriesInBatchTest.java
@@ -1,0 +1,125 @@
+package org.apache.pulsar.broker.service.persistent;
+
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.service.Dispatcher;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.awaitility.Awaitility;
+import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker-api")
+public class PersistentDispatcherMultipleConsumerMaxEntriesInBatchTest extends ProducerConsumerBase {
+    @BeforeClass(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+
+    /**
+     * in this test, entry size > consumer's permis > {@link org.apache.pulsar.broker.ServiceConfiguration#getDispatcherMaxRoundRobinBatchSize()}
+     * so, dispatcherMaxRoundRobinBatchSize's limitation will reach first.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testMaxEntriesInBatchWithDispatcherMaxRoundRobinBatchSizeSmallest() throws Exception {
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
+        final String subscription = "s1";
+        admin.topics().createNonPartitionedTopic(topicName);
+        final int dispatcherMaxRoundRobinBatchSize = 20;
+        conf.setDispatcherMaxRoundRobinBatchSize(dispatcherMaxRoundRobinBatchSize);
+        final int messageSize = 200;
+        final int consumerQueueSize = 200;
+        final int batchSize = 5;
+
+        admin.topics().createSubscription(topicName, subscription, MessageId.earliest);
+
+        Consumer<String> consumer =
+                pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subscription)
+                        .receiverQueueSize(consumerQueueSize)
+                        .subscriptionType(SubscriptionType.Shared).subscribe();
+
+        Dispatcher dispatcher = pulsar.getBrokerService()
+                .getTopic(topicName, false).join().get()
+                .getSubscription(subscription).getDispatcher();
+
+        Awaitility.await().atMost(30000, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertTrue(((PersistentDispatcherMultipleConsumers) dispatcher).getNextConsumer() != null);
+        });
+        for (int i = 1; i < messageSize; i++) {
+            int maxEntriesInThisBatch = ((PersistentDispatcherMultipleConsumers) dispatcher).getMaxEntriesInThisBatch(i,
+                    ((PersistentDispatcherMultipleConsumers) dispatcher).getNextConsumer(), batchSize);
+            if (i / batchSize < conf.getDispatcherMaxRoundRobinBatchSize()) {
+                assertEquals(maxEntriesInThisBatch, i % batchSize == 0 ? i / batchSize : i / batchSize + 1);
+            } else {
+                assertEquals(maxEntriesInThisBatch, conf.getDispatcherMaxRoundRobinBatchSize());
+            }
+        }
+
+        consumer.close();
+        admin.topics().delete(topicName, false);
+    }
+
+    /**
+     * in this test, entry size > {@link org.apache.pulsar.broker.ServiceConfiguration#getDispatcherMaxRoundRobinBatchSize()} > consumer' permits.
+     * so, consumer's permits limitation will reach first.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testMaxEntriesInBatchWithMessageRangeAndSmallestQueueSize() throws Exception {
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
+        final String subscription = "s1";
+        admin.topics().createNonPartitionedTopic(topicName);
+        final int dispatcherMaxRoundRobinBatchSize = 20;
+        conf.setDispatcherMaxRoundRobinBatchSize(dispatcherMaxRoundRobinBatchSize);
+        final int messageSize = 200;
+        final int consumerQueueSize = 75;
+        final int batchSize = 5;
+
+        admin.topics().createSubscription(topicName, subscription, MessageId.earliest);
+
+        Consumer<String> consumer =
+                pulsarClient.newConsumer(Schema.STRING).topic(topicName).subscriptionName(subscription)
+                        .receiverQueueSize(consumerQueueSize)
+                        .subscriptionType(SubscriptionType.Shared).subscribe();
+
+        Dispatcher dispatcher = pulsar.getBrokerService()
+                .getTopic(topicName, false).join().get()
+                .getSubscription(subscription).getDispatcher();
+
+        Awaitility.await().atMost(30000, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertTrue(((PersistentDispatcherMultipleConsumers) dispatcher).getNextConsumer() != null);
+        });
+        for (int i = 1; i < messageSize; i++) {
+            int maxEntriesInThisBatch = ((PersistentDispatcherMultipleConsumers) dispatcher).getMaxEntriesInThisBatch(i,
+                    ((PersistentDispatcherMultipleConsumers) dispatcher).getNextConsumer(), batchSize);
+            if (i / batchSize < consumerQueueSize / batchSize) {
+                assertEquals(maxEntriesInThisBatch, i % batchSize == 0 ? i / batchSize : i / batchSize + 1);
+            } else {
+                assertEquals(maxEntriesInThisBatch, consumerQueueSize % batchSize == 0 ? consumerQueueSize / batchSize : consumerQueueSize / batchSize + 1);
+            }
+        }
+
+        consumer.close();
+        admin.topics().delete(topicName, false);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumerMaxEntriesInBatchTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumerMaxEntriesInBatchTest.java
@@ -25,10 +25,13 @@ public class PersistentDispatcherMultipleConsumerMaxEntriesInBatchTest {
                     PersistentDispatcherMultipleConsumers.getMaxEntriesInThisBatch(i, maxUnackedMessages,
                             unackedMessages,
                             avgBatchSizePerMsg, availablePermits, dispatcherMaxRoundRobinBatchSize);
-            if (i / avgBatchSizePerMsg < dispatcherMaxRoundRobinBatchSize) {
+            int entries = i / avgBatchSizePerMsg;
+            // if entries < dispatcherMaxRoundRobinBatchSize,  maxEntriesInThisBatch will be entries itself.
+            if (entries < dispatcherMaxRoundRobinBatchSize) {
                 assertEquals(maxEntriesInThisBatch,
-                        i % avgBatchSizePerMsg == 0 ? i / avgBatchSizePerMsg : i / avgBatchSizePerMsg + 1);
+                        i % avgBatchSizePerMsg == 0 ? entries : entries + 1);
             } else {
+                // as entries getting bigger, will reach the dispatcherMaxRoundRobinBatchSize limitation, so maxEntriesInThisBatch will be dispatcherMaxRoundRobinBatchSize
                 assertEquals(maxEntriesInThisBatch, dispatcherMaxRoundRobinBatchSize);
             }
         }
@@ -53,10 +56,13 @@ public class PersistentDispatcherMultipleConsumerMaxEntriesInBatchTest {
                     PersistentDispatcherMultipleConsumers.getMaxEntriesInThisBatch(i, maxUnackedMessages,
                             unackedMessages,
                             avgBatchSizePerMsg, availablePermits, dispatcherMaxRoundRobinBatchSize);
+            // if remainingMessages less than availablePermits, maxEntriesInThisBatch will be entries itself.
             if (i < availablePermits) {
+                int entries = i / avgBatchSizePerMsg;
                 assertEquals(maxEntriesInThisBatch,
-                        i % avgBatchSizePerMsg == 0 ? i / avgBatchSizePerMsg : i / avgBatchSizePerMsg + 1);
+                        i % avgBatchSizePerMsg == 0 ? entries : entries + 1);
             } else {
+                // as entries getting bigger, will reach the consumer's permits limitation, so maxEntriesInThisBatch will be (availablePermits / avgBatchSizePerMsg)
                 assertEquals(maxEntriesInThisBatch,
                         availablePermits % avgBatchSizePerMsg == 0 ? availablePermits / avgBatchSizePerMsg :
                                 availablePermits / avgBatchSizePerMsg + 1);
@@ -84,11 +90,16 @@ public class PersistentDispatcherMultipleConsumerMaxEntriesInBatchTest {
                     PersistentDispatcherMultipleConsumers.getMaxEntriesInThisBatch(i, maxUnackedMessages,
                             unackedMessages,
                             avgBatchSizePerMsg, availablePermits, dispatcherMaxRoundRobinBatchSize);
-            if (i < (maxUnackedMessages - unackedMessages)) {
+            // if remainingMessages less than maxAdditionalUnackedMessages, maxEntriesInThisBatch will be entries itself.
+            int maxAdditionalUnackedMessages = maxUnackedMessages - unackedMessages;
+
+            if (i < maxAdditionalUnackedMessages) {
+                int entries = i / avgBatchSizePerMsg;
                 assertEquals(maxEntriesInThisBatch,
-                        i % avgBatchSizePerMsg == 0 ? i / avgBatchSizePerMsg : i / avgBatchSizePerMsg + 1);
+                        i % avgBatchSizePerMsg == 0 ? entries : entries + 1);
             } else {
-                assertEquals(maxEntriesInThisBatch, (maxUnackedMessages - unackedMessages) / avgBatchSizePerMsg);
+                // as entries getting bigger, will reach the unAckedMessages limitation, so maxEntriesInThisBatch will be (maxAdditionalUnackedMessages / avgBatchSizePerMsg)
+                assertEquals(maxEntriesInThisBatch, maxAdditionalUnackedMessages / avgBatchSizePerMsg);
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/24094
### Motivation
in order to test MaxEntriesInThisBatch in the PersistentDispatcherMultipleConsumers, extract from trySendMessagesToConsumers() into a method.
### Modifications

- [x] Make sure that the change passes the CI checks.
* If the box was checked, please highlight the changes*
- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/3pacccccc/pulsar/pull/1

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
