### PR TITLE
[fix][broker] Add topic consistency check

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1443,12 +1443,12 @@ public class NamespaceService implements AutoCloseable {
      */
     public CompletableFuture<Boolean> checkNonPersistentNonPartitionedTopicExists(String topic) {
         TopicName topicName = TopicName.get(topic);
-        // "non-partitioned & non-persistent" topics only exist on the owner broker.
+        // "non-partitioned & non-persistent" topics only exist on the cache of the owner broker.
         return checkTopicOwnership(TopicName.get(topic)).thenCompose(isOwned -> {
             // The current broker is the owner.
             if (isOwned) {
                CompletableFuture<Optional<Topic>> nonPersistentTopicFuture = pulsar.getBrokerService()
-                       .getTopic(topic, false);
+                       .getTopics().get(topic);
                if (nonPersistentTopicFuture != null) {
                    return nonPersistentTopicFuture.thenApply(Optional::isPresent);
                } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1417,9 +1417,15 @@ public class NamespaceService implements AutoCloseable {
                         topic.isPartitioned() ? TopicName.get(topic.getPartitionedTopicName()) : topic)
                 .thenCompose(metadata -> {
                     if (metadata.partitions > 0) {
-                        return CompletableFuture.completedFuture(
-                                topic.isPartitioned() ? TopicExistsInfo.newNonPartitionedTopicExists() :
-                                        TopicExistsInfo.newPartitionedTopicExists(metadata.partitions));
+                        if (!topic.isPartitioned()) {
+                            return CompletableFuture.completedFuture(
+                                    TopicExistsInfo.newPartitionedTopicExists(metadata.partitions));
+                        } else {
+                            if (topic.getPartitionIndex() < metadata.partitions) {
+                                return CompletableFuture.completedFuture(
+                                        TopicExistsInfo.newNonPartitionedTopicExists());
+                            }
+                        }
                     }
                     // Direct query the single topic.
                     return checkNonPartitionedTopicExists(topic).thenApply(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1062,6 +1062,64 @@ public class BrokerService implements Closeable {
     }
 
     /**
+     * Validates that the topic is consistent with its partition metadata.
+     *
+     * This method ensures the topic (partitioned or non-partitioned) correctly
+     * matches the actual partitions in the metadata. Inconsistencies typically
+     * indicate configuration issues or metadata synchronization problems.
+     *
+     * This validation is particularly important in geo-replicated environments where
+     * topic metadata may not be fully synchronized across all regions, potentially
+     * leading to access errors if not properly handled.
+     *
+     * @param topicName The topic name to validate
+     * @param metadata  The partition metadata retrieved for this topic
+     * @return CompletableFuture that completes normally if validation passes, or
+     * completes exceptionally with NotAllowedException if validation fails
+     */
+    private CompletableFuture<Void> validateTopicConsistency(TopicName topicName, PartitionedTopicMetadata metadata) {
+        if (NamespaceService.isHeartbeatNamespace(topicName.getNamespaceObject())) {
+            // Skip validation for heartbeat namespace.
+            return CompletableFuture.completedFuture(null);
+        }
+
+        if (topicName.isPartitioned()) {
+            if (metadata.partitions == 0) {
+                // Edge case: When a complete partitioned topic name is provided but metadata shows 0 partitions.
+                // This indicates that the partitioned topic metadata doesn't exist.
+                //
+                // Resolution options:
+                // 1. Creates the partitioned topic via admin API.
+                // 2. Uses the basic topic name and then rely on auto-creation if enabled.
+                return FutureUtil.failedFuture(
+                        new BrokerServiceException.NotAllowedException(
+                                "Partition metadata not found for the partitioned topic: " + topicName));
+            }
+            if (topicName.getPartitionIndex() >= metadata.partitions) {
+                final String errorMsg =
+                        String.format(
+                                "Illegal topic partition name %s with max allowed "
+                                        + "%d partitions", topicName,
+                                metadata.partitions);
+                log.warn(errorMsg);
+                return FutureUtil.failedFuture(
+                        new BrokerServiceException.NotAllowedException(errorMsg));
+            }
+        } else if (metadata.partitions > 0) {
+            // Edge case: Non-partitioned topic name was provided, but metadata indicates this is actually a partitioned
+            // topic (partitions > 0).
+            //
+            // Resolution: Must use the complete partitioned topic name('topic-name-partition-N').
+            //
+            // This ensures proper routing to the specific partition and prevents ambiguity in topic addressing.
+            return FutureUtil.failedFuture(new BrokerServiceException.NotAllowedException(
+                    "Found partitioned metadata for non-partitioned topic: " + topicName));
+        }
+
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
      * Retrieves or creates a topic based on the specified parameters.
      * 0. If disable PersistentTopics or NonPersistentTopics, it will return a failed future with NotAllowedException.
      * 1. If topic future exists in the cache returned directly regardless of whether it fails or timeout.
@@ -1107,30 +1165,9 @@ public class BrokerService implements Closeable {
                         throw FutureUtil.wrapToCompletionException(new ServiceUnitNotReadyException(errorInfo));
                     }).thenCompose(optionalTopicPolicies -> {
                         final TopicPolicies topicPolicies = optionalTopicPolicies.orElse(null);
-                        if (topicName.isPartitioned()) {
-                            final TopicName topicNameEntity = TopicName.get(topicName.getPartitionedTopicName());
-                            return fetchPartitionedTopicMetadataAsync(topicNameEntity)
-                                    .thenCompose((metadata) -> {
-                                        // Allow creating non-partitioned persistent topic that name includes
-                                        // `partition`
-                                        if (metadata.partitions == 0
-                                                || topicName.getPartitionIndex() < metadata.partitions) {
-                                            return topics.computeIfAbsent(topicName.toString(), (tpName) ->
-                                                    loadOrCreatePersistentTopic(tpName,
-                                                            createIfMissing, properties, topicPolicies));
-                                        } else {
-                                            final String errorMsg =
-                                                    String.format("Illegal topic partition name %s with max allowed "
-                                                            + "%d partitions", topicName, metadata.partitions);
-                                            log.warn(errorMsg);
-                                            return FutureUtil.failedFuture(
-                                                    new BrokerServiceException.NotAllowedException(errorMsg));
-                                        }
-                                    });
-                        } else {
-                            return topics.computeIfAbsent(topicName.toString(), (tpName) ->
-                                    loadOrCreatePersistentTopic(tpName, createIfMissing, properties, topicPolicies));
-                        }
+                        return topics.computeIfAbsent(topicName.toString(),
+                                (tpName) -> loadOrCreatePersistentTopic(tpName, createIfMissing, properties,
+                                        topicPolicies));
                     });
                 });
             } else {
@@ -1144,29 +1181,10 @@ public class BrokerService implements Closeable {
                 if (!topics.containsKey(topicName.toString())) {
                     topicEventsDispatcher.notify(topicName.toString(), TopicEvent.LOAD, EventStage.BEFORE);
                 }
-                if (topicName.isPartitioned()) {
-                    final TopicName partitionedTopicName = TopicName.get(topicName.getPartitionedTopicName());
-                    return this.fetchPartitionedTopicMetadataAsync(partitionedTopicName).thenCompose((metadata) -> {
-                        if (topicName.getPartitionIndex() < metadata.partitions) {
-                            return topics.computeIfAbsent(topicName.toString(), (name) -> {
-                                topicEventsDispatcher
-                                        .notify(topicName.toString(), TopicEvent.CREATE, EventStage.BEFORE);
-
-                                CompletableFuture<Optional<Topic>> res = createNonPersistentTopic(name);
-
-                                CompletableFuture<Optional<Topic>> eventFuture = topicEventsDispatcher
-                                        .notifyOnCompletion(res, topicName.toString(), TopicEvent.CREATE);
-                                topicEventsDispatcher
-                                        .notifyOnCompletion(eventFuture, topicName.toString(), TopicEvent.LOAD);
-                                return res;
-                            });
-                        }
-                        topicEventsDispatcher.notify(topicName.toString(), TopicEvent.LOAD, EventStage.FAILURE);
-                        return CompletableFuture.completedFuture(Optional.empty());
-                    });
-                } else if (createIfMissing) {
+                if (topicName.isPartitioned() || createIfMissing) {
                     return topics.computeIfAbsent(topicName.toString(), (name) -> {
-                        topicEventsDispatcher.notify(topicName.toString(), TopicEvent.CREATE, EventStage.BEFORE);
+                        topicEventsDispatcher
+                                .notify(topicName.toString(), TopicEvent.CREATE, EventStage.BEFORE);
 
                         CompletableFuture<Optional<Topic>> res = createNonPersistentTopic(name);
 
@@ -1358,7 +1376,13 @@ public class BrokerService implements Closeable {
             return topicFuture;
         }
         CompletableFuture<Void> isOwner = checkTopicNsOwnership(topic);
-        isOwner.thenRun(() -> {
+        TopicName topicName = TopicName.get(topic);
+        TopicName baseTopicName =
+                topicName.isPartitioned() ? TopicName.get(topicName.getPartitionedTopicName()) : topicName;
+        isOwner.thenCompose(__ -> fetchPartitionedTopicMetadataAsync(baseTopicName))
+                .thenCompose(
+                        (partitionedTopicMetadata) -> validateTopicConsistency(topicName, partitionedTopicMetadata))
+                .thenRun(() -> {
             nonPersistentTopic.initialize()
                     .thenCompose(__ -> nonPersistentTopic.checkReplication())
                     .thenRun(() -> {
@@ -1375,17 +1399,7 @@ public class BrokerService implements Closeable {
                 return null;
             });
         }).exceptionally(e -> {
-            log.warn("CheckTopicNsOwnership fail when createNonPersistentTopic! {}", topic, e.getCause());
-            // CheckTopicNsOwnership fail dont create nonPersistentTopic, when topic do lookup will find the correct
-            // broker. When client get non-persistent-partitioned topic
-            // metadata will the non-persistent-topic will be created.
-            // so we should add checkTopicNsOwnership logic otherwise the topic will be created
-            // if it dont own by this broker,we should return success
-            // otherwise it will keep retrying getPartitionedTopicMetadata
-            topicFuture.complete(Optional.of(nonPersistentTopic));
-            // after get metadata return success, we should delete this topic from this broker, because this topic not
-            // owner by this broker and it don't initialize and checkReplication
-            pulsar.getExecutor().execute(() -> topics.remove(topic, topicFuture));
+            topicFuture.completeExceptionally(FutureUtil.unwrapCompletionException(e));
             return null;
         });
 
@@ -1772,8 +1786,11 @@ public class BrokerService implements Closeable {
                 : CompletableFuture.completedFuture(null);
 
         CompletableFuture<Void> isTopicAlreadyMigrated = checkTopicAlreadyMigrated(topicName);
-
-        maxTopicsCheck.thenCompose(__ -> isTopicAlreadyMigrated)
+        TopicName baseTopicName =
+                topicName.isPartitioned() ? TopicName.get(topicName.getPartitionedTopicName()) : topicName;
+        maxTopicsCheck.thenCompose(__ -> fetchPartitionedTopicMetadataAsync(baseTopicName))
+                .thenCompose(partitionedTopicMetadata -> validateTopicConsistency(topicName, partitionedTopicMetadata))
+                .thenCompose(__ -> isTopicAlreadyMigrated)
                 .thenCompose(__ -> getManagedLedgerConfig(topicName, topicPolicies))
         .thenAccept(managedLedgerConfig -> {
             if (isBrokerEntryMetadataEnabled() || isBrokerPayloadProcessorEnabled()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1187,7 +1187,7 @@ public class BrokerService implements Closeable {
                 if (!topics.containsKey(topicName.toString())) {
                     topicEventsDispatcher.notify(topicName.toString(), TopicEvent.LOAD, EventStage.BEFORE);
                 }
-                if (createIfMissing) {
+                if (topicName.isPartitioned() || createIfMissing) {
                     return topics.computeIfAbsent(topicName.toString(), (name) -> {
                         topicEventsDispatcher
                                 .notify(topicName.toString(), TopicEvent.CREATE, EventStage.BEFORE);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -2912,10 +2912,8 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testPersistentTopicsExpireMessagesInvalidPartitionIndex() throws Exception {
-        // Force to create a topic
-        publishMessagesOnPersistentTopic("persistent://prop-xyz/ns1/ds2-partition-2", 0);
-        assertEquals(admin.topics().getList("prop-xyz/ns1"),
-                List.of("persistent://prop-xyz/ns1/ds2-partition-2"));
+        // Create a topic
+        admin.topics().createPartitionedTopic("persistent://prop-xyz/ns1/ds2", 3);
 
         // create consumer and subscription
         @Cleanup

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -141,7 +141,7 @@ import org.apache.pulsar.compaction.Compactor;
 import org.apache.pulsar.compaction.CompactorMXBean;
 import org.apache.pulsar.compaction.PulsarCompactionServiceFactory;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
-import org.apache.pulsar.metadata.impl.FaultInjectionMetadataStore;
+import org.apache.pulsar.metadata.impl.FaultInjectionMetadataStore.OperationType;
 import org.awaitility.Awaitility;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -1464,8 +1464,6 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         doReturn(CompletableFuture.completedFuture(null)).when(ledgerMock).asyncTruncate();
 
         // create topic
-        brokerService.pulsar().getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
-                .createPartitionedTopic(TopicName.get(successTopicName), new PartitionedTopicMetadata(2));
         PersistentTopic topic = (PersistentTopic) brokerService.getOrCreateTopic(successTopicName).get();
 
         Field isFencedField = AbstractTopic.class.getDeclaredField("isFenced");
@@ -1477,8 +1475,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         assertFalse((boolean) isClosingOrDeletingField.get(topic));
 
         metadataStore.failConditional(new MetadataStoreException("injected error"), (op, path) ->
-                op == FaultInjectionMetadataStore.OperationType.PUT &&
-                        path.equals("/admin/partitioned-topics/prop/use/ns-abc/persistent/successTopic"));
+                op == OperationType.EXISTS && path.equals("/admin/flags/policies-readonly"));
         try {
             topic.delete().get();
             fail();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -127,7 +127,6 @@ import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.api.proto.ProducerAccessMode;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.TopicPolicies;
 import org.apache.pulsar.common.policies.data.stats.SubscriptionStatsImpl;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -71,7 +71,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
-import org.apache.pulsar.broker.service.BrokerServiceException.NamingException;
+import org.apache.pulsar.broker.service.BrokerServiceException.NotAllowedException;
 import org.apache.pulsar.broker.service.persistent.PersistentReplicator;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.stats.OpenTelemetryReplicatorStats;
@@ -1208,7 +1208,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
             if (!isPartitionedTopic) {
                 fail("Topic creation should not fail without any partitioned topic");
             }
-            assertTrue(e.getCause() instanceof NamingException);
+            assertTrue(e.getCause() instanceof NotAllowedException);
         }
 
         // non-persistent topic test
@@ -1221,7 +1221,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
             if (!isPartitionedTopic) {
                 fail("Topic creation should not fail without any partitioned topic");
             }
-            assertTrue(e.getCause() instanceof NamingException);
+            assertTrue(e.getCause() instanceof NotAllowedException);
         }
 
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
@@ -18,6 +18,10 @@
  */
 package org.apache.pulsar.broker.service.nonpersistent;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
 import java.lang.reflect.Field;
 import java.util.Optional;
 import java.util.UUID;
@@ -42,12 +46,6 @@ import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertThrows;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.fail;
 
 @Test(groups = "broker")
 public class NonPersistentTopicTest extends BrokerTestBase {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
@@ -43,6 +43,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -113,19 +114,16 @@ public class NonPersistentTopicTest extends BrokerTestBase {
     }
 
     @Test
-    public void testCreateNonExistentPartitions() throws PulsarAdminException, PulsarClientException {
+    public void testCreateNonExistentPartitions() throws PulsarAdminException {
         final String topicName = "non-persistent://prop/ns-abc/testCreateNonExistentPartitions";
         admin.topics().createPartitionedTopic(topicName, 4);
         TopicName partition = TopicName.get(topicName).getPartition(4);
-        try {
+        assertThrows(PulsarClientException.NotAllowedException.class, () -> {
             @Cleanup
-            Producer<byte[]> producer = pulsarClient.newProducer()
+            Producer<byte[]> ignored = pulsarClient.newProducer()
                     .topic(partition.toString())
                     .create();
-            fail("unexpected behaviour");
-        } catch (PulsarClientException.TopicDoesNotExistException ignored) {
-
-        }
+        });
         assertEquals(admin.topics().getPartitionedTopicMetadata(topicName).partitions, 4);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pulsar.broker.service.persistent;
 
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
 import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.parseMetrics;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -36,6 +34,8 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
@@ -576,37 +576,6 @@ public class PersistentTopicTest extends BrokerTestBase {
         } catch (PulsarClientException.NotAllowedException ex) {
         }
         Assert.assertEquals(admin.topics().getPartitionedTopicMetadata(topicName).partitions, 4);
-    }
-
-    @Test
-    public void testCompatibilityWithPartitionKeyword() throws PulsarAdminException, PulsarClientException {
-        final String topicName = "persistent://prop/ns-abc/testCompatibilityWithPartitionKeyword";
-        TopicName topicNameEntity = TopicName.get(topicName);
-        String partition2 = topicNameEntity.getPartition(2).toString();
-        // Create a non-partitioned topic with -partition- keyword
-        Producer<byte[]> producer = pulsarClient.newProducer()
-                .topic(partition2)
-                .create();
-        List<String> topics = admin.topics().getList("prop/ns-abc");
-        // Close previous producer to simulate reconnect
-        producer.close();
-        // Disable auto topic creation
-        conf.setAllowAutoTopicCreation(false);
-        // Check the topic exist in the list.
-        Assert.assertTrue(topics.contains(partition2));
-        // Check this topic has no partition metadata.
-        Assert.assertThrows(PulsarAdminException.NotFoundException.class,
-                () -> admin.topics().getPartitionedTopicMetadata(topicName));
-        // Reconnect to the broker and expect successful because the topic has existed in the broker.
-        producer = pulsarClient.newProducer()
-                .topic(partition2)
-                .create();
-        producer.close();
-        // Check the topic exist in the list again.
-        Assert.assertTrue(topics.contains(partition2));
-        // Check this topic has no partition metadata again.
-        Assert.assertThrows(PulsarAdminException.NotFoundException.class,
-                () -> admin.topics().getPartitionedTopicMetadata(topicName));
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerCreationTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.client.api;
+
+import static org.testng.Assert.assertThrows;
+import lombok.Cleanup;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.PulsarClientException.NotAllowedException;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker-api")
+public class ConsumerCreationTest extends ProducerConsumerBase {
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @DataProvider(name = "topicDomainProvider")
+    public Object[][] topicDomainProvider() {
+        return new Object[][]{
+                {TopicDomain.persistent},
+                {TopicDomain.non_persistent}
+        };
+    }
+
+    @Test(dataProvider = "topicDomainProvider")
+    public void testCreateConsumerWhenTopicTypeMismatch(TopicDomain domain)
+            throws PulsarAdminException, PulsarClientException {
+        String nonPartitionedTopic =
+                TopicName.get(domain.value(), "public", "default",
+                                "testCreateConsumerWhenTopicTypeMismatch-nonPartitionedTopic")
+                        .toString();
+        admin.topics().createNonPartitionedTopic(nonPartitionedTopic);
+
+        // Topic type is non-partitioned, Trying to create consumer on partitioned topic.
+        assertThrows(NotAllowedException.class, () -> {
+            @Cleanup
+            Consumer<byte[]> ignored =
+                    pulsarClient.newConsumer().topic(TopicName.get(nonPartitionedTopic).getPartition(2).toString())
+                            .subscriptionName("my-sub").subscribe();
+        });
+
+        // Topic type is partitioned, Trying to create consumer on non-partitioned topic.
+        String partitionedTopic = TopicName.get(domain.value(), "public", "default",
+                        "testCreateConsumerWhenTopicTypeMismatch-partitionedTopic")
+                .toString();
+        admin.topics().createPartitionedTopic(partitionedTopic, 3);
+
+        // Works fine because the lookup can help our to find the correct topic.
+        {
+            @Cleanup
+            Consumer<byte[]> ignored =
+                    pulsarClient.newConsumer().topic(TopicName.get(partitionedTopic).getPartition(2).toString())
+                            .subscriptionName("my-sub").subscribe();
+        }
+
+        // Partition index is out of range.
+        assertThrows(NotAllowedException.class, () -> {
+            @Cleanup
+            Consumer<byte[]> ignored =
+                    pulsarClient.newConsumer().topic(TopicName.get(partitionedTopic).getPartition(100).toString())
+                            .subscriptionName("my-sub").subscribe();
+        });
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerCreationTest.java
@@ -106,12 +106,13 @@ public class ConsumerCreationTest extends ProducerConsumerBase {
         conf.setAllowAutoTopicCreation(allowAutoTopicCreation);
 
         String partitionedTopic = TopicName.get(domain.value(), "public", "default",
-                        "testCreateConsumerWhenTopicTypeMismatch-partitionedTopic-" + allowAutoTopicCreation)
+                        "testCreateConsumerWhenSinglePartitionIsDeleted-" + allowAutoTopicCreation)
                 .toString();
         admin.topics().createPartitionedTopic(partitionedTopic, 3);
         admin.topics().delete(TopicName.get(partitionedTopic).getPartition(1).toString());
 
-        if (allowAutoTopicCreation) {
+        // Non-persistent topic only have the metadata, and no partition, so it works fine.
+        if (allowAutoTopicCreation || domain.equals(TopicDomain.non_persistent)) {
             @Cleanup
             Consumer<byte[]> ignored =
                     pulsarClient.newConsumer().topic(partitionedTopic).subscriptionName("my-sub").subscribe();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerCreationTest.java
@@ -248,12 +248,13 @@ public class ProducerCreationTest extends ProducerConsumerBase {
         conf.setAllowAutoTopicCreation(allowAutoTopicCreation);
 
         String partitionedTopic = TopicName.get(domain.value(), "public", "default",
-                        "testCreateProducerWhenSinglePartitionIsDeleted-partitionedTopic-" + allowAutoTopicCreation)
+                        "testCreateProducerWhenSinglePartitionIsDeleted-" + allowAutoTopicCreation)
                 .toString();
         admin.topics().createPartitionedTopic(partitionedTopic, 3);
         admin.topics().delete(TopicName.get(partitionedTopic).getPartition(1).toString());
 
-        if (allowAutoTopicCreation) {
+        // Non-persistent topic only have the metadata, and no partition, so it works fine.
+        if (allowAutoTopicCreation || domain == TopicDomain.non_persistent) {
             @Cleanup
             Producer<byte[]> ignored = pulsarClient.newProducer().topic(partitionedTopic).create();
         } else {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/LookupServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/LookupServiceTest.java
@@ -19,13 +19,19 @@
 package org.apache.pulsar.client.impl;
 
 import static org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace.Mode;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.testng.annotations.AfterClass;
@@ -125,4 +131,63 @@ public class LookupServiceTest extends ProducerConsumerBase {
         admin.topics().delete(nonPartitionedTopic, false);
     }
 
+    @Test(dataProvider = "isUsingHttpLookup")
+    public void testGetPartitionedTopicMetadataByPulsarClient(boolean isUsingHttpLookup) {
+        LookupService lookupService = getLookupService(isUsingHttpLookup);
+
+        // metadataAutoCreationEnabled is true.
+        assertThat(lookupService.getPartitionedTopicMetadata(
+                TopicName.get(BrokerTestUtil.newUniqueName("persistent://public/default/tp")), true))
+                .succeedsWithin(3, TimeUnit.SECONDS)
+                .matches(n -> n.partitions == 0);
+
+        // metadataAutoCreationEnabled is true.
+        // Allow the get the metadata of single partition topic, because the auto-creation is enabled.
+        // But the producer/consumer is unavailable because the topic doesn't have the metadata.
+        assertThat(lookupService.getPartitionedTopicMetadata(
+                TopicName.get(BrokerTestUtil.newUniqueName("persistent://public/default/tp") + "-partition-10"),
+                true))
+                .succeedsWithin(3, TimeUnit.SECONDS)
+                .matches(n -> n.partitions == 0);
+
+        Class<? extends Throwable> expectedExceptionClass =
+                isUsingHttpLookup ? PulsarClientException.NotFoundException.class :
+                        PulsarClientException.TopicDoesNotExistException.class;
+        // metadataAutoCreationEnabled is false.
+        assertThat(lookupService.getPartitionedTopicMetadata(
+                TopicName.get(BrokerTestUtil.newUniqueName("persistent://public/default/tp")), false))
+                .failsWithin(3, TimeUnit.SECONDS)
+                .withThrowableThat()
+                .withCauseInstanceOf(expectedExceptionClass);
+
+        // metadataAutoCreationEnabled is false.
+        assertThat(lookupService.getPartitionedTopicMetadata(
+                TopicName.get(BrokerTestUtil.newUniqueName("persistent://public/default/tp") + "-partition-10"),
+                false))
+                .failsWithin(3, TimeUnit.SECONDS)
+                .withThrowableThat()
+                .withCauseInstanceOf(expectedExceptionClass);
+    }
+
+    @Test
+    public void testGetPartitionedTopicMedataByAdmin() throws PulsarAdminException {
+        String nonPartitionedTopic = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
+        String partitionedTopic = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
+        String partitionedTopicWithPartitionIndex = partitionedTopic + "-partition-10";
+        // No topic, so throw the NotFound.
+        // BTW: The admin api doesn't allow to creat the metadata of topic default.
+        assertThrows(PulsarAdminException.NotFoundException.class, () -> admin.topics()
+                .getPartitionedTopicMetadata(nonPartitionedTopic));
+        assertThrows(PulsarAdminException.NotFoundException.class, () -> admin.topics()
+                .getPartitionedTopicMetadata(partitionedTopic));
+        assertThrows(PulsarAdminException.NotFoundException.class,
+                () -> admin.topics().getPartitionedTopicMetadata(partitionedTopicWithPartitionIndex));
+
+        admin.topics().createNonPartitionedTopic(nonPartitionedTopic);
+        assertEquals(admin.topics().getPartitionedTopicMetadata(nonPartitionedTopic).partitions, 0);
+
+        admin.topics().createPartitionedTopic(partitionedTopic, 20);
+        assertEquals(admin.topics().getPartitionedTopicMetadata(partitionedTopic).partitions, 20);
+        assertEquals(admin.topics().getPartitionedTopicMetadata(partitionedTopicWithPartitionIndex).partitions, 0);
+    }
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -961,7 +961,9 @@ public class PulsarClientException extends IOException {
     public static Throwable wrap(Throwable t, String msg) {
         msg += "\n" + t.getMessage();
         // wrap an exception with new message info
-        if (t instanceof TimeoutException) {
+        if(t instanceof TopicDoesNotExistException){
+            return new TopicDoesNotExistException(msg);
+        } else if (t instanceof TimeoutException) {
             return new TimeoutException(msg);
         } else if (t instanceof InvalidConfigurationException) {
             return new InvalidConfigurationException(msg);

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -961,7 +961,7 @@ public class PulsarClientException extends IOException {
     public static Throwable wrap(Throwable t, String msg) {
         msg += "\n" + t.getMessage();
         // wrap an exception with new message info
-        if(t instanceof TopicDoesNotExistException){
+        if (t instanceof TopicDoesNotExistException) {
             return new TopicDoesNotExistException(msg);
         } else if (t instanceof TimeoutException) {
             return new TimeoutException(msg);


### PR DESCRIPTION
### Motivation

In Apache Pulsar, clients can produce or consume messages using a fully qualified partition topic name (`public/default/test-partitioned-topic-partition-N`). However, if the topic metadata does not exist and `allowAutoTopicCreationType=non-partitioned` is enabled, Pulsar automatically creates the topic as non-partitioned. This leads to inconsistencies when listing topics, as the expected partitioned topic structure is not maintained.

This issue is especially prevalent in geo-replicated environments, where topic metadata may not be fully synchronized across all regions. Currently, Pulsar lacks validation to ensure that the topic type (partitioned or non-partitioned) matches the actual partition metadata.

### Modifications

- Added a topic consistency check:
  - **For non-partitioned topic**: If partition metadata exists (which shouldn't be there), the broker will reject message produce and consume operations.
  - **For partitioned topic**: If partition metadata is missing (which should be there), the broker will reject message produce and consume operations.
- Fixed affected tests to align with the new validation logic.
- Added `testGetPartitionedTopicMetadataByPulsarClient` and `testGetPartitionedTopicMedataByAdmin` instead of `testCompatibilityWithPartitionKeyword` because the broker rejects message produce and consume operations when no metadata. Note: we still allow user lookup topic name with `-partition-` but no metadata: https://github.com/apache/pulsar/pull/19171.
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
