### PR TITLE
[improve][client] Prevent NullPointException when closing ClientCredentialsFlow

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/ClientCredentialsFlow.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/ClientCredentialsFlow.java
@@ -109,7 +109,9 @@ class ClientCredentialsFlow extends FlowBase {
 
     @Override
     public void close() throws Exception {
-        exchanger.close();
+        if (exchanger != null) {
+            exchanger.close();
+        }
     }
 
     /**


### PR DESCRIPTION
### Motivation
If `ClientCredentialsFlow` initialization fails, the `exchanger` might be null, which could lead to a NullPointerException when closing.

```
2025-03-11 12:26:43,050 WARN  org.apache.pulsar.client.impl.PulsarClientImpl               [] - Failed to close authentication
java.io.IOException: java.lang.NullPointerException: Cannot invoke "org.apache.pulsar.client.impl.auth.oauth2.protocol.ClientCredentialsExchanger.close()" because "this.exchanger" is null
```

### Modifications
- Add null check.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
