### PR TITLE
[fix][ml] Return 1 when bytes size is 0 or negative for entry count estimation

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCountEstimator.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCountEstimator.java
@@ -73,8 +73,8 @@ class EntryCountEstimator {
                                                      Long lastLedgerId, long lastLedgerTotalEntries,
                                                      long lastLedgerTotalSize) {
         if (maxSizeBytes <= 0) {
-            // If the specified maximum size is invalid (e.g., non-positive), return 0
-            return 0;
+            // If the specified maximum size is invalid (e.g., non-positive), return 1
+            return 1;
         }
 
         // If the maximum size is Long.MAX_VALUE, return the maximum number of entries

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCountEstimatorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCountEstimatorTest.java
@@ -83,7 +83,13 @@ public class EntryCountEstimatorTest {
     @Test
     public void testZeroMaxSize() {
         int result = estimateEntryCountByBytesSize(0);
-        assertEquals(result, 0, "Should return 0 when max size is 0");
+        assertEquals(result, 1, "Should return 1 when max size is 0");
+    }
+
+    @Test
+    public void testNegativeMaxSize() {
+        int result = estimateEntryCountByBytesSize(-1);
+        assertEquals(result, 1, "Should return 1 when max size is negative");
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Following up on #24089 changes. The changes cause a regression which is visible in branch-3.0 where a test fails (`org.apache.pulsar.sql.presto.TestCacheSizeAllocator#cacheSizeAllocatorTest`). This test is missing from newer branches. The regression is caused by the logic added in #24089 to return 0 when bytes size <= 0. 

### Modifications

- return 1 when bytes size <= 0 so that the previous behavior is preserved

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->