### PR TITLE
[improve][meta] Change log level from error to warn for unknown notification types in OxiaMetadataStore

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/oxia/OxiaMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/oxia/OxiaMetadataStore.java
@@ -120,7 +120,7 @@ public class OxiaMetadataStore extends AbstractMetadataStore {
                             NotificationType.Deleted, keyDeleted.key()));
             notifyParentChildrenChanged(keyDeleted.key());
         } else {
-            log.error("Unknown notification type {}", notification);
+            log.warn("Unknown notification type {}", notification);
         }
     }
 


### PR DESCRIPTION
### Motivation

We found a lot of error logs with "the notification type Unknown" for Oxia metadata and I think it's best to classify this as warn level.
```
2025-03-26T03:24:31,999+0000 [grpc-default-worker-ELG-2-1] ERROR org.apache.pulsar.metadata.impl.oxia.OxiaMetadataStore - Unknown notification type KeyRangeDelete[startKeyInclusive=/sequenceId/, endKeyExclusive=/sequenceId/-0000000 │
│ 0000000000015]                                                                                                                                                                                                                          │
│ 2025-03-26T03:24:31,999+0000 [grpc-default-worker-ELG-2-1] ERROR org.apache.pulsar.metadata.impl.oxia.OxiaMetadataStore - Unknown notification type KeyRangeDelete[startKeyInclusive=/sequenceId/, endKeyExclusive=/sequenceId/-0000000 │
│ 0000000000015]                                                                                                                                                                                                                          │
│ 2025-03-26T03:24:31,999+0000 [grpc-default-worker-ELG-2-1] ERROR org.apache.pulsar.metadata.impl.oxia.OxiaMetadataStore - Unknown notification type KeyRangeDelete[startKeyInclusive=/sequenceId/, endKeyExclusive=/sequenceId/-0000000 │
│ 0000000000015]                                                                                                                                                                                                                          │
│ 2025-03-26T03:24:32,000+0000 [grpc-default-worker-ELG-2-1] ERROR org.apache.pulsar.metadata.impl.oxia.OxiaMetadataStore - Unknown notification type KeyRangeDelete[startKeyInclusive=/sequenceId/, endKeyExclusive=/sequenceId/-0000000 │
│ 0000000000015]                                                                                                                                                                                                                          │
│ 2025-03-26T03:24:32,000+0000 [grpc-default-worker-ELG-2-1] ERROR org.apache.pulsar.metadata.impl.oxia.OxiaMetadataStore - Unknown notification type KeyRangeDelete[startKeyInclusive=/sequenceId/, endKeyExclusive=/sequenceId/-0000000 │
│ 0000000000015]                                                                                                                                                                                                                          │
│ 2025-03-26T03:24:32,000+0000 [grpc-default-worker-ELG-2-1] ERROR org.apache.pulsar.metadata.impl.oxia.OxiaMetadataStore - Unknown notification type KeyRangeDelete[startKeyInclusive=/sequenceId/, endKeyExclusive=/sequenceId/-0000000 │
│ 0000000000015]                                                                                                                                                                                                                          │
│ 2025-03-26T03:24:32,000+0000 [grpc-default-worker-ELG-2-1] ERROR org.apache.pulsar.metadata.impl.oxia.OxiaMetadataStore - Unknown notification type KeyRangeDelete[startKeyInclusive=/sequenceId/, endKeyExclusive=/sequenceId/-0000000 │
│ 0000000000015]                                                                                                                                                                                                                          │
│ 2025-03-26T03:24:32,000+0000 [grpc-default-worker-ELG-2-1] ERROR org.apache.pulsar.metadata.impl.oxia.OxiaMetadataStore - Unknown notification type KeyRangeDelete[startKeyInclusive=/sequenceId/, endKeyExclusive=/sequenceId/-0000000 │
│ 0000000000015]                                                                                                                                                                                                                          │
│ 2025-03-26T03:24:32,000+0000 [grpc-default-worker-ELG-2-1] ERROR org.apache.pulsar.metadata.impl.oxia.OxiaMetadataStore - Unknown notification type KeyRangeDelete[startKeyInclusive=/sequenceId/, endKeyExclusive=/sequenceId/-0000000 │
│ 0000000000015]
```

### Modifications

Change log level from error to warn for unknown notification types

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
