### PR TITLE
[improve][client] Refactor wrap and unwrap methods in PulsarClientException

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -1295,7 +1295,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
             producer.newMessage(transaction).send();
             Assert.fail();
         } catch (Exception e) {
-            Assert.assertTrue(e.getCause().getCause() instanceof TransactionCoordinatorClientException
+            Assert.assertTrue(e.getCause() instanceof TransactionCoordinatorClientException
                     .InvalidTxnStatusException);
         }
         try {

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -995,8 +995,6 @@ public class PulsarClientException extends IOException {
     public static PulsarClientException unwrap(Throwable t) {
         if (t instanceof PulsarClientException) {
             return (PulsarClientException) t;
-        } else if (t instanceof RuntimeException) {
-            throw (RuntimeException) t;
         } else if (t instanceof InterruptedException) {
             return createPulsarException(t);
         } else if (!(t instanceof ExecutionException)) {

--- a/pulsar-client-api/src/test/java/org/apache/pulsar/client/api/PulsarClientExceptionTest.java
+++ b/pulsar-client-api/src/test/java/org/apache/pulsar/client/api/PulsarClientExceptionTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.concurrent.ExecutionException;
+import lombok.extern.slf4j.Slf4j;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class PulsarClientExceptionTest {
+
+    @Test
+    public void testWrap() {
+        IllegalArgumentException argumentException = new IllegalArgumentException("name is required");
+        Throwable wrapped = PulsarClientException.wrap(argumentException, "check");
+        assertThat(wrapped)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContainingAll("check", "name is required")
+                .isInstanceOf(IllegalArgumentException.class)
+                .matches(n -> {
+                    assertThat(n.getStackTrace()).isEqualTo(argumentException.getStackTrace());
+                    return true;
+                })
+                .hasNoCause();
+
+        NullPointerException cause = new NullPointerException("name is null");
+        IllegalArgumentException argumentExceptionWithCause =
+                new IllegalArgumentException("name is required", cause);
+        Throwable wrappedWithCause = PulsarClientException.wrap(argumentExceptionWithCause, "check");
+        assertThat(wrappedWithCause)
+                .isInstanceOf(IllegalArgumentException.class)
+                .matches(n -> {
+                    assertThat(n.getStackTrace()).isEqualTo(argumentExceptionWithCause.getStackTrace());
+                    return true;
+                })
+                .hasMessageContainingAll("check", "name is required")
+                .cause()
+                .isEqualTo(cause);
+    }
+
+    @Test
+    public void testUnwrapPulsarClientException() {
+        PulsarClientException exception = new PulsarClientException("Pulsar client error");
+        PulsarClientException result = PulsarClientException.unwrap(exception);
+        assertThat(result).isEqualTo(exception);
+    }
+
+    @Test
+    public void testUnwrapExecutionExceptionNestedException() {
+        Exception originalException = new Exception("Nested cause");
+        ExecutionException exception = new ExecutionException("Execution error", originalException);
+        PulsarClientException result = PulsarClientException.unwrap(exception);
+        assertThat(result)
+                .isInstanceOf(PulsarClientException.class)
+                .matches(n -> {
+                    assertThat(n.getStackTrace()).isEqualTo(originalException.getStackTrace());
+                    return true;
+                })
+                .cause()
+                .isEqualTo(originalException);
+    }
+
+    @Test
+    public void testUnwrapExecutionExceptionNestedPulsarClientException() {
+        PulsarClientException originalException = new PulsarClientException("Nested cause");
+        ExecutionException exception = new ExecutionException("Execution error", originalException);
+        PulsarClientException result = PulsarClientException.unwrap(exception);
+        assertThat(result)
+                .isInstanceOf(PulsarClientException.class)
+                .matches(n -> {
+                    assertThat(n.getStackTrace()).isEqualTo(originalException.getStackTrace());
+                    return true;
+                })
+                .isEqualTo(originalException);
+    }
+}


### PR DESCRIPTION
### Motivation

The current implementation of `wrap` and `unwrap` methods in PulsarClientException use long chains of if-else statements to handle different exception types. This approach has several drawbacks:

- Maintainability issues: When new exception types are added, developers must remember to update both methods, which is error-prone and can lead to inconsistent behavior.

- Code duplication: The same pattern is repeated for each exception type, resulting in nearly 200 lines of duplicated logic.

- Potential for bugs: If a new exception type is added but the methods aren't updated, the exception handling will fall back to generic handling, potentially losing important context.

This PR refactors these methods to use a more maintainable and robust approach that automatically handles all exception types, including future ones.

### Modifications

- Refactored wrap method:
  - Replaced the if-else chain with a reflection-based approach that creates a new exception of the same type.
  - Preserved stack traces and cause information when wrapping exceptions.
  - Added special handling for exceptions that shouldn't be wrapped (CompletionException, InterruptedException, ExecutionException).

- Refactored unwrap method:

  - Simplified the method to recursively unwrap nested exceptions.
  - Eliminated the need to maintain a list of all exception types.
  - Preserved stack traces in the unwrapped exceptions.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->