### PR TITLE
[fix][ml] Don't estimate number of entries when ledgers are empty, return 1 instead

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCountEstimator.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCountEstimator.java
@@ -19,7 +19,6 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import static org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImpl.BOOKKEEPER_READ_OVERHEAD_PER_ENTRY;
-import static org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImpl.DEFAULT_ESTIMATED_ENTRY_SIZE;
 import java.util.Collection;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -98,8 +97,7 @@ class EntryCountEstimator {
 
         long estimatedEntryCount = 0;
         long remainingBytesSize = maxSizeBytes;
-        // Start with a default estimated average size per entry, including any overhead
-        long currentAvgSize = DEFAULT_ESTIMATED_ENTRY_SIZE + BOOKKEEPER_READ_OVERHEAD_PER_ENTRY;
+        long currentAvgSize = 0;
         // Get a collection of ledger info starting from the read position
         Collection<MLDataFormats.ManagedLedgerInfo.LedgerInfo> ledgersAfterReadPosition =
                 ledgersInfo.tailMap(readPosition.getLedgerId(), true).values();
@@ -160,7 +158,26 @@ class EntryCountEstimator {
 
         // Add any remaining bytes to the estimated entry count considering the current average entry size
         if (remainingBytesSize > 0 && estimatedEntryCount < maxEntries) {
-            estimatedEntryCount += remainingBytesSize / currentAvgSize;
+            // need to find the previous non-empty ledger to find the average size
+            if (currentAvgSize == 0) {
+                Collection<MLDataFormats.ManagedLedgerInfo.LedgerInfo> ledgersBeforeReadPosition =
+                        ledgersInfo.headMap(readPosition.getLedgerId(), false).descendingMap().values();
+                for (MLDataFormats.ManagedLedgerInfo.LedgerInfo ledgerInfo : ledgersBeforeReadPosition) {
+                    long ledgerTotalSize = ledgerInfo.getSize();
+                    long ledgerTotalEntries = ledgerInfo.getEntries();
+                    // Skip processing ledgers that have no entries or size
+                    if (ledgerTotalEntries == 0 || ledgerTotalSize == 0) {
+                        continue;
+                    }
+                    // Update the average entry size based on the current ledger's size and entry count
+                    currentAvgSize = Math.max(1, ledgerTotalSize / ledgerTotalEntries)
+                            + BOOKKEEPER_READ_OVERHEAD_PER_ENTRY;
+                    break;
+                }
+            }
+            if (currentAvgSize > 0) {
+                estimatedEntryCount += remainingBytesSize / currentAvgSize;
+            }
         }
 
         // Ensure at least one entry is always returned as the result


### PR DESCRIPTION
### Motivation

Following up on #24089 changes. The changes cause a regression which is visible in branch-3.0 where a test fails (`org.apache.pulsar.compaction.CompactionTest#testDispatcherMaxReadSizeBytes`). This test is different in newer branches. The regression is caused by the logic added in #24089 to use `DEFAULT_ESTIMATED_ENTRY_SIZE + BOOKKEEPER_READ_OVERHEAD_PER_ENTRY` as the default average entry size. 
Another gap is that when all ledgers are empty, no average size would be used. That is also fixed in this PR

### Modifications

- when the ledger is completely empty, don't estimate the number of entries, simply return 1 as the estimated entry count
- when all ledgers are empty beyond the read position, find the latest ledger with entries to calculate the average entry count to be used in the estimation
- add test coverage to cover these cases

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->