### PR TITLE
[fix][test] Fix flaky NonPersistentTopicTest.testMsgDropStat

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -899,7 +899,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
                     }
                 });
             }
-            assertTrue(latch.await(10, TimeUnit.SECONDS));
+            assertTrue(latch.await(5, TimeUnit.SECONDS));
 
             NonPersistentTopic topic =
                     (NonPersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -890,7 +890,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
                             latch.countDown();
                         }
 
-                        Thread.sleep(50);
+                        Thread.sleep(10);
                     } catch (PulsarClientException e) {
                         throw new RuntimeException(e);
                     } catch (InterruptedException e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -871,7 +871,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
                 .messageRoutingMode(MessageRoutingMode.SinglePartition)
                 .create();
             @Cleanup("shutdownNow")
-            ExecutorService executor = Executors.newFixedThreadPool(5);
+            ExecutorService executor = Executors.newFixedThreadPool(10);
             byte[] msgData = "testData".getBytes();
             final int totalProduceMessages = 1000;
             CountDownLatch latch = new CountDownLatch(1);


### PR DESCRIPTION

<!-- Either this PR fixes an issue, -->

Fixes #20386

### Motivation

It seems that messages are dropped very fast, so the drop stats are already 0 again once we reach the assertion.

### Modifications

- Sleep 10ms after producing a message. With this, the time it takes until all messages are produced is extended. The drop stats are > 0 for a longer time (and at the time when we reach the assertion).
- Increase the number of threads used for the producer from 5 to 10 to increase concurrency and the probability that messages are dropped.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/pdolif/pulsar/pull/9

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
