### PR TITLE
[improve][io] Enhance Kafka connector logging with focused bootstrap server information

### DIFF
--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSink.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSink.java
@@ -81,11 +81,11 @@ public abstract class KafkaAbstractSink<K, V> implements Sink<byte[]> {
         kafkaSinkConfig = KafkaSinkConfig.load(config, sinkContext);
         if (kafkaSinkConfig.getBatchSize() <= 0) {
             throw new IllegalArgumentException("Invalid Kafka Producer batchSize : "
-                + kafkaSinkConfig.getBatchSize());
+                    + kafkaSinkConfig.getBatchSize());
         }
         if (kafkaSinkConfig.getMaxRequestSize() <= 0) {
             throw new IllegalArgumentException("Invalid Kafka Producer maxRequestSize : "
-                + kafkaSinkConfig.getMaxRequestSize());
+                    + kafkaSinkConfig.getMaxRequestSize());
         }
         if (kafkaSinkConfig.getProducerConfigProperties() != null) {
             props.putAll(kafkaSinkConfig.getProducerConfigProperties());
@@ -122,7 +122,7 @@ public abstract class KafkaAbstractSink<K, V> implements Sink<byte[]> {
 
         producer = new KafkaProducer<>(beforeCreateProducer(props));
 
-        log.info("Kafka sink started : {}.", props);
+        log.info("Kafka sink started : {}.", props.getOrDefault(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, ""));
     }
 
     public abstract KeyValue<K, V> extractKeyValue(Record<byte[]> message);

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaBytesSink.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaBytesSink.java
@@ -33,10 +33,10 @@ import org.apache.pulsar.io.core.annotations.IOType;
  * apply schema into it.
  */
 @Connector(
-    name = "kafka",
-    type = IOType.SINK,
-    help = "The KafkaBytesSink is used for moving messages from Pulsar to Kafka.",
-    configClass = KafkaSinkConfig.class
+        name = "kafka",
+        type = IOType.SINK,
+        help = "The KafkaBytesSink is used for moving messages from Pulsar to Kafka.",
+        configClass = KafkaSinkConfig.class
 )
 @Slf4j
 public class KafkaBytesSink extends KafkaAbstractSink<String, byte[]> {
@@ -45,7 +45,7 @@ public class KafkaBytesSink extends KafkaAbstractSink<String, byte[]> {
     protected Properties beforeCreateProducer(Properties props) {
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
-        log.info("Created kafka producer config : {}", props);
+        log.info("Created kafka producer on : {}", props.getOrDefault(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, ""));
         return props;
     }
 

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaBytesSource.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaBytesSource.java
@@ -49,22 +49,22 @@ import org.apache.pulsar.io.core.annotations.Connector;
 import org.apache.pulsar.io.core.annotations.IOType;
 
 /**
- *  Kafka Source that transfers the data from Kafka to Pulsar and sets the Schema type properly.
- *  We use the key and the value deserializer in order to decide the type of Schema to be set on the topic on Pulsar.
- *  In case of KafkaAvroDeserializer we use the Schema Registry to download the schema and apply it to the topic.
- *  Please refer to {@link #getSchemaFromDeserializerAndAdaptConfiguration(String, Properties, boolean)} for the list
- *  of supported Deserializers.
- *  If you set StringDeserializer for the key then we use the raw key as key for the Pulsar message.
- *  If you set another Deserializer for the key we use the KeyValue schema type in Pulsar with the SEPARATED encoding.
- *  This way the Key is stored in the Pulsar key, encoded as base64 string and with a Schema, the Value of the message
- *  is stored in the Pulsar value with a Schema.
- *  This way there is a one-to-one mapping between Kafka key/value pair and the Pulsar data model.
+ * Kafka Source that transfers the data from Kafka to Pulsar and sets the Schema type properly.
+ * We use the key and the value deserializer in order to decide the type of Schema to be set on the topic on Pulsar.
+ * In case of KafkaAvroDeserializer we use the Schema Registry to download the schema and apply it to the topic.
+ * Please refer to {@link #getSchemaFromDeserializerAndAdaptConfiguration(String, Properties, boolean)} for the list
+ * of supported Deserializers.
+ * If you set StringDeserializer for the key then we use the raw key as key for the Pulsar message.
+ * If you set another Deserializer for the key we use the KeyValue schema type in Pulsar with the SEPARATED encoding.
+ * This way the Key is stored in the Pulsar key, encoded as base64 string and with a Schema, the Value of the message
+ * is stored in the Pulsar value with a Schema.
+ * This way there is a one-to-one mapping between Kafka key/value pair and the Pulsar data model.
  */
 @Connector(
-    name = "kafka",
-    type = IOType.SOURCE,
-    help = "Transfer data from Kafka to Pulsar.",
-    configClass = KafkaSourceConfig.class
+        name = "kafka",
+        type = IOType.SOURCE,
+        help = "Transfer data from Kafka to Pulsar.",
+        configClass = KafkaSourceConfig.class
 )
 @Slf4j
 public class KafkaBytesSource extends KafkaAbstractSource<ByteBuffer> {
@@ -78,7 +78,7 @@ public class KafkaBytesSource extends KafkaAbstractSource<ByteBuffer> {
     protected Properties beforeCreateConsumer(Properties props) {
         props.putIfAbsent(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         props.putIfAbsent(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
-        log.info("Created kafka consumer config : {}", props);
+        log.info("Created kafka consumer on : {}", props.getOrDefault(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, ""));
 
         keySchema = getSchemaFromDeserializerAndAdaptConfiguration(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
                 props, true);
@@ -86,7 +86,7 @@ public class KafkaBytesSource extends KafkaAbstractSource<ByteBuffer> {
                 props, false);
 
         boolean needsSchemaCache = keySchema == DeferredSchemaPlaceholder.INSTANCE
-                                    || valueSchema == DeferredSchemaPlaceholder.INSTANCE;
+                || valueSchema == DeferredSchemaPlaceholder.INSTANCE;
 
         if (needsSchemaCache) {
             initSchemaCache(props);
@@ -174,8 +174,8 @@ public class KafkaBytesSource extends KafkaAbstractSource<ByteBuffer> {
 
         Schema<?> result;
         if (ByteArrayDeserializer.class.getName().equals(kafkaDeserializerClass)
-            || ByteBufferDeserializer.class.getName().equals(kafkaDeserializerClass)
-            || BytesDeserializer.class.getName().equals(kafkaDeserializerClass)) {
+                || ByteBufferDeserializer.class.getName().equals(kafkaDeserializerClass)
+                || BytesDeserializer.class.getName().equals(kafkaDeserializerClass)) {
             result = Schema.BYTEBUFFER;
         } else if (StringDeserializer.class.getName().equals(kafkaDeserializerClass)) {
             if (isKey) {
@@ -193,7 +193,7 @@ public class KafkaBytesSource extends KafkaAbstractSource<ByteBuffer> {
             result = Schema.INT64;
         } else if (ShortDeserializer.class.getName().equals(kafkaDeserializerClass)) {
             result = Schema.INT16;
-        } else if (KafkaAvroDeserializer.class.getName().equals(kafkaDeserializerClass)){
+        } else if (KafkaAvroDeserializer.class.getName().equals(kafkaDeserializerClass)) {
             // in this case we have to inject our custom deserializer
             // that extracts Avro schema information
             props.put(key, ExtractKafkaAvroSchemaDeserializer.class.getName());
@@ -238,7 +238,7 @@ public class KafkaBytesSource extends KafkaAbstractSource<ByteBuffer> {
         }
     }
 
-     static final class DeferredSchemaPlaceholder extends ByteBufferSchemaWrapper {
+    static final class DeferredSchemaPlaceholder extends ByteBufferSchemaWrapper {
         DeferredSchemaPlaceholder() {
             super(SchemaInfoImpl
                     .builder()
@@ -247,6 +247,7 @@ public class KafkaBytesSource extends KafkaAbstractSource<ByteBuffer> {
                     .schema(new byte[0])
                     .build());
         }
+
         static final DeferredSchemaPlaceholder INSTANCE = new DeferredSchemaPlaceholder();
     }
 


### PR DESCRIPTION
### Motivation

The current Kafka connector logging outputs the entire properties object, which adds unnecessary log lines. This PR improves logging for Kafka connectors by specifically logging the bootstrap server information rather than dumping all properties, enhancing readability and focusing on the most relevant connection detail. Users can continue to retrieve connector state information using Admin API when needed.

### Modifications

- Changed log statements in Kafka connector classes to only output bootstrap server information instead of full properties
- Updated logging in the following files:
  - `KafkaConnectSink.java`
  - `KafkaAbstractSink.java`
  - `KafkaBytesSink.java`
  - `KafkaBytesSource.java`
- Used the `getOrDefault` method to extract bootstrap server information from properties with fallback handling

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage. The modifications only affect log output formatting and don't change any functional behavior, so no additional tests are required.

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->