### PR TITLE
[improve][io] Remove sleep when sourceTask.poll of kafka return null

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
@@ -169,7 +169,6 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
                 flushFuture = new CompletableFuture<>();
                 List<SourceRecord> recordList = sourceTask.poll();
                 if (recordList == null || recordList.isEmpty()) {
-                    Thread.sleep(1000);
                     continue;
                 }
                 outstandingRecords.addAndGet(recordList.size());


### PR DESCRIPTION
### Motivation

We observe our debezium source connector latency min is 1s when traffic is small.

According to the [Kafka Source API definition](https://github.com/a0x8o/kafka/blob/master/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java#L94-L105), when there is no data, the implementation should block for a period of time. We don't need to actively sleep here to avoid CPU spinning.

```
"platform/resource/debezium-postgres-source-0" #20 prio=5 os_prio=0 cpu=15396.95ms elapsed=21030.80s tid=0x00007f8cbc99f020 nid=0x20 waiting on condition  [0x00007f8cbb92c000]
   java.lang.Thread.State: TIMED_WAITING (sleeping)
	at java.lang.Thread.sleep(java.base@17.0.13/Native Method)
	at org.apache.pulsar.io.kafka.connect.AbstractKafkaConnectSource.read(AbstractKafkaConnectSource.java:172)
	- locked <0x00000000cf3044a0> (a org.apache.pulsar.io.debezium.postgres.DebeziumPostgresSource)
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.readInput(JavaInstanceRunnable.java:529)
	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:320)
	at java.lang.Thread.run(java.base@17.0.13/Thread.java:840)
```


### Modifications
- Remove sleep when sourceTask.poll of kafka return null

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
