### PR TITLE
[fix][test] Fix flaky DisabledCreateTopicToRemoteClusterForReplicationTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/DisabledCreateTopicToRemoteClusterForReplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/DisabledCreateTopicToRemoteClusterForReplicationTest.java
@@ -108,10 +108,7 @@ public class DisabledCreateTopicToRemoteClusterForReplicationTest extends OneWay
         admin2.topics().createPartitionedTopic(tp, 1);
         Consumer<String> consumer2 = client2.newConsumer(Schema.STRING).topic(tp).isAckReceiptEnabled(true)
                 .subscriptionName("s1").subscribe();
-        Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
-            assertEquals(consumer2.receive().getValue(), msgValue);
-        });
-
+        assertEquals(consumer2.receive(20, TimeUnit.SECONDS).getValue(), msgValue);
         consumer2.close();
 
         // cleanup.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/DisabledCreateTopicToRemoteClusterForReplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/DisabledCreateTopicToRemoteClusterForReplicationTest.java
@@ -108,7 +108,10 @@ public class DisabledCreateTopicToRemoteClusterForReplicationTest extends OneWay
         admin2.topics().createPartitionedTopic(tp, 1);
         Consumer<String> consumer2 = client2.newConsumer(Schema.STRING).topic(tp).isAckReceiptEnabled(true)
                 .subscriptionName("s1").subscribe();
-        assertEquals(consumer2.receive(10, TimeUnit.SECONDS).getValue(), msgValue);
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertEquals(consumer2.receive().getValue(), msgValue);
+        });
+
         consumer2.close();
 
         // cleanup.


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/23827
### Motivation
fix flaky-test, I think the flaky-test is due to replication not complete yet within 10 seconds, so I added to 30 seconds and change the assertion into await().atMost(30, TimeUnit.SECONDS)
### Verifying this change

- [x] Make sure that the change passes the CI checks.
### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/3pacccccc/pulsar/pull/2